### PR TITLE
 [IOTDB-1166] Remove redundant toString() calls

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/ClientMain.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/ClientMain.java
@@ -461,7 +461,7 @@ public class ClientMain {
           for (int i = 0; i < colNum; i++) {
             stringBuilder.append(set.getString(i + 1)).append(",");
           }
-          System.out.println(stringBuilder.toString());
+          System.out.println(stringBuilder);
         }
       }
     }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
@@ -267,7 +267,7 @@ public class Coordinator {
       status =
           StatusUtils.getStatus(
               StatusUtils.EXECUTE_STATEMENT_ERROR,
-              MSG_MULTIPLE_ERROR + errorCodePartitionGroups.toString());
+              MSG_MULTIPLE_ERROR + errorCodePartitionGroups);
     }
     logger.debug("{}: executed {} with answer {}", name, plan, status);
     return status;
@@ -421,7 +421,7 @@ public class Coordinator {
       status =
           StatusUtils.getStatus(
               StatusUtils.EXECUTE_STATEMENT_ERROR,
-              MSG_MULTIPLE_ERROR + errorCodePartitionGroups.toString());
+              MSG_MULTIPLE_ERROR + errorCodePartitionGroups);
     }
     return status;
   }
@@ -573,7 +573,7 @@ public class Coordinator {
       status =
           StatusUtils.getStatus(
               StatusUtils.EXECUTE_STATEMENT_ERROR,
-              MSG_MULTIPLE_ERROR + errorCodePartitionGroups.toString());
+              MSG_MULTIPLE_ERROR + errorCodePartitionGroups);
     }
     return status;
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
@@ -266,8 +266,7 @@ public class Coordinator {
     } else {
       status =
           StatusUtils.getStatus(
-              StatusUtils.EXECUTE_STATEMENT_ERROR,
-              MSG_MULTIPLE_ERROR + errorCodePartitionGroups);
+              StatusUtils.EXECUTE_STATEMENT_ERROR, MSG_MULTIPLE_ERROR + errorCodePartitionGroups);
     }
     logger.debug("{}: executed {} with answer {}", name, plan, status);
     return status;
@@ -420,8 +419,7 @@ public class Coordinator {
     } else {
       status =
           StatusUtils.getStatus(
-              StatusUtils.EXECUTE_STATEMENT_ERROR,
-              MSG_MULTIPLE_ERROR + errorCodePartitionGroups);
+              StatusUtils.EXECUTE_STATEMENT_ERROR, MSG_MULTIPLE_ERROR + errorCodePartitionGroups);
     }
     return status;
   }
