### PR TITLE
e2e: add a simple E2E case and set up the workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,27 +17,5 @@
 # under the License.
 #
 
-# docker build context is the root path of the repository
-
-FROM openjdk:11-jre-slim
-
-ADD distribution/target/apache-iotdb-*-bin.zip /
-
-RUN apt update \
-  && apt install lsof procps unzip -y \
-  && unzip /apache-iotdb-*-bin.zip -d / \
-  && rm /apache-iotdb-*-bin.zip \
-  && mv /apache-iotdb-* /iotdb \
-  && apt remove unzip -y \
-  && apt autoremove -y \
-  && apt purge --auto-remove -y \
-  && apt clean -y
-
-EXPOSE 6667
-EXPOSE 31999
-EXPOSE 5555
-EXPOSE 8181
-VOLUME /iotdb/data
-VOLUME /iotdb/logs
-ENV PATH="/iotdb/sbin/:/iotdb/tools/:${PATH}"
-ENTRYPOINT ["/iotdb/sbin/start-server.sh"]
+*
+!distribution

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ on:
       - 'docs/**'
         
 jobs:
-  E2E Test:
+  E2E:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,8 +45,8 @@ jobs:
           docker images
 
       - name: Run Test Case ${{ matrix.case }}
-        run: test/e2e/cases/${{ matrix.case }}/run.sh
+        run: bash test/e2e/cases/${{ matrix.case }}/run.sh
 
       - name: Clean Up
         if: ${{ always() }}
-        run: test/e2e/cases/${{ matrix.case }}/cleanup.sh
+        run: bash test/e2e/cases/${{ matrix.case }}/cleanup.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,5 +48,5 @@ jobs:
         run: test/e2e/cases/${{ matrix.case }}/run.sh
 
       - name: Clean Up
-        if: always
+        if: ${{ always() }}
         run: test/e2e/cases/${{ matrix.case }}/cleanup.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: true
+      matrix:
+        case:
+          - cli
     steps:
       - uses: actions/checkout@v2
 
@@ -40,5 +44,9 @@ jobs:
           docker build . -f docker/src/main/Dockerfile -t "iotdb:$GITHUB_SHA"
           docker images
 
-      - name: Run E2E Tests
-        run: echo "TODO"
+      - name: Run Test Case ${{ matrix.case }}
+        run: test/e2e/cases/${{ matrix.case }}/run.sh
+
+      - name: Clean Up
+        if: always
+        run: test/e2e/cases/${{ matrix.case }}/cleanup.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ on:
       - 'docs/**'
         
 jobs:
-  build:
+  E2E Test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,44 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: E2E Tests
+
+on:
+  push:
+    branches: 
+      - master
+      - 'rel/*'
+      - test/e2e
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    branches: 
+      - master
+      - 'rel/*'
+      - cluster_new
+    paths-ignore:
+      - 'docs/**'
+        
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build Distribution Zip
+        run: ./mvnw.sh -B -DskipTests clean package
+
+      - name: Build Docker Image
+        run: |
+          docker build . -f docker/src/main/Dockerfile -t "iotdb:$GITHUB_SHA"
+          docker images
+
+      - name: Run E2E Tests
+        run: echo "TODO"

--- a/test/e2e/base/docker-compose.yaml
+++ b/test/e2e/base/docker-compose.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+version: '3.8'
+
+services:
+  server-prototype:
+    build:
+      context: ../../..
+      dockerfile: docker/src/main/Dockerfile
+    ports:
+      - 6667:6667
+    networks:
+      iotdb:
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/6667" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  initializer:
+    build:
+      context: ../../..
+      dockerfile: docker/src/main/Dockerfile
+    networks:
+      iotdb:
+    entrypoint:
+      - bash
+      - -c
+      - |
+        cat /res/init.sql | xargs -I {} /iotdb/sbin/start-cli.sh -h server -e {}
+        echo "Ready to Run IoTDB E2E Tests"
+
+networks:
+  iotdb:

--- a/test/e2e/base/docker-compose.yaml
+++ b/test/e2e/base/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
       - bash
       - -c
       - |
-        cat /res/init.sql | xargs -I {} /iotdb/sbin/start-cli.sh -h server -e {}
+        cat /res/init.sql | grep -v '^--' | xargs -I {} /iotdb/sbin/start-cli.sh -h server -e {}
         echo "Ready to Run IoTDB E2E Tests"
 
 networks:

--- a/test/e2e/cases/README.md
+++ b/test/e2e/cases/README.md
@@ -1,0 +1,53 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# IoTDB E2E tests cases
+
+Test cases are organized into sub-directories, each of which contains the following files:
+
+* `run.sh`: the entry of the test case.
+* `cleanup.sh`: a cleanup script to clean up resources that are created during the test.
+* `res`: resources files that will be mounted into the container(s) and be used there.
+* `docker-compose.yaml`: orchestrates the services used in the test process.
+* `README.md` (Optional): docs or notes when running this case manually.
+
+any other additional files are completely acceptable here, for example, when building
+a case to test the JDBC SDK, the files structure may be something like:
+
+```text
+.
+├── README.md
+├── cleanup.sh
+├── docker-compose.yaml
+├── app      <------- Java application that uses JDBC SDK to communicate with IoTDB
+│   ├── pom.xml
+│   ├── src
+│   │   ├── main
+│   │   │   └── java
+│   │   └── test
+│   │       └── java
+│   └── src
+│       ├── main
+│       └── test
+├── res
+│   └── init.sql
+└── run.sh
+```

