### PR TITLE
[IOTDB-768] Extend more functions in aggregation group by level

### DIFF
--- a/docs/UserGuide/Operation Manual/DML Data Manipulation Language.md
+++ b/docs/UserGuide/Operation Manual/DML Data Manipulation Language.md
@@ -169,31 +169,38 @@ select count(status) from root.ln.wf01.wt01;
 | 4              |
 
 
-##### Count Points By Level
+##### Aggregation By Level
 
-Level could be defined to show count the number of points of each node at the given level in current Metadata Tree.
+**Aggregation by level statement** is used for aggregating upon specific hierarchical level of timeseries path.
+For all timeseries path, by convention, "level=0" represents *root* level. 
+That is, to tally the points of any measurements under "root.ln", the level should be set to 1.
 
-This could be used to query the number of points under each device.
-
-The SQL statement is:
-
+For example, there are multiple series under "root.ln.wf01", such as "root.ln.wf01.wt01.status","root.ln.wf01.wt02.status","root.ln.wf01.wt03.status".
+To count the number of "status" points of all these series, use query:
 ```
-select count(status) from root.ln.wf01.wt01 group by level=1;
+select count(status) from root.ln.wf01.* group by level=2
 ```
+Result:
+
+| count(root.ln.wf01.*.status) |
+| ---------------------------- |
+| 7                            |
 
 
-| Time   | count(root.ln) |
-| ------ | -------------- |
-| 0      | 7              |
-
-
+Assuming another timeseries is added, called "root.ln.wf02.wt01.status".
+To query the number of "status" points of both two paths "root.ln.wf01" and "root.ln.wf02".
 ```
-select count(status) from root.ln.wf01.wt01 group by level=2;
+select count(status) from root.ln.*.* group by level=2
 ```
+Result：
 
-| Time   | count(root.ln.wf01) | count(root.ln.wf02) |
-| ------ | ------------------- | ------------------- |
-| 0      | 4                   | 3                   |
+| count(root.ln.wf01.*.status) | count(root.ln.wf02.*.status) |
+| ---------------------------- | ---------------------------- |
+| 7                            | 4
+
+All supported aggregation functions are: count, sum, avg, last_value, first_value, min_time, max_time, min_value, max_value.
+When using four aggregations: sum, avg, min_value and max_value, please make sure all the aggregated series have exactly the same data type.
+Otherwise, it will generate a syntax error.
 
 ### Down-Frequency Aggregate Query
 

--- a/docs/UserGuide/Operation Manual/DML Data Manipulation Language.md
+++ b/docs/UserGuide/Operation Manual/DML Data Manipulation Language.md
@@ -172,7 +172,7 @@ select count(status) from root.ln.wf01.wt01;
 ##### Aggregation By Level
 
 **Aggregation by level statement** is used for aggregating upon specific hierarchical level of timeseries path.
-For all timeseries path, by convention, "level=0" represents *root* level. 
+For all timeseries paths, by convention, "level=0" represents *root* level. 
 That is, to tally the points of any measurements under "root.ln", the level should be set to 1.
 
 For example, there are multiple series under "root.ln.wf01", such as "root.ln.wf01.wt01.status","root.ln.wf01.wt02.status","root.ln.wf01.wt03.status".

--- a/docs/zh/UserGuide/Operation Manual/DML Data Manipulation Language.md
+++ b/docs/zh/UserGuide/Operation Manual/DML Data Manipulation Language.md
@@ -202,32 +202,37 @@ select count(status) from root.ln.wf01.wt01;
 | 4              |
 
 
-##### 按层级统计
-通过定义LEVEL来统计指定层级下的数据点个数。
+#### 分层聚合查询
 
-这可以用来查询不同层级下的数据点总个数
+在时间序列层级结构中，分层聚合查询用于对某一层级进行聚合查询。
+这里使用LEVEL来统计指定层级下的聚合范围，该语句约定root为第0层序列，若统计"root.ln"下所有序列则需指定level为1。
 
-语法是：
-
-这个可以用来查询某个路径下的总数据点数
-
+例如：在"root.ln.wf01"下存在多个子序列：wt01，wt02，wt03等均有名为status的序列，
+如果需要统计这些子序列的status包含的点个数，使用以下查询:
 ```
-select count(status) from root.ln.wf01.wt01 group by level=1;
+select count(status) from root.ln.wf01.* group by level=2
 ```
+运行结果为：
+
+| count(root.ln.wf01.*.status) |
+| ---------------------------- |
+| 7                            |
 
 
-| Time   | count(root.ln) |
-| ------ | -------------- |
-| 0      | 7              |
-
-
+假设此时在"root.ln"下面加入名为wf02的子序列，如"root.ln.wf02.wt01.status"。
+需要同时查询"root.ln.wf01"和"root.ln.wf02"下各自status子序列的点个数。则使用查询：
 ```
-select count(status) from root.ln.wf01.wt01 group by level=2;
+select count(status) from root.ln.*.* group by level=2
 ```
