### PR TITLE
[IOTDB-939]update google guava version

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -224,7 +224,7 @@ commons-lang:commons-lang:2.6
 com.nimbusds:content-type:2.0
 com.google.code.gson:gson:2.8.6
 it.unimi.dsi:fastutil:7.0.6
-com.google.guava.guava:21.0
+com.google.guava.guava:24.1.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.0
 com.fasterxml.jackson.core:jackson-core:2.10.0
 com.fasterxml.jackson.core:jackson-databind:2.10.0

--- a/flink-iotdb-connector/pom.xml
+++ b/flink-iotdb-connector/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>[${guava.version},)</version>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <common.lang.version>2.6</common.lang.version>
         <common.lang3.version>3.8.1</common.lang3.version>
         <common.logging.version>1.1.3</common.logging.version>
-        <guava.version>21.0</guava.version>
+        <guava.version>24.1.1</guava.version>
         <jline.version>2.14.5</jline.version>
         <jetty.version>9.4.24.v20191120</jetty.version>
         <metrics.version>3.2.6</metrics.version>
@@ -184,7 +184,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
+                <version>[${guava.version},)</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>


### PR DESCRIPTION
As google guava version under 24.1.1 have some vulnerability according to [1][2], so I think we need to upgrade the version.

[1]https://www.cvedetails.com/cve/CVE-2018-10237/

[2]https://github.com/google/guava/wiki/CVE-2018-10237