### PR TITLE
[IOTDB-1167] Remove unnecessary modifier

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualPartitioner.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualPartitioner.java
@@ -28,12 +28,12 @@ public interface VirtualPartitioner {
    * @param deviceId device id
    * @return virtual storage group id
    */
-  public int deviceToVirtualStorageGroupId(PartialPath deviceId);
+  int deviceToVirtualStorageGroupId(PartialPath deviceId);
 
   /**
    * get total number of virtual storage group
    *
    * @return total number of virtual storage group
    */
-  public int getPartitionCount();
+  int getPartitionCount();
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/RamUsageEstimator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/RamUsageEstimator.java
@@ -57,7 +57,7 @@ public final class RamUsageEstimator {
 
     public final String description;
 
-    private JvmFeature(String description) {
+    JvmFeature(String description) {
       this.description = description;
     }
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileUtils.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileUtils.java
@@ -71,7 +71,7 @@ public class FileUtils {
     return ((double) a) / Math.pow(10, round);
   }
 
-  public static enum Unit {
+  public enum Unit {
     B,
     KB,
     MB,


### PR DESCRIPTION
Remove unnecessary modifier, e.g.: `public` is unnecessary in interface.