### PR TITLE
[IOTDB-971] More precise error messages of slimit and soffset

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -745,7 +745,9 @@ public class PhysicalGenerator {
 
     // check parameter range
     if (seriesOffset >= size) {
-      throw new QueryProcessException("SOFFSET <SOFFSETValue>: SOFFSETValue exceeds the range.");
+      throw new QueryProcessException(String.format(
+          "The value of SOFFSET (%d) is equal to or exceeds the number of sequences (%d) that can actually be returned.",
+          seriesOffset, size));
     }
     int endPosition = seriesOffset + seriesLimit;
     if (endPosition > size) {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryMemoryControlIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryMemoryControlIT.java
@@ -132,11 +132,9 @@ public class IoTDBQueryMemoryControlIT {
       ResultSetMetaData resultSetMetaData = statement.getResultSet().getMetaData();
       assertEquals(1 + 5, resultSetMetaData.getColumnCount());
       for (int i = 2; i < 3 + 2; ++i) {
-        System.out.println(resultSetMetaData.getColumnName(i));
         assertTrue(resultSetMetaData.getColumnName(i).contains("root.ln.wf02.wt0"));
       }
       for (int i = 3 + 2; i < 5 + 2; ++i) {
-        System.out.println(resultSetMetaData.getColumnName(i));
         assertTrue(resultSetMetaData.getColumnName(i).contains("root.ln.wf03.wt0"));
       }
     } catch (Exception e) {
@@ -154,7 +152,6 @@ public class IoTDBQueryMemoryControlIT {
       ResultSetMetaData resultSetMetaData = statement.getResultSet().getMetaData();
       assertEquals(1 + 5, resultSetMetaData.getColumnCount());
       for (int i = 2; i < 5 + 2; ++i) {
-        System.out.println(resultSetMetaData.getColumnName(i));
         assertTrue(resultSetMetaData.getColumnName(i).contains("root.ln.wf02.wt0"));
       }
     } catch (Exception e) {
@@ -172,11 +169,9 @@ public class IoTDBQueryMemoryControlIT {
       ResultSetMetaData resultSetMetaData = statement.getResultSet().getMetaData();
       assertEquals(1 + 10, resultSetMetaData.getColumnCount());
       for (int i = 2; i < 5 + 2; ++i) {
-        System.out.println(resultSetMetaData.getColumnName(i));
         assertTrue(resultSetMetaData.getColumnName(i).contains("root.ln.wf03.wt0"));
       }
       for (int i = 5 + 2; i < 10 + 2; ++i) {
-        System.out.println(resultSetMetaData.getColumnName(i));
         assertTrue(resultSetMetaData.getColumnName(i).contains("root.ln.wf02.wt0"));
       }
     } catch (Exception e) {
@@ -205,15 +200,14 @@ public class IoTDBQueryMemoryControlIT {
       ResultSetMetaData resultSetMetaData = statement.getResultSet().getMetaData();
       assertEquals(1 + 3, resultSetMetaData.getColumnCount());
       for (int i = 2; i < 1 + 2; ++i) {
-        System.out.println(resultSetMetaData.getColumnName(i));
         assertTrue(resultSetMetaData.getColumnName(i).contains("root.ln.wf01.wt0"));
       }
       for (int i = 1 + 2; i < 3 + 2; ++i) {
-        System.out.println(resultSetMetaData.getColumnName(i));
         assertTrue(resultSetMetaData.getColumnName(i).contains("root.ln.wf02.wt0"));
       }
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("Too many paths in one query!"));
+      e.printStackTrace();
+      fail(e.getMessage());
     }
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
@@ -22,6 +22,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
+import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.runtime.SQLParserException;
 import org.apache.iotdb.db.metadata.PartialPath;

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
@@ -21,9 +21,7 @@ package org.apache.iotdb.db.qp.plan;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
-import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.runtime.SQLParserException;
 import org.apache.iotdb.db.metadata.PartialPath;
@@ -185,7 +183,7 @@ public class LogicalPlanSmallTest {
     ConcatPathOptimizer concatPathOptimizer = new ConcatPathOptimizer();
     concatPathOptimizer.transform(operator, 1000);
     IoTDB.metaManager.clear();
-    // expected to throw LogicalOptimizeException: SOFFSET <SOFFSETValue>: SOFFSETValue exceeds the range.
+    // expected to throw LogicalOptimizeException: The value of SOFFSET (%d) is equal to or exceeds the number of sequences (%d) that can actually be returned.
   }
 
   @Test


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/IOTDB-971

```
IoTDB> select count from root.group_0.d_0 slimit 10 soffset 10
Msg: 500: toIndex = 20

IoTDB> select count from root.group_0aaaa slimit 10 soffset 10
Msg: 411: Meet error in query process: SOFFSET <SOFFSETValue>: SOFFSETValue exceeds the range.
```


> The result from the first example makes little sense to users, and I think it is probably not right even, since there are 100 measurements for each device.

I think the bug has already been fixed by my PR #1884. Please check whether the problem can be reproduced on master branch before merging this PR.

I added some tests for the scenario in this PR.

--- 

> The second result is also confusing, "root.group_0aaaa" does not exist and that should be the root cause.

I made the error messages more precise in this PR. Users will know how many time series that the original data set contains when the slimit error occurs.
