### PR TITLE
[To 0.11]fix merge delete cache bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -41,14 +41,16 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.ChunkMetadataCache;
-import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.TsFileManagement;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionLogAnalyzer;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionLogger;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
@@ -56,48 +58,51 @@ import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * The TsFileManagement for LEVEL_COMPACTION, use level struct to manage TsFile list
- */
+/** The TsFileManagement for LEVEL_COMPACTION, use level struct to manage TsFile list */
 public class LevelCompactionTsFileManagement extends TsFileManagement {
 
-  private static final Logger logger = LoggerFactory
-      .getLogger(LevelCompactionTsFileManagement.class);
+  private static final Logger logger =
+      LoggerFactory.getLogger(LevelCompactionTsFileManagement.class);
 
-  private final int seqLevelNum = Math
-      .max(IoTDBDescriptor.getInstance().getConfig().getSeqLevelNum(), 1);
-  private final int seqFileNumInEachLevel = Math
-      .max(IoTDBDescriptor.getInstance().getConfig().getSeqFileNumInEachLevel(), 1);
-  private final int unseqLevelNum = Math
-      .max(IoTDBDescriptor.getInstance().getConfig().getUnseqLevelNum(), 1);
-  private final int unseqFileNumInEachLevel = Math
-      .max(IoTDBDescriptor.getInstance().getConfig().getUnseqFileNumInEachLevel(), 1);
+  private final int seqLevelNum =
+      Math.max(IoTDBDescriptor.getInstance().getConfig().getSeqLevelNum(), 1);
+  private final int seqFileNumInEachLevel =
+      Math.max(IoTDBDescriptor.getInstance().getConfig().getSeqFileNumInEachLevel(), 1);
+  private final int unseqLevelNum =
+      Math.max(IoTDBDescriptor.getInstance().getConfig().getUnseqLevelNum(), 1);
+  private final int unseqFileNumInEachLevel =
+      Math.max(IoTDBDescriptor.getInstance().getConfig().getUnseqFileNumInEachLevel(), 1);
 
-  private final boolean enableUnseqCompaction = IoTDBDescriptor.getInstance().getConfig()
-      .isEnableUnseqCompaction();
-  private final boolean isForceFullMerge = IoTDBDescriptor.getInstance().getConfig()
-      .isForceFullMerge();
+  private final boolean enableUnseqCompaction =
+      IoTDBDescriptor.getInstance().getConfig().isEnableUnseqCompaction();
+  private final boolean isForceFullMerge =
+      IoTDBDescriptor.getInstance().getConfig().isForceFullMerge();
   // First map is partition list; Second list is level list; Third list is file list in level;
-  private final Map<Long, List<SortedSet<TsFileResource>>> sequenceTsFileResources = new ConcurrentSkipListMap<>();
-  private final Map<Long, List<List<TsFileResource>>> unSequenceTsFileResources = new ConcurrentSkipListMap<>();
+  private final Map<Long, List<SortedSet<TsFileResource>>> sequenceTsFileResources =
+      new ConcurrentSkipListMap<>();
+  private final Map<Long, List<List<TsFileResource>>> unSequenceTsFileResources =
+      new ConcurrentSkipListMap<>();
   private final List<List<TsFileResource>> forkedSequenceTsFileResources = new ArrayList<>();
   private final List<List<TsFileResource>> forkedUnSequenceTsFileResources = new ArrayList<>();
   private final List<TsFileResource> sequenceRecoverTsFileResources = new CopyOnWriteArrayList<>();
-  private final List<TsFileResource> unSequenceRecoverTsFileResources = new CopyOnWriteArrayList<>();
+  private final List<TsFileResource> unSequenceRecoverTsFileResources =
+      new CopyOnWriteArrayList<>();
 
   public LevelCompactionTsFileManagement(String storageGroupName, String storageGroupDir) {
     super(storageGroupName, storageGroupDir);
     clear();
   }
 
-  public void renameLevelFilesMods(Collection<Modification> filterModification,
+  public void renameLevelFilesMods(
+      Collection<Modification> filterModification,
       Collection<TsFileResource> mergeTsFiles,
-      TsFileResource targetTsFile) throws IOException {
+      TsFileResource targetTsFile)
+      throws IOException {
     logger.debug("{} [compaction] merge starts to rename real file's mod", storageGroupName);
     List<Modification> modifications = new ArrayList<>();
     for (TsFileResource mergeTsFile : mergeTsFiles) {
-      try (ModificationFile sourceModificationFile = new ModificationFile(
-          mergeTsFile.getTsFilePath() + ModificationFile.FILE_SUFFIX)) {
+      try (ModificationFile sourceModificationFile =
+          new ModificationFile(mergeTsFile.getTsFilePath() + ModificationFile.FILE_SUFFIX)) {
         modifications.addAll(sourceModificationFile.getModifications());
         if (sourceModificationFile.exists()) {
           sourceModificationFile.remove();
@@ -106,8 +111,8 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
     }
     modifications.removeAll(filterModification);
     if (!modifications.isEmpty()) {
-      try (ModificationFile modificationFile = new ModificationFile(
-          targetTsFile.getTsFilePath() + ModificationFile.FILE_SUFFIX)) {
+      try (ModificationFile modificationFile =
+          new ModificationFile(targetTsFile.getTsFilePath() + ModificationFile.FILE_SUFFIX)) {
         for (Modification modification : modifications) {
           modificationFile.write(modification);
         }
@@ -119,13 +124,13 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
     logger.debug("{} [compaction] merge starts to delete real file", storageGroupName);
     for (TsFileResource mergeTsFile : mergeTsFiles) {
       deleteLevelFile(mergeTsFile);
-      logger
-          .info("{} [Compaction] delete TsFile {}", storageGroupName, mergeTsFile.getTsFilePath());
+      logger.info(
+          "{} [Compaction] delete TsFile {}", storageGroupName, mergeTsFile.getTsFilePath());
     }
   }
 
-  private void deleteLevelFilesInList(long timePartitionId,
-      Collection<TsFileResource> mergeTsFiles, int level, boolean sequence) {
+  private void deleteLevelFilesInList(
+      long timePartitionId, Collection<TsFileResource> mergeTsFiles, int level, boolean sequence) {
     logger.debug("{} [compaction] merge starts to delete file list", storageGroupName);
     if (sequence) {
       if (sequenceTsFileResources.containsKey(timePartitionId)) {
@@ -149,7 +154,9 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
   private void deleteLevelFile(TsFileResource seqFile) {
     seqFile.writeLock();
     try {
+      ChunkCache.getInstance().clear();
       ChunkMetadataCache.getInstance().remove(seqFile);
+      TimeSeriesMetadataCache.getInstance().clear();
       FileReaderManager.getInstance().closeFileAndRemoveReader(seqFile.getTsFilePath());
       seqFile.setDeleted(true);
       seqFile.delete();
@@ -165,8 +172,8 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
     List<TsFileResource> result = new ArrayList<>();
     if (sequence) {
       synchronized (sequenceTsFileResources) {
-        for (List<SortedSet<TsFileResource>> sequenceTsFileList : sequenceTsFileResources
-            .values()) {
+        for (List<SortedSet<TsFileResource>> sequenceTsFileList :
+            sequenceTsFileResources.values()) {
           for (int i = sequenceTsFileList.size() - 1; i >= 0; i--) {
             result.addAll(sequenceTsFileList.get(i));
           }
@@ -193,15 +200,15 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
   public void remove(TsFileResource tsFileResource, boolean sequence) {
     if (sequence) {
       synchronized (sequenceTsFileResources) {
-        for (SortedSet<TsFileResource> sequenceTsFileResource : sequenceTsFileResources
-            .get(tsFileResource.getTimePartition())) {
+        for (SortedSet<TsFileResource> sequenceTsFileResource :
+            sequenceTsFileResources.get(tsFileResource.getTimePartition())) {
           sequenceTsFileResource.remove(tsFileResource);
         }
       }
     } else {
       synchronized (unSequenceTsFileResources) {
-        for (List<TsFileResource> unSequenceTsFileResource : unSequenceTsFileResources
-            .get(tsFileResource.getTimePartition())) {
+        for (List<TsFileResource> unSequenceTsFileResource :
+            unSequenceTsFileResources.get(tsFileResource.getTimePartition())) {
           unSequenceTsFileResource.remove(tsFileResource);
         }
       }
@@ -212,8 +219,8 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
   public void removeAll(List<TsFileResource> tsFileResourceList, boolean sequence) {
     if (sequence) {
       synchronized (sequenceTsFileResources) {
-        for (List<SortedSet<TsFileResource>> partitionSequenceTsFileResource : sequenceTsFileResources
-            .values()) {
+        for (List<SortedSet<TsFileResource>> partitionSequenceTsFileResource :
+            sequenceTsFileResources.values()) {
           for (SortedSet<TsFileResource> levelTsFileResource : partitionSequenceTsFileResource) {
             levelTsFileResource.removeAll(tsFileResourceList);
           }
@@ -221,8 +228,8 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
       }
     } else {
       synchronized (unSequenceTsFileResources) {
-        for (List<List<TsFileResource>> partitionUnSequenceTsFileResource : unSequenceTsFileResources
-            .values()) {
+        for (List<List<TsFileResource>> partitionUnSequenceTsFileResource :
+            unSequenceTsFileResources.values()) {
           for (List<TsFileResource> levelTsFileResource : partitionUnSequenceTsFileResource) {
             levelTsFileResource.removeAll(tsFileResourceList);
           }
@@ -240,7 +247,8 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
         if (level <= seqLevelNum - 1) {
           // current file has normal level
           sequenceTsFileResources
-              .computeIfAbsent(timePartitionId, this::newSequenceTsFileResources).get(level)
+              .computeIfAbsent(timePartitionId, this::newSequenceTsFileResources)
+              .get(level)
               .add(tsFileResource);
         } else {
           // current file has too high level
@@ -255,13 +263,15 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
         if (level <= unseqLevelNum - 1) {
           // current file has normal level
           unSequenceTsFileResources
-              .computeIfAbsent(timePartitionId, this::newUnSequenceTsFileResources).get(level)
+              .computeIfAbsent(timePartitionId, this::newUnSequenceTsFileResources)
+              .get(level)
               .add(tsFileResource);
         } else {
           // current file has too high level
           unSequenceTsFileResources
               .computeIfAbsent(timePartitionId, this::newUnSequenceTsFileResources)
-              .get(unseqLevelNum - 1).add(tsFileResource);
+              .get(unseqLevelNum - 1)
+              .add(tsFileResource);
         }
       }
     }
@@ -290,15 +300,17 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
   @Override
   public boolean contains(TsFileResource tsFileResource, boolean sequence) {
     if (sequence) {
-      for (SortedSet<TsFileResource> sequenceTsFileResource : sequenceTsFileResources
-          .computeIfAbsent(tsFileResource.getTimePartition(), this::newSequenceTsFileResources)) {
+      for (SortedSet<TsFileResource> sequenceTsFileResource :
+          sequenceTsFileResources.computeIfAbsent(
+              tsFileResource.getTimePartition(), this::newSequenceTsFileResources)) {
         if (sequenceTsFileResource.contains(tsFileResource)) {
           return true;
         }
       }
     } else {
-      for (List<TsFileResource> unSequenceTsFileResource : unSequenceTsFileResources
-          .computeIfAbsent(tsFileResource.getTimePartition(), this::newUnSequenceTsFileResources)) {
+      for (List<TsFileResource> unSequenceTsFileResource :
+          unSequenceTsFileResources.computeIfAbsent(
+              tsFileResource.getTimePartition(), this::newUnSequenceTsFileResources)) {
         if (unSequenceTsFileResource.contains(tsFileResource)) {
           return true;
         }
@@ -317,8 +329,8 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
   @SuppressWarnings("squid:S3776")
   public boolean isEmpty(boolean sequence) {
     if (sequence) {
-      for (List<SortedSet<TsFileResource>> partitionSequenceTsFileResource : sequenceTsFileResources
-          .values()) {
+      for (List<SortedSet<TsFileResource>> partitionSequenceTsFileResource :
+          sequenceTsFileResources.values()) {
         for (SortedSet<TsFileResource> sequenceTsFileResource : partitionSequenceTsFileResource) {
           if (!sequenceTsFileResource.isEmpty()) {
             return false;
@@ -326,8 +338,8 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
         }
       }
     } else {
-      for (List<List<TsFileResource>> partitionUnSequenceTsFileResource : unSequenceTsFileResources
-          .values()) {
+      for (List<List<TsFileResource>> partitionUnSequenceTsFileResource :
+          unSequenceTsFileResources.values()) {
         for (List<TsFileResource> unSequenceTsFileResource : partitionUnSequenceTsFileResource) {
           if (!unSequenceTsFileResource.isEmpty()) {
             return false;
@@ -342,15 +354,15 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
   public int size(boolean sequence) {
     int result = 0;
     if (sequence) {
-      for (List<SortedSet<TsFileResource>> partitionSequenceTsFileResource : sequenceTsFileResources
-          .values()) {
+      for (List<SortedSet<TsFileResource>> partitionSequenceTsFileResource :
+          sequenceTsFileResources.values()) {
         for (int i = seqLevelNum - 1; i >= 0; i--) {
           result += partitionSequenceTsFileResource.get(i).size();
         }
       }
     } else {
-      for (List<List<TsFileResource>> partitionUnSequenceTsFileResource : unSequenceTsFileResources
-          .values()) {
+      for (List<List<TsFileResource>> partitionUnSequenceTsFileResource :
+          unSequenceTsFileResources.values()) {
         for (int i = unseqLevelNum - 1; i >= 0; i--) {
           result += partitionUnSequenceTsFileResource.get(i).size();
         }
@@ -359,14 +371,13 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
     return result;
   }
 
-  /**
-   * recover files
-   */
+  /** recover files */
   @Override
   @SuppressWarnings("squid:S3776")
   public void recover() {
-    File logFile = FSFactoryProducer.getFSFactory()
-        .getFile(storageGroupDir, storageGroupName + COMPACTION_LOG_NAME);
+    File logFile =
+        FSFactoryProducer.getFSFactory()
+            .getFile(storageGroupDir, storageGroupName + COMPACTION_LOG_NAME);
     try {
       if (logFile.exists()) {
         CompactionLogAnalyzer logAnalyzer = new CompactionLogAnalyzer(logFile);
@@ -399,12 +410,17 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
               writer.getIOWriterOut().truncate(offset - 1);
             }
             writer.close();
-            CompactionLogger compactionLogger = new CompactionLogger(storageGroupDir,
-                storageGroupName);
+            CompactionLogger compactionLogger =
+                new CompactionLogger(storageGroupDir, storageGroupName);
             List<Modification> modifications = new ArrayList<>();
-            CompactionUtils
-                .merge(targetTsFileResource, getTsFileList(isSeq), storageGroupName,
-                    compactionLogger, deviceSet, isSeq, modifications);
+            CompactionUtils.merge(
+                targetTsFileResource,
+                getTsFileList(isSeq),
+                storageGroupName,
+                compactionLogger,
+                deviceSet,
+                isSeq,
+                modifications);
             compactionLogger.close();
           } else {
             writer.close();
@@ -428,13 +444,17 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
               writer.getIOWriterOut().truncate(offset - 1);
             }
             writer.close();
-            CompactionLogger compactionLogger = new CompactionLogger(storageGroupDir,
-                storageGroupName);
+            CompactionLogger compactionLogger =
+                new CompactionLogger(storageGroupDir, storageGroupName);
             List<Modification> modifications = new ArrayList<>();
-            CompactionUtils
-                .merge(targetResource, sourceTsFileResources, storageGroupName,
-                    compactionLogger, deviceSet,
-                    isSeq, modifications);
+            CompactionUtils.merge(
+                targetResource,
+                sourceTsFileResources,
+                storageGroupName,
+                compactionLogger,
+                deviceSet,
+                isSeq,
+                modifications);
             // complete compaction and delete source file
             writeLock();
             try {
@@ -473,18 +493,16 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
 
   private void deleteAllSubLevelFiles(boolean isSeq, long timePartition) {
     if (isSeq) {
-      for (int level = 0; level < sequenceTsFileResources.get(timePartition).size();
-          level++) {
-        SortedSet<TsFileResource> currLevelMergeFile = sequenceTsFileResources.get(timePartition)
-            .get(level);
+      for (int level = 0; level < sequenceTsFileResources.get(timePartition).size(); level++) {
+        SortedSet<TsFileResource> currLevelMergeFile =
+            sequenceTsFileResources.get(timePartition).get(level);
         deleteLevelFilesInDisk(currLevelMergeFile);
         deleteLevelFilesInList(timePartition, currLevelMergeFile, level, isSeq);
       }
     } else {
-      for (int level = 0; level < unSequenceTsFileResources.get(timePartition).size();
-          level++) {
-        SortedSet<TsFileResource> currLevelMergeFile = sequenceTsFileResources.get(timePartition)
-            .get(level);
+      for (int level = 0; level < unSequenceTsFileResources.get(timePartition).size(); level++) {
+        SortedSet<TsFileResource> currLevelMergeFile =
+            sequenceTsFileResources.get(timePartition).get(level);
         deleteLevelFilesInDisk(currLevelMergeFile);
         deleteLevelFilesInList(timePartition, currLevelMergeFile, level, isSeq);
       }
@@ -497,26 +515,30 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
       forkTsFileList(
           forkedSequenceTsFileResources,
           sequenceTsFileResources.computeIfAbsent(timePartition, this::newSequenceTsFileResources),
-          seqLevelNum, seqFileNumInEachLevel);
+          seqLevelNum,
+          seqFileNumInEachLevel);
     }
     // we have to copy all unseq file
     synchronized (unSequenceTsFileResources) {
       forkTsFileList(
           forkedUnSequenceTsFileResources,
-          unSequenceTsFileResources
-              .computeIfAbsent(timePartition, this::newUnSequenceTsFileResources),
-          unseqLevelNum + 1, unseqFileNumInEachLevel);
+          unSequenceTsFileResources.computeIfAbsent(
+              timePartition, this::newUnSequenceTsFileResources),
+          unseqLevelNum + 1,
+          unseqFileNumInEachLevel);
     }
   }
 
   private void forkTsFileList(
       List<List<TsFileResource>> forkedTsFileResources,
-      List rawTsFileResources, int currMaxLevel, int currFileNumInEachLevel) {
+      List rawTsFileResources,
+      int currMaxLevel,
+      int currFileNumInEachLevel) {
     forkedTsFileResources.clear();
     for (int i = 0; i < currMaxLevel - 1; i++) {
       List<TsFileResource> forkedLevelTsFileResources = new ArrayList<>();
-      Collection<TsFileResource> levelRawTsFileResources = (Collection<TsFileResource>) rawTsFileResources
-          .get(i);
+      Collection<TsFileResource> levelRawTsFileResources =
+          (Collection<TsFileResource>) rawTsFileResources.get(i);
       for (TsFileResource tsFileResource : levelRawTsFileResources) {
         if (tsFileResource.isClosed()) {
           forkedLevelTsFileResources.add(tsFileResource);
@@ -531,20 +553,30 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
 
   @Override
   protected void merge(long timePartition) {
-    merge(forkedSequenceTsFileResources, true, timePartition, seqLevelNum,
-        seqFileNumInEachLevel);
+    merge(forkedSequenceTsFileResources, true, timePartition, seqLevelNum, seqFileNumInEachLevel);
     if (enableUnseqCompaction && unseqLevelNum <= 1 && forkedUnSequenceTsFileResources.size() > 0) {
-      merge(isForceFullMerge, getTsFileList(true), forkedUnSequenceTsFileResources.get(0),
+      merge(
+          isForceFullMerge,
+          getTsFileList(true),
+          forkedUnSequenceTsFileResources.get(0),
           Long.MAX_VALUE);
     } else {
-      merge(forkedUnSequenceTsFileResources, false, timePartition, unseqLevelNum,
+      merge(
+          forkedUnSequenceTsFileResources,
+          false,
+          timePartition,
+          unseqLevelNum,
           unseqFileNumInEachLevel);
     }
   }
 
   @SuppressWarnings("squid:S3776")
-  private void merge(List<List<TsFileResource>> mergeResources, boolean sequence,
-      long timePartition, int currMaxLevel, int currMaxFileNumInEachLevel) {
+  private void merge(
+      List<List<TsFileResource>> mergeResources,
+      boolean sequence,
+      long timePartition,
+      int currMaxLevel,
+      int currMaxFileNumInEachLevel) {
     // wait until unseq merge has finished
     while (isUnseqMerging) {
       try {
@@ -563,37 +595,48 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
         if (currMaxFileNumInEachLevel <= mergeResources.get(i).size()) {
           // level is numbered from 0
           if (enableUnseqCompaction && !sequence && i == currMaxLevel - 2) {
-            // do not merge current unseq file level to upper level and just merge all of them to seq file
+            // do not merge current unseq file level to upper level and just merge all of them to
+            // seq file
             isSeqMerging = false;
             merge(isForceFullMerge, getTsFileList(true), mergeResources.get(i), Long.MAX_VALUE);
           } else {
-            CompactionLogger compactionLogger = new CompactionLogger(storageGroupDir,
-                storageGroupName);
+            CompactionLogger compactionLogger =
+                new CompactionLogger(storageGroupDir, storageGroupName);
             // log source file list and target file for recover
             for (TsFileResource mergeResource : mergeResources.get(i)) {
               compactionLogger.logFile(SOURCE_NAME, mergeResource.getTsFile());
             }
-            File newLevelFile = createNewTsFileName(mergeResources.get(i).get(0).getTsFile(),
-                i + 1);
+            File newLevelFile =
+                createNewTsFileName(mergeResources.get(i).get(0).getTsFile(), i + 1);
             compactionLogger.logSequence(sequence);
             compactionLogger.logFile(TARGET_NAME, newLevelFile);
             List<TsFileResource> toMergeTsFiles = mergeResources.get(i);
-            logger.info("{} [Compaction] merge level-{}'s {} TsFiles to next level",
-                storageGroupName, i, toMergeTsFiles.size());
+            logger.info(
+                "{} [Compaction] merge level-{}'s {} TsFiles to next level",
+                storageGroupName,
+                i,
+                toMergeTsFiles.size());
             for (TsFileResource toMergeTsFile : toMergeTsFiles) {
-              logger.info("{} [Compaction] start to merge TsFile {}", storageGroupName,
-                  toMergeTsFile);
+              logger.info(
+                  "{} [Compaction] start to merge TsFile {}", storageGroupName, toMergeTsFile);
             }
 
             TsFileResource newResource = new TsFileResource(newLevelFile);
             List<Modification> modifications = new ArrayList<>();
             // merge, read from source files and write to target file
-            CompactionUtils
-                .merge(newResource, toMergeTsFiles, storageGroupName, compactionLogger,
-                    new HashSet<>(), sequence, modifications);
+            CompactionUtils.merge(
+                newResource,
+                toMergeTsFiles,
+                storageGroupName,
+                compactionLogger,
+                new HashSet<>(),
+                sequence,
+                modifications);
             logger.info(
                 "{} [Compaction] merged level-{}'s {} TsFiles to next level, and start to delete old files",
-                storageGroupName, i, toMergeTsFiles.size());
+                storageGroupName,
+                i,
+                toMergeTsFiles.size());
             writeLock();
             try {
               if (sequence) {
@@ -611,8 +654,9 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
             deleteLevelFilesInDisk(toMergeTsFiles);
             renameLevelFilesMods(modifications, toMergeTsFiles, newResource);
             compactionLogger.close();
-            File logFile = FSFactoryProducer.getFSFactory()
-                .getFile(storageGroupDir, storageGroupName + COMPACTION_LOG_NAME);
+            File logFile =
+                FSFactoryProducer.getFSFactory()
+                    .getFile(storageGroupDir, storageGroupName + COMPACTION_LOG_NAME);
             if (logFile.exists()) {
               Files.delete(logFile.toPath());
             }
@@ -624,15 +668,15 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
     } finally {
       isSeqMerging = false;
       // reset the merge working state to false
-      logger.info("{} [Compaction] merge end time isSeq = {}, consumption: {} ms",
-          storageGroupName, sequence,
+      logger.info(
+          "{} [Compaction] merge end time isSeq = {}, consumption: {} ms",
+          storageGroupName,
+          sequence,
           System.currentTimeMillis() - startTimeMillis);
     }
   }
 
-  /**
-   * if level < maxLevel-1, the file need compaction else, the file can be merged later
-   */
+  /** if level < maxLevel-1, the file need compaction else, the file can be merged later */
   private File createNewTsFileName(File sourceFile, int level) {
     String path = sourceFile.getPath();
     String prefixPath = path.substring(0, path.lastIndexOf(FILE_NAME_SEPARATOR) + 1);
@@ -642,18 +686,22 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
   private List<SortedSet<TsFileResource>> newSequenceTsFileResources(Long k) {
     List<SortedSet<TsFileResource>> newSequenceTsFileResources = new CopyOnWriteArrayList<>();
     for (int i = 0; i < seqLevelNum; i++) {
-      newSequenceTsFileResources.add(Collections.synchronizedSortedSet(new TreeSet<>(
-          (o1, o2) -> {
-            try {
-              int rangeCompare = Long
-                  .compare(Long.parseLong(o1.getTsFile().getParentFile().getName()),
-                      Long.parseLong(o2.getTsFile().getParentFile().getName()));
-              return rangeCompare == 0 ? compareFileName(o1.getTsFile(), o2.getTsFile())
-                  : rangeCompare;
-            } catch (NumberFormatException e) {
-              return compareFileName(o1.getTsFile(), o2.getTsFile());
-            }
-          })));
+      newSequenceTsFileResources.add(
+          Collections.synchronizedSortedSet(
+              new TreeSet<>(
+                  (o1, o2) -> {
+                    try {
+                      int rangeCompare =
+                          Long.compare(
+                              Long.parseLong(o1.getTsFile().getParentFile().getName()),
+                              Long.parseLong(o2.getTsFile().getParentFile().getName()));
+                      return rangeCompare == 0
+                          ? compareFileName(o1.getTsFile(), o2.getTsFile())
+                          : rangeCompare;
+                    } catch (NumberFormatException e) {
+                      return compareFileName(o1.getTsFile(), o2.getTsFile());
+                    }
+                  })));
     }
     return newSequenceTsFileResources;
   }
@@ -667,9 +715,10 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
   }
 
   public static int getMergeLevel(File file) {
-    String mergeLevelStr = file.getPath()
-        .substring(file.getPath().lastIndexOf(FILE_NAME_SEPARATOR) + 1)
-        .replaceAll(TSFILE_SUFFIX, "");
+    String mergeLevelStr =
+        file.getPath()
+            .substring(file.getPath().lastIndexOf(FILE_NAME_SEPARATOR) + 1)
+            .replaceAll(TSFILE_SUFFIX, "");
     return Integer.parseInt(mergeLevelStr);
   }
 
@@ -694,24 +743,24 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
 
   private TsFileResource getTsFileResource(String filePath, boolean isSeq) throws IOException {
     if (isSeq) {
-      for (List<SortedSet<TsFileResource>> tsFileResourcesWithLevel : sequenceTsFileResources
-          .values()) {
+      for (List<SortedSet<TsFileResource>> tsFileResourcesWithLevel :
+          sequenceTsFileResources.values()) {
         for (SortedSet<TsFileResource> tsFileResources : tsFileResourcesWithLevel) {
           for (TsFileResource tsFileResource : tsFileResources) {
-            if (Files
-                .isSameFile(tsFileResource.getTsFile().toPath(), new File(filePath).toPath())) {
+            if (Files.isSameFile(
+                tsFileResource.getTsFile().toPath(), new File(filePath).toPath())) {
               return tsFileResource;
             }
           }
         }
       }
     } else {
-      for (List<List<TsFileResource>> tsFileResourcesWithLevel : unSequenceTsFileResources
-          .values()) {
+      for (List<List<TsFileResource>> tsFileResourcesWithLevel :
+          unSequenceTsFileResources.values()) {
         for (List<TsFileResource> tsFileResources : tsFileResourcesWithLevel) {
           for (TsFileResource tsFileResource : tsFileResources) {
-            if (Files
-                .isSameFile(tsFileResource.getTsFile().toPath(), new File(filePath).toPath())) {
+            if (Files.isSameFile(
+                tsFileResource.getTsFile().toPath(), new File(filePath).toPath())) {
               return tsFileResource;
             }
           }


### PR DESCRIPTION
After compaction, we need to delete a file. However, the chunk cache and timeseriesMetadata cache is also active which may be queried. So we have to clear it after the deletion of a file.