### PR TITLE
[IOTDB-1021] [To rel/0.10] Fix NullPointerException when showing child paths of non-existent path

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -743,6 +743,9 @@ public class MTree implements Serializable {
    */
   private void findChildNodePathInNextLevel(
       MNode node, String[] nodes, int idx, String parent, Set<String> res, int length) {
+    if (node == null) {
+      return;
+    }
     String nodeReg = MetaUtils.getNodeRegByIdx(idx, nodes);
     if (!nodeReg.contains(PATH_WILDCARD)) {
       if (idx == length) {

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -371,7 +371,8 @@ public class MManagerBasicTest {
         "[root.laptop.b1.d1, root.laptop.b1.d2, root.vehicle.b1.d0, root.vehicle.b1.d2, root.vehicle.b1.d3]",
         "[root.laptop.b1.d1, root.laptop.b1.d2]",
         "[root.vehicle.b1.d0, root.vehicle.b1.d2, root.vehicle.b1.d3, root.vehicle.b2.d0]",
-        "[root.laptop.b1.d1.s0, root.laptop.b1.d1.s1, root.laptop.b1.d2.s0, root.laptop.b2.d1.s1, root.laptop.b2.d1.s3, root.laptop.b2.d2.s2]"
+        "[root.laptop.b1.d1.s0, root.laptop.b1.d1.s1, root.laptop.b1.d2.s0, root.laptop.b2.d1.s1, root.laptop.b2.d1.s3, root.laptop.b2.d2.s2]",
+        "[]"
     };
 
     try {
@@ -407,6 +408,7 @@ public class MManagerBasicTest {
       assertEquals(res[5], manager.getChildNodePathInNextLevel("root.l*.b1").toString());
       assertEquals(res[6], manager.getChildNodePathInNextLevel("root.v*.*").toString());
       assertEquals(res[7], manager.getChildNodePathInNextLevel("root.l*.b*.*").toString());
+      assertEquals(res[8], manager.getChildNodePathInNextLevel("root.laptopp").toString());
     } catch (MetadataException e) {
       e.printStackTrace();
       fail(e.getMessage());


### PR DESCRIPTION
When executing `show child paths` for non-existent path, NullPointerException may be thrown.