### PR TITLE
[Distributed] Fix auto create schema hang

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
@@ -447,7 +447,7 @@ public class LocalQueryExecutor {
    */
   public List<String> getUnregisteredTimeseries(List<String> timeseriesList)
       throws CheckConsistencyException {
-    dataGroupMember.syncLeaderWithConsistencyCheck(false);
+    dataGroupMember.syncLeaderWithConsistencyCheck(true);
 
     List<String> result = new ArrayList<>();
     for (String seriesPath : timeseriesList) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -1468,7 +1468,7 @@ public class MetaGroupMember extends RaftMember {
         try {
           ((CMManager) IoTDB.metaManager).createSchema(plan);
           return processPartitionedPlan(plan);
-        } catch (MetadataException e) {
+        } catch (MetadataException | CheckConsistencyException e) {
           logger.error(
               String.format("Failed to set storage group or create timeseries, because %s", e));
         }
@@ -1551,7 +1551,7 @@ public class MetaGroupMember extends RaftMember {
     boolean hasCreate;
     try {
       hasCreate = ((CMManager) IoTDB.metaManager).createTimeseries(plan);
-    } catch (IllegalPathException e) {
+    } catch (IllegalPathException | CheckConsistencyException e) {
       return StatusUtils.getStatus(StatusUtils.EXECUTE_STATEMENT_ERROR, e.getMessage());
     }
     if (hasCreate) {


### PR DESCRIPTION
This bug will lead to a hang when auto creating schema in cluster module because the leader's wants to get unregistered timeseries from the header of partitiongroup, even he is the leader who is responsible to this work.