### PR TITLE
Fix common issue 0.11 (copyright, readme)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache IoTDB
-Copyright 2018-2020 The Apache Software Foundation.
+Copyright 2018-2021 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache IoTDB
-Copyright 2018-2020 The Apache Software Foundation.
+Copyright 2018-2021 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -100,7 +100,7 @@ IoTDB提供了三种安装方法，您可以参考以下建议，选择最适合
 
 * 从二进制文件安装。推荐的方法是从官方网站下载二进制文件，您将获得一个开箱即用的二进制发布包。
 
-* 使用Docker: dockerfile的路径是https://github.com/apache/incubat-iotdb/tree/master/docker/src/main
+* 使用Docker: dockerfile的路径是https://github.com/apache/iotdb/tree/master/docker/src/main
 
 在这篇《快速入门》中，我们简要介绍如何使用源代码安装IoTDB。如需进一步资料，请参阅《用户指南》第3章。
 
@@ -124,7 +124,7 @@ git checkout release/x.x.x
 > mvn clean package -DskipTests
 ```
 
-执行完成之后，可以在**distribution/target/apache-iotdb-{project.version}-incubating-bin.zip**找到编译完成的二进制版本(包括服务器和客户端)
+执行完成之后，可以在**distribution/target/apache-iotdb-{project.version}-bin.zip**找到编译完成的二进制版本(包括服务器和客户端)
 
 > 注意:"thrift/target/generated-sources/thrift" 和 "antlr/target/generated-sources/antlr4" 目录需要添加到源代码根中，以免在 IDE 中产生编译错误。
 

--- a/client-cpp/client-cpp-example/pom.xml
+++ b/client-cpp/client-cpp-example/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <artifactId>client-cpp</artifactId>
         <groupId>org.apache.iotdb</groupId>
-        <version>0.11.1-SNAPSHOT</version>
+        <version>0.11.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.iotdb</groupId>
     <artifactId>client-cpp-example</artifactId>
-    <version>0.11.1-SNAPSHOT</version>
+    <version>0.11.3-SNAPSHOT</version>
     <profiles>
         <profile>
             <id>os-unix</id>

--- a/client-cpp/pom.xml
+++ b/client-cpp/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <artifactId>iotdb-parent</artifactId>
         <groupId>org.apache.iotdb</groupId>
-        <version>0.11.1-SNAPSHOT</version>
+        <version>0.11.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.iotdb</groupId>
     <artifactId>client-cpp</artifactId>
-    <version>0.11.1-SNAPSHOT</version>
+    <version>0.11.3-SNAPSHOT</version>
     <name>Client for cpp</name>
     <description>C++ client</description>
     <packaging>pom</packaging>

--- a/compile-tools/boost/pom.xml
+++ b/compile-tools/boost/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>client-cpp-tools</artifactId>
-        <version>0.11.1-SNAPSHOT</version>
+        <version>0.11.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>client-cpp-tools-boost</artifactId>

--- a/compile-tools/pom.xml
+++ b/compile-tools/pom.xml
@@ -22,12 +22,10 @@
     <parent>
         <artifactId>iotdb-parent</artifactId>
         <groupId>org.apache.iotdb</groupId>
-        <version>0.11.1-SNAPSHOT</version>
+        <version>0.11.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>client-cpp-tools</artifactId>
-    <groupId>org.apache.iotdb</groupId>
-    <version>0.11.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Compile Tools</name>
     <properties>

--- a/compile-tools/thrift/pom.xml
+++ b/compile-tools/thrift/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>client-cpp-tools</artifactId>
-        <version>0.11.1-SNAPSHOT</version>
+        <version>0.11.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>client-cpp-tools-thrift</artifactId>


### PR DESCRIPTION
## Description

### CopyRight issue

in NOTICE the copyright time is 2008 - 2020.

### version Client-CPP module

change it to 0.11.3-SNAPSHOT

### "incubating" keyword in README_ZH.md

they should be removed.
