### PR TITLE
[IOTDB-1034] Show timeseries error in Chinese on Windows

### DIFF
--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.rpc;
 
+import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -415,7 +416,11 @@ public class IoTDBRpcDataSet {
       case DOUBLE:
         return String.valueOf(BytesUtils.bytesToDouble(values[index]));
       case TEXT:
-        return new String(values[index]);
+        try {
+          return new String(values[index], "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+          return new String(values[index]);
+        }
       default:
         return null;
     }


### PR DESCRIPTION
Change the charset of Windows console to UTF-8 does not fix the problem, since the column header is wrong again...
We'd better unify the charset to "UTF-8" instead of letting it depend on the platform.