### PR TITLE
[IOTDB-1148]fix the client leak of client pool&use remote schema cache when check timeseries exist or not

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/DataClientProvider.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/DataClientProvider.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.cluster.client.sync.SyncClientPool;
 import org.apache.iotdb.cluster.client.sync.SyncDataClient;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
-
+import org.apache.iotdb.cluster.rpc.thrift.RaftService.Client;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.slf4j.Logger;
@@ -77,6 +77,10 @@ public class DataClientProvider {
   }
 
   /**
+   * IMPORTANT!!! After calling this function, the caller should make sure to call {@link
+   * org.apache.iotdb.cluster.utils.ClientUtils#putBackSyncClient(Client)} to put the client back
+   * into the client pool, otherwise there is a risk of client leakage.
+   * <p>
    * Get a thrift client that will connect to "node" using the data port.
    *
    * @param node the node to be connected

--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/DataClientProvider.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/DataClientProvider.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.cluster.client.sync.SyncDataClient;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.rpc.thrift.RaftService.Client;
+
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.slf4j.Logger;
@@ -80,8 +81,8 @@ public class DataClientProvider {
    * IMPORTANT!!! After calling this function, the caller should make sure to call {@link
    * org.apache.iotdb.cluster.utils.ClientUtils#putBackSyncClient(Client)} to put the client back
    * into the client pool, otherwise there is a risk of client leakage.
-   * <p>
-   * Get a thrift client that will connect to "node" using the data port.
+   *
+   * <p>Get a thrift client that will connect to "node" using the data port.
    *
    * @param node the node to be connected
    * @param timeout timeout threshold of connection

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -673,10 +673,12 @@ public class CMManager extends MManager {
         } else {
           SyncDataClient syncDataClient = null;
           try {
-            syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
-                RaftServer.getReadOperationTimeoutMS());
-            result = syncDataClient
-                .getUnregisteredTimeseries(partitionGroup.getHeader(), seriesList);
+            syncDataClient =
+                metaGroupMember
+                    .getClientProvider()
+                    .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+            result =
+                syncDataClient.getUnregisteredTimeseries(partitionGroup.getHeader(), seriesList);
           } finally {
             ClientUtils.putBackSyncClient(syncDataClient);
           }
@@ -855,8 +857,10 @@ public class CMManager extends MManager {
     } else {
       SyncDataClient syncDataClient = null;
       try {
-        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
-            RaftServer.getReadOperationTimeoutMS());
+        syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
         PullSchemaResp pullSchemaResp = syncDataClient.pullTimeSeriesSchema(request);
         ByteBuffer buffer = pullSchemaResp.schemaBytes;
         int size = buffer.getInt();
@@ -867,7 +871,6 @@ public class CMManager extends MManager {
       } finally {
         ClientUtils.putBackSyncClient(syncDataClient);
       }
-
     }
 
     return schemas;
@@ -1093,8 +1096,10 @@ public class CMManager extends MManager {
     } else {
       SyncDataClient syncDataClient = null;
       try {
-        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
-            RaftServer.getReadOperationTimeoutMS());
+        syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
         result = syncDataClient.getAllPaths(header, pathsToQuery, withAlias);
       } finally {
         ClientUtils.putBackSyncClient(syncDataClient);
@@ -1215,8 +1220,10 @@ public class CMManager extends MManager {
     } else {
       SyncDataClient syncDataClient = null;
       try {
-        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
-            RaftServer.getReadOperationTimeoutMS());
+        syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
         paths = syncDataClient.getAllDevices(header, pathsToQuery);
       } finally {
         ClientUtils.putBackSyncClient(syncDataClient);
@@ -1539,11 +1546,14 @@ public class CMManager extends MManager {
       SyncDataClient syncDataClient = null;
       try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
           DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream)) {
-        syncDataClient = metaGroupMember
-            .getClientProvider().getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+        syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
         plan.serialize(dataOutputStream);
-        resultBinary = syncDataClient.getAllMeasurementSchema(group.getHeader(),
-            ByteBuffer.wrap(byteArrayOutputStream.toByteArray()));
+        resultBinary =
+            syncDataClient.getAllMeasurementSchema(
+                group.getHeader(), ByteBuffer.wrap(byteArrayOutputStream.toByteArray()));
       } finally {
         ClientUtils.putBackSyncClient(syncDataClient);
       }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -372,6 +372,27 @@ public class CMManager extends MManager {
     return super.getSeriesSchema(device, measurement);
   }
 
+  /**
+   * Check whether the path exists.
+   *
+   * @param path a full path or a prefix path
+   */
+  @Override
+  public boolean isPathExist(PartialPath path) {
+    boolean localExist = super.isPathExist(path);
+    if (localExist) {
+      return true;
+    }
+
+    // search the cache
+    cacheLock.readLock().lock();
+    try {
+      return mRemoteMetaCache.containsKey(path);
+    } finally {
+      cacheLock.readLock().unlock();
+    }
+  }
+
   private static class RemoteMetaCache extends LRUCache<PartialPath, MeasurementMNode> {
 
     RemoteMetaCache(int cacheSize) {
@@ -396,6 +417,10 @@ public class CMManager extends MManager {
         // not happening
         return null;
       }
+    }
+
+    public synchronized boolean containsKey(PartialPath key) {
+      return cache.containsKey(key);
     }
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -1537,11 +1537,10 @@ public class CMManager extends MManager {
       resultBinary = SyncClientAdaptor.getAllMeasurementSchema(client, group.getHeader(), plan);
     } else {
       SyncDataClient syncDataClient = null;
-      try {
+      try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+          DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream)) {
         syncDataClient = metaGroupMember
             .getClientProvider().getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
         plan.serialize(dataOutputStream);
         resultBinary = syncDataClient.getAllMeasurementSchema(group.getHeader(),
             ByteBuffer.wrap(byteArrayOutputStream.toByteArray()));

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -646,14 +646,16 @@ public class CMManager extends MManager {
               SyncClientAdaptor.getUnregisteredMeasurements(
                   client, partitionGroup.getHeader(), seriesList);
         } else {
-          SyncDataClient syncDataClient =
-              metaGroupMember
-                  .getClientProvider()
-                  .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-          result = syncDataClient.getUnregisteredTimeseries(partitionGroup.getHeader(), seriesList);
-          ClientUtils.putBackSyncClient(syncDataClient);
+          SyncDataClient syncDataClient = null;
+          try {
+            syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
+                RaftServer.getReadOperationTimeoutMS());
+            result = syncDataClient
+                .getUnregisteredTimeseries(partitionGroup.getHeader(), seriesList);
+          } finally {
+            ClientUtils.putBackSyncClient(syncDataClient);
+          }
         }
-
         if (result != null) {
           return result;
         }
@@ -826,17 +828,21 @@ public class CMManager extends MManager {
               .getAsyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
       schemas = SyncClientAdaptor.pullTimeseriesSchema(client, request);
     } else {
-      SyncDataClient syncDataClient =
-          metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-      PullSchemaResp pullSchemaResp = syncDataClient.pullTimeSeriesSchema(request);
-      ByteBuffer buffer = pullSchemaResp.schemaBytes;
-      int size = buffer.getInt();
-      schemas = new ArrayList<>(size);
-      for (int i = 0; i < size; i++) {
-        schemas.add(TimeseriesSchema.deserializeFrom(buffer));
+      SyncDataClient syncDataClient = null;
+      try {
+        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
+            RaftServer.getReadOperationTimeoutMS());
+        PullSchemaResp pullSchemaResp = syncDataClient.pullTimeSeriesSchema(request);
+        ByteBuffer buffer = pullSchemaResp.schemaBytes;
+        int size = buffer.getInt();
+        schemas = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+          schemas.add(TimeseriesSchema.deserializeFrom(buffer));
+        }
+      } finally {
+        ClientUtils.putBackSyncClient(syncDataClient);
       }
+
     }
 
     return schemas;
