### PR TITLE
[IOTDB-1040]【rel/0.11】fix when one row failed, then insertRecords() does not clear the failed messages

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -1253,9 +1253,10 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     }
 
     List<TSStatus> statusList = new ArrayList<>();
-    InsertRowPlan plan = new InsertRowPlan();
+
     for (int i = 0; i < req.deviceIds.size(); i++) {
       try {
+        InsertRowPlan plan = new InsertRowPlan();
         plan.setDeviceId(new PartialPath(req.getDeviceIds().get(i)));
         plan.setTime(req.getTimestamps().get(i));
         plan.setMeasurements(req.getMeasurementsList().get(i).toArray(new String[0]));


### PR DESCRIPTION
In `insertRecords()`,

if one Row has some failed measurements, then the `failedMeasurements` field is not cleaned, which leads to the info is broadcast to the next Row...