### PR TITLE
Fix the condition of logger with the right level globally

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
@@ -389,7 +389,7 @@ public class DataGroupMember extends RaftMember {
 
     snapshot.deserialize(ByteBuffer.wrap(request.getSnapshotBytes()));
     if (logger.isDebugEnabled()) {
-      logger.info("{} received a snapshot {}", name, snapshot);
+      logger.debug("{} received a snapshot {}", name, snapshot);
     }
     snapshot.getDefaultInstaller(this).install(snapshot, -1);
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -595,7 +595,7 @@ public class MetaGroupMember extends RaftMember {
   }
 
   private void handleConfigInconsistency(AddNodeResponse resp) throws ConfigInconsistentException {
-    if (logger.isInfoEnabled()) {
+    if (logger.isErrorEnabled()) {
       CheckStatusResponse checkStatusResponse = resp.getCheckStatusResponse();
       String parameters =
           (checkStatusResponse.isPartitionalIntervalEquals() ? "" : ", partition interval")

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -559,7 +559,7 @@ public class TsFileProcessor {
     } finally {
       flushQueryLock.writeLock().unlock();
       if (logger.isDebugEnabled()) {
-        logger.error(FLUSH_QUERY_WRITE_RELEASE, storageGroupName,
+        logger.debug(FLUSH_QUERY_WRITE_RELEASE, storageGroupName,
             tsFileResource.getTsFile().getName());
       }
     }


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

        http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->

<!-- Thanks for trying to help us make Apache IoTDB be the best it can be! 
Please fill out as much of the following information as is possible (where relevant, and remove it 
when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

## Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue, 
it's not necessary to repeat the description here, 
however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section 
for each of them. For example: -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read
    - [x] concurrent write
    - [x] concurrent read and write 
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. 
- [x] added or updated version, __license__, or notice information
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

<!-- Template copied and modified from Apache Druid-->