### PR TITLE
[IOTDB-1007]Fix session pool concurrency and leakage issue when pool.close is called

### DIFF
--- a/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -151,7 +151,7 @@ public class SessionPool {
           //Meanwhile, we have to set size--
           synchronized (this) {
             size--;
-            this.notifyAll();
+            this.notify();
             if (logger.isDebugEnabled()) {
               logger.debug("open session failed, reduce the count and notify others...");
             }
@@ -206,7 +206,7 @@ public class SessionPool {
   private void putBack(Session session) {
     queue.push(session);
     synchronized (this) {
-      this.notifyAll();
+      this.notify();
       //comment the following codes as putBack is too frequently called.
 //      if (logger.isTraceEnabled()) {
 //        logger.trace("put a session back and notify others..., queue.size = {}", queue.size());
@@ -262,7 +262,7 @@ public class SessionPool {
   private synchronized void removeSession() {
     logger.warn("Remove a broken Session {}, {}, {}", ip, port, user);
     size--;
-    this.notifyAll();
+    this.notify();
     if (logger.isDebugEnabled()) {
         logger.debug("remove a broken session and notify others..., queue.size = {}", queue.size());
     }

--- a/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
+++ b/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
@@ -237,4 +237,11 @@ public class SessionPoolTest {
     }
   }
 
+  @Test
+  public void testClose() {
+    SessionPool pool = new SessionPool("127.0.0.1", 6667, "root", "root", 3, 1, 60000, false, null);
+    write10Data(pool, true);
+
+  }
+
 }

--- a/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
+++ b/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
@@ -33,6 +33,7 @@ import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -240,8 +241,18 @@ public class SessionPoolTest {
   @Test
   public void testClose() {
     SessionPool pool = new SessionPool("127.0.0.1", 6667, "root", "root", 3, 1, 60000, false, null);
-    write10Data(pool, true);
-
+    pool.close();
+    try {
+      pool.insertRecord("root.sg1.d1", 1, Collections.singletonList("s1" ),
+          Collections.singletonList(TSDataType.INT64),
+          Collections.singletonList(1L));
+    } catch (IoTDBConnectionException e) {
+      Assert.assertEquals("Session pool is closed", e.getMessage());
+    } catch (StatementExecutionException e) {
+      fail();
+    }
+    //some other test cases are not covered:
+    //e.g., thread A created a new session, but not returned; thread B close the pool; A get the session.
   }
 
 }


### PR DESCRIPTION
Current session Pool has some concurrency problems:

1.

public static void main() {
    queryByRowRecord(); // this method open a new thread to use session.
    Thread.sleep(1000);
    pool.close(); // this method close pool.
}
Then the pool will clear all existing sessions, which may lead to some leakage and deadlock.

2. `notifyAll()` is not called, which will lead to `wait(1000)` waits too long time.


3. More log is printed.