### PR TITLE
[To rel/0.10]Null pointer log010

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -599,7 +599,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
 
       return resp;
     } catch (NullPointerException e) {
-      e.printStackTrace();
+      logger.error("{}: Internal server error: ", IoTDBConstant.GLOBAL_DB_NAME, e);
       return RpcUtils.getTSExecuteStatementResp(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());
     } catch (Exception e) {
       logger.error("{}: Internal server error: ", IoTDBConstant.GLOBAL_DB_NAME, e);


### PR DESCRIPTION
In Query process, when we meet NullPointerException, it will not print the exception in log_error, it just use e.printStack method which won't be recorded.