### PR TITLE
upgrade sonar plugin version and testing the permission 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,7 +546,7 @@
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.6.1.1688</version>
+                    <version>3.8.0.2131</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
This PR upgrades the sonar plugin version
And, it is for checking whether non-apache repo has the permission to upload data to sonarcloud.