### PR TITLE
[IOTDB-1002] Fix interrupting-related exceptions in travis CI

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -175,6 +175,7 @@ public class MLogWriter {
   }
 
   public void clear() throws IOException {
+    channel.force(true);
     channel.close();
     fileOutputStream.close();
     Files.delete(logFile.toPath());

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -74,7 +74,8 @@ public class EnvironmentUtils {
 
   private static IoTDB daemon;
 
-  public static boolean examinePorts = Boolean.valueOf(System.getProperty("test.port.closed", "false"));
+  public static boolean examinePorts = Boolean
+      .parseBoolean(System.getProperty("test.port.closed", "false"));
 
   public static void cleanEnv() throws IOException, StorageEngineException {
     logger.warn("EnvironmentUtil cleanEnv...");
@@ -147,6 +148,7 @@ public class EnvironmentUtils {
         transport.close();
         return false;
       } catch (TTransportException e) {
+        //do nothing
       }
     }
     //try sync service
@@ -158,6 +160,7 @@ public class EnvironmentUtils {
         transport.close();
         return false;
       } catch (TTransportException e) {
+        //do nothing
       }
     }
     //try jmx connection
@@ -172,20 +175,14 @@ public class EnvironmentUtils {
       //do nothing
     }
     //try MetricService
-    Socket socket = new Socket();
-    try {
+    try (Socket socket = new Socket()) {
       socket.connect(new InetSocketAddress("127.0.0.1", 8181), 100);
       logger.error("stop MetricService failed. 8181 can be connected now.");
       return false;
     } catch (Exception e) {
       //do nothing
-    } finally {
-      try {
-        socket.close();
-      } catch (IOException e) {
-        //do nothing
-      }
     }
+    //do nothing
     return true;
   }
 
@@ -256,7 +253,7 @@ public class EnvironmentUtils {
   }
 
   public static void shutdownDaemon() throws Exception {
-    if(daemon != null) {
+    if (daemon != null) {
       daemon.shutdown();
     }
   }
@@ -278,6 +275,7 @@ public class EnvironmentUtils {
 
   public static void restartDaemon() throws Exception {
     shutdownDaemon();
+    stopDaemon();
     reactiveDaemon();
   }
 


### PR DESCRIPTION
Fix all interrupting-related exceptions (such as `ClosedByInterruptException` / `InterruptedException`) when shutting down or restarting IoTDB in travis CI.