### PR TITLE
Fix sync schema bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
@@ -18,6 +18,14 @@
  */
 package org.apache.iotdb.db.sync.receiver.transfer;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import org.apache.iotdb.db.concurrent.ThreadName;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
@@ -44,15 +52,6 @@ import org.apache.iotdb.service.sync.thrift.SyncStatus;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 
 public class SyncServiceImpl implements SyncService.Iface {
 
@@ -280,7 +279,8 @@ public class SyncServiceImpl implements SyncService.Iface {
             }
             IoTDB.metaManager.operation(plan);
           } catch (Exception e) {
-            logger.error("Can not operate metadata operation {} for err:{}", plan.getOperatorType(), e);
+            logger.error("Can not operate metadata operation {} for err:{}",
+                plan == null ? "" : plan.getOperatorType(), e);
           }
         }
       } catch (IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
@@ -270,10 +270,11 @@ public class SyncServiceImpl implements SyncService.Iface {
   private void loadMetadata() {
     logger.info("Start to load metadata in sync process.");
     if (currentFile.get().exists()) {
-      try (MLogReader mLogReader = new MLogReader(config.getSchemaDir(), MetadataConstant.METADATA_LOG)) {
+      try (MLogReader mLogReader = new MLogReader(currentFile.get())) {
         while (mLogReader.hasNext()) {
-          PhysicalPlan plan = mLogReader.next();
+          PhysicalPlan plan = null;
           try {
+            plan = mLogReader.next();
             if (plan == null) {
               continue;
             }

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
@@ -72,7 +72,6 @@ import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.service.sync.thrift.ConfirmInfo;
 import org.apache.iotdb.service.sync.thrift.SyncService;
 import org.apache.iotdb.service.sync.thrift.SyncStatus;
-import org.apache.iotdb.tsfile.utils.BytesUtils;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
@@ -89,8 +88,6 @@ public class SyncClient implements ISyncClient {
 
   private static SyncSenderConfig config = SyncSenderDescriptor.getInstance().getConfig();
 
-  private static final int BATCH_LINE = 1000;
-
   private static final int TIMEOUT_MS = 1000;
 
   /**
@@ -99,7 +96,7 @@ public class SyncClient implements ISyncClient {
    * location is recorded once after each synchronization task for the next synchronization task to
    * use.
    */
-  private int schemaFileLinePos;
+  private int schemaFilePos;
 
   private TTransport transport;
 
@@ -365,45 +362,25 @@ public class SyncClient implements ISyncClient {
   }
 
   private boolean tryToSyncSchema() {
-    int schemaPos = readSyncSchemaPos(getSchemaPosFile());
+    schemaFilePos = readSyncSchemaPos(getSchemaPosFile());
 
     // start to sync file data and get digest of this file.
-    try (BufferedReader br = new BufferedReader(new FileReader(getSchemaLogFile()));
+    try (FileInputStream fis = new FileInputStream(getSchemaLogFile());
         ByteArrayOutputStream bos = new ByteArrayOutputStream(SyncConstant.DATA_CHUNK_SIZE)) {
-      schemaFileLinePos = 0;
-      String line;
-      while (schemaFileLinePos < schemaPos) {
-        line = br.readLine();
-        schemaFileLinePos++;
-      }
+      fis.skip(schemaFilePos);
       MessageDigest md = MessageDigest.getInstance(SyncConstant.MESSAGE_DIGIT_NAME);
-      int cntLine = 0;
-      while ((line = br.readLine()) != null) {
-        schemaFileLinePos++;
-        byte[] singleLineData = BytesUtils.stringToBytes(line);
-        bos.write(singleLineData);
-        bos.write("\r\n".getBytes());
-        if (cntLine++ == BATCH_LINE) {
-          md.update(bos.toByteArray());
-          ByteBuffer buffToSend = ByteBuffer.wrap(bos.toByteArray());
-          bos.reset();
-          SyncStatus status = serviceClient.syncData(buffToSend);
-          if (status.code != SUCCESS_CODE) {
-            logger.error("Receiver failed to receive metadata because {}, retry.", status.msg);
-            return false;
-          }
-          cntLine = 0;
-        }
-      }
-      if (bos.size() != 0) {
-        md.update(bos.toByteArray());
+      byte[] buffer = new byte[SyncConstant.DATA_CHUNK_SIZE];
+      int dataLength;
+      while ((dataLength = fis.read(buffer)) != -1) {
+        bos.write(buffer, 0, dataLength);
+        md.update(buffer, 0, dataLength);
         ByteBuffer buffToSend = ByteBuffer.wrap(bos.toByteArray());
-        bos.reset();
         SyncStatus status = serviceClient.syncData(buffToSend);
         if (status.code != SUCCESS_CODE) {
           logger.error("Receiver failed to receive metadata because {}, retry.", status.msg);
           return false;
         }
+        schemaFilePos += dataLength;
       }
 
       // check digest
@@ -453,7 +430,7 @@ public class SyncClient implements ISyncClient {
         syncSchemaLogFile.createNewFile();
       }
       try (BufferedWriter br = new BufferedWriter(new FileWriter(syncSchemaLogFile))) {
-        br.write(Integer.toString(schemaFileLinePos));
+        br.write(Integer.toString(schemaFilePos));
       }
     } catch (IOException e) {
       logger.error("Can not find file {}", syncSchemaLogFile.getAbsoluteFile(), e);


### PR DESCRIPTION
In pr [#1721](https://github.com/apache/iotdb/pull/1721), a bug of schema synchronization in the sync module is introduced. Which will lead to that the schema can not be loaded correctly on the receiver. This pr solves this problem.