### PR TITLE
[IOTDB-1049] [rel/0.11]Fix Nullpointer exception and a delete bug in Last query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -78,6 +78,7 @@ public class LastQueryExecutor {
    *
    * @param context query context
    */
+  @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public QueryDataSet execute(QueryContext context, LastQueryPlan lastQueryPlan)
       throws StorageEngineException, IOException, QueryProcessException {
 

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -105,8 +105,12 @@ public class LastQueryExecutor {
         resultRecord.addField(pathField);
 
         Field valueField = new Field(TSDataType.TEXT);
-        valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
-        resultRecord.addField(valueField);
+        if (lastTimeValuePair.getValue() != null) {
+          valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
+          resultRecord.addField(valueField);
+        } else {
+          resultRecord.addField(null);
+        }
 
         dataSet.putRecord(resultRecord);
       }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/fill/LastPointReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/fill/LastPointReader.java
@@ -99,7 +99,8 @@ public class LastPointReader {
           FileLoaderUtils.loadTimeSeriesMetadata(
               resource, seriesPath, context, timeFilter, deviceMeasurements);
       if (timeseriesMetadata != null) {
-        if (endtimeContainedByTimeFilter(timeseriesMetadata.getStatistics())) {
+        if (!timeseriesMetadata.isModified() &&
+            endtimeContainedByTimeFilter(timeseriesMetadata.getStatistics())) {
           return constructLastPair(
               timeseriesMetadata.getStatistics().getEndTime(),
               timeseriesMetadata.getStatistics().getLastValue(),

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
@@ -44,8 +44,7 @@ import org.junit.Test;
 
 public class IoTDBLastIT {
 
-  private static String[] dataSet1 = new String[]{
-      "SET STORAGE GROUP TO root.ln.wf01.wt01",
+  private static final String[] dataSet1 = new String[]{
       "CREATE TIMESERIES root.ln.wf01.wt01.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
       "CREATE TIMESERIES root.ln.wf01.wt01.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN",
       "CREATE TIMESERIES root.ln.wf01.wt01.id WITH DATATYPE=INT32, ENCODING=PLAIN",
@@ -62,8 +61,7 @@ public class IoTDBLastIT {
       "flush",
   };
 
-  private static String[] dataSet2 = new String[]{
-      "SET STORAGE GROUP TO root.ln.wf01.wt02",
+  private static final String[] dataSet2 = new String[]{
       "CREATE TIMESERIES root.ln.wf01.wt02.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
       "CREATE TIMESERIES root.ln.wf01.wt02.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN",
       "CREATE TIMESERIES root.ln.wf01.wt02.id WITH DATATYPE=INT32, ENCODING=PLAIN",
@@ -76,8 +74,7 @@ public class IoTDBLastIT {
       "flush",
   };
 
-  private static String[] dataSet3 = new String[]{
-      "SET STORAGE GROUP TO root.ln.wf01.wt03",
+  private static final String[] dataSet3 = new String[]{
       "CREATE TIMESERIES root.ln.wf01.wt03.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
       "CREATE TIMESERIES root.ln.wf01.wt03.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN",
       "CREATE TIMESERIES root.ln.wf01.wt03.id WITH DATATYPE=INT32, ENCODING=PLAIN",
@@ -103,6 +100,30 @@ public class IoTDBLastIT {
   @After
   public void tearDown() throws Exception {
     EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void lastWithEmptySeriesTest() throws Exception {
+    String[] retArray = new String[]{
+            "root.ln.wf02.temperature,null",
+        };
+
+    try (Connection connection =
+             DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+
+      statement.execute(
+          "CREATE TIMESERIES root.ln.wf02.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN");
+      statement.execute("select last temperature from root.ln.wf02");
+
+      ResultSet resultSet = statement.getResultSet();
+      int cnt = 0;
+      while (resultSet.next()) {
+        String ans = resultSet.getString(TIMESEIRES_STR) + ","
+            + resultSet.getString(VALUE_STR);
+        Assert.assertEquals(retArray[cnt], ans);
+      }
+    }
   }
 
   @Test
@@ -255,6 +276,7 @@ public class IoTDBLastIT {
         }
       }
 
+      // Inject unsequential data
       statement.execute(
           "INSERT INTO root.ln.wf01.wt02(timestamp,temperature,status, id) values(600, 10.2, false, 6)");
       statement.execute(
@@ -309,7 +331,7 @@ public class IoTDBLastIT {
   public void lastWithEmptyChunkMetadataTest() throws SQLException, MetadataException {
     String[] retArray =
         new String[]{
-            "300,root.ln.wf01.wt03.temperature,23.1",
+            "300,root.ln.wf01.wt03.temperature,23.1"
         };
 
     try (Connection connection =
@@ -349,14 +371,13 @@ public class IoTDBLastIT {
   public void lastWithUnseqTimeLargerThanSeqTimeTest() throws SQLException, MetadataException {
     String[] retArray =
         new String[]{
-            "150,root.ln.wf01.wt04.temperature,31.2",
+            "150,root.ln.wf01.wt04.temperature,31.2"
         };
 
     try (Connection connection =
         DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
 
-      statement.execute("SET STORAGE GROUP TO root.ln.wf01.wt04");
       statement.execute(
           "CREATE TIMESERIES root.ln.wf01.wt04.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN");
       statement.execute(
@@ -369,7 +390,7 @@ public class IoTDBLastIT {
       statement.execute("flush");
 
       MNode node = IoTDB.metaManager
-          .getNodeByPath(new PartialPath("root.ln.wf01.wt03.temperature"));
+          .getNodeByPath(new PartialPath("root.ln.wf01.wt04.temperature"));
       ((MeasurementMNode) node).resetCache();
 
       boolean hasResultSet = statement.execute(
@@ -392,31 +413,28 @@ public class IoTDBLastIT {
   }
 
   @Test
-  public void lastWithDeletionTest() throws SQLException, MetadataException {
+  public void lastAfterDeletionTest() throws SQLException, MetadataException {
     String[] retArray =
         new String[]{
-            "350,root.ln.wf01.wt04.temperature,31.2",
-            "200,root.ln.wf01.wt04.temperature,78.2"
+            "350,root.ln.wf01.wt05.temperature,31.2",
+            "200,root.ln.wf01.wt05.temperature,78.2"
         };
 
     try (Connection connection =
         DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
 
-      statement.execute("SET STORAGE GROUP TO root.ln.wf01.wt04");
       statement.execute(
-          "CREATE TIMESERIES root.ln.wf01.wt04.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN");
+          "CREATE TIMESERIES root.ln.wf01.wt05.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN");
       statement.execute(
-          "CREATE TIMESERIES root.ln.wf01.wt04.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN");
-      statement.execute("INSERT INTO root.ln.wf01.wt04(timestamp,temperature) values(100,22.1)");
+          "CREATE TIMESERIES root.ln.wf01.wt05.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN");
+      statement.execute("INSERT INTO root.ln.wf01.wt05(timestamp,temperature) values(100,22.1)");
       statement.execute(
-          "INSERT INTO root.ln.wf01.wt04(timestamp,temperature, status) values(200, 78.2, true)");
-      statement.execute("INSERT INTO root.ln.wf01.wt04(timestamp,temperature) values(350,31.2)");
+          "INSERT INTO root.ln.wf01.wt05(timestamp,temperature, status) values(200, 78.2, true)");
+      statement.execute("INSERT INTO root.ln.wf01.wt05(timestamp,temperature) values(350,31.2)");
       statement.execute("flush");
 
-      boolean hasResultSet = statement.execute(
-          "select last temperature from root.ln.wf01.wt04");
-
+      boolean hasResultSet = statement.execute("select last temperature from root.ln.wf01.wt05");
       assertTrue(hasResultSet);
       int cnt = 0;
       try (ResultSet resultSet = statement.getResultSet()) {
@@ -432,7 +450,8 @@ public class IoTDBLastIT {
       }
 
       statement
-          .execute("delete from root.ln.wf01.wt04.temperature where time > 200 and time < 400");
+          .execute("delete from root.ln.wf01.wt05.temperature where time > 200 and time < 400");
+      statement.execute("select last temperature from root.ln.wf01.wt05");
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
           String ans =
@@ -447,10 +466,10 @@ public class IoTDBLastIT {
   }
 
   @Test
-  public void lastCacheWithFilterTest() throws SQLException, MetadataException {
+  public void lastWithFilterTest() throws SQLException, MetadataException {
     String[] retArray =
         new String[]{
-            "500,root.ln.wf01.wt01.temperature,22.1",
+            "500,root.ln.wf01.wt01.temperature,22.1"
         };
 
     try (Connection connection =


### PR DESCRIPTION
This PR fixed two bugs related to Last Query:
- Nullpointer exception when querying Last: https://issues.apache.org/jira/browse/IOTDB-1049
- Querying Last of a timeseries after deletion gives incorrect result, because the invalid statistics is still used.