### PR TITLE
[Distributed] fix client is null cause NullPointerException

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/DataClientProvider.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/DataClientProvider.java
@@ -27,9 +27,14 @@ import org.apache.iotdb.cluster.client.sync.SyncClientPool;
 import org.apache.iotdb.cluster.client.sync.SyncDataClient;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
+import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocolFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DataClientProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(DataClientProvider.class);
   /**
    * dataClientPool provides reusable thrift clients to connect to the DataGroupMembers of other
    * nodes
@@ -56,11 +61,14 @@ public class DataClientProvider {
   /**
    * Get a thrift client that will connect to "node" using the data port.
    *
-   * @param node the node to be connected
+   * @param node    the node to be connected
    * @param timeout timeout threshold of connection
    */
   public AsyncDataClient getAsyncDataClient(Node node, int timeout) throws IOException {
     AsyncDataClient client = (AsyncDataClient) getDataAsyncClientPool().getClient(node);
+    if (client == null) {
+      throw new IOException("can not get client for node=" + node);
+    }
     client.setTimeout(timeout);
     return client;
   }
@@ -68,11 +76,14 @@ public class DataClientProvider {
   /**
    * Get a thrift client that will connect to "node" using the data port.
    *
-   * @param node the node to be connected
+   * @param node    the node to be connected
    * @param timeout timeout threshold of connection
    */
-  public SyncDataClient getSyncDataClient(Node node, int timeout) {
+  public SyncDataClient getSyncDataClient(Node node, int timeout) throws TException {
     SyncDataClient client = (SyncDataClient) getDataSyncClientPool().getClient(node);
+    if (client == null) {
+      throw new TException("can not get client for node=" + node);
+    }
     client.setTimeout(timeout);
     return client;
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/async/AsyncClientPool.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/async/AsyncClientPool.java
@@ -75,10 +75,12 @@ public class AsyncClientPool {
 
   /**
    * Get a client of the given node from the cache if one is available, or create a new one.
+   * <p>
+   * IMPORTANT!!! The caller should check whether the return value is null or not!
    *
-   * @param node
-   * @return
-   * @throws IOException
+   * @param node the node want to connect
+   * @return if the node can connect, return the client, otherwise null
+   * @throws IOException if the node can not be connected
    */
   public AsyncClient getClient(Node node) throws IOException {
     ClusterNode clusterNode = new ClusterNode(node);
@@ -128,7 +130,8 @@ public class AsyncClientPool {
         this.wait(WAIT_CLIENT_TIMEOUT_MS);
         if (clientStack.isEmpty()
             && System.currentTimeMillis() - waitStart >= WAIT_CLIENT_TIMEOUT_MS) {
-          logger.warn("Cannot get an available client after {}ms, create a new one, factory {} now is {}",
+          logger.warn(
+              "Cannot get an available client after {}ms, create a new one, factory {} now is {}",
               WAIT_CLIENT_TIMEOUT_MS, asyncClientFactory, nodeClientNum);
           nodeClientNumMap.put(node, nodeClientNum + 1);
           return asyncClientFactory.getAsyncClient(node, this);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterPreviousFill.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterPreviousFill.java
@@ -72,7 +72,7 @@ public class ClusterPreviousFill extends PreviousFill {
   @Override
   public void configureFill(PartialPath path, TSDataType dataType, long queryTime,
       Set<String> deviceMeasurements,
-      QueryContext context)  {
+      QueryContext context) {
     try {
       fillResult = performPreviousFill(path, dataType, queryTime, getBeforeRange(),
           deviceMeasurements, context);
@@ -195,7 +195,8 @@ public class ClusterPreviousFill extends PreviousFill {
       byteBuffer = SyncClientAdaptor.previousFill(asyncDataClient, request);
     } catch (Exception e) {
       logger
-          .error("{}: Cannot perform previous fill of {} to {}", metaGroupMember, arguments.getPath(), node,
+          .error("{}: Cannot perform previous fill of {} to {}", metaGroupMember,
+              arguments.getPath(), node,
               e);
     }
     return byteBuffer;
@@ -204,10 +205,10 @@ public class ClusterPreviousFill extends PreviousFill {
   private ByteBuffer remoteSyncPreviousFill(Node node, PreviousFillRequest request,
       PreviousFillArguments arguments) {
     ByteBuffer byteBuffer = null;
-    SyncDataClient syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
-        RaftServer.getReadOperationTimeoutMS());
-
+    SyncDataClient syncDataClient = null;
     try {
+      syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
+          RaftServer.getReadOperationTimeoutMS());
       byteBuffer = syncDataClient.previousFill(request);
     } catch (Exception e) {
       logger

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/DataSourceInfo.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/DataSourceInfo.java
@@ -191,7 +191,7 @@ public class DataSourceInfo {
         : metaGroupMember.getClientProvider().getAsyncDataClient(this.curSource, timeout);
   }
 
-  SyncDataClient getCurSyncClient(int timeout) {
+  SyncDataClient getCurSyncClient(int timeout) throws TException {
     return isNoClient ? null :
         metaGroupMember.getClientProvider().getSyncDataClient(this.curSource, timeout);
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -1802,9 +1802,15 @@ public class MetaGroupMember extends RaftMember {
     return forwardPlanAsync(plan, receiver, header, client);
   }
 
-  private TSStatus forwardDataPlanSync(PhysicalPlan plan, Node receiver, Node header) {
-    Client client = getClientProvider().getSyncDataClient(receiver,
-        RaftServer.getWriteOperationTimeoutMS());
+  private TSStatus forwardDataPlanSync(PhysicalPlan plan, Node receiver, Node header)
+      throws IOException {
+    Client client = null;
+    try {
+      client = getClientProvider().getSyncDataClient(receiver,
+          RaftServer.getWriteOperationTimeoutMS());
+    } catch (TException e) {
+      throw new IOException(e);
+    }
     return forwardPlanSync(plan, receiver, header, client);
   }
 

--- a/cluster/src/test/java/org/apache/iotdb/cluster/client/DataClientProviderTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/client/DataClientProviderTest.java
@@ -23,10 +23,13 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import org.apache.iotdb.cluster.client.sync.SyncDataClient;
 import org.apache.iotdb.cluster.common.TestUtils;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
+import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol.Factory;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class DataClientProviderTest {
@@ -61,8 +64,13 @@ public class DataClientProviderTest {
       boolean useAsyncServer = ClusterDescriptor.getInstance().getConfig().isUseAsyncServer();
       ClusterDescriptor.getInstance().getConfig().setUseAsyncServer(false);
       DataClientProvider provider = new DataClientProvider(new Factory());
-
-      assertNotNull(provider.getSyncDataClient(node, 100));
+      SyncDataClient client = null;
+      try {
+        client = provider.getSyncDataClient(node, 100);
+      } catch (TException e) {
+        Assert.fail(e.getMessage());
+      }
+      assertNotNull(client);
       ClusterDescriptor.getInstance().getConfig().setUseAsyncServer(useAsyncServer);
     } finally {
       serverSocket.close();


### PR DESCRIPTION
if the node can not be connected, the server will cause NullPointerException, this pr try to solve the problem.