@@ -572,8 +570,7 @@ public class Coordinator {
     } else {
       status =
           StatusUtils.getStatus(
-              StatusUtils.EXECUTE_STATEMENT_ERROR,
-              MSG_MULTIPLE_ERROR + errorCodePartitionGroups);
+              StatusUtils.EXECUTE_STATEMENT_ERROR, MSG_MULTIPLE_ERROR + errorCodePartitionGroups);
     }
     return status;
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/logtypes/PhysicalPlanLog.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/logtypes/PhysicalPlanLog.java
@@ -90,7 +90,7 @@ public class PhysicalPlanLog extends Log {
 
   @Override
   public String toString() {
-    return plan.toString() + ",term:" + getCurrLogTerm() + ",index:" + getCurrLogIndex();
+    return plan + ",term:" + getCurrLogTerm() + ",index:" + getCurrLogIndex();
   }
 
   @Override

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/StoppedMemberManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/StoppedMemberManager.java
@@ -95,7 +95,7 @@ public class StoppedMemberManager {
   public synchronized void remove(Node header) {
     removedMemberMap.remove(header);
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(stoppedMembersFileName, true))) {
-      writer.write(RESUMED + ";" + header.toString());
+      writer.write(RESUMED + ";" + header);
       writer.newLine();
     } catch (IOException e) {
       logger.error("Cannot record resumed member of header {}", header, e);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/monitor/Timer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/monitor/Timer.java
@@ -322,7 +322,7 @@ public class Timer {
   private static void printTo(Statistic currNode, StringBuilder out) {
     if (currNode != Statistic.ROOT && currNode.valid) {
       indent(out, currNode.level);
-      out.append(currNode.toString()).append("\n");
+      out.append(currNode).append("\n");
     }
     for (Statistic child : currNode.children) {
       printTo(child, out);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/utils/nodetool/function/Host.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/utils/nodetool/function/Host.java
@@ -71,7 +71,7 @@ public class Host extends NodeToolCmd {
         builder.append(", ").append(nodeToString(raftGroup.get(i)));
       }
       builder.append(')');
-      msgPrintln(String.format("%-50s->%20s", builder.toString(), slotNum));
+      msgPrintln(String.format("%-50s->%20s", builder, slotNum));
     }
   }
 }

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -516,7 +516,7 @@ public class SessionExample {
         builder.append("null");
       }
 
-      System.out.println(builder.toString());
+      System.out.println(builder);
     }
 
     dataSet.closeOperationHandle();

--- a/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
@@ -107,7 +107,7 @@ public class SessionPoolExample {
                 for (String columnName : wrapper.getColumnNames()) {
                   builder.append(dataIterator.getString(columnName) + " ");
                 }
-                System.out.println(builder.toString());
+                System.out.println(builder);
               }
             } catch (IoTDBConnectionException | StatementExecutionException e) {
               e.printStackTrace();

--- a/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSFile.java
+++ b/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSFile.java
@@ -99,7 +99,7 @@ public class HDFSFile extends File {
     try {
       return fs.getFileStatus(hdfsPath).getLen();
     } catch (IOException e) {
-      logger.error("Fail to get length of the file {}, ", hdfsPath.toUri().toString(), e);
+      logger.error("Fail to get length of the file {}, ", hdfsPath.toUri(), e);
       return 0;
     }
   }
@@ -109,7 +109,7 @@ public class HDFSFile extends File {
     try {
       return fs.exists(hdfsPath);
     } catch (IOException e) {
-      logger.error("Fail to check whether the file {} exists. ", hdfsPath.toUri().toString(), e);
+      logger.error("Fail to check whether the file {} exists. ", hdfsPath.toUri(), e);
       return false;
     }
   }
@@ -124,7 +124,7 @@ public class HDFSFile extends File {
       }
       return files.toArray(new HDFSFile[0]);
     } catch (IOException e) {
-      logger.error("Fail to list files in {}. ", hdfsPath.toUri().toString(), e);
+      logger.error("Fail to list files in {}. ", hdfsPath.toUri(), e);
       return null;
     }
   }
@@ -144,7 +144,7 @@ public class HDFSFile extends File {
     try {
       return !fs.exists(hdfsPath) || fs.delete(hdfsPath, true);
     } catch (IOException e) {
-      logger.error("Fail to delete file {}. ", hdfsPath.toUri().toString(), e);
+      logger.error("Fail to delete file {}. ", hdfsPath.toUri(), e);
       return false;
     }
   }
@@ -154,7 +154,7 @@ public class HDFSFile extends File {
     try {
       return !exists() && fs.mkdirs(hdfsPath);
     } catch (IOException e) {
-      logger.error("Fail to create directory {}. ", hdfsPath.toUri().toString(), e);
+      logger.error("Fail to create directory {}. ", hdfsPath.toUri(), e);
       return false;
     }
   }
@@ -164,7 +164,7 @@ public class HDFSFile extends File {
     try {
       return exists() && fs.getFileStatus(hdfsPath).isDirectory();
     } catch (IOException e) {
-      logger.error("Fail to judge whether {} is a directory. ", hdfsPath.toUri().toString(), e);
+      logger.error("Fail to judge whether {} is a directory. ", hdfsPath.toUri(), e);
       return false;
     }
   }
