### PR TITLE
[IOTDB-951] Fix auto-creating schema in parallel may write unrecognizable timeseries in mlog.txt

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -94,7 +94,7 @@ public class MLogWriter {
     final String newLine = System.getProperty("line.separator");
     buf.append(newLine);
 
-    writeSeries(ByteBuffer.wrap(buf.toString().getBytes()));
+    writeTimeseries(ByteBuffer.wrap(buf.toString().getBytes()));
     ++lineNumber;
   }
 
@@ -176,13 +176,12 @@ public class MLogWriter {
     ++lineNumber;
   }
 
-  private synchronized void writeSeries(ByteBuffer buffer) throws IOException {
-    FileOutputStream fos = new FileOutputStream(logFile, true);
-    FileChannel channel = fos.getChannel();
-    channel.write(buffer);
-    channel.force(true);
-    channel.close();
-    fos.close();
+  private synchronized void writeTimeseries(ByteBuffer buffer) throws IOException {
+    try (FileOutputStream fos = new FileOutputStream(logFile, true);
+         FileChannel channel = fos.getChannel()) {
+      channel.write(buffer);
+      channel.force(true);
+    }
   }
 
   int getLineNumber() {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -94,9 +94,7 @@ public class MLogWriter {
     final String newLine = System.getProperty("line.separator");
     buf.append(newLine);
 
-    FileChannel channel = new FileOutputStream(logFile, true).getChannel();
-    channel.write(ByteBuffer.wrap(buf.toString().getBytes()));
-    channel.force(true);
+    writeSeries(ByteBuffer.wrap(buf.toString().getBytes()));
     ++lineNumber;
   }
 
@@ -176,6 +174,12 @@ public class MLogWriter {
     writer.newLine();
     writer.flush();
     ++lineNumber;
+  }
+
+  private synchronized void writeSeries(ByteBuffer buffer) throws IOException {
+    FileChannel channel = new FileOutputStream(logFile, true).getChannel();
+    channel.write(buffer);
+    channel.force(true);
   }
 
   int getLineNumber() {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -92,8 +92,7 @@ public class MLogWriter {
     if (offset >= 0) {
       buf.append(offset);
     }
-    final String newLine = System.getProperty("line.separator");
-    buf.append(newLine);
+    buf.append(System.getProperty("line.separator"));
     channel.write(ByteBuffer.wrap(buf.toString().getBytes()));
     ++lineNumber;
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -177,7 +177,6 @@ public class MLogWriter {
     channel.close();
     fileOutputStream.close();
     Files.delete(logFile.toPath());
-    FileWriter fileWriter = new FileWriter(logFile, true);
     fileOutputStream = new FileOutputStream(logFile, true);
     channel = fileOutputStream.getChannel();
     lineNumber = 0;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -177,9 +177,12 @@ public class MLogWriter {
   }
 
   private synchronized void writeSeries(ByteBuffer buffer) throws IOException {
-    FileChannel channel = new FileOutputStream(logFile, true).getChannel();
+    FileOutputStream fos = new FileOutputStream(logFile, true);
+    FileChannel channel = fos.getChannel();
     channel.write(buffer);
     channel.force(true);
+    channel.close();
+    fos.close();
   }
 
   int getLineNumber() {


### PR DESCRIPTION
Jira Issue: https://issues.apache.org/jira/browse/IOTDB-951
