### PR TITLE
Fix hive-connector CI

### DIFF
--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -194,7 +194,8 @@
     </build>
     <!-- org.pentaho:pentaho-aggdesigner-algorithm is in repo.spring.io and we have to claim
     to use https-->
-    <!-- Anonymous access using /libs-snapshot or /libs-milestone in the pom.xml, or with
+    <!-- Please note the notice in https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020
+    Anonymous access using /libs-snapshot or /libs-milestone in the pom.xml, or with
     these configured in a remote repository, should replace them with /snapshot and /milestone, 
     respectively.-->
     <repositories>

--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -198,7 +198,7 @@
         <repository>
             <id>for_pentaho</id>
             <name>spring.io</name>
-            <url>https://repo.spring.io/libs-milestone</url>
+            <url>https://repo.spring.io/milestone</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>

--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -194,6 +194,9 @@
     </build>
     <!-- org.pentaho:pentaho-aggdesigner-algorithm is in repo.spring.io and we have to claim
     to use https-->
+    <!-- Anonymous access using /libs-snapshot or /libs-milestone in the pom.xml, or with
+    these configured in a remote repository, should replace them with /snapshot and /milestone, 
+    respectively.-->
     <repositories>
         <repository>
             <id>for_pentaho</id>


### PR DESCRIPTION
Please note the notice in https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020

Anonymous access using /libs-snapshot or /libs-milestone in the pom.xml, or with these configured in a remote repository, should replace them with /snapshot and /milestone, respectively.