### PR TITLE
fix bug that when rpc compression = true, sync client does not use compression mode

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
@@ -74,6 +74,7 @@ import org.apache.iotdb.service.sync.thrift.SyncStatus;
 import org.apache.iotdb.tsfile.utils.BytesUtils;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TFastFramedTransport;
 import org.apache.thrift.transport.TSocket;
@@ -274,7 +275,12 @@ public class SyncClient implements ISyncClient {
   @Override
   public void establishConnection(String serverIp, int serverPort) throws SyncConnectionException {
     transport = new TFastFramedTransport(new TSocket(serverIp, serverPort, TIMEOUT_MS));
-    TProtocol protocol = new TBinaryProtocol(transport);
+    TProtocol protocol = null;
+    if (IoTDBDescriptor.getInstance().getConfig().isRpcThriftCompressionEnable()) {
+      protocol = new TBinaryProtocol(transport);
+    } else {
+      protocol = new TCompactProtocol(transport);
+    }
     serviceClient = new SyncService.Client(protocol);
     try {
       if (!transport.isOpen()) {


### PR DESCRIPTION
When the thrift server is initialized, the protocol is:
```
    if (compress) {
      protocolFactory = new TCompactProtocol.Factory();
    } else {
      protocolFactory = new TBinaryProtocol.Factory();
    }
```
So, the client must be the same.