@@ -1060,12 +1066,14 @@ public class CMManager extends MManager {
               .getAsyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
       result = SyncClientAdaptor.getAllPaths(client, header, pathsToQuery, withAlias);
     } else {
-      SyncDataClient syncDataClient =
-          metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-      result = syncDataClient.getAllPaths(header, pathsToQuery, withAlias);
-      ClientUtils.putBackSyncClient(syncDataClient);
+      SyncDataClient syncDataClient = null;
+      try {
+        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
+            RaftServer.getReadOperationTimeoutMS());
+        result = syncDataClient.getAllPaths(header, pathsToQuery, withAlias);
+      } finally {
+        ClientUtils.putBackSyncClient(syncDataClient);
+      }
     }
 
     if (result != null) {
@@ -1180,12 +1188,14 @@ public class CMManager extends MManager {
               .getAsyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
       paths = SyncClientAdaptor.getAllDevices(client, header, pathsToQuery);
     } else {
-      SyncDataClient syncDataClient =
-          metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-      paths = syncDataClient.getAllDevices(header, pathsToQuery);
-      ClientUtils.putBackSyncClient(syncDataClient);
+      SyncDataClient syncDataClient = null;
+      try {
+        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
+            RaftServer.getReadOperationTimeoutMS());
+        paths = syncDataClient.getAllDevices(header, pathsToQuery);
+      } finally {
+        ClientUtils.putBackSyncClient(syncDataClient);
+      }
     }
     return paths;
   }
