### PR TITLE
Do not run  coverall and sonarcloud on forked repo and allow manually run action.

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -24,6 +24,8 @@ on:
       - 'compile-tools/**'
       - 'thrift/**'
       - 'service-rpc/**'
+  # allow manually run the action:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,9 @@ on:
       - cluster_new
     paths-ignore:
       - 'docs/**'
-        
+  # allow manually run the action:
+  workflow_dispatch:
+
 jobs:
   E2E:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-linux.yml
+++ b/.github/workflows/main-linux.yml
@@ -19,6 +19,7 @@ on:
       - cluster_new
     paths-ignore:
       - 'docs/**'
+  # allow manually run the action:
   workflow_dispatch:
 
 jobs:
@@ -47,17 +48,17 @@ jobs:
       - name: IT/UT Test
         run:  mvn -B clean post-integration-test -Dtest.port.closed=true -Pcode-coverage
       - name: Code Coverage (Coveralls)
-        if: ${{ success() && matrix.java == '11'}}
+        if: ${{ success() && matrix.java == '11' && github.repository == 'apache/iotdb'}}
         run: |
           mvn -B post-integration-test -Pcode-coverage -pl code-coverage
           mvn -B coveralls:report \
           -DserviceName=travis_ci \
           -Dbranch=$BRANCH_NAME \
           -DpullRequest=$PR_NUMBER \
-          -DrepoToken=MiEOlMMMNQhLNV4yayn7rRUPyVSQzbzbZ \
+          -DrepoToken=${{ secrets.COVERALL_TOKEN }} \
           -Pcode-coverage
       - name: SonarCloud Report
-        if: ${{ success() &&  matrix.java == '11'}}
+        if: ${{ success() &&  matrix.java == '11' && github.repository == 'apache/iotdb'}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}

--- a/.github/workflows/main-mac.yml
+++ b/.github/workflows/main-mac.yml
@@ -17,6 +17,8 @@ on:
       - cluster_new
     paths-ignore:
       - 'docs/**'
+  # allow manually run the action:
+  workflow_dispatch:
 
 jobs:
   unix:

--- a/.github/workflows/main-win.yml
+++ b/.github/workflows/main-win.yml
@@ -17,6 +17,8 @@ on:
       - cluster_new
     paths-ignore:
       - 'docs/**'
+  # allow manually run the action:
+  workflow_dispatch:
 
 jobs:
   win:

--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -34,6 +34,7 @@
             <plugin>
                 <artifactId>exec-maven-plugin</artifactId>
                 <groupId>org.codehaus.mojo</groupId>
+                <version>1.6.0</version>
                 <executions>
                     <execution>
                         <id>make-cmake-executable</id>

--- a/compile-tools/thrift/pom.xml
+++ b/compile-tools/thrift/pom.xml
@@ -49,6 +49,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
                         <executions>
                             <execution>
                                 <id>make-cmake-executable</id>
@@ -84,6 +85,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
                         <executions>
                             <execution>
                                 <id>make-cmake-executable</id>

--- a/grafana/pom.xml
+++ b/grafana/pom.xml
@@ -106,6 +106,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.6.0</version>
                     <configuration>
                         <mainClass>${start-class}</mainClass>
                     </configuration>


### PR DESCRIPTION
1. Do not run  coverall and sonarcloud on forked repo;
2. allow manually run action.
3. add exec-maven-plugin's version for avoiding warning log.