### PR TITLE
Fix zeppelin bug on Show Storage Group

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/iotdb/IoTDBInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/iotdb/IoTDBInterpreterTest.java
@@ -37,6 +37,7 @@ import static org.apache.zeppelin.iotdb.IoTDBInterpreter.SET_TIMESTAMP_DISPLAY;
 
 import java.io.IOException;
 import java.util.Properties;
+import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -69,6 +70,7 @@ public class IoTDBInterpreterTest {
   }
 
   private void initInsert() {
+    interpreter.internalInterpret("set storage group to root.test.wf01", null);
     interpreter.internalInterpret(
         "INSERT INTO root.test.wf01.wt01 (timestamp, temperature, status, hardware) VALUES (1, 1.1, false, 11)",
         null);
@@ -83,6 +85,14 @@ public class IoTDBInterpreterTest {
         null);
     interpreter.internalInterpret(
         "INSERT INTO root.test.wf01.wt01 (timestamp, temperature, status, hardware) VALUES (5, 5.5, false, 55)",
+        null);
+
+    interpreter.internalInterpret("set storage group to root.test.wf02", null);
+    interpreter.internalInterpret(
+        "INSERT INTO root.test.wf02.wt02 (timestamp, temperature, status, hardware) VALUES (44, 4.4, false, 44)",
+        null);
+    interpreter.internalInterpret(
+        "INSERT INTO root.test.wf02.wt02 (timestamp, temperature, status, hardware) VALUES (54, 5.5, false, 55)",
         null);
   }
 
@@ -270,5 +280,93 @@ public class IoTDBInterpreterTest {
         "SELECT * FROM root.test.wf01.wt01 WHERE time >= 1  AND time <= 6",
     };
     Assert.assertArrayEquals(gt, IoTDBInterpreter.parseMultiLinesSQL(query));
+  }
+
+  @Test
+  public void testShowVersion() {
+    InterpreterResult actual = interpreter
+        .internalInterpret("SHOW VERSION", null);
+    String gt = "version\n" + IoTDBConstant.VERSION;
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(Code.SUCCESS, actual.code());
+    Assert.assertEquals(gt, actual.message().get(0).getData());
+  }
+
+  @Test
+  public void testShowTimeseries() {
+    InterpreterResult actual = interpreter
+        .internalInterpret("show timeseries", null);
+    String gt =
+        "timeseries\talias\tstorage group\tdataType\tencoding\tcompression\ttags\tattributes\n"
+            + "root.test.wf02.wt02.temperature\tnull\troot.test.wf02\tFLOAT\tGORILLA\tSNAPPY\tnull\tnull\n"
+            + "root.test.wf02.wt02.status\tnull\troot.test.wf02\tBOOLEAN\tRLE\tSNAPPY\tnull\tnull\n"
+            + "root.test.wf02.wt02.hardware\tnull\troot.test.wf02\tFLOAT\tGORILLA\tSNAPPY\tnull\tnull\n"
+            + "root.test.wf01.wt01.temperature\tnull\troot.test.wf01\tFLOAT\tGORILLA\tSNAPPY\tnull\tnull\n"
+            + "root.test.wf01.wt01.status\tnull\troot.test.wf01\tBOOLEAN\tRLE\tSNAPPY\tnull\tnull\n"
+            + "root.test.wf01.wt01.hardware\tnull\troot.test.wf01\tFLOAT\tGORILLA\tSNAPPY\tnull\tnull";
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(Code.SUCCESS, actual.code());
+    Assert.assertEquals(gt, actual.message().get(0).getData());
+  }
+
+  @Test
+  public void testShowDevices() {
+    InterpreterResult actual = interpreter
+        .internalInterpret("show devices", null);
+    String gt = "devices\n"
+        + "root.test.wf01.wt01\n"
+        + "root.test.wf02.wt02";
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(Code.SUCCESS, actual.code());
+    Assert.assertEquals(gt, actual.message().get(0).getData());
+  }
+
+  @Test
+  public void testShowAllTTL() {
+    interpreter.internalInterpret("SET TTL TO root.test.wf01 12345", null);
+    InterpreterResult actual = interpreter
+        .internalInterpret("SHOW ALL TTL", null);
+    String gt = "storage group\tttl\n"
+        + "root.test.wf02\tnull\n"
+        + "root.test.wf01\t12345";
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(Code.SUCCESS, actual.code());
+    Assert.assertEquals(gt, actual.message().get(0).getData());
+  }
+
+  @Test
+  public void testShowTTL() {
+    interpreter.internalInterpret("SET TTL TO root.test.wf01 12345", null);
+    InterpreterResult actual = interpreter
+        .internalInterpret("SHOW TTL ON root.test.wf01", null);
+    String gt = "storage group\tttl\n"
+        + "root.test.wf01\t12345";
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(Code.SUCCESS, actual.code());
+    Assert.assertEquals(gt, actual.message().get(0).getData());
+  }
+
+  @Test
+  public void testShowStorageGroup() {
+    InterpreterResult actual = interpreter
+        .internalInterpret("SHOW STORAGE GROUP", null);
+    String gt = "storage group\n"
+        + "root.test.wf02\n"
+        + "root.test.wf01";
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(Code.SUCCESS, actual.code());
+    Assert.assertEquals(gt, actual.message().get(0).getData());
+  }
+
+  @Test
+  public void testListUser() {
+    interpreter.internalInterpret("CREATE USER user1 'password1'", null);
+    InterpreterResult actual = interpreter.internalInterpret("LIST USER", null);
+    String gt = "user\n"
+        + "root\n"
+        + "user1";
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(Code.SUCCESS, actual.code());
+    Assert.assertEquals(gt, actual.message().get(0).getData());
   }
 }


### PR DESCRIPTION
## Description
Fix bugs on query statements that ignore timestamps, namely, the result's first column is not `time`.

### Changing executeQuery
Referring to `org.apache.iotdb.cli.AbstractCli`, use `isIgnoreTimeStamp` to justify whether the result table has a timestamp column.

### Adding Test
Including:
* testShowAllTTL
* testShowDevices
* testShowStorageGroup
* testShowTimeseries
* testShowTTL
* testShowVersion 

### Code Optimization 
Encapsulate `stringBuilder.deleteCharAt(stringBuilder.length() - 1)` everywhere into the function `deleteLast(StringBuilder stringBuilder)`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] test zeppelin on MacOS 10.14.1, Chrome  87.0.4280.141.
- [x] added integration tests.
- [x]  added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.

<hr>

## Key changed/added classes
* org.apache.zeppelin.iotdb.IoTDBInterpreter
* org.apache.zeppelin.iotdb.IoTDBInterpreterTest