### PR TITLE
IOTDB-1126 unseq tsfile delete due to merge

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
@@ -286,6 +286,7 @@ public class MergeMultiChunkTask {
       try {
         futures.get(i).get();
       } catch (InterruptedException e) {
+        logger.error("MergeChunkHeapTask interrupted", e);
         Thread.currentThread().interrupt();
         return false;
       } catch (ExecutionException e) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeTask.java
@@ -111,9 +111,8 @@ public class MergeTask implements Callable<Void> {
   }
 
   private void doMerge() throws IOException, MetadataException {
-    if (resource.getSeqFiles().size() == 0) {
-      logger.info("{} starts to merge {} seqFiles, so will abort task.", taskName ,
-              resource.getSeqFiles().size());
+    if (resource.getSeqFiles().isEmpty()) {
+      logger.info("{} no sequence file to merge into, so will abort task.", taskName);
       abort();
       return;
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeTask.java
@@ -111,6 +111,12 @@ public class MergeTask implements Callable<Void> {
   }
 
   private void doMerge() throws IOException, MetadataException {
+    if (resource.getSeqFiles().size() == 0) {
+      logger.info("{} starts to merge {} seqFiles, so will abort task.", taskName ,
+              resource.getSeqFiles().size());
+      abort();
+      return;
+    }
     if (logger.isInfoEnabled()) {
       logger.info("{} starts to merge {} seqFiles, {} unseqFiles", taskName,
           resource.getSeqFiles().size(), resource.getUnseqFiles().size());

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1733,6 +1733,45 @@ public class StorageGroupProcessor {
 
 
   /**
+   * <p>
+   *  update latest flush time for partition id
+   *  </>
+   * @param partitionId partition id
+   * @param latestFlushTime lastest flush time
+   * @return true if update latest flush time success
+   */
+  private boolean updateLatestFlushTimeToPartition(long partitionId, long latestFlushTime) {
+    // update the largest timestamp in the last flushing memtable
+    Map<String, Long> curPartitionDeviceLatestTime = latestTimeForEachDevice
+            .get(partitionId);
+
+    if (curPartitionDeviceLatestTime == null) {
+      logger.warn("Partition: {} does't have latest time for each device. "
+                      + "No valid record is written into memtable.  latest flush time is: {}",
+              partitionId, latestFlushTime);
+      return false;
+    }
+
+    for (Entry<String, Long> entry : curPartitionDeviceLatestTime.entrySet()) {
+      // set lastest flush time to latestTimeForEachDevice
+      entry.setValue(latestFlushTime);
+
+      partitionLatestFlushedTimeForEachDevice
+              .computeIfAbsent(partitionId, id -> new HashMap<>())
+              .put(entry.getKey(), entry.getValue());
+      newlyFlushedPartitionLatestFlushedTimeForEachDevice
+              .computeIfAbsent(partitionId, id -> new HashMap<>())
+              .put(entry.getKey(), entry.getValue());
+      if (globalLatestFlushedTimeForEachDevice
+              .getOrDefault(entry.getKey(), Long.MIN_VALUE) < entry.getValue()) {
+        globalLatestFlushedTimeForEachDevice.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return true;
+  }
+
+
+  /**
    * used for upgrading
    */
   public void updateNewlyFlushedPartitionLatestFlushedTimeForEachDevice(long partitionId,
@@ -2600,6 +2639,7 @@ public class StorageGroupProcessor {
       if (filter.satisfy(logicalStorageGroupName, partitionId)) {
         processor.syncClose();
         iterator.remove();
+        updateLatestFlushTimeToPartition(partitionId, Long.MIN_VALUE);
         logger.debug("{} is removed during deleting partitions",
             processor.getTsFileResource().getTsFilePath());
       }
@@ -2613,6 +2653,7 @@ public class StorageGroupProcessor {
       if (filter.satisfy(logicalStorageGroupName, tsFileResource.getTimePartition())) {
         tsFileResource.remove();
         iterator.remove();
+        updateLatestFlushTimeToPartition(tsFileResource.getTimePartition(), Long.MIN_VALUE);
         logger.debug("{} is removed during deleting partitions", tsFileResource.getTsFilePath());
       }
     }

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
@@ -281,4 +281,32 @@ public class MergeTaskTest extends MergeTest {
     assertEquals(70, count);
     tsFilesReader.close();
   }
+
+  @Test
+  public void testOnlyUnseqMerge() throws Exception {
+    // unseq and no seq merge
+    List<TsFileResource> testSeqResources = new ArrayList<>();
+    List<TsFileResource> testUnseqResource = unseqResources.subList(5, 6);
+    MergeTask mergeTask =
+            new MergeTask(new MergeResource(testSeqResources, testUnseqResource), tempSGDir.getPath(),
+                    (k, v, l) -> {
+                    }, "test", false, 1, MERGE_TEST_SG);
+    mergeTask.call();
+
+    QueryContext context = new QueryContext();
+    PartialPath path = new PartialPath(
+            deviceIds[0] + TsFileConstant.PATH_SEPARATOR + measurementSchemas[0].getMeasurementId());
+    List<TsFileResource> resources = new ArrayList<>();
+    resources.add(seqResources.get(2));
+    IBatchReader tsFilesReader = new SeriesRawDataBatchReader(path, measurementSchemas[0].getType(),
+            context, resources, new ArrayList<>(), null, null, true);
+    int count = 0;
+    while (tsFilesReader.hasNextBatch()) {
+      BatchData batchData = tsFilesReader.nextBatch();
+      for (int i = 0; i < batchData.length(); i++) {
+        assertEquals(batchData.getTimeByIndex(i) + 0.0, batchData.getDoubleByIndex(i), 0.001);
+      }
+    }
+    tsFilesReader.close();
+  }
 }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBRemovePartitionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBRemovePartitionIT.java
@@ -151,6 +151,109 @@ public class IoTDBRemovePartitionIT {
     }
   }
 
+  @Test
+  public void testRemoveOnePartitionAndInsertData() {
+    try (Connection connection = DriverManager
+            .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("set storage group to root.test");
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(1,true)");
+      statement.execute("select * from root.test.wf02.wt02");
+      statement.execute("DELETE PARTITION root.test 0");
+      statement.execute("select * from root.test.wf02.wt02");
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(1,true)");
+      try (ResultSet resultSet = statement.executeQuery("select * from root.test.wf02.wt02")) {
+        assertEquals(true, resultSet.next());
+      }
+      statement.execute("flush");
+      try (ResultSet resultSet = statement.executeQuery("select * from root.test.wf02.wt02")) {
+        assertEquals(true, resultSet.next());
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testRemovePartitionAndInsertUnSeqDataAndMerge() {
+    try (Connection connection = DriverManager
+            .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("set storage group to root.test");
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(2,true)");
+      statement.execute("select * from root.test.wf02.wt02");
+      statement.execute("DELETE PARTITION root.test 0");
+      statement.execute("select * from root.test.wf02.wt02");
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(1,true)");
+      try (ResultSet resultSet = statement.executeQuery("select * from root.test.wf02.wt02")) {
+        assertEquals(true, resultSet.next());
+      }
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(3,true)");
+      statement.execute("merge");
+      int count = 0;
+      try (ResultSet resultSet = statement.executeQuery("select * from root.test.wf02.wt02")) {
+        while (resultSet.next()) {
+          count ++;
+        }
+        assertEquals(2, count);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testRemovePartitionAndInsertUnSeqDataAndUnSeqDataMerge() {
+    try (Connection connection = DriverManager
+            .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("set storage group to root.test");
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(2,true)");
+      statement.execute("select * from root.test.wf02.wt02");
+      statement.execute("DELETE PARTITION root.test 0");
+      statement.execute("select * from root.test.wf02.wt02");
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(1,true)");
+      try (ResultSet resultSet = statement.executeQuery("select * from root.test.wf02.wt02")) {
+        assertEquals(true, resultSet.next());
+      }
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(2,true)");
+      statement.execute("merge");
+      int count = 0;
+      try (ResultSet resultSet = statement.executeQuery("select * from root.test.wf02.wt02")) {
+        while (resultSet.next()) {
+          count ++;
+        }
+        assertEquals(2, count);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testFlushAndRemoveOnePartitionAndInsertData() {
+    try (Connection connection = DriverManager
+            .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("set storage group to root.test");
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(1,true)");
+      statement.execute("flush");
+      statement.execute("DELETE PARTITION root.test 0");
+      statement.execute("select * from root.test.wf02.wt02");
+      statement.execute("insert into root.test.wf02.wt02(timestamp,status) values(1,true)");
+      try (ResultSet resultSet = statement.executeQuery("select * from root.test.wf02.wt02")) {
+        assertEquals(true, resultSet.next());
+      }
+      statement.execute("flush");
+      int count = 0;
+      try (ResultSet resultSet = statement.executeQuery("select * from root.test.wf02.wt02")) {
+        assertEquals(true, resultSet.next());
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
   private static void insertData() throws ClassNotFoundException {
     List<String> sqls = new ArrayList<>(Arrays.asList(
         "SET STORAGE GROUP TO root.test1",


### PR DESCRIPTION
reproduce:
set storage group to root.test
insert into root.test.wf02.wt02(timestamp,status) values(1,true)
select * from root.test.wf02.wt02;
DELETE PARTITION root.test 0;
select * from root.test.wf02.wt02;
insert into root.test.wf02.wt02(timestamp,status) values(1,true)
select * from root.test.wf02.wt02;
flush
select * from root.test.wf02.wt02;
this is null.

Reason:
After the partition is deleted, if the insert data is non-sequential data. when the flush operation, 1 Unseq-file and 0 seq-file are merged,
The MergeTask traverses sequential files. If the sequential files are empty, the merge is skipped.
After the execution is complete, delete the unordered files. However, the merged file is not generated. Therefore, the data in the unordered file is lost.