### PR TITLE
increase max open file in linux

### DIFF
--- a/server/src/assembly/resources/sbin/start-server.sh
+++ b/server/src/assembly/resources/sbin/start-server.sh
@@ -18,6 +18,8 @@
 # under the License.
 #
 
+# Set max number of open files
+ulimit -n 65535
 
 echo ---------------------
 echo Starting IoTDB


### PR DESCRIPTION
need to increase max number of opened files in linux to avoid TsFileSequenceReader exception.