### PR TITLE
[IOTDB-1071] Built-in UDF registration service

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -86,8 +86,15 @@ public class IoTDBConstant {
   public static final String COLUMN_CANCELLED = "cancelled";
   public static final String COLUMN_DONE = "done";
 
-  public static final String COLUMN_FUNCTION_NAME = "UDF name";
-  public static final String COLUMN_FUNCTION_CLASS = "class name";
+  public static final String COLUMN_FUNCTION_NAME = "function name";
+  public static final String COLUMN_FUNCTION_TYPE = "function type";
+  public static final String COLUMN_FUNCTION_CLASS = "class name (UDF)";
+
+  public static final String FUNCTION_TYPE_NATIVE = "native";
+  public static final String FUNCTION_TYPE_BUILTIN_UDAF = "built-in UDAF";
+  public static final String FUNCTION_TYPE_BUILTIN_UDTF = "built-in UDTF";
+  public static final String FUNCTION_TYPE_EXTERNAL_UDAF = "external UDAF";
+  public static final String FUNCTION_TYPE_EXTERNAL_UDTF = "external UDTF";
 
   public static final String PATH_WILDCARD = "*";
   public static final String TIME = "time";

--- a/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
@@ -18,8 +18,11 @@
  */
 package org.apache.iotdb.db.qp.constant;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.sql.SqlBaseLexer;
 
@@ -69,6 +72,9 @@ public class SQLConstant {
   public static final String SUM = "sum";
 
   public static final String ALL = "all";
+
+  private static final Set<String> NATIVE_FUNCTION_NAMES = new HashSet<>(Arrays.asList(
+      MIN_TIME, MAX_TIME, MIN_VALUE, MAX_VALUE, FIRST_VALUE, LAST_VALUE, COUNT, SUM, AVG));
 
   public static final int KW_AND = 1;
   public static final int KW_OR = 2;
@@ -264,5 +270,9 @@ public class SQLConstant {
 
   public static boolean isReservedPath(PartialPath pathStr) {
     return pathStr.equals(TIME_PATH);
+  }
+
+  public static Set<String> getNativeFunctionNames() {
+    return NATIVE_FUNCTION_NAMES;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/ListDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/ListDataSet.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.query.dataset;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -28,11 +29,10 @@ import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 
 public class ListDataSet extends QueryDataSet {
 
-  private List<RowRecord> records = new ArrayList<>();
+  private final List<RowRecord> records = new ArrayList<>();
   private int index = 0;
 
-  public ListDataSet(List<PartialPath> paths,
-      List<TSDataType> dataTypes) {
+  public ListDataSet(List<PartialPath> paths, List<TSDataType> dataTypes) {
     super(new ArrayList<>(paths), dataTypes);
   }
 
@@ -51,6 +51,10 @@ public class ListDataSet extends QueryDataSet {
   }
 
   public void sortByTime() {
-    records.sort(((o1, o2) -> Long.compare(o2.getTimestamp(), o1.getTimestamp())));
+    records.sort((o1, o2) -> Long.compare(o2.getTimestamp(), o1.getTimestamp()));
+  }
+
+  public void sort(Comparator<RowRecord> c) {
+    records.sort(c);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/builtin/BuiltinFunction.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/builtin/BuiltinFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.builtin;
+
+/**
+ * All built-in UDFs need to register function names and full class names here.
+ */
+public enum BuiltinFunction {
+  ;
+
+  private final String functionName;
+  private final String functionClass;
+
+  BuiltinFunction(String functionName, String functionClass) {
+    this.functionName = functionName;
+    this.functionClass = functionClass;
+  }
+
+  public String getFunctionName() {
+    return functionName;
+  }
+
+  public String getFunctionClass() {
+    return functionClass;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/builtin/BuiltinFunction.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/builtin/BuiltinFunction.java
@@ -26,18 +26,18 @@ public enum BuiltinFunction {
   ;
 
   private final String functionName;
-  private final String functionClass;
+  private final String className;
 
-  BuiltinFunction(String functionName, String functionClass) {
+  BuiltinFunction(String functionName, String className) {
     this.functionName = functionName;
-    this.functionClass = functionClass;
+    this.className = className;
   }
 
   public String getFunctionName() {
     return functionName;
   }
 
-  public String getFunctionClass() {
-    return functionClass;
+  public String getClassName() {
+    return className;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationInformation.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationInformation.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.db.query.udf.service;
 
+import org.apache.iotdb.db.query.udf.api.UDTF;
+
 public class UDFRegistrationInformation {
 
   private final String functionName;
@@ -62,5 +64,13 @@ public class UDFRegistrationInformation {
 
   public void updateFunctionClass(UDFClassLoader udfClassLoader) throws ClassNotFoundException {
     functionClass = Class.forName(className, true, udfClassLoader);
+  }
+
+  public boolean isUDTF() {
+    return functionClass.isInstance(UDTF.class);
+  }
+
+  public boolean isUDAF() {
+    return false;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationInformation.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationInformation.java
@@ -24,14 +24,16 @@ public class UDFRegistrationInformation {
   private final String functionName;
   private final String className;
   private final boolean isTemporary;
+  private final boolean isBuiltin;
 
   private Class<?> functionClass;
 
   public UDFRegistrationInformation(String functionName, String className, boolean isTemporary,
-      Class<?> functionClass) {
+      boolean isBuiltin, Class<?> functionClass) {
     this.functionName = functionName;
     this.className = className;
     this.isTemporary = isTemporary;
+    this.isBuiltin = isBuiltin;
     this.functionClass = functionClass;
   }
 
@@ -43,8 +45,15 @@ public class UDFRegistrationInformation {
     return className;
   }
 
+  /**
+   * For a builtin function, this method always returns false.
+   */
   public boolean isTemporary() {
-    return isTemporary;
+    return !isBuiltin && isTemporary;
+  }
+
+  public boolean isBuiltin() {
+    return isBuiltin;
   }
 
   public Class<?> getFunctionClass() {

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationInformation.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationInformation.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.query.udf.service;
 
+import java.lang.reflect.InvocationTargetException;
 import org.apache.iotdb.db.query.udf.api.UDTF;
 
 public class UDFRegistrationInformation {
@@ -66,8 +67,9 @@ public class UDFRegistrationInformation {
     functionClass = Class.forName(className, true, udfClassLoader);
   }
 
-  public boolean isUDTF() {
-    return functionClass.isInstance(UDTF.class);
+  public boolean isUDTF()
+      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    return functionClass.getDeclaredConstructor().newInstance() instanceof UDTF;
   }
 
   public boolean isUDAF() {

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.db.exception.UDFRegistrationException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.db.query.udf.api.UDF;
+import org.apache.iotdb.db.query.udf.builtin.BuiltinFunction;
 import org.apache.iotdb.db.query.udf.core.context.UDFContext;
 import org.apache.iotdb.db.service.IService;
 import org.apache.iotdb.db.service.ServiceType;
@@ -83,14 +84,41 @@ public class UDFRegistrationService implements IService {
     registrationLock.unlock();
   }
 
-  @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void register(String functionName, String className, boolean isTemporary,
       boolean writeToTemporaryLogFile) throws UDFRegistrationException {
     validateFunctionName(functionName, className);
+    checkIfRegistered(functionName, className, isTemporary);
+    doRegister(functionName, className, isTemporary);
+    tryAppendRegistrationLog(functionName, className, isTemporary, writeToTemporaryLogFile);
+  }
 
+  private static void validateFunctionName(String functionName, String className)
+      throws UDFRegistrationException {
+    if (!BUILTIN_FUNCTION_NAMES.contains(functionName.toLowerCase())) {
+      return;
+    }
+
+    String errorMessage = String.format(
+        "Failed to register UDF %s(%s), because the given function name conflicts with the built-in function name",
+        functionName, className);
+
+    logger.warn(errorMessage);
+    throw new UDFRegistrationException(errorMessage);
+  }
+
+  private void checkIfRegistered(String functionName, String className, boolean isTemporary)
+      throws UDFRegistrationException {
     UDFRegistrationInformation information = registrationInformation.get(functionName);
-    if (information != null) {
-      String errorMessage;
+    if (information == null) {
+      return;
+    }
+
+    String errorMessage;
+    if (information.isBuiltin()) {
+      errorMessage = String.format(
+          "Failed to register UDF %s(%s), because the given function name is the same as a built-in UDF function name.",
+          functionName, className);
+    } else {
       if (information.getClassName().equals(className)) {
         errorMessage = String.format(
             "Failed to register %sTEMPORARY UDF %s(%s), because a %sTEMPORARY UDF %s(%s) with the same function name and the class name has already been registered.",
@@ -103,10 +131,14 @@ public class UDFRegistrationService implements IService {
             functionName, className,
             information.getFunctionName(), information.getClassName());
       }
-      logger.warn(errorMessage);
-      throw new UDFRegistrationException(errorMessage);
     }
 
+    logger.warn(errorMessage);
+    throw new UDFRegistrationException(errorMessage);
+  }
+
+  private void doRegister(String functionName, String className, boolean isTemporary)
+      throws UDFRegistrationException {
     acquireRegistrationLock();
     try {
       UDFClassLoader currentActiveClassLoader = UDFClassLoaderManager.getInstance()
@@ -116,7 +148,8 @@ public class UDFRegistrationService implements IService {
       Class<?> functionClass = Class.forName(className, true, currentActiveClassLoader);
       functionClass.getDeclaredConstructor().newInstance();
       registrationInformation.put(functionName,
-          new UDFRegistrationInformation(functionName, className, isTemporary, functionClass));
+          new UDFRegistrationInformation(functionName, className, isTemporary, false,
+              functionClass));
     } catch (IOException | InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
       String errorMessage = String.format(
           "Failed to register UDF %s(%s), because its instance can not be constructed successfully. Exception: %s",
@@ -126,36 +159,32 @@ public class UDFRegistrationService implements IService {
     } finally {
       releaseRegistrationLock();
     }
-
-    if (writeToTemporaryLogFile && !isTemporary) {
-      try {
-        appendRegistrationLog(functionName, className);
-      } catch (IOException e) {
-        registrationInformation.remove(functionName);
-        String errorMessage = String
-            .format("Failed to append UDF log when registering UDF %s(%s), because %s",
-                functionName, className, e.toString());
-        logger.error(errorMessage);
-        throw new UDFRegistrationException(errorMessage, e);
-      }
-    }
   }
 
-  private static void validateFunctionName(String functionName, String className)
-      throws UDFRegistrationException {
-    if (BUILTIN_FUNCTION_NAMES.contains(functionName.toLowerCase())) {
-      String errorMessage = String.format(
-          "Failed to register UDF %s(%s), because the given function name conflicts with the built-in function name",
-          functionName, className);
-      logger.warn(errorMessage);
-      throw new UDFRegistrationException(errorMessage);
+  private void tryAppendRegistrationLog(String functionName, String className, boolean isTemporary,
+      boolean writeToTemporaryLogFile) throws UDFRegistrationException {
+    if (!writeToTemporaryLogFile || isTemporary) {
+      return;
+    }
+
+    try {
+      appendRegistrationLog(functionName, className);
+    } catch (IOException e) {
+      registrationInformation.remove(functionName);
+      String errorMessage = String
+          .format("Failed to append UDF log when registering UDF %s(%s), because %s",
+              functionName, className, e.toString());
+      logger.error(errorMessage);
+      throw new UDFRegistrationException(errorMessage, e);
     }
   }
 
   private void updateAllRegisteredClasses(UDFClassLoader activeClassLoader)
       throws ClassNotFoundException {
     for (UDFRegistrationInformation information : getRegistrationInformation()) {
-      information.updateFunctionClass(activeClassLoader);
+      if (!information.isBuiltin()) {
+        information.updateFunctionClass(activeClassLoader);
+      }
     }
   }
 
@@ -164,6 +193,13 @@ public class UDFRegistrationService implements IService {
     if (information == null) {
       String errorMessage = String.format("UDF %s does not exist.", functionName);
       logger.warn(errorMessage);
+      throw new UDFRegistrationException(errorMessage);
+    }
+
+    if (information.isBuiltin()) {
+      String errorMessage = String
+          .format("Built-in function %s can not be deregistered.", functionName);
+      logger.error(errorMessage);
       throw new UDFRegistrationException(errorMessage);
     }
 
@@ -209,8 +245,11 @@ public class UDFRegistrationService implements IService {
       throw new QueryProcessException(errorMessage);
     }
 
-    Thread.currentThread()
-        .setContextClassLoader(UDFClassLoaderManager.getInstance().getActiveClassLoader());
+    if (!information.isBuiltin()) {
+      Thread.currentThread()
+          .setContextClassLoader(UDFClassLoaderManager.getInstance().getActiveClassLoader());
+    }
+
     try {
       return (UDF) information.getFunctionClass().getDeclaredConstructor().newInstance();
     } catch (InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
@@ -228,11 +267,23 @@ public class UDFRegistrationService implements IService {
   @Override
   public void start() throws StartupException {
     try {
+      registerBuiltinFunctions();
       makeDirIfNecessary();
       doRecovery();
       logWriter = new UDFLogWriter(LOG_FILE_NAME);
     } catch (Exception e) {
       throw new StartupException(e);
+    }
+  }
+
+  private void registerBuiltinFunctions() throws ClassNotFoundException {
+    ClassLoader classLoader = getClass().getClassLoader();
+    for (BuiltinFunction builtinFunction : BuiltinFunction.values()) {
+      String functionName = builtinFunction.getFunctionName();
+      String className = builtinFunction.getClassName();
+      Class<?> functionClass = Class.forName(className, true, classLoader);
+      registrationInformation.put(functionName,
+          new UDFRegistrationInformation(functionName, className, false, true, functionClass));
     }
   }
 
@@ -305,7 +356,7 @@ public class UDFRegistrationService implements IService {
   private void writeTemporaryLogFile() throws IOException {
     UDFLogWriter temporaryLogFile = new UDFLogWriter(TEMPORARY_LOG_FILE_NAME);
     for (UDFRegistrationInformation information : registrationInformation.values()) {
-      if (information.isTemporary()) {
+      if (information.isBuiltin() || information.isTemporary()) {
         continue;
       }
       temporaryLogFile.register(information.getFunctionName(), information.getClassName());
@@ -316,7 +367,9 @@ public class UDFRegistrationService implements IService {
   @TestOnly
   public void deregisterAll() throws UDFRegistrationException {
     for (UDFRegistrationInformation information : getRegistrationInformation()) {
-      deregister(information.getFunctionName());
+      if (!information.isBuiltin()) {
+        deregister(information.getFunctionName());
+      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
@@ -374,6 +374,11 @@ public class UDFRegistrationService implements IService {
         new UDFRegistrationInformation(functionName, className, false, true, functionClass));
   }
 
+  @TestOnly
+  public void deregisterBuiltinFunction(String functionName) {
+    registrationInformation.remove(functionName);
+  }
+
   @Override
   public ServiceType getID() {
     return ServiceType.UDF_REGISTRATION_SERVICE;

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDFManagementIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDFManagementIT.java
@@ -346,6 +346,8 @@ public class IoTDBUDFManagementIT {
       throwable.printStackTrace();
       assertTrue(throwable.getMessage()
           .contains("the given function name is the same as a built-in UDF function name"));
+    } finally {
+      UDFRegistrationService.getInstance().deregisterBuiltinFunction("adder");
     }
   }
 
@@ -362,6 +364,8 @@ public class IoTDBUDFManagementIT {
       throwable.printStackTrace();
       assertTrue(
           throwable.getMessage().contains("Built-in function adder can not be deregistered"));
+    } finally {
+      UDFRegistrationService.getInstance().deregisterBuiltinFunction("adder");
     }
   }
 
@@ -376,6 +380,8 @@ public class IoTDBUDFManagementIT {
     } catch (SQLException throwable) {
       throwable.printStackTrace();
       fail(throwable.getMessage());
+    } finally {
+      UDFRegistrationService.getInstance().deregisterBuiltinFunction("adder");
     }
   }
 
@@ -425,6 +431,8 @@ public class IoTDBUDFManagementIT {
     } catch (SQLException throwable) {
       throwable.printStackTrace();
       fail(throwable.getMessage());
+    } finally {
+      UDFRegistrationService.getInstance().deregisterBuiltinFunction("adder");
     }
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDFManagementIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDFManagementIT.java
@@ -19,6 +19,9 @@
 
 package org.apache.iotdb.db.integration;
 
+import static org.apache.iotdb.db.conf.IoTDBConstant.FUNCTION_TYPE_BUILTIN_UDTF;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FUNCTION_TYPE_EXTERNAL_UDTF;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FUNCTION_TYPE_NATIVE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -29,6 +32,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.apache.iotdb.db.metadata.PartialPath;
+import org.apache.iotdb.db.qp.constant.SQLConstant;
+import org.apache.iotdb.db.query.udf.service.UDFRegistrationService;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
@@ -41,6 +46,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class IoTDBUDFManagementIT {
+
+  private static final int NATIVE_FUNCTIONS_COUNT = SQLConstant.getNativeFunctionNames().size();
 
   @Before
   public void setUp() throws Exception {
@@ -67,26 +74,34 @@ public class IoTDBUDFManagementIT {
         Statement statement = connection.createStatement()) {
       statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
       statement.execute("select udf(*, *) from root.vehicle");
+
       ResultSet resultSet = statement.executeQuery("show functions");
-      assertEquals(2, resultSet.getMetaData().getColumnCount());
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
       int count = 0;
       while (resultSet.next()) {
-        ++count;
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
           stringBuilder.append(resultSet.getString(i)).append(",");
         }
-        Assert.assertEquals("udf,org.apache.iotdb.db.query.udf.example.Adder,",
-            stringBuilder.toString());
+        String result = stringBuilder.toString();
+        if (result.contains(FUNCTION_TYPE_NATIVE)) {
+          continue;
+        }
+
+        Assert.assertEquals(String.format("udf,%s,org.apache.iotdb.db.query.udf.example.Adder,",
+            FUNCTION_TYPE_EXTERNAL_UDTF), result);
+        ++count;
       }
       Assert.assertEquals(1, count);
+
       resultSet = statement.executeQuery("show temporary functions");
       count = 0;
       while (resultSet.next()) {
         ++count;
       }
       Assert.assertEquals(0, count);
-      assertEquals(2, resultSet.getMetaData().getColumnCount());
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
+
       statement.execute("drop function udf");
     } catch (SQLException throwable) {
       throwable.printStackTrace();
@@ -101,57 +116,64 @@ public class IoTDBUDFManagementIT {
         Statement statement = connection.createStatement()) {
       statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
       statement.execute("select udf(*, *) from root.vehicle");
+
       ResultSet resultSet = statement.executeQuery("show functions");
       int count = 0;
       while (resultSet.next()) {
         ++count;
       }
-      Assert.assertEquals(1, count);
-      assertEquals(2, resultSet.getMetaData().getColumnCount());
+      Assert.assertEquals(1 + NATIVE_FUNCTIONS_COUNT, count);
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
+
       resultSet = statement.executeQuery("show temporary functions");
       count = 0;
       while (resultSet.next()) {
         ++count;
       }
       Assert.assertEquals(0, count);
-      assertEquals(2, resultSet.getMetaData().getColumnCount());
-      statement.execute("drop function udf");
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
 
+      statement.execute("drop function udf");
       statement.execute(
           "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
       statement.execute("select udf(*, *) from root.vehicle");
+
       resultSet = statement.executeQuery("show functions");
       count = 0;
       while (resultSet.next()) {
         ++count;
       }
-      Assert.assertEquals(1, count);
-      assertEquals(2, resultSet.getMetaData().getColumnCount());
+      Assert.assertEquals(1 + NATIVE_FUNCTIONS_COUNT, count);
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
+
       resultSet = statement.executeQuery("show temporary functions");
       count = 0;
       while (resultSet.next()) {
         ++count;
       }
       Assert.assertEquals(1, count);
-      assertEquals(2, resultSet.getMetaData().getColumnCount());
-      statement.execute("drop function udf");
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
 
+      statement.execute("drop function udf");
       statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
       statement.execute("select udf(*, *) from root.vehicle");
+
       resultSet = statement.executeQuery("show functions");
       count = 0;
       while (resultSet.next()) {
         ++count;
       }
-      Assert.assertEquals(1, count);
-      assertEquals(2, resultSet.getMetaData().getColumnCount());
+      Assert.assertEquals(1 + NATIVE_FUNCTIONS_COUNT, count);
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
+
       resultSet = statement.executeQuery("show temporary functions");
       count = 0;
       while (resultSet.next()) {
         ++count;
       }
       Assert.assertEquals(0, count);
-      assertEquals(2, resultSet.getMetaData().getColumnCount());
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
+
       statement.execute("drop function udf");
     } catch (SQLException throwable) {
       throwable.printStackTrace();
@@ -218,6 +240,7 @@ public class IoTDBUDFManagementIT {
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
       statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
+
       try {
         statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
         fail();
@@ -234,6 +257,7 @@ public class IoTDBUDFManagementIT {
         Statement statement = connection.createStatement()) {
       statement.execute(
           "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
+
       try {
         statement.execute(
             "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
@@ -251,6 +275,7 @@ public class IoTDBUDFManagementIT {
         Statement statement = connection.createStatement()) {
       statement.execute(
           "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
+
       try {
         statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
         fail();
@@ -267,6 +292,7 @@ public class IoTDBUDFManagementIT {
         Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
       statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
+
       try {
         statement.execute(
             "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
@@ -285,6 +311,7 @@ public class IoTDBUDFManagementIT {
         Statement statement = connection.createStatement()) {
       statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
       statement.execute("drop function udf");
+
       try {
         statement.execute("drop function udf");
         fail();
@@ -303,6 +330,101 @@ public class IoTDBUDFManagementIT {
       fail();
     } catch (SQLException throwable) {
       assertTrue(throwable.getMessage().contains("does not exist"));
+    }
+  }
+
+  @Test
+  public void testCreateBuiltinFunction() throws ClassNotFoundException {
+    UDFRegistrationService.getInstance().registerBuiltinFunction("adder",
+        "org.apache.iotdb.db.query.udf.example.Adder");
+    try (Connection connection = DriverManager.getConnection(
+        Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("create function adder as \"org.apache.iotdb.db.query.udf.example.Adder\"");
+      fail();
+    } catch (SQLException throwable) {
+      throwable.printStackTrace();
+      assertTrue(throwable.getMessage()
+          .contains("the given function name is the same as a built-in UDF function name"));
+    }
+  }
+
+  @Test
+  public void testDropBuiltinFunction() throws ClassNotFoundException {
+    UDFRegistrationService.getInstance().registerBuiltinFunction("adder",
+        "org.apache.iotdb.db.query.udf.example.Adder");
+    try (Connection connection = DriverManager.getConnection(
+        Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("drop function adder");
+      fail();
+    } catch (SQLException throwable) {
+      throwable.printStackTrace();
+      assertTrue(
+          throwable.getMessage().contains("Built-in function adder can not be deregistered"));
+    }
+  }
+
+  @Test
+  public void testReflectBuiltinFunction() throws ClassNotFoundException {
+    UDFRegistrationService.getInstance().registerBuiltinFunction("adder",
+        "org.apache.iotdb.db.query.udf.example.Adder");
+    try (Connection connection = DriverManager.getConnection(
+        Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("select adder(*, *) from root.vehicle");
+    } catch (SQLException throwable) {
+      throwable.printStackTrace();
+      fail(throwable.getMessage());
+    }
+  }
+
+  @Test
+  public void testShowBuiltinFunction() throws ClassNotFoundException {
+    UDFRegistrationService.getInstance().registerBuiltinFunction("adder",
+        "org.apache.iotdb.db.query.udf.example.Adder");
+    try (Connection connection = DriverManager.getConnection(
+        Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
+
+      ResultSet resultSet = statement.executeQuery("show functions");
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
+      int count = 0;
+      while (resultSet.next()) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
+          stringBuilder.append(resultSet.getString(i)).append(",");
+        }
+        String result = stringBuilder.toString();
+        if (result.contains(FUNCTION_TYPE_NATIVE)) {
+          continue;
+        }
+
+        if (result.contains(FUNCTION_TYPE_EXTERNAL_UDTF)) {
+          Assert.assertEquals(String.format("udf,%s,org.apache.iotdb.db.query.udf.example.Adder,",
+              FUNCTION_TYPE_EXTERNAL_UDTF), result);
+          ++count;
+        } else if (result.contains(FUNCTION_TYPE_BUILTIN_UDTF)) {
+          Assert.assertEquals(String.format("adder,%s,org.apache.iotdb.db.query.udf.example.Adder,",
+              FUNCTION_TYPE_BUILTIN_UDTF), result);
+          ++count;
+        }
+      }
+      Assert.assertEquals(2, count);
+
+      resultSet = statement.executeQuery("show temporary functions");
+      count = 0;
+      while (resultSet.next()) {
+        ++count;
+      }
+      Assert.assertEquals(0, count);
+      assertEquals(3, resultSet.getMetaData().getColumnCount());
+
+      statement.execute("drop function udf");
+    } catch (SQLException throwable) {
+      throwable.printStackTrace();
+      fail(throwable.getMessage());
     }
   }
 }


### PR DESCRIPTION
If we want to write a built-in function by writing a UDF in the future, and require this function to be automatically loaded when the system starts and cannot be unloaded by the user, we need a special built-in UDF function registration service.

JIRA: https://issues.apache.org/jira/browse/IOTDB-1071