### PR TITLE
[IOTDB-989]fix doc not found in the website

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -247,7 +247,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <fileset>
-                                <directory>${project.build.directory}/download/0.10.x.zip/iotdb-rel-0.10/docs/UserGuide</directory>
+                                <directory>${project.build.directory}/download/0.10.x.zip/incubator-iotdb-rel-0.10/docs/UserGuide</directory>
                                 <outputDirectory>${project.build.directory}/vue-source/src/UserGuide/V0.10.x</outputDirectory>
                             </fileset>
                         </configuration>
@@ -260,7 +260,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <fileset>
-                                <directory>${project.build.directory}/download/0.10.x.zip/iotdb-rel-0.10/docs/zh/UserGuide</directory>
+                                <directory>${project.build.directory}/download/0.10.x.zip/incubator-iotdb-rel-0.10/docs/zh/UserGuide</directory>
                                 <outputDirectory>${project.build.directory}/vue-source/src/zh/UserGuide/V0.10.x</outputDirectory>
                             </fileset>
                         </configuration>
@@ -273,7 +273,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <fileset>
-                                <directory>${project.build.directory}/download/0.9.x.zip/iotdb-rel-0.9/docs/UserGuide</directory>
+                                <directory>${project.build.directory}/download/0.9.x.zip/incubator-iotdb-rel-0.9/docs/UserGuide</directory>
                                 <outputDirectory>${project.build.directory}/vue-source/src/UserGuide/V0.9.x</outputDirectory>
                             </fileset>
                         </configuration>
@@ -286,7 +286,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <fileset>
-                                <directory>${project.build.directory}/download/0.9.x.zip/iotdb-rel-0.9/docs/zh/UserGuide</directory>
+                                <directory>${project.build.directory}/download/0.9.x.zip/incubator-iotdb-rel-0.9/docs/zh/UserGuide</directory>
                                 <outputDirectory>${project.build.directory}/vue-source/src/zh/UserGuide/V0.9.x</outputDirectory>
                             </fileset>
                         </configuration>
@@ -299,7 +299,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <fileset>
-                                <directory>${project.build.directory}/download/0.8.x.zip/iotdb-rel-0.8/docs/UserGuide</directory>
+                                <directory>${project.build.directory}/download/0.8.x.zip/incubator-iotdb-rel-0.8/docs/UserGuide</directory>
                                 <outputDirectory>${project.build.directory}/vue-source/src/UserGuide/V0.8.x</outputDirectory>
                             </fileset>
                         </configuration>
@@ -312,7 +312,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <fileset>
-                                <directory>${project.build.directory}/download/0.8.x.zip/iotdb-rel-0.8/docs/zh/UserGuide</directory>
+                                <directory>${project.build.directory}/download/0.8.x.zip/incubator-iotdb-rel-0.8/docs/zh/UserGuide</directory>
                                 <outputDirectory>${project.build.directory}/vue-source/src/zh/UserGuide/V0.8.x</outputDirectory>
                             </fileset>
                         </configuration>


### PR DESCRIPTION
When graduated from the incubator, I incorrectly modify the website pom file, which leads to the docs of v0.10/0.9/0.8 lost.