### PR TITLE
[IOTDB-1156] Add .git-blame-ignore-revs for ignore the 70fc76d commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# This feature requires Git >= 2.24
+# To use it by default in git blame:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+70fc76de8b5a032269b2d4f10b956d045b0e95ec


### PR DESCRIPTION
Add .git-blame-ignore-revs for ignore the commit(70fc76de8b) of  code format refactor
This feature requires Git >= 2.24
To use it by default in git blame:
git config blame.ignoreRevsFile .git-blame-ignore-revs
