### PR TITLE
[To rel/0.10]fix: hive-connector CI in release/0.10.0

### DIFF
--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -155,11 +155,15 @@
     </build>
     <!-- org.pentaho:pentaho-aggdesigner-algorithm is in repo.spring.io and we have to claim
     to use https-->
+    <!-- Please note the notice in https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020
+    Anonymous access using /libs-snapshot or /libs-milestone in the pom.xml, or with
+    these configured in a remote repository, should replace them with /snapshot and /milestone,
+    respectively.-->
     <repositories>
         <repository>
             <id>for_pentaho</id>
             <name>spring.io</name>
-            <url>https://repo.spring.io/libs-milestone</url>
+            <url>https://repo.spring.io/milestone</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>


### PR DESCRIPTION
Fixes  the issue #2676 

**Describe the bug**

While packaging this project using maven with a version of release/0.10.0, a 401 Unauthorized error occurs in the hive-connector module.


**To Reproduce**
Steps to reproduce the behavior:
1. Checking out the branch into release/0.10.0 
2.  ```mvn clean package -DskipTests```
3. The following error occurs:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.7.0:process (process-resource-bundles) on project hive-connector: 
Execution process-resource-bundles of goal org.apache.maven.plugins:maven-remote-resources-plugin:1.7.0:
process failed: Error resolving project artifact: Could not transfer artifact org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde from/to for_pentaho (https://repo.spring.io/libs-milestone): 
Authentication failed for https://repo.spring.io/libs-milestone/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom 401 Unauthorized for project org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde -> [Help 1] [ERROR]  
 ``` 


**Screenshots**


![failure](https://user-images.githubusercontent.com/25195216/107781226-9e10a880-6d82-11eb-93f0-7b84afb84e1c.png)


**Desktop:**
 - OS: Windows 10
 - Java version:  1.8.0_241
 - Maven version:  3.6.3



**Additional context**
At the same computer, while changing the branch to the current master(05a628dd59256e94510307184a5ecb1d2a6da23f), and trying to do the same behavior, the same maven package finished without error.


##### Key changed/added classes (or packages if there are too many classes) in this PR
Change the pom.xml as the PR #2279 