### PR TITLE
[IOTDB-1138]Do not remove the overlap files which is merging when do snapshot

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -325,7 +325,7 @@ seq_file_num_in_each_level=6
 seq_level_num=3
 
 # Works when compaction_strategy is LEVEL_COMPACTION.
-# The max ujseq file num of each level.
+# The max unseq file num of each level.
 # When the num of files in one level exceeds this,
 # the files in this level will merge to one and put to upper level.
 unseq_file_num_in_each_level=10

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -2182,6 +2182,7 @@ public class StorageGroupProcessor {
       TsFileResource existingTsFile = iterator.next();
       if (newTsFile.isPlanRangeCovers(existingTsFile)
           && !newTsFile.getTsFile().equals(existingTsFile.getTsFile())
+          && !existingTsFile.isMerging()
           && existingTsFile.tryWriteLock()) {
         logger.info("{} is covered by {}: [{}, {}], [{}, {}], remove it", existingTsFile,
             newTsFile, existingTsFile.minPlanIndex, existingTsFile.maxPlanIndex,


### PR DESCRIPTION
After discussion with @zhanglingzhe0820 , there are three possible concurrency problems related to merge

1. After snapshot pulls the file, it will delete the local overlap file
2. The checkttl operation will also delete the expired data.
3. The user initiatively initiates the data deletion operation.

This PR only considers the first scenario. We need to comprehensively consider the concurrency problem to solve all the above problems.

I have opened an issue
https://github.com/apache/iotdb/issues/2618

