### PR TITLE
[IOTDB-1103] [To rel/0.11] Fix frame size larger than max length error

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
@@ -59,8 +59,12 @@ public class Config {
    */
   public static final int DEFAULT_INITIAL_BUFFER_CAPACITY = 1024;
 
+  public static final String INITIAL_BUFFER_CAPACITY = "initial_buffer_capacity";
+
   /**
    * thrift max frame size (16384000 bytes by default), we change it to 64MB
    */
   public static final int DEFAULT_MAX_FRAME_SIZE = 67108864;
+
+  public static final String MAX_FRAME_SIZE = "max_frame_size";
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
@@ -54,4 +54,13 @@ public class Config {
 
   public static boolean rpcThriftCompressionEnable = false;
 
+  /**
+   * thrift init buffer size, 1KB by default
+   */
+  public static final int DEFAULT_INITIAL_BUFFER_CAPACITY = 1024;
+
+  /**
+   * thrift max frame size (16384000 bytes by default), we change it to 64MB
+   */
+  public static final int DEFAULT_MAX_FRAME_SIZE = 67108864;
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -40,7 +40,14 @@ import java.util.Properties;
 import java.util.concurrent.Executor;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
-import org.apache.iotdb.service.rpc.thrift.*;
+import org.apache.iotdb.service.rpc.thrift.ServerProperties;
+import org.apache.iotdb.service.rpc.thrift.TSCloseSessionReq;
+import org.apache.iotdb.service.rpc.thrift.TSIService;
+import org.apache.iotdb.service.rpc.thrift.TSOpenSessionReq;
+import org.apache.iotdb.service.rpc.thrift.TSOpenSessionResp;
+import org.apache.iotdb.service.rpc.thrift.TSProtocolVersion;
+import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
@@ -78,10 +85,9 @@ public class IoTDBConnection implements Connection {
     params = Utils.parseUrl(url, info);
 
     openTransport();
-    if(Config.rpcThriftCompressionEnable) {
+    if (Config.rpcThriftCompressionEnable) {
       setClient(new TSIService.Client(new TCompactProtocol(transport)));
-    }
-    else {
+    } else {
       setClient(new TSIService.Client(new TBinaryProtocol(transport)));
     }
     // open client session
@@ -120,7 +126,8 @@ public class IoTDBConnection implements Connection {
     try {
       getClient().closeSession(req);
     } catch (TException e) {
-      throw new SQLException("Error occurs when closing session at server. Maybe server is down.", e);
+      throw new SQLException("Error occurs when closing session at server. Maybe server is down.",
+          e);
     } finally {
       isClosed = true;
       if (transport != null) {
@@ -408,7 +415,7 @@ public class IoTDBConnection implements Connection {
 
   private void openTransport() throws TTransportException {
     transport = new TFastFramedTransport(new TSocket(params.getHost(), params.getPort(),
-        Config.connectionTimeoutInMs));
+        Config.connectionTimeoutInMs), params.getInitialBufferCapacity(), params.getMaxFrameSize());
     if (!transport.isOpen()) {
       transport.open();
     }
@@ -463,10 +470,9 @@ public class IoTDBConnection implements Connection {
         if (transport != null) {
           transport.close();
           openTransport();
-          if(Config.rpcThriftCompressionEnable) {
+          if (Config.rpcThriftCompressionEnable) {
             setClient(new TSIService.Client(new TCompactProtocol(transport)));
-          }
-          else {
+          } else {
             setClient(new TSIService.Client(new TBinaryProtocol(transport)));
           }
           openSession();

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
@@ -86,7 +86,15 @@ public class IoTDBConnectionParams {
     return initialBufferCapacity;
   }
 
+  public void setInitialBufferCapacity(int initialBufferCapacity) {
+    this.initialBufferCapacity = initialBufferCapacity;
+  }
+
   public int getMaxFrameSize() {
     return maxFrameSize;
+  }
+
+  public void setMaxFrameSize(int maxFrameSize) {
+    this.maxFrameSize = maxFrameSize;
   }
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
@@ -27,6 +27,9 @@ public class IoTDBConnectionParams {
   private String username = Config.DEFAULT_USER;
   private String password = Config.DEFALUT_PASSWORD;
 
+  private int initialBufferCapacity = Config.DEFAULT_INITIAL_BUFFER_CAPACITY;
+  private int maxFrameSize = Config.DEFAULT_MAX_FRAME_SIZE;
+
   public IoTDBConnectionParams(String url) {
     this.jdbcUriString = url;
   }
@@ -79,4 +82,11 @@ public class IoTDBConnectionParams {
     this.password = password;
   }
 
+  public int getInitialBufferCapacity() {
+    return initialBufferCapacity;
+  }
+
+  public int getMaxFrameSize() {
+    return maxFrameSize;
+  }
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
@@ -62,10 +62,11 @@ public class Utils {
       params.setPassword(info.getProperty(Config.AUTH_PASSWORD));
     }
     if (info.containsKey(Config.INITIAL_BUFFER_CAPACITY)) {
-      params.setInitialBufferCapacity(info.getProperty(Config.DEFAULT_INITIAL_BUFFER_CAPACITY));
+      params.setInitialBufferCapacity(Integer.parseInt(
+          info.getProperty(Config.INITIAL_BUFFER_CAPACITY)));
     }
     if (info.containsKey(Config.MAX_FRAME_SIZE)) {
-      params.setMaxFrameSize(info.getProperty(Config.DEFAULT_MAX_FRAME_SIZE));
+      params.setMaxFrameSize(Integer.parseInt(info.getProperty(Config.MAX_FRAME_SIZE)));
     }
     return params;
   }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
@@ -49,7 +49,8 @@ public class Utils {
       }
     }
     if (!isUrlLegal) {
-      throw new IoTDBURLException("Error url format, url should be jdbc:iotdb://anything:port/ or jdbc:iotdb://anything:port");
+      throw new IoTDBURLException(
+          "Error url format, url should be jdbc:iotdb://anything:port/ or jdbc:iotdb://anything:port");
     }
     params.setHost(matcher.group(1));
     params.setPort(Integer.parseInt(matcher.group(2)));
@@ -60,8 +61,12 @@ public class Utils {
     if (info.containsKey(Config.AUTH_PASSWORD)) {
       params.setPassword(info.getProperty(Config.AUTH_PASSWORD));
     }
-
+    if (info.containsKey(Config.INITIAL_BUFFER_CAPACITY)) {
+      params.setInitialBufferCapacity(info.getProperty(Config.DEFAULT_INITIAL_BUFFER_CAPACITY));
+    }
+    if (info.containsKey(Config.MAX_FRAME_SIZE)) {
+      params.setMaxFrameSize(info.getProperty(Config.DEFAULT_MAX_FRAME_SIZE));
+    }
     return params;
   }
-  
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -160,7 +160,7 @@ public class TimeSeriesMetadataCache {
           BloomFilter bloomFilter = reader.readBloomFilter();
           if (bloomFilter != null && !bloomFilter.contains(path.getFullPath())) {
             if (config.isDebugOn()) {
-              DEBUG_LOGGER.info("TimeSeries meta data " + key + " is filter by bloomFilter!");
+              DEBUG_LOGGER.info("TimeSeries meta data {} is filter by bloomFilter!", key);
             }
             return null;
           }
@@ -186,14 +186,14 @@ public class TimeSeriesMetadataCache {
     }
     if (timeseriesMetadata == null) {
       if (config.isDebugOn()) {
-        DEBUG_LOGGER.info("The file doesn't have this time series " + key);
+        DEBUG_LOGGER.info("The file doesn't have this time series {}", key);
       }
       return null;
     } else {
       if (config.isDebugOn()) {
         DEBUG_LOGGER.info(
-            "Get timeseries: " + key.device + "." + key.measurement + " metadata in file: "
-                + key.filePath + " from cache: " + timeseriesMetadata);
+            "Get timeseries: {}. {} metadata in file: {} from cache: {}",
+            key.device, key.measurement, key.filePath, timeseriesMetadata);
       }
       return new TimeseriesMetadata(timeseriesMetadata);
     }

--- a/session/src/main/java/org/apache/iotdb/session/Config.java
+++ b/session/src/main/java/org/apache/iotdb/session/Config.java
@@ -26,4 +26,14 @@ public class Config {
   public static final int DEFAULT_TIMEOUT_MS = 0;
   public static final int RETRY_NUM = 3;
   public static final long RETRY_INTERVAL_MS = 1000;
+
+  /**
+   * thrift init buffer size, 1KB by default
+   */
+  public static final int DEFAULT_INITIAL_BUFFER_CAPACITY = 1024;
+
+  /**
+   * thrift max frame size (16384000 bytes by default), we change it to 64MB
+   */
+  public static final int DEFAULT_MAX_FRAME_SIZE = 67108864;
 }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -119,6 +119,7 @@ public class Session {
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY, Config.DEFAULT_MAX_FRAME_SIZE);
   }
 
+  @SuppressWarnings("squid:S107")
   public Session(String host, int rpcPort, String username, String password, int fetchSize,
       ZoneId zoneId, int initialBufferCapacity, int maxFrameSize) {
     this.host = host;


### PR DESCRIPTION
When querying large amount size of data, `Frame size larger than max length` may thrown in client.