### PR TITLE
[IOTDB-1068] Fix Time series metadata cache bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -134,10 +134,9 @@ public class TimeSeriesMetadataCache {
       printCacheLog(true);
     } else {
       if (config.isDebugOn()) {
-        DEBUG_LOGGER.info(
-            "Cache miss: " + key.device + "." + key.measurement + " metadata in file: "
-                + key.filePath);
-        DEBUG_LOGGER.info("Device: " + key.device + " all sensors: " + allSensors);
+        DEBUG_LOGGER
+            .info("Cache miss: {}.{} in file: {}", key.device, key.measurement, key.filePath);
+        DEBUG_LOGGER.info("Device: {}, all sensors: {}", key.device, allSensors);
       }
       // allow for the parallelism of different devices
       synchronized (devices
@@ -159,7 +158,7 @@ public class TimeSeriesMetadataCache {
           BloomFilter bloomFilter = reader.readBloomFilter();
           if (bloomFilter != null && !bloomFilter.contains(path.getFullPath())) {
             if (config.isDebugOn()) {
-              DEBUG_LOGGER.info("TimeSeries meta data " + key + " is filter by bloomFilter!");
+              DEBUG_LOGGER.info("TimeSeries meta data {} is filter by bloomFilter!", key);
             }
             return null;
           }
@@ -185,14 +184,14 @@ public class TimeSeriesMetadataCache {
     }
     if (timeseriesMetadata == null) {
       if (config.isDebugOn()) {
-        DEBUG_LOGGER.info("The file doesn't have this time series " + key);
+        DEBUG_LOGGER.info("The file doesn't have this time series {}.", key);
       }
       return null;
     } else {
       if (config.isDebugOn()) {
         DEBUG_LOGGER.info(
-            "Get timeseries: " + key.device + "." + key.measurement + " metadata in file: "
-                + key.filePath + " from cache: " + timeseriesMetadata);
+            "Get timeseries: {}.{}  metadata in file: {}  from cache: {}.", key.device,
+            key.measurement, key.filePath, timeseriesMetadata);
       }
       return new TimeseriesMetadata(timeseriesMetadata);
     }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimeSeriesMetadataReadTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimeSeriesMetadataReadTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.tsfile.read;
+
+import java.io.IOException;
+import java.util.*;
+import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
+import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.utils.FileGenerator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TimeSeriesMetadataReadTest {
+
+  private static final String FILE_PATH = FileGenerator.outputDataFile;
+  private final TSFileConfig conf = TSFileDescriptor.getInstance().getConfig();
+  private int maxDegreeOfIndexNode;
+
+  @Before
+  public void before() throws IOException {
+    int rowCount = 100;
+    maxDegreeOfIndexNode = conf.getMaxDegreeOfIndexNode();
+    conf.setMaxDegreeOfIndexNode(3);
+    FileGenerator.generateFile(rowCount, 10000);
+  }
+
+  @After
+  public void after() throws IOException {
+    FileGenerator.after();
+    conf.setMaxDegreeOfIndexNode(maxDegreeOfIndexNode);
+  }
+
+  @Test
+  public void testReadTimeseriesMetadata() throws IOException {
+    TsFileSequenceReader reader = new TsFileSequenceReader(FILE_PATH);
+    Path path = new Path("d1", "s1");
+    Set<String> set = new HashSet<>();
+    set.add("s1");
+    set.add("s2");
+    set.add("s3");
+    // the Max Degree Of Index Node is set to be 3, so the leaf node should only contains 3 sensors
+    // s4 should not be returned as result
+    set.add("s4");
+    List<TimeseriesMetadata> timeseriesMetadataList = reader.readTimeseriesMetadata(path, set);
+    Assert.assertEquals(3, timeseriesMetadataList.size());
+    for (int i = 1; i <= timeseriesMetadataList.size(); i++) {
+      Assert.assertEquals("s" + i, timeseriesMetadataList.get(i - 1).getMeasurementId());
+    }
+
+    path = new Path("d1", "s5");
+    set.clear();
+    set.add("s5");
+    set.add("s6");
+    // this is a fake one, this file doesn't contain this measurement
+    // so the result is not supposed to contain this measurement's timeseries metadata
+    set.add("s8");
+    timeseriesMetadataList = reader.readTimeseriesMetadata(path, set);
+    Assert.assertEquals(2, timeseriesMetadataList.size());
+    for (int i = 5; i < 7; i++) {
+      Assert.assertEquals("s" + i, timeseriesMetadataList.get(i - 5).getMeasurementId());
+    }
+  }
+}

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimeSeriesMetadataReadTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimeSeriesMetadataReadTest.java
@@ -19,9 +19,12 @@
 package org.apache.iotdb.tsfile.read;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.constant.TestConstant;
 import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.utils.FileGenerator;
@@ -32,7 +35,8 @@ import org.junit.Test;
 
 public class TimeSeriesMetadataReadTest {
 
-  private static final String FILE_PATH = FileGenerator.outputDataFile;
+  private static final String FILE_PATH = TestConstant.BASE_OUTPUT_PATH
+      .concat("TimeSeriesMetadataReadTest.tsfile");
   private final TSFileConfig conf = TSFileDescriptor.getInstance().getConfig();
   private int maxDegreeOfIndexNode;
 
@@ -41,7 +45,7 @@ public class TimeSeriesMetadataReadTest {
     int rowCount = 100;
     maxDegreeOfIndexNode = conf.getMaxDegreeOfIndexNode();
     conf.setMaxDegreeOfIndexNode(3);
-    FileGenerator.generateFile(rowCount, 10000);
+    FileGenerator.generateFile(rowCount, 10000, FILE_PATH);
   }
 
   @After

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
@@ -29,15 +29,12 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
-import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.footer.ChunkGroupFooter;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
-import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.read.common.Chunk;
-import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.utils.FileGenerator;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.junit.After;
@@ -49,14 +46,10 @@ public class TsFileSequenceReaderTest {
 
   private static final String FILE_PATH = FileGenerator.outputDataFile;
   private ReadOnlyTsFile tsFile;
-  private final TSFileConfig conf = TSFileDescriptor.getInstance().getConfig();
-  private int maxDegreeOfIndexNode;
 
   @Before
   public void before() throws IOException {
     int rowCount = 100;
-    maxDegreeOfIndexNode = conf.getMaxDegreeOfIndexNode();
-    conf.setMaxDegreeOfIndexNode(3);
     FileGenerator.generateFile(rowCount, 10000);
     TsFileSequenceReader fileReader = new TsFileSequenceReader(FILE_PATH);
     tsFile = new ReadOnlyTsFile(fileReader);
@@ -66,7 +59,6 @@ public class TsFileSequenceReaderTest {
   public void after() throws IOException {
     tsFile.close();
     FileGenerator.after();
-    conf.setMaxDegreeOfIndexNode(maxDegreeOfIndexNode);
   }
 
   @Test
@@ -161,36 +153,5 @@ public class TsFileSequenceReaderTest {
     // test for non-exist device "d3"
     Assert.assertTrue(reader.readChunkMetadataInDevice("d3").isEmpty());
     reader.close();
-  }
-
-  @Test
-  public void testReadTimeseriesMetadata() throws IOException {
-    TsFileSequenceReader reader = new TsFileSequenceReader(FILE_PATH);
-    Path path = new Path("d1", "s1");
-    Set<String> set = new HashSet<>();
-    set.add("s1");
-    set.add("s2");
-    set.add("s3");
-    // the Max Degree Of Index Node is set to be 3, so the leaf node should only contains 3 sensors
-    // s4 should not be returned as result
-    set.add("s4");
-    List<TimeseriesMetadata> timeseriesMetadataList = reader.readTimeseriesMetadata(path, set);
-    Assert.assertEquals(3, timeseriesMetadataList.size());
-    for (int i = 1; i <= timeseriesMetadataList.size(); i++) {
-      Assert.assertEquals("s" + i, timeseriesMetadataList.get(i - 1).getMeasurementId());
-    }
-
-    path = new Path("d1", "s5");
-    set.clear();
-    set.add("s5");
-    set.add("s6");
-    // this is a fake one, this file doesn't contain this measurement
-    // so the result is not supposed to contain this measurement's timeseries metadata
-    set.add("s8");
-    timeseriesMetadataList = reader.readTimeseriesMetadata(path, set);
-    Assert.assertEquals(2, timeseriesMetadataList.size());
-    for (int i = 5; i < 7; i++) {
-      Assert.assertEquals("s" + i, timeseriesMetadataList.get(i - 5).getMeasurementId());
-    }
   }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
@@ -60,6 +60,16 @@ public class FileGenerator {
     config.setMaxNumberOfPointsInPage(oldMaxNumberOfPointsInPage);
   }
 
+  public static void generateFile(int rowCount, int maxNumberOfPointsInPage, String filePath) throws IOException {
+    ROW_COUNT = rowCount;
+    int oldMaxNumberOfPointsInPage = config.getMaxNumberOfPointsInPage();
+    config.setMaxNumberOfPointsInPage(maxNumberOfPointsInPage);
+
+    prepare();
+    write(filePath);
+    config.setMaxNumberOfPointsInPage(oldMaxNumberOfPointsInPage);
+  }
+
   public static void generateFile(int maxNumberOfPointsInPage, int deviceNum,
       int measurementNum) throws IOException {
     ROW_COUNT = 1;
@@ -90,11 +100,15 @@ public class FileGenerator {
   }
 
   public static void after() {
+    after(outputDataFile);
+  }
+
+  public static void after(String filePath) {
     File file = new File(inputDataFile);
     if (file.exists()) {
       file.delete();
     }
-    file = new File(outputDataFile);
+    file = new File(filePath);
     if (file.exists()) {
       file.delete();
     }
@@ -184,7 +198,11 @@ public class FileGenerator {
   }
 
   static public void write() throws IOException {
-    File file = new File(outputDataFile);
+    write(outputDataFile);
+  }
+
+  static public void write(String filePath) throws IOException {
+    File file = new File(filePath);
     File errorFile = new File(errorOutputDataFile);
     if (file.exists()) {
       file.delete();

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
@@ -186,12 +186,8 @@ public class FileGenerator {
   static public void write() throws IOException {
     File file = new File(outputDataFile);
     File errorFile = new File(errorOutputDataFile);
-    if (file.exists()) {
-      file.delete();
-    }
-    if (errorFile.exists()) {
-      errorFile.delete();
-    }
+    Files.delete(file.toPath());
+    Files.delete(errorFile.toPath());
 
     innerWriter = new TsFileWriter(file, schema, config);
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
@@ -186,9 +186,13 @@ public class FileGenerator {
   static public void write() throws IOException {
     File file = new File(outputDataFile);
     File errorFile = new File(errorOutputDataFile);
-    Files.delete(file.toPath());
-    Files.delete(errorFile.toPath());
-    file.createNewFile();
+    if (file.exists()) {
+      file.delete();
+    }
+    if (errorFile.exists()) {
+      errorFile.delete();
+    }
+
     innerWriter = new TsFileWriter(file, schema, config);
 
     // write

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
@@ -188,7 +188,7 @@ public class FileGenerator {
     File errorFile = new File(errorOutputDataFile);
     Files.delete(file.toPath());
     Files.delete(errorFile.toPath());
-
+    file.createNewFile();
     innerWriter = new TsFileWriter(file, schema, config);
 
     // write


### PR DESCRIPTION
Currently, we add the entry size each time we put it into cache map. However, if the key already exists in cache, we will add the size again which will cause the cache used size is higher than the actual size.

Also, in this PR, I improve the process of deserializing time series metadata cache from disk.