### PR TITLE
fix insert partial tablet with binary NullPointer bug

### DIFF
--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
@@ -111,11 +111,11 @@ public class IoTDBSessionSimpleIT {
     schemaList.add(new MeasurementSchema("s2", TSDataType.DOUBLE));
     schemaList.add(new MeasurementSchema("s3", TSDataType.TEXT));
 
-    Tablet tablet = new Tablet("root.sg.d", schemaList, 100);
+    Tablet tablet = new Tablet("root.sg.d", schemaList, 10);
 
     long timestamp = System.currentTimeMillis();
 
-    for (long row = 0; row < 10; row++) {
+    for (long row = 0; row < 15; row++) {
       int rowIndex = tablet.rowSize++;
       tablet.addTimestamp(rowIndex, timestamp);
       tablet.addValue("s1", rowIndex, 1L);
@@ -136,9 +136,9 @@ public class IoTDBSessionSimpleIT {
     SessionDataSet dataSet = session.executeQueryStatement("select count(*) from root");
     while (dataSet.hasNext()) {
       RowRecord rowRecord = dataSet.next();
-      Assert.assertEquals(10L, rowRecord.getFields().get(0).getLongV());
-      Assert.assertEquals(10L, rowRecord.getFields().get(1).getLongV());
-      Assert.assertEquals(10L, rowRecord.getFields().get(2).getLongV());
+      Assert.assertEquals(15L, rowRecord.getFields().get(0).getLongV());
+      Assert.assertEquals(15L, rowRecord.getFields().get(1).getLongV());
+      Assert.assertEquals(15L, rowRecord.getFields().get(2).getLongV());
     }
     session.close();
   }

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -43,6 +44,10 @@ import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.common.RowRecord;
+import org.apache.iotdb.tsfile.utils.Binary;
+import org.apache.iotdb.tsfile.write.record.Tablet;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -93,6 +98,49 @@ public class IoTDBSessionSimpleIT {
       i++;
     }
 
+    session.close();
+  }
+
+  @Test
+  public void testInsertPartialTablet()
+      throws IoTDBConnectionException, StatementExecutionException {
+    session = new Session("127.0.0.1", 6667, "root", "root");
+    session.open();
+
+    List<MeasurementSchema> schemaList = new ArrayList<>();
+    schemaList.add(new MeasurementSchema("s1", TSDataType.INT64));
+    schemaList.add(new MeasurementSchema("s2", TSDataType.DOUBLE));
+    schemaList.add(new MeasurementSchema("s3", TSDataType.TEXT));
+
+    Tablet tablet = new Tablet("root.sg.d", schemaList, 100);
+
+    long timestamp = System.currentTimeMillis();
+
+    for (long row = 0; row < 10; row++) {
+      int rowIndex = tablet.rowSize++;
+      tablet.addTimestamp(rowIndex, timestamp);
+      tablet.addValue("s1", rowIndex, 1L);
+      tablet.addValue("s2", rowIndex, 1D);
+      tablet.addValue("s3", rowIndex, new Binary("1"));
+      if (tablet.rowSize == tablet.getMaxRowNumber()) {
+        session.insertTablet(tablet, true);
+        tablet.reset();
+      }
+      timestamp++;
+    }
+
+    if (tablet.rowSize != 0) {
+      session.insertTablet(tablet);
+      tablet.reset();
+    }
+
+    SessionDataSet dataSet = session.executeQueryStatement("select count(*) from root");
+    while (dataSet.hasNext()) {
+      RowRecord rowRecord = dataSet.next();
+      Assert.assertEquals(10L, rowRecord.getFields().get(0).getLongV());
+      Assert.assertEquals(10L, rowRecord.getFields().get(1).getLongV());
+      Assert.assertEquals(10L, rowRecord.getFields().get(2).getLongV());
+    }
     session.close();
   }
 

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
@@ -235,8 +235,9 @@ public class Tablet {
           break;
         case TEXT:
           valueOccupation += rowSize * 4;
-          for (Binary value : (Binary[]) values[i]) {
-            valueOccupation += value.getLength();
+          Binary[] binaries = (Binary[]) values[i];
+          for (int rowIndex = 0; rowIndex < rowSize; rowIndex++) {
+            valueOccupation += binaries[rowIndex].getLength();
           }
           break;
         default:


### PR DESCRIPTION
When using insertTablet, we create a Binary[100], then insert 10 values.
The getValueBytesSize do not use the rowCount 10 when calculating the size.

#2179 