### PR TITLE
[IOTDB-1098] Add interface `validate` for UDF

### DIFF
--- a/docs/UserGuide/Operation Manual/UDF User Defined Function.md
+++ b/docs/UserGuide/Operation Manual/UDF User Defined Function.md
@@ -63,11 +63,20 @@ The following table shows all the interfaces available for user implementation.
 
 | Interface definition                                         | Description                                                  | Required to Implement                                 |
 | :----------------------------------------------------------- | :----------------------------------------------------------- | ----------------------------------------------------- |
+| `void validate(UDFParameterValidator validator) throws Exception` | This method is mainly used to validate `UDFParameters` and it is executed before `beforeStart(UDFParameters, UDTFConfigurations)` is called. | Optional                                              |
 | `void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) throws Exception` | The initialization method to call the user-defined initialization behavior before a UDTF processes the input data. Every time a user executes a UDTF query, the framework will construct a new UDF instance, and `beforeStart` will be called. | Required                                              |
-| `void beforeDestroy() `                                      | This method is called by the framework after the last input data is processed, and will only be called once in the life cycle of each UDF instance. | Optional                                              |
 | `void transform(Row row, PointCollector collector) throws Exception` | This method is called by the framework. This data processing method will be called when you choose to use the `RowByRowAccessStrategy` strategy (set in `beforeStart`) to consume raw data. Input data is passed in by `Row`, and the transformation result should be output by `PointCollector`. You need to call the data collection method provided by `collector`  to determine the output data. | Required to implement at least one `transform` method |
 | `void transform(RowWindow rowWindow, PointCollector collector) throws Exception` | This method is called by the framework. This data processing method will be called when you choose to use the `SlidingSizeWindowAccessStrategy` or `SlidingTimeWindowAccessStrategy` strategy (set in `beforeStart`) to consume raw data. Input data is passed in by `RowWindow`, and the transformation result should be output by `PointCollector`. You need to call the data collection method provided by `collector`  to determine the output data. | Required to implement at least one `transform` method |
 | `void terminate(PointCollector collector) throws Exception`  | This method is called by the framework. This method will be called once after all `transform` calls have been executed. In a single UDF query, this method will and will only be called once. You need to call the data collection method provided by `collector`  to determine the output data. | Optional                                              |
+| `void beforeDestroy() `                                      | This method is called by the framework after the last input data is processed, and will only be called once in the life cycle of each UDF instance. | Optional                                              |
+
+In the life cycle of a UDTF instance, the calling sequence of each method is as follows:
+
+1. `void validate(UDFParameterValidator validator) throws Exception`
+2. `void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) throws Exception`
+3. `void transform(Row row, PointCollector collector) throws Exception`或者`void transform(RowWindow rowWindow, PointCollector collector) throws Exception`
+4. `void terminate(PointCollector collector) throws Exception`
+5. `void beforeDestroy() `
 
 Note that every time the framework executes a UDTF query, a new UDF instance will be constructed. When the query ends, the corresponding instance will be destroyed. Therefore, the internal data of the instances in different UDTF queries (even in the same SQL statement) are isolated. You can maintain some state data in the UDTF without considering the influence of concurrency and other factors.
 
@@ -75,7 +84,17 @@ The usage of each interface will be described in detail below.
 
 
 
-### `void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) throws Exception`
+### void validate(UDFParameterValidator validator) throws Exception
+
+The `validate` method is used to validate the parameters entered by the user.
+
+In this method, you can limit the number and types of input time series, check the attributes of user input, or perform any custom verification.
+
+Please refer to the Javadoc for the usage of `UDFParameterValidator`.
+
+
+
+### void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) throws Exception
 
 This method is mainly used to customize UDTF. In this method, the user can do the following things:
 
@@ -86,7 +105,7 @@ This method is mainly used to customize UDTF. In this method, the user can do th
 
 
 
-#### `UDFParameters`
+#### UDFParameters
 
 `UDFParameters` is used to parse UDF parameters in SQL statements (the part in parentheses after the UDF function name in SQL). The input parameters have two parts. The first part is the paths (measurements) and their data types of the time series that the UDF needs to process, and the second part is the key-value pair attributes for customization. Only the second part can be empty.
 
@@ -119,7 +138,7 @@ void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) th
 
 
 
-####  `UDTFConfigurations`
+####  UDTFConfigurations
 
 You must use `UDTFConfigurations` to specify the strategy used by UDF to access raw data and the type of output sequence.
 
@@ -141,7 +160,7 @@ The `setAccessStrategy` method is used to set the UDF's strategy for accessing t
 
 
 
-##### `setAccessStrategy`
+##### setAccessStrategy
 
 Note that the raw data access strategy you set here determines which `transform` method the framework will call. Please implement the `transform` method corresponding to the raw data access strategy. Of course, you can also dynamically decide which strategy to set based on the attribute parameters parsed by `UDFParameters`. Therefore, two `transform` methods are also allowed to be implemented in one UDF.
 