@@ -1501,17 +1511,18 @@ public class CMManager extends MManager {
               .getAsyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
       resultBinary = SyncClientAdaptor.getAllMeasurementSchema(client, group.getHeader(), plan);
     } else {
-      SyncDataClient syncDataClient =
-          metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
-      plan.serialize(dataOutputStream);
-      resultBinary =
-          syncDataClient.getAllMeasurementSchema(
-              group.getHeader(), ByteBuffer.wrap(byteArrayOutputStream.toByteArray()));
-      ClientUtils.putBackSyncClient(syncDataClient);
+      SyncDataClient syncDataClient = null;
+      try {
+        syncDataClient = metaGroupMember
+            .getClientProvider().getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+        plan.serialize(dataOutputStream);
+        resultBinary = syncDataClient.getAllMeasurementSchema(group.getHeader(),
+            ByteBuffer.wrap(byteArrayOutputStream.toByteArray()));
+      } finally {
+        ClientUtils.putBackSyncClient(syncDataClient);
+      }
     }
     return resultBinary;
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/MetaPuller.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/MetaPuller.java
@@ -223,8 +223,10 @@ public class MetaPuller {
     } else {
       SyncDataClient syncDataClient = null;
       try {
-        syncDataClient = metaGroupMember
-            .getClientProvider().getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+        syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
         PullSchemaResp pullSchemaResp = syncDataClient.pullTimeSeriesSchema(request);
         ByteBuffer buffer = pullSchemaResp.schemaBytes;
         int size = buffer.getInt();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/MetaPuller.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/MetaPuller.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.cluster.rpc.thrift.PullSchemaRequest;
 import org.apache.iotdb.cluster.rpc.thrift.PullSchemaResp;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
+import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.cluster.utils.ClusterUtils;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.PartialPath;
@@ -220,16 +221,19 @@ public class MetaPuller {
               .getAsyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
       schemas = SyncClientAdaptor.pullMeasurementSchema(client, request);
     } else {
-      SyncDataClient syncDataClient =
-          metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-      PullSchemaResp pullSchemaResp = syncDataClient.pullTimeSeriesSchema(request);
-      ByteBuffer buffer = pullSchemaResp.schemaBytes;
-      int size = buffer.getInt();
-      schemas = new ArrayList<>(size);
-      for (int i = 0; i < size; i++) {
-        schemas.add(MeasurementSchema.deserializeFrom(buffer));
+      SyncDataClient syncDataClient = null;
+      try {
+        syncDataClient = metaGroupMember
+            .getClientProvider().getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+        PullSchemaResp pullSchemaResp = syncDataClient.pullTimeSeriesSchema(request);
+        ByteBuffer buffer = pullSchemaResp.schemaBytes;
+        int size = buffer.getInt();
+        schemas = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+          schemas.add(MeasurementSchema.deserializeFrom(buffer));
+        }
+      } finally {
+        ClientUtils.putBackSyncClient(syncDataClient);
       }
     }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
@@ -254,21 +254,19 @@ public class ClusterPlanExecutor extends PlanExecutor {
               SyncClientAdaptor.getPathCount(
                   client, partitionGroup.getHeader(), pathsToQuery, level);
         } else {
-          SyncDataClient syncDataClient =
-              metaGroupMember
-                  .getClientProvider()
-                  .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-          syncDataClient.setTimeout(RaftServer.getReadOperationTimeoutMS());
-          count = syncDataClient.getPathCount(partitionGroup.getHeader(), pathsToQuery, level);
-          ClientUtils.putBackSyncClient(syncDataClient);
+          SyncDataClient syncDataClient = null;
+          try {
+            syncDataClient = metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+            syncDataClient.setTimeout(RaftServer.getReadOperationTimeoutMS());
+            count = syncDataClient.getPathCount(partitionGroup.getHeader(), pathsToQuery, level);
+          } finally {
+            ClientUtils.putBackSyncClient(syncDataClient);
+          }
         }
-
-        logger.debug(
-            "{}: get path count of {} from {}, result {}",
-            metaGroupMember.getName(),
-            partitionGroup,
-            node,
-            count);
+        logger.debug("{}: get path count of {} from {}, result {}", metaGroupMember.getName(),
+            partitionGroup, node, count);
         if (count != null) {
           return count;
         }
@@ -357,14 +355,16 @@ public class ClusterPlanExecutor extends PlanExecutor {
               SyncClientAdaptor.getNodeList(
                   client, group.getHeader(), schemaPattern.getFullPath(), level);
         } else {
-          SyncDataClient syncDataClient =
-              metaGroupMember
-                  .getClientProvider()
-                  .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-          paths = syncDataClient.getNodeList(group.getHeader(), schemaPattern.getFullPath(), level);
-          ClientUtils.putBackSyncClient(syncDataClient);
+          SyncDataClient syncDataClient = null;
+          try {
+            syncDataClient = metaGroupMember.getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+            paths = syncDataClient
+                .getNodeList(group.getHeader(), schemaPattern.getFullPath(), level);
+          } finally {
+            ClientUtils.putBackSyncClient(syncDataClient);
+          }
         }
-
         if (paths != null) {
           break;
         }
@@ -377,7 +377,6 @@ public class ClusterPlanExecutor extends PlanExecutor {
         Thread.currentThread().interrupt();
       }
     }
-
     return PartialPath.fromStringList(paths);
   }
 
