### PR TITLE
[Distributed] Fix thrift NPE caused by null alias

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/PartialPath.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/PartialPath.java
@@ -40,9 +40,9 @@ public class PartialPath extends Path implements Comparable<Path> {
 
   private String[] nodes;
   // alias of measurement
-  private String measurementAlias = null;
+  private String measurementAlias = "";
   // alias of time series used in SELECT AS
-  private String tsAlias = null;
+  private String tsAlias = "";
 
   /**
    * Construct the PartialPath using a String, will split the given String into String[]
@@ -227,12 +227,20 @@ public class PartialPath extends Path implements Comparable<Path> {
     this.measurementAlias = measurementAlias;
   }
 
+  public boolean isMeasurementAliasExists(){
+    return measurementAlias != null && !measurementAlias.isEmpty();
+  }
+
   public String getTsAlias() {
     return tsAlias;
   }
 
   public void setTsAlias(String tsAlias) {
     this.tsAlias = tsAlias;
+  }
+
+  public boolean isTsAliasExists() {
+    return tsAlias != null && !tsAlias.isEmpty();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -437,7 +437,7 @@ public class PhysicalGenerator {
           try {
             // remove stars in SELECT to get actual paths
             List<PartialPath> actualPaths = getMatchedTimeseries(fullPath);
-            if (suffixPath.getTsAlias() != null) {
+            if (suffixPath.isTsAliasExists()) {
               if (actualPaths.size() == 1) {
                 String columnName = actualPaths.get(0).getMeasurement();
                 if (originAggregations != null && !originAggregations.isEmpty()) {
@@ -700,10 +700,11 @@ public class PhysicalGenerator {
     if (queryPlan instanceof LastQueryPlan) {
       for (int i = 0; i < paths.size(); i++) {
         PartialPath path = paths.get(i);
-        String column = path.getTsAlias();
-        if (column == null) {
-          column =
-              path.getMeasurementAlias() != null ? path.getFullPathWithAlias() : path.toString();
+        String column;
+        if (path.isTsAliasExists()) {
+          column = path.getTsAlias();
+        } else {
+          column = path.isMeasurementAliasExists() ? path.getFullPathWithAlias() : path.toString();
         }
         if (!columnSet.contains(column)) {
           TSDataType seriesType = dataTypes.get(i);
@@ -727,10 +728,12 @@ public class PhysicalGenerator {
     int deduplicatedPathNum = 0;
     int index = 0;
     for (Pair<PartialPath, Integer> indexedPath : indexedPaths) {
-      String column = indexedPath.left.getTsAlias();
-      if (column == null) {
+      String column;
+      if (indexedPath.left.isTsAliasExists()) {
+        column = indexedPath.left.getTsAlias();
+      } else {
         column =
-            indexedPath.left.getMeasurementAlias() != null ? indexedPath.left.getFullPathWithAlias()
+            indexedPath.left.isMeasurementAliasExists() ? indexedPath.left.getFullPathWithAlias()
                 : indexedPath.left.toString();
         if (queryPlan instanceof AggregationPlan) {
           column = queryPlan.getAggregations().get(indexedPath.right) + "(" + column + ")";

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
@@ -172,7 +172,7 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
       PartialPath selectPath = suffixPaths.get(i);
       for (PartialPath fromPath : fromPaths) {
         PartialPath fullPath = fromPath.concatPath(selectPath);
-        if (selectPath.getTsAlias() != null) {
+        if (selectPath.isTsAliasExists()) {
           fullPath.setTsAlias(selectPath.getTsAlias());
         }
         allPaths.add(fullPath);
@@ -284,7 +284,7 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
         Pair<List<PartialPath>, Integer> pair = removeWildcard(paths.get(i), limit, offset);
 
         List<PartialPath> actualPaths = pair.left;
-        if (paths.get(i).getTsAlias() != null) {
+        if (paths.get(i).isTsAliasExists()) {
           if (actualPaths.size() == 1) {
             actualPaths.get(0).setTsAlias(paths.get(i).getTsAlias());
           } else if (actualPaths.size() >= 2) {

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -89,10 +89,10 @@ public class LastQueryExecutor {
       if (lastTimeValuePair != null && lastTimeValuePair.getValue() != null) {
         RowRecord resultRecord = new RowRecord(lastTimeValuePair.getTimestamp());
         Field pathField = new Field(TSDataType.TEXT);
-        if (selectedSeries.get(i).getTsAlias() != null) {
+        if (selectedSeries.get(i).isTsAliasExists()) {
           pathField.setBinaryV(new Binary(selectedSeries.get(i).getTsAlias()));
         } else {
-          if (selectedSeries.get(i).getMeasurementAlias() != null) {
+          if (selectedSeries.get(i).isMeasurementAliasExists()) {
             pathField.setBinaryV(new Binary(selectedSeries.get(i).getFullPathWithAlias()));
           } else {
             pathField.setBinaryV(new Binary(selectedSeries.get(i).getFullPath()));

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -889,9 +889,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       case QUERY:
       case FILL:
         for (PartialPath path : paths) {
-          String column = path.getTsAlias();
-          if (column == null) {
-            column = path.getMeasurementAlias() != null ? path.getFullPathWithAlias()
+          String column;
+          if (path.isTsAliasExists()) {
+            column = path.getTsAlias();
+          } else {
+            column = path.isMeasurementAliasExists() ? path.getFullPathWithAlias()
                 : path.getFullPath();
           }
           respColumns.add(column);
@@ -909,9 +911,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         }
         for (int i = 0; i < paths.size(); i++) {
           PartialPath path = paths.get(i);
-          String column = path.getTsAlias();
-          if (column == null) {
-            column = path.getMeasurementAlias() != null
+          String column;
+          if (path.isTsAliasExists()) {
+            column = path.getTsAlias();
+          } else {
+            column = path.isMeasurementAliasExists()
                 ? aggregations.get(i) + "(" + paths.get(i).getFullPathWithAlias() + ")"
                 : aggregations.get(i) + "(" + paths.get(i).getFullPath() + ")";
           }
@@ -1747,7 +1751,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     } catch (QueryProcessException e) {
       logger.error("meet error while processing non-query. ", e);
       Throwable cause = e;
-      while (cause.getCause() != null){
+      while (cause.getCause() != null) {
         cause = cause.getCause();
       }
       return RpcUtils.getStatus(e.getErrorCode(), cause.getMessage());

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -20,7 +20,6 @@ package org.apache.iotdb.db.metadata;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -188,9 +187,9 @@ public class MTreeTest {
           .getAllTimeseriesPathWithAlias(new PartialPath("root.a.*.s0"), 0, 0).left;
       assertEquals(2, result2.size());
       assertEquals("root.a.d0.s0", result2.get(0).getFullPath());
-      assertNull(result2.get(0).getMeasurementAlias());
+      assertFalse(result2.get(0).isMeasurementAliasExists());
       assertEquals("root.a.d1.s0", result2.get(1).getFullPath());
-      assertNull(result2.get(1).getMeasurementAlias());
+      assertFalse(result2.get(1).isMeasurementAliasExists());
 
       result2 = root.getAllTimeseriesPathWithAlias(new PartialPath("root.a.*.temperature"), 0, 0).left;
       assertEquals(2, result2.size());


### PR DESCRIPTION
Solution: use "" rather than `null` to represent  `there is no alias` 