### PR TITLE
[To rel/0.11]Change parallelism in timeseries metadata cache

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -20,9 +20,13 @@
 package org.apache.iotdb.db.engine.cache;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -59,6 +63,10 @@ public class TimeSeriesMetadataCache {
   private final AtomicLong cacheRequestNum = new AtomicLong();
 
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+  private final Map<String, WeakReference<String>> devices = Collections
+      .synchronizedMap(new WeakHashMap<>());
+  private static final String SEPARATOR = "$";
 
 
   private TimeSeriesMetadataCache() {
@@ -126,8 +134,9 @@ public class TimeSeriesMetadataCache {
       cacheHitNum.incrementAndGet();
       printCacheLog(true);
     } else {
-      // allow for the parallelism of different devices
-      synchronized (key.device.intern()) {
+      // allow for the parallelism of different devices in different files
+      synchronized (devices
+          .computeIfAbsent(key.device + SEPARATOR + key.filePath, WeakReference::new)) {
         // double check
         lock.readLock().lock();
         try {


### PR DESCRIPTION
Before, the parallelism in timeseries metadata cache is in device granularity. However, it's not reasonable, because same device in different files should not block each other.
So, we change the granularity to one device in one file.