### PR TITLE
[IOTDB-1060] Support full deletion for delete statement without where clause

### DIFF
--- a/docs/UserGuide/Operation Manual/DML Data Manipulation Language.md
+++ b/docs/UserGuide/Operation Manual/DML Data Manipulation Language.md
@@ -1343,6 +1343,12 @@ Msg: 303: Check metadata error: For delete statement, where clause can only cont
 expressions like : time > XXX, time <= XXX, or two atomic expressions connected by 'AND'
 ```
 
+If no "where" clause specified in a delete statement, all the data in a timeseries will be deleted.
+
+```
+delete from root.ln.wf02.status
+```
+
 
 ### Delete Multiple Timeseries
 If both the power supply status and hardware version of the ln group wf02 plant wt02 device before 2017-11-01 16:26:00 need to be deleted, [the prefix path with broader meaning or the path with star](../Concept/Data%20Model%20and%20Terminology.md) can be used to delete the data. The SQL statement for this operation is:

--- a/docs/zh/UserGuide/Operation Manual/DML Data Manipulation Language.md
+++ b/docs/zh/UserGuide/Operation Manual/DML Data Manipulation Language.md
@@ -1421,6 +1421,11 @@ Msg: 303: Check metadata error: For delete statement, where clause can only cont
 expressions like : time > XXX, time <= XXX, or two atomic expressions connected by 'AND'
 ```
 
+如果delete语句中未指定where子句，则会删除时间序列中的所有数据。
+```
+delete from root.ln.wf02.status
+```
+
 #### 多传感器时间序列值删除    
 
 当ln集团wf02子站的wt02设备在2017-11-01 16:26:00之前的供电状态和设备硬件版本都需要删除，此时可以使用含义更广的[前缀路径或带`*`路径](../Concept/Data%20Model%20and%20Terminology.md)进行删除操作，进行此操作的SQL语句为：

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -313,6 +313,9 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
       Pair<Long, Long> timeInterval = parseDeleteTimeInterval(deleteDataOp);
       deleteDataOp.setStartTime(timeInterval.left);
       deleteDataOp.setEndTime(timeInterval.right);
+    } else {
+      deleteDataOp.setStartTime(Long.MIN_VALUE);
+      deleteDataOp.setEndTime(Long.MAX_VALUE);
     }
     return deleteDataOp;
   }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
@@ -203,6 +203,24 @@ public class IoTDBDeletionIT {
   }
 
   @Test
+  public void testFullDeleteWithoutWhereClause() throws SQLException {
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root",
+            "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("DELETE FROM root.vehicle.d0.s0");
+      try (ResultSet set = statement.executeQuery("SELECT s0 FROM root.vehicle.d0")) {
+        int cnt = 0;
+        while (set.next()) {
+          cnt++;
+        }
+        assertEquals(0, cnt);
+      }
+      cleanData();
+    }
+  }
+
+  @Test
   public void testPartialPathRangeDelete() throws SQLException {
     prepareData();
     try (Connection connection = DriverManager


### PR DESCRIPTION
This PR supports to delete all data in a timeseries if there is no where clause in delete statements.
```
delete from root.sg.d1.s0
```