### PR TITLE
Remove `final` if there are no subclasses by design.(Happy New Year)

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/JMXService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/JMXService.java
@@ -38,7 +38,7 @@ public class JMXService implements IService {
   private JMXService() {
   }
 
-  public static final JMXService getInstance() {
+  public static JMXService getInstance() {
     return JMXServerHolder.INSTANCE;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/MQTTService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/MQTTService.java
@@ -41,7 +41,11 @@ import org.slf4j.LoggerFactory;
 public class MQTTService implements IService {
     private static final Logger LOG = LoggerFactory.getLogger(MQTTService.class);
     private Server server = new Server();
-    
+
+    private MQTTService(){
+
+    }
+
     @Override
     public void start() throws StartupException {
         startup();
@@ -91,7 +95,7 @@ public class MQTTService implements IService {
         return ServiceType.MQTT_SERVICE;
     }
 
-    public static final MQTTService getInstance() {
+    public static MQTTService getInstance() {
         return MQTTServiceHolder.INSTANCE;
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/MetricsService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/MetricsService.java
@@ -47,7 +47,11 @@ public class MetricsService implements MetricsServiceMBean, IService {
   private Server server;
   private ExecutorService executorService;
 
-  public static final MetricsService getInstance() {
+  private MetricsService(){
+
+  }
+
+  public static MetricsService getInstance() {
     return MetricsServiceHolder.INSTANCE;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/RPCService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/RPCService.java
@@ -36,7 +36,7 @@ public class RPCService extends ThriftService implements RPCServiceMBean {
   private RPCService() {
   }
 
-  public static final RPCService getInstance() {
+  public static RPCService getInstance() {
     return RPCServiceHolder.INSTANCE;
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
@@ -47,7 +47,7 @@ public class TSFileDescriptor {
     loadProps();
   }
 
-  public static final TSFileDescriptor getInstance() {
+  public static TSFileDescriptor getInstance() {
     return TsfileDescriptorHolder.INSTANCE;
   }
 


### PR DESCRIPTION
Remove `final` if there are no subclasses by design, In this PR would like to using `static` take over `static final`. 