### PR TITLE
fix flink iotdb example for writing data with incorrect data types

### DIFF
--- a/example/flink/pom.xml
+++ b/example/flink/pom.xml
@@ -54,5 +54,10 @@
             <artifactId>flink-tsfile-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_${scala.library.version}</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/example/flink/pom.xml
+++ b/example/flink/pom.xml
@@ -58,6 +58,26 @@
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients_${scala.library.version}</artifactId>
             <version>${flink.version}</version>
+            <exclusions>
+                <!-- hive-serde 2.8.4 uses orc-core 1.3.2,
+                which is under incompatible license. So, exclude it.-->
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-storage-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.assembly.version>3.1.0</maven.assembly.version>
+        <scala.library.version>2.11</scala.library.version>
         <scala.version>2.11.12</scala.version>
         <hadoop2.version>2.7.3</hadoop2.version>
         <hive2.version>2.3.6</hive2.version>


### PR DESCRIPTION
1. in master, flink-iotdb-sink registers a series with TEXT data type but write Double...
2. To run flink-iotdb-sink example on IDEA, the following dependency is needed:
```
        <dependency>
            <groupId>org.apache.flink</groupId>
            <artifactId>flink-clients_${scala.library.version}</artifactId>
            <version>${flink.version}</version>
        </dependency>
``` 