### PR TITLE
Fix query bug

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -1028,6 +1028,7 @@ public class TsFileSequenceReader implements AutoCloseable {
    */
   public List<ChunkMetadata> readChunkMetaDataList(TimeseriesMetadata timeseriesMetaData)
       throws IOException {
+    readFileMetadata();
     List<Pair<Long, Long>> versionInfo = tsFileMetaData.getVersionInfo();
     ArrayList<ChunkMetadata> chunkMetadataList = new ArrayList<>();
     long startOffsetOfChunkMetadataList = timeseriesMetaData.getOffsetOfChunkMetaDataList();


### PR DESCRIPTION
If the previous query load the timeseries metadata into cache. And when it has finished for a while(the file reader has been removed from the file reader manager cache), current query use the same timeseries metadata, the cache hits. However, we have to reopne the file reader and use the reopened file reader and cached timeseries metadata to load the chunk metadata.
But the reopened reader has not init the tsfileMetadata.