@@ -174,7 +174,7 @@ public class HDFSFile extends File {
     try {
       return fs.getStatus().getRemaining();
     } catch (IOException e) {
-      logger.error("Fail to get free space of {}. ", hdfsPath.toUri().toString(), e);
+      logger.error("Fail to get free space of {}. ", hdfsPath.toUri(), e);
       return 0L;
     }
   }
@@ -214,7 +214,7 @@ public class HDFSFile extends File {
     try {
       return fs.rename(hdfsPath, new Path(dest.getAbsolutePath()));
     } catch (IOException e) {
-      logger.error("Failed to rename file {} to {}. ", hdfsPath.toString(), dest.getName(), e);
+      logger.error("Failed to rename file {} to {}. ", hdfsPath, dest.getName(), e);
       return false;
     }
   }

--- a/hive-connector/src/main/java/org/apache/iotdb/hive/TsFileDeserializer.java
+++ b/hive-connector/src/main/java/org/apache/iotdb/hive/TsFileDeserializer.java
@@ -68,7 +68,7 @@ public class TsFileDeserializer {
       return null;
     }
 
-    LOG.debug("device_id: {}", mapWritable.get(new Text("device_id")).toString());
+    LOG.debug("device_id: {}", mapWritable.get(new Text("device_id")));
     LOG.debug("time_stamp: {}", mapWritable.get(new Text("time_stamp")));
 
     for (int i = 0; i < columnNames.size(); i++) {

--- a/server/src/main/java/org/apache/iotdb/db/auth/authorizer/OpenIdAuthorizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/authorizer/OpenIdAuthorizer.java
@@ -77,7 +77,7 @@ public class OpenIdAuthorizer extends BasicAuthorizer {
     try {
       providerKey = RSAKey.parse(jwk).toRSAPublicKey();
     } catch (java.text.ParseException | JOSEException e) {
-      throw new AuthException("Unable to get OIDC Provider Key from JWK " + jwk.toString(), e);
+      throw new AuthException("Unable to get OIDC Provider Key from JWK " + jwk, e);
     }
     logger.info("Initialized with providerKey: {}", providerKey);
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeManager.java
@@ -337,7 +337,7 @@ public class MergeManager implements IService, MergeManagerMBean {
           .append(storageGroup)
           .append(System.lineSeparator());
       for (TaskStatus status : statusList) {
-        builder.append("\t\t").append(status.toString()).append(System.lineSeparator());
+        builder.append("\t\t").append(status).append(System.lineSeparator());
       }
     }
 
@@ -351,7 +351,7 @@ public class MergeManager implements IService, MergeManagerMBean {
           .append(storageGroup)
           .append(System.lineSeparator());
       for (TaskStatus status : statusList) {
-        builder.append("\t\t").append(status.toString()).append(System.lineSeparator());
+        builder.append("\t\t").append(status).append(System.lineSeparator());
       }
     }
     return builder.toString();

--- a/server/src/main/java/org/apache/iotdb/db/engine/modification/io/LocalTextModificationAccessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/modification/io/LocalTextModificationAccessor.java
@@ -127,7 +127,7 @@ public class LocalTextModificationAccessor
   }
 
   private static String encodeDeletion(Deletion del) {
-    return del.getType().toString()
+    return del.getType()
         + SEPARATOR
         + del.getPathString()
         + SEPARATOR

--- a/server/src/main/java/org/apache/iotdb/db/exception/query/UnSupportedFillTypeException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/query/UnSupportedFillTypeException.java
@@ -27,7 +27,7 @@ public class UnSupportedFillTypeException extends QueryProcessException {
 
   public UnSupportedFillTypeException(TSDataType dataType) {
     super(
-        String.format("Unsupported linear fill data type: [%s]", dataType.toString()),
+        String.format("Unsupported linear fill data type: [%s]", dataType),
         TSStatusCode.UNSUPPORTED_FILL_TYPE_ERROR.getStatusCode());
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -278,7 +278,7 @@ public class MManager {
             "spend {} ms to deserialize mtree from mlog.bin", System.currentTimeMillis() - time);
         return idx;
       } catch (Exception e) {
-        throw new IOException("Failed to parser mlog.bin for err:" + e.toString());
+        throw new IOException("Failed to parser mlog.bin for err:" + e);
       }
     } else {
       return 0;
@@ -1117,7 +1117,7 @@ public class MManager {
 
   /** Get metadata in string */
   public String getMetadataInString() {
-    return TIME_SERIES_TREE_HEADER + mtree.toString();
+    return TIME_SERIES_TREE_HEADER + mtree;
   }
 
   public void setTTL(PartialPath storageGroup, long dataTTL) throws MetadataException, IOException {

--- a/server/src/main/java/org/apache/iotdb/db/metrics/ui/MetricsPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metrics/ui/MetricsPage.java
@@ -175,7 +175,7 @@ public class MetricsPage {
                 + sqlArgument.getPlan().getOperatorType()
                 + "</br>===========================</br>"
                 + "Path: "
-                + sqlArgument.getPlan().getPaths().toString()
+                + sqlArgument.getPlan().getPaths()
                 + "</pre>"
                 + "</div>"
                 + "</td>"

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AuthorPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AuthorPlan.java
@@ -415,7 +415,7 @@ public class AuthorPlan extends PhysicalPlan {
         type = PhysicalPlanType.DELETE_USER.ordinal();
         break;
       default:
-        throw new IllegalArgumentException("Unknown operator: " + operatorType.toString());
+        throw new IllegalArgumentException("Unknown operator: " + operatorType);
     }
     return type;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DataAuthPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DataAuthPlan.java
@@ -93,7 +93,7 @@ public class DataAuthPlan extends PhysicalPlan {
     } else if (operatorType == OperatorType.REVOKE_WATERMARK_EMBEDDING) {
       type = PhysicalPlanType.REVOKE_WATERMARK_EMBEDDING.ordinal();
     } else {
-      throw new IllegalArgumentException("Unknown operator: " + operatorType.toString());
+      throw new IllegalArgumentException("Unknown operator: " + operatorType);
     }
     return type;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowPlan.java
@@ -97,7 +97,7 @@ public class ShowPlan extends PhysicalPlan {
 
   @Override
   public String toString() {
-    return String.format("%s %s", getOperatorType().toString(), showContentType);
+    return String.format("%s %s", getOperatorType(), showContentType);
   }
 
   public enum ShowContentType {

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesDataTypeNotValidException.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/api/exception/UDFInputSeriesDataTypeNotValidException.java
@@ -30,7 +30,7 @@ public class UDFInputSeriesDataTypeNotValidException extends UDFParameterNotVali
     super(
         String.format(
             "the data type of the input series (index: %d) is not valid. expected: %s. actual: %s.",
-            index, expected.toString(), actual.toString()));
+            index, expected, actual));
   }
 
   public UDFInputSeriesDataTypeNotValidException(
@@ -38,6 +38,6 @@ public class UDFInputSeriesDataTypeNotValidException extends UDFParameterNotVali
     super(
         String.format(
             "the data type of the input series (index: %d) is not valid. expected: %s. actual: %s.",
-            index, Arrays.toString(expected), actual.toString()));
+            index, Arrays.toString(expected), actual));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/core/executor/UDTFExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/core/executor/UDTFExecutor.java
@@ -100,7 +100,7 @@ public class UDTFExecutor {
     throw new QueryProcessException(
         String.format(
                 "Error occurred during executing UDTF#%s: %s", methodName, System.lineSeparator())
-            + e.toString());
+            + e);
   }
 
   public UDFContext getContext() {

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/TemporaryQueryDataFileService.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/TemporaryQueryDataFileService.java
@@ -80,8 +80,7 @@ public class TemporaryQueryDataFileService implements IService {
       } catch (IOException e) {
         logger.warn(
             String.format(
-                "Failed to close file in method deregister(%d), because %s",
-                queryId, e.toString()));
+                "Failed to close file in method deregister(%d), because %s", queryId, e));
       }
     }
     try {
@@ -89,7 +88,7 @@ public class TemporaryQueryDataFileService implements IService {
     } catch (IOException e) {
       logger.warn(
           String.format(
-              "Failed to clean dir in method deregister(%d), because %s", queryId, e.toString()));
+              "Failed to clean dir in method deregister(%d), because %s", queryId, e));
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/TemporaryQueryDataFileService.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/TemporaryQueryDataFileService.java
@@ -79,16 +79,14 @@ public class TemporaryQueryDataFileService implements IService {
         recorder.closeFile();
       } catch (IOException e) {
         logger.warn(
-            String.format(
-                "Failed to close file in method deregister(%d), because %s", queryId, e));
+            String.format("Failed to close file in method deregister(%d), because %s", queryId, e));
       }
     }
     try {
       FileUtils.cleanDirectory(SystemFileFactory.INSTANCE.getFile(getDirName(queryId)));
     } catch (IOException e) {
       logger.warn(
-          String.format(
-              "Failed to clean dir in method deregister(%d), because %s", queryId, e));
+          String.format("Failed to clean dir in method deregister(%d), because %s", queryId, e));
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
@@ -224,8 +224,7 @@ public class UDFRegistrationService implements IService {
         registrationInformation.put(functionName, information);
         String errorMessage =
             String.format(
-                "Failed to append UDF log when deregistering UDF %s, because %s",
-                functionName, e);
+                "Failed to append UDF log when deregistering UDF %s, because %s", functionName, e);
         logger.error(errorMessage);
         throw new UDFRegistrationException(errorMessage, e);
       }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
