### PR TITLE
[Github Issue 2639] [To rel/0.11] Fix possible NPE during end query process

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/control/QueryFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/QueryFileManager.java
@@ -91,20 +91,18 @@ public class QueryFileManager {
    * this jdbc request must be cleared and thus the usage reference must be decreased.
    */
   void removeUsedFilesForQuery(long queryId) {
-    Set<TsFileResource> tsFiles = sealedFilePathsMap.get(queryId);
-    if (tsFiles != null) {
-      for (TsFileResource tsFile : sealedFilePathsMap.get(queryId)) {
+    sealedFilePathsMap.computeIfPresent(queryId, (k, v) -> {
+      for (TsFileResource tsFile : v) {
         FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, true);
       }
-      sealedFilePathsMap.remove(queryId);
-    }
-    tsFiles = unsealedFilePathsMap.get(queryId);
-    if (tsFiles != null) {
-      for (TsFileResource tsFile : unsealedFilePathsMap.get(queryId)) {
-        FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, false);
+      return null;
+    });
+    unsealedFilePathsMap.computeIfPresent(queryId, (k, v) -> {
+      for (TsFileResource tsFile : v) {
+        FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, true);
       }
-      unsealedFilePathsMap.remove(queryId);
-    }
+      return null;
+    });
   }
 
   /**


### PR DESCRIPTION
We should assure that the remove used file operation in end query process is a atomic operation.
![image](https://user-images.githubusercontent.com/16079446/106981880-da01a780-679d-11eb-9193-155cbdc1f7b8.png)


#2639 