### PR TITLE
[Distributed] Fix a deadlock when concurrently inserting and registering && applier skip remaining logs after a wrong exception && fix test

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/AsyncDataLogApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/AsyncDataLogApplier.java
@@ -117,7 +117,7 @@ public class AsyncDataLogApplier implements LogApplier {
       while (!allConsumersEmpty()) {
         // wait until all consumers empty
         try {
-          consumerEmptyCondition.wait();
+          consumerEmptyCondition.wait(5);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           return;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
@@ -692,6 +692,7 @@ public abstract class RaftLogManager {
 
   @TestOnly
   public void setMaxHaveAppliedCommitIndex(long maxHaveAppliedCommitIndex) {
+    this.checkLogApplierExecutorService.shutdown();
     this.maxHaveAppliedCommitIndex = maxHaveAppliedCommitIndex;
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -1298,7 +1298,7 @@ public abstract class RaftMember {
   @SuppressWarnings("java:S2445")
   void commitLog(Log log) throws LogExecutionException {
     synchronized (logManager) {
-      logManager.commitTo(log.getCurrLogIndex(), false);
+      logManager.commitTo(log.getCurrLogIndex());
     }
     // when using async applier, the log here may not be applied. To return the execution
     // result, we must wait until the log is applied.
@@ -1306,7 +1306,7 @@ public abstract class RaftMember {
       while (!log.isApplied()) {
         // wait until the log is applied
         try {
-          log.wait();
+          log.wait(5);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           throw new LogExecutionException(e);

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/applier/DataLogApplierTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/applier/DataLogApplierTest.java
@@ -58,6 +58,7 @@ import org.apache.iotdb.cluster.server.service.MetaAsyncService;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.storagegroup.StorageGroupProcessor;
+import org.apache.iotdb.db.engine.tsfilemanagement.HotCompactionMergeTaskPoolManager;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
@@ -118,6 +119,7 @@ public class DataLogApplierTest extends IoTDBTest {
   @Before
   public void setUp()
       throws org.apache.iotdb.db.exception.StartupException, QueryProcessException, IllegalPathException {
+    HotCompactionMergeTaskPoolManager.getInstance().stop();
     IoTDB.setMetaManager(CMManager.getInstance());
     MetaPuller.getInstance().init(testMetaGroupMember);
     super.setUp();

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/catchup/CatchUpTaskTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/catchup/CatchUpTaskTest.java
@@ -208,7 +208,7 @@ public class CatchUpTaskTest {
     receivedLogs.clear();
 
     sender.getLogManager().append(logList);
-    sender.getLogManager().commitTo(9, false);
+    sender.getLogManager().commitTo(9);
     sender.getLogManager().setMaxHaveAppliedCommitIndex(sender.getLogManager().getCommitLogIndex());
     Node receiver = new Node();
     sender.setCharacter(NodeCharacter.LEADER);
@@ -233,7 +233,7 @@ public class CatchUpTaskTest {
       }
     }
     sender.getLogManager().append(logList);
-    sender.getLogManager().commitTo(9, false);
+    sender.getLogManager().commitTo(9);
     sender.getLogManager().setMaxHaveAppliedCommitIndex(sender.getLogManager().getCommitLogIndex());
     Node receiver = new Node();
     sender.setCharacter(NodeCharacter.LEADER);
@@ -264,7 +264,7 @@ public class CatchUpTaskTest {
         }
       }
       sender.getLogManager().append(logList);
-      sender.getLogManager().commitTo(9, false);
+      sender.getLogManager().commitTo(9);
       sender.getLogManager().setMaxHaveAppliedCommitIndex(sender.getLogManager().getCommitLogIndex());
       Node receiver = new Node();
       sender.setCharacter(NodeCharacter.LEADER);
@@ -291,7 +291,7 @@ public class CatchUpTaskTest {
       logList.add(log);
     }
     sender.getLogManager().append(logList);
-    sender.getLogManager().commitTo(9, false);
+    sender.getLogManager().commitTo(9);
     sender.getLogManager().setMaxHaveAppliedCommitIndex(sender.getLogManager().getCommitLogIndex());
     Node receiver = new Node();
     sender.setCharacter(NodeCharacter.LEADER);
@@ -316,7 +316,7 @@ public class CatchUpTaskTest {
       logList.add(log);
     }
     sender.getLogManager().append(logList);
-    sender.getLogManager().commitTo(9, false);
+    sender.getLogManager().commitTo(9);
     sender.getLogManager().setMaxHaveAppliedCommitIndex(sender.getLogManager().getCommitLogIndex());
     Node receiver = new Node();
     sender.setCharacter(NodeCharacter.LEADER);

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/manage/FilePartitionedSnapshotLogManagerTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/manage/FilePartitionedSnapshotLogManagerTest.java
@@ -63,7 +63,7 @@ public class FilePartitionedSnapshotLogManagerTest extends IoTDBTest {
     try {
       List<Log> logs = TestUtils.prepareTestLogs(10);
       manager.append(logs);
-      manager.commitTo(10, false);
+      manager.commitTo(10);
       manager.setMaxHaveAppliedCommitIndex(manager.getCommitLogIndex());
 
       Map<PartialPath, List<Pair<Long, Boolean>>> storageGroupPartitionIds = new HashMap<>();

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/manage/MetaSingleSnapshotLogManagerTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/manage/MetaSingleSnapshotLogManagerTest.java
@@ -66,7 +66,7 @@ public class MetaSingleSnapshotLogManagerTest extends IoTDBTest {
   public void testTakeSnapshot() throws Exception {
     List<Log> testLogs = TestUtils.prepareTestLogs(10);
     logManager.append(testLogs);
-    logManager.commitTo(4, false);
+    logManager.commitTo(4);
     logManager.setMaxHaveAppliedCommitIndex(logManager.getCommitLogIndex());
 
     logManager.takeSnapshot();

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/manage/RaftLogManagerTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/manage/RaftLogManagerTest.java
@@ -1349,9 +1349,9 @@ public class RaftLogManagerTest {
     RaftLogManager raftLogManager = new TestRaftLogManager(committedEntryManager,
         syncLogDequeSerializer, logApplier);
 
-    int maxNumberOfLogs = 100;
+    int minNumberOfLogs = 100;
     List<Log> testLogs1;
-    raftLogManager.setMinNumOfLogsInMem(maxNumberOfLogs);
+    raftLogManager.setMinNumOfLogsInMem(minNumberOfLogs);
     testLogs1 = TestUtils.prepareNodeLogs(130);
     raftLogManager.append(testLogs1);
 
@@ -1362,7 +1362,7 @@ public class RaftLogManagerTest {
     }
     // wait log is applied
     long startTime = System.currentTimeMillis();
-    for (int i = 0; i < testLogs1.size() - 1 - 30; i++) {
+    for (int i = 0; i < testLogs1.size() - 30; i++) {
       while (!testLogs1.get(i).isApplied()) {
         if ((System.currentTimeMillis() - startTime) > 60_000) {
           System.out.println("apply log time out");
@@ -1383,8 +1383,8 @@ public class RaftLogManagerTest {
     assertEquals(raftLogManager.getCommitLogIndex(), raftLogManager.getMaxHaveAppliedCommitIndex());
 
     raftLogManager.checkDeleteLog();
-    assertEquals(maxNumberOfLogs, committedEntryManager.getTotalSize());
-    assertEquals(maxNumberOfLogs, syncLogDequeSerializer.getLogSizeDeque().size());
+    assertEquals(minNumberOfLogs, committedEntryManager.getTotalSize());
+    assertEquals(minNumberOfLogs, syncLogDequeSerializer.getLogSizeDeque().size());
 
     for (int i = testLogs1.size() - 30; i < testLogs1.size(); i++) {
       try {

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/manage/RaftLogManagerTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/manage/RaftLogManagerTest.java
@@ -1245,10 +1245,10 @@ public class RaftLogManagerTest {
     RaftLogManager raftLogManager = new TestRaftLogManager(committedEntryManager,
         syncLogDequeSerializer, logApplier);
 
-    int maxNumberOfLogs = 100;
+    int minNumberOfLogs = 100;
     List<Log> testLogs1;
 
-    raftLogManager.setMinNumOfLogsInMem(maxNumberOfLogs);
+    raftLogManager.setMinNumOfLogsInMem(minNumberOfLogs);
     testLogs1 = TestUtils.prepareNodeLogs(130);
     raftLogManager.append(testLogs1);
     try {
@@ -1260,17 +1260,17 @@ public class RaftLogManagerTest {
     assertEquals(130, committedEntryManager.getTotalSize());
     assertEquals(130, syncLogDequeSerializer.getLogSizeDeque().size());
 
-    // the maxHaveAppliedCommitIndex is smaller than 130-maxNumberOfLogs
-    long remainNumber = 130 - maxNumberOfLogs - 20;
+    // the maxHaveAppliedCommitIndex is smaller than 130-minNumberOfLogs
+    long remainNumber = 130 - 20;
     raftLogManager.setMaxHaveAppliedCommitIndex(20);
     raftLogManager.checkDeleteLog();
-    assertEquals(maxNumberOfLogs + remainNumber, committedEntryManager.getTotalSize());
-    assertEquals(maxNumberOfLogs + remainNumber, syncLogDequeSerializer.getLogSizeDeque().size());
+    assertEquals(remainNumber, committedEntryManager.getTotalSize());
+    assertEquals(remainNumber, syncLogDequeSerializer.getLogSizeDeque().size());
 
     raftLogManager.setMaxHaveAppliedCommitIndex(100);
     raftLogManager.checkDeleteLog();
-    assertEquals(maxNumberOfLogs, committedEntryManager.getTotalSize());
-    assertEquals(maxNumberOfLogs, syncLogDequeSerializer.getLogSizeDeque().size());
+    assertEquals(minNumberOfLogs, committedEntryManager.getTotalSize());
+    assertEquals(minNumberOfLogs, syncLogDequeSerializer.getLogSizeDeque().size());
 
     raftLogManager.close();
 
@@ -1278,8 +1278,8 @@ public class RaftLogManagerTest {
     syncLogDequeSerializer = new SyncLogDequeSerializer(testIdentifier);
     try {
       List<Log> logs = syncLogDequeSerializer.recoverLog();
-      assertEquals(maxNumberOfLogs, logs.size());
-      for (int i = 0; i < maxNumberOfLogs; i++) {
+      assertEquals(minNumberOfLogs, logs.size());
+      for (int i = 0; i < minNumberOfLogs; i++) {
         assertEquals(testLogs1.get(i + 30), logs.get(i));
       }
     } finally {

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/heartbeat/DataHeartbeatThreadTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/heartbeat/DataHeartbeatThreadTest.java
@@ -131,7 +131,7 @@ public class DataHeartbeatThreadTest extends HeartbeatThreadTest {
     dataLogManager = new TestLogManager(2);
     List<Log> logs = TestUtils.prepareTestLogs(14);
     dataLogManager.append(logs);
-    dataLogManager.commitTo(13, false);
+    dataLogManager.commitTo(13);
   }
 
   @Override

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/heartbeat/HeartbeatThreadTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/heartbeat/HeartbeatThreadTest.java
@@ -145,7 +145,7 @@ public class HeartbeatThreadTest {
     member.getTerm().set(10);
     List<Log> logs = TestUtils.prepareTestLogs(7);
     logManager.append(logs);
-    logManager.commitTo(6, false);
+    logManager.commitTo(6);
 
     respondToElection = false;
     testHeartbeat = false;


### PR DESCRIPTION
 fix a deadlock when concurrently inserting and registering && applier skip remaining logs after a wrong exception && fix test