### PR TITLE
Allow compression buffer to oversize maxLength during compression and shrink it later

### DIFF
--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
@@ -44,6 +44,12 @@ public class RpcUtils {
    * How big is the largest allowable frame? Defaults to 16MB.
    */
   public static final int DEFAULT_MAX_LENGTH = 16384000;
+  /**
+   * It is used to prevent the size of the parsing package from being too large and allocating the
+   * buffer will cause oom. Therefore, the maximum length of the requested memory is limited when
+   * reading. The default value is 512MB
+   */
+  public static final int FRAME_HARD_MAX_LENGTH = 536870912;
 
   private RpcUtils() {
     // util class

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TCompressedElasticFramedTransport.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TCompressedElasticFramedTransport.java
@@ -36,8 +36,8 @@ public abstract class TCompressedElasticFramedTransport extends TElasticFramedTr
   private int bufTooLargeCounter = MAX_BUFFER_OVERSIZE_TIME;
 
   protected TCompressedElasticFramedTransport(TTransport underlying, int initialBufferCapacity,
-      int maxSoftLength) {
-    super(underlying, initialBufferCapacity, maxSoftLength);
+      int softMaxLength) {
+    super(underlying, initialBufferCapacity, softMaxLength);
     writeCompressBuffer = new TByteBuffer(ByteBuffer.allocate(initialBufferCapacity));
     readCompressBuffer = new TByteBuffer(ByteBuffer.allocate(initialBufferCapacity));
   }
@@ -86,7 +86,7 @@ public abstract class TCompressedElasticFramedTransport extends TElasticFramedTr
       int newCapacity = Math.max(growCapacity, size);
       byteBuffer = new TByteBuffer(ByteBuffer.allocate(newCapacity));
       bufTooLargeCounter = MAX_BUFFER_OVERSIZE_TIME;
-    } else if (currentCapacity > maxSoftLength && currentCapacity * loadFactor > size
+    } else if (currentCapacity > softMaxLength && currentCapacity * loadFactor > size
         && bufTooLargeCounter-- <= 0
         && System.currentTimeMillis() - lastShrinkTime > MIN_SHRINK_INTERVAL) {
       // do not shrink beneath the initial size and do not shrink too often
@@ -116,8 +116,8 @@ public abstract class TCompressedElasticFramedTransport extends TElasticFramedTr
     }
 
     writeBuffer.reset();
-    if (maxSoftLength < length) {
-      writeBuffer.resizeIfNecessary(maxSoftLength);
+    if (softMaxLength < length) {
+      writeBuffer.resizeIfNecessary(softMaxLength);
     }
     underlying.flush();
   }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TCompressedElasticFramedTransport.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TCompressedElasticFramedTransport.java
@@ -30,9 +30,14 @@ public abstract class TCompressedElasticFramedTransport extends TElasticFramedTr
   private TByteBuffer writeCompressBuffer;
   private TByteBuffer readCompressBuffer;
 
+  private static final long MIN_SHRINK_INTERVAL = 60_000L;
+  private static final int MAX_BUFFER_OVERSIZE_TIME = 5;
+  private long lastShrinkTime;
+  private int bufTooLargeCounter = MAX_BUFFER_OVERSIZE_TIME;
+
   protected TCompressedElasticFramedTransport(TTransport underlying, int initialBufferCapacity,
-      int maxLength) {
-    super(underlying, initialBufferCapacity, maxLength);
+      int maxSoftLength) {
+    super(underlying, initialBufferCapacity, maxSoftLength);
     writeCompressBuffer = new TByteBuffer(ByteBuffer.allocate(initialBufferCapacity));
     readCompressBuffer = new TByteBuffer(ByteBuffer.allocate(initialBufferCapacity));
   }
@@ -64,14 +69,30 @@ public abstract class TCompressedElasticFramedTransport extends TElasticFramedTr
     }
   }
 
-  private TByteBuffer resizeCompressBuf(int size, TByteBuffer byteBuffer) {
-    double expandFactor = 1.5;
-    double loadFactor = 0.6;
-    if (byteBuffer.getByteBuffer().capacity() < size) {
-      int newCap = (int) Math.min(size * expandFactor, maxLength);
-      byteBuffer = new TByteBuffer(ByteBuffer.allocate(newCap));
-    } else if (byteBuffer.getByteBuffer().capacity() * loadFactor > size) {
-      byteBuffer = new TByteBuffer(ByteBuffer.allocate(size));
+  private TByteBuffer resizeCompressBuf(int size, TByteBuffer byteBuffer)
+      throws TTransportException {
+    if (size > RpcUtils.FRAME_HARD_MAX_LENGTH) {
+      close();
+      throw new TTransportException(TTransportException.CORRUPTED_DATA,
+          "Frame size (" + size + ") larger than protect max length (" + RpcUtils.FRAME_HARD_MAX_LENGTH
+              + ")!");
+    }
+
+    final int currentCapacity = byteBuffer.getByteBuffer().capacity();
+    final double loadFactor = 0.6;
+    if (currentCapacity < size) {
+      // Increase by a factor of 1.5x
+      int growCapacity = currentCapacity + (currentCapacity >> 1);
+      int newCapacity = Math.max(growCapacity, size);
+      byteBuffer = new TByteBuffer(ByteBuffer.allocate(newCapacity));
+      bufTooLargeCounter = MAX_BUFFER_OVERSIZE_TIME;
+    } else if (currentCapacity > maxSoftLength && currentCapacity * loadFactor > size
+        && bufTooLargeCounter-- <= 0
+        && System.currentTimeMillis() - lastShrinkTime > MIN_SHRINK_INTERVAL) {
+      // do not shrink beneath the initial size and do not shrink too often
+      byteBuffer = new TByteBuffer(ByteBuffer.allocate(size + (currentCapacity - size) / 2));
+      lastShrinkTime = System.currentTimeMillis();
+      bufTooLargeCounter = MAX_BUFFER_OVERSIZE_TIME;
     }
     return byteBuffer;
   }
@@ -95,8 +116,8 @@ public abstract class TCompressedElasticFramedTransport extends TElasticFramedTr
     }
 
     writeBuffer.reset();
-    if (maxLength < length) {
-      writeBuffer.resizeIfNecessary(maxLength);
+    if (maxSoftLength < length) {
+      writeBuffer.resizeIfNecessary(maxSoftLength);
     }
     underlying.flush();
   }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TSnappyElasticFramedTransport.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TSnappyElasticFramedTransport.java
@@ -43,7 +43,7 @@ public class TSnappyElasticFramedTransport extends TCompressedElasticFramedTrans
 
     @Override
     public TTransport getTransport(TTransport trans) {
-      return new TSnappyElasticFramedTransport(trans, initialCapacity, maxSoftLength);
+      return new TSnappyElasticFramedTransport(trans, initialCapacity, softMaxLength);
     }
   }
 

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TSnappyElasticFramedTransport.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TSnappyElasticFramedTransport.java
@@ -43,7 +43,7 @@ public class TSnappyElasticFramedTransport extends TCompressedElasticFramedTrans
 
     @Override
     public TTransport getTransport(TTransport trans) {
-      return new TSnappyElasticFramedTransport(trans, initialCapacity, maxLength);
+      return new TSnappyElasticFramedTransport(trans, initialCapacity, maxSoftLength);
     }
   }
 


### PR DESCRIPTION
Change the previous `maxLength` to a more precise `maxSoftLength`, and allow compression buffer to oversize maxLength during compression and shrink it later, if the adjacent requests are smaller.