### PR TITLE
debug log always display null in here

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -206,7 +206,7 @@ public class TsFileIOWriter {
     out.write(chunk.getData());
     endCurrentChunk();
     if (logger.isDebugEnabled()) {
-      logger.debug("end flushing a chunk:{}, totalvalue:{}", currentChunkMetadata,
+      logger.debug("end flushing a chunk:{}, totalvalue:{}", chunkHeader.getMeasurementID(),
           chunkMetadata.getNumOfPoints());
     }
   }


### PR DESCRIPTION
after `endCurrentChunk()`, currentChunkMetadata is null. so debug log keep displaying null in here.