### PR TITLE
Optimize VirtualStorageGroupManage class to make it more compact

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -270,9 +270,9 @@ public class StorageEngine implements IService {
           // for recovery in test
           VirtualStorageGroupManager virtualStorageGroupManager = processorMap
               .computeIfAbsent(storageGroup.getPartialPath(),
-                  id -> new VirtualStorageGroupManager());
+                  id -> new VirtualStorageGroupManager(storageGroup));
 
-          virtualStorageGroupManager.recover(storageGroup);
+          virtualStorageGroupManager.recover();
 
           logger.info("Storage Group Processor {} is recovered successfully",
               storageGroup.getFullPath());
@@ -422,7 +422,7 @@ public class StorageEngine implements IService {
         synchronized (storageGroupMNode) {
           virtualStorageGroupManager = processorMap.get(storageGroupMNode.getPartialPath());
           if (virtualStorageGroupManager == null) {
-            virtualStorageGroupManager = new VirtualStorageGroupManager();
+            virtualStorageGroupManager = new VirtualStorageGroupManager(storageGroupMNode);
             processorMap.put(storageGroupMNode.getPartialPath(), virtualStorageGroupManager);
           }
         }
@@ -434,7 +434,7 @@ public class StorageEngine implements IService {
             TSStatusCode.STORAGE_GROUP_NOT_READY.getStatusCode());
       }
     }
-    return virtualStorageGroupManager.getProcessor(devicePath, storageGroupMNode);
+    return virtualStorageGroupManager.getProcessor(devicePath);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualStorageGroupManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualStorageGroupManager.java
@@ -58,8 +58,14 @@ public class VirtualStorageGroupManager {
    */
   private long monitorSeriesValue;
 
-  public VirtualStorageGroupManager() {
-    virtualStorageGroupProcessor = new StorageGroupProcessor[partitioner.getPartitionCount()];
+  /**
+   *  storageGroupMNode logical sg mnode
+   */
+  private StorageGroupMNode storageGroupMNode;
+
+  public VirtualStorageGroupManager(StorageGroupMNode storageGroupMNode) {
+    this.storageGroupMNode = storageGroupMNode;
+    this.virtualStorageGroupProcessor = new StorageGroupProcessor[partitioner.getPartitionCount()];
   }
 
   /**
@@ -103,8 +109,7 @@ public class VirtualStorageGroupManager {
    */
   @SuppressWarnings("java:S2445")
   // actually storageGroupMNode is a unique object on the mtree, synchronize it is reasonable
-  public StorageGroupProcessor getProcessor(PartialPath partialPath,
-      StorageGroupMNode storageGroupMNode)
+  public StorageGroupProcessor getProcessor(PartialPath partialPath)
       throws StorageGroupProcessorException, StorageEngineException {
     int loc = partitioner.deviceToVirtualStorageGroupId(partialPath);
 
@@ -134,10 +139,8 @@ public class VirtualStorageGroupManager {
 
   /**
    * recover
-   *
-   * @param storageGroupMNode logical sg mnode
    */
-  public void recover(StorageGroupMNode storageGroupMNode) {
+  public void recover() {
     List<Thread> threadList = new ArrayList<>(partitioner.getPartitionCount());
     for (int i = 0; i < partitioner.getPartitionCount(); i++) {
       int cur = i;


### PR DESCRIPTION
Use storageGroupMNode as the param of VirtualStorageGroupManag's constructor. Because they have a corresponding relationship.