### PR TITLE
[IOTDB-964] Fix mlog recover log level

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -325,7 +325,14 @@ public class MManager {
         }
         break;
       case MetadataOperationType.SET_STORAGE_GROUP:
-        setStorageGroup(new PartialPath(args[1]));
+        try {
+          setStorageGroup(new PartialPath(args[1]));
+        }
+        // two time series may set one storage group concurrently,
+        // that's normal in our concurrency control protocol
+        catch (MetadataException e){
+          logger.info("concurrently operate set storage group cmd {} twice", cmd);
+        }
         break;
       case MetadataOperationType.DELETE_STORAGE_GROUP:
         deleteStorageGroups(Collections.singletonList(new PartialPath(args[1])));


### PR DESCRIPTION
There are some duplicate set storage group logs in mlog. So in recovery, an error log "root.sg1.d1" has already been set to storage group appeared. But that's normal in our concurrency control protocol. So we just catch that exception and change log level to info.