### PR TITLE
Fix Last query output when last value does not exist in a series

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -92,7 +92,7 @@ public class LastQueryExecutor {
             selectedSeries, dataTypes, context, expression, lastQueryPlan);
 
     for (int i = 0; i < lastPairList.size(); i++) {
-      if (lastPairList.get(i).right != null) {
+      if (lastPairList.get(i).right != null && lastPairList.get(i).right.getValue() != null) {
         TimeValuePair lastTimeValuePair = lastPairList.get(i).right;
         RowRecord resultRecord = new RowRecord(lastTimeValuePair.getTimestamp());
         Field pathField = new Field(TSDataType.TEXT);
@@ -108,12 +108,8 @@ public class LastQueryExecutor {
         resultRecord.addField(pathField);
 
         Field valueField = new Field(TSDataType.TEXT);
-        if (lastTimeValuePair.getValue() != null) {
-          valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
-          resultRecord.addField(valueField);
-        } else {
-          resultRecord.addField(null);
-        }
+        valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
+        resultRecord.addField(valueField);
 
         dataSet.putRecord(resultRecord);
       }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -92,7 +92,7 @@ public class LastQueryExecutor {
             selectedSeries, dataTypes, context, expression, lastQueryPlan);
 
     for (int i = 0; i < lastPairList.size(); i++) {
-      if (lastPairList.get(i).right != null) {
+      if (Boolean.TRUE.equals(lastPairList.get(i).left)) {
         TimeValuePair lastTimeValuePair = lastPairList.get(i).right;
         RowRecord resultRecord = new RowRecord(lastTimeValuePair.getTimestamp());
         Field pathField = new Field(TSDataType.TEXT);
@@ -167,10 +167,12 @@ public class LastQueryExecutor {
     int index = 0;
     for (int i = 0; i < resultContainer.size(); i++) {
       if (Boolean.FALSE.equals(resultContainer.get(i).left)) {
-        resultContainer.get(i).left = true;
         resultContainer.get(i).right = readerList.get(index++).readLastPoint();
-        if (CACHE_ENABLED) {
-          cacheAccessors.get(i).write(resultContainer.get(i).right);
+        if (resultContainer.get(i).right.getValue() != null) {
+          resultContainer.get(i).left = true;
+          if (CACHE_ENABLED) {
+            cacheAccessors.get(i).write(resultContainer.get(i).right);
+          }
         }
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -92,7 +92,7 @@ public class LastQueryExecutor {
             selectedSeries, dataTypes, context, expression, lastQueryPlan);
 
     for (int i = 0; i < lastPairList.size(); i++) {
-      if (Boolean.TRUE.equals(lastPairList.get(i).left)) {
+      if (lastPairList.get(i).right != null) {
         TimeValuePair lastTimeValuePair = lastPairList.get(i).right;
         RowRecord resultRecord = new RowRecord(lastTimeValuePair.getTimestamp());
         Field pathField = new Field(TSDataType.TEXT);
@@ -108,8 +108,12 @@ public class LastQueryExecutor {
         resultRecord.addField(pathField);
 
         Field valueField = new Field(TSDataType.TEXT);
-        valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
-        resultRecord.addField(valueField);
+        if (lastTimeValuePair.getValue() != null) {
+          valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
+          resultRecord.addField(valueField);
+        } else {
+          resultRecord.addField(null);
+        }
 
         dataSet.putRecord(resultRecord);
       }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -108,12 +108,8 @@ public class LastQueryExecutor {
         resultRecord.addField(pathField);
 
         Field valueField = new Field(TSDataType.TEXT);
-        if (lastTimeValuePair.getValue() != null) {
-          valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
-          resultRecord.addField(valueField);
-        } else {
-          resultRecord.addField(null);
-        }
+        valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
+        resultRecord.addField(valueField);
 
         dataSet.putRecord(resultRecord);
       }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
@@ -103,9 +103,8 @@ public class IoTDBLastIT {
   @Test
   public void lastWithEmptySeriesTest() throws Exception {
     String[] retArray = new String[]{
-            "root.ln.wf02.temperature,null",
-            "root.ln.wf02.status,true"
-        };
+            "root.ln.wf02.status,true",
+    };
 
     try (Connection connection =
              DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
@@ -127,6 +126,14 @@ public class IoTDBLastIT {
         Assert.assertEquals(retArray[cnt], ans);
         cnt++;
       }
+
+      // Last query resultSet is empty after deletion
+      statement.execute("INSERT INTO root.ln.wf02(timestamp, temperature) values(300, 100.0)");
+      statement.execute("delete from root.ln.wf02.status where time > 0");
+      statement.execute("select last status from root.ln.wf02");
+
+      resultSet = statement.getResultSet();
+      Assert.assertFalse(resultSet.next());
     }
   }
 


### PR DESCRIPTION
After deleting all data in a timeseries, execute Last statement gives incorrect output.

```
create timeseries root.ln.wf01.wt01.temperature WITH DATATYPE=FLOAT, ENCODING=RLE
insert into root.ln.wf01.wt01(timestamp,temperature) values(200,37.7)
delete from root.ln.wf01.wt01.temperature where time < 1000
select last temperature from root.ln.wf01.wt01
```

Incorrect Output:
```
+---------------------------------------+-----------------------------+-----+
|                                   Time|                   timeseries|value|
+---------------------------------------+-----------------------------+-----+
|-292275055-05-17T00.-808:52:48+08:05:43|root.ln.wf01.wt01.temperature| null|
+---------------------------------------+-----------------------------+-----+
```

This PR fixed this issue and the result should be null.

```
+----+----------+-----+
|Time|timeseries|value|
+----+----------+-----+
+----+----------+-----+
```
