### PR TITLE
[IOTDB-1084] [To rel/0.11] Fix temporary memory of flushing may cause OOM

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -267,8 +267,11 @@ max_waiting_time_when_insert_blocked=10000
 # estimated metadata size (in byte) of one timeseries in Mtree
 estimated_series_size=300
 
-# size of ioTaskQueue and encodingTaskQueue. The default value is 2147483647
-queue_size_for_flushing=2147483647
+# size of encodingTaskQueue. The default value is 2147483647
+encoding_task_queue_size_for_flushing=2147483647
+
+# size of ioTaskQueue. The default value is 2147483647
+io_task_queue_size_for_flushing=2147483647
 
 ####################
 ### Upgrade Configurations

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -267,6 +267,9 @@ max_waiting_time_when_insert_blocked=10000
 # estimated metadata size (in byte) of one timeseries in Mtree
 estimated_series_size=300
 
+# size of ioTaskQueue and encodingTaskQueue. The default value is 2147483647
+queue_size_for_flushing=2147483647
+
 ####################
 ### Upgrade Configurations
 ####################

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -759,6 +759,11 @@ public class IoTDBConfig {
    */
   private boolean debugState = false;
 
+  /**
+   * the size of ioTaskQueue and encodingTaskQueue
+   */
+  private int queueSizeForFlushing = Integer.MAX_VALUE;
+
   public IoTDBConfig() {
     // empty constructor
   }
@@ -2044,5 +2049,13 @@ public class IoTDBConfig {
 
   public void setDebugState(boolean debugState) {
     this.debugState = debugState;
+  }
+
+  public int getQueueSizeForFlushing() {
+    return queueSizeForFlushing;
+  }
+
+  public void setQueueSizeForFlushing(int queueSizeForFlushing) {
+    this.queueSizeForFlushing = queueSizeForFlushing;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -760,9 +760,14 @@ public class IoTDBConfig {
   private boolean debugState = false;
 
   /**
-   * the size of ioTaskQueue and encodingTaskQueue
+   * the size of ioTaskQueue
    */
-  private int queueSizeForFlushing = Integer.MAX_VALUE;
+  private int ioTaskQueueSizeForFlushing = Integer.MAX_VALUE;
+
+  /**
+   * the size of encodingTaskQueue
+   */
+  private int encodingTaskQueueSizeForFlushing = Integer.MAX_VALUE;
 
   public IoTDBConfig() {
     // empty constructor
@@ -2051,11 +2056,19 @@ public class IoTDBConfig {
     this.debugState = debugState;
   }
 
-  public int getQueueSizeForFlushing() {
-    return queueSizeForFlushing;
+  public int getEncodingTaskQueueSizeForFlushing() {
+    return encodingTaskQueueSizeForFlushing;
   }
 
-  public void setQueueSizeForFlushing(int queueSizeForFlushing) {
-    this.queueSizeForFlushing = queueSizeForFlushing;
+  public void setEncodingTaskQueueSizeForFlushing(int encodingTaskQueueSizeForFlushing) {
+    this.encodingTaskQueueSizeForFlushing = encodingTaskQueueSizeForFlushing;
+  }
+
+  public int getIoTaskQueueSizeForFlushing() {
+    return ioTaskQueueSizeForFlushing;
+  }
+
+  public void setIoTaskQueueSizeForFlushing(int ioTaskQueueSizeForFlushing) {
+    this.ioTaskQueueSizeForFlushing = ioTaskQueueSizeForFlushing;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -295,9 +295,13 @@ public class IoTDBDescriptor {
           .getProperty("estimated_series_size",
               Integer.toString(conf.getEstimatedSeriesSize()))));
 
-      conf.setQueueSizeForFlushing(Integer.parseInt(properties
-          .getProperty("queue_size_for_flushing",
-              Integer.toString(conf.getQueueSizeForFlushing()))));
+      conf.setIoTaskQueueSizeForFlushing(Integer.parseInt(properties
+          .getProperty("io_task_queue_size_for_flushing",
+              Integer.toString(conf.getIoTaskQueueSizeForFlushing()))));
+
+      conf.setEncodingTaskQueueSizeForFlushing(Integer.parseInt(properties
+          .getProperty("encoding_task_queue_size_for_flushing",
+              Integer.toString(conf.getEncodingTaskQueueSizeForFlushing()))));
 
       conf.setMergeChunkPointNumberThreshold(Integer.parseInt(properties
           .getProperty("merge_chunk_point_number",

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -295,6 +295,10 @@ public class IoTDBDescriptor {
           .getProperty("estimated_series_size",
               Integer.toString(conf.getEstimatedSeriesSize()))));
 
+      conf.setQueueSizeForFlushing(Integer.parseInt(properties
+          .getProperty("queue_size_for_flushing",
+              Integer.toString(conf.getQueueSizeForFlushing()))));
+
       conf.setMergeChunkPointNumberThreshold(Integer.parseInt(properties
           .getProperty("merge_chunk_point_number",
               Integer.toString(conf.getMergeChunkPointNumberThreshold()))));

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -186,7 +186,8 @@ public class MemTableFlushTask {
             try {
               ioTaskQueue.put(task);
             } catch (InterruptedException e) {
-              logger.warn("Put task into ioTaskQueue Interrupted");
+              logger.error("Put task into ioTaskQueue Interrupted");
+              Thread.currentThread().interrupt();
             }
           } else {
             long starTime = System.currentTimeMillis();
@@ -196,7 +197,8 @@ public class MemTableFlushTask {
             try {
               ioTaskQueue.put(seriesWriter);
             } catch (InterruptedException e) {
-              logger.warn("Put task into ioTaskQueue Interrupted");
+              logger.error("Put task into ioTaskQueue Interrupted");
+              Thread.currentThread().interrupt();
             }
             memSerializeTime += System.currentTimeMillis() - starTime;
           }

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -193,6 +193,7 @@ public class MemTableFlushTask {
           IChunkWriter seriesWriter = new ChunkWriterImpl(encodingMessage.right);
           writeOneSeries(encodingMessage.left, seriesWriter, encodingMessage.right.getType());
           seriesWriter.sealCurrentPage();
+          seriesWriter.clearPageWriter();
           try {
             ioTaskQueue.put(seriesWriter);
           } catch (InterruptedException e) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -19,10 +19,12 @@
 package org.apache.iotdb.db.engine.flush;
 
 import java.io.IOException;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.flush.pool.FlushSubTaskPoolManager;
 import org.apache.iotdb.db.engine.memtable.IMemTable;
 import org.apache.iotdb.db.engine.memtable.IWritableMemChunk;
@@ -42,12 +44,15 @@ public class MemTableFlushTask {
   private static final Logger logger = LoggerFactory.getLogger(MemTableFlushTask.class);
   private static final FlushSubTaskPoolManager subTaskPoolManager = FlushSubTaskPoolManager
       .getInstance();
+  private static IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private final Future<?> encodingTaskFuture;
   private final Future<?> ioTaskFuture;
   private RestorableTsFileIOWriter writer;
 
-  private final ConcurrentLinkedQueue<Object> ioTaskQueue = new ConcurrentLinkedQueue<>();
-  private final ConcurrentLinkedQueue<Object> encodingTaskQueue = new ConcurrentLinkedQueue<>();
+  private final LinkedBlockingQueue<Object> ioTaskQueue =
+      new LinkedBlockingQueue<>(config.getQueueSizeForFlushing());
+  private final LinkedBlockingQueue<Object> encodingTaskQueue = 
+      new LinkedBlockingQueue<>(config.getQueueSizeForFlushing());
   private String storageGroup;
 
   private IMemTable memTable;
@@ -84,16 +89,16 @@ public class MemTableFlushTask {
     long sortTime = 0;
 
     for (String deviceId : memTable.getMemTableMap().keySet()) {
-      encodingTaskQueue.add(new StartFlushGroupIOTask(deviceId));
+      encodingTaskQueue.put(new StartFlushGroupIOTask(deviceId));
       for (String measurementId : memTable.getMemTableMap().get(deviceId).keySet()) {
         long startTime = System.currentTimeMillis();
         IWritableMemChunk series = memTable.getMemTableMap().get(deviceId).get(measurementId);
         MeasurementSchema desc = series.getSchema();
         TVList tvList = series.getSortedTVList();
         sortTime += System.currentTimeMillis() - startTime;
-        encodingTaskQueue.add(new Pair<>(tvList, desc));
+        encodingTaskQueue.put(new Pair<>(tvList, desc));
       }
-      encodingTaskQueue.add(new EndChunkGroupIoTask());
+      encodingTaskQueue.put(new EndChunkGroupIoTask());
     }
     noMoreEncodingTask = true;
     logger.debug(
@@ -176,23 +181,25 @@ public class MemTableFlushTask {
           if (noMoreMessages) {
             break;
           }
-          try {
-            TimeUnit.MILLISECONDS.sleep(10);
-          } catch (@SuppressWarnings("squid:S2142") InterruptedException e) {
-            logger.error("Storage group {} memtable {}, encoding task is interrupted.",
-                storageGroup, memTable.getVersion(), e);
-            // generally it is because the thread pool is shutdown so the task should be aborted
-            break;
-          }
         } else {
           if (task instanceof StartFlushGroupIOTask || task instanceof EndChunkGroupIoTask) {
-            ioTaskQueue.add(task);
+            try {
+              ioTaskQueue.put(task);
+            } catch (InterruptedException e) {
+              // TODO Auto-generated catch block
+              e.printStackTrace();
+            }
           } else {
             long starTime = System.currentTimeMillis();
             Pair<TVList, MeasurementSchema> encodingMessage = (Pair<TVList, MeasurementSchema>) task;
             IChunkWriter seriesWriter = new ChunkWriterImpl(encodingMessage.right);
             writeOneSeries(encodingMessage.left, seriesWriter, encodingMessage.right.getType());
-            ioTaskQueue.add(seriesWriter);
+            try {
+              ioTaskQueue.put(seriesWriter);
+            } catch (InterruptedException e) {
+              // TODO Auto-generated catch block
+              e.printStackTrace();
+            }
             memSerializeTime += System.currentTimeMillis() - starTime;
           }
         }
@@ -216,14 +223,6 @@ public class MemTableFlushTask {
       Object ioMessage = ioTaskQueue.poll();
       if (ioMessage == null) {
         if (returnWhenNoTask) {
-          break;
-        }
-        try {
-          TimeUnit.MILLISECONDS.sleep(10);
-        } catch (@SuppressWarnings("squid:S2142") InterruptedException e) {
-          logger.error("Storage group {} memtable {}, io task is interrupted.", storageGroup
-              , memTable.getVersion(), e);
-          // generally it is because the thread pool is shutdown so the task should be aborted
           break;
         }
       } else {

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -186,8 +186,7 @@ public class MemTableFlushTask {
             try {
               ioTaskQueue.put(task);
             } catch (InterruptedException e) {
-              // TODO Auto-generated catch block
-              e.printStackTrace();
+              logger.warn("Put task into ioTaskQueue Interrupted");
             }
           } else {
             long starTime = System.currentTimeMillis();
@@ -197,8 +196,7 @@ public class MemTableFlushTask {
             try {
               ioTaskQueue.put(seriesWriter);
             } catch (InterruptedException e) {
-              // TODO Auto-generated catch block
-              e.printStackTrace();
+              logger.warn("Put task into ioTaskQueue Interrupted");
             }
             memSerializeTime += System.currentTimeMillis() - starTime;
           }

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -50,9 +50,9 @@ public class MemTableFlushTask {
   private RestorableTsFileIOWriter writer;
 
   private final LinkedBlockingQueue<Object> ioTaskQueue =
-      new LinkedBlockingQueue<>(config.getQueueSizeForFlushing());
+      new LinkedBlockingQueue<>(config.getIoTaskQueueSizeForFlushing());
   private final LinkedBlockingQueue<Object> encodingTaskQueue = 
-      new LinkedBlockingQueue<>(config.getQueueSizeForFlushing());
+      new LinkedBlockingQueue<>(config.getEncodingTaskQueueSizeForFlushing());
   private String storageGroup;
 
   private IMemTable memTable;

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -57,8 +57,6 @@ public class MemTableFlushTask {
 
   private IMemTable memTable;
 
-  private volatile boolean noMoreEncodingTask = false;
-  private volatile boolean noMoreIOTask = false;
 
   /**
    * @param memTable the memTable to flush
@@ -100,7 +98,7 @@ public class MemTableFlushTask {
       }
       encodingTaskQueue.put(new EndChunkGroupIoTask());
     }
-    noMoreEncodingTask = true;
+    encodingTaskQueue.put(new TaskEnd());
     logger.debug(
         "Storage group {} memtable {}, flushing into disk: data sort time cost {} ms.",
         storageGroup, memTable.getVersion(), sortTime);
@@ -108,8 +106,6 @@ public class MemTableFlushTask {
     try {
       encodingTaskFuture.get();
     } catch (InterruptedException | ExecutionException e) {
-      // avoid ioTask waiting forever
-      noMoreIOTask = true;
       ioTaskFuture.cancel(true);
       throw e;
     }
@@ -169,42 +165,49 @@ public class MemTableFlushTask {
     @Override
     public void run() {
       long memSerializeTime = 0;
-      boolean noMoreMessages = false;
       logger.debug("Storage group {} memtable {}, starts to encoding data.", storageGroup,
           memTable.getVersion());
       while (true) {
-        if (noMoreEncodingTask) {
-          noMoreMessages = true;
+
+        Object task = null;
+        try {
+          task = encodingTaskQueue.take();
+        } catch (InterruptedException e1) {
+          logger.error("Take task into ioTaskQueue Interrupted");
+          Thread.currentThread().interrupt();
+          break;
         }
-        Object task = encodingTaskQueue.poll();
-        if (task == null) {
-          if (noMoreMessages) {
+        if (task instanceof StartFlushGroupIOTask || task instanceof EndChunkGroupIoTask) {
+          try {
+            ioTaskQueue.put(task);
+          } catch (InterruptedException e) {
+            logger.error("Put task into ioTaskQueue Interrupted");
+            Thread.currentThread().interrupt();
             break;
           }
+        } else if (task instanceof TaskEnd) {
+          break;
         } else {
-          if (task instanceof StartFlushGroupIOTask || task instanceof EndChunkGroupIoTask) {
-            try {
-              ioTaskQueue.put(task);
-            } catch (InterruptedException e) {
-              logger.error("Put task into ioTaskQueue Interrupted");
-              Thread.currentThread().interrupt();
-            }
-          } else {
-            long starTime = System.currentTimeMillis();
-            Pair<TVList, MeasurementSchema> encodingMessage = (Pair<TVList, MeasurementSchema>) task;
-            IChunkWriter seriesWriter = new ChunkWriterImpl(encodingMessage.right);
-            writeOneSeries(encodingMessage.left, seriesWriter, encodingMessage.right.getType());
-            try {
-              ioTaskQueue.put(seriesWriter);
-            } catch (InterruptedException e) {
-              logger.error("Put task into ioTaskQueue Interrupted");
-              Thread.currentThread().interrupt();
-            }
-            memSerializeTime += System.currentTimeMillis() - starTime;
+          long starTime = System.currentTimeMillis();
+          Pair<TVList, MeasurementSchema> encodingMessage = (Pair<TVList, MeasurementSchema>) task;
+          IChunkWriter seriesWriter = new ChunkWriterImpl(encodingMessage.right);
+          writeOneSeries(encodingMessage.left, seriesWriter, encodingMessage.right.getType());
+          seriesWriter.sealCurrentPage();
+          try {
+            ioTaskQueue.put(seriesWriter);
+          } catch (InterruptedException e) {
+            logger.error("Put task into ioTaskQueue Interrupted");
+            Thread.currentThread().interrupt();
           }
+          memSerializeTime += System.currentTimeMillis() - starTime;
         }
       }
-      noMoreIOTask = true;
+      try {
+        ioTaskQueue.put(new TaskEnd());
+      } catch (InterruptedException e) {
+        logger.error("Put task into ioTaskQueue Interrupted");
+        Thread.currentThread().interrupt();
+      }
       logger.debug("Storage group {}, flushing memtable {} into disk: Encoding data cost "
               + "{} ms.",
           storageGroup, memTable.getVersion(), memSerializeTime);
@@ -214,39 +217,46 @@ public class MemTableFlushTask {
   @SuppressWarnings("squid:S135")
   private Runnable ioTask = () -> {
     long ioTime = 0;
-    boolean returnWhenNoTask = false;
     logger.debug("Storage group {} memtable {}, start io.", storageGroup, memTable.getVersion());
     while (true) {
-      if (noMoreIOTask) {
-        returnWhenNoTask = true;
+      Object ioMessage = null;
+      try {
+        ioMessage = ioTaskQueue.take();
+      } catch (InterruptedException e1) {
+        logger.error("take task from ioTaskQueue Interrupted");
+        Thread.currentThread().interrupt();
+        break;
       }
-      Object ioMessage = ioTaskQueue.poll();
-      if (ioMessage == null) {
-        if (returnWhenNoTask) {
+      long starTime = System.currentTimeMillis();
+      try {
+        if (ioMessage instanceof StartFlushGroupIOTask) {
+          this.writer.startChunkGroup(((StartFlushGroupIOTask) ioMessage).deviceId);
+        } else if (ioMessage instanceof TaskEnd) {
           break;
         }
-      } else {
-        long starTime = System.currentTimeMillis();
-        try {
-          if (ioMessage instanceof StartFlushGroupIOTask) {
-            this.writer.startChunkGroup(((StartFlushGroupIOTask) ioMessage).deviceId);
-          } else if (ioMessage instanceof IChunkWriter) {
-            ChunkWriterImpl chunkWriter = (ChunkWriterImpl) ioMessage;
-            chunkWriter.writeToFileWriter(this.writer);
-          } else {
-            this.writer.endChunkGroup();
-          }
-        } catch (IOException e) {
-          logger.error("Storage group {} memtable {}, io task meets error.", storageGroup,
-              memTable.getVersion(), e);
-          throw new FlushRunTimeException(e);
+        else if (ioMessage instanceof IChunkWriter) {
+          ChunkWriterImpl chunkWriter = (ChunkWriterImpl) ioMessage;
+          chunkWriter.writeToFileWriter(this.writer);
+        } else {
+          this.writer.endChunkGroup();
         }
-        ioTime += System.currentTimeMillis() - starTime;
+      } catch (IOException e) {
+        logger.error("Storage group {} memtable {}, io task meets error.", storageGroup,
+            memTable.getVersion(), e);
+        throw new FlushRunTimeException(e);
       }
+      ioTime += System.currentTimeMillis() - starTime;
     }
     logger.debug("flushing a memtable {} in storage group {}, io cost {}ms", memTable.getVersion(),
         storageGroup, ioTime);
   };
+  
+  static class TaskEnd {
+    
+    TaskEnd() {
+      
+    }
+  }
 
   static class EndChunkGroupIoTask {
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
@@ -240,8 +240,9 @@ public class ChunkWriterImpl implements IChunkWriter {
 
   @Override
   public void sealCurrentPage() {
-    if (pageWriter.getPointNumber() > 0) {
+    if (pageWriter != null && pageWriter.getPointNumber() > 0) {
       writePageToPageBuffer();
+      pageWriter = null;
     }
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
@@ -242,8 +242,11 @@ public class ChunkWriterImpl implements IChunkWriter {
   public void sealCurrentPage() {
     if (pageWriter != null && pageWriter.getPointNumber() > 0) {
       writePageToPageBuffer();
-      pageWriter = null;
     }
+  }
+  
+  public void clearPageWriter() {
+    pageWriter = null;
   }
 
   @Override

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/IChunkWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/IChunkWriter.java
@@ -115,6 +115,11 @@ public interface IChunkWriter {
    * seal the current page which may has not enough data points in force.
    */
   void sealCurrentPage();
+  
+  /**
+   * set the current pageWriter to null, friendly for gc
+   */
+  void clearPageWriter();
 
   int getNumOfPages();
 


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

        http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->

<!-- Thanks for trying to help us make Apache IoTDB be the best it can be! 
Please fill out as much of the following information as is possible (where relevant, and remove it 
when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue, 
it's not necessary to repeat the description here, 
however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section 
for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [x] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

<!-- Template copied and modified from Apache Druid-->