### PR TITLE
Fix TsfileResource serialize bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -265,7 +265,7 @@ public class TsFileResource {
     Arrays.fill(times, defaultTime);
   }
 
-  public void serialize() throws IOException {
+  public synchronized void serialize() throws IOException {
     try (OutputStream outputStream = fsFactory.getBufferedOutputStream(
         file + RESOURCE_SUFFIX + TEMP_SUFFIX)) {
       ReadWriteIOUtils.write(this.deviceToIndex.size(), outputStream);


### PR DESCRIPTION
Currently delete data in files and merge will serialize tsfile resource concurrently. We need synchronize to protect it.