### PR TITLE
[IOTDB-1151]fix dependency error because some jars are removed from maven's central repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>2.4.0-b180725.0644</version>
+                <version>3.0.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>jakarta.activation</groupId>


### PR DESCRIPTION
we use jaxb-runtime (v2.4) to solve compatibility problem of JDK 8 and 11, but its dependency, com.sun.xml.fastinfoset:FastInfoset:jar:1.2.14, is removed from maven's central repo. 

![image](https://user-images.githubusercontent.com/1021782/107522992-3b3ad800-6bef-11eb-99db-6fe1d5f1dc50.png)

So, we have to upgrade jaxb-runtime.