### PR TITLE
[IOTDB-1069] restrict the flushing memtable number to avoid OOM when mem_control is disabled

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -266,7 +266,7 @@ public class IoTDBConfig {
   /**
    * Maximum MemTable number. Invalid when enableMemControl is true.
    */
-  private int maxMemtableNumber = 20;
+  private int maxMemtableNumber = 0;
 
   /**
    * The amount of data iterate each time in server

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -264,6 +264,11 @@ public class IoTDBConfig {
   private String walDir = DEFAULT_BASE_DIR + File.separator + "wal";
 
   /**
+   * Maximum MemTable number. Invalid when enableMemControl is true.
+   */
+  private int maxMemtableNumber = 20;
+
+  /**
    * The amount of data iterate each time in server
    */
   private int batchSize = 100000;
@@ -1087,6 +1092,14 @@ public class IoTDBConfig {
 
   void setBatchSize(int batchSize) {
     this.batchSize = batchSize;
+  }
+
+  public int getMaxMemtableNumber() {
+    return maxMemtableNumber;
+  }
+
+  public void setMaxMemtableNumber(int maxMemtableNumber) {
+    this.maxMemtableNumber = maxMemtableNumber;
   }
 
   public int getConcurrentFlushThread() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -824,7 +824,7 @@ public class StorageGroupProcessor {
     try {
       tsFileProcessor.insertTablet(insertTabletPlan, start, end, results);
     } catch (WriteProcessRejectException e) {
-      logger.warn("insert to TsFileProcessor rejected ", e);
+      logger.warn("insert to TsFileProcessor rejected ", e.getMessage());
       return false;
     } catch (WriteProcessException e) {
       logger.error("insert to TsFileProcessor error ", e);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -824,7 +824,7 @@ public class StorageGroupProcessor {
     try {
       tsFileProcessor.insertTablet(insertTabletPlan, start, end, results);
     } catch (WriteProcessRejectException e) {
-      logger.warn("insert to TsFileProcessor rejected ", e.getMessage());
+      logger.warn("insert to TsFileProcessor rejected, {}", e.getMessage());
       return false;
     } catch (WriteProcessException e) {
       logger.error("insert to TsFileProcessor error ", e);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1012,13 +1012,13 @@ public class TsFileProcessor {
 
   private IMemTable getAvailableMemTable() {
     synchronized (flushingMemTables) {
-      if (flushingMemTables.isEmpty()) {
+      if (flushingMemTables.size() < 2) {
         return new PrimitiveMemTable(enableMemControl);
       } else {
-        // wait until flushingMemTables is empty
+        // wait until the size of flushingMemTables is less than 2
         int waitCount = 1;
         while (true) {
-          if (flushingMemTables.isEmpty()) {
+          if (flushingMemTables.size() < 2) {
             return new PrimitiveMemTable(enableMemControl);
           }
           try {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -56,6 +55,7 @@ import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertTabletPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
+import org.apache.iotdb.db.rescon.MemTableManager;
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
 import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.db.utils.MemUtils;
@@ -173,11 +173,11 @@ public class TsFileProcessor {
     if (workMemTable == null) {
       if (enableMemControl) {
         workMemTable = new PrimitiveMemTable(enableMemControl);
+        MemTableManager.getInstance().addMemtableNumber();
       }
       else {
-        workMemTable = getAvailableMemTable();
+        workMemTable = MemTableManager.getInstance().getAvailableMemTable(tsFileResource);
       }
-      SystemInfo.getInstance().addMemtableNumber();
     }
 
     if (enableMemControl) {
@@ -224,9 +224,9 @@ public class TsFileProcessor {
         workMemTable = new PrimitiveMemTable(enableMemControl);
       }
       else {
-        workMemTable = getAvailableMemTable();
+        workMemTable = MemTableManager.getInstance().getAvailableMemTable(tsFileResource);
       }
-      SystemInfo.getInstance().addMemtableNumber();
+      MemTableManager.getInstance().addMemtableNumber();
     }
 
     try {
@@ -684,7 +684,7 @@ public class TsFileProcessor {
             memTable.isSignalMemTable(), flushingMemTables.size());
       }
       memTable.release();
-      SystemInfo.getInstance().resetMemtableNumber();
+      MemTableManager.getInstance().resetMemtableNumber();
       if (enableMemControl) {
         // reset the mem cost in StorageGroupProcessorInfo
         storageGroupInfo.releaseStorageGroupMemCost(memTable.getTVListsRamCost());
@@ -1022,29 +1022,5 @@ public class TsFileProcessor {
 
   public void addCloseFileListeners(Collection<CloseFileListener> listeners) {
     closeFileListeners.addAll(listeners);
-  }
-
-  /**
-   * Called when memory control is disabled
-   */
-  private IMemTable getAvailableMemTable() {
-    if (!SystemInfo.getInstance().reachMaxMemtableNumber()) {
-      return new PrimitiveMemTable(enableMemControl);
-    } else {
-      // wait until the size of flushingMemTables is less than 2
-      int waitCount = 1;
-      while (true) {
-        if (!SystemInfo.getInstance().reachMaxMemtableNumber()) {
-          return new PrimitiveMemTable(enableMemControl);
-        }
-        try {
-          TimeUnit.MILLISECONDS.sleep(100);
-        } catch (InterruptedException e) {
-          logger.error("{} fails to wait for memtables {}, continue to wait", tsFileResource, e);
-          Thread.currentThread().interrupt();
-        }
-        logger.info("{} has waited for a memtable for {}ms", tsFileResource, waitCount++ * 100);
-      }
-    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1022,12 +1022,12 @@ public class TsFileProcessor {
           return new PrimitiveMemTable(enableMemControl);
         }
         try {
-          TimeUnit.MILLISECONDS.sleep(1000);
+          TimeUnit.MILLISECONDS.sleep(100);
         } catch (InterruptedException e) {
           logger.error("{} fails to wait for memtables {}, continue to wait", tsFileResource, e);
           Thread.currentThread().interrupt();
         }
-        logger.info("{} has waited for a memtable for {}ms", tsFileResource, waitCount++ * 1000);
+        logger.info("{} has waited for a memtable for {}ms", tsFileResource, waitCount++ * 100);
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1019,7 +1019,7 @@ public class TsFileProcessor {
         int waitCount = 1;
         while (true) {
           if (flushingMemTables.isEmpty()) {
-            return new PrimitiveMemTable();
+            return new PrimitiveMemTable(enableMemControl);
           }
           try {
             flushingMemTables.wait(1000);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -222,11 +222,11 @@ public class TsFileProcessor {
     if (workMemTable == null) {
       if (enableMemControl) {
         workMemTable = new PrimitiveMemTable(enableMemControl);
+        MemTableManager.getInstance().addMemtableNumber();
       }
       else {
         workMemTable = MemTableManager.getInstance().getAvailableMemTable(tsFileResource);
       }
-      MemTableManager.getInstance().addMemtableNumber();
     }
 
     try {
@@ -684,7 +684,7 @@ public class TsFileProcessor {
             memTable.isSignalMemTable(), flushingMemTables.size());
       }
       memTable.release();
-      MemTableManager.getInstance().resetMemtableNumber();
+      MemTableManager.getInstance().decreaseMemtableNumber();
       if (enableMemControl) {
         // reset the mem cost in StorageGroupProcessorInfo
         storageGroupInfo.releaseStorageGroupMemCost(memTable.getTVListsRamCost());

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1024,10 +1024,10 @@ public class TsFileProcessor {
           try {
             flushingMemTables.wait(1000);
           } catch (InterruptedException e) {
-            logger.error("{} fails to wait for memtables {}, continue to wait", tsFileResource.toString(), e);
+            logger.error("{} fails to wait for memtables {}, continue to wait", tsFileResource, e);
             Thread.currentThread().interrupt();
           }
-          logger.info("{} has waited for a memtable for {}ms", tsFileResource.toString(), waitCount++ * 1000);
+          logger.info("{} has waited for a memtable for {}ms", tsFileResource, waitCount++ * 1000);
         }
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -176,7 +176,7 @@ public class TsFileProcessor {
         MemTableManager.getInstance().addMemtableNumber();
       }
       else {
-        workMemTable = MemTableManager.getInstance().getAvailableMemTable(tsFileResource);
+        workMemTable = MemTableManager.getInstance().getAvailableMemTable(storageGroupName);
       }
     }
 
@@ -225,7 +225,7 @@ public class TsFileProcessor {
         MemTableManager.getInstance().addMemtableNumber();
       }
       else {
-        workMemTable = MemTableManager.getInstance().getAvailableMemTable(tsFileResource);
+        workMemTable = MemTableManager.getInstance().getAvailableMemTable(storageGroupName);
       }
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -171,7 +171,13 @@ public class TsFileProcessor {
   public void insert(InsertRowPlan insertRowPlan) throws WriteProcessException {
 
     if (workMemTable == null) {
-      workMemTable = getAvailableMemTable();
+      if (enableMemControl) {
+        workMemTable = new PrimitiveMemTable(enableMemControl);
+      }
+      else {
+        workMemTable = getAvailableMemTable();
+      }
+      SystemInfo.getInstance().addMemtableNumber();
     }
 
     if (enableMemControl) {
@@ -214,7 +220,13 @@ public class TsFileProcessor {
       TSStatus[] results) throws WriteProcessException {
 
     if (workMemTable == null) {
-      workMemTable = getAvailableMemTable();
+      if (enableMemControl) {
+        workMemTable = new PrimitiveMemTable(enableMemControl);
+      }
+      else {
+        workMemTable = getAvailableMemTable();
+      }
+      SystemInfo.getInstance().addMemtableNumber();
     }
 
     try {
@@ -672,6 +684,7 @@ public class TsFileProcessor {
             memTable.isSignalMemTable(), flushingMemTables.size());
       }
       memTable.release();
+      SystemInfo.getInstance().resetMemtableNumber();
       if (enableMemControl) {
         // reset the mem cost in StorageGroupProcessorInfo
         storageGroupInfo.releaseStorageGroupMemCost(memTable.getTVListsRamCost());
@@ -1011,14 +1024,17 @@ public class TsFileProcessor {
     closeFileListeners.addAll(listeners);
   }
 
+  /**
+   * Called when memory control is disabled
+   */
   private IMemTable getAvailableMemTable() {
-    if (flushingMemTables.size() < 2) {
+    if (!SystemInfo.getInstance().reachMaxMemtableNumber()) {
       return new PrimitiveMemTable(enableMemControl);
     } else {
       // wait until the size of flushingMemTables is less than 2
       int waitCount = 1;
       while (true) {
-        if (flushingMemTables.size() < 2) {
+        if (!SystemInfo.getInstance().reachMaxMemtableNumber()) {
           return new PrimitiveMemTable(enableMemControl);
         }
         try {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -81,6 +81,7 @@ import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.ShowTimeSeriesResult;
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.db.utils.RandomDeleteCache;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.db.utils.TestOnly;
@@ -574,6 +575,9 @@ public class MManager {
   public void setStorageGroup(PartialPath storageGroup) throws MetadataException {
     try {
       mtree.setStorageGroup(storageGroup);
+      if (!config.isEnableMemControl()) {
+        SystemInfo.getInstance().addOrDeleteStorageGroup(1);
+      }
       if (!isRecovering) {
         logWriter.setStorageGroup(storageGroup);
       }
@@ -605,6 +609,10 @@ public class MManager {
           removeFromTagInvertedIndex(leafMNode);
           // update statistics in schemaDataTypeNumMap
           updateSchemaDataTypeNumMap(leafMNode.getSchema().getType(), -1);
+        }
+
+        if (!config.isEnableMemControl()) {
+          SystemInfo.getInstance().addOrDeleteStorageGroup(-1);
         }
 
         // if success

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -80,6 +80,7 @@ import org.apache.iotdb.db.qp.physical.sys.SetTTLPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.ShowTimeSeriesResult;
+import org.apache.iotdb.db.rescon.MemTableManager;
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
 import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.db.utils.RandomDeleteCache;
@@ -576,7 +577,7 @@ public class MManager {
     try {
       mtree.setStorageGroup(storageGroup);
       if (!config.isEnableMemControl()) {
-        SystemInfo.getInstance().addOrDeleteStorageGroup(1);
+        MemTableManager.getInstance().addOrDeleteStorageGroup(1);
       }
       if (!isRecovering) {
         logWriter.setStorageGroup(storageGroup);
@@ -612,7 +613,7 @@ public class MManager {
         }
 
         if (!config.isEnableMemControl()) {
-          SystemInfo.getInstance().addOrDeleteStorageGroup(-1);
+          MemTableManager.getInstance().addOrDeleteStorageGroup(-1);
         }
 
         // if success

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -82,7 +82,6 @@ import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.ShowTimeSeriesResult;
 import org.apache.iotdb.db.rescon.MemTableManager;
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
-import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.db.utils.RandomDeleteCache;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.db.utils.TestOnly;

--- a/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
@@ -79,7 +79,7 @@ public class MemTableManager {
     currentMemtableNumber++;
   }
 
-  public synchronized void resetMemtableNumber() {
+  public synchronized void decreaseMemtableNumber() {
     currentMemtableNumber--;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
@@ -61,12 +61,14 @@ public class MemTableManager {
           return new PrimitiveMemTable();
         }
         try {
-          TimeUnit.MILLISECONDS.sleep(WAIT_TIME);
+          wait(WAIT_TIME);
         } catch (InterruptedException e) {
           logger.error("{} fails to wait for memtables {}, continue to wait", tsFileResource, e);
           Thread.currentThread().interrupt();
         }
-        logger.info("{} has waited for a memtable for {}ms", tsFileResource, waitCount++ * 100);
+        if (waitCount++ % 500 == 0) {
+          logger.info("{} has waited for a memtable for {}ms", tsFileResource, waitCount * 500);
+        }
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
@@ -53,7 +53,7 @@ public class MemTableManager {
       currentMemtableNumber++;
       return new PrimitiveMemTable();
     } else {
-      // wait until the size of flushingMemTables is less than 2
+      // wait until the total number of memtable is less than the system capacity
       int waitCount = 1;
       while (true) {
         if (!reachMaxMemtableNumber()) {

--- a/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.memtable.IMemTable;
 import org.apache.iotdb.db.engine.memtable.PrimitiveMemTable;
-import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +45,7 @@ public class MemTableManager {
   /**
    * Called when memory control is disabled
    */
-  public synchronized IMemTable getAvailableMemTable(TsFileResource tsFileResource) {
+  public synchronized IMemTable getAvailableMemTable(String storageGroup) {
     if (!reachMaxMemtableNumber()) {
       currentMemtableNumber++;
       return new PrimitiveMemTable();
@@ -61,11 +60,11 @@ public class MemTableManager {
         try {
           wait(WAIT_TIME);
         } catch (InterruptedException e) {
-          logger.error("{} fails to wait for memtables {}, continue to wait", tsFileResource, e);
+          logger.error("{} fails to wait for memtables {}, continue to wait", storageGroup, e);
           Thread.currentThread().interrupt();
         }
-        if (waitCount++ % 500 == 0) {
-          logger.info("{} has waited for a memtable for {}ms", tsFileResource, waitCount * 500);
+        if (waitCount++ % 10 == 0) {
+          logger.info("{} has waited for a memtable for {}ms", storageGroup, waitCount * WAIT_TIME);
         }
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.rescon;
+
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.memtable.IMemTable;
+import org.apache.iotdb.db.engine.memtable.PrimitiveMemTable;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class MemTableManager {
+
+  private static final IoTDBConfig CONFIG = IoTDBDescriptor.getInstance().getConfig();
+
+  private static final Logger logger = LoggerFactory.getLogger(MemTableManager.class);
+
+  private static final int WAIT_TIME = 100;
+  public static final int MEMTABLE_NUM_FOR_EACH_PARTITION = 4;
+  private int currentMemtableNumber = 0;
+
+  private MemTableManager() {
+  }
+
+  public static MemTableManager getInstance() {
+    return InstanceHolder.INSTANCE;
+  }
+
+  /**
+   * Called when memory control is disabled
+   */
+  public synchronized IMemTable getAvailableMemTable(TsFileResource tsFileResource) {
+    if (!reachMaxMemtableNumber()) {
+      currentMemtableNumber++;
+      return new PrimitiveMemTable();
+    } else {
+      // wait until the size of flushingMemTables is less than 2
+      int waitCount = 1;
+      while (true) {
+        if (!reachMaxMemtableNumber()) {
+          currentMemtableNumber++;
+          return new PrimitiveMemTable();
+        }
+        try {
+          TimeUnit.MILLISECONDS.sleep(WAIT_TIME);
+        } catch (InterruptedException e) {
+          logger.error("{} fails to wait for memtables {}, continue to wait", tsFileResource, e);
+          Thread.currentThread().interrupt();
+        }
+        logger.info("{} has waited for a memtable for {}ms", tsFileResource, waitCount++ * 100);
+      }
+    }
+  }
+
+  public synchronized int getCurrentMemtableNumber() {
+    return currentMemtableNumber;
+  }
+
+  public synchronized void addMemtableNumber() {
+    currentMemtableNumber++;
+  }
+
+  public synchronized void resetMemtableNumber() {
+    currentMemtableNumber--;
+  }
+
+  /**
+   * Called when memory control is disabled
+   */
+  private boolean reachMaxMemtableNumber() {
+    return currentMemtableNumber >= CONFIG.getMaxMemtableNumber();
+  }
+
+  /**
+   * Called when memory control is disabled
+   */
+  public synchronized void addOrDeleteStorageGroup(int diff) {
+    int maxMemTableNum = CONFIG.getMaxMemtableNumber();
+    maxMemTableNum += MEMTABLE_NUM_FOR_EACH_PARTITION 
+        * CONFIG.getConcurrentWritingTimePartition() * diff;
+    CONFIG.setMaxMemtableNumber(maxMemTableNum);
+  }
+
+  private static class InstanceHolder {
+
+    private static final MemTableManager INSTANCE = new MemTableManager();
+
+    private InstanceHolder() {
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/MemTableManager.java
@@ -26,8 +26,6 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
-
 public class MemTableManager {
 
   private static final IoTDBConfig CONFIG = IoTDBDescriptor.getInstance().getConfig();

--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -48,8 +48,6 @@ public class SystemInfo {
   private static final double REJECT_THERSHOLD = 
       config.getAllocateMemoryForWrite() * config.getRejectProportion();
 
-  private int currentMemtableNumber = 0;
-  public static final int MEMTABLE_NUM_FOR_EACH_PARTITION = 4;
 
   /**
    * Report current mem cost of storage group to system. Called when the memory of
@@ -187,39 +185,9 @@ public class SystemInfo {
     return rejected;
   }
 
-  public synchronized void addMemtableNumber() {
-    currentMemtableNumber++;
-  }
-
-  public synchronized void resetMemtableNumber() {
-    currentMemtableNumber--;
-  }
-
-  public synchronized int getCurrentMemtableNumber() {
-    return currentMemtableNumber;
-  }
-
-  /**
-   * Called when memory control is disabled
-   */
-  public synchronized boolean reachMaxMemtableNumber() {
-    return currentMemtableNumber >= config.getMaxMemtableNumber();
-  }
-
-  /**
-   * Called when memory control is disabled
-   */
-  public synchronized void addOrDeleteStorageGroup(int diff) {
-    int maxMemTableNum = config.getMaxMemtableNumber();
-    maxMemTableNum += MEMTABLE_NUM_FOR_EACH_PARTITION 
-        * config.getConcurrentWritingTimePartition() * diff;
-    config.setMaxMemtableNumber(maxMemTableNum);
-  }
-
   public void close() {
     reportedSgMemCostMap.clear();
     totalSgMemCost = 0;
-    currentMemtableNumber = 0;
     rejected = false;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -195,14 +195,14 @@ public class SystemInfo {
     currentMemtableNumber--;
   }
 
-  public int getCurrentMemtableNumber() {
+  public synchronized int getCurrentMemtableNumber() {
     return currentMemtableNumber;
   }
 
   /**
    * Called when memory control is disabled
    */
-  public boolean reachMaxMemtableNumber() {
+  public synchronized boolean reachMaxMemtableNumber() {
     return currentMemtableNumber >= config.getMaxMemtableNumber();
   }
 
@@ -211,7 +211,8 @@ public class SystemInfo {
    */
   public synchronized void addOrDeleteStorageGroup(int diff) {
     int maxMemTableNum = config.getMaxMemtableNumber();
-    maxMemTableNum += MEMTABLE_NUM_FOR_EACH_PARTITION * config.getConcurrentWritingTimePartition() * diff;
+    maxMemTableNum += MEMTABLE_NUM_FOR_EACH_PARTITION 
+        * config.getConcurrentWritingTimePartition() * diff;
     config.setMaxMemtableNumber(maxMemTableNum);
   }
 


### PR DESCRIPTION
To reproduce this bug, 
set JVM memory size to 32GB, 
tsfile_size_threshold=268435456
memtable_size_threshold=268435456
enable_mem_control=false
and insert 200 timeseries to IoTDB.

This pr restricts the flushing memtable size in one TsfileProcessor to one. 