### PR TITLE
[IOTDB-1028] fix create a timeseries but the MAX_POINT_NUMBER is not positive integer

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
@@ -640,4 +640,47 @@ public class IoTDBSimpleQueryIT {
       Assert.assertEquals(r3.getLong(3), 10L);
     }
   }
+
+  @Test
+  public void testInvalidMaxPointNumber() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/",
+            "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("SET STORAGE GROUP TO root.sg1");
+      statement.execute("CREATE TIMESERIES root.sg1.d1.s1 with datatype=FLOAT, encoding=TS_2DIFF, "
+          + "max_point_number=4");
+      statement.execute("CREATE TIMESERIES root.sg1.d1.s2 with datatype=FLOAT, encoding=TS_2DIFF, "
+          + "max_point_number=2.5");
+      statement.execute("CREATE TIMESERIES root.sg1.d1.s3 with datatype=FLOAT, encoding=RLE, "
+          + "max_point_number=q");
+      statement.execute("CREATE TIMESERIES root.sg1.d1.s4 with datatype=FLOAT, encoding=RLE, "
+          + "max_point_number=-1");
+      statement.execute("insert into root.sg1.d1(timestamp,s1,s2,s3,s4) values(1,1.1234,1.1234,1.1234,1.1234)");
+
+      try (ResultSet r1 = statement.executeQuery("select s1 from root.sg1.d1")) {
+        r1.next();
+        Assert.assertEquals(1.1234f, r1.getFloat(2), 0);
+      }
+
+      try (ResultSet r2 = statement.executeQuery("select s3 from root.sg1.d1")) {
+        r2.next();
+        Assert.assertEquals(1.12f, r2.getFloat(2), 0);
+      }
+
+      try (ResultSet r3 = statement.executeQuery("select s3 from root.sg1.d1")) {
+        r3.next();
+        Assert.assertEquals(1.12f, r3.getFloat(2), 0);
+      }
+
+      try (ResultSet r4 = statement.executeQuery("select s4 from root.sg1.d1")) {
+        r4.next();
+        Assert.assertEquals(1.12f, r4.getFloat(2), 0);
+      }
+
+    } catch (SQLException e) {
+      fail();
+    }
+  }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/TSEncodingBuilder.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/TSEncodingBuilder.java
@@ -158,7 +158,12 @@ public abstract class TSEncodingBuilder {
       if (props == null || !props.containsKey(Encoder.MAX_POINT_NUMBER)) {
         maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
       } else {
-        maxPointNumber = Integer.valueOf(props.get(Encoder.MAX_POINT_NUMBER));
+        try {
+          this.maxPointNumber = Integer.parseInt(props.get(Encoder.MAX_POINT_NUMBER));
+        } catch (NumberFormatException e) {
+          logger.warn("The format of max point number {} is not correct."
+              + " Using default float precision.", props.get(Encoder.MAX_POINT_NUMBER));
+        }
         if (maxPointNumber < 0) {
           maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
           logger
@@ -206,7 +211,12 @@ public abstract class TSEncodingBuilder {
       if (props == null || !props.containsKey(Encoder.MAX_POINT_NUMBER)) {
         maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
       } else {
-        maxPointNumber = Integer.valueOf(props.get(Encoder.MAX_POINT_NUMBER));
+        try {
+          this.maxPointNumber = Integer.parseInt(props.get(Encoder.MAX_POINT_NUMBER));
+        } catch (NumberFormatException e) {
+          logger.warn("The format of max point number {} is not correct."
+              + " Using default float precision.", props.get(Encoder.MAX_POINT_NUMBER));
+        }
         if (maxPointNumber < 0) {
           maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
           logger


### PR DESCRIPTION
Using default float precision when max_point_number is invalid.