### PR TITLE
[To 0.11] Some RestartTests failed because the compaction module does not allow…

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -163,14 +163,22 @@ public class IoTDB implements IoTDBMBean {
 
   }
 
+  /**
+   * stop IoTDB's daemon service.
+   */
   @Override
   public void stop() {
     deactivate();
   }
 
+  /**
+   * stop accept new requests.
+   * @throws Exception
+   */
   public void shutdown() throws Exception {
     logger.info("Deactivating IoTDB...");
-    IoTDB.metaManager.clear();
+    //we can not clear the metadata manager before the compaction process really stops.
+    //IoTDB.metaManager.clear();
     TracingManager.getInstance().close();
     registerManager.shutdownAll();
     PrimitiveArrayManager.close();

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -255,7 +255,7 @@ public class EnvironmentUtils {
     }
   }
 
-  public static void shutdownDaemon() throws Exception {
+  private static void shutdownDaemon() throws Exception {
     if (daemon != null) {
       daemon.shutdown();
     }
@@ -279,6 +279,7 @@ public class EnvironmentUtils {
   public static void restartDaemon() throws Exception {
     shutdownDaemon();
     stopDaemon();
+    IoTDB.metaManager.clear();
     reactiveDaemon();
   }
 


### PR DESCRIPTION
Some RestartTests failed because the compaction module does not allow clear the MManamger before it is stopped.
see #2426 https://github.com/apache/iotdb/pull/2426/checks?check_run_id=1650191463 and
#2425 https://github.com/apache/iotdb/pull/2425/checks?check_run_id=1649494523

Master branch fixes it in #2436 2436
