### PR TITLE
IOTDB-889 Fix key word `EQUAL_NS` in `SQLConstant` error

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
@@ -80,7 +80,6 @@ public class SQLConstant {
   public static final int LESSTHAN = SqlBaseLexer.OPERATOR_LT;
   public static final int GREATERTHANOREQUALTO = SqlBaseLexer.OPERATOR_GTE;
   public static final int GREATERTHAN = SqlBaseLexer.OPERATOR_GT;
-  public static final int EQUAL_NS = SqlBaseLexer.OPERATOR_NEQ;
   public static final int IN = SqlBaseLexer.OPERATOR_IN;
 
   public static final int TOK_SELECT = 21;
@@ -181,7 +180,6 @@ public class SQLConstant {
     tokenSymbol.put(KW_NOT, "!");
     tokenSymbol.put(EQUAL, "=");
     tokenSymbol.put(NOTEQUAL, "<>");
-    tokenSymbol.put(EQUAL_NS, "<=>");
     tokenSymbol.put(LESSTHANOREQUALTO, "<=");
     tokenSymbol.put(LESSTHAN, "<");
     tokenSymbol.put(GREATERTHANOREQUALTO, ">=");
@@ -194,7 +192,6 @@ public class SQLConstant {
     tokenNames.put(KW_NOT, "not");
     tokenNames.put(EQUAL, "equal");
     tokenNames.put(NOTEQUAL, "not_equal");
-    tokenNames.put(EQUAL_NS, "equal_ns");
     tokenNames.put(LESSTHANOREQUALTO, "lessthan_or_equalto");
     tokenNames.put(LESSTHAN, "lessthan");
     tokenNames.put(GREATERTHANOREQUALTO, "greaterthan_or_equalto");


### PR DESCRIPTION
As `NOTEQUAL` equals `EQUAL_NS`, When adding two entry with the same key, the latter will overlap the former one.