### PR TITLE
bug fix - fetch size calculation error for group by month

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -672,8 +672,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
   private int getFetchSizeForGroupByTimePlan(GroupByTimePlan groupByTimePlan) {
     int rows =  (int) ((groupByTimePlan.getEndTime() - groupByTimePlan.getStartTime()) / groupByTimePlan
         .getInterval());
-    // edge case for group by months when starttime is in February
-    // ie. time range = [2020-02-02, 2020-03-02), interval = 1mo, rows will get 0
+    // rows gets 0 is caused by: the end time - the start time < the time interval.
     if (rows == 0 && groupByTimePlan.isIntervalByMonth()) {
       Calendar calendar = Calendar.getInstance();
       calendar.setTimeInMillis(groupByTimePlan.getStartTime());

--- a/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByIT.java
@@ -796,7 +796,6 @@ public class IOTDBGroupByIT {
       String[] retArray1 = {"10/31/2019:19:57:18", "30.0", "11/30/2019:19:57:18", "31.0",
           "12/31/2019:19:57:18", "31.0", "01/31/2020:19:57:18", "29.0", "02/29/2020:19:57:18", "31.0",
           "03/31/2020:19:57:18", "1.0"};
-      List<String> start = new ArrayList<>();
 
       for (long i = startTime; i <= endTime; i += 86400_000L) {
         statement.execute("insert into root.sg1.d1(timestamp, temperature) values (" + i + ", 1)");
@@ -823,7 +822,6 @@ public class IOTDBGroupByIT {
         }
         Assert.assertEquals(retArray1.length, cnt);
       }
-      System.out.println(start.toString());
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());
@@ -871,6 +869,41 @@ public class IOTDBGroupByIT {
         }
         Assert.assertEquals(retArray1.length, cnt);
       }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void groupByNaturalMonth3() {
+    //test when endtime - starttime = interval
+    try (Connection connection = DriverManager.
+        getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      //2/1/2021:15:20
+      long startTime = 1612164041000L;
+      //3/1/2021:15:20
+      long endTime = 1614583241000L;
+
+      for (long i = startTime; i <= endTime; i += 86400_000L) {
+        statement.execute("insert into root.sg1.d1(timestamp, temperature) values (" + i + ", 1)");
+      }
+
+      DateFormat df = new SimpleDateFormat("MM/dd/yyyy:HH:mm:ss");
+      df.setTimeZone(TimeZone.getTimeZone("GMT+8:00"));
+
+      boolean hasResultSet = statement.execute(
+          "select sum(temperature) from root.sg1.d1 "
+              + "GROUP BY ([1612164041000, 1614583241000), 1mo)");
+
+      Assert.assertTrue(hasResultSet);
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        cnt++;
+      }
+      Assert.assertEquals(1, cnt);
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());


### PR DESCRIPTION
currently when use group by month and starttime is in February, there is a calculation error. 

```
IoTDB> select count(*) from root.sg1 group by ([2020-02-13, 2020-03-13), 1mo)
+----+---------------------+---------------------+---------------------+
|Time|count(root.sg1.d1.s4)|count(root.sg1.d1.s5)|count(root.sg1.d1.s2)|
+----+---------------------+---------------------+---------------------+
+----+---------------------+---------------------+---------------------+

IoTDB> select count(*) from root.sg1 group by ([2020-04-01, 2020-05-01), 1mo)
+-----------------------------+---------------------+---------------------+---------------------+
|                         Time|count(root.sg1.d1.s4)|count(root.sg1.d1.s5)|count(root.sg1.d1.s2)|
+-----------------------------+---------------------+---------------------+---------------------+
|2020-04-01T00:00:00.000+08:00|                    0|                    0|                    0|
+-----------------------------+---------------------+---------------------+---------------------+
Total line number = 1
It costs 0.003s
```

but it should be
```
IoTDB> select count(*) from root.sg1 group by ([2020-02-01, 2020-03-01), 1mo)
+-----------------------------+---------------------+---------------------+---------------------+
|                         Time|count(root.sg1.d1.s4)|count(root.sg1.d1.s5)|count(root.sg1.d1.s2)|
+-----------------------------+---------------------+---------------------+---------------------+
|2020-02-01T00:00:00.000+08:00|                    0|                    0|                    0|
+-----------------------------+---------------------+---------------------+---------------------+
```