### PR TITLE
[IOTDB-993] Fix tlog bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -430,6 +430,9 @@ public class MManager {
       if (plan.getTags() != null) {
         // tag key, tag value
         for (Entry<String, String> entry : plan.getTags().entrySet()) {
+          if (entry.getKey() == null || entry.getValue() == null) {
+            continue;
+          }
           tagIndex.computeIfAbsent(entry.getKey(), k -> new ConcurrentHashMap<>())
               .computeIfAbsent(entry.getValue(), v -> new CopyOnWriteArraySet<>()).add(leafMNode);
         }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/TagLogFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/TagLogFile.java
@@ -128,10 +128,6 @@ public class TagLogFile implements AutoCloseable {
     ReadWriteIOUtils.write(map.size(), byteBuffer);
     byte[] bytes;
     for (Map.Entry<String, String> entry : map.entrySet()) {
-      if (entry.getKey() == null || entry.getKey().isEmpty() || entry.getValue() == null || entry
-          .getValue().isEmpty()) {
-        throw new MetadataException("Tag key or value shouldn't be null or empty string.");
-      }
       // serialize key
       bytes = entry.getKey().getBytes();
       length += (4 + bytes.length);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/TagLogFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/TagLogFile.java
@@ -128,6 +128,10 @@ public class TagLogFile implements AutoCloseable {
     ReadWriteIOUtils.write(map.size(), byteBuffer);
     byte[] bytes;
     for (Map.Entry<String, String> entry : map.entrySet()) {
+      if (entry.getKey() == null || entry.getKey().isEmpty() || entry.getValue() == null || entry
+          .getValue().isEmpty()) {
+        throw new MetadataException("Tag key or value shouldn't be null or empty string.");
+      }
       // serialize key
       bytes = entry.getKey().getBytes();
       length += (4 + bytes.length);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
@@ -341,7 +341,7 @@ public class ReadWriteIOUtils {
   public static int write(String s, OutputStream outputStream) throws IOException {
     int len = 0;
     if (s == null) {
-      len += write(0, outputStream);
+      len += write(-1, outputStream);
       return len;
     }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
@@ -591,8 +591,10 @@ public class ReadWriteIOUtils {
    */
   public static String readString(ByteBuffer buffer) {
     int strLength = readInt(buffer);
-    if (strLength <= 0) {
+    if (strLength < 0) {
       return null;
+    } else if (strLength == 0) {
+      return "";
     }
     byte[] bytes = new byte[strLength];
     buffer.get(bytes, 0, strLength);


### PR DESCRIPTION
When should check if the tag key or value is empty before inserting it into tlog.txt. Otherwise, while restarting, we replay the tlog and when we read key and value string from tlog, will get the string length to be zero, and then will return a null.
Null can't be used as a ConcurrentHashMap key, so it will throw a NullPointerException.