### PR TITLE
[IOTDB-947] Fix error when counting node with wildcard

### DIFF
--- a/docs/UserGuide/Operation Manual/DDL Data Definition Language.md
+++ b/docs/UserGuide/Operation Manual/DDL Data Definition Language.md
@@ -248,7 +248,7 @@ You will get following results:
 
 ## Count Nodes
 
-IoTDB is able to use `COUNT NODES <Path> LEVEL=<INTEGER>` to count the number of nodes at the given level in current Metadata Tree. This could be used to query the number of devices. The usage are as follows:
+IoTDB is able to use `COUNT NODES <PrefixPath> LEVEL=<INTEGER>` to count the number of nodes at the given level in current Metadata Tree. This could be used to query the number of devices. The usage are as follows:
 
 ```
 IoTDB > COUNT NODES root LEVEL=2
@@ -261,6 +261,7 @@ As for the above mentioned example and Metadata tree, you can get following resu
 <center><img style="width:100%; max-width:800px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/69792060-c73a2d00-1200-11ea-8ec4-be7145fd6c8c.png"></center>
 
 > Note: The path of timeseries is just a filter condition, which has no relationship with the definition of level.
+`PrefixPath` could contains `*`, but all nodes after `*` would be ignored. Only the prefix path before `*` is valid.
 
 ## Delete Timeseries
 

--- a/docs/UserGuide/Operation Manual/SQL Reference.md
+++ b/docs/UserGuide/Operation Manual/SQL Reference.md
@@ -238,6 +238,7 @@ Note: This statement can be used in IoTDB Client and JDBC.
 COUNT NODES <Path> LEVEL=<INTEGER>
 Eg: IoTDB > COUNT NODES root LEVEL=2
 Eg: IoTDB > COUNT NODES root.ln LEVEL=2
+Eg: IoTDB > COUNT NODES root.ln.* LEVEL=3
 Eg: IoTDB > COUNT NODES root.ln.wf01 LEVEL=3
 Note: The path can be prefix path or timeseries path.
 Note: This statement can be used in IoTDB Client and JDBC.

--- a/docs/zh/UserGuide/Operation Manual/DDL Data Definition Language.md
+++ b/docs/zh/UserGuide/Operation Manual/DDL Data Definition Language.md
@@ -247,7 +247,7 @@ IoTDB > COUNT TIMESERIES root.ln.wf01 GROUP BY LEVEL=2
 
 ## 统计节点数
 
-IoTDB支持使用`COUNT NODES <Path> LEVEL=<INTEGER>`来统计当前Metadata树下指定层级的节点个数，这条语句可以用来统计设备数。例如：
+IoTDB支持使用`COUNT NODES <PrefixPath> LEVEL=<INTEGER>`来统计当前Metadata树下指定层级的节点个数，这条语句可以用来统计设备数。例如：
 
 ```
 IoTDB > COUNT NODES root LEVEL=2
@@ -259,6 +259,7 @@ IoTDB > COUNT NODES root.ln.wf01 LEVEL=3
 <center><img style="width:100%; max-width:800px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/69792060-c73a2d00-1200-11ea-8ec4-be7145fd6c8c.png"></center>
 
 > 注意：时间序列的路径只是过滤条件，与level的定义无关。
+其中`PrefixPath`可以包含`*`，但是`*`及其后的所有节点将被忽略，仅在`*`前的前缀路径有效。
 
 ## 删除时间序列
 

--- a/docs/zh/UserGuide/Operation Manual/SQL Reference.md
+++ b/docs/zh/UserGuide/Operation Manual/SQL Reference.md
@@ -227,6 +227,7 @@ Note: This statement can be used in IoTDB Client and JDBC.
 COUNT NODES <Path> LEVEL=<INTEGER>
 Eg: IoTDB > COUNT NODES root LEVEL=2
 Eg: IoTDB > COUNT NODES root.ln LEVEL=2
+Eg: IoTDB > COUNT NODES root.ln.* LEVEL=3
 Eg: IoTDB > COUNT NODES root.ln.wf01 LEVEL=3
 Note: The path can be prefix path or timeseries path.
 Note: This statement can be used in IoTDB Client and JDBC.

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -174,7 +174,6 @@ public class MTree implements Serializable {
 
   /**
    * combine multiple metadata in string format
-   *
    */
   @TestOnly
   static JsonObject combineMetadataInStrings(String[] metadataStrs) {
@@ -187,7 +186,7 @@ public class MTree implements Serializable {
     for (int i = 1; i < jsonObjects.length; i++) {
       root = combineJsonObjects(root, jsonObjects[i]);
     }
-    
+
     return root;
   }
 
@@ -812,14 +811,18 @@ public class MTree implements Serializable {
       throw new IllegalPathException(prefixPath.getFullPath());
     }
     MNode node = root;
-    for (int i = 1; i < nodes.length; i++) {
+    int i;
+    for (i = 1; i < nodes.length; i++) {
+      if (nodes[i].equals("*")) {
+        break;
+      }
       if (node.getChild(nodes[i]) != null) {
         node = node.getChild(nodes[i]);
       } else {
         throw new MetadataException(nodes[i - 1] + NO_CHILDNODE_MSG + nodes[i]);
       }
     }
-    return getCountInGivenLevel(node, level - (nodes.length - 1));
+    return getCountInGivenLevel(node, level - (i - 1));
   }
 
   /**

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -441,6 +441,8 @@ public class MTreeTest {
 
       assertEquals(2, root.getNodesCountInGivenLevel(new PartialPath("root.laptop"), 2));
       assertEquals(4, root.getNodesCountInGivenLevel(new PartialPath("root.laptop"), 3));
+      assertEquals(2, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.*"), 2));
+      assertEquals(4, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.*"), 3));
       assertEquals(2, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.d1"), 3));
       assertEquals(0, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.d1"), 4));
     } catch (MetadataException e) {


### PR DESCRIPTION
`COUNT NODES root.ln.* LEVEL=2` and `COUNT NODES root.ln LEVEL=2` are equivalent,
which means: `PrefixPath` could contains `*`, but all nodes after `*` would be ignored. Only the prefix path before `*` is valid.