### PR TITLE
[IOTDB-1168] Remove duplicated-throws

### DIFF
--- a/example/hadoop/src/main/java/org/apache/iotdb/hadoop/tsfile/TsFileHelper.java
+++ b/example/hadoop/src/main/java/org/apache/iotdb/hadoop/tsfile/TsFileHelper.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -128,7 +127,7 @@ public class TsFileHelper {
     }
   }
 
-  public static void main(String[] args) throws FileNotFoundException, IOException {
+  public static void main(String[] args) throws IOException {
     String filePath = "example_mr.tsfile";
     File file = new File(filePath);
     if (file.exists()) {

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb;
 
-import org.apache.iotdb.rpc.BatchExecutionException;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -135,7 +134,7 @@ public class SessionExample {
   }
 
   private static void createMultiTimeseries()
-      throws IoTDBConnectionException, BatchExecutionException, StatementExecutionException {
+      throws IoTDBConnectionException, StatementExecutionException {
 
     if (!session.checkTimeseriesExists("root.sg1.d2.s1")
         && !session.checkTimeseriesExists("root.sg1.d2.s2")) {

--- a/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TsFileTestHelper.java
+++ b/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TsFileTestHelper.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -109,7 +108,7 @@ public class TsFileTestHelper {
     }
   }
 
-  public static void main(String[] args) throws FileNotFoundException, IOException {
+  public static void main(String[] args) throws IOException {
     String filePath = "example_mr.tsfile";
     File file = new File(filePath);
     if (file.exists()) {

--- a/hive-connector/src/test/java/org/apache/iotdb/hive/TsFileTestHelper.java
+++ b/hive-connector/src/test/java/org/apache/iotdb/hive/TsFileTestHelper.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -114,7 +113,7 @@ public class TsFileTestHelper {
     }
   }
 
-  public static void main(String[] args) throws FileNotFoundException, IOException {
+  public static void main(String[] args) throws IOException {
     String filePath = "test.tsfile";
     File file = new File(filePath);
     if (file.exists()) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
@@ -53,8 +53,7 @@ public class MergeTaskTest extends MergeTest {
 
   @Override
   @Before
-  public void setUp()
-      throws IOException, WriteProcessException, MetadataException, MetadataException {
+  public void setUp() throws IOException, WriteProcessException, MetadataException {
     super.setUp();
     tempSGDir = new File(TestConstant.BASE_OUTPUT_PATH.concat("tempSG"));
     tempSGDir.mkdirs();


### PR DESCRIPTION
  Remove duplicated-throws,e.g.: `throws IoTDBConnectionException, BatchExecutionException, StatementExecutionException`
Remove `BatchExecutionException` due to there is a more general exception, 'org.apache.iotdb.rpc.StatementExecutionException', in the throws list already.

using `mvn spotless:check ` and `mvn spotless:apply` format code.