### PR TITLE
[IOTDB-1091] add linear fill test case for sdt encoding

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
@@ -260,7 +260,7 @@ public class IoTDBSimpleQueryIT {
         }
       }
     } catch (SQLException e) {
-      e.printStackTrace();
+      fail();
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
@@ -30,7 +30,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.MManager;
@@ -204,6 +207,57 @@ public class IoTDBSimpleQueryIT {
         assertEquals(timestamps[count], resultSet.getString("Time"));
         assertEquals(values[count], resultSet.getString("root.sg1.d0.s0"));
         count++;
+      }
+    } catch (SQLException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testSDTEncodingSelectFill() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/",
+            "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.setFetchSize(5);
+      statement.execute("SET STORAGE GROUP TO root.sg1");
+      double compDev = 2;
+      //test set sdt property
+      statement
+          .execute(
+              "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN,LOSS=SDT,COMPDEV=" + compDev);
+
+      int[] originalValues = new int[1000];
+
+      Map<String, Integer> map = new HashMap<>();
+
+      Random rand = new Random();
+      for (int i = 1; i < originalValues.length; i++) {
+        originalValues[i] = rand.nextInt(500);
+        String sql = "insert into root.sg1.d0(timestamp,s0) values(" + i + "," + originalValues[i] + ")";
+        statement.execute(sql);
+        map.put(i + "", originalValues[i]);
+      }
+      statement.execute("flush");
+
+      for (int i = 1; i < originalValues.length; i++) {
+        String sql = "select * from root where time = " + i
+            + " fill(int32 [linear, 20ms, 20ms])";
+        ResultSet resultSet = statement.executeQuery(sql);
+
+        while (resultSet.next()) {
+          String time = resultSet.getString("Time");
+          String value = resultSet.getString("root.sg1.d0.s0");
+          //last value is not stored, cannot linear fill
+          if (value == null) {
+            continue;
+          }
+          // sdt parallelogram's height is 2 * compDev, so after linear fill, the values will fall inside
+          // the parallelogram of two stored points
+          assertTrue(Math.abs(Integer.parseInt(value) - map.get(time)) <= 2 * compDev);
+        }
       }
     } catch (SQLException e) {
       e.printStackTrace();


### PR DESCRIPTION
SDT algorithm uses a  parallelogram to filter raw data and its height is 2 * compression deviation. After SDT compression, if user uses linear fill, the resulting values will fall inside the parallelogram of two stored points. The absolute difference between filled value and original value is <= 2 * compression deviation. 