@@ -467,15 +466,16 @@ public class ClusterPlanExecutor extends PlanExecutor {
           nextChildren =
               SyncClientAdaptor.getNextChildren(client, group.getHeader(), path.getFullPath());
         } else {
-          SyncDataClient syncDataClient =
-              metaGroupMember
-                  .getClientProvider()
-                  .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-          nextChildren =
-              syncDataClient.getChildNodePathInNextLevel(group.getHeader(), path.getFullPath());
-          ClientUtils.putBackSyncClient(syncDataClient);
+          SyncDataClient syncDataClient = null;
+          try {
+            syncDataClient = metaGroupMember.getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+            nextChildren = syncDataClient
+                .getChildNodePathInNextLevel(group.getHeader(), path.getFullPath());
+          } finally {
+            ClientUtils.putBackSyncClient(syncDataClient);
+          }
         }
-
         if (nextChildren != null) {
           break;
         }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
@@ -256,17 +256,22 @@ public class ClusterPlanExecutor extends PlanExecutor {
         } else {
           SyncDataClient syncDataClient = null;
           try {
-            syncDataClient = metaGroupMember
-                .getClientProvider()
-                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+            syncDataClient =
+                metaGroupMember
+                    .getClientProvider()
+                    .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
             syncDataClient.setTimeout(RaftServer.getReadOperationTimeoutMS());
             count = syncDataClient.getPathCount(partitionGroup.getHeader(), pathsToQuery, level);
           } finally {
             ClientUtils.putBackSyncClient(syncDataClient);
           }
         }
-        logger.debug("{}: get path count of {} from {}, result {}", metaGroupMember.getName(),
-            partitionGroup, node, count);
+        logger.debug(
+            "{}: get path count of {} from {}, result {}",
+            metaGroupMember.getName(),
+            partitionGroup,
+            node,
+            count);
         if (count != null) {
           return count;
         }
