### PR TITLE
[IOTDB-1012] Remove unfriendly query process error for users

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -586,7 +586,7 @@ public class PhysicalGenerator {
           IExpression expression = filterOperator.transformToExpression(pathTSDataTypeHashMap);
           ((RawDataQueryPlan) queryPlan).setExpression(expression);
         } catch (MetadataException e) {
-          throw new LogicalOptimizeException(e);
+          throw new LogicalOptimizeException(e.getMessage());
         }
       }
     }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
@@ -434,7 +434,7 @@ public class IoTDBMultiSeriesIT {
     } catch (SQLException e) {
       e.printStackTrace();
       assertEquals(
-          "411: Meet error in query process: org.apache.iotdb.db.exception.metadata.PathNotExistException: Path [root.vehicle.d0.s10] does not exist",
+          "411: Meet error in query process: Path [root.vehicle.d0.s10] does not exist",
           e.getMessage());
     }
   }


### PR DESCRIPTION
When selecting non-exist timeseries, an error message will be logged:
```
"411: Meet error in query process: org.apache.iotdb.db.exception.metadata.PathNotExistException: 
Path [root....] does not exist"
```
The exception is very unfriendly to users and may make them confused.