@@ -188,7 +207,7 @@ Please see the Javadoc for more details.
 
 
 
-##### `setOutputDataType`
+##### setOutputDataType
 
 Note that the type of output sequence you set here determines the type of data that the `PointCollector` can actually receive in the `transform` method. The relationship between the output data type set in `setOutputDataType` and the actual data output type that `PointCollector` can receive is as follows:
 
@@ -217,15 +236,7 @@ void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) th
 
 
 
-### `void beforeDestroy() `
-
-The method for terminating a UDF.
-
-This method is called by the framework. For a UDF instance, `beforeDestroy` will be called after the last record is processed. In the entire life cycle of the instance, `beforeDestroy` will only be called once.
-
-
-
-### `void transform(Row row, PointCollector collector) throws Exception`
+### void transform(Row row, PointCollector collector) throws Exception
 
 You need to implement this method when you specify the strategy of UDF to read the original data as `RowByRowAccessStrategy`.
 
@@ -263,7 +274,7 @@ public class Adder implements UDTF {
 
 
 
-### `void transform(RowWindow rowWindow, PointCollector collector) throws Exception`
+### void transform(RowWindow rowWindow, PointCollector collector) throws Exception
 
 You need to implement this method when you specify the strategy of UDF to read the original data as `SlidingTimeWindowAccessStrategy` or `SlidingSizeWindowAccessStrategy`.
 
@@ -305,7 +316,7 @@ public class Counter implements UDTF {
 
 
 
-### `void terminate(PointCollector collector) throws Exception`
+### void terminate(PointCollector collector) throws Exception
 
 In some scenarios, a UDF needs to traverse all the original data to calculate the final output data points. The `terminate` interface provides support for those scenarios.
 
@@ -354,6 +365,14 @@ public class Max implements UDTF {
   }
 }
 ```
+
+
+
+### void beforeDestroy() 
+
+The method for terminating a UDF.
+
+This method is called by the framework. For a UDF instance, `beforeDestroy` will be called after the last record is processed. In the entire life cycle of the instance, `beforeDestroy` will only be called once.
 
 
 
@@ -424,7 +443,7 @@ The usage of UDF is similar to that of built-in aggregation functions.
 
 
 
-### Queries with `*` in `SELECT` Clauses
+### Queries with * in SELECT Clauses
 
 Assume that there are 2 time series (`root.sg.d1.s1` and `root.sg.d1.s2`)  in the system.
 

--- a/docs/UserGuide/Operation Manual/UDF User Defined Function.md
+++ b/docs/UserGuide/Operation Manual/UDF User Defined Function.md
@@ -74,7 +74,7 @@ In the life cycle of a UDTF instance, the calling sequence of each method is as 
 
 1. `void validate(UDFParameterValidator validator) throws Exception`
 2. `void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) throws Exception`
-3. `void transform(Row row, PointCollector collector) throws Exception`或者`void transform(RowWindow rowWindow, PointCollector collector) throws Exception`
+3. `void transform(Row row, PointCollector collector) throws Exception` or `void transform(RowWindow rowWindow, PointCollector collector) throws Exception`
 4. `void terminate(PointCollector collector) throws Exception`
 5. `void beforeDestroy() `
 

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/UDF.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/UDF.java
@@ -26,11 +26,11 @@ import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
 public interface UDF {
 
   /**
-   * This method is mainly used to validate UDFParameters and it is executed before {@link
+   * This method is mainly used to validate {@link UDFParameters} and it is executed before {@link
    * UDTF#beforeStart(UDFParameters, UDTFConfigurations)} is called.
    *
-   * @param validator the validator used to validate UDFParameters
-   * @throws Exception if any parameter is invalid
+   * @param validator the validator used to validate {@link UDFParameters}
+   * @throws Exception if any parameter is not valid
    */
   @SuppressWarnings("squid:S112")
   default void validate(UDFParameterValidator validator) throws Exception {

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/UDF.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/UDF.java
@@ -19,7 +19,22 @@
 
 package org.apache.iotdb.db.query.udf.api;
 
+import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameterValidator;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
+
 public interface UDF {
+
+  /**
+   * This method is mainly used to validate UDFParameters and it is executed before {@link
+   * UDTF#beforeStart(UDFParameters, UDTFConfigurations)} is called.
+   *
+   * @param validator the validator used to validate UDFParameters
+   * @throws Exception if any parameter is invalid
+   */
+  @SuppressWarnings("squid:S112")
+  default void validate(UDFParameterValidator validator) throws Exception {
+  }
 
   /**
    * This method is mainly used to release the resources used in the UDF.

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/UDTF.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/UDTF.java
@@ -25,8 +25,8 @@ import org.apache.iotdb.db.query.udf.api.collector.PointCollector;
 import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
 import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.RowByRowAccessStrategy;
-import org.apache.iotdb.db.query.udf.api.customizer.strategy.SlidingTimeWindowAccessStrategy;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.SlidingSizeWindowAccessStrategy;
+import org.apache.iotdb.db.query.udf.api.customizer.strategy.SlidingTimeWindowAccessStrategy;
 
 /**
  * User-defined Time-series Generating Function (UDTF)

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/UDTF.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/UDTF.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.query.udf.api.access.Row;
 import org.apache.iotdb.db.query.udf.api.access.RowWindow;
 import org.apache.iotdb.db.query.udf.api.collector.PointCollector;
 import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameterValidator;
 import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.RowByRowAccessStrategy;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.SlidingSizeWindowAccessStrategy;
@@ -42,6 +43,13 @@ import org.apache.iotdb.db.query.udf.api.customizer.strategy.SlidingTimeWindowAc
  * <li>{@link UDTF#transform(RowWindow, PointCollector)} or {@link UDTF#transform(Row,
  * PointCollector)}
  * </ul>
+ * In the life cycle of a UDTF instance, the calling sequence of each method is as follows:
+ * <p>
+ * 1. {@link UDTF#validate(UDFParameterValidator)}
+ * 2. {@link UDTF#beforeStart(UDFParameters, UDTFConfigurations)}
+ * 3. {@link UDTF#transform(RowWindow, PointCollector)} or {@link UDTF#transform(Row, PointCollector)}
+ * 4. {@link UDTF#terminate(PointCollector)}
+ * 5. {@link UDTF#beforeDestroy()}
  * <p>
  * The query engine will instantiate an independent UDTF instance for each udf query column, and
  * different UDTF instances will not affect each other.

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameterValidator.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameterValidator.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.api.customizer.parameter;
+
+import org.apache.iotdb.db.exception.metadata.MetadataException;
+import org.apache.iotdb.db.query.udf.api.exception.UDFAttributeNotProvidedException;
+import org.apache.iotdb.db.query.udf.api.exception.UDFInputSeriesDataTypeNotValidException;
+import org.apache.iotdb.db.query.udf.api.exception.UDFInputSeriesIndexNotValidException;
+import org.apache.iotdb.db.query.udf.api.exception.UDFInputSeriesNumberNotValidException;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+public class UDFParameterValidator {
+
+  private final String functionName;
+  private final UDFParameters parameters;
+
+  public UDFParameterValidator(String functionName, UDFParameters parameters) {
+    this.functionName = functionName;
+    this.parameters = parameters;
+  }
+
+  public UDFParameterValidator validateRequiredAttribute(String attributeKey)
+      throws UDFAttributeNotProvidedException {
+    if (!parameters.hasAttribute(attributeKey)) {
+      throw new UDFAttributeNotProvidedException(functionName, attributeKey);
+    }
+    return this;
+  }
+
+  public UDFParameterValidator validateInputSeriesDataType(int index, TSDataType expectedDataType)
+      throws UDFInputSeriesIndexNotValidException, UDFInputSeriesDataTypeNotValidException, MetadataException {
+    validateInputSeriesIndex(index);
+
+    TSDataType actualDataType = parameters.getDataType(index);
+    if (!expectedDataType.equals(actualDataType)) {
+      throw new UDFInputSeriesDataTypeNotValidException(functionName, index, actualDataType,
+          expectedDataType);
+    }
+    return this;
+  }
+
+  public UDFParameterValidator validateInputSeriesDataType(int index,
+      TSDataType... expectedDataTypes)
+      throws UDFInputSeriesIndexNotValidException, UDFInputSeriesDataTypeNotValidException, MetadataException {
+    validateInputSeriesIndex(index);
+
+    TSDataType actualDataType = parameters.getDataType(index);
+    for (TSDataType expectedDataType : expectedDataTypes) {
+      if (expectedDataType.equals(actualDataType)) {
+        return this;
+      }
+    }
+
+    throw new UDFInputSeriesDataTypeNotValidException(functionName, index, actualDataType,
+        expectedDataTypes);
+  }
+
+  public UDFParameterValidator validateInputSeriesNumber(int expectedSeriesNumber)
+      throws UDFInputSeriesNumberNotValidException {
+    int actualSeriesNumber = parameters.getPaths().size();
+    if (actualSeriesNumber != expectedSeriesNumber) {
+      throw new UDFInputSeriesNumberNotValidException(functionName, actualSeriesNumber,
+          expectedSeriesNumber);
+    }
+    return this;
+  }
+
+  public UDFParameterValidator validateInputSeriesNumber(int expectedSeriesNumberLowerBound,
+      int expectedSeriesNumberUpperBound) throws UDFInputSeriesNumberNotValidException {
+    int actualSeriesNumber = parameters.getPaths().size();
+    if (actualSeriesNumber < expectedSeriesNumberLowerBound
+        || expectedSeriesNumberUpperBound < actualSeriesNumber) {
+      throw new UDFInputSeriesNumberNotValidException(functionName, actualSeriesNumber,
+          expectedSeriesNumberLowerBound, expectedSeriesNumberUpperBound);
+    }
+    return this;
+  }
+
+  public UDFParameterValidator validateInputSeriesIndex(int index)
+      throws UDFInputSeriesIndexNotValidException {
+    int actualSeriesNumber = parameters.getPaths().size();
+    if (index < 0 || actualSeriesNumber <= index) {
+      throw new UDFInputSeriesIndexNotValidException(functionName, index, actualSeriesNumber);
+    }
+    return this;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameterValidator.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameterValidator.java
@@ -36,6 +36,10 @@ public class UDFParameterValidator {
     this.parameters = parameters;
   }
 
+  public UDFParameters getParameters() {
+    return parameters;
+  }
+
   /**
    * Validates whether the attributes entered by the user contain an attribute whose key is
    * attributeKey.
@@ -167,19 +171,40 @@ public class UDFParameterValidator {
    * Validates the input parameters according to the validation rule given by the user.
    *
    * @param validationRule the validation rule, which can be a lambda expression
-   * @param messageToThrow the message to throw when the given args are not valid
-   * @param args           the given args
-   * @throws UDFParameterNotValidException if the given args are not valid
+   * @param messageToThrow the message to throw when the given argument is not valid
+   * @param argument       the given argument
+   * @throws UDFParameterNotValidException if the given argument is not valid
    */
-  public UDFParameterValidator validate(ValidationRule validationRule, String messageToThrow,
-      Object... args) throws UDFParameterNotValidException {
-    if (!validationRule.validate(args)) {
+  public UDFParameterValidator validate(SingleObjectValidationRule validationRule,
+      String messageToThrow, Object argument) throws UDFParameterNotValidException {
+    if (!validationRule.validate(argument)) {
       throw new UDFParameterNotValidException(messageToThrow);
     }
     return this;
   }
 
-  private interface ValidationRule {
+  public interface SingleObjectValidationRule {
+
+    boolean validate(Object arg);
+  }
+
+  /**
+   * Validates the input parameters according to the validation rule given by the user.
+   *
+   * @param validationRule the validation rule, which can be a lambda expression
+   * @param messageToThrow the message to throw when the given arguments are not valid
+   * @param arguments      the given arguments
+   * @throws UDFParameterNotValidException if the given arguments are not valid
+   */
+  public UDFParameterValidator validate(MultipleObjectsValidationRule validationRule,
+      String messageToThrow, Object... arguments) throws UDFParameterNotValidException {
+    if (!validationRule.validate(arguments)) {
+      throw new UDFParameterNotValidException(messageToThrow);
+    }
+    return this;
+  }
+
+  public interface MultipleObjectsValidationRule {
 
     boolean validate(Object... args);
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameterValidator.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameterValidator.java
@@ -150,24 +150,6 @@ public class UDFParameterValidator {
   }
 
   /**
-   * Validates whether the index of the specified column is out of bound.
-   * </p>
-   * bound: [0, parameters.getPaths().size())
-   *
-   * @param index the index of the specified column
-   * @throws UDFInputSeriesIndexNotValidException if the index of the specified column is out of
-   *                                              bound
-   */
-  public UDFParameterValidator validateInputSeriesIndex(int index)
-      throws UDFInputSeriesIndexNotValidException {
-    int actualSeriesNumber = parameters.getPaths().size();
-    if (index < 0 || actualSeriesNumber <= index) {
-      throw new UDFInputSeriesIndexNotValidException(index, actualSeriesNumber);
-    }
-    return this;
-  }
-
-  /**
    * Validates the input parameters according to the validation rule given by the user.
    *
    * @param validationRule the validation rule, which can be a lambda expression
@@ -207,5 +189,21 @@ public class UDFParameterValidator {
   public interface MultipleObjectsValidationRule {
 
     boolean validate(Object... args);
+  }
+
+  /**
+   * Validates whether the index of the specified column is out of bound.
+   * </p>
+   * bound: [0, parameters.getPaths().size())
+   *
+   * @param index the index of the specified column
+   * @throws UDFInputSeriesIndexNotValidException if the index of the specified column is out of
+   *                                              bound
+   */
+  private void validateInputSeriesIndex(int index) throws UDFInputSeriesIndexNotValidException {
+    int actualSeriesNumber = parameters.getPaths().size();
+    if (index < 0 || actualSeriesNumber <= index) {
+      throw new UDFInputSeriesIndexNotValidException(index, actualSeriesNumber);
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameterValidator.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameterValidator.java
@@ -36,6 +36,13 @@ public class UDFParameterValidator {
     this.parameters = parameters;
   }
 
+  /**
+   * Validates whether the attributes entered by the user contain an attribute whose key is
+   * attributeKey.
+   *
+   * @param attributeKey key of the attribute
+   * @throws UDFAttributeNotProvidedException if the attribute is not provided
+   */
   public UDFParameterValidator validateRequiredAttribute(String attributeKey)
       throws UDFAttributeNotProvidedException {
     if (!parameters.hasAttribute(attributeKey)) {
@@ -44,6 +51,18 @@ public class UDFParameterValidator {
     return this;
   }
 
+  /**
+   * Validates whether the data type of the input series at the specified column is as expected.
+   *
+   * @param index            index of the specified column
+   * @param expectedDataType the expected data type
+   * @throws UDFInputSeriesIndexNotValidException    if the index of the specified column is out of
+   *                                                 bound
+   * @throws UDFInputSeriesDataTypeNotValidException if the data type of the input series at the
+   *                                                 specified column is not as expected
+   * @throws MetadataException                       if error occurs when getting the data type of
+   *                                                 the input series
+   */
   public UDFParameterValidator validateInputSeriesDataType(int index, TSDataType expectedDataType)
       throws UDFInputSeriesIndexNotValidException, UDFInputSeriesDataTypeNotValidException, MetadataException {
     validateInputSeriesIndex(index);
@@ -56,6 +75,18 @@ public class UDFParameterValidator {
     return this;
   }
 
+  /**
+   * Validates whether the data type of the input series at the specified column is as expected.
+   *
+   * @param index             index of the specified column
+   * @param expectedDataTypes the expected data types
+   * @throws UDFInputSeriesIndexNotValidException    if the index of the specified column is out of
+   *                                                 bound
+   * @throws UDFInputSeriesDataTypeNotValidException if the data type of the input series at the
+   *                                                 specified column is not as expected
+   * @throws MetadataException                       if error occurs when getting the data type of
+   *                                                 the input series
+   */
   public UDFParameterValidator validateInputSeriesDataType(int index,
       TSDataType... expectedDataTypes)
       throws UDFInputSeriesIndexNotValidException, UDFInputSeriesDataTypeNotValidException, MetadataException {
@@ -72,6 +103,13 @@ public class UDFParameterValidator {
         expectedDataTypes);
   }
 
+  /**
+   * Validates whether the number of the input series is as expected.
+   *
+   * @param expectedSeriesNumber the expected number of the input series
+   * @throws UDFInputSeriesNumberNotValidException if the number of the input series is not as
+   *                                               expected
+   */
   public UDFParameterValidator validateInputSeriesNumber(int expectedSeriesNumber)
       throws UDFInputSeriesNumberNotValidException {
     int actualSeriesNumber = parameters.getPaths().size();
@@ -82,6 +120,16 @@ public class UDFParameterValidator {
     return this;
   }
 
+  /**
+   * Validates whether the number of the input series is as expected.
+   *
+   * @param expectedSeriesNumberLowerBound the number of the input series must be greater than or
+   *                                       equal to the expectedSeriesNumberLowerBound
+   * @param expectedSeriesNumberUpperBound the number of the input series must be less than or equal
+   *                                       to the expectedSeriesNumberUpperBound
+   * @throws UDFInputSeriesNumberNotValidException if the number of the input series is not as
+   *                                               expected
+   */
   public UDFParameterValidator validateInputSeriesNumber(int expectedSeriesNumberLowerBound,
       int expectedSeriesNumberUpperBound) throws UDFInputSeriesNumberNotValidException {
     int actualSeriesNumber = parameters.getPaths().size();
@@ -93,6 +141,15 @@ public class UDFParameterValidator {
     return this;
   }
 
+  /**
+   * Validates whether the index of the specified column is out of bound.
+   * </p>
+   * bound: [0, parameters.getPaths().size())
+   *
+   * @param index the index of the specified column
+   * @throws UDFInputSeriesIndexNotValidException if the index of the specified column is out of
+   *                                              bound
+   */
   public UDFParameterValidator validateInputSeriesIndex(int index)
       throws UDFInputSeriesIndexNotValidException {
     int actualSeriesNumber = parameters.getPaths().size();

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameters.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/customizer/parameter/UDFParameters.java
@@ -58,6 +58,10 @@ public class UDFParameters {
     return paths.get(index);
   }
 
+  public boolean hasAttribute(String attributeKey) {
+    return attributes.containsKey(attributeKey);
+  }
+
   public String getString(String key) {
     return attributes.get(key);
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFAttributeNotProvidedException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFAttributeNotProvidedException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.api.exception;
+
+public class UDFAttributeNotProvidedException extends UDFException {
+
+  public UDFAttributeNotProvidedException(String functionName, String requiredAttribute) {
+    super(functionName,
+        String.format("attribute \"%s\" is required but was not provided.", requiredAttribute));
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFException.java
@@ -21,11 +21,11 @@ package org.apache.iotdb.db.query.udf.api.exception;
 
 public class UDFException extends Exception {
 
-  public UDFException(String functionName, String message) {
-    super(String.format("%s: %s", functionName, message));
+  public UDFException(String message) {
+    super(message);
   }
 
-  public UDFException(String functionName, String message, Throwable cause) {
-    super(String.format("%s: %s", functionName, message), cause);
+  public UDFException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.api.exception;
+
+public class UDFException extends Exception {
+
+  public UDFException(String functionName, String message) {
+    super(String.format("%s: %s", functionName, message));
+  }
+
+  public UDFException(String functionName, String message, Throwable cause) {
+    super(String.format("%s: %s", functionName, message), cause);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesDataTypeNotValidException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesDataTypeNotValidException.java
@@ -22,18 +22,18 @@ package org.apache.iotdb.db.query.udf.api.exception;
 import java.util.Arrays;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
-public class UDFInputSeriesDataTypeNotValidException extends UDFException {
+public class UDFInputSeriesDataTypeNotValidException extends UDFParameterNotValidException {
 
-  public UDFInputSeriesDataTypeNotValidException(String functionName, int index, TSDataType actual,
+  public UDFInputSeriesDataTypeNotValidException(int index, TSDataType actual,
       TSDataType expected) {
-    super(functionName, String.format(
+    super(String.format(
         "the data type of the input series (index: %d) is not valid. expected: %s. actual: %s.",
         index, expected.toString(), actual.toString()));
   }
 
-  public UDFInputSeriesDataTypeNotValidException(String functionName, int index, TSDataType actual,
+  public UDFInputSeriesDataTypeNotValidException(int index, TSDataType actual,
       TSDataType... expected) {
-    super(functionName, String.format(
+    super(String.format(
         "the data type of the input series (index: %d) is not valid. expected: %s. actual: %s.",
         index, Arrays.toString(expected), actual.toString()));
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesDataTypeNotValidException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesDataTypeNotValidException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.api.exception;
+
+import java.util.Arrays;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+public class UDFInputSeriesDataTypeNotValidException extends UDFException {
+
+  public UDFInputSeriesDataTypeNotValidException(String functionName, int index, TSDataType actual,
+      TSDataType expected) {
+    super(functionName, String.format(
+        "the data type of the input series (index: %d) is not valid. expected: %s. actual: %s.",
+        index, expected.toString(), actual.toString()));
+  }
+
+  public UDFInputSeriesDataTypeNotValidException(String functionName, int index, TSDataType actual,
+      TSDataType... expected) {
+    super(functionName, String.format(
+        "the data type of the input series (index: %d) is not valid. expected: %s. actual: %s.",
+        index, Arrays.toString(expected), actual.toString()));
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesIndexNotValidException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesIndexNotValidException.java
@@ -19,12 +19,11 @@
 
 package org.apache.iotdb.db.query.udf.api.exception;
 
-public class UDFInputSeriesIndexNotValidException extends UDFException {
+public class UDFInputSeriesIndexNotValidException extends UDFParameterNotValidException {
 
-  public UDFInputSeriesIndexNotValidException(String functionName, int providedIndex,
-      int validIndexUpperBound) {
-    super(functionName, String.format(
-        "the index (%d) of the input series is not valid. valid index range: [0, %d).",
-        providedIndex, validIndexUpperBound));
+  public UDFInputSeriesIndexNotValidException(int providedIndex, int validIndexUpperBound) {
+    super(String
+        .format("the index (%d) of the input series is not valid. valid index range: [0, %d).",
+            providedIndex, validIndexUpperBound));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesIndexNotValidException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesIndexNotValidException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.api.exception;
+
+public class UDFInputSeriesIndexNotValidException extends UDFException {
+
+  public UDFInputSeriesIndexNotValidException(String functionName, int providedIndex,
+      int validIndexUpperBound) {
+    super(functionName, String.format(
+        "the index (%d) of the input series is not valid. valid index range: [0, %d).",
+        providedIndex, validIndexUpperBound));
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesNumberNotValidException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesNumberNotValidException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.api.exception;
+
+public class UDFInputSeriesNumberNotValidException extends UDFException {
+
+  public UDFInputSeriesNumberNotValidException(String functionName, int actual, int expected) {
+    super(functionName, String
+        .format("the number of the input series is not valid. expected: %d. actual: %d.",
+            expected, actual));
+  }
+
+  public UDFInputSeriesNumberNotValidException(String functionName, int actual,
+      int expectedLowerBound, int expectedUpperBound) {
+    super(functionName, String
+        .format("the number of the input series is not valid. expected: [%d, %d]. actual: %d.",
+            expectedLowerBound, expectedUpperBound, actual));
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesNumberNotValidException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesNumberNotValidException.java
@@ -19,17 +19,17 @@
 
 package org.apache.iotdb.db.query.udf.api.exception;
 
-public class UDFInputSeriesNumberNotValidException extends UDFException {
+public class UDFInputSeriesNumberNotValidException extends UDFParameterNotValidException {
 
-  public UDFInputSeriesNumberNotValidException(String functionName, int actual, int expected) {
-    super(functionName, String
-        .format("the number of the input series is not valid. expected: %d. actual: %d.",
-            expected, actual));
+  public UDFInputSeriesNumberNotValidException(int actual, int expected) {
+    super(String
+        .format("the number of the input series is not valid. expected: %d. actual: %d.", expected,
+            actual));
   }
 
-  public UDFInputSeriesNumberNotValidException(String functionName, int actual,
-      int expectedLowerBound, int expectedUpperBound) {
-    super(functionName, String
+  public UDFInputSeriesNumberNotValidException(int actual, int expectedLowerBound,
+      int expectedUpperBound) {
+    super(String
         .format("the number of the input series is not valid. expected: [%d, %d]. actual: %d.",
             expectedLowerBound, expectedUpperBound, actual));
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFParameterNotValidException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFParameterNotValidException.java
@@ -19,9 +19,9 @@
 
 package org.apache.iotdb.db.query.udf.api.exception;
 
-public class UDFAttributeNotProvidedException extends UDFParameterNotValidException {
+public class UDFParameterNotValidException extends UDFException {
 
-  public UDFAttributeNotProvidedException(String requiredAttribute) {
-    super(String.format("attribute \"%s\" is required but was not provided.", requiredAttribute));
+  public UDFParameterNotValidException(String message) {
+    super(message);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFAlignByTimeQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFAlignByTimeQueryIT.java
@@ -127,6 +127,8 @@ public class IoTDBUDTFAlignByTimeQueryIT {
       statement.execute("create function max as \"org.apache.iotdb.db.query.udf.example.Max\"");
       statement.execute(
           "create function terminate as \"org.apache.iotdb.db.query.udf.example.TerminateTester\"");
+      statement.execute(
+          "create function validate as \"org.apache.iotdb.db.query.udf.example.ValidateTester\"");
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
@@ -357,6 +359,48 @@ public class IoTDBUDTFAlignByTimeQueryIT {
       assertFalse(resultSet.next());
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
+    }
+  }
+
+  @Test
+  public void queryWithoutValueFilter8() {
+    String sqlStr = "select validate(s1, s2, 'k'='') from root.vehicle.d3";
+
+    try (Statement statement = DriverManager.getConnection(
+        Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root").createStatement()) {
+      statement.executeQuery(sqlStr);
+      fail();
+    } catch (SQLException throwable) {
+      assertTrue(throwable.getMessage().contains(
+          "the data type of the input series (index: 0) is not valid. expected: [INT32, INT64]. actual: FLOAT."));
+    }
+  }
+
+  @Test
+  public void queryWithoutValueFilter9() {
+    String sqlStr = "select validate(s1, s2, s1, 'k'=''), * from root.vehicle.d1";
+
+    try (Statement statement = DriverManager.getConnection(
+        Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root").createStatement()) {
+      statement.executeQuery(sqlStr);
+      fail();
+    } catch (SQLException throwable) {
+      assertTrue(throwable.getMessage().contains(
+          "the number of the input series is not valid. expected: 2. actual: 3."));
+    }
+  }
+
+  @Test
+  public void queryWithoutValueFilter10() {
+    String sqlStr = "select validate(s1, s2), * from root.vehicle.d1";
+
+    try (Statement statement = DriverManager.getConnection(
+        Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root").createStatement()) {
+      statement.executeQuery(sqlStr);
+      fail();
+    } catch (SQLException throwable) {
+      assertTrue(
+          throwable.getMessage().contains("attribute \"k\" is required but was not provided."));
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/query/udf/example/Accumulator.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/udf/example/Accumulator.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.query.udf.api.access.RowIterator;
 import org.apache.iotdb.db.query.udf.api.access.RowWindow;
 import org.apache.iotdb.db.query.udf.api.collector.PointCollector;
 import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameterValidator;
 import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.RowByRowAccessStrategy;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.SlidingTimeWindowAccessStrategy;
@@ -35,6 +36,13 @@ import org.apache.iotdb.db.query.udf.api.customizer.strategy.SlidingSizeWindowAc
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
 public class Accumulator implements UDTF {
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator
+        .validateInputSeriesNumber(1)
+        .validateInputSeriesDataType(0, TSDataType.INT32);
+  }
 
   @Override
   public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {

--- a/server/src/test/java/org/apache/iotdb/db/query/udf/example/Adder.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/udf/example/Adder.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.query.udf.api.UDTF;
 import org.apache.iotdb.db.query.udf.api.access.Row;
 import org.apache.iotdb.db.query.udf.api.collector.PointCollector;
 import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameterValidator;
 import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.RowByRowAccessStrategy;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
@@ -31,6 +32,16 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 public class Adder implements UDTF {
 
   private double addend;
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator
+        .validateInputSeriesNumber(2)
+        .validateInputSeriesDataType(0, TSDataType.INT32, TSDataType.INT64, TSDataType.FLOAT,
+            TSDataType.DOUBLE)
+        .validateInputSeriesDataType(1, TSDataType.INT32, TSDataType.INT64, TSDataType.FLOAT,
+            TSDataType.DOUBLE);
+  }
 
   @Override
   public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {

--- a/server/src/test/java/org/apache/iotdb/db/query/udf/example/Max.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/udf/example/Max.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.query.udf.api.UDTF;
 import org.apache.iotdb.db.query.udf.api.access.Row;
 import org.apache.iotdb.db.query.udf.api.collector.PointCollector;
 import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameterValidator;
 import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.RowByRowAccessStrategy;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -32,6 +33,13 @@ public class Max implements UDTF {
 
   private Long time;
   private int value;
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator
+        .validateInputSeriesNumber(1)
+        .validateInputSeriesDataType(0, TSDataType.INT32);
+  }
 
   @Override
   public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {

--- a/server/src/test/java/org/apache/iotdb/db/query/udf/example/Multiplier.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/udf/example/Multiplier.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.query.udf.api.UDTF;
 import org.apache.iotdb.db.query.udf.api.access.Row;
 import org.apache.iotdb.db.query.udf.api.collector.PointCollector;
 import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameterValidator;
 import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.RowByRowAccessStrategy;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -31,6 +32,13 @@ public class Multiplier implements UDTF {
 
   private long a;
   private long b;
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator
+        .validateInputSeriesNumber(1)
+        .validateInputSeriesDataType(0, TSDataType.INT64);
+  }
 
   @Override
   public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {

--- a/server/src/test/java/org/apache/iotdb/db/query/udf/example/SlidingSizeWindowConstructorTester1.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/udf/example/SlidingSizeWindowConstructorTester1.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.query.udf.api.UDTF;
 import org.apache.iotdb.db.query.udf.api.access.Row;
 import org.apache.iotdb.db.query.udf.api.collector.PointCollector;
 import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameterValidator;
 import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.RowByRowAccessStrategy;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -30,6 +31,13 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 public class SlidingSizeWindowConstructorTester1 implements UDTF {
 
   private int consumptionPoint;
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator
+        .validateInputSeriesNumber(1)
+        .validateInputSeriesDataType(0, TSDataType.INT32);
+  }
 
   @Override
   public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {

--- a/server/src/test/java/org/apache/iotdb/db/query/udf/example/SlidingTimeWindowConstructionTester.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/udf/example/SlidingTimeWindowConstructionTester.java
@@ -27,11 +27,19 @@ import org.apache.iotdb.db.query.udf.api.access.RowIterator;
 import org.apache.iotdb.db.query.udf.api.access.RowWindow;
 import org.apache.iotdb.db.query.udf.api.collector.PointCollector;
 import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameterValidator;
 import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.db.query.udf.api.customizer.strategy.SlidingTimeWindowAccessStrategy;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
 public class SlidingTimeWindowConstructionTester implements UDTF {
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator
+        .validateInputSeriesNumber(1)
+        .validateInputSeriesDataType(0, TSDataType.INT32);
+  }
 
   @Override
   public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {

--- a/server/src/test/java/org/apache/iotdb/db/query/udf/example/ValidateTester.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/udf/example/ValidateTester.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.db.query.udf.api.UDTF;
+import org.apache.iotdb.db.query.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameterValidator;
+import org.apache.iotdb.db.query.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.db.query.udf.api.customizer.strategy.RowByRowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+public class ValidateTester implements UDTF {
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator
+        .validateRequiredAttribute("k")
+        .validateInputSeriesNumber(2)
+        .validateInputSeriesDataType(0, TSDataType.INT32, TSDataType.INT64)
+        .validateInputSeriesDataType(1, TSDataType.INT32, TSDataType.INT64);
+  }
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    configurations
+        .setAccessStrategy(new RowByRowAccessStrategy())
+        .setOutputDataType(TSDataType.INT32);
+  }
+}


### PR DESCRIPTION
The interface is mainly used to validate UDFParameters and it is executed before UDTF#beforeStart is called.

JIRA: https://issues.apache.org/jira/browse/IOTDB-1098