@@ -357,10 +362,12 @@ public class ClusterPlanExecutor extends PlanExecutor {
         } else {
           SyncDataClient syncDataClient = null;
           try {
-            syncDataClient = metaGroupMember.getClientProvider()
-                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-            paths = syncDataClient
-                .getNodeList(group.getHeader(), schemaPattern.getFullPath(), level);
+            syncDataClient =
+                metaGroupMember
+                    .getClientProvider()
+                    .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+            paths =
+                syncDataClient.getNodeList(group.getHeader(), schemaPattern.getFullPath(), level);
           } finally {
             ClientUtils.putBackSyncClient(syncDataClient);
           }
@@ -468,10 +475,12 @@ public class ClusterPlanExecutor extends PlanExecutor {
         } else {
           SyncDataClient syncDataClient = null;
           try {
-            syncDataClient = metaGroupMember.getClientProvider()
-                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-            nextChildren = syncDataClient
-                .getChildNodePathInNextLevel(group.getHeader(), path.getFullPath());
+            syncDataClient =
+                metaGroupMember
+                    .getClientProvider()
+                    .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+            nextChildren =
+                syncDataClient.getChildNodePathInNextLevel(group.getHeader(), path.getFullPath());
           } finally {
             ClientUtils.putBackSyncClient(syncDataClient);
           }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/aggregate/ClusterAggregator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/aggregate/ClusterAggregator.java
@@ -273,8 +273,10 @@ public class ClusterAggregator {
     } else {
       SyncDataClient syncDataClient = null;
       try {
-        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
-            RaftServer.getReadOperationTimeoutMS());
+        syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
         resultBuffers = syncDataClient.getAggrResult(request);
       } finally {
         ClientUtils.putBackSyncClient(syncDataClient);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/aggregate/ClusterAggregator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/aggregate/ClusterAggregator.java
@@ -271,12 +271,14 @@ public class ClusterAggregator {
       // each buffer is an AggregationResult
       resultBuffers = SyncClientAdaptor.getAggrResult(client, request);
     } else {
-      SyncDataClient syncDataClient =
-          metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-      resultBuffers = syncDataClient.getAggrResult(request);
-      ClientUtils.putBackSyncClient(syncDataClient);
+      SyncDataClient syncDataClient = null;
+      try {
+        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
+            RaftServer.getReadOperationTimeoutMS());
+        resultBuffers = syncDataClient.getAggrResult(request);
+      } finally {
+        ClientUtils.putBackSyncClient(syncDataClient);
+      }
     }
     return resultBuffers;
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterPreviousFill.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterPreviousFill.java
@@ -249,12 +249,8 @@ public class ClusterPreviousFill extends PreviousFill {
               .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
       byteBuffer = syncDataClient.previousFill(request);
     } catch (Exception e) {
-      logger.error(
-          "{}: Cannot perform previous fill of {} to {}",
-          metaGroupMember.getName(),
-          arguments.getPath(),
-          node,
-          e);
+      logger.error("{}: Cannot perform previous fill of {} to {}", metaGroupMember.getName(),
+          arguments.getPath(), node, e);
     } finally {
       ClientUtils.putBackSyncClient(syncDataClient);
     }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterPreviousFill.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterPreviousFill.java
@@ -249,8 +249,12 @@ public class ClusterPreviousFill extends PreviousFill {
               .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
       byteBuffer = syncDataClient.previousFill(request);
     } catch (Exception e) {
-      logger.error("{}: Cannot perform previous fill of {} to {}", metaGroupMember.getName(),
-          arguments.getPath(), node, e);
+      logger.error(
+          "{}: Cannot perform previous fill of {} to {}",
+          metaGroupMember.getName(),
+          arguments.getPath(),
+          node,
+          e);
     } finally {
       ClientUtils.putBackSyncClient(syncDataClient);
     }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutor.java
@@ -85,14 +85,17 @@ public class RemoteGroupByExecutor implements GroupByExecutor {
             SyncClientAdaptor.getGroupByResult(
                 client, header, executorId, curStartTime, curEndTime);
       } else {
-        SyncDataClient syncDataClient =
-            metaGroupMember
-                .getClientProvider()
-                .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
-        aggrBuffers = syncDataClient.getGroupByResult(header, executorId, curStartTime, curEndTime);
-        ClientUtils.putBackSyncClient(syncDataClient);
+        SyncDataClient syncDataClient = null;
+        try {
+          syncDataClient = metaGroupMember
+              .getClientProvider()
+              .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
+          aggrBuffers = syncDataClient
+              .getGroupByResult(header, executorId, curStartTime, curEndTime);
+        } finally {
+          ClientUtils.putBackSyncClient(syncDataClient);
+        }
       }
-
     } catch (TException e) {
       throw new IOException(e);
     } catch (InterruptedException e) {
@@ -129,15 +132,17 @@ public class RemoteGroupByExecutor implements GroupByExecutor {
             SyncClientAdaptor.peekNextNotNullValue(
                 client, header, executorId, nextStartTime, nextEndTime);
       } else {
-        SyncDataClient syncDataClient =
-            metaGroupMember
-                .getClientProvider()
-                .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
-        aggrBuffer =
-            syncDataClient.peekNextNotNullValue(header, executorId, nextStartTime, nextEndTime);
-        ClientUtils.putBackSyncClient(syncDataClient);
+        SyncDataClient syncDataClient = null;
+        try {
+          syncDataClient = metaGroupMember
+              .getClientProvider()
+              .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
+          aggrBuffer = syncDataClient
+              .peekNextNotNullValue(header, executorId, nextStartTime, nextEndTime);
+        } finally {
+          ClientUtils.putBackSyncClient(syncDataClient);
+        }
       }
-
     } catch (TException e) {
       throw new IOException(e);
     } catch (InterruptedException e) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutor.java
@@ -87,11 +87,12 @@ public class RemoteGroupByExecutor implements GroupByExecutor {
       } else {
         SyncDataClient syncDataClient = null;
         try {
-          syncDataClient = metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
-          aggrBuffers = syncDataClient
-              .getGroupByResult(header, executorId, curStartTime, curEndTime);
+          syncDataClient =
+              metaGroupMember
+                  .getClientProvider()
+                  .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
+          aggrBuffers =
+              syncDataClient.getGroupByResult(header, executorId, curStartTime, curEndTime);
         } finally {
           ClientUtils.putBackSyncClient(syncDataClient);
         }
@@ -134,11 +135,12 @@ public class RemoteGroupByExecutor implements GroupByExecutor {
       } else {
         SyncDataClient syncDataClient = null;
         try {
-          syncDataClient = metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
-          aggrBuffer = syncDataClient
-              .peekNextNotNullValue(header, executorId, nextStartTime, nextEndTime);
+          syncDataClient =
+              metaGroupMember
+                  .getClientProvider()
+                  .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
+          aggrBuffer =
+              syncDataClient.peekNextNotNullValue(header, executorId, nextStartTime, nextEndTime);
         } finally {
           ClientUtils.putBackSyncClient(syncDataClient);
         }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
@@ -246,33 +246,25 @@ public class ClusterLastQueryExecutor extends LastQueryExecutor {
       } catch (IOException e) {
         return null;
       }
-      buffer =
-          SyncClientAdaptor.last(
-              asyncDataClient,
-              seriesPaths,
-              dataTypeOrdinals,
-              context,
+      buffer = SyncClientAdaptor
+          .last(asyncDataClient, seriesPaths, dataTypeOrdinals, context,
               queryPlan.getDeviceToMeasurements(),
               group.getHeader());
       return buffer;
     }
 
     private ByteBuffer lastSync(Node node, QueryContext context) throws TException {
-      SyncDataClient syncDataClient =
-          metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-      ByteBuffer result =
-          syncDataClient.last(
-              new LastQueryRequest(
-                  PartialPath.toStringList(seriesPaths),
-                  dataTypeOrdinals,
-                  context.getQueryId(),
-                  queryPlan.getDeviceToMeasurements(),
-                  group.getHeader(),
-                  syncDataClient.getNode()));
-      ClientUtils.putBackSyncClient(syncDataClient);
-      return result;
+      SyncDataClient syncDataClient = null;
+      try {
+        syncDataClient = metaGroupMember
+            .getClientProvider().getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+        return syncDataClient
+            .last(new LastQueryRequest(PartialPath.toStringList(seriesPaths), dataTypeOrdinals,
+                context.getQueryId(), queryPlan.getDeviceToMeasurements(), group.getHeader(),
+                syncDataClient.getNode()));
+      } finally {
+        ClientUtils.putBackSyncClient(syncDataClient);
+      }
     }
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
@@ -246,8 +246,12 @@ public class ClusterLastQueryExecutor extends LastQueryExecutor {
       } catch (IOException e) {
         return null;
       }
-      buffer = SyncClientAdaptor
-          .last(asyncDataClient, seriesPaths, dataTypeOrdinals, context,
+      buffer =
+          SyncClientAdaptor.last(
+              asyncDataClient,
+              seriesPaths,
+              dataTypeOrdinals,
+              context,
               queryPlan.getDeviceToMeasurements(),
               group.getHeader());
       return buffer;
@@ -256,11 +260,17 @@ public class ClusterLastQueryExecutor extends LastQueryExecutor {
     private ByteBuffer lastSync(Node node, QueryContext context) throws TException {
       SyncDataClient syncDataClient = null;
       try {
-        syncDataClient = metaGroupMember
-            .getClientProvider().getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-        return syncDataClient
-            .last(new LastQueryRequest(PartialPath.toStringList(seriesPaths), dataTypeOrdinals,
-                context.getQueryId(), queryPlan.getDeviceToMeasurements(), group.getHeader(),
+        syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+        return syncDataClient.last(
+            new LastQueryRequest(
+                PartialPath.toStringList(seriesPaths),
+                dataTypeOrdinals,
+                context.getQueryId(),
+                queryPlan.getDeviceToMeasurements(),
+                group.getHeader(),
                 syncDataClient.getNode()));
       } finally {
         ClientUtils.putBackSyncClient(syncDataClient);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
@@ -659,8 +659,10 @@ public class ClusterReaderFactory {
     } else {
       SyncDataClient syncDataClient = null;
       try {
-        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
-            RaftServer.getReadOperationTimeoutMS());
+        syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
         executorId = syncDataClient.getGroupByExecutor(request);
       } finally {
         ClientUtils.putBackSyncClient(syncDataClient);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
@@ -657,12 +657,14 @@ public class ClusterReaderFactory {
               .getAsyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
       executorId = SyncClientAdaptor.getGroupByExecutor(client, request);
     } else {
-      SyncDataClient syncDataClient =
-          metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-      executorId = syncDataClient.getGroupByExecutor(request);
-      ClientUtils.putBackSyncClient(syncDataClient);
+      SyncDataClient syncDataClient = null;
+      try {
+        syncDataClient = metaGroupMember.getClientProvider().getSyncDataClient(node,
+            RaftServer.getReadOperationTimeoutMS());
+        executorId = syncDataClient.getGroupByExecutor(request);
+      } finally {
+        ClientUtils.putBackSyncClient(syncDataClient);
+      }
     }
     return executorId;
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/DataSourceInfo.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/DataSourceInfo.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.rpc.thrift.SingleSeriesQueryRequest;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
+import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.utils.SerializeUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.filter.TimeFilter;
@@ -176,7 +177,7 @@ public class DataSourceInfo {
       }
       return newReaderId;
     } finally {
-      client.putBack();
+      ClientUtils.putBackSyncClient(client);
     }
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/RemoteSeriesReaderByTimestamp.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/RemoteSeriesReaderByTimestamp.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.cluster.client.sync.SyncDataClient;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.handlers.caller.GenericHandler;
+import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.query.reader.series.IReaderByTimestamp;
 import org.apache.iotdb.db.utils.SerializeUtils;
 
@@ -104,7 +105,7 @@ public class RemoteSeriesReaderByTimestamp implements IReaderByTimestamp {
       return fetchResultSync(timestamp);
     } finally {
       if (curSyncClient != null) {
-        curSyncClient.putBack();
+        ClientUtils.putBackSyncClient(curSyncClient);
       }
     }
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/RemoteSeriesReaderByTimestamp.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/RemoteSeriesReaderByTimestamp.java
@@ -92,11 +92,9 @@ public class RemoteSeriesReaderByTimestamp implements IReaderByTimestamp {
   private ByteBuffer fetchResultSync(long timestamp) throws IOException {
     SyncDataClient curSyncClient = null;
     try {
-      curSyncClient = sourceInfo
-          .getCurSyncClient(RaftServer.getReadOperationTimeoutMS());
-      return curSyncClient
-          .fetchSingleSeriesByTimestamp(sourceInfo.getHeader(),
-              sourceInfo.getReaderId(), timestamp);
+      curSyncClient = sourceInfo.getCurSyncClient(RaftServer.getReadOperationTimeoutMS());
+      return curSyncClient.fetchSingleSeriesByTimestamp(
+          sourceInfo.getHeader(), sourceInfo.getReaderId(), timestamp);
     } catch (TException e) {
       // try other node
       if (!sourceInfo.switchNode(true, timestamp)) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/RemoteSimpleSeriesReader.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/RemoteSimpleSeriesReader.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.cluster.client.sync.SyncDataClient;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.handlers.caller.GenericHandler;
+import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.utils.SerializeUtils;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.common.BatchData;
@@ -158,7 +159,7 @@ public class RemoteSimpleSeriesReader implements IPointReader {
       return fetchResultSync();
     } finally {
       if (curSyncClient != null) {
-        curSyncClient.putBack();
+        ClientUtils.putBackSyncClient(curSyncClient);
       }
     }
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/RemoteSimpleSeriesReader.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/RemoteSimpleSeriesReader.java
@@ -146,11 +146,8 @@ public class RemoteSimpleSeriesReader implements IPointReader {
   private ByteBuffer fetchResultSync() throws IOException {
     SyncDataClient curSyncClient = null;
     try {
-      curSyncClient = sourceInfo
-          .getCurSyncClient(RaftServer.getReadOperationTimeoutMS());
-      return curSyncClient
-          .fetchSingleSeries(sourceInfo.getHeader(),
-              sourceInfo.getReaderId());
+      curSyncClient = sourceInfo.getCurSyncClient(RaftServer.getReadOperationTimeoutMS());
+      return curSyncClient.fetchSingleSeries(sourceInfo.getHeader(), sourceInfo.getReaderId());
     } catch (TException e) {
       // try other node
       if (!sourceInfo.switchNode(false, lastTimestamp)) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.cluster.query.RemoteQueryContext;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.server.handlers.caller.GenericHandler;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
+import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
@@ -312,10 +313,14 @@ public class ClientServer extends TSServiceImpl {
                       queriedNode, RaftServer.getReadOperationTimeoutMS());
               client.endQuery(header, coordinator.getThisNode(), queryId, handler);
             } else {
-              SyncDataClient syncDataClient =
-                  coordinator.getSyncDataClient(
-                      queriedNode, RaftServer.getReadOperationTimeoutMS());
-              syncDataClient.endQuery(header, coordinator.getThisNode(), queryId);
+              SyncDataClient syncDataClient = null;
+              try {
+                syncDataClient = coordinator.getSyncDataClient(queriedNode,
+                    RaftServer.getReadOperationTimeoutMS());
+                syncDataClient.endQuery(header, coordinator.getThisNode(), queryId);
+              } finally {
+                ClientUtils.putBackSyncClient(syncDataClient);
+              }
             }
           } catch (IOException | TException e) {
             logger.error("Cannot end query {} in {}", queryId, queriedNode);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
@@ -315,8 +315,9 @@ public class ClientServer extends TSServiceImpl {
             } else {
               SyncDataClient syncDataClient = null;
               try {
-                syncDataClient = coordinator.getSyncDataClient(queriedNode,
-                    RaftServer.getReadOperationTimeoutMS());
+                syncDataClient =
+                    coordinator.getSyncDataClient(
+                        queriedNode, RaftServer.getReadOperationTimeoutMS());
                 syncDataClient.endQuery(header, coordinator.getThisNode(), queryId);
               } finally {
                 ClientUtils.putBackSyncClient(syncDataClient);

--- a/cluster/src/test/java/org/apache/iotdb/cluster/client/DataClientProviderTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/client/DataClientProviderTest.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.cluster.client.sync.SyncDataClient;
 import org.apache.iotdb.cluster.common.TestUtils;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
-
+import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol.Factory;
 import org.junit.Assert;
@@ -73,6 +73,8 @@ public class DataClientProviderTest {
         client = provider.getSyncDataClient(node, 100);
       } catch (TException e) {
         Assert.fail(e.getMessage());
+      } finally {
+        ClientUtils.putBackSyncClient(client);
       }
       assertNotNull(client);
       ClusterDescriptor.getInstance().getConfig().setUseAsyncServer(useAsyncServer);

--- a/cluster/src/test/java/org/apache/iotdb/cluster/client/DataClientProviderTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/client/DataClientProviderTest.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.cluster.common.TestUtils;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.utils.ClientUtils;
+
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol.Factory;
 import org.junit.Assert;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/PublicBAOS.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/PublicBAOS.java
@@ -78,8 +78,12 @@ public class PublicBAOS extends ByteArrayOutputStream {
     count = 0;
   }
 
+  /**
+   * The synchronized keyword in this function is intentionally removed. For details, see
+   * https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=173085039
+   */
   @Override
-  public synchronized int size() {
+  public int size() {
     return count;
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/PublicBAOS.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/PublicBAOS.java
@@ -79,7 +79,7 @@ public class PublicBAOS extends ByteArrayOutputStream {
   }
 
   @Override
-  public int size() {
+  public synchronized int size() {
     return count;
   }
 }


### PR DESCRIPTION
for more details, please see https://issues.apache.org/jira/browse/IOTDB-1148