### PR TITLE
[To rel/0.11] [IOTDB-993] Fix tlog bug

### DIFF
--- a/grafana/pom.xml
+++ b/grafana/pom.xml
@@ -165,7 +165,7 @@
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                         <resource>META-INF/spring.schemas</resource>
                                     </transformer>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <mainClass>${start-class}</mainClass>
                                     </transformer>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -223,7 +223,7 @@
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>
-                                                <ignore />
+                                                <ignore/>
                                             </action>
                                         </pluginExecution>
                                     </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <sonar.exclusions>**/generated-sources</sonar.exclusions>
         <!-- By default, the argLine is empty-->
         <gson.version>2.8.6</gson.version>
-        <argLine />
+        <argLine/>
     </properties>
     <!--
         if we claim dependencies in dependencyManagement, then we do not claim
@@ -599,7 +599,7 @@
                         <id>enforce-version-convergence</id>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                         <goals>
@@ -645,7 +645,7 @@
                                 </requireJavaVersion>
                                 <!-- Disabled for now as it breaks the ability to build single modules -->
                                 <!--reactorModuleConvergence/-->
-                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies" />
+                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
                             </rules>
                         </configuration>
                     </execution>

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -430,6 +430,9 @@ public class MManager {
       if (plan.getTags() != null) {
         // tag key, tag value
         for (Entry<String, String> entry : plan.getTags().entrySet()) {
+          if (entry.getKey() == null || entry.getValue() == null) {
+            continue;
+          }
           tagIndex.computeIfAbsent(entry.getKey(), k -> new ConcurrentHashMap<>())
               .computeIfAbsent(entry.getValue(), v -> new CopyOnWriteArraySet<>()).add(leafMNode);
         }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/TagLogFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/TagLogFile.java
@@ -40,7 +40,8 @@ public class TagLogFile implements AutoCloseable {
   private static final String LENGTH_EXCEED_MSG = "Tag/Attribute exceeds the max length limit. "
       + "Please enlarge tag_attribute_total_size in iotdb-engine.properties";
 
-  private static final int MAX_LENGTH = IoTDBDescriptor.getInstance().getConfig().getTagAttributeTotalSize();
+  private static final int MAX_LENGTH = IoTDBDescriptor.getInstance().getConfig()
+      .getTagAttributeTotalSize();
 
   private static final byte FILL_BYTE = 0;
 
@@ -57,7 +58,9 @@ public class TagLogFile implements AutoCloseable {
 
     File logFile = SystemFileFactory.INSTANCE.getFile(schemaDir + File.separator + logFileName);
 
-    this.fileChannel = FileChannel.open(logFile.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.DSYNC);
+    this.fileChannel = FileChannel
+        .open(logFile.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE,
+            StandardOpenOption.CREATE, StandardOpenOption.DSYNC);
     // move the current position to the tail of the file
     this.fileChannel.position(fileChannel.size());
   }
@@ -65,7 +68,8 @@ public class TagLogFile implements AutoCloseable {
   /**
    * @return tags map, attributes map
    */
-  public Pair<Map<String, String>, Map<String, String>> read(int size, long position) throws IOException {
+  public Pair<Map<String, String>, Map<String, String>> read(int size, long position)
+      throws IOException {
     if (position < 0) {
       return new Pair<>(Collections.emptyMap(), Collections.emptyMap());
     }
@@ -82,7 +86,8 @@ public class TagLogFile implements AutoCloseable {
     return ReadWriteIOUtils.readMap(byteBuffer);
   }
 
-  public long write(Map<String, String> tagMap, Map<String, String> attributeMap) throws IOException, MetadataException {
+  public long write(Map<String, String> tagMap, Map<String, String> attributeMap)
+      throws IOException, MetadataException {
     long offset = fileChannel.position();
     ByteBuffer byteBuffer = convertMapToByteBuffer(tagMap, attributeMap);
     fileChannel.write(byteBuffer);
@@ -92,12 +97,14 @@ public class TagLogFile implements AutoCloseable {
   /**
    * This method does not modify this file's current position.
    */
-  public void write(Map<String, String> tagMap, Map<String, String> attributeMap, long position) throws IOException, MetadataException {
+  public void write(Map<String, String> tagMap, Map<String, String> attributeMap, long position)
+      throws IOException, MetadataException {
     ByteBuffer byteBuffer = convertMapToByteBuffer(tagMap, attributeMap);
     fileChannel.write(byteBuffer, position);
   }
 
-  private ByteBuffer convertMapToByteBuffer(Map<String, String> tagMap, Map<String, String> attributeMap) throws MetadataException {
+  private ByteBuffer convertMapToByteBuffer(Map<String, String> tagMap,
+      Map<String, String> attributeMap) throws MetadataException {
     ByteBuffer byteBuffer = ByteBuffer.allocate(MAX_LENGTH);
     int length = serializeMap(tagMap, byteBuffer, 0);
     length = serializeMap(attributeMap, byteBuffer, length);
@@ -112,7 +119,8 @@ public class TagLogFile implements AutoCloseable {
     return byteBuffer;
   }
 
-  private int serializeMap(Map<String, String> map, ByteBuffer byteBuffer, int length) throws MetadataException {
+  private int serializeMap(Map<String, String> map, ByteBuffer byteBuffer, int length)
+      throws MetadataException {
     if (map == null) {
       length += Integer.BYTES;
       if (length > MAX_LENGTH) {
@@ -128,6 +136,10 @@ public class TagLogFile implements AutoCloseable {
     ReadWriteIOUtils.write(map.size(), byteBuffer);
     byte[] bytes;
     for (Map.Entry<String, String> entry : map.entrySet()) {
+      if (entry.getKey() == null || entry.getKey().isEmpty() || entry.getValue() == null || entry
+          .getValue().isEmpty()) {
+        throw new MetadataException("Tag key or value shouldn't be null or empty string.");
+      }
       // serialize key
       bytes = entry.getKey().getBytes();
       length += (4 + bytes.length);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/TagLogFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/TagLogFile.java
@@ -136,10 +136,6 @@ public class TagLogFile implements AutoCloseable {
     ReadWriteIOUtils.write(map.size(), byteBuffer);
     byte[] bytes;
     for (Map.Entry<String, String> entry : map.entrySet()) {
-      if (entry.getKey() == null || entry.getKey().isEmpty() || entry.getValue() == null || entry
-          .getValue().isEmpty()) {
-        throw new MetadataException("Tag key or value shouldn't be null or empty string.");
-      }
       // serialize key
       bytes = entry.getKey().getBytes();
       length += (4 + bytes.length);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
@@ -341,7 +341,7 @@ public class ReadWriteIOUtils {
   public static int write(String s, OutputStream outputStream) throws IOException {
     int len = 0;
     if (s == null) {
-      len += write(0, outputStream);
+      len += write(-1, outputStream);
       return len;
     }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
@@ -591,8 +591,10 @@ public class ReadWriteIOUtils {
    */
   public static String readString(ByteBuffer buffer) {
     int strLength = readInt(buffer);
-    if (strLength <= 0) {
+    if (strLength < 0) {
       return null;
+    } else if (strLength == 0) {
+      return "";
     }
     byte[] bytes = new byte[strLength];
     buffer.get(bytes, 0, strLength);


### PR DESCRIPTION
When should check if the tag key or value is empty before inserting it into tlog.txt. Otherwise, while restarting, we replay the tlog and when we read key and value string from tlog, will get the string length to be zero, and then will return a null.
Null can't be used as a ConcurrentHashMap key, so it will throw a NullPointerException.