### PR TITLE
[IOTDB-948] Use binary search when checking the follower's match index when catchup	

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -232,7 +232,7 @@ public abstract class RaftMember {
    */
   private LogDispatcher logDispatcher;
 
-  public RaftMember() {
+  protected RaftMember() {
   }
 
   protected RaftMember(String name, AsyncClientPool asyncPool, SyncClientPool syncPool,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;


### PR DESCRIPTION
Now, when the follower lags behind the leader a lot, one catchup task will be triggered. When catchup, it will judge whether a certain log saved in the leader's memory is consistent with the follower. If so, the leader can use logs in its memory to catch up. If the leader cannot find a log in memory that matches the follower, the leader needs to send snapshots.

When checking whether the leader's log match with the follower's, the current implementation starts from the largest index of the stored log in memory, and traverses from large to small to see whether it is consistent with the follower. However, each traversal will send one RPC. Since the maximum number of logs in memory is 1000, there may be 1000 times of RPC, and the time is O( n ). If it becomes a binary search, it only needs O(log n), and 1000 logs only need 10 RPC communications, it'll save communication cost.
