### PR TITLE
Fix getting total memory size when there are more than one memories installed in a Windows OS computer

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-env.bat
+++ b/server/src/assembly/resources/conf/iotdb-env.bat
@@ -55,7 +55,7 @@ set as=%system_cpu_cores%
 if ["%system_cpu_cores%"] LSS ["1"] set system_cpu_cores="1"
 
 set liner=0
-for /f  %%b in ('wmic memorychip get capacity') do (
+for /f  %%b in ('wmic ComputerSystem get TotalPhysicalMemory') do (
 	set /a liner+=1
 	if !liner!==2 set system_memory=%%b
 )


### PR DESCRIPTION
When there are more than one memories installed in the computer, the pervious version of command can only get one memory size but not the total physical size. 