### PR TITLE
fix travis closing some ports failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,7 +174,7 @@ script:
     - mvn -B apache-rat:check
     # Output something every 10 minutes or Travis kills the job
     - while sleep 540; do echo "=====[ $SECONDS seconds still running ]====="; done &
-    - mvn -B clean test integration-test
+    - mvn -B clean test integration-test -Dtest.port.closed=true
     # Killing background sleep loop
     - kill %1
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -264,16 +264,25 @@ public class StorageEngine implements IService {
     if (ttlCheckThread != null) {
       ttlCheckThread.shutdownNow();
       try {
-        ttlCheckThread.awaitTermination(30, TimeUnit.SECONDS);
+        ttlCheckThread.awaitTermination(60, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
-        logger.warn("TTL check thread still doesn't exit after 30s");
+        logger.warn("TTL check thread still doesn't exit after 60s");
         Thread.currentThread().interrupt();
-        throw new StorageEngineFailureException("StorageEngine failed to stop.", e);
+        throw new StorageEngineFailureException("StorageEngine failed to stop because of "
+            + "ttlCheckThread.", e);
       }
     }
     recoveryThreadPool.shutdownNow();
     if (!recoverAllSgThreadPool.isShutdown()) {
       recoverAllSgThreadPool.shutdownNow();
+      try {
+        recoverAllSgThreadPool.awaitTermination(60, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.warn("recoverAllSgThreadPool thread still doesn't exit after 60s");
+        Thread.currentThread().interrupt();
+        throw new StorageEngineFailureException("StorageEngine failed to stop because of "
+            + "recoverAllSgThreadPool.", e);
+      }
     }
     this.reset();
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/RegisterManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/RegisterManager.java
@@ -58,6 +58,7 @@ public class RegisterManager {
     for (IService service : iServices) {
       try {
         service.waitAndStop(10000);
+        logger.info(service.getID() + "deregistered");
       } catch (Exception e) {
         logger.error("Failed to stop {} because:", service.getID().getName(), e);
       }

--- a/server/src/main/java/org/apache/iotdb/db/service/RegisterManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/RegisterManager.java
@@ -58,7 +58,7 @@ public class RegisterManager {
     for (IService service : iServices) {
       try {
         service.waitAndStop(10000);
-        logger.info(service.getID() + "deregistered");
+        logger.info("{} deregistered", service.getID());
       } catch (Exception e) {
         logger.error("Failed to stop {} because:", service.getID().getName(), e);
       }

--- a/server/src/test/java/org/apache/iotdb/db/sync/receiver/load/FileLoaderTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/receiver/load/FileLoaderTest.java
@@ -83,8 +83,8 @@ public class FileLoaderTest {
 
   @After
   public void tearDown() throws InterruptedException, IOException, StorageEngineException {
-    IoTDBDescriptor.getInstance().getConfig().setSyncEnable(false);
     EnvironmentUtils.cleanEnv();
+    IoTDBDescriptor.getInstance().getConfig().setSyncEnable(false);
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/sync/receiver/recover/SyncReceiverLogAnalyzerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/receiver/recover/SyncReceiverLogAnalyzerTest.java
@@ -88,8 +88,8 @@ public class SyncReceiverLogAnalyzerTest {
 
   @After
   public void tearDown() throws InterruptedException, IOException, StorageEngineException {
-    IoTDBDescriptor.getInstance().getConfig().setSyncEnable(false);
     EnvironmentUtils.cleanEnv();
+    IoTDBDescriptor.getInstance().getConfig().setSyncEnable(false);
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -73,7 +73,7 @@ public class EnvironmentUtils {
 
   private static IoTDB daemon;
 
-  public static boolean examinePorts = false;
+  public static boolean examinePorts = Boolean.valueOf(System.getProperty("test.port.closed", "false"));
 
   public static void cleanEnv() throws IOException, StorageEngineException {
     logger.warn("EnvironmentUtil cleanEnv...");

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -49,6 +49,7 @@ import org.apache.iotdb.db.service.IoTDB;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +94,7 @@ public class EnvironmentUtils {
           transport.open();
           logger.error("stop daemon failed. 6667 can be connected now.");
           transport.close();
+          Assert.fail("stop daemon failed. 6667 can be connected now.");
         } catch (TTransportException e) {
         }
       }
@@ -103,6 +105,7 @@ public class EnvironmentUtils {
           transport.open();
           logger.error("stop Sync daemon failed. 5555 can be connected now.");
           transport.close();
+          Assert.fail("stop daemon failed. 6667 can be connected now.");
         } catch (TTransportException e) {
         }
       }
@@ -113,6 +116,7 @@ public class EnvironmentUtils {
         JMXConnector jmxConnector = JMXConnectorFactory.connect(url);
         logger.error("stop JMX failed. 31999 can be connected now.");
         jmxConnector.close();
+        Assert.fail("stop daemon failed. 6667 can be connected now.");
       } catch (IOException e) {
         //do nothing
       }
@@ -121,6 +125,7 @@ public class EnvironmentUtils {
       try {
         socket.connect(new InetSocketAddress("127.0.0.1", 8181), 100);
         logger.error("stop MetricService failed. 8181 can be connected now.");
+        Assert.fail("stop daemon failed. 6667 can be connected now.");
       } catch (Exception e) {
         //do nothing
       } finally {

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.stream.IntStream;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
@@ -88,48 +89,18 @@ public class EnvironmentUtils {
 
     if (examinePorts) {
       // TODO: this is just too slow, especially on Windows, consider a better way
-      TTransport transport = new TSocket("127.0.0.1", 6667, 100);
-      if (!transport.isOpen()) {
+      boolean closed = examinePorts();
+      if (!closed) {
+        //sleep 10 seconds
         try {
-          transport.open();
-          logger.error("stop daemon failed. 6667 can be connected now.");
-          transport.close();
-          Assert.fail("stop daemon failed. 6667 can be connected now.");
-        } catch (TTransportException e) {
+          Thread.sleep(10_000);
+        } catch (InterruptedException e) {
+          //do nothing
         }
-      }
-      //try sync service
-      transport = new TSocket("127.0.0.1", 5555, 100);
-      if (!transport.isOpen()) {
-        try {
-          transport.open();
-          logger.error("stop Sync daemon failed. 5555 can be connected now.");
-          transport.close();
-          Assert.fail("stop daemon failed. 6667 can be connected now.");
-        } catch (TTransportException e) {
+
+        if (!examinePorts()) {
+          fail("failed to close some ports");
         }
-      }
-      //try jmx connection
-      try {
-        JMXServiceURL url =
-            new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:31999/jmxrmi");
-        JMXConnector jmxConnector = JMXConnectorFactory.connect(url);
-        logger.error("stop JMX failed. 31999 can be connected now.");
-        jmxConnector.close();
-        Assert.fail("stop daemon failed. 6667 can be connected now.");
-      } catch (IOException e) {
-        //do nothing
-      }
-      //try MetricService
-      Socket socket = new Socket();
-      try {
-        socket.connect(new InetSocketAddress("127.0.0.1", 8181), 100);
-        logger.error("stop MetricService failed. 8181 can be connected now.");
-        Assert.fail("stop daemon failed. 6667 can be connected now.");
-      } catch (Exception e) {
-        //do nothing
-      } finally {
-        socket.close();
       }
     }
 
@@ -166,6 +137,59 @@ public class EnvironmentUtils {
     config.setTsFileSizeThreshold(oldTsFileThreshold);
     config.setMemtableSizeThreshold(oldGroupSizeInByte);
   }
+
+
+  private static boolean examinePorts() {
+    TTransport transport = new TSocket("127.0.0.1", 6667, 100);
+    if (!transport.isOpen()) {
+      try {
+        transport.open();
+        logger.error("stop daemon failed. 6667 can be connected now.");
+        transport.close();
+        return false;
+      } catch (TTransportException e) {
+      }
+    }
+    //try sync service
+    transport = new TSocket("127.0.0.1", 5555, 100);
+    if (!transport.isOpen()) {
+      try {
+        transport.open();
+        logger.error("stop Sync daemon failed. 5555 can be connected now.");
+        transport.close();
+        return false;
+      } catch (TTransportException e) {
+      }
+    }
+    //try jmx connection
+    try {
+      JMXServiceURL url =
+          new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:31999/jmxrmi");
+      JMXConnector jmxConnector = JMXConnectorFactory.connect(url);
+      logger.error("stop JMX failed. 31999 can be connected now.");
+      jmxConnector.close();
+      return false;
+    } catch (IOException e) {
+      //do nothing
+    }
+    //try MetricService
+    Socket socket = new Socket();
+    try {
+      socket.connect(new InetSocketAddress("127.0.0.1", 8181), 100);
+      logger.error("stop MetricService failed. 8181 can be connected now.");
+      return false;
+    } catch (Exception e) {
+      //do nothing
+    } finally {
+      try {
+        socket.close();
+      } catch (IOException e) {
+        //do nothing
+      }
+    }
+    return true;
+  }
+
 
   public static void cleanAllDir() throws IOException {
     // delete sequential files

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.stream.IntStream;
+import java.util.concurrent.TimeUnit;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
@@ -50,7 +50,6 @@ import org.apache.iotdb.db.service.IoTDB;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,7 +92,7 @@ public class EnvironmentUtils {
       if (!closed) {
         //sleep 10 seconds
         try {
-          Thread.sleep(10_000);
+          TimeUnit.SECONDS.sleep(10);
         } catch (InterruptedException e) {
           //do nothing
         }

--- a/server/src/test/resources/logback.xml
+++ b/server/src/test/resources/logback.xml
@@ -45,6 +45,7 @@
     <logger name="org.apache.iotdb.db.service.MetricsService" level="INFO"/>
     <logger name="org.apache.iotdb.db.engine.flush.FlushManager" level="INFO"/>
     <logger name="org.apache.iotdb.db.integration.IoTDBMergeTest" level="INFO"/>
+    <logger name="org.apache.iotdb.db.service.RegisterManager" level="INFO"/>
     <logger name="org.apache.iotdb.db.service.IoTDB" level="INFO"/>
     <logger name="org.apache.iotdb.db.service.RPCService" level="INFO"/>
     <logger name="org.apache.iotdb.db.service.MQTTService" level="INFO"/>

--- a/server/src/test/resources/logback.xml
+++ b/server/src/test/resources/logback.xml
@@ -41,6 +41,7 @@
     <logger name="FileMonitor" level="info"/>
     -->
     <logger name="org.apache.iotdb.db.engine.merge" level="DEBUG"/>
+    <logger name="org.apache.iotdb.db.service.thrift.ThriftServiceThread" level="DEBUG"/>
     <logger name="org.eclipse.jetty.util.thread.QueuedThreadPool" level="DEBUG"/>
     <logger name="org.apache.iotdb.db.service.MetricsService" level="INFO"/>
     <logger name="org.apache.iotdb.db.engine.flush.FlushManager" level="INFO"/>


### PR DESCRIPTION
1. Travis usually closes 5555 port failed, because of a bug in some `tearDown()` methods..
2. This PR prolongs the wait time of closing checkTTLThread() from 30 seconds to 60 seconds
3. Once Travis finds some ports are closed failed, the travis will fail directly.