### PR TITLE
[IOTDB-1086] Improve document of Zeppelin installation

### DIFF
--- a/docs/UserGuide/Ecosystem Integration/Zeppelin-IoTDB.md
+++ b/docs/UserGuide/Ecosystem Integration/Zeppelin-IoTDB.md
@@ -52,7 +52,7 @@ Zeppelin is a web-based notebook that enables interactive data analytics. You ca
 Install IoTDB: Reference to [IoTDB Quick Start](https://iotdb.apache.org/UserGuide/Master/Get%20Started/QuickStart.html). Suppose IoTDB is placed at `$IoTDB_HOME`.
 
 Install Zeppelin:
-> Method A. Download directly: You can download [Zeppelin](https://zeppelin.apache.org/download.html#) and unpack the binary package. [netinst](http://www.apache.org/dyn/closer.cgi/zeppelin/zeppelin-0.9.0/zeppelin-0.9.0-bin-netinst.tgz) binary package is recommended.
+> Method A. Download directly: You can download [Zeppelin](https://zeppelin.apache.org/download.html#) and unpack the binary package. [netinst](http://www.apache.org/dyn/closer.cgi/zeppelin/zeppelin-0.9.0/zeppelin-0.9.0-bin-netinst.tgz) binary package is recommended since it's relatively small by excluding irrelevant interpreters.
 > 
 > Method B. Compile from source code: Reference to [build Zeppelin from source](https://zeppelin.apache.org/docs/latest/setup/basics/how_to_build.html). The command is `mvn clean package -pl zeppelin-web,zeppelin-server -am -DskipTests`.
 

--- a/docs/UserGuide/Ecosystem Integration/Zeppelin-IoTDB.md
+++ b/docs/UserGuide/Ecosystem Integration/Zeppelin-IoTDB.md
@@ -49,11 +49,14 @@ Zeppelin is a web-based notebook that enables interactive data analytics. You ca
 | :-----------: | :-----------: | :--------------: |
 |  >=`0.12.0-SNAPSHOT`   | >=`1.8.0_271` |    `>=0.9.0`     |
 
-You can install IoTDB according to [IoTDB Quick Start](https://iotdb.apache.org/UserGuide/Master/Get%20Started/QuickStart.html). Suppose IoTDB is placed at `$IoTDB_HOME`.
+Install IoTDB: Reference to [IoTDB Quick Start](https://iotdb.apache.org/UserGuide/Master/Get%20Started/QuickStart.html). Suppose IoTDB is placed at `$IoTDB_HOME`.
 
-You can download [Zeppelin](https://zeppelin.apache.org/download.html#) and unpack the binary package directly or [build Zeppelin from source](https://zeppelin.apache.org/docs/latest/setup/basics/how_to_build.html). Suppose Zeppelin is placed at `$Zeppelin_HOME`.
+Install Zeppelin:
+> Method A. Download directly: You can download [Zeppelin](https://zeppelin.apache.org/download.html#) and unpack the binary package. [netinst](http://www.apache.org/dyn/closer.cgi/zeppelin/zeppelin-0.9.0/zeppelin-0.9.0-bin-netinst.tgz) binary package is recommended.
+> 
+> Method B. Compile from source code: Reference to [build Zeppelin from source](https://zeppelin.apache.org/docs/latest/setup/basics/how_to_build.html). The command is `mvn clean package -pl zeppelin-web,zeppelin-server -am -DskipTests`.
 
-
+Suppose Zeppelin is placed at `$Zeppelin_HOME`.
 
 ## 3.2 Build Interpreter
 

--- a/docs/zh/UserGuide/Ecosystem Integration/Zeppelin-IoTDB.md
+++ b/docs/zh/UserGuide/Ecosystem Integration/Zeppelin-IoTDB.md
@@ -48,11 +48,14 @@ Apache Zeppelin 是一个基于网页的交互式数据分析系统。用户可�
 | :--------: | :-----------: | :-----------: |
 | >=`0.12.0-SNAPSHOT` | >=`1.8.0_271` |   `>=0.9.0`   |
 
-> 用户需要首先安装IoTDB：[IoTDB Quick Start](https://iotdb.apache.org/UserGuide/Master/Get%20Started/QuickStart.html). 假设 IoTDB 安装在 `$IoTDB_HOME`.
+安装 IoTDB：参考 [IoTDB Quick Start](https://iotdb.apache.org/UserGuide/Master/Get%20Started/QuickStart.html). 假设 IoTDB 安装在 `$IoTDB_HOME`.
+
+安装 Zeppelin：
+> 方法1 直接下载：下载 [Zeppelin](https://zeppelin.apache.org/download.html#) 并解压二进制文件。推荐下载 [netinst](http://www.apache.org/dyn/closer.cgi/zeppelin/zeppelin-0.9.0/zeppelin-0.9.0-bin-netinst.tgz) 二进制包。
 >
-> 用户可以下载 [Zeppelin](https://zeppelin.apache.org/download.html#) 并解压二进制文件，或 [从源码构建Zeppelin](https://zeppelin.apache.org/docs/latest/setup/basics/how_to_build.html). 假设 Zeppelin 安装在 `$Zeppelin_HOME`.
+> 方法2 源码编译：参考[从源码构建 Zeppelin](https://zeppelin.apache.org/docs/latest/setup/basics/how_to_build.html) ，使用命令为 `mvn clean package -pl zeppelin-web,zeppelin-server -am -DskipTests`。
 
-
+假设 Zeppelin 安装在 `$Zeppelin_HOME`.
 
 ## 3.2 编译解释器
 

--- a/docs/zh/UserGuide/Ecosystem Integration/Zeppelin-IoTDB.md
+++ b/docs/zh/UserGuide/Ecosystem Integration/Zeppelin-IoTDB.md
@@ -51,7 +51,7 @@ Apache Zeppelin 是一个基于网页的交互式数据分析系统。用户可�
 安装 IoTDB：参考 [IoTDB Quick Start](https://iotdb.apache.org/UserGuide/Master/Get%20Started/QuickStart.html). 假设 IoTDB 安装在 `$IoTDB_HOME`.
 
 安装 Zeppelin：
-> 方法1 直接下载：下载 [Zeppelin](https://zeppelin.apache.org/download.html#) 并解压二进制文件。推荐下载 [netinst](http://www.apache.org/dyn/closer.cgi/zeppelin/zeppelin-0.9.0/zeppelin-0.9.0-bin-netinst.tgz) 二进制包。
+> 方法1 直接下载：下载 [Zeppelin](https://zeppelin.apache.org/download.html#) 并解压二进制文件。推荐下载 [netinst](http://www.apache.org/dyn/closer.cgi/zeppelin/zeppelin-0.9.0/zeppelin-0.9.0-bin-netinst.tgz) 二进制包，此包由于未编译不相关的interpreter，因此大小相对较小。
 >
 > 方法2 源码编译：参考[从源码构建 Zeppelin](https://zeppelin.apache.org/docs/latest/setup/basics/how_to_build.html) ，使用命令为 `mvn clean package -pl zeppelin-web,zeppelin-server -am -DskipTests`。
 


### PR DESCRIPTION
If users download Zeppelin directly, the binary package is about 1.5G.

We could give two ways of installation to avoid this big surprise.