### PR TITLE
update vue to 1.7.1 and fix shell render name in markdowns

### DIFF
--- a/docs/SystemDesign/TsFile/Format.md
+++ b/docs/SystemDesign/TsFile/Format.md
@@ -260,7 +260,7 @@ An example on Windows:
 
 ```
 D:\iotdb\server\target\iotdb-server-0.11.0-SNAPSHOT\tools\tsfileToolSet>.\print-iotdb-data-dir.bat D:\\data\data
-​````````````````````````
+````````````````````````
 Starting Printing the IoTDB Data Directory Overview
 ​````````````````````````
 output save path:IoTDB_data_dir_overview.txt
@@ -311,7 +311,7 @@ An example on Windows:
 
 ```
 D:\iotdb\server\target\iotdb-server-0.10.0\tools\tsfileToolSet>.\print-tsfile-resource-files.bat D:\data\data\sequence\root.vehicle
-​````````````````````````
+````````````````````````
 Starting Printing the TsFileResources
 ​````````````````````````
 12:31:59.861 [main] WARN org.apache.iotdb.db.conf.IoTDBDescriptor - Cannot find IOTDB_HOME or IOTDB_CONF environment variable when loading config file iotdb-engine.properties, use default configuration
@@ -344,11 +344,11 @@ For Linux or MacOs:
 
 An example on macOS:
 
-```console
+```shell
 /iotdb/server/target/iotdb-server-0.10.0/tools/tsfileToolSet$ ./print-tsfile-sketch.sh test.tsfile
-​````````````````````````
+````````````````````````
 Starting Printing the TsFile Sketch
-​````````````````````````
+````````````````````````
 TsFile path:test.tsfile
 Sketch save path:TsFile_sketch_view.txt
 -------------------------------- TsFile Sketch --------------------------------
@@ -559,7 +559,6 @@ file length: 33436
                33436| END of TsFile
 
 ---------------------------------- TsFile Sketch End ----------------------------------
-
 
 ````````````````````````
 

--- a/docs/UserGuide/Get Started/Publication.md
+++ b/docs/UserGuide/Get Started/Publication.md
@@ -25,6 +25,8 @@ Apache IoTDB starts at Tsinghua University, School of Software. IoTDB is a datab
 
 The research papers related are as follows:
 
+* [Apache IoTDB: time-series database for internet of things](http://www.vldb.org/pvldb/vol13/p2901-wang.pdf), Chen Wang, Xiangdong Huang, Jialin Qiao,
+ Tian Jiang, Lei Rui, Jinrui Zhang, Rong Kang, Julian Feinauer, Kevin A. McGrail, Peng Wang, Jun Yuan, Jianmin Wang, Jiaguang Sun. VLDB 2020
 * [PISA: An Index for Aggregating Big Time Series Data](https://dl.acm.org/citation.cfm?id=2983775&dl=ACM&coll=DL), Xiangdong Huang and Jianmin Wang and Raymond K. Wong and Jinrui Zhang and Chen Wang. CIKM 2016.
 * [Matching Consecutive Subpatterns over Streaming Time Series](https://link.springer.com/chapter/10.1007/978-3-319-96893-3_8), Rong Kang and Chen Wang and Peng Wang and Yuting Ding and Jianmin Wang. APWeb/WAIM 2018.
 * [KV-match: A Subsequence Matching Approach Supporting Normalization and Time Warping](https://www.semanticscholar.org/paper/KV-match%3A-A-Subsequence-Matching-Approach-and-Time-Wu-Wang/9ed84cb15b7e5052028fc5b4d667248713ac8592), Jiaye Wu and Peng Wang and Chen Wang and Wei Wang and Jianmin Wang. ICDE 2019.

--- a/docs/zh/SystemDesign/TsFile/Format.md
+++ b/docs/zh/SystemDesign/TsFile/Format.md
@@ -260,7 +260,7 @@ For Linux or MacOs:
 
 ```
 D:\incubator-iotdb\server\target\iotdb-server-0.11.0-SNAPSHOT\tools\tsfileToolSet>.\print-iotdb-data-dir.bat D:\\data\data
-​````````````````````````
+````````````````````````
 Starting Printing the IoTDB Data Directory Overview
 ​````````````````````````
 output save path:IoTDB_data_dir_overview.txt
@@ -309,7 +309,7 @@ Linux or MacOs:
 
 ```
 D:\incubator-iotdb\server\target\iotdb-server-0.10.0\tools\tsfileToolSet>.\print-tsfile-resource-files.bat D:\data\data\sequence\root.vehicle
-​````````````````````````
+````````````````````````
 Starting Printing the TsFileResources
 ​````````````````````````
 12:31:59.861 [main] WARN org.apache.iotdb.db.conf.IoTDBDescriptor - Cannot find IOTDB_HOME or IOTDB_CONF environment variable when loading config file iotdb-engine.properties, use default configuration
@@ -342,9 +342,9 @@ Linux or MacOs:
 
 在mac系统中的示例:
 
-```console
+```shell
 /iotdb/server/target/iotdb-server-0.10.0/tools/tsfileToolSet$ ./print-tsfile-sketch.sh test.tsfile
-​````````````````````````
+````````````````````````
 Starting Printing the TsFile Sketch
 ​````````````````````````
 TsFile path:test.tsfile

--- a/docs/zh/UserGuide/Ecosystem Integration/Hive TsFile.md
+++ b/docs/zh/UserGuide/Ecosystem Integration/Hive TsFile.md
@@ -73,7 +73,7 @@ TsFile的Hive连接器实现了对Hive读取外部Tsfile类型的文件格式的
 
 然后在hive的命令行中，使用`add jar XXX`命令添加依赖。例如:
 
-```console
+```shell
 hive> add jar /Users/hive/iotdb/hive-connector/target/hive-connector-0.11.0-SNAPSHOT-jar-with-dependencies.jar;
 
 Added [/Users/hive/iotdb/hive-connector/target/hive-connector-0.11.0-SNAPSHOT-jar-with-dependencies.jar] to class path

--- a/docs/zh/UserGuide/Server/Docker Image.md
+++ b/docs/zh/UserGuide/Server/Docker Image.md
@@ -28,7 +28,7 @@ Dockerfile 存放在的 docker 工程下的 src/main/Dockerfile 中.
 $ docker build -t iotdb:base git://github.com/apache/iotdb#master:docker
 ```
 或者:
-```console
+```shell
 $ git clone https://github.com/apache/iotdb
 $ cd iotdb
 $ cd docker

--- a/site/src/main/package.json
+++ b/site/src/main/package.json
@@ -37,7 +37,8 @@
     "unified-engine": "^7.0.0",
     "vfile-reporter": "^6.0.1",
     "vue-tabs-component": "^1.5.0",
-    "vuepress": "^1.5.0",
-    "vuepress-plugin-tabs": "^0.3.0"
+    "vuepress": "^1.7.1",
+    "vuepress-plugin-tabs": "^0.3.0",
+    "vue-router": "3.4.5"
   }
 }


### PR DESCRIPTION
1. fix some errors in markdown:
"```$xslt" can not be recognized correctly. So, replacing it to shell.

2. update vue-press version to 1.7.1 