### PR TITLE
Remove mqtt log and add InsertRowPlan check

### DIFF
--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -202,6 +202,7 @@
         <appender-ref ref="FILEALL"/>
         <appender-ref ref="stdout"/>
     </root>
+    <logger level="OFF" name="io.moquette.broker.metrics.MQTTMessageLogger"/>
     <logger level="info" name="org.apache.iotdb.db.service"/>
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">

--- a/server/src/main/java/org/apache/iotdb/db/mqtt/PublishHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mqtt/PublishHandler.java
@@ -98,7 +98,7 @@ public class PublishHandler extends AbstractInterceptHandler {
             try {
                 plan.setDeviceId(new PartialPath(event.getDevice()));
                 status = executeNonQuery(plan);
-            } catch (QueryProcessException | StorageGroupNotSetException | StorageEngineException | IllegalPathException e ) {
+            } catch (Exception e) {
                 LOG.warn(
                     "meet error when inserting device {}, measurements {}, at time {}, because ",
                     event.getDevice(), event.getMeasurements(), event.getTimestamp(), e);

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -909,26 +909,30 @@ public class PlanExecutor implements IPlanExecutor {
     }
   }
 
-  private MNode getSeriesSchemas(InsertPlan insertPlan)
-      throws MetadataException {
-    return IoTDB.metaManager
-        .getSeriesSchemasAndReadLockDevice(insertPlan);
+  private MNode getSeriesSchemas(InsertPlan insertPlan) throws MetadataException {
+    return IoTDB.metaManager.getSeriesSchemasAndReadLockDevice(insertPlan);
   }
 
   @Override
   public void insert(InsertRowPlan insertRowPlan) throws QueryProcessException {
     try {
+
+      // check insert plan
+      if (insertRowPlan.getMeasurements() == null) {
+        throw new QueryProcessException(
+            "The measurements of InsertRowPlan is null, deviceId:" + insertRowPlan.getDeviceId()
+                + ", time:" + insertRowPlan.getTime());
+      }
+      if (insertRowPlan.getValues().length == 0) {
+        throw new QueryProcessException(
+            "The size of values in this InsertRowPlan is 0, deviceId:" + insertRowPlan.getDeviceId()
+                + ", time:" + insertRowPlan.getTime());
+      }
+
       insertRowPlan
           .setMeasurementMNodes(new MeasurementMNode[insertRowPlan.getMeasurements().length]);
       getSeriesSchemas(insertRowPlan);
       insertRowPlan.transferType();
-
-      //check insert plan
-      if (insertRowPlan.getValues().length == 0) {
-        logger.warn("Can't insert row with only time/timestamp");
-        return;
-      }
-
       StorageEngine.getInstance().insert(insertRowPlan);
       if (insertRowPlan.getFailedMeasurements() != null) {
         // check if all path not exist exceptions


### PR DESCRIPTION
In an on-line IoTDB, there is a lot of MQTT log, which causes much trouble.

2020-10-10 00:00:48,121 [nioEventLoopGroup-3-16] INFO  io.moquette.broker.metrics.MQTTMessageLogger:92 - C<-B PUBACK <1> packetID <62818> 

Besides, the measurements is null, we need to add a check

2020-06-08 15:53:11,507 [pool-4-thread-2] ERROR org.apache.iotdb.db.concurrent.IoTDBDefaultThreadExceptionHandler:31 - Exception in thread pool-4-thread-2-35 
java.lang.NullPointerException: null
	at org.apache.iotdb.db.qp.executor.PlanExecutor.insert(PlanExecutor.java:891)
	at org.apache.iotdb.db.qp.executor.PlanExecutor.processNonQuery(PlanExecutor.java:200)
	at org.apache.iotdb.db.mqtt.PublishHandler.executeNonQuery(PublishHandler.java:116)
	at org.apache.iotdb.db.mqtt.PublishHandler.onPublish(PublishHandler.java:99)
	at io.moquette.interception.BrokerInterceptor.lambda$notifyTopicPublished$3(BrokerInterceptor.java:133)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)