### PR TITLE
upgrade guava version

### DIFF
--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>[${guava.version},)</version>
         </dependency>
     </dependencies>
     <build>

--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>[${guava.version},)</version>
         </dependency>
         <!-- force upgrade the dependency of hive-serde-->
         <dependency>

--- a/spark-iotdb-connector/pom.xml
+++ b/spark-iotdb-connector/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>[${guava.version},)</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
As the google guava version under 24.1.1 have some vulnerability according to [1][2], so I think we need to upgrade the version.

[1]https://www.cvedetails.com/cve/CVE-2018-10237/

[2]https://github.com/google/guava/wiki/CVE-2018-10237