@@ -164,7 +164,7 @@ public class UDFRegistrationService implements IService {
       String errorMessage =
           String.format(
               "Failed to register UDF %s(%s), because its instance can not be constructed successfully. Exception: %s",
-              functionName, className, e.toString());
+              functionName, className, e);
       logger.warn(errorMessage);
       throw new UDFRegistrationException(errorMessage);
     } finally {
@@ -186,7 +186,7 @@ public class UDFRegistrationService implements IService {
       String errorMessage =
           String.format(
               "Failed to append UDF log when registering UDF %s(%s), because %s",
-              functionName, className, e.toString());
+              functionName, className, e);
       logger.error(errorMessage);
       throw new UDFRegistrationException(errorMessage, e);
     }
@@ -225,7 +225,7 @@ public class UDFRegistrationService implements IService {
         String errorMessage =
             String.format(
                 "Failed to append UDF log when deregistering UDF %s, because %s",
-                functionName, e.toString());
+                functionName, e);
         logger.error(errorMessage);
         throw new UDFRegistrationException(errorMessage, e);
       }
@@ -276,7 +276,7 @@ public class UDFRegistrationService implements IService {
       String errorMessage =
           String.format(
               "Failed to reflect UDF %s(%s) instance, because %s",
-              functionName, information.getClassName(), e.toString());
+              functionName, information.getClassName(), e);
       logger.warn(errorMessage);
       throw new QueryProcessException(errorMessage);
     }

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -772,7 +772,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           FilePathUtils.getPathByLevel((AggregationPlan) plan, pathIndex);
       for (Map.Entry<String, AggregateResult> entry : finalPaths.entrySet()) {
         respColumns.add(
-            entry.getValue().getAggregationType().toString() + "(" + entry.getKey() + ")");
+            entry.getValue().getAggregationType() + "(" + entry.getKey() + ")");
         columnsTypes.add(entry.getValue().getResultDataType().toString());
       }
     } else {
@@ -1658,7 +1658,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       if (!checkAuthorization(paths, plan, sessionIdUsernameMap.get(sessionId))) {
         return RpcUtils.getStatus(
             TSStatusCode.NO_PERMISSION_ERROR,
-            "No permissions for this operation " + plan.getOperatorType().toString());
+            "No permissions for this operation " + plan.getOperatorType());
       }
     } catch (AuthException e) {
       LOGGER.warn("meet error while checking authorization.", e);

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -771,8 +771,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       Map<String, AggregateResult> finalPaths =
           FilePathUtils.getPathByLevel((AggregationPlan) plan, pathIndex);
       for (Map.Entry<String, AggregateResult> entry : finalPaths.entrySet()) {
-        respColumns.add(
-            entry.getValue().getAggregationType() + "(" + entry.getKey() + ")");
+        respColumns.add(entry.getValue().getAggregationType() + "(" + entry.getKey() + ")");
         columnsTypes.add(entry.getValue().getResultDataType().toString());
       }
     } else {

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
@@ -83,7 +83,7 @@ public class TsFileSketchTool {
         for (ChunkGroupMetadata chunkGroupMetadata : allChunkGroupMetadata) {
           printlnBoth(
               pw,
-              str1.toString()
+              str1
                   + "\t[Chunk Group] of "
                   + chunkGroupMetadata.getDevice()
                   + ", num of Chunks:"
@@ -126,7 +126,7 @@ public class TsFileSketchTool {
 
           printlnBoth(
               pw,
-              str1.toString() + "\t[Chunk Group] of " + chunkGroupMetadata.getDevice() + " ends");
+              str1 + "\t[Chunk Group] of " + chunkGroupMetadata.getDevice() + " ends");
         }
 
         // metadata begins

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
@@ -124,9 +124,7 @@ public class TsFileSketchTool {
                     - 1;
           }
 
-          printlnBoth(
-              pw,
-              str1 + "\t[Chunk Group] of " + chunkGroupMetadata.getDevice() + " ends");
+          printlnBoth(pw, str1 + "\t[Chunk Group] of " + chunkGroupMetadata.getDevice() + " ends");
         }
 
         // metadata begins

--- a/server/src/main/java/org/apache/iotdb/db/utils/AuthUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/AuthUtils.java
@@ -133,7 +133,7 @@ public class AuthUtils {
           return;
         default:
           throw new AuthException(
-              String.format("Illegal privilege %s on seriesPath %s", type.toString(), path));
+              String.format("Illegal privilege %s on seriesPath %s", type, path));
       }
     } else {
       switch (type) {

--- a/server/src/main/java/org/apache/iotdb/db/utils/EncodingInferenceUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/EncodingInferenceUtils.java
@@ -48,7 +48,7 @@ public class EncodingInferenceUtils {
         return conf.getDefaultTextEncoding();
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Data type %s is not supported.", dataType.toString()));
+            String.format("Data type %s is not supported.", dataType));
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
@@ -238,9 +238,7 @@ public class SchemaUtils {
       throws MetadataException {
     if (!schemaChecker.get(dataType).contains(encoding)) {
       throw new MetadataException(
-          String.format(
-              "encoding %s does not support %s", encoding, dataType),
-          true);
+          String.format("encoding %s does not support %s", encoding, dataType), true);
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
@@ -239,7 +239,7 @@ public class SchemaUtils {
     if (!schemaChecker.get(dataType).contains(encoding)) {
       throw new MetadataException(
           String.format(
-              "encoding %s does not support %s", encoding.toString(), dataType.toString()),
+              "encoding %s does not support %s", encoding, dataType),
           true);
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/constant/TestConstant.java
+++ b/server/src/test/java/org/apache/iotdb/db/constant/TestConstant.java
@@ -101,7 +101,6 @@ public class TestConstant {
       measurements.append(",").append(dataPoint.getMeasurementId());
       values.append(",").append(dataPoint.getValue());
     }
-    return String.format(
-        insertTemplate, record.deviceId, measurements, record.time, values);
+    return String.format(insertTemplate, record.deviceId, measurements, record.time, values);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/constant/TestConstant.java
+++ b/server/src/test/java/org/apache/iotdb/db/constant/TestConstant.java
@@ -102,6 +102,6 @@ public class TestConstant {
       values.append(",").append(dataPoint.getValue());
     }
     return String.format(
-        insertTemplate, record.deviceId, measurements.toString(), record.time, values);
+        insertTemplate, record.deviceId, measurements, record.time, values);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBFlushQueryMergeIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBFlushQueryMergeIT.java
@@ -129,14 +129,14 @@ public class IoTDBFlushQueryMergeIT {
 
       for (int i = 1; i <= 3; i++) {
         for (int j = 10; j < 20; j++) {
-          statement.execute(String.format(insertTemplate, i, j, j, j * 0.1, String.valueOf(j)));
+          statement.execute(String.format(insertTemplate, i, j, j, j * 0.1, j));
         }
       }
       statement.execute("FLUSH");
 
       for (int i = 1; i <= 3; i++) {
         for (int j = 0; j < 10; j++) {
-          statement.execute(String.format(insertTemplate, i, j, j, j * 0.1, String.valueOf(j)));
+          statement.execute(String.format(insertTemplate, i, j, j, j * 0.1, j));
         }
       }
       statement.execute("FLUSH root.group1");
@@ -144,7 +144,7 @@ public class IoTDBFlushQueryMergeIT {
 
       for (int i = 1; i <= 3; i++) {
         for (int j = 0; j < 30; j++) {
-          statement.execute(String.format(insertTemplate, i, j, j, j * 0.1, String.valueOf(j)));
+          statement.execute(String.format(insertTemplate, i, j, j, j * 0.1, j));
         }
       }
       statement.execute("FLUSH root.group1 TRUE");

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMergeTest.java
@@ -374,7 +374,7 @@ public class IoTDBMergeTest {
           for (int i = 0; i < colNum; i++) {
             stringBuilder.append(resultSet.getString(i + 1)).append(",");
           }
-          System.out.println(stringBuilder.toString());
+          System.out.println(stringBuilder);
           cnt++;
         }
       }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/expression/impl/GlobalTimeExpression.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/expression/impl/GlobalTimeExpression.java
@@ -56,6 +56,6 @@ public class GlobalTimeExpression implements IUnaryExpression, Serializable {
 
   @Override
   public String toString() {
-    return "[" + this.filter.toString() + "]";
+    return "[" + this.filter + "]";
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
@@ -173,7 +173,7 @@ public class DataSetWithoutTimeGenerator extends QueryDataSet {
         field.setBinaryV(col.getBinary());
         break;
       default:
-        throw new UnSupportedDataTypeException("UnSupported" + String.valueOf(col.getDataType()));
+        throw new UnSupportedDataTypeException("UnSupported" + col.getDataType());
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/TsFileWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/TsFileWriter.java
@@ -161,7 +161,7 @@ public class TsFileWriter implements AutoCloseable {
   public void registerTimeseries(Path path, MeasurementSchema measurementSchema)
       throws WriteProcessException {
     if (schema.containsTimeseries(path)) {
-      throw new WriteProcessException("given timeseries has exists! " + path.toString());
+      throw new WriteProcessException("given timeseries has exists! " + path);
     }
     schema.registerTimeseries(path, measurementSchema);
   }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/WriteTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/WriteTest.java
@@ -250,7 +250,7 @@ public class WriteTest {
     try {
       tsFileWriter.registerTimeseries(path, dupTimeseries);
     } catch (WriteProcessException e) {
-      assertEquals("given timeseries has exists! " + path.toString(), e.getMessage());
+      assertEquals("given timeseries has exists! " + path, e.getMessage());
     }
     try {
       tsFileWriter.close();


### PR DESCRIPTION
Remove redundant toString() calls,e.g,:

`"Unknown operator: " + operatorType.toString()`-> `Unknown operator: " + operatorType`

Any calls to toString() used in string concatenations and as arguments to the print() and println() methods of java.io.PrintWriter and java.io.PrintStream, the append() method of java.lang.StringBuilder and java.lang.StringBuffer or the trace(), debug(), info(), warn() and error() methods of org.slf4j.Logger. In these cases the conversion to string will be handled by the underlying library methods and an explicit call to toString() is no needed.

And using `mvn spotless:check ` and `mvn spotless:apply` format code.