### PR TITLE
[To rel/0.11] [IOTDB-1065] Fix deletion bug while trying to delete data from a timeseries which contains comma

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/modification/io/LocalTextModificationAccessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/modification/io/LocalTextModificationAccessor.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import org.apache.iotdb.db.engine.modification.Deletion;
@@ -127,33 +128,63 @@ public class LocalTextModificationAccessor implements ModificationReader, Modifi
         + del.getStartTime() + SEPARATOR + del.getEndTime();
   }
 
+  /**
+   * Decode a range deletion record. E.g. "DELETION,root.ln.wf01.wt01.temperature,111,100,300"
+   * the index of field endTimestamp is length - 1, startTimestamp is length - 2,
+   * versionNum is length - 3. Fields in index range [1, length -3) all belong
+   * to a timeseries path in case when the path contains comma.
+   */
   private static Deletion decodeDeletion(String[] fields) throws IOException {
-    if (fields.length != 5 && fields.length != 4) {
+    if (fields.length < 4) {
       throw new IOException("Incorrect deletion fields number: " + fields.length);
     }
 
-    String path = fields[1];
-    long versionNum;
-    long startTimestamp = Long.MIN_VALUE;
+    String path = "";
+    long startTimestamp;
     long endTimestamp;
+    long versionNum;
     try {
-      versionNum = Long.parseLong(fields[2]);
+      versionNum = Long.parseLong(fields[fields.length - 3]);
     } catch (NumberFormatException e) {
-      throw new IOException("Invalid version number: " + fields[2]);
+      return decodePointDeletion(fields);
     }
 
     try {
-      if (fields.length == 4) {
-        endTimestamp = Long.parseLong(fields[3]);
-
-      } else {
-        startTimestamp = Long.parseLong(fields[3]);
-        endTimestamp = Long.parseLong(fields[4]);
-      }
-      return new Deletion(new PartialPath(path), versionNum, startTimestamp, endTimestamp);
-    } catch (NumberFormatException | IllegalPathException e) {
+      endTimestamp = Long.parseLong(fields[fields.length - 1]);
+      startTimestamp = Long.parseLong(fields[fields.length - 2]);
+    } catch (NumberFormatException e) {
       throw new IOException("Invalid timestamp: " + e.getMessage());
     }
+    try {
+      String[] pathArray = Arrays.copyOfRange(fields, 1, fields.length - 3);
+      path = String.join(SEPARATOR, pathArray);
+      return new Deletion(new PartialPath(path), versionNum, startTimestamp, endTimestamp);
+    } catch (IllegalPathException e) {
+      throw new IOException("Invalid series path: " + path);
+    }
+  }
 
+  /**
+   * Decode a point deletion record. E.g. "DELETION,root.ln.wf01.wt01.temperature,111,300"
+   * the index of field endTimestamp is length - 1, versionNum is length - 2.
+   * Fields in index range [1, length - 2) compose timeseries path.
+   */
+  private static Deletion decodePointDeletion(String[] fields) throws IOException {
+    String path = "";
+    long versionNum;
+    long endTimestamp;
+    try {
+      endTimestamp = Long.parseLong(fields[fields.length - 1]);
+      versionNum = Long.parseLong(fields[fields.length - 2]);
+    } catch (NumberFormatException e) {
+      throw new IOException("Invalid timestamp: " + e.getMessage());
+    }
+    try {
+      String[] pathArray = Arrays.copyOfRange(fields, 1, fields.length - 2);
+      path = String.join(SEPARATOR, pathArray);
+      return new Deletion(new PartialPath(path), versionNum, endTimestamp);
+    } catch (IllegalPathException e) {
+      throw new IOException("Invalid series path: " + path);
+    }
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -276,6 +277,40 @@ public class IoTDBDeletionIT {
       cleanData();
     }
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(size);
+  }
+
+  @Test
+  public void testDelSeriesWithSpecialSymbol() throws SQLException {
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root",
+            "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("CREATE TIMESERIES root.ln.d1.\"status,01\" WITH DATATYPE=BOOLEAN,"
+          + " ENCODING=PLAIN");
+      statement.execute("INSERT INTO root.ln.d1(timestamp,\"status,01\") "
+          + "values(300,true)");
+      statement.execute("INSERT INTO root.ln.d1(timestamp,\"status,01\") VALUES(500, false)");
+
+      statement.execute("DELETE FROM root.ln.d1.\"status,01\" WHERE time <= 400");
+
+      try (ResultSet resultSet = statement.executeQuery("select \"status,01\" from root.ln.d1")) {
+        int cnt = 0;
+        while (resultSet.next()) {
+          cnt++;
+        }
+        Assert.assertEquals(1, cnt);
+      }
+
+      statement.execute("DELETE FROM root.ln.d1.\"status,01\"");
+
+      try (ResultSet resultSet = statement.executeQuery("select \"status,01\" from root.ln.d1")) {
+        int cnt = 0;
+        while (resultSet.next()) {
+          cnt++;
+        }
+        Assert.assertEquals(0, cnt);
+      }
+    }
   }
 
   private static void prepareSeries() {


### PR DESCRIPTION
cherry pick from #2306

<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

        http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->

<!-- Thanks for trying to help us make Apache IoTDB be the best it can be! 
Please fill out as much of the following information as is possible (where relevant, and remove it 
when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

## Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue, 
it's not necessary to repeat the description here, 
however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section 
for each of them. For example: -->

### Content1 ...
### Content2 ...
### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

<!-- Template copied and modified from Apache Druid-->