### PR TITLE
filter slots for snapshots

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/FilePartitionedSnapshotLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/FilePartitionedSnapshotLogManager.java
@@ -117,11 +117,23 @@ public class FilePartitionedSnapshotLogManager extends PartitionedSnapshotLogMan
     collectTsFiles();
 
     // 2.register the measurement
+    boolean slotExistsInPartition;
+    List<Integer> slots = null;
+    if (dataGroupMember.getMetaGroupMember() != null) {
+      slots =
+          ((SlotPartitionTable) dataGroupMember.getMetaGroupMember().getPartitionTable())
+              .getNodeSlots(dataGroupMember.getHeader());
+    }
+
     for (Map.Entry<Integer, Collection<TimeseriesSchema>> entry : slotTimeseries.entrySet()) {
       int slotNum = entry.getKey();
-      FileSnapshot snapshot = slotSnapshots.computeIfAbsent(slotNum, s -> new FileSnapshot());
-      if (snapshot.getTimeseriesSchemas().isEmpty()) {
-        snapshot.setTimeseriesSchemas(entry.getValue());
+      slotExistsInPartition = slots == null || slots.contains(slotNum);
+
+      if (slotExistsInPartition) {
+        FileSnapshot snapshot = slotSnapshots.computeIfAbsent(slotNum, s -> new FileSnapshot());
+        if (snapshot.getTimeseriesSchemas().isEmpty()) {
+          snapshot.setTimeseriesSchemas(entry.getValue());
+        }
       }
     }
   }


### PR DESCRIPTION
currently we generate snapshot for slots in all storage groups. 
this pr fixes it and generates timeseries schema snapshot for slots in current data group member only