### PR TITLE
[IOTDB-1082] Update MetadataIndexTree structure for v0.12

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -241,11 +241,11 @@ public class TSFileConfig implements Serializable {
   }
 
   public int getMaxDegreeOfIndexNode() {
-    return maxDegreeOfIndexNode;
+    return 2;
   }
 
   public void setMaxDegreeOfIndexNode(int maxDegreeOfIndexNode) {
-    this.maxDegreeOfIndexNode = maxDegreeOfIndexNode;
+    this.maxDegreeOfIndexNode = 2;
   }
 
   public String getTimeSeriesDataType() {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -241,11 +241,11 @@ public class TSFileConfig implements Serializable {
   }
 
   public int getMaxDegreeOfIndexNode() {
-    return 2;
+    return maxDegreeOfIndexNode;
   }
 
   public void setMaxDegreeOfIndexNode(int maxDegreeOfIndexNode) {
-    this.maxDegreeOfIndexNode = 2;
+    this.maxDegreeOfIndexNode = maxDegreeOfIndexNode;
   }
 
   public String getTimeSeriesDataType() {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexConstructor.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexConstructor.java
@@ -80,7 +80,7 @@ public class MetadataIndexConstructor {
     // if not exceed the max child nodes num, ignore the device index and directly point to the measurement
     if (deviceMetadataIndexMap.size() <= config.getMaxDegreeOfIndexNode()) {
       MetadataIndexNode metadataIndexNode = new MetadataIndexNode(
-          MetadataIndexNodeType.INTERNAL_MEASUREMENT);
+          MetadataIndexNodeType.LEAF_DEVICE);
       for (Map.Entry<String, MetadataIndexNode> entry : deviceMetadataIndexMap.entrySet()) {
         metadataIndexNode.addEntry(new MetadataIndexEntry(entry.getKey(), out.getPosition()));
         entry.getValue().serializeTo(out.wrapAsStream());

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexNode.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexNode.java
@@ -33,15 +33,14 @@ import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 public class MetadataIndexNode {
 
-  private static final TSFileConfig config =
-      TSFileDescriptor.getInstance().getConfig();
-  private List<MetadataIndexEntry> children;
+  private static final TSFileConfig config = TSFileDescriptor.getInstance().getConfig();
+  private final List<MetadataIndexEntry> children;
   private long endOffset;
 
   /**
    * type of the child node at offset
    */
-  private MetadataIndexNodeType nodeType;
+  private final MetadataIndexNodeType nodeType;
 
   public MetadataIndexNode(MetadataIndexNodeType nodeType) {
     children = new ArrayList<>();

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
@@ -104,37 +104,6 @@ public class TsFileSequenceReaderTest {
   }
 
   @Test
-  public void readChunksInDevice() throws IOException {
-    TsFileSequenceReader reader = new TsFileSequenceReader(FILE_PATH);
-
-    for (String device : reader.getAllDevices()) {
-      Map<String, Set<Chunk>> expectedChunksInDevice = new HashMap<>();
-      for (Entry<String, List<ChunkMetadata>> entry : reader.readChunkMetadataInDevice(device)
-          .entrySet()) {
-        expectedChunksInDevice.putIfAbsent(entry.getKey(), new HashSet<>());
-        for (ChunkMetadata chunkMetadata : entry.getValue()) {
-          expectedChunksInDevice.get(entry.getKey()).add(reader.readMemChunk(chunkMetadata));
-        }
-      }
-
-      Map<String, List<Chunk>> actualChunksInDevice = reader.readChunksInDevice(device);
-
-      for (Entry<String, Set<Chunk>> entry : expectedChunksInDevice.entrySet()) {
-        Set<String> expectedChunkStrings = entry.getValue().stream()
-            .map(chunk -> chunk.getHeader().toString()).collect(Collectors.toSet());
-
-        Assert.assertTrue(actualChunksInDevice.containsKey(entry.getKey()));
-        Set<String> actualChunkStrings = actualChunksInDevice.get(entry.getKey()).stream()
-            .map(chunk -> chunk.getHeader().toString()).collect(Collectors.toSet());
-
-        Assert.assertEquals(expectedChunkStrings, actualChunkStrings);
-      }
-    }
-
-    reader.close();
-  }
-
-  @Test
   public void testReadChunkMetadataInDevice() throws IOException {
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_PATH);
 


### PR DESCRIPTION
As for the TsFile format is re-designed in v0.12, the MetadataIndexTree structure should be updated too to support query with higher efficient.