### PR TITLE
Refactor LastQueryExecutor to separate the execution into multiple stages

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -110,8 +110,8 @@ public class MTree implements Serializable {
       try {
         QueryDataSource dataSource = QueryResourceManager.getInstance().
                 getQueryDataSource(node.getPartialPath(), queryContext, null);
-        Set<String> measurementSet = new HashSet<String>() {{
-          add(node.getPartialPath().getFullPath()); }};
+        Set<String> measurementSet = new HashSet<>();
+        measurementSet.add(node.getPartialPath().getFullPath());
         LastPointReader lastReader = new LastPointReader(node.getPartialPath(),
                 node.getSchema().getType(), measurementSet, queryContext,
                 dataSource, Long.MAX_VALUE, null);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
@@ -111,8 +110,10 @@ public class MTree implements Serializable {
       try {
         QueryDataSource dataSource = QueryResourceManager.getInstance().
                 getQueryDataSource(node.getPartialPath(), queryContext, null);
+        Set<String> measurementSet = new HashSet<String>() {{
+          add(node.getPartialPath().getFullPath()); }};
         LastPointReader lastReader = new LastPointReader(node.getPartialPath(),
-                node.getSchema().getType(), Collections.emptySet(), queryContext,
+                node.getSchema().getType(), measurementSet, queryContext,
                 dataSource, Long.MAX_VALUE, null);
         last = lastReader.readLastPoint();
         return (last != null ? last.getTimestamp() : Long.MIN_VALUE);

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByFillDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByFillDataSet.java
@@ -109,12 +109,12 @@ public class GroupByFillDataSet extends QueryDataSet {
     for (int i = 0; i < paths.size(); i++) {
       seriesPaths.add((PartialPath) paths.get(i));
     }
-    List<Pair<Boolean, TimeValuePair>> lastPairList =
+    List<Pair<Boolean, TimeValuePair>> lastContainer =
             LastQueryExecutor.calculateLastPairForSeriesLocally(
                     seriesPaths, dataTypes, context, null, groupByFillPlan);
-    for (int i = 0; i < lastPairList.size(); i++) {
-      if (lastPairList.get(i).left) {
-        lastTimeArray[i] = lastPairList.get(i).right.getTimestamp();
+    for (int i = 0; i < lastContainer.size(); i++) {
+      if (Boolean.TRUE.equals(lastContainer.get(i).left)) {
+        lastTimeArray[i] = lastContainer.get(i).right.getTimestamp();
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByFillDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByFillDataSet.java
@@ -109,12 +109,12 @@ public class GroupByFillDataSet extends QueryDataSet {
     for (int i = 0; i < paths.size(); i++) {
       seriesPaths.add((PartialPath) paths.get(i));
     }
-    List<Pair<Boolean, TimeValuePair>> lastContainer =
+    List<Pair<Boolean, TimeValuePair>> lastValueContainer =
             LastQueryExecutor.calculateLastPairForSeriesLocally(
                     seriesPaths, dataTypes, context, null, groupByFillPlan);
-    for (int i = 0; i < lastContainer.size(); i++) {
-      if (Boolean.TRUE.equals(lastContainer.get(i).left)) {
-        lastTimeArray[i] = lastContainer.get(i).right.getTimestamp();
+    for (int i = 0; i < lastValueContainer.size(); i++) {
+      if (Boolean.TRUE.equals(lastValueContainer.get(i).left)) {
+        lastTimeArray[i] = lastValueContainer.get(i).right.getTimestamp();
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByFillDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByFillDataSet.java
@@ -105,13 +105,16 @@ public class GroupByFillDataSet extends QueryDataSet {
       throws IOException, StorageEngineException, QueryProcessException {
     lastTimeArray = new long[paths.size()];
     Arrays.fill(lastTimeArray, Long.MAX_VALUE);
+    List<PartialPath> seriesPaths = new ArrayList<>();
     for (int i = 0; i < paths.size(); i++) {
-      TimeValuePair lastTimeValuePair;
-      lastTimeValuePair = LastQueryExecutor.calculateLastPairForOneSeriesLocally(
-          (PartialPath) paths.get(i), dataTypes.get(i), context, null,
-          groupByFillPlan.getAllMeasurementsInDevice(paths.get(i).getDevice()));
-      if (lastTimeValuePair != null && lastTimeValuePair.getValue() != null) {
-        lastTimeArray[i] = lastTimeValuePair.getTimestamp();
+      seriesPaths.add((PartialPath) paths.get(i));
+    }
+    List<Pair<Boolean, TimeValuePair>> lastPairList =
+            LastQueryExecutor.calculateLastPairForSeriesLocally(
+                    seriesPaths, dataTypes, context, null, groupByFillPlan);
+    for (int i = 0; i < lastPairList.size(); i++) {
+      if (lastPairList.get(i).left) {
+        lastTimeArray[i] = lastPairList.get(i).right.getTimestamp();
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -59,7 +59,7 @@ public class LastQueryExecutor {
   private List<PartialPath> selectedSeries;
   private List<TSDataType> dataTypes;
   private IExpression expression;
-  private static final boolean lastCacheEnabled =
+  private static final boolean CACHE_ENABLED =
           IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled();
 
   public LastQueryExecutor(LastQueryPlan lastQueryPlan) {
@@ -89,7 +89,7 @@ public class LastQueryExecutor {
             selectedSeries, dataTypes, context, expression, lastQueryPlan);
 
     for (int i = 0; i < lastPairList.size(); i++) {
-      if (lastPairList.get(i).left) {
+      if (Boolean.TRUE.equals(lastPairList.get(i).left)) {
         TimeValuePair lastTimeValuePair = lastPairList.get(i).right;
         RowRecord resultRecord = new RowRecord(lastTimeValuePair.getTimestamp());
         Field pathField = new Field(TSDataType.TEXT);
@@ -150,10 +150,10 @@ public class LastQueryExecutor {
 
     int index = 0;
     for (int i = 0; i < resultContainer.size(); i++) {
-      if (!resultContainer.get(i).left) {
+      if (Boolean.FALSE.equals(resultContainer.get(i).left)) {
         resultContainer.get(i).left = true;
         resultContainer.get(i).right = readerList.get(index++).readLastPoint();
-        if (lastCacheEnabled) {
+        if (CACHE_ENABLED) {
           cacheAccessors.get(i).write(resultContainer.get(i).right);
         }
       }
@@ -164,7 +164,7 @@ public class LastQueryExecutor {
   private static List<Pair<Boolean, TimeValuePair>> readLastPairsFromCache(List<PartialPath> seriesPaths,
           Filter filter, List<LastCacheAccessor> cacheAccessors, List<PartialPath> restPaths) {
     List<Pair<Boolean, TimeValuePair>> resultContainer = new ArrayList<>();
-    if (lastCacheEnabled) {
+    if (CACHE_ENABLED) {
       for (PartialPath path : seriesPaths) {
         cacheAccessors.add(new LastCacheAccessor(path, filter));
       }
@@ -223,10 +223,10 @@ public class LastQueryExecutor {
     public void write(TimeValuePair pair) {
       IoTDB.metaManager.updateLastCache(path, pair, false, Long.MIN_VALUE, node);
     }
-  }
 
-  private static boolean satisfyFilter(Filter filter, TimeValuePair tvPair) {
-    return filter == null ||
-            filter.satisfy(tvPair.getTimestamp(), tvPair.getValue().getValue());
+    private static boolean satisfyFilter(Filter filter, TimeValuePair tvPair) {
+      return filter == null ||
+              filter.satisfy(tvPair.getTimestamp(), tvPair.getValue().getValue());
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -133,6 +133,7 @@ public class LastQueryExecutor {
       return resultContainer;
     }
 
+    // Acquire query resources for the rest series paths
     List<LastPointReader> readerList = new ArrayList<>();
     List<StorageGroupProcessor> list = StorageEngine.getInstance().mergeLock(restPaths);
     try {
@@ -148,6 +149,7 @@ public class LastQueryExecutor {
       StorageEngine.getInstance().mergeUnLock(list);
     }
 
+    // Compute Last result for the rest series paths by scanning Tsfiles
     int index = 0;
     for (int i = 0; i < resultContainer.size(); i++) {
       if (Boolean.FALSE.equals(resultContainer.get(i).left)) {
@@ -170,6 +172,9 @@ public class LastQueryExecutor {
       }
     } else {
       restPaths.addAll(seriesPaths);
+      for (int i = 0; i < seriesPaths.size(); i++) {
+        resultContainer.add(new Pair<>(false, null));
+      }
     }
     for (int i = 0; i < cacheAccessors.size(); i++) {
       TimeValuePair tvPair = cacheAccessors.get(i).read();

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -89,7 +89,7 @@ public class LastQueryExecutor {
             selectedSeries, dataTypes, context, expression, lastQueryPlan);
 
     for (int i = 0; i < lastPairList.size(); i++) {
-      if (Boolean.TRUE.equals(lastPairList.get(i).left)) {
+      if (lastPairList.get(i).right != null) {
         TimeValuePair lastTimeValuePair = lastPairList.get(i).right;
         RowRecord resultRecord = new RowRecord(lastTimeValuePair.getTimestamp());
         Field pathField = new Field(TSDataType.TEXT);

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -24,9 +24,9 @@ import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TIMESERIES;
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_VALUE;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
@@ -37,6 +37,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
 import org.apache.iotdb.db.qp.physical.crud.LastQueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.dataset.ListDataSet;
@@ -51,13 +52,14 @@ import org.apache.iotdb.tsfile.read.expression.impl.GlobalTimeExpression;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.utils.Binary;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 public class LastQueryExecutor {
 
   private List<PartialPath> selectedSeries;
   private List<TSDataType> dataTypes;
   private IExpression expression;
-  private static boolean lastCacheEnabled =
+  private static final boolean lastCacheEnabled =
           IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled();
 
   public LastQueryExecutor(LastQueryPlan lastQueryPlan) {
@@ -83,36 +85,31 @@ public class LastQueryExecutor {
         Arrays.asList(new PartialPath(COLUMN_TIMESERIES, false), new PartialPath(COLUMN_VALUE, false)),
         Arrays.asList(TSDataType.TEXT, TSDataType.TEXT));
 
-    List<StorageGroupProcessor> list = StorageEngine.getInstance().mergeLock(selectedSeries);
-    try {
-      for (int i = 0; i < selectedSeries.size(); i++) {
-        TimeValuePair lastTimeValuePair;
-        lastTimeValuePair = calculateLastPairForOneSeries(
-            selectedSeries.get(i), dataTypes.get(i), context,
-            lastQueryPlan.getAllMeasurementsInDevice(selectedSeries.get(i).getDevice()));
-        if (lastTimeValuePair != null && lastTimeValuePair.getValue() != null) {
-          RowRecord resultRecord = new RowRecord(lastTimeValuePair.getTimestamp());
-          Field pathField = new Field(TSDataType.TEXT);
-          if (selectedSeries.get(i).getTsAlias() != null) {
-            pathField.setBinaryV(new Binary(selectedSeries.get(i).getTsAlias()));
+    List<Pair<Boolean, TimeValuePair>> lastPairList = calculateLastPairForSeriesLocally(
+            selectedSeries, dataTypes, context, expression, lastQueryPlan);
+
+    for (int i = 0; i < lastPairList.size(); i++) {
+      if (lastPairList.get(i).left) {
+        TimeValuePair lastTimeValuePair = lastPairList.get(i).right;
+        RowRecord resultRecord = new RowRecord(lastTimeValuePair.getTimestamp());
+        Field pathField = new Field(TSDataType.TEXT);
+        if (selectedSeries.get(i).getTsAlias() != null) {
+          pathField.setBinaryV(new Binary(selectedSeries.get(i).getTsAlias()));
+        } else {
+          if (selectedSeries.get(i).getMeasurementAlias() != null) {
+            pathField.setBinaryV(new Binary(selectedSeries.get(i).getFullPathWithAlias()));
           } else {
-            if (selectedSeries.get(i).getMeasurementAlias() != null) {
-              pathField.setBinaryV(new Binary(selectedSeries.get(i).getFullPathWithAlias()));
-            } else {
-              pathField.setBinaryV(new Binary(selectedSeries.get(i).getFullPath()));
-            }
+            pathField.setBinaryV(new Binary(selectedSeries.get(i).getFullPath()));
           }
-          resultRecord.addField(pathField);
-
-          Field valueField = new Field(TSDataType.TEXT);
-          valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
-          resultRecord.addField(valueField);
-
-          dataSet.putRecord(resultRecord);
         }
+        resultRecord.addField(pathField);
+
+        Field valueField = new Field(TSDataType.TEXT);
+        valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
+        resultRecord.addField(valueField);
+
+        dataSet.putRecord(resultRecord);
       }
-    } finally {
-      StorageEngine.getInstance().mergeUnLock(list);
     }
 
     if (!lastQueryPlan.isAscending()) {
@@ -121,35 +118,90 @@ public class LastQueryExecutor {
     return dataSet;
   }
 
-  protected TimeValuePair calculateLastPairForOneSeries(
-      PartialPath seriesPath, TSDataType tsDataType, QueryContext context, Set<String> deviceMeasurements)
-      throws IOException, QueryProcessException, StorageEngineException {
-    return calculateLastPairForOneSeriesLocally(seriesPath, tsDataType, context,
-        expression, deviceMeasurements);
+  public static List<Pair<Boolean, TimeValuePair>> calculateLastPairForSeriesLocally(
+          List<PartialPath> seriesPaths, List<TSDataType> dataTypes, QueryContext context,
+          IExpression expression, RawDataQueryPlan lastQueryPlan)
+          throws QueryProcessException, StorageEngineException, IOException {
+    List<LastCacheAccessor> cacheAccessors = new ArrayList<>();
+    Filter filter = (expression == null) ? null : ((GlobalTimeExpression) expression).getFilter();
+
+    List<PartialPath> restPaths = new ArrayList<>();
+    List<Pair<Boolean, TimeValuePair>> resultContainer =
+            readLastPairsFromCache(seriesPaths, filter, cacheAccessors, restPaths);
+    // If any '>' or '>=' filters are specified, only access cache to get Last result.
+    if (filter != null || restPaths.isEmpty()) {
+      return resultContainer;
+    }
+
+    List<LastPointReader> readerList = new ArrayList<>();
+    List<StorageGroupProcessor> list = StorageEngine.getInstance().mergeLock(restPaths);
+    try {
+      for (int i = 0; i < restPaths.size(); i++) {
+        QueryDataSource dataSource =
+                QueryResourceManager.getInstance().getQueryDataSource(seriesPaths.get(i), context, null);
+        LastPointReader lastReader = new LastPointReader(seriesPaths.get(i), dataTypes.get(i),
+                lastQueryPlan.getAllMeasurementsInDevice(seriesPaths.get(i).getDevice()),
+                context, dataSource, Long.MAX_VALUE, null);
+        readerList.add(lastReader);
+      }
+    } finally {
+      StorageEngine.getInstance().mergeUnLock(list);
+    }
+
+    int index = 0;
+    for (int i = 0; i < resultContainer.size(); i++) {
+      if (!resultContainer.get(i).left) {
+        resultContainer.get(i).left = true;
+        resultContainer.get(i).right = readerList.get(index++).readLastPoint();
+        if (lastCacheEnabled) {
+          cacheAccessors.get(i).write(resultContainer.get(i).right);
+        }
+      }
+    }
+    return resultContainer;
   }
 
-  /**
-   * get last result for one series
-   *
-   * @param context query context
-   * @return TimeValuePair, result can be null
-   */
-  public static TimeValuePair calculateLastPairForOneSeriesLocally(
-      PartialPath seriesPath, TSDataType tsDataType, QueryContext context,
-      IExpression expression, Set<String> deviceMeasurements)
-      throws IOException, QueryProcessException, StorageEngineException {
-
-    // Retrieve last value from MNode
-    MeasurementMNode node = null;
-    Filter filter = null;
+  private static List<Pair<Boolean, TimeValuePair>> readLastPairsFromCache(List<PartialPath> seriesPaths,
+          Filter filter, List<LastCacheAccessor> cacheAccessors, List<PartialPath> restPaths) {
+    List<Pair<Boolean, TimeValuePair>> resultContainer = new ArrayList<>();
     if (lastCacheEnabled) {
-      if (expression != null) {
-        filter = ((GlobalTimeExpression) expression).getFilter();
+      for (PartialPath path : seriesPaths) {
+        cacheAccessors.add(new LastCacheAccessor(path, filter));
       }
+    } else {
+      restPaths.addAll(seriesPaths);
+    }
+    for (int i = 0; i < cacheAccessors.size(); i++) {
+      TimeValuePair tvPair = cacheAccessors.get(i).read();
+      if (tvPair != null) {
+        resultContainer.add(new Pair<>(true, tvPair));
+      } else {
+        resultContainer.add(new Pair<>(false, null));
+        restPaths.add(seriesPaths.get(i));
+      }
+    }
+    return resultContainer;
+  }
+
+  private static class LastCacheAccessor {
+    private PartialPath path;
+    private Filter filter;
+    private MeasurementMNode node;
+
+    LastCacheAccessor(PartialPath seriesPath) {
+      this.path = seriesPath;
+    }
+
+    LastCacheAccessor(PartialPath seriesPath, Filter filter) {
+      this.path = seriesPath;
+      this.filter = filter;
+    }
+
+    public TimeValuePair read() {
       try {
-        node = (MeasurementMNode) IoTDB.metaManager.getNodeByPath(seriesPath);
+        node = (MeasurementMNode) IoTDB.metaManager.getNodeByPath(path);
       } catch (MetadataException e) {
-        TimeValuePair timeValuePair = IoTDB.metaManager.getLastCache(seriesPath);
+        TimeValuePair timeValuePair = IoTDB.metaManager.getLastCache(path);
         if (timeValuePair != null && satisfyFilter(filter, timeValuePair)) {
           return timeValuePair;
         } else if (timeValuePair != null) {
@@ -165,37 +217,16 @@ public class LastQueryExecutor {
           return null;
         }
       }
+      return null;
     }
 
-    return calculateLastPairByScanningTsFiles(
-        seriesPath, tsDataType, context, filter, deviceMeasurements, node);
-  }
-
-  private static TimeValuePair calculateLastPairByScanningTsFiles(
-          PartialPath seriesPath, TSDataType tsDataType, QueryContext context,
-          Filter filter, Set<String> deviceMeasurements, MeasurementMNode node)
-      throws QueryProcessException, StorageEngineException, IOException {
-
-    QueryDataSource dataSource =
-        QueryResourceManager.getInstance().getQueryDataSource(seriesPath, context, filter);
-
-    LastPointReader lastReader = new LastPointReader(
-        seriesPath, tsDataType, deviceMeasurements, context, dataSource, Long.MAX_VALUE, filter);
-    TimeValuePair resultPair = lastReader.readLastPoint();
-
-    // Update cached last value with low priority unless "FROM" expression exists
-    if (lastCacheEnabled) {
-      IoTDB.metaManager.updateLastCache(
-          seriesPath, resultPair, false, Long.MIN_VALUE, node);
+    public void write(TimeValuePair pair) {
+      IoTDB.metaManager.updateLastCache(path, pair, false, Long.MIN_VALUE, node);
     }
-    return resultPair;
   }
 
   private static boolean satisfyFilter(Filter filter, TimeValuePair tvPair) {
-    if (filter == null ||
-        filter.satisfy(tvPair.getTimestamp(), tvPair.getValue().getValue())) {
-      return true;
-    }
-    return false;
+    return filter == null ||
+            filter.satisfy(tvPair.getTimestamp(), tvPair.getValue().getValue());
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/QueryRouter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/QueryRouter.java
@@ -225,8 +225,12 @@ public class QueryRouter implements IQueryRouter {
   @Override
   public QueryDataSet lastQuery(LastQueryPlan lastQueryPlan, QueryContext context)
       throws StorageEngineException, QueryProcessException, IOException {
-    LastQueryExecutor lastQueryExecutor = new LastQueryExecutor(lastQueryPlan);
+    LastQueryExecutor lastQueryExecutor = getLastQueryExecutor(lastQueryPlan);
     return lastQueryExecutor.execute(context, lastQueryPlan);
+  }
+
+  protected LastQueryExecutor getLastQueryExecutor(LastQueryPlan lastQueryPlan) {
+    return new LastQueryExecutor(lastQueryPlan);
   }
 
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/QueryRouter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/QueryRouter.java
@@ -225,12 +225,8 @@ public class QueryRouter implements IQueryRouter {
   @Override
   public QueryDataSet lastQuery(LastQueryPlan lastQueryPlan, QueryContext context)
       throws StorageEngineException, QueryProcessException, IOException {
-    LastQueryExecutor lastQueryExecutor = getLastQueryExecutor(lastQueryPlan);
+    LastQueryExecutor lastQueryExecutor = new LastQueryExecutor(lastQueryPlan);
     return lastQueryExecutor.execute(context, lastQueryPlan);
-  }
-
-  protected LastQueryExecutor getLastQueryExecutor(LastQueryPlan lastQueryPlan) {
-    return new LastQueryExecutor(lastQueryPlan);
   }
 
 }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
@@ -18,11 +18,9 @@
  */
 package org.apache.iotdb.db.integration;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.List;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;


### PR DESCRIPTION
A merge lock has already been added locking the whole Last query procedure, however, this procedure may take a long time. 
This PR refactor the Last query execution process, separating it into multiple stages:

1. Get Last result by accessing cache.
2. Hold merge lock and obtain query resource.
3. Scan TsFiles to get Last value.

Now only the stage 2 will be locked.