### PR TITLE
[IOTDB-975] Improve readTimeseriesMetadata

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -330,13 +331,12 @@ public class TsFileSequenceReader implements AutoCloseable {
     Pair<MetadataIndexEntry, Long> metadataIndexPair = getMetadataAndEndOffset(
         deviceMetadataIndexNode, device, MetadataIndexNodeType.INTERNAL_DEVICE);
     List<TimeseriesMetadata> resultTimeseriesMetadataList = new ArrayList<>();
-    int maxDegreeOfIndexNode = config.getMaxDegreeOfIndexNode();
-    if (measurements.size() > maxDegreeOfIndexNode / Math.log(maxDegreeOfIndexNode)) {
-      traverseAndReadTimeseriesMetadataInOneDevice(resultTimeseriesMetadataList,
-          MetadataIndexNodeType.INTERNAL_MEASUREMENT, metadataIndexPair, measurements);
-      return resultTimeseriesMetadataList;
-    }
-    for (String measurement : measurements) {
+    List<String> measurementList = new ArrayList<>(measurements);
+    Set<String> measurementsHadFound = new HashSet<>();
+    for (int i = 0; i < measurementList.size(); i++) {
+      if (measurementsHadFound.contains(measurementList.get(i))) {
+        continue;
+      }
       ByteBuffer buffer = readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right);
       Pair<MetadataIndexEntry, Long> measurementMetadataIndexPair = metadataIndexPair;
       List<TimeseriesMetadata> timeseriesMetadataList = new ArrayList<>();
@@ -344,22 +344,41 @@ public class TsFileSequenceReader implements AutoCloseable {
       if (!metadataIndexNode.getNodeType().equals(MetadataIndexNodeType.LEAF_MEASUREMENT)) {
         metadataIndexNode = MetadataIndexNode.deserializeFrom(buffer);
         measurementMetadataIndexPair = getMetadataAndEndOffset(metadataIndexNode,
-            measurement, MetadataIndexNodeType.INTERNAL_MEASUREMENT);
+            measurementList.get(i), MetadataIndexNodeType.INTERNAL_MEASUREMENT);
       }
       buffer = readData(measurementMetadataIndexPair.left.getOffset(),
           measurementMetadataIndexPair.right);
       while (buffer.hasRemaining()) {
         timeseriesMetadataList.add(TimeseriesMetadata.deserializeFrom(buffer));
       }
-      int searchResult = binarySearchInTimeseriesMetadataList(timeseriesMetadataList,
-          measurement);
-      if (searchResult >= 0) {
-        resultTimeseriesMetadataList.add(timeseriesMetadataList.get(searchResult));
+      for (int j = i; j < measurementList.size(); j++) {
+        String current = measurementList.get(j);
+        if (!measurementsHadFound.contains(current)) {
+          int searchResult = binarySearchInTimeseriesMetadataList(timeseriesMetadataList, current);
+          if (searchResult >= 0) {
+            resultTimeseriesMetadataList.add(timeseriesMetadataList.get(searchResult));
+            measurementsHadFound.add(current);
+          }
+        }
+        if (measurementsHadFound.size() == measurements.size()) {
+          return resultTimeseriesMetadataList;
+        }
       }
     }
     return resultTimeseriesMetadataList;
   }
 
+  /**
+   * Traverse and read TimeseriesMetadata of specific measurements in one device. This method need
+   * to deserialize all TimeseriesMetadata and then judge, in order to avoid frequent I/O when the
+   * number of queried measurements is too large. Attention: This method is not used currently
+   *
+   * @param timeseriesMetadataList TimeseriesMetadata list, to store the result
+   * @param type                   MetadataIndexNode type
+   * @param metadataIndexPair      <MetadataIndexEntry, offset> pair
+   * @param measurements           measurements to be queried
+   * @throws IOException io error
+   */
   private void traverseAndReadTimeseriesMetadataInOneDevice(
       List<TimeseriesMetadata> timeseriesMetadataList, MetadataIndexNodeType type,
       Pair<MetadataIndexEntry, Long> metadataIndexPair, Set<String> measurements)


### PR DESCRIPTION
Improve `readTimeseriesMetadata()` method by not deserializing `TimeseriesMetadata` repeatedly when the buffer contains more than one measurements to be queried.