### PR TITLE
[IOTDB-1119] Fix C++ SessionDataSet bug when reading value buffer

### DIFF
--- a/client-cpp/client-cpp-example/src/SessionExample.cpp
+++ b/client-cpp/client-cpp-example/src/SessionExample.cpp
@@ -255,6 +255,17 @@ void deleteTimeseries() {
     session->deleteTimeseries(paths);
 }
 
+void queryLast() {
+    SessionDataSet *dataSet = session->executeQueryStatement("select last s1,s2,s3 from root.sg1.d1");
+    for (string name: dataSet->getColumnNames()) {
+        cout << name << "  ";
+    }
+    cout << endl;
+    while (dataSet->hasNext()) {
+        cout << dataSet->next()->toString();
+    }
+}
+
 int main() {
     session = new Session("127.0.0.1", 6667, "root", "root");
     session->open(false);
@@ -275,6 +286,8 @@ int main() {
     createMultiTimeseries();
 
     insertRecord();
+
+    queryLast();
 
     insertTablet();
 

--- a/client-cpp/src/main/Session.cpp
+++ b/client-cpp/src/main/Session.cpp
@@ -259,44 +259,44 @@ void SessionDataSet::constructOneRow() {
         if (duplicateLocation.find(i) != duplicateLocation.end()) {
             field = new Field(*outFields[duplicateLocation[i]]);
         } else {
-            MyStringBuffer bitmapBuffer = MyStringBuffer(tsQueryDataSet->bitmapList[loc]);
+            MyStringBuffer *bitmapBuffer = bitmapBuffers[loc].get();
             // another new 8 row, should move the bitmap buffer position to next byte
             if (rowsIndex % 8 == 0) {
-                currentBitmap[loc] = bitmapBuffer.getChar();
+                currentBitmap[loc] = bitmapBuffer->getChar();
             }
 
             if (!isNull(loc, rowsIndex)) {
-                MyStringBuffer valueBuffer = MyStringBuffer(tsQueryDataSet->valueList[loc]);
+                MyStringBuffer *valueBuffer = valueBuffers[loc].get();
                 TSDataType::TSDataType dataType = getTSDataTypeFromString(columnTypeDeduplicatedList[loc]);
                 field = new Field(dataType);
                 switch (dataType) {
                 case TSDataType::BOOLEAN: {
-                    bool booleanValue = valueBuffer.getBool();
+                    bool booleanValue = valueBuffer->getBool();
                     field->boolV = booleanValue;
                     break;
                 }
                 case TSDataType::INT32: {
-                    int intValue = valueBuffer.getInt();
+                    int intValue = valueBuffer->getInt();
                     field->intV = intValue;
                     break;
                 }
                 case TSDataType::INT64: {
-                    int64_t longValue = valueBuffer.getLong();
+                    int64_t longValue = valueBuffer->getLong();
                     field->longV = longValue;
                     break;
                 }
                 case TSDataType::FLOAT: {
-                    float floatValue = valueBuffer.getFloat();
+                    float floatValue = valueBuffer->getFloat();
                     field->floatV = floatValue;
                     break;
                 }
                 case TSDataType::DOUBLE: {
-                    double doubleValue = valueBuffer.getDouble();
+                    double doubleValue = valueBuffer->getDouble();
                     field->doubleV = doubleValue;
                     break;
                 }
                 case TSDataType::TEXT: {
-                    string stringValue = valueBuffer.getString();
+                    string stringValue = valueBuffer->getString();
                     field->stringV = stringValue;
                     break;
                 }

--- a/client-cpp/src/main/Session.h
+++ b/client-cpp/src/main/Session.h
@@ -514,6 +514,8 @@ private:
     int rowsIndex = 0; // used to record the row index in current TSQueryDataSet
     std::shared_ptr<TSQueryDataSet> tsQueryDataSet;
     MyStringBuffer tsQueryDataSetTimeBuffer;
+    std::vector<std::unique_ptr<MyStringBuffer>> valueBuffers;
+    std::vector<std::unique_ptr<MyStringBuffer>> bitmapBuffers;
     RowRecord rowRecord;
     char* currentBitmap; // used to cache the current bitmap for every column
     static const int flag = 0x80; // used to do `or` operation with bitmap to judge whether the value is null
@@ -540,6 +542,8 @@ public:
                 this->columnMap[name] = i;
                 this->columnTypeDeduplicatedList.push_back(columnTypeList[i]);
             }
+            this->valueBuffers.push_back(std::unique_ptr<MyStringBuffer>(new MyStringBuffer(queryDataSet->valueList[i])));
+            this->bitmapBuffers.push_back(std::unique_ptr<MyStringBuffer>(new MyStringBuffer(queryDataSet->bitmapList[i])));
         }
         this->tsQueryDataSet = queryDataSet;
     }

--- a/client-cpp/src/test/cpp/sessionIT.cpp
+++ b/client-cpp/src/test/cpp/sessionIT.cpp
@@ -169,3 +169,25 @@ TEST_CASE( "Test insertTablet ", "[testInsertTablet]") {
   }
   REQUIRE( count == 100 );
 }
+
+TEST_CASE( "Test Last query ", "[testLastQuery]") {
+  prepareTimeseries();
+  string deviceId = "root.test.d1";
+  vector<string> measurements = { "s1", "s2", "s3" };
+
+  for (long time = 0; time < 100; time++) {
+    vector<string> values = { "1", "2", "3" };
+    session->insertRecord(deviceId, time, measurements, values);
+  }
+
+  vector<string> measurementValues = { "1", "2", "3" };
+  SessionDataSet *sessionDataSet = session->executeQueryStatement("select last s1,s2,s3 from root.test.d1");
+  sessionDataSet->setBatchSize(1024);
+  long index = 0;
+  while (sessionDataSet->hasNext()) {
+    vector<Field*> fields = sessionDataSet->next()->fields;
+    REQUIRE( fields[0]->stringV == deviceId + "." + measurements[index] );
+    REQUIRE( fields[1]->stringV == measurementValues[index] );
+    index++;
+  }
+}


### PR DESCRIPTION
This PR fixes JIRA Issue: https://issues.apache.org/jira/browse/IOTDB-1119
  
When executing "select last s1,s2,s3 from root.sg1.d1", it gives wrong answer:
```
+----------------------------------------+
| timestamp |     timeseries    |  value |
|     100   |  root.sg1.d1.s1   |    1   |
|     100   |  root.sg1.d1.s1   |    1   |
|     100   |  root.sg1.d1.s1   |    1   |
+----------------------------------------+
```

Query through CLI will give correct result:
```
+----------------------------------------+
| timestamp |     timeseries    |  value |
|     100   |  root.sg1.d1.s1   |    1   |
|     100   |  root.sg1.d1.s2   |    2   |
|     100   |  root.sg1.d1.s3   |    3   |
+----------------------------------------+
```