### PR TITLE
Change parallelism in timeseries metadata cache

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -64,7 +64,9 @@ public class TimeSeriesMetadataCache {
 
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
-  private final Map<String, WeakReference<String>> devices = Collections.synchronizedMap(new WeakHashMap<>());
+  private final Map<String, WeakReference<String>> devices = Collections
+      .synchronizedMap(new WeakHashMap<>());
+  private static final String SEPARATOR = "$";
 
   private TimeSeriesMetadataCache() {
     if (CACHE_ENABLE) {
@@ -132,7 +134,8 @@ public class TimeSeriesMetadataCache {
       printCacheLog(true);
     } else {
       // allow for the parallelism of different devices
-      synchronized (devices.computeIfAbsent(key.device, WeakReference::new)) {
+      synchronized (devices
+          .computeIfAbsent(key.device + SEPARATOR + key.filePath, WeakReference::new)) {
         // double check
         lock.readLock().lock();
         try {


### PR DESCRIPTION
Before, the parallelism in timeseries metadata cache is in device granularity. However, it's not reasonable, because same device in different files should not block each other.
So, we change the granularity to one device in one file.