### PR TITLE
Change null pointer exception log print way in query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -772,9 +772,10 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
 
       return resp;
     } catch (Exception e) {
-      logger.warn("{}: Internal server error: ", IoTDBConstant.GLOBAL_DB_NAME, e);
       if (e instanceof NullPointerException) {
-        e.printStackTrace();
+        logger.error("{}: Internal server error: ", IoTDBConstant.GLOBAL_DB_NAME, e);
+      } else {
+        logger.warn("{}: Internal server error: ", IoTDBConstant.GLOBAL_DB_NAME, e);
       }
       if (queryId != -1) {
         try {


### PR DESCRIPTION
In Query process, when we meet NullPointerException, it will not print the exception in log_error, it just use e.printStack method which won't be recorded.