### PR TITLE
fix metaGroupMember bug when follower foward non-query plan to leader

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -37,6 +37,7 @@ import org.apache.iotdb.cluster.exception.LogExecutionException;
 import org.apache.iotdb.cluster.exception.PartitionTableUnavailableException;
 import org.apache.iotdb.cluster.exception.SnapshotInstallationException;
 import org.apache.iotdb.cluster.exception.StartUpCheckFailureException;
+import org.apache.iotdb.cluster.exception.UnsupportedPlanException;
 import org.apache.iotdb.cluster.log.Log;
 import org.apache.iotdb.cluster.log.LogApplier;
 import org.apache.iotdb.cluster.log.applier.MetaLogApplier;
@@ -69,6 +70,7 @@ import org.apache.iotdb.cluster.server.NodeReport;
 import org.apache.iotdb.cluster.server.NodeReport.MetaMemberReport;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.Response;
+import org.apache.iotdb.cluster.server.Timer;
 import org.apache.iotdb.cluster.server.handlers.caller.AppendGroupEntryHandler;
 import org.apache.iotdb.cluster.server.handlers.caller.GenericHandler;
 import org.apache.iotdb.cluster.server.handlers.caller.NodeStatusHandler;
@@ -1315,6 +1317,30 @@ public class MetaGroupMember extends RaftMember {
     MetaSimpleSnapshot snapshot = new MetaSimpleSnapshot();
     snapshot.deserialize(request.snapshotBytes);
     snapshot.getDefaultInstaller(this).install(snapshot, -1);
+  }
+
+  /**
+   * Execute a non-query plan. According to the type of the plan, the plan will be executed on all
+   * nodes (like timeseries deletion) or the nodes that belong to certain groups (like data
+   * ingestion).
+   *
+   * @param plan a non-query plan.
+   */
+  @Override
+  public TSStatus executeNonQueryPlan(PhysicalPlan plan) {
+    TSStatus result;
+    long startTime = Timer.Statistic.COORDINATOR_EXECUTE_NON_QUERY.getOperationStartTime();
+    if (PartitionUtils.isGlobalMetaPlan(plan)) {
+      // do it in local, only the follower forward the plan to local
+      logger.debug("receive a global meta plan {}", plan);
+      result = processNonPartitionedMetaPlan(plan);
+    } else {
+      // do nothing
+      logger.warn("receive a plan {} could not be processed in local", plan);
+      result = StatusUtils.UNSUPPORTED_OPERATION;
+    }
+    Timer.Statistic.COORDINATOR_EXECUTE_NON_QUERY.calOperationCostTimeFromStart(startTime);
+    return result;
   }
 
   /**

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -37,7 +37,6 @@ import org.apache.iotdb.cluster.exception.LogExecutionException;
 import org.apache.iotdb.cluster.exception.PartitionTableUnavailableException;
 import org.apache.iotdb.cluster.exception.SnapshotInstallationException;
 import org.apache.iotdb.cluster.exception.StartUpCheckFailureException;
-import org.apache.iotdb.cluster.exception.UnsupportedPlanException;
 import org.apache.iotdb.cluster.log.Log;
 import org.apache.iotdb.cluster.log.LogApplier;
 import org.apache.iotdb.cluster.log.applier.MetaLogApplier;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -737,9 +737,7 @@ public abstract class RaftMember {
    * @param plan a non-query plan.
    * @return A TSStatus indicating the execution result.
    */
-  protected TSStatus executeNonQueryPlan(PhysicalPlan plan) {
-    return StatusUtils.OK;
-  }
+  abstract TSStatus executeNonQueryPlan(PhysicalPlan plan);
 
   /**
    * according to the consistency configuration, decide whether to execute syncLeader or not and

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/MetaGroupMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/MetaGroupMemberTest.java
@@ -456,6 +456,7 @@ public class MetaGroupMemberTest extends MemberTest {
       }
 
     };
+    metaGroupMember.getCoordinator().setMetaGroupMember(metaGroupMember);
     metaGroupMember.setLeader(node);
     metaGroupMember.setAllNodes(allNodes);
     metaGroupMember.setCharacter(NodeCharacter.LEADER);
@@ -720,6 +721,42 @@ public class MetaGroupMemberTest extends MemberTest {
     mockDataClusterServer = true;
     // as a leader
     testMetaMember.setCharacter(LEADER);
+    testMetaMember.setAppendLogThreadPool(testThreadPool);
+    for (int i = 10; i < 20; i++) {
+      // process a non partitioned plan
+      SetStorageGroupPlan setStorageGroupPlan =
+        new SetStorageGroupPlan(new PartialPath(TestUtils.getTestSg(i)));
+      TSStatus status = coordinator.executeNonQueryPlan(setStorageGroupPlan);
+      assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.code);
+      assertTrue(IoTDB.metaManager.isPathExist(new PartialPath(TestUtils.getTestSg(i))));
+
+      // process a partitioned plan
+      TimeseriesSchema schema = TestUtils.getTestTimeSeriesSchema(i, 0);
+      CreateTimeSeriesPlan createTimeSeriesPlan = new CreateTimeSeriesPlan(
+        new PartialPath(schema.getFullPath()), schema.getType(),
+        schema.getEncodingType(), schema.getCompressor(), schema.getProps(),
+        Collections.emptyMap(), Collections.emptyMap(), null);
+      status = coordinator.executeNonQueryPlan(createTimeSeriesPlan);
+      if (status.getCode() == TSStatusCode.NEED_REDIRECTION.getStatusCode()) {
+        status.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
+      }
+      assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.code);
+      assertTrue(IoTDB.metaManager.isPathExist(new PartialPath(TestUtils.getTestSeries(i, 0))));
+    }
+    testThreadPool.shutdownNow();
+  }
+
+  @Test
+  public void testProcessNonQueryAsFollower() throws IllegalPathException, QueryProcessException {
+    System.out.println("Start testProcessNonQuery()");
+    mockDataClusterServer = true;
+
+    MetaGroupMember testMetaMember2 = getMetaGroupMember(TestUtils.getNode(2));
+    testMetaMember2.setCharacter(LEADER);
+
+    // as a follower
+    testMetaMember.setCharacter(FOLLOWER);
+    testMetaMember.setLeader(testMetaMember2.thisNode);
     testMetaMember.setAppendLogThreadPool(testThreadPool);
     for (int i = 10; i < 20; i++) {
       // process a non partitioned plan


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

        http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->

<!-- Thanks for trying to help us make Apache IoTDB be the best it can be! 
Please fill out as much of the following information as is possible (where relevant, and remove it 
when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

## Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue, 
it's not necessary to repeat the description here, 
however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section 
for each of them. For example: -->

### Content1 ...
### Content2 ...
### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

<!-- Template copied and modified from Apache Druid-->