### PR TITLE
Fix dependencies Convergence for packaing 

### DIFF
--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -45,6 +45,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- many of hadoop dependencies use guava11, but org.apache.curator from hadoop-common uses
         guava16 -->

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -59,6 +59,13 @@
             <artifactId>guava</artifactId>
             <version>21.0</version>
         </dependency>
+        <!-- many of hadoop dependencies use guava11, but org.apache.curator from hadoop-common uses
+        guava16 -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>16.0.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -46,6 +46,13 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
         </dependency>
+        <!-- many of hadoop dependencies use guava11, but org.apache.curator from hadoop-common uses
+        guava16 -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>16.0.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -59,13 +59,6 @@
             <artifactId>guava</artifactId>
             <version>21.0</version>
         </dependency>
-        <!-- many of hadoop dependencies use guava11, but org.apache.curator from hadoop-common uses
-        guava16 -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>16.0.1</version>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>21.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -54,7 +54,18 @@
                     <groupId>org.apache.hive</groupId>
                     <artifactId>hive-storage-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <!-- many of hadoop dependencies use guava11, but org.apache.curator from hadoop-common uses
+        guava16 -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>21.0</version>
         </dependency>
         <!-- force upgrade the dependency of hive-serde-->
         <dependency>
@@ -76,6 +87,10 @@
                 <exclusion>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -584,6 +584,86 @@
         </pluginManagement>
         <plugins>
             <!--
+                      Strange things usually happen if you run with a too low Java version.
+                      This plugin not only checks the minimum java version of 1.8, but also
+                      checks all dependencies (and transitive dependencies) for reported CVEs.
+                    -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <!--$NO-MVN-MAN-VER$-->
+                <executions>
+                    <!-- Ensure we're not mixing dependency versions -->
+                    <execution>
+                        <id>enforce-version-convergence</id>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                    <!--
+                        Fails the build if classes are included from multiple
+                        artifacts and these are not identical.
+                    -->
+                    <!--execution>
+                        <id>enforce-ban-duplicate-classes</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <banDuplicateClasses>
+                                    <scopes>
+                                        <scope>compile</scope>
+                                        <scope>provided</scope>
+                                    </scopes>
+                                    <findAllDuplicates>true</findAllDuplicates>
+                                    <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                                </banDuplicateClasses>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution-->
+                    <!-- Make sure no dependencies are used for which known vulnerabilities exist. -->
+                    <execution>
+                        <id>vulnerability-checks</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Just generate warnings for now -->
+                            <fail>false</fail>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>1.8.0</version>
+                                </requireJavaVersion>
+                                <!-- Disabled for now as it breaks the ability to build single modules -->
+                                <!--reactorModuleConvergence/-->
+                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.sonatype.ossindex.maven</groupId>
+                        <artifactId>ossindex-maven-enforcer-rules</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <!--
               Even if Maven transitively pulls in dependencies, relying on these can
               quite often cause hard to find problems. So it's a good practice to make
               sure everything directly required is also directly added as a dependency.
@@ -1013,86 +1093,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <!--
-                      Strange things usually happen if you run with a too low Java version.
-                      This plugin not only checks the minimum java version of 1.8, but also
-                      checks all dependencies (and transitive dependencies) for reported CVEs.
-                    -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>3.0.0-M2</version>
-                        <!--$NO-MVN-MAN-VER$-->
-                        <executions>
-                            <!-- Ensure we're not mixing dependency versions -->
-                            <execution>
-                                <id>enforce-version-convergence</id>
-                                <configuration>
-                                    <rules>
-                                        <dependencyConvergence/>
-                                    </rules>
-                                </configuration>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                            </execution>
-                            <!--
-                                Fails the build if classes are included from multiple
-                                artifacts and these are not identical.
-                            -->
-                            <!--execution>
-                                <id>enforce-ban-duplicate-classes</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <banDuplicateClasses>
-                                            <scopes>
-                                                <scope>compile</scope>
-                                                <scope>provided</scope>
-                                            </scopes>
-                                            <findAllDuplicates>true</findAllDuplicates>
-                                            <ignoreWhenIdentical>true</ignoreWhenIdentical>
-                                        </banDuplicateClasses>
-                                    </rules>
-                                    <fail>true</fail>
-                                </configuration>
-                            </execution-->
-                            <!-- Make sure no dependencies are used for which known vulnerabilities exist. -->
-                            <execution>
-                                <id>vulnerability-checks</id>
-                                <phase>validate</phase>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <!-- Just generate warnings for now -->
-                                    <fail>false</fail>
-                                    <rules>
-                                        <requireJavaVersion>
-                                            <version>1.8.0</version>
-                                        </requireJavaVersion>
-                                        <!-- Disabled for now as it breaks the ability to build single modules -->
-                                        <!--reactorModuleConvergence/-->
-                                        <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.sonatype.ossindex.maven</groupId>
-                                <artifactId>ossindex-maven-enforcer-rules</artifactId>
-                                <version>1.0.0</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.codehaus.mojo</groupId>
-                                <artifactId>extra-enforcer-rules</artifactId>
-                                <version>1.2</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -951,7 +951,7 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Make sure the source assembly has the right name (includes "incubating") -->
+        <!-- Make sure the source assembly has the right name -->
         <profile>
             <id>apache-release</id>
             <build>
@@ -973,7 +973,7 @@
                                     See  https://issues.apache.org/jira/browse/MNG-5454  sigh.
                                  -->
                                 <configuration combine.self="append">
-                                    <finalName>apache-iotdb-${project.version}-incubating</finalName>
+                                    <finalName>apache-iotdb-${project.version}</finalName>
                                     <archive>
                                         <manifest>
                                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
@@ -1006,7 +1006,7 @@
                                         <fileSet>
                                             <directory>${project.build.directory}</directory>
                                             <includes>
-                                                <include>apache-iotdb-${project.version}-incubating-source-release.zip</include>
+                                                <include>apache-iotdb-${project.version}-source-release.zip</include>
                                             </includes>
                                         </fileSet>
                                     </fileSets>

--- a/spark-iotdb-connector/pom.xml
+++ b/spark-iotdb-connector/pom.xml
@@ -60,6 +60,19 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- many of hadoop dependencies use guava11, but org.apache.curator from hadoop-common uses
+        guava16 -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>21.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
when releasing a new version, maven will check whether there are two different versions for a dependency.

Sadly, two dependencies in hadoop-client depend on different guava version.
Therefore, we have to converge them into one version.