### PR TITLE
[IOTDB-912] Implement wasNull method in AbstractIoTDBJDBCResultSet

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBJDBCResultSet.java
@@ -160,7 +160,12 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
 
   @Override
   public BigDecimal getBigDecimal(String columnName) throws SQLException {
-    return new BigDecimal(Objects.requireNonNull(getValueByName(columnName)));
+    String value = getValueByName(columnName);
+    if (value != null) {
+      return new BigDecimal(value);
+    } else {
+      return null;
+    }
   }
 
   @Override
@@ -480,16 +485,12 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
 
   @Override
   public short getShort(int columnIndex) throws SQLException {
-    try {
-      return getShort(ioTDBRpcDataSet.findColumnNameByIndex(columnIndex));
-    } catch (StatementExecutionException e) {
-      throw new SQLException(e.getMessage());
-    }
+    throw new SQLException(Constant.METHOD_NOT_SUPPORTED);
   }
 
   @Override
   public short getShort(String columnName) throws SQLException {
-    return Short.parseShort(Objects.requireNonNull(getValueByName(columnName)));
+    throw new SQLException(Constant.METHOD_NOT_SUPPORTED);
   }
 
   @Override
@@ -1099,8 +1100,8 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
   }
 
   @Override
-  public boolean wasNull() throws SQLException {
-    throw new SQLException(Constant.METHOD_NOT_SUPPORTED);
+  public boolean wasNull() {
+    return ioTDBRpcDataSet.lastReadWasNull;
   }
 
   abstract void checkRecord() throws SQLException;

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
@@ -89,16 +89,20 @@ public class IoTDBNonAlignJDBCResultSet extends AbstractIoTDBJDBCResultSet {
       String column = columnName.substring(TIMESTAMP_STR_LENGTH);
       int index = ioTDBRpcDataSet.columnOrdinalMap.get(column) - START_INDEX;
       if (times[index] != null) {
+        ioTDBRpcDataSet.lastReadWasNull = false;
         return BytesUtils.bytesToLong(times[index]);
       } else {
-        throw new SQLException(String.format(VALUE_IS_NULL, columnName));
+        ioTDBRpcDataSet.lastReadWasNull = true;
+        return 0;
       }
     }
     int index = ioTDBRpcDataSet.columnOrdinalMap.get(columnName) - START_INDEX;
     if (ioTDBRpcDataSet.values[index] != null) {
+      ioTDBRpcDataSet.lastReadWasNull = false;
       return BytesUtils.bytesToLong(ioTDBRpcDataSet.values[index]);
     } else {
-      throw new SQLException(String.format(VALUE_IS_NULL, columnName));
+      ioTDBRpcDataSet.lastReadWasNull = true;
+      return 0;
     }
   }
 

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -54,6 +54,7 @@ public class IoTDBRpcDataSet {
   public int fetchSize;
   public boolean emptyResultSet = false;
   public boolean hasCachedRecord = false;
+  public boolean lastReadWasNull;
 
 
   public byte[][] values; // used to cache the current row record value
@@ -284,9 +285,11 @@ public class IoTDBRpcDataSet {
     checkRecord();
     int index = columnOrdinalMap.get(columnName) - START_INDEX;
     if (!isNull(index, rowsIndex - 1)) {
+      lastReadWasNull = false;
       return BytesUtils.bytesToBool(values[index]);
     } else {
-      throw new StatementExecutionException(String.format(VALUE_IS_NULL, columnName));
+      lastReadWasNull = true;
+      return false;
     }
   }
 
@@ -298,9 +301,11 @@ public class IoTDBRpcDataSet {
     checkRecord();
     int index = columnOrdinalMap.get(columnName) - START_INDEX;
     if (!isNull(index, rowsIndex - 1)) {
+      lastReadWasNull = false;
       return BytesUtils.bytesToDouble(values[index]);
     } else {
-      throw new StatementExecutionException(String.format(VALUE_IS_NULL, columnName));
+      lastReadWasNull = true;
+      return 0;
     }
   }
 
@@ -312,9 +317,11 @@ public class IoTDBRpcDataSet {
     checkRecord();
     int index = columnOrdinalMap.get(columnName) - START_INDEX;
     if (!isNull(index, rowsIndex - 1)) {
+      lastReadWasNull = false;
       return BytesUtils.bytesToFloat(values[index]);
     } else {
-      throw new StatementExecutionException(String.format(VALUE_IS_NULL, columnName));
+      lastReadWasNull = true;
+      return 0;
     }
   }
 
@@ -326,9 +333,11 @@ public class IoTDBRpcDataSet {
     checkRecord();
     int index = columnOrdinalMap.get(columnName) - START_INDEX;
     if (!isNull(index, rowsIndex - 1)) {
+      lastReadWasNull = false;
       return BytesUtils.bytesToInt(values[index]);
     } else {
-      throw new StatementExecutionException(String.format(VALUE_IS_NULL, columnName));
+      lastReadWasNull = true;
+      return 0;
     }
   }
 
@@ -343,9 +352,11 @@ public class IoTDBRpcDataSet {
     }
     int index = columnOrdinalMap.get(columnName) - START_INDEX;
     if (!isNull(index, rowsIndex - 1)) {
+      lastReadWasNull = false;
       return BytesUtils.bytesToLong(values[index]);
     } else {
-      throw new StatementExecutionException(String.format(VALUE_IS_NULL, columnName));
+      lastReadWasNull = true;
+      return 0;
     }
   }
 
@@ -384,8 +395,10 @@ public class IoTDBRpcDataSet {
     }
     int index = columnOrdinalMap.get(columnName) - START_INDEX;
     if (index < 0 || index >= values.length || isNull(index, rowsIndex - 1)) {
+      lastReadWasNull = true;
       return null;
     }
+    lastReadWasNull = false;
     return getString(index, columnTypeDeduplicatedList.get(index), values);
   }
 


### PR DESCRIPTION
The wasNull method had been implemented and getXXX method should be modified according to the JDBC specification while there is null.