### PR TITLE
[IOTDB-1091] SDT improvement store last point

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -158,6 +158,11 @@ public class MemTableFlushTask {
           continue;
         }
 
+        //store last point for SDT
+        if (i + 1 == tvPairs.size()) {
+          ((ChunkWriterImpl) seriesWriterImpl).setLastPoint(true);
+        }
+
         switch (dataType) {
           case BOOLEAN:
             seriesWriterImpl.write(time, tvPairs.getBoolean(i));

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
@@ -186,7 +186,7 @@ public class IoTDBSimpleQueryIT {
       while (resultSet.next()) {
         count++;
       }
-      assertEquals(14, count);
+      assertEquals(15, count);
 
     } catch (SQLException e) {
       e.printStackTrace();
@@ -226,8 +226,8 @@ public class IoTDBSimpleQueryIT {
       ResultSet resultSet = statement.executeQuery("select * from root");
       int count = 0;
 
-      String[] timestamps = {"1", "15", "16", "17"};
-      String[] values = {"1", "10", "20", "1"};
+      String[] timestamps = {"1", "7", "15", "16", "17", "18"};
+      String[] values = {"1", "1", "10", "20", "1", "30"};
 
       while (resultSet.next()) {
         assertEquals(timestamps[count], resultSet.getString("Time"));
@@ -272,8 +272,9 @@ public class IoTDBSimpleQueryIT {
       ResultSet resultSet = statement.executeQuery("select * from root");
       int count = 0;
 
-      String[] timestamps = {"1", "15", "17"};
-      String[] values = {"1", "10", "1"};
+      //will not store time = 16 since time distance to last stored time 15 is within compMinTime
+      String[] timestamps = {"1", "7", "15", "17", "18"};
+      String[] values = {"1", "1", "10", "1", "30"};
 
       while (resultSet.next()) {
         assertEquals(timestamps[count], resultSet.getString("Time"));
@@ -305,13 +306,11 @@ public class IoTDBSimpleQueryIT {
       }
       statement.execute("flush");
 
-
-      statement.execute("flush");
       ResultSet resultSet = statement.executeQuery("select * from root");
       int count = 0;
 
-      String[] timestamps = {"1", "21", "41"};
-      String[] values = {"1", "1", "1"};
+      String[] timestamps = {"1", "21", "41", "49"};
+      String[] values = {"1", "1", "1", "1"};
 
       while (resultSet.next()) {
         assertEquals(timestamps[count], resultSet.getString("Time"));
@@ -364,7 +363,7 @@ public class IoTDBSimpleQueryIT {
       while (resultSet.next()) {
         count++;
       }
-      assertEquals(17, count);
+      assertEquals(18, count);
 
     } catch (SQLException e) {
       e.printStackTrace();
@@ -408,7 +407,7 @@ public class IoTDBSimpleQueryIT {
       while (resultSet.next()) {
         count++;
       }
-      assertEquals(14, count);
+      assertEquals(15, count);
 
       //no sdt encoding when merging
       statement.execute("merge");
@@ -417,7 +416,7 @@ public class IoTDBSimpleQueryIT {
       while (resultSet.next()) {
         count++;
       }
-      assertEquals(14, count);
+      assertEquals(15, count);
 
     } catch (SQLException e) {
       e.printStackTrace();
@@ -465,7 +464,7 @@ public class IoTDBSimpleQueryIT {
       while (resultSet.next()) {
         count++;
       }
-      assertEquals(17, count);
+      assertEquals(18, count);
 
       //no sdt encoding when merging
       statement.execute("merge");
@@ -474,7 +473,7 @@ public class IoTDBSimpleQueryIT {
       while (resultSet.next()) {
         count++;
       }
-      assertEquals(17, count);
+      assertEquals(18, count);
 
     } catch (SQLException e) {
       e.printStackTrace();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
@@ -155,20 +155,26 @@ public class ChunkWriterImpl implements IChunkWriter {
 
   @Override
   public void write(long time, long value) {
-    if (!isSdtEncoding || isLastPoint) {
+    // store last point for sdtEncoding, it still needs to go through encoding process
+    // in case it exceeds compdev and needs to store second last point
+    if (!isSdtEncoding || sdtEncoder.encodeLong(time, value)) {
+      pageWriter.write(isSdtEncoding ? sdtEncoder.getTime() : time,
+          isSdtEncoding ? sdtEncoder.getLongValue() : value);
+    }
+    if (isSdtEncoding && isLastPoint) {
       pageWriter.write(time, value);
-    } else if (sdtEncoder.encodeLong(time, value)) {
-      pageWriter.write(sdtEncoder.getTime(), sdtEncoder.getLongValue());
     }
     checkPageSizeAndMayOpenANewPage();
   }
 
   @Override
   public void write(long time, int value) {
-    if (!isSdtEncoding || isLastPoint) {
+    if (!isSdtEncoding || sdtEncoder.encodeInt(time, value)) {
+      pageWriter.write(isSdtEncoding ? sdtEncoder.getTime() : time,
+          isSdtEncoding ? sdtEncoder.getIntValue() : value);
+    }
+    if (isSdtEncoding && isLastPoint) {
       pageWriter.write(time, value);
-    } else if (sdtEncoder.encodeInt(time, value)) {
-      pageWriter.write(sdtEncoder.getTime(), sdtEncoder.getIntValue());
     }
     checkPageSizeAndMayOpenANewPage();
   }
@@ -181,20 +187,25 @@ public class ChunkWriterImpl implements IChunkWriter {
 
   @Override
   public void write(long time, float value) {
-    if (!isSdtEncoding || isLastPoint) {
+    if (!isSdtEncoding || sdtEncoder.encodeFloat(time, value)) {
+      pageWriter.write(isSdtEncoding ? sdtEncoder.getTime() : time,
+          isSdtEncoding ? sdtEncoder.getFloatValue() : value);
+    }
+    //store last point for sdt encoding
+    if (isSdtEncoding && isLastPoint) {
       pageWriter.write(time, value);
-    } else if (sdtEncoder.encodeFloat(time, value)) {
-      pageWriter.write(sdtEncoder.getTime(), sdtEncoder.getFloatValue());
     }
     checkPageSizeAndMayOpenANewPage();
   }
 
   @Override
   public void write(long time, double value) {
-    if (!isSdtEncoding || isLastPoint) {
+    if (!isSdtEncoding || sdtEncoder.encodeDouble(time, value)) {
+      pageWriter.write(isSdtEncoding ? sdtEncoder.getTime() : time,
+          isSdtEncoding ? sdtEncoder.getDoubleValue() : value);
+    }
+    if (isSdtEncoding && isLastPoint) {
       pageWriter.write(time, value);
-    } else if (sdtEncoder.encodeDouble(time, value)) {
-      pageWriter.write(sdtEncoder.getTime(), sdtEncoder.getDoubleValue());
     }
     checkPageSizeAndMayOpenANewPage();
   }


### PR DESCRIPTION
store last point when use sdt encoding
SDT compression is trigger by flushing, in current implementation the last point before flushing is not stored. 
The pr fixes this issue. 