### PR TITLE
[Distributed] Fix init serialToParallelPool bug if cpu.cores > 100

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -295,7 +295,7 @@ public abstract class RaftMember {
             new ThreadFactoryBuilder().setNameFormat(getName() +
                 "-AppendLog%d").build());
     if (!ClusterDescriptor.getInstance().getConfig().isUseAsyncServer()) {
-      serialToParallelPool = new ThreadPoolExecutor(allNodes.size(), Runtime.getRuntime().availableProcessors(),
+      serialToParallelPool = new ThreadPoolExecutor(allNodes.size(), Math.max(allNodes.size(), Runtime.getRuntime().availableProcessors()),
           1000L, TimeUnit.MILLISECONDS,
           new LinkedBlockingQueue<>(), new ThreadFactoryBuilder().setNameFormat(getName() +
           "-SerialToParallel%d").build());

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -295,8 +295,8 @@ public abstract class RaftMember {
             new ThreadFactoryBuilder().setNameFormat(getName() +
                 "-AppendLog%d").build());
     if (!ClusterDescriptor.getInstance().getConfig().isUseAsyncServer()) {
-      serialToParallelPool = new ThreadPoolExecutor(Runtime.getRuntime().availableProcessors(), 100,
-          0L, TimeUnit.MILLISECONDS,
+      serialToParallelPool = new ThreadPoolExecutor(allNodes.size(), Runtime.getRuntime().availableProcessors(),
+          1000L, TimeUnit.MILLISECONDS,
           new LinkedBlockingQueue<>(), new ThreadFactoryBuilder().setNameFormat(getName() +
           "-SerialToParallel%d").build());
     }


### PR DESCRIPTION
We will encounter a exception when starting cluster server if cpu.cores > 100, so we should change the parameters for `ThreadPoolExecutor`. As `serialToParallelPool` will only do heartbeat or add/remove node, I think the coreSize can be 'allNode.size()', and the maxSize can be set to `Math.max(allNodes.size(), Runtime.getRuntime().availableProcessors())`. 