### PR TITLE
[IOTDB-1136] Improved reliability in flush error

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -288,6 +288,12 @@ estimated_series_size=300
 # size of ioTaskQueue. The default value is 10
 io_task_queue_size_for_flushing=10
 
+# read only recover retry attempts, The default value is 3
+recover_read_only_retry_attempts=3
+
+# read only recover retry sleep interval ms, The default value is 10 * 60 * 1000 ms
+recover_read_only_retry_sleep_interval=600000
+
 ####################
 ### Upgrade Configurations
 ####################

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -288,10 +288,10 @@ estimated_series_size=300
 # size of ioTaskQueue. The default value is 10
 io_task_queue_size_for_flushing=10
 
-# read only recover retry attempts, The default value is 3
+# read only recover retry attempts. The default value is 3
 recover_read_only_retry_attempts=3
 
-# read only recover retry sleep interval ms, The default value is 10 * 60 * 1000 ms
+# read only recover retry sleep interval ms. The default value is 10 * 60 * 1000 ms
 recover_read_only_retry_sleep_interval=600000
 
 ####################

--- a/server/src/main/java/org/apache/iotdb/db/common/RetryCounter.java
+++ b/server/src/main/java/org/apache/iotdb/db/common/RetryCounter.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+public class RetryCounter {
+
+  private static final Logger logger = LoggerFactory.getLogger(RetryCounter.class);
+
+  private RetryConfig retryConfig;
+  private int attempts;
+
+  public RetryCounter(RetryConfig retryConfig) {
+    this.attempts = 1;
+    this.retryConfig = retryConfig;
+  }
+
+  public void sleepToNextRetry() throws InterruptedException {
+    int attempts = getAttempts();
+    long sleepTime = getBackoffTime();
+    logger.trace("Sleeping {} ms before retry {}", sleepTime, attempts);
+    retryConfig.getTimeUnit().sleep(sleepTime);
+    useRetry();
+  }
+
+  public boolean shouldRetry() {
+    return attempts < retryConfig.getMaxAttempts();
+  }
+
+  public RetryConfig getRetryConfig() {
+    return retryConfig;
+  }
+
+  public int getAttempts() {
+    return attempts;
+  }
+
+  public long getBackoffTime() {
+    return this.retryConfig.backoffPolicy.getBackoffTime(this.retryConfig, getAttempts());
+  }
+
+  private void useRetry() {
+    attempts++;
+  }
+
+  public static class RetryConfig {
+    private int maxAttempts;
+    private long sleepInterval;
+    private TimeUnit timeUnit;
+    private BackoffPolicy backoffPolicy;
+    private float jitter;
+
+    private static final BackoffPolicy DEFAULT_BACKOFF_POLICY = new ExponentialBackoffPolicy();
+
+    public RetryConfig() {
+      maxAttempts = 1;
+      sleepInterval = 100;
+      timeUnit = TimeUnit.MILLISECONDS;
+      backoffPolicy = DEFAULT_BACKOFF_POLICY;
+      jitter = 0.0f;
+    }
+
+    public RetryConfig setMaxAttempts(int maxAttempts) {
+      this.maxAttempts = maxAttempts;
+      return this;
+    }
+
+    public RetryConfig setSleepInterval(long sleepInterval) {
+      this.sleepInterval = sleepInterval;
+      return this;
+    }
+
+    public int getMaxAttempts() {
+      return maxAttempts;
+    }
+
+    public long getSleepInterval() {
+      return sleepInterval;
+    }
+
+    public TimeUnit getTimeUnit() {
+      return timeUnit;
+    }
+
+    public float getJitter() {
+      return jitter;
+    }
+  }
+
+  private static long addJitter(long interval, float jitter) {
+    long jitterInterval = (long) (interval * ThreadLocalRandom.current().nextFloat() * jitter);
+    return interval + jitterInterval;
+  }
+
+  public static class BackoffPolicy {
+    public long getBackoffTime(RetryConfig config, int attempts) {
+      return addJitter(config.getSleepInterval(), config.getJitter());
+    }
+  }
+
+  public static class ExponentialBackoffPolicy extends BackoffPolicy {
+    @Override
+    public long getBackoffTime(RetryConfig config, int attempts) {
+      long backoffTime = (long) (config.getSleepInterval() * Math.pow(2, attempts));
+      return addJitter(config.getSleepInterval(), config.getJitter());
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/common/RetryCounterFactory.java
+++ b/server/src/main/java/org/apache/iotdb/db/common/RetryCounterFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.common;
+
+public class RetryCounterFactory {
+  private final RetryCounter.RetryConfig retryConfig;
+
+  public RetryCounterFactory(RetryCounter.RetryConfig retryConfig) {
+    this.retryConfig = retryConfig;
+  }
+
+  public RetryCounter create() {
+    return new RetryCounter(retryConfig);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -636,6 +636,12 @@ public class IoTDBConfig {
   /** the number of virtual storage groups per user-defined storage group */
   private int virtualStorageGroupNum = 1;
 
+  /** read only recover retry attempts */
+  private int readOnlyRecoverRetryAttempts = 3;
+
+  /** read only recover retry sleep interval ms */
+  private long readOnlyRecoverRetrySleepInterval = 10 * 60 * 1000L;
+
   public IoTDBConfig() {
     // empty constructor
   }
@@ -2057,5 +2063,21 @@ public class IoTDBConfig {
 
   public void setIoTaskQueueSizeForFlushing(int ioTaskQueueSizeForFlushing) {
     this.ioTaskQueueSizeForFlushing = ioTaskQueueSizeForFlushing;
+  }
+
+  public int getReadOnlyRecoverRetryAttempts() {
+    return readOnlyRecoverRetryAttempts;
+  }
+
+  public void setReadOnlyRecoverRetryAttempts(int readOnlyRecoverRetryAttempts) {
+    this.readOnlyRecoverRetryAttempts = readOnlyRecoverRetryAttempts;
+  }
+
+  public long getReadOnlyRecoverRetrySleepInterval() {
+    return readOnlyRecoverRetrySleepInterval;
+  }
+
+  public void setReadOnlyRecoverRetrySleepInterval(long readOnlyRecoverRetrySleepInterval) {
+    this.readOnlyRecoverRetrySleepInterval = readOnlyRecoverRetrySleepInterval;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -337,6 +337,18 @@ public class IoTDBDescriptor {
                   "io_task_queue_size_for_flushing",
                   Integer.toString(conf.getIoTaskQueueSizeForFlushing()))));
 
+      conf.setReadOnlyRecoverRetryAttempts(
+          Integer.parseInt(
+              properties.getProperty(
+                  "recover_read_only_retry_attempts",
+                  Integer.toString(conf.getReadOnlyRecoverRetryAttempts()))));
+
+      conf.setReadOnlyRecoverRetrySleepInterval(
+          Long.parseLong(
+              properties.getProperty(
+                  "recover_read_only_retry_sleep_interval",
+                  Long.toString(conf.getReadOnlyRecoverRetrySleepInterval()))));
+
       conf.setMergeChunkPointNumberThreshold(
           Integer.parseInt(
               properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -67,6 +67,7 @@ import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/server/src/main/java/org/apache/iotdb/db/exception/RecoverReadOnlyException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/RecoverReadOnlyException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.exception;
+
+public class RecoverReadOnlyException extends RuntimeException {
+  public RecoverReadOnlyException(Exception exception) {
+    super(exception);
+  }
+
+  public RecoverReadOnlyException(String exception) {
+    super(exception);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/writelog/manager/MultiFileLogNodeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/manager/MultiFileLogNodeManager.java
@@ -54,6 +54,7 @@ public class MultiFileLogNodeManager implements WriteLogNodeManager, IService {
   private void forceTask() {
     if (IoTDBDescriptor.getInstance().getConfig().isReadOnly()) {
       logger.warn("system mode is read-only, the force flush WAL task is stopped");
+      ReadOnlyRecoverManager.getInstance().executeRecover();
       return;
     }
     if (Thread.interrupted()) {

--- a/server/src/main/java/org/apache/iotdb/db/writelog/manager/ReadOnlyRecoverManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/manager/ReadOnlyRecoverManager.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.writelog.manager;
+
+import org.apache.iotdb.db.common.RetryCounter;
+import org.apache.iotdb.db.common.RetryCounterFactory;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.StorageEngine;
+import org.apache.iotdb.db.exception.RecoverReadOnlyException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** read only mode recover default: 10 min once, retry 3 times */
+public class ReadOnlyRecoverManager {
+  private static final Logger logger = LoggerFactory.getLogger(ReadOnlyRecoverManager.class);
+
+  private static final int READ_ONLY_RECOVER_DEFAULT_RETRY_ATTEMPTS = 3;
+
+  private static final long READ_ONLY_RECOVER_DEFAULT_RETRY_SLEEP_IINTERVAL = 10 * 60 * 1000L;
+
+  private static final ReadOnlyRecoverManager INSTANCE = new ReadOnlyRecoverManager();
+
+  static {
+    ReadOnlyRecoverManager.getInstance().registerRecover(new DefaultRecoverCallBack());
+  }
+
+  private final List<RecoverCallBack> recoverCallBacks = new ArrayList<>();
+
+  private RetryCounterFactory retryCounterFactory;
+
+  private volatile boolean isRecovering = false;
+
+  private AtomicBoolean isCloseFailed = new AtomicBoolean(false);
+
+  private ReadOnlyRecoverManager() {
+    this.retryCounterFactory =
+        new RetryCounterFactory(
+            new RetryCounter.RetryConfig()
+                .setMaxAttempts(READ_ONLY_RECOVER_DEFAULT_RETRY_ATTEMPTS)
+                .setSleepInterval(READ_ONLY_RECOVER_DEFAULT_RETRY_SLEEP_IINTERVAL));
+  }
+
+  public static ReadOnlyRecoverManager getInstance() {
+    return INSTANCE;
+  }
+
+  public synchronized void executeRecover() {
+    if (isRecovering) {
+      logger.info("Read-Only mode is recovering");
+    }
+    isRecovering = true;
+
+    new Thread(
+            () -> {
+              RetryCounter retryCounter = retryCounterFactory.create();
+              while (true) {
+                try {
+                  isCloseFailed.set(false);
+                  for (RecoverCallBack recoverCallBack : recoverCallBacks) {
+                    logger.info("Start read-only mode recovering");
+                    recoverCallBack.callBack();
+                  }
+                  if (isCloseFailed.get()) {
+                    throw new RecoverReadOnlyException("recovering is failed");
+                  }
+                  logger.info("recover read-write mode.");
+                  IoTDBDescriptor.getInstance().getConfig().setReadOnly(false);
+                  isRecovering = false;
+                  break;
+                } catch (Exception e) {
+                  retryOrThrow(retryCounter, e);
+                }
+              }
+            })
+        .start();
+  }
+
+  private void retryOrThrow(RetryCounter retryCounter, Exception e) {
+    if (retryCounter.shouldRetry()) {
+      try {
+        logger.warn("Failed to recover read-only mode, retry again", e);
+        retryCounter.sleepToNextRetry();
+      } catch (InterruptedException ex) {
+        // ignore
+        logger.warn("Sleep Interrupted:", e);
+      }
+      return;
+    }
+    clear();
+    throw new RecoverReadOnlyException(e);
+  }
+
+  public void registerRecover(RecoverCallBack recoverCallBack) {
+    if (!recoverCallBacks.contains(recoverCallBack)) {
+      recoverCallBacks.add(recoverCallBack);
+    }
+  }
+
+  public void setClosingFailed(boolean bool) {
+    this.isCloseFailed.set(bool);
+  }
+
+  private void clear() {
+    this.isCloseFailed.set(false);
+    this.isRecovering = false;
+  }
+
+  interface RecoverCallBack {
+    void callBack();
+  }
+
+  static class DefaultRecoverCallBack implements RecoverCallBack {
+    @Override
+    public void callBack() {
+      StorageEngine.getInstance().syncCloseAllProcessor();
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/writelog/manager/ReadOnlyRecoverManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/manager/ReadOnlyRecoverManager.java
@@ -35,10 +35,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ReadOnlyRecoverManager {
   private static final Logger logger = LoggerFactory.getLogger(ReadOnlyRecoverManager.class);
 
-  private static final int READ_ONLY_RECOVER_DEFAULT_RETRY_ATTEMPTS = 3;
-
-  private static final long READ_ONLY_RECOVER_DEFAULT_RETRY_SLEEP_IINTERVAL = 10 * 60 * 1000L;
-
   private static final ReadOnlyRecoverManager INSTANCE = new ReadOnlyRecoverManager();
 
   static {
@@ -57,8 +53,12 @@ public class ReadOnlyRecoverManager {
     this.retryCounterFactory =
         new RetryCounterFactory(
             new RetryCounter.RetryConfig()
-                .setMaxAttempts(READ_ONLY_RECOVER_DEFAULT_RETRY_ATTEMPTS)
-                .setSleepInterval(READ_ONLY_RECOVER_DEFAULT_RETRY_SLEEP_IINTERVAL));
+                .setMaxAttempts(
+                    IoTDBDescriptor.getInstance().getConfig().getReadOnlyRecoverRetryAttempts())
+                .setSleepInterval(
+                    IoTDBDescriptor.getInstance()
+                        .getConfig()
+                        .getReadOnlyRecoverRetrySleepInterval()));
   }
 
   public static ReadOnlyRecoverManager getInstance() {

--- a/server/src/test/java/org/apache/iotdb/db/writelog/ReadOnlyRecoverManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/ReadOnlyRecoverManagerTest.java
@@ -64,6 +64,14 @@ public class ReadOnlyRecoverManagerTest {
     assertEquals(false, IoTDBDescriptor.getInstance().getConfig().isReadOnly());
   }
 
+  @Test
+  public void testRetryDefaultSleepIntervalAndAttempts() {
+    assertEquals(3, IoTDBDescriptor.getInstance().getConfig().getReadOnlyRecoverRetryAttempts());
+    assertEquals(
+        10 * 60 * 1000L,
+        IoTDBDescriptor.getInstance().getConfig().getReadOnlyRecoverRetrySleepInterval());
+  }
+
   private static void insertData() throws ClassNotFoundException {
     List<String> sqls =
         new ArrayList<>(

--- a/server/src/test/java/org/apache/iotdb/db/writelog/ReadOnlyRecoverManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/ReadOnlyRecoverManagerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.writelog;
+
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.db.writelog.manager.ReadOnlyRecoverManager;
+import org.apache.iotdb.jdbc.Config;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ReadOnlyRecoverManagerTest {
+
+  private static int partitionInterval = 100;
+
+  @Before
+  public void setUp() throws Exception {
+    EnvironmentUtils.envSetUp();
+    insertData();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    EnvironmentUtils.cleanEnv();
+    IoTDBDescriptor.getInstance().getConfig().setReadOnly(false);
+  }
+
+  @Test
+  public void testRecoverExecute() {
+    IoTDBDescriptor.getInstance().getConfig().setReadOnly(true);
+    ReadOnlyRecoverManager.getInstance().executeRecover();
+    try {
+      Thread.sleep(3000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    assertEquals(false, IoTDBDescriptor.getInstance().getConfig().isReadOnly());
+  }
+
+  private static void insertData() throws ClassNotFoundException {
+    List<String> sqls =
+        new ArrayList<>(
+            Arrays.asList(
+                "SET STORAGE GROUP TO root.test1",
+                "SET STORAGE GROUP TO root.test2",
+                "CREATE TIMESERIES root.test1.s0 WITH DATATYPE=INT64,ENCODING=PLAIN",
+                "CREATE TIMESERIES root.test2.s0 WITH DATATYPE=INT64,ENCODING=PLAIN"));
+    // 10 partitions, each one with one seq file and one unseq file
+    for (int i = 0; i < 10; i++) {
+      // seq files
+      for (int j = 1; j <= 2; j++) {
+        sqls.add(
+            String.format(
+                "INSERT INTO root.test%d(timestamp, s0) VALUES (%d, %d)",
+                j, i * partitionInterval + 50, i * partitionInterval + 50));
+      }
+      // last file is unclosed
+      if (i < 9) {
+        sqls.add("FLUSH");
+      }
+      // unseq files
+      for (int j = 1; j <= 2; j++) {
+        sqls.add(
+            String.format(
+                "INSERT INTO root.test%d(timestamp, s0) VALUES (%d, %d)",
+                j, i * partitionInterval, i * partitionInterval));
+      }
+      sqls.add("MERGE");
+      // last file is unclosed
+      if (i < 9) {
+        sqls.add("FLUSH");
+      }
+    }
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      for (String sql : sqls) {
+        statement.execute(sql);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
The flushing fails due to OOM or insufficient disk space etc.... As a result, the cluster is in read-only mode.
We need a mechanism to restore read-only mode.
If the fault is caused by a common error
1. If the flush fails, a retry mechanism can be added. By default, the retry mechanism is used for three times at an interval of 1s.
2. After the read-only mode is enabled, the system can recover the read-only mode and pull the data every 10 minutes.