### PR TITLE
Fix merge bug that  page statistics incorrectly use the chunk statistics for new Tsfile Format

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
@@ -85,8 +85,8 @@ public class CompactionUtils {
           newChunkMetadata = chunkMetadata;
           newChunk = chunk;
         } else {
-          newChunkMetadata.mergeChunkMetadata(chunkMetadata);
           newChunk.mergeChunk(chunk);
+          newChunkMetadata.mergeChunkMetadata(chunkMetadata);
         }
       }
     }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBNewTsFileCompactionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBNewTsFileCompactionIT.java
@@ -624,6 +624,11 @@ public class IoTDBNewTsFileCompactionIT {
         }
       }
       assertEquals(retArray.length, cnt);
+
+      try (ResultSet resultSet = statement.executeQuery("SELECT count(s1) FROM root.sg1.d1 where time < 4")) {
+        assertTrue(resultSet.next());
+        assertEquals(3L, resultSet.getLong("count(root.sg1.d1.s1)"));
+      }
     } catch (StorageEngineException | InterruptedException e) {
       e.printStackTrace();
       fail();


### PR DESCRIPTION
Error message:
![image](https://user-images.githubusercontent.com/1021782/105490046-24d7e580-5cef-11eb-833c-9e2e97817e1e.png)


Since the tsfile format has been changed, while the chunk has only one page, the page will share the same statistic with its chunk.
So, think about the following case:
chunk1 has only one page named page1, chunk2 has only one page named page2, in the current process of merging, we first merge the two chunks' statistics, so the chunk1's statistics has been updated. Since chunk1 and chunk2 being merged, the current merged chunk has two pages, so we should generate two new statistics for each page. Since page1 shares the same statistics with chunk1 so, it has been updated before serializing to disk which is not right.
So, we should update chunk's statistic after chunk data being merged.