### PR TITLE
Fix a bug of cal MaxDeduplicatedPathNum

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
@@ -97,7 +97,7 @@ public class QueryResourceManager {
   }
 
   public int getMaxDeduplicatedPathNum(int fetchSize) {
-    return Math.min((int) ((totalFreeMemoryForRead.get() / fetchSize) / POINT_ESTIMATED_SIZE),
+    return (int) Math.min(((totalFreeMemoryForRead.get() / fetchSize) / POINT_ESTIMATED_SIZE),
         CONFIG.getMaxQueryDeduplicatedPathNum());
   }
 


### PR DESCRIPTION
When cal parameter `MaxDeduplicatedPathNum`, the result of `(totalFreeMemoryForRead.get() / fetchSize) / POINT_ESTIMATED_SIZE` may larger than `Integer.MAX_VALUE`. Which may lead to that `MaxDeduplicatedPathNum` will set to a nagative number, which will reject all `count(*)` query.