--- a/test/e2e/cases/cli/README.md
+++ b/test/e2e/cases/cli/README.md
@@ -1,0 +1,24 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# Standalone Server Test
+
+The simplest test case that starts up an IoTDB server and verifies that the CLI works.

--- a/test/e2e/cases/cli/cleanup.sh
+++ b/test/e2e/cases/cli/cleanup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -x
+
+cd "$(dirname "$0")" || exit 1
+
+docker-compose down
+
+cd - || exit 1

--- a/test/e2e/cases/cli/docker-compose.yaml
+++ b/test/e2e/cases/cli/docker-compose.yaml
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+version: '3.8'
+
+services:
+  server:
+    extends:
+      file: ../../base/docker-compose.yaml
+      service: server-prototype
+    volumes:
+      - ./res:/resources
+
+  initializer:
+    extends:
+      service: initializer
+      file: ../../base/docker-compose.yaml
+    volumes:
+      - ./res:/res:ro
+    depends_on:
+      server:
+        condition: service_healthy
+
+networks:
+  iotdb:

--- a/test/e2e/cases/cli/res/init.sql
+++ b/test/e2e/cases/cli/res/init.sql
@@ -1,0 +1,7 @@
+SET STORAGE GROUP TO root.ln;
+SHOW STORAGE GROUP;
+
+CREATE TIMESERIES root.ln.wf01.wt01.temperature WITH DATATYPE=FLOAT, ENCODING=PLAIN;
+
+INSERT INTO root.ln.wf01.wt01(timestamp,temperature) values(100, 16);
+INSERT INTO root.ln.wf01.wt01(timestamp,temperature) values(200, 26);

--- a/test/e2e/cases/cli/res/init.sql
+++ b/test/e2e/cases/cli/res/init.sql
@@ -1,3 +1,22 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
 SET STORAGE GROUP TO root.ln;
 SHOW STORAGE GROUP;
 

--- a/test/e2e/cases/cli/run.sh
+++ b/test/e2e/cases/cli/run.sh
@@ -37,8 +37,6 @@ while ! docker-compose logs | grep -c 'Ready to Run IoTDB E2E Tests' > /dev/null
   attempts=$((attempts+1))
 done
 
-cd -
-
 results=$(docker-compose exec server /iotdb/sbin/start-cli.sh -e 'SELECT temperature FROM root.ln.wf01.wt01')
 
 if [[ $results != *"Total line number = 2"* ]]; then
@@ -46,3 +44,5 @@ if [[ $results != *"Total line number = 2"* ]]; then
   echo "$results"
   exit 1
 fi
+
+cd -

--- a/test/e2e/cases/cli/run.sh
+++ b/test/e2e/cases/cli/run.sh
@@ -37,7 +37,7 @@ while ! docker-compose logs | grep -c 'Ready to Run IoTDB E2E Tests' > /dev/null
   attempts=$((attempts+1))
 done
 
-results=$(docker-compose exec server /iotdb/sbin/start-cli.sh -e 'SELECT temperature FROM root.ln.wf01.wt01')
+results=$(docker-compose exec -T server /iotdb/sbin/start-cli.sh -e 'SELECT temperature FROM root.ln.wf01.wt01')
 
 if [[ $results != *"Total line number = 2"* ]]; then
   echo "Total line number should be 2"

--- a/test/e2e/cases/cli/run.sh
+++ b/test/e2e/cases/cli/run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+cd "$(dirname "$0")"
+
+docker-compose up -d
+
+max_attempts=10
+attempts=1
+
+while ! docker-compose logs | grep -c 'Ready to Run IoTDB E2E Tests' > /dev/null 2>&1; do
+  if [[ $attempts -gt $max_attempts ]]; then
+    echo "Preparation is not ready after $max_attempts attempts, will exit now"
+    exit 1
+  fi
+  echo "Preparation is not ready yet, retrying ($attempts/$max_attempts)"
+  sleep 3
+  attempts=$((attempts+1))
+done
+
+cd -
+
+results=$(docker-compose exec server /iotdb/sbin/start-cli.sh -e 'SELECT temperature FROM root.ln.wf01.wt01')
+
+if [[ $results != *"Total line number = 2"* ]]; then
+  echo "Total line number should be 2"
+  echo "$results"
+  exit 1
+fi


### PR DESCRIPTION
To enable building an image from the `master` branch on the fly, this patch rewrites the `Dockerfile` that was not able to build a docker image, and sets up an workflow yaml file for future E2E tests.

The result can be found [here](https://github.com/kezhenxu94/iotdb/runs/1486877542?check_suite_focus=true).

> P.S. Seems some of the docs links are staled and 404 now