### PR TITLE
Print error log when set illegal storage group name

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -1637,7 +1637,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     } catch (BatchInsertionException e) {
       return RpcUtils.getStatus(Arrays.asList(e.getFailingStatus()));
     } catch (QueryProcessException e) {
-      logger.debug("meet error while processing non-query. ", e);
+      logger.error("meet error while processing non-query. ", e);
       return RpcUtils.getStatus(e.getErrorCode(), e.getMessage());
     } catch (Exception e) {
       logger.error("{}: server Internal Error: ", IoTDBConstant.GLOBAL_DB_NAME, e);


### PR DESCRIPTION
When setting `root.tpc@127` as storage group, it should print error log in IoTDB server.