### PR TITLE
[Distributed] fix session cache leader interface and docs

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/partition/PartitionTable.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/partition/PartitionTable.java
@@ -31,8 +31,7 @@ import org.apache.iotdb.db.service.IoTDB;
 
 /**
  * PartitionTable manages the map whose key is the StorageGroupName with a time interval and the
- * value is a PartitionGroup with contains all nodes that manage the corresponding data.
- * currently, we do not support auto-create storage group in the cluster mode.
+ * value is a PartitionGroup witch contains all nodes that manage the corresponding data.
  */
 public interface PartitionTable {
 

--- a/docs/UserGuide/Client/Programming - Native API.md
+++ b/docs/UserGuide/Client/Programming - Native API.md
@@ -407,4 +407,12 @@ Create multiple timeseries with a single method. Users can provide props, tags, 
 ```
 boolean checkTimeseriesExists(String path)
 ```
+
 Add a method to check whether the specific timeseries exists.
+
+```
+public Session(String host, int rpcPort, String username, String password,
+      boolean isEnableCacheLeader)
+```
+
+Open a session and specifies whether the Leader cache is enabled. Note that this interface improves performance for distributed IoTDB, but adds less cost to the client for stand-alone IoTDB.

--- a/docs/UserGuide/Server/Cluster Setup.md
+++ b/docs/UserGuide/Server/Cluster Setup.md
@@ -74,7 +74,7 @@ When both exist, the specified configuration item will overwrite the configurati
 ```
 
 Note: The distributed version uses the 707 identifier to instruct the client to do the appropriate metadata cache so that the data can then be sent directly to the leader of the corresponding data group later.
-Therefore, it is recommended to re-install `mvn install -pl jdbc -am -Dmaven.test.skip=true` and `mvn install -pl jdbc -am -Dmaven.test.skip=true` on current branch to update the latest client.
+Therefore, it is recommended to re-install `mvn package -pl jdbc -am -DskipTests` and `mvn package -pl session -am -DskipTests` on current branch to update the latest client.
 
 ## OverWrite the configurations of Stand-alone node
 

--- a/docs/zh/UserGuide/Client/Programming - Native API.md
+++ b/docs/zh/UserGuide/Client/Programming - Native API.md
@@ -396,4 +396,12 @@ void createMultiTimeseries(List<String> paths, List<TSDataType> dataTypes, List<
 ```
 boolean checkTimeseriesExists(String path)
 ```
+
 用于检测时间序列是否存在
+
+```
+public Session(String host, int rpcPort, String username, String password,
+      boolean isEnableCacheLeader)
+```
+
+开启一个session，并指定是否启用leader缓存。注意此接口对于分布式写入能够提高性能，但对于单机版写入反而会给客户端增加较少的消耗。

--- a/docs/zh/UserGuide/Server/Cluster Setup.md
+++ b/docs/zh/UserGuide/Server/Cluster Setup.md
@@ -68,8 +68,8 @@ or
 > nohup cluster\target\cluster-0.11.0-SNAPSHOT2\sbin\start-node.bat  -internal_meta_port 9007 -internal_data_port 40014 -cluster_rpc_port 55562
 ```
 
-注：分布式版使用了707标识符来指示客户端做相应的元数据缓存以便之后能够直接将数据发送给对应数据组的 leader。因此建议在当前分支重新 `mvn install -pl jdbc -am -Dmaven.test.skip=true` 和
-`mvn install -pl session -am -Dmaven.test.skip=true`以更新最新的客户端。
+注：分布式版使用了707标识符来指示客户端做相应的元数据缓存以便之后能够直接将数据发送给对应数据组的 leader。因此建议在当前分支重新 `mvn package -pl jdbc -am -DskipTests` 和
+`mvn package -pl session -am -DskipTests`以更新最新的客户端。
 
 ## 被覆盖的单机版选项
 

--- a/session/src/main/java/org/apache/iotdb/session/Config.java
+++ b/session/src/main/java/org/apache/iotdb/session/Config.java
@@ -24,7 +24,7 @@ public class Config {
   public static final String DEFAULT_PASSWORD = "root";
   public static final int DEFAULT_FETCH_SIZE = 10000;
   public static final int DEFAULT_TIMEOUT_MS = 0;
-  public static final boolean DEFAULT_CACHE_LEADER_MODE = true;
+  public static final boolean DEFAULT_CACHE_LEADER_MODE = false;
 
   public static final int RETRY_NUM = 3;
   public static final long RETRY_INTERVAL_MS = 1000;

--- a/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -75,6 +75,7 @@ public class SessionPool {
   private long timeout; //ms
   private static int FINAL_RETRY = RETRY - 1;
   private boolean enableCompression = false;
+  private boolean enableCacheLeader = false;
   private ZoneId zoneId;
 
   private boolean closed;//whether the queue is closed.
@@ -134,7 +135,7 @@ public class SessionPool {
         if (logger.isDebugEnabled()) {
           logger.debug("Create a new Session {}, {}, {}, {}", ip, port, user, password);
         }
-        session = new Session(ip, port, user, password, fetchSize, zoneId);
+        session = new Session(ip, port, user, password, fetchSize, zoneId, enableCacheLeader);
         try {
           session.open(enableCompression);
           //avoid someone has called close() the session pool


### PR DESCRIPTION
As cluster_new is closing to merge into master, It is better not to open the leader cache by default and give an parameter interface for distributed IoTDB, otherwise it will cause unnecessary performance waste to the stand-alone IoTDB.