### PR TITLE
Add Thrift compiler related issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ Skip this paragraph if you are using Windows. As we use Thrift for our RPC modul
 protocol definition), we involve Thrift during the compilation, so Thrift compiler 0.13.0 (or
 higher) is required to generate Thrift Java code. Thrift officially provides binary compiler for
 Windows, but unfortunately, they do not provide that for Unix OSs. However, we compiled a Unix
-compiler ourselves and put it onto GitHub, and with the help of a maven plugin, it will
+compiler ourselves and put it onto GitHub, and with the help of a maven plugin, it will be
 downloaded automatically during compilation. This compiler works fine with gcc8 or later, Ubuntu
 MacOS, and CentOS, but previous versions and other OSs are not guaranteed. Should you find your gcc
-version or OS does not support the thrift compiler, please upgrade your gcc version or follow the
+version or OS does not support the precompiled compiler, please upgrade your gcc version or follow the
 Thrift official instructions to compile the compiler yourself and rename it into `{project_root}\thrift\target\tools\thrift_0.12.0_0.13.0_linux.exe`.
-Here is thrift official site: https://thrift.apache.org/
+Here is the Thrift official site: https://thrift.apache.org/
 
 You can download the source code from:
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ downloaded automatically during compilation. This compiler works fine with gcc8 
 MacOS, and CentOS, but previous versions and other OSs are not guaranteed. Should you find your gcc
 version or OS does not support the precompiled compiler, please upgrade your gcc version or follow the
 Thrift official instructions to compile the compiler yourself and rename it into `{project_root}\thrift\target\tools\thrift_0.12.0_0.13.0_linux.exe`.
+If you have already installed a compatible Thrift compiler, you may add the following parameter
+when running Maven: `-Dthrift.download-url=http://apache.org/licenses/LICENSE-2.0.txt -Dthrift.exec.absolute.path=<YOUR LOCAL THRIFT BINARY FILE>`.
+If you want to download the Thrift compiler from another position, you may add the following
+parameter: `-Dthrift.download-url=<THE REMOTE URL FOR DOWNLOADING> -Dthrift.exec.absolute.path=<THE DOWNLOADED BINARY FILE NAME>`. Or you may directly modify our root pom if you are skilled enough.
 Here is the Thrift official site: https://thrift.apache.org/
 
 You can download the source code from:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ Here in the Quick Start, we give a brief introduction of using source code to in
 
 ## Build from source
 
+Skip this paragraph if you are using Windows. As we use Thrift for our RPC module (communication and
+protocol definition), we involve Thrift during the compilation, so Thrift compiler 0.13.0 (or
+higher) is required to generate Thrift Java code. Thrift officially provides binary compiler for
+Windows, but unfortunately, they do not provide that for Unix OSs. However, we compiled a Unix
+compiler ourselves and put it onto GitHub, and with the help of a maven plugin, it will
+downloaded automatically during compilation. This compiler works fine with gcc8 or later, Ubuntu
+MacOS, and CentOS, but previous versions and other OSs are not guaranteed. Should you find your gcc
+version or OS does not support the thrift compiler, please upgrade your gcc version or follow the
+Thrift official instructions to compile the compiler yourself and rename it into `{project_root}\thrift\target\tools\thrift_0.12.0_0.13.0_linux.exe`.
+Here is thrift official site: https://thrift.apache.org/
+
 You can download the source code from:
 
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -104,6 +104,9 @@ IoTDB提供了三种安装方法，您可以参考以下建议，选择最适合
 ，借助一个Maven插件，在编译时可以自动将其下载。该预编译的Thrift编译器在gcc8，Ubuntu, CentOS, MacOS下可以工作，但是在更低的gcc
 版本以及其他操作系统上尚未确认。如果您在编译时发现了Thrift编译器相关的问题，请升级您的gcc版本或者依照Thrift
 官方的指示自行编译编译器，并将编译器放置到目录`{project_root}\thrift\target\tools\thrift_0.12.0_0.13.0_linux.exe`。
+如果您已经安装了一个兼容的Thrift编译器，您可以在运行Maven时通过以下参数指定使用您的编译器：`-Dthrift.download-url=http://apache.org/licenses/LICENSE-2.0.txt -Dthrift.exec.absolute.path=<YOUR LOCAL THRIFT BINARY FILE>`。
+您也可以使用以下Maven参数来更换Thrift编译器的下载地址：`-Dthrift.download-url=<THE REMOTE URL FOR DOWNLOADING> -Dthrift.exec.absolute.path=<THE DOWNLOADED BINARY FILE NAME>`。
+如果您对Maven足够熟悉，您也可以直接修改我们的根pom文件来避免每次编译都使用上述参数。
 Thrift官方网址为：https://thrift.apache.org/
 
 从 git 克隆源代码:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -99,6 +99,13 @@ IoTDB提供了三种安装方法，您可以参考以下建议，选择最适合
 
 ## 从源码构建
 
+如果您使用Windows，请跳过此段。我们使用Thrift作为RPC模块来提供客户端-服务器间的通信和协议支持，因此在编译阶段我们需要使用Thrift 0.13.0
+（或更高）编译器生成对应的Java代码。Thrift只提供了Windows下的二进制编译器，Unix下需要通过源码自行编译。但我们预先编译了一个Thrift编译器，并将其上传到了GitHub
+，借助一个Maven插件，在编译时可以自动将其下载。该预编译的Thrift编译器在gcc8，Ubuntu, CentOS, MacOS下可以工作，但是在更低的gcc
+版本以及其他操作系统上尚未确认。如果您在编译时发现了Thrift编译器相关的问题，请升级您的gcc版本或者依照Thrift
+官方的指示自行编译编译器，并将编译器放置到目录`{project_root}\thrift\target\tools\thrift_0.12.0_0.13.0_linux.exe`。
+Thrift官方网址为：https://thrift.apache.org/
+
 从 git 克隆源代码:
 
 ```


### PR DESCRIPTION
Inform the developers to upgrade their gcc or compile the Thrift compiler themselves when the precompiled compiler encounters some compatibility problems.