### PR TITLE
[IOTDB-1137] MNode.getLeafCount error when existing sub-device

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -232,7 +232,7 @@ public class MManager {
       List<PartialPath> storageGroups = mtree.getAllStorageGroupPaths();
       for (PartialPath sg : storageGroups) {
         MNode node = mtree.getNodeByPath(sg);
-        totalSeriesNumber.addAndGet(node.getLeafCount());
+        totalSeriesNumber.addAndGet(node.getMeasurementMNodeCount());
       }
 
       logWriter = new MLogWriter(config.getSchemaDir(), MetadataConstant.METADATA_LOG);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
@@ -54,8 +54,8 @@ public class MNode implements Serializable {
   protected String fullPath;
 
   /**
-   * use in Measurement Node so it's protected suppress warnings reason: volatile for double
-   * synchronized check
+   * use in Measurement Node so it's protected
+   * suppress warnings reason: volatile for double synchronized check
    */
   @SuppressWarnings("squid:S3077")
   protected transient volatile ConcurrentMap<String, MNode> children = null;
@@ -70,11 +70,6 @@ public class MNode implements Serializable {
    * Constructor of MNode.
    */
   public MNode(MNode parent, String name) {
-    this.parent = parent;
-    this.name = name;
-  }
-
-  public MNode(MNode parent, String name, boolean isEnd) {
     this.parent = parent;
     this.name = name;
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
@@ -18,11 +18,6 @@
  */
 package org.apache.iotdb.db.metadata.mnode;
 
-import org.apache.iotdb.db.conf.IoTDBConstant;
-import org.apache.iotdb.db.metadata.PartialPath;
-import org.apache.iotdb.db.metadata.logfile.MLogWriter;
-import org.apache.iotdb.db.rescon.CachedStringPool;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -32,6 +27,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.metadata.PartialPath;
+import org.apache.iotdb.db.metadata.logfile.MLogWriter;
+import org.apache.iotdb.db.rescon.CachedStringPool;
 
 /**
  * This class is the implementation of Metadata Node. One MNode instance represents one node in the
@@ -55,8 +54,8 @@ public class MNode implements Serializable {
   protected String fullPath;
 
   /**
-   * use in Measurement Node so it's protected
-   * suppress warnings reason: volatile for double synchronized check
+   * use in Measurement Node so it's protected suppress warnings reason: volatile for double
+   * synchronized check
    */
   @SuppressWarnings("squid:S3077")
   protected transient volatile ConcurrentMap<String, MNode> children = null;
@@ -75,6 +74,11 @@ public class MNode implements Serializable {
     this.name = name;
   }
 
+  public MNode(MNode parent, String name, boolean isEnd) {
+    this.parent = parent;
+    this.name = name;
+  }
+
   /**
    * check whether the MNode has a child with the name
    */
@@ -85,7 +89,8 @@ public class MNode implements Serializable {
 
   /**
    * add a child to current mnode
-   * @param name child's name
+   *
+   * @param name  child's name
    * @param child child's node
    */
   public void addChild(String name, MNode child) {
@@ -138,17 +143,20 @@ public class MNode implements Serializable {
   }
 
   /**
-   * get the count of all leaves whose ancestor is current node
+   * get the count of all MeasurementMNode whose ancestor is current node
    */
-  public int getLeafCount() {
+  public int getMeasurementMNodeCount() {
     if (children == null) {
-      return 0;
+      return 1;
     }
-    int leafCount = 0;
+    int measurementMNodeCount = 0;
+    if (this instanceof MeasurementMNode) {
+      measurementMNodeCount += 1; // current node itself may be MeasurementMNode
+    }
     for (MNode child : children.values()) {
-      leafCount += child.getLeafCount();
+      measurementMNodeCount += child.getMeasurementMNodeCount();
     }
-    return leafCount;
+    return measurementMNodeCount;
   }
 
   /**

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.apache.iotdb.db.exception.metadata.AliasAlreadyExistException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
+import org.apache.iotdb.db.metadata.mnode.MNode;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -190,7 +191,8 @@ public class MTreeTest {
       assertEquals("root.a.d1.s0", result2.get(1).getFullPath());
       assertFalse(result2.get(1).isMeasurementAliasExists());
 
-      result2 = root.getAllTimeseriesPathWithAlias(new PartialPath("root.a.*.temperature"), 0, 0).left;
+      result2 = root
+          .getAllTimeseriesPathWithAlias(new PartialPath("root.a.*.temperature"), 0, 0).left;
       assertEquals(2, result2.size());
       assertEquals("root.a.d0.temperature", result2.get(0).getFullPathWithAlias());
       assertEquals("root.a.d1.temperature", result2.get(1).getFullPathWithAlias());
@@ -522,6 +524,35 @@ public class MTreeTest {
 
       assertFalse(root.isPathExist(new PartialPath("root.sg1.a.b.c")));
       assertTrue(root.isPathExist(new PartialPath("root.sg1.a.b")));
+
+    } catch (MetadataException e1) {
+      fail(e1.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetMeasurementMNodeCount() throws MetadataException {
+    MTree root = new MTree();
+    PartialPath sgPath = new PartialPath("root.sg1");
+    root.setStorageGroup(sgPath);
+    try {
+      root.createTimeseries(new PartialPath("root.sg1.a.b"), TSDataType.INT32, TSEncoding.RLE,
+          TSFileDescriptor.getInstance().getConfig().getCompressor(), Collections.emptyMap(), null);
+      MNode sgNode = root.getNodeByPath(sgPath);
+      assertEquals(1, sgNode.getMeasurementMNodeCount()); // b
+
+      root.createTimeseries(new PartialPath("root.sg1.a.b.c"), TSDataType.INT32, TSEncoding.RLE,
+          TSFileDescriptor.getInstance().getConfig().getCompressor(), Collections.emptyMap(), null);
+      assertEquals(2, sgNode.getMeasurementMNodeCount()); // b and c
+      MNode cNode = sgNode.getChild("a").getChild("b").getChild("c");
+      assertEquals(1, cNode.getMeasurementMNodeCount()); // c and d
+
+      root.createTimeseries(new PartialPath("root.sg1.a.b.c.d"), TSDataType.INT32, TSEncoding.RLE,
+          TSFileDescriptor.getInstance().getConfig().getCompressor(), Collections.emptyMap(), null);
+      assertEquals(3, sgNode.getMeasurementMNodeCount()); // b, c and d
+      assertEquals(2, cNode.getMeasurementMNodeCount()); // c and d
+      MNode dNode = cNode.getChild("d");
+      assertEquals(1, dNode.getMeasurementMNodeCount()); // d
 
     } catch (MetadataException e1) {
       fail(e1.getMessage());

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -545,7 +545,7 @@ public class MTreeTest {
           TSFileDescriptor.getInstance().getConfig().getCompressor(), Collections.emptyMap(), null);
       assertEquals(2, sgNode.getMeasurementMNodeCount()); // b and c
       MNode cNode = sgNode.getChild("a").getChild("b").getChild("c");
-      assertEquals(1, cNode.getMeasurementMNodeCount()); // c and d
+      assertEquals(1, cNode.getMeasurementMNodeCount()); // c
 
       root.createTimeseries(new PartialPath("root.sg1.a.b.c.d"), TSDataType.INT32, TSEncoding.RLE,
           TSFileDescriptor.getInstance().getConfig().getCompressor(), Collections.emptyMap(), null);


### PR DESCRIPTION
When existing [sub-device](https://issues.apache.org/jira/browse/IOTDB-750), `MNode.getLeafCount()` may get wrong result.

For example: We have 3 timeseries: `root.a.b.c`, `root.a.b.c.d`, `root.a.b.c.d.e`
The "leaf" count of `root.a` should be 3: c, d and e, which represents the number of timeseries.

Besides, the function name is also ambiguous, which should be modified to `getMeasurementMNodeCount()`.