### PR TITLE
[IOTDB-1155] One letter improvement, which add detailed error log information for exceptions

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -502,7 +502,7 @@ public class StorageGroupProcessor {
                 tsFileManagement.new CompactionRecoverTask(this::closeCompactionMergeCallBack));
       } catch (RejectedExecutionException e) {
         this.closeCompactionMergeCallBack();
-        logger.error("{} - {} compaction submit task failed", logicalStorageGroupName, virtualStorageGroupId);
+        logger.error("{} - {} compaction submit task failed", logicalStorageGroupName, virtualStorageGroupId, e);
       }
     } else {
       logger.error("{} compaction pool not started ,recover failed",
@@ -1806,7 +1806,7 @@ public class StorageGroupProcessor {
                     tsFileProcessor.getTimeRangeId()));
       } catch (IOException | RejectedExecutionException e) {
         this.closeCompactionMergeCallBack();
-        logger.error("{} compaction submit task failed", logicalStorageGroupName + "-" + virtualStorageGroupId);
+        logger.error("{} compaction submit task failed", logicalStorageGroupName + "-" + virtualStorageGroupId, e);
       }
     } else {
       logger.info("{} last compaction merge task is working, skip current merge",


### PR DESCRIPTION
One letter improvement, which add detailed error log information for exceptions.

Add more error info for `compaction submit task failed` in StorageGroupProcessor. for trace the error as follow:

`ERROR [2021-02-11 14:05:57,910] [pool-27-IoTDB-Flush-ServerServiceImpl-thread-1] org.apache.iotdb.db.engine.storagegroup.StorageGroupProcessor:1809 - root.fit.d2-0 compaction submit task failed `