+运行结果：
 
-| Time   | count(root.ln.wf01) | count(root.ln.wf02) |
-| ------ | ------------------- | ------------------- |
-| 0      | 4                   | 3                   |
+| count(root.ln.wf01.*.status) | count(root.ln.wf02.*.status) |
+| ---------------------------- | ---------------------------- |
+| 7                            | 4
+
+分层聚合查询也可被用于其他聚合函数，当前所支持的聚合函数为：count, sum, avg, last_value, first_value, min_time, max_time, min_value, max_value
+
+对于sum, avg, min_value, max_value四种聚合函数，需保证所有聚合的时间序列数据类型相同。其他聚合函数没有此限制。
 
 ### 降频聚合查询
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -965,6 +965,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     parseTimeInterval(ctx.timeInterval());
 
     if (ctx.INT() != null) {
+      queryOp.setGroupByLevel(true);
       queryOp.setLevel(Integer.parseInt(ctx.INT().getText()));
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -380,7 +380,7 @@ public class PhysicalGenerator {
       } else if (queryOperator.isGroupByLevel()){
         ((AggregationPlan) queryPlan).setLevel(queryOperator.getLevel());
         try {
-          if (!VerifyAllAggregationDataTypesEqual(queryOperator)) {
+          if (!verifyAllAggregationDataTypesEqual(queryOperator)) {
             throw new QueryProcessException("Aggregate among unmatched data types");
           }
         } catch (MetadataException e) {
@@ -796,7 +796,7 @@ public class PhysicalGenerator {
     return new ArrayList<>(columnList.subList(seriesOffset, endPosition));
   }
 
-  private boolean VerifyAllAggregationDataTypesEqual(QueryOperator queryOperator)
+  private boolean verifyAllAggregationDataTypesEqual(QueryOperator queryOperator)
       throws MetadataException{
     List<String> aggregations = queryOperator.getSelectOperator().getAggregations();
     if (aggregations.isEmpty()) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -377,7 +377,7 @@ public class PhysicalGenerator {
             throw new QueryProcessException("Group By Fill only support last_value function");
           }
         }
-      } else if (queryOperator.isGroupByLevel()){
+      } else {
         ((AggregationPlan) queryPlan).setLevel(queryOperator.getLevel());
         try {
           if (!verifyAllAggregationDataTypesEqual(queryOperator)) {
@@ -816,7 +816,7 @@ public class PhysicalGenerator {
         return true;
     }
   }
-
+  
   protected List<PartialPath> getMatchedTimeseries(PartialPath path) throws MetadataException {
     return IoTDB.metaManager.getAllTimeseriesPath(path);
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -379,13 +379,7 @@ public class PhysicalGenerator {
         }
       } else {
         ((AggregationPlan) queryPlan).setLevel(queryOperator.getLevel());
-        if (queryOperator.getLevel() >= 0) {
-          for (String aggregation : queryPlan.getAggregations()) {
-            if (!SQLConstant.COUNT.equals(aggregation)) {
-              throw new QueryProcessException("group by level only support count now.");
-            }
-          }
-        }
+
       }
     } else if (queryOperator.isFill()) {
       queryPlan = new FillQueryPlan();

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -377,7 +377,7 @@ public class PhysicalGenerator {
             throw new QueryProcessException("Group By Fill only support last_value function");
           }
         }
-      } else {
+      } else if (queryOperator.isGroupByLevel()) {
         ((AggregationPlan) queryPlan).setLevel(queryOperator.getLevel());
         try {
           if (!verifyAllAggregationDataTypesEqual(queryOperator)) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
@@ -86,6 +86,9 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
     }
 
     checkAggrOfSelectOperator(select);
+    if (((QueryOperator) operator).isGroupByLevel()) {
+      checkAggrOfGroupByLevel(select);
+    }
 
     boolean isAlignByDevice = false;
     if (operator instanceof QueryOperator) {
@@ -147,6 +150,13 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
         && selectOperator.getSuffixPaths().size() != selectOperator.getAggregations().size()) {
       throw new LogicalOptimizeException(
           "Common queries and aggregated queries are not allowed to appear at the same time");
+    }
+  }
+
+  private void checkAggrOfGroupByLevel(SelectOperator selectOperator) throws LogicalOptimizeException {
+    if (selectOperator.getAggregations().size() != 1) {
+      throw new LogicalOptimizeException(
+          "Aggregation function is restricted to one if group by level clause exists");
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/aggregation/AggregateResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/aggregation/AggregateResult.java
@@ -245,7 +245,7 @@ public abstract class AggregateResult {
     return booleanValue;
   }
 
-  protected void setBooleanValue(boolean booleanValue) {
+  public void setBooleanValue(boolean booleanValue) {
     this.hasCandidateResult = true;
     this.booleanValue = booleanValue;
   }
@@ -254,7 +254,7 @@ public abstract class AggregateResult {
     return intValue;
   }
 
-  protected void setIntValue(int intValue) {
+  public void setIntValue(int intValue) {
     this.hasCandidateResult = true;
     this.intValue = intValue;
   }
@@ -263,7 +263,7 @@ public abstract class AggregateResult {
     return longValue;
   }
 
-  protected void setLongValue(long longValue) {
+  public void setLongValue(long longValue) {
     this.hasCandidateResult = true;
     this.longValue = longValue;
   }
@@ -272,7 +272,7 @@ public abstract class AggregateResult {
     return floatValue;
   }
 
-  protected void setFloatValue(float floatValue) {
+  public void setFloatValue(float floatValue) {
     this.hasCandidateResult = true;
     this.floatValue = floatValue;
   }
@@ -281,7 +281,7 @@ public abstract class AggregateResult {
     return doubleValue;
   }
 
-  protected void setDoubleValue(double doubleValue) {
+  public void setDoubleValue(double doubleValue) {
     this.hasCandidateResult = true;
     this.doubleValue = doubleValue;
   }
@@ -290,7 +290,7 @@ public abstract class AggregateResult {
     return binaryValue;
   }
 
-  protected void setBinaryValue(Binary binaryValue) {
+  public void setBinaryValue(Binary binaryValue) {
     this.hasCandidateResult = true;
     this.binaryValue = binaryValue;
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByTimeDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByTimeDataSet.java
@@ -75,9 +75,7 @@ public class GroupByTimeDataSet extends QueryDataSet {
         TSDataType dataType = resultData.getResultDataType();
         curRecord.addField(resultData.getResult(), dataType);
       }
-      if (curRecord != null) {
-        records.add(curRecord);
-      }
+      records.add(curRecord);
     }
 
     this.dataTypes = new ArrayList<>();

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByTimeDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByTimeDataSet.java
@@ -67,9 +67,10 @@ public class GroupByTimeDataSet extends QueryDataSet {
       logger.debug("only group by level, paths:" + groupByTimePlan.getPaths());
     }
     while (dataSet != null && dataSet.hasNextWithoutConstraint()) {
-      RowRecord curRecord = new RowRecord(0);
+      RowRecord rawRecord = dataSet.nextWithoutConstraint();
+      RowRecord curRecord = new RowRecord(rawRecord.getTimestamp());
       List<AggregateResult> mergedAggResults = FilePathUtils.mergeRecordByPath(
-              plan, dataSet.nextWithoutConstraint(), finalPaths, pathIndex);
+              plan, rawRecord, finalPaths, pathIndex);
       for (AggregateResult resultData : mergedAggResults) {
         TSDataType dataType = resultData.getResultDataType();
         curRecord.addField(resultData.getResult(), dataType);

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -27,6 +27,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +86,7 @@ import org.apache.iotdb.db.qp.physical.sys.DeleteTimeSeriesPlan;
 import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
+import org.apache.iotdb.db.query.aggregation.AggregateResult;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.control.TracingManager;
@@ -862,12 +864,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       // because the query dataset and query id is different although the header of last query is same.
       return StaticResps.LAST_RESP.deepCopy();
     } else if (plan instanceof AggregationPlan && ((AggregationPlan) plan).getLevel() >= 0) {
-      Map<String, Long> finalPaths = FilePathUtils
-          .getPathByLevel(((AggregationPlan) plan).getDeduplicatedPaths(),
-              ((AggregationPlan) plan).getLevel(), null);
-      for (Map.Entry<String, Long> entry : finalPaths.entrySet()) {
-        respColumns.add("count(" + entry.getKey() + ")");
-        columnsTypes.add(TSDataType.INT64.toString());
+      Map<Integer, String> pathIndex = new HashMap<>();
+      Map<String, AggregateResult> finalPaths = FilePathUtils.getPathByLevel((AggregationPlan) plan, pathIndex);
+      for (Map.Entry<String, AggregateResult> entry : finalPaths.entrySet()) {
+        respColumns.add(entry.getValue().getAggregationType().toString() + "(" + entry.getKey() + ")");
+        columnsTypes.add(entry.getValue().getResultDataType().toString());
       }
     } else {
       getWideQueryHeaders(plan, respColumns, columnsTypes);

--- a/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
@@ -19,15 +19,21 @@
 package org.apache.iotdb.db.utils;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.MetaUtils;
 import org.apache.iotdb.db.metadata.PartialPath;
+import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
+import org.apache.iotdb.db.query.aggregation.AggregateResult;
+import org.apache.iotdb.db.query.factory.AggregateResultFactory;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
+import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Field;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
@@ -58,46 +64,49 @@ public class FilePathUtils {
   }
 
   /**
-   * get paths from group by level, like root.sg1.d2.s0, root.sg1.d1.s1
-   * level=1, return [root.sg1, 0] and pathIndex turns to be [[0, root.sg1], [1, root.sg1]]
-   * @param rawPaths
-   * @param level
-   * @param pathIndex
+   * get paths from group by level, like root.sg1.d2.s0, root.sg1.d1.s0
+   * level=1, return [root.sg1.*.s0, 0] and pathIndex turns to be [[0, root.sg1.*.s0],
+   * [1, root.sg1.*.s0]]
+   * @param plan the original Aggregation Plan
+   * @param pathIndex the mapping from index of aggregations to the result path name
    * @return
    */
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
-  public static Map<String, Long> getPathByLevel(List<PartialPath> rawPaths, int level, Map<Integer, String> pathIndex)
-      throws QueryProcessException {
+  public static Map<String, AggregateResult> getPathByLevel(AggregationPlan plan,
+          Map<Integer, String> pathIndex) throws QueryProcessException {
     // pathGroupByLevel -> count
-    Map<String, Long> finalPaths = new TreeMap<>();
+    Map<String, AggregateResult> finalPaths = new TreeMap<>();
 
-    int i = 0;
-    for (PartialPath value : rawPaths) {
+    List<PartialPath> seriesPaths = plan.getDeduplicatedPaths();
+    List<TSDataType> dataTypes = plan.getDeduplicatedDataTypes();
+    for (int i = 0; i < seriesPaths.size(); i++) {
       String[] tmpPath;
       try {
-        tmpPath = MetaUtils.splitPathToDetachedPath(value.getFullPath());
+        tmpPath = MetaUtils.splitPathToDetachedPath(seriesPaths.get(i).getFullPath());
       } catch (IllegalPathException e) {
         throw new QueryProcessException(e.getMessage());
       }
 
       String key;
-      if (tmpPath.length <= level) {
-        key = value.getFullPath();
+      if (tmpPath.length <= plan.getLevel()) {
+        key = seriesPaths.get(i).getFullPath();
       } else {
         StringBuilder path = new StringBuilder();
-        for (int k = 0; k <= level; k++) {
-          if (k == 0) {
-            path.append(tmpPath[k]);
-          } else {
+        path.append(tmpPath[0]);
+        for (int k = 1; k < tmpPath.length - 1; k++) {
+          if (k <= plan.getLevel()) {
             path.append(TsFileConstant.PATH_SEPARATOR).append(tmpPath[k]);
+          } else {
+            path.append(TsFileConstant.PATH_SEPARATOR).append(IoTDBConstant.PATH_WILDCARD);
           }
         }
+        path.append(TsFileConstant.PATH_SEPARATOR).append(seriesPaths.get(i).getMeasurement());
         key = path.toString();
       }
-      finalPaths.putIfAbsent(key, 0L);
-      if (pathIndex != null) {
-        pathIndex.put(i++, key);
-      }
+      AggregateResult aggRet = AggregateResultFactory
+              .getAggrResultByName(plan.getAggregations().get(i), dataTypes.get(i));
+      finalPaths.putIfAbsent(key, aggRet);
+      pathIndex.put(i, key);
     }
 
     return finalPaths;
@@ -114,32 +123,68 @@ public class FilePathUtils {
    * @param pathIndex
    * @return
    */
-  public static RowRecord mergeRecordByPath(RowRecord newRecord,
-                                      Map<String, Long> finalPaths,
-                                      Map<Integer, String> pathIndex) {
+  public static List<AggregateResult> mergeRecordByPath(
+          AggregationPlan plan, RowRecord newRecord, Map<String, AggregateResult> finalPaths,
+          Map<Integer, String> pathIndex) {
     if (newRecord.getFields().size() < finalPaths.size()) {
       return null;
     }
+    List<AggregateResult> aggregateResultList = new ArrayList<>();
+    for (int i = 0; i < newRecord.getFields().size(); i++) {
+      TSDataType dataType = plan.getDeduplicatedDataTypes().get(i);
+      AggregateResult aggRet = AggregateResultFactory.getAggrResultByName(
+              plan.getAggregations().get(i), dataType);
+      switch (dataType) {
+        case TEXT:
+          aggRet.setBinaryValue(newRecord.getFields().get(i).getBinaryV());
+          break;
+        case INT32:
+          aggRet.setIntValue(newRecord.getFields().get(i).getIntV());
+          break;
+        case INT64:
+          aggRet.setLongValue(newRecord.getFields().get(i).getLongV());
+          break;
+        case FLOAT:
+          aggRet.setFloatValue(newRecord.getFields().get(i).getFloatV());
+          break;
+        case DOUBLE:
+          aggRet.setDoubleValue(newRecord.getFields().get(i).getDoubleV());
+          break;
+        case BOOLEAN:
+          aggRet.setBooleanValue(newRecord.getFields().get(i).getBoolV());
+          break;
+        default:
+          throw new UnSupportedDataTypeException(dataType.toString());
+      }
+      aggregateResultList.add(aggRet);
+    }
+    return mergeRecordByPath(aggregateResultList, finalPaths, pathIndex);
+  }
 
-    // reset final paths
-    for (Map.Entry<String, Long> entry : finalPaths.entrySet()) {
-      entry.setValue(0L);
+  public static List<AggregateResult> mergeRecordByPath(
+          List<AggregateResult> aggResults, Map<String, AggregateResult> finalPaths,
+          Map<Integer, String> pathIndex) {
+    if (aggResults.size() < finalPaths.size()) {
+      return null;
     }
 
-    RowRecord tmpRecord = new RowRecord(newRecord.getTimestamp());
-
-    for (int i = 0; i < newRecord.getFields().size(); i++) {
-      if (newRecord.getFields().get(i) != null) {
-        finalPaths.put(pathIndex.get(i),
-          finalPaths.get(pathIndex.get(i)) + newRecord.getFields().get(i).getLongV());
+    List<AggregateResult> resultSet = new ArrayList<>();
+    for (int i = 0; i < aggResults.size(); i++) {
+      if (aggResults.get(i) != null) {
+        AggregateResult tempAggResult = finalPaths.get(pathIndex.get(i));
+        if (tempAggResult == null) {
+          finalPaths.put(pathIndex.get(i), aggResults.get(i));
+        } else {
+          tempAggResult.merge(aggResults.get(i));
+          finalPaths.put(pathIndex.get(i), tempAggResult);
+        }
       }
     }
 
-    for (Map.Entry<String, Long> entry : finalPaths.entrySet()) {
-      tmpRecord.addField(Field.getField(entry.getValue(), TSDataType.INT64));
+    for (Map.Entry<String, AggregateResult> entry : finalPaths.entrySet()) {
+      resultSet.add(entry.getValue());
     }
-
-    return tmpRecord;
+    return resultSet;
   }
 
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.utils;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -35,7 +36,6 @@ import org.apache.iotdb.db.query.factory.AggregateResultFactory;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.read.common.Field;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
 
 public class FilePathUtils {
@@ -127,7 +127,7 @@ public class FilePathUtils {
           AggregationPlan plan, RowRecord newRecord, Map<String, AggregateResult> finalPaths,
           Map<Integer, String> pathIndex) {
     if (newRecord.getFields().size() < finalPaths.size()) {
-      return null;
+      return Collections.emptyList();
     }
     List<AggregateResult> aggregateResultList = new ArrayList<>();
     for (int i = 0; i < newRecord.getFields().size(); i++) {
@@ -165,7 +165,7 @@ public class FilePathUtils {
           List<AggregateResult> aggResults, Map<String, AggregateResult> finalPaths,
           Map<Integer, String> pathIndex) {
     if (aggResults.size() < finalPaths.size()) {
-      return null;
+      return Collections.emptyList();
     }
     for (Map.Entry<String, AggregateResult> entry : finalPaths.entrySet()) {
       entry.getValue().reset();

--- a/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
@@ -131,32 +131,37 @@ public class FilePathUtils {
     }
     List<AggregateResult> aggregateResultList = new ArrayList<>();
     for (int i = 0; i < newRecord.getFields().size(); i++) {
-      TSDataType dataType = newRecord.getFields().get(i).getDataType();
-      AggregateResult aggRet = AggregateResultFactory.getAggrResultByName(
-              plan.getAggregations().get(i), dataType);
-      switch (dataType) {
-        case TEXT:
-          aggRet.setBinaryValue(newRecord.getFields().get(i).getBinaryV());
-          break;
-        case INT32:
-          aggRet.setIntValue(newRecord.getFields().get(i).getIntV());
-          break;
-        case INT64:
-          aggRet.setLongValue(newRecord.getFields().get(i).getLongV());
-          break;
-        case FLOAT:
-          aggRet.setFloatValue(newRecord.getFields().get(i).getFloatV());
-          break;
-        case DOUBLE:
-          aggRet.setDoubleValue(newRecord.getFields().get(i).getDoubleV());
-          break;
-        case BOOLEAN:
-          aggRet.setBooleanValue(newRecord.getFields().get(i).getBoolV());
-          break;
-        default:
-          throw new UnSupportedDataTypeException(dataType.toString());
+      if (newRecord.getFields().get(i) == null) {
+        aggregateResultList.add(AggregateResultFactory.getAggrResultByName(
+            plan.getAggregations().get(i), plan.getDeduplicatedDataTypes().get(i)));
+      } else {
+        TSDataType dataType = newRecord.getFields().get(i).getDataType();
+        AggregateResult aggRet = AggregateResultFactory.getAggrResultByName(
+            plan.getAggregations().get(i), dataType);
+        switch (dataType) {
+          case TEXT:
+            aggRet.setBinaryValue(newRecord.getFields().get(i).getBinaryV());
+            break;
+          case INT32:
+            aggRet.setIntValue(newRecord.getFields().get(i).getIntV());
+            break;
+          case INT64:
+            aggRet.setLongValue(newRecord.getFields().get(i).getLongV());
+            break;
+          case FLOAT:
+            aggRet.setFloatValue(newRecord.getFields().get(i).getFloatV());
+            break;
+          case DOUBLE:
+            aggRet.setDoubleValue(newRecord.getFields().get(i).getDoubleV());
+            break;
+          case BOOLEAN:
+            aggRet.setBooleanValue(newRecord.getFields().get(i).getBoolV());
+            break;
+          default:
+            throw new UnSupportedDataTypeException(dataType.toString());
+        }
+        aggregateResultList.add(aggRet);
       }
-      aggregateResultList.add(aggRet);
     }
     return mergeRecordByPath(aggregateResultList, finalPaths, pathIndex);
   }

--- a/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
@@ -168,7 +168,7 @@ public class FilePathUtils {
       return Collections.emptyList();
     }
     for (Map.Entry<String, AggregateResult> entry : finalPaths.entrySet()) {
-      entry.getValue().reset();
+      finalPaths.put(entry.getKey(), null);
     }
 
     List<AggregateResult> resultSet = new ArrayList<>();

--- a/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
@@ -131,7 +131,7 @@ public class FilePathUtils {
     }
     List<AggregateResult> aggregateResultList = new ArrayList<>();
     for (int i = 0; i < newRecord.getFields().size(); i++) {
-      TSDataType dataType = plan.getDeduplicatedDataTypes().get(i);
+      TSDataType dataType = newRecord.getFields().get(i).getDataType();
       AggregateResult aggRet = AggregateResultFactory.getAggrResultByName(
               plan.getAggregations().get(i), dataType);
       switch (dataType) {
@@ -166,6 +166,9 @@ public class FilePathUtils {
           Map<Integer, String> pathIndex) {
     if (aggResults.size() < finalPaths.size()) {
       return null;
+    }
+    for (Map.Entry<String, AggregateResult> entry : finalPaths.entrySet()) {
+      entry.getValue().reset();
     }
 
     List<AggregateResult> resultSet = new ArrayList<>();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAggregationByLevel.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAggregationByLevel.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import org.apache.iotdb.db.qp.Planner;
+import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IoTDBAggregationByLevel {
+  private Planner processor = new Planner();
+  private static final String[] dataSet = new String[]{
+      "SET STORAGE GROUP TO root.sg1",
+      "SET STORAGE GROUP TO root.sg2",
+      "CREATE TIMESERIES root.sg1.d1.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
+      "CREATE TIMESERIES root.sg1.d1.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN",
+      "CREATE TIMESERIES root.sg1.d2.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
+      "CREATE TIMESERIES root.sg1.d2.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN",
+
+      "CREATE TIMESERIES root.sg2.d1.status WITH DATATYPE=INT32, ENCODING=PLAIN",
+      "CREATE TIMESERIES root.sg2.d1.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN",
+      "CREATE TIMESERIES root.sg2.d2.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN",
+
+      "INSERT INTO root.sg1.d1(timestamp,status) values(150,true)",
+      "INSERT INTO root.sg1.d1(timestamp,status,temperature) values(200,false,20.71)",
+      "INSERT INTO root.sg1.d1(timestamp,status,temperature) values(600,false,71.12)",
+      "INSERT INTO root.sg1.d2(timestamp,status,temperature) values(200,false,42.66)",
+      "INSERT INTO root.sg1.d2(timestamp,status,temperature) values(300,false,46.77)",
+      "INSERT INTO root.sg1.d2(timestamp,status,temperature) values(700,true,62.15)",
+
+      "INSERT INTO root.sg2.d1(timestamp,status,temperature) values(100,3,88.24)",
+      "INSERT INTO root.sg2.d1(timestamp,status,temperature) values(500,5,125.5)",
+      "INSERT INTO root.sg2.d2(timestamp,temperature) values(200,105.5)",
+      "INSERT INTO root.sg2.d2(timestamp,temperature) values(800,61.22)",
+  };
+
+  private static final String TIMESTAMP_STR = "Time";
+  private static final double DOUBLE_PRECISION = 0.001d;
+
+  @Before
+  public void setUp() throws Exception {
+    EnvironmentUtils.closeStatMonitor();
+    EnvironmentUtils.envSetUp();
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    prepareData();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void sumFuncGroupByLevelTest() throws Exception {
+    double[] retArray = new double[]{
+        243.410d,
+        380.460d,
+        623.870d,
+    };
+    try (Connection connection = DriverManager.
+        getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("select sum(temperature) from root.sg1.* GROUP BY level=1");
+
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1);
+          Assert.assertEquals(retArray[cnt], Double.parseDouble(ans), DOUBLE_PRECISION);
+          cnt++;
+        }
+      }
+
+      statement.execute("select sum(temperature) from root.sg2.* GROUP BY level=1");
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1);
+          Assert.assertEquals(retArray[cnt], Double.parseDouble(ans), DOUBLE_PRECISION);
+          cnt++;
+        }
+      }
+
+      statement.execute("select sum(temperature) from root.*.* GROUP BY level=0");
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1);
+          Assert.assertEquals(retArray[cnt], Double.parseDouble(ans), DOUBLE_PRECISION);
+          cnt++;
+        }
+      }
+      Assert.assertEquals(retArray.length, cnt);
+    }
+
+  }
+
+  @Test
+  public void avgFuncGroupByLevelTest() throws Exception {
+    double[] retArray = new double[]{
+        48.682d,
+        95.115d,
+        69.319d,
+    };
+    try (Connection connection = DriverManager.
+        getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("select avg(temperature) from root.sg1.* GROUP BY level=1");
+
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1);
+          Assert.assertEquals(retArray[cnt], Double.parseDouble(ans), DOUBLE_PRECISION);
+          cnt++;
+        }
+      }
+
+      statement.execute("select avg(temperature) from root.sg2.* GROUP BY level=1");
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1);
+          Assert.assertEquals(retArray[cnt], Double.parseDouble(ans), DOUBLE_PRECISION);
+          cnt++;
+        }
+      }
+
+      statement.execute("select avg(temperature) from root.*.* GROUP BY level=0");
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1);
+          Assert.assertEquals(retArray[cnt], Double.parseDouble(ans), DOUBLE_PRECISION);
+          cnt++;
+        }
+      }
+      Assert.assertEquals(retArray.length, cnt);
+    }
+
+  }
+
+  @Test
+  public void timeFuncGroupByLevelTest() throws Exception {
+    String[] retArray = new String[]{
+        "100",
+        "600,700",
+    };
+    try (Connection connection = DriverManager.
+        getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("select min_time(temperature) from root.*.* GROUP BY level=0");
+
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+      }
+
+      statement.execute("select max_time(status) from root.sg1.* GROUP BY level=2");
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1) + "," +
+              resultSet.getString(2);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+      }
+      Assert.assertEquals(retArray.length, cnt);
+    }
+
+  }
+
+  @Test
+  public void valueFuncGroupByLevelTest() throws Exception {
+    String[] retArray = new String[]{
+        "61.22",
+        "71.12,62.15",
+    };
+    try (Connection connection = DriverManager.
+        getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("select last_value(temperature) from root.*.* GROUP BY level=0");
+
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+      }
+
+      statement.execute("select max_value(temperature) from root.sg1.* GROUP BY level=2");
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1) + "," +
+              resultSet.getString(2);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+      }
+      Assert.assertEquals(retArray.length, cnt);
+    }
+
+  }
+
+  @Test
+  public void mismatchedFuncGroupByLevelTest() throws Exception {
+    String[] retArray = new String[]{
+        "true",
+        "3",
+    };
+    try (Connection connection = DriverManager.
+        getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("select last_value(status) from root.*.* GROUP BY level=0");
+
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(1);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+      }
+
+      try {
+        processor.parseSQLToPhysicalPlan("select avg(status) from root.sg2.* GROUP BY level=1");
+      } catch (Exception e) {
+        Assert.assertEquals("Aggregate among unmatched data types", e.getMessage());
+      }
+    }
+
+  }
+
+  private void prepareData() {
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root",
+            "root");
+         Statement statement = connection.createStatement()) {
+
+      for (String sql : dataSet) {
+        statement.execute(sql);
+      }
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAggregationByLevelIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAggregationByLevelIT.java
@@ -23,7 +23,6 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import org.apache.iotdb.db.qp.Planner;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
 import org.junit.After;
@@ -31,7 +30,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class IoTDBAggregationByLevel {
+public class IoTDBAggregationByLevelIT {
   private Planner processor = new Planner();
   private static final String[] dataSet = new String[]{
       "SET STORAGE GROUP TO root.sg1",
@@ -58,7 +57,6 @@ public class IoTDBAggregationByLevel {
       "INSERT INTO root.sg2.d2(timestamp,temperature) values(800,61.22)",
   };
 
-  private static final String TIMESTAMP_STR = "Time";
   private static final double DOUBLE_PRECISION = 0.001d;
 
   @Before

--- a/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByLevelDataSetTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByLevelDataSetTest.java
@@ -155,13 +155,5 @@ public class GroupByLevelDataSetTest {
     assertTrue(dataSet.hasNext());
     assertEquals("0\t1", dataSet.next().toString());
 
-    // not count
-    try {
-      queryPlan = (QueryPlan) processor
-        .parseSQLToPhysicalPlan("select sum(s0) from root.test.* group by level=6");
-      fail();
-    } catch (Exception e) {
-      assertEquals("group by level only support count now.", e.getMessage());
-    }
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByLevelDataSetTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByLevelDataSetTest.java
@@ -130,22 +130,7 @@ public class GroupByLevelDataSetTest {
 
     assertTrue(dataSet.hasNext());
     assertEquals("0\t12\t10", dataSet.next().toString());
-
-    // with multi result
-    queryPlan = (QueryPlan) processor
-      .parseSQLToPhysicalPlan("select count(s1), count(s0) from root.test.* group by level=6");
-    dataSet = queryExecutor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
-
-    assertTrue(dataSet.hasNext());
-    assertEquals("0\t12\t12", dataSet.next().toString());
-
-    // with multi result
-    /*queryPlan = (QueryPlan) processor
-      .parseSQLToPhysicalPlan("select count(s1), count(s3) from root.test.* group by level=2");
-    dataSet = queryExecutor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
-
-    assertTrue(dataSet.hasNext());
-    assertEquals("0\t13", dataSet.next().toString());*/
+    
 
     // with double quotation mark
     queryPlan = (QueryPlan) processor

--- a/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByLevelDataSetTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByLevelDataSetTest.java
@@ -140,12 +140,12 @@ public class GroupByLevelDataSetTest {
     assertEquals("0\t12\t12", dataSet.next().toString());
 
     // with multi result
-    queryPlan = (QueryPlan) processor
+    /*queryPlan = (QueryPlan) processor
       .parseSQLToPhysicalPlan("select count(s1), count(s3) from root.test.* group by level=2");
     dataSet = queryExecutor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
 
     assertTrue(dataSet.hasNext());
-    assertEquals("0\t13", dataSet.next().toString());
+    assertEquals("0\t13", dataSet.next().toString());*/
 
     // with double quotation mark
     queryPlan = (QueryPlan) processor

--- a/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByTimeDataSetTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByTimeDataSetTest.java
@@ -160,15 +160,7 @@ public class GroupByTimeDataSetTest {
 
     assertTrue(dataSet.hasNext());
     assertEquals("0\t1", dataSet.next().toString());
-
-    // with multi result
-    queryPlan = (QueryPlan) processor
-        .parseSQLToPhysicalPlan(
-            "select count(s1), count(s1) from root.test.* group by ([0,20), 3ms, 10ms), level=6");
-    dataSet = queryExecutor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
-
-    assertTrue(dataSet.hasNext());
-    assertEquals("0\t1", dataSet.next().toString());
+    
 
     // with double quotation mark
     queryPlan = (QueryPlan) processor

--- a/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByTimeDataSetTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/dataset/GroupByTimeDataSetTest.java
@@ -181,14 +181,6 @@ public class GroupByTimeDataSetTest {
     assertTrue(dataSet.hasNext());
     assertEquals("10\t1", dataSet.next().toString());
 
-    // not count
-    try {
-      processor.parseSQLToPhysicalPlan(
-          "select sum(s0) from root.test.* group by ([0,200), 1ms), level=6");
-      fail();
-    } catch (Exception e) {
-      assertEquals("group by level only support count now.", e.getMessage());
-    }
   }
 
   @Test


### PR DESCRIPTION
This PR plans to extend the "groupby level" syntax to more aggregation functions, including sum, avg, last_value, first_value, min_time, max_time, min_value, max_value.

Pay attention that this syntax currently only supports one single aggregation function with one measurement, e.g.
```
select func(<measurement>) from <path> group by level=n
```
Adding multiple aggregation functions will be regarded as wrong syntax and rejected by the server.

For the details, please refer to the design doc: https://cwiki.apache.org/confluence/display/IOTDB/Group+by+Level
