### PR TITLE
[IOTDB-1159] set storage group exception message more clear

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/exception/metadata/StorageGroupAlreadySetException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/metadata/StorageGroupAlreadySetException.java
@@ -26,16 +26,13 @@ public class StorageGroupAlreadySetException extends MetadataException {
   private static final long serialVersionUID = 9110669164701929779L;
 
   public StorageGroupAlreadySetException(String path) {
-    super(
-        getMessage(path, false),
-        TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode());
+    super(getMessage(path, false), TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode());
   }
 
   public StorageGroupAlreadySetException(String path, boolean hasChild) {
-    super(getMessage(path, hasChild), 
-      TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode());
+    super(getMessage(path, hasChild), TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode());
   }
-  
+
   private static String getMessage(String path, boolean hasChild) {
     if (hasChild) {
       return String.format("some children of %s have already been set to storage group", path);

--- a/server/src/main/java/org/apache/iotdb/db/exception/metadata/StorageGroupAlreadySetException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/metadata/StorageGroupAlreadySetException.java
@@ -27,7 +27,20 @@ public class StorageGroupAlreadySetException extends MetadataException {
 
   public StorageGroupAlreadySetException(String path) {
     super(
-        String.format("%s has already been set to storage group", path),
+        getMessage(path, false),
         TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode());
+  }
+
+  public StorageGroupAlreadySetException(String path, boolean hasChild) {
+    super(getMessage(path, hasChild), 
+      TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode());
+  }
+  
+  private static String getMessage(String path, boolean hasChild) {
+    if (hasChild) {
+      return String.format("some children of %s have already been set to storage group", path);
+    } else {
+      return String.format("%s has already been set to storage group", path);
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -364,7 +364,11 @@ public class MTree implements Serializable {
     }
     if (cur.hasChild(nodeNames[i])) {
       // node b has child sg
-      throw new StorageGroupAlreadySetException(path.getFullPath(), true);
+      if (cur.getChild(nodeNames[i]) instanceof StorageGroupMNode) {
+        throw new StorageGroupAlreadySetException(path.getFullPath());
+      } else {
+        throw new StorageGroupAlreadySetException(path.getFullPath(), true);
+      }
     } else {
       StorageGroupMNode storageGroupMNode =
           new StorageGroupMNode(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -364,7 +364,7 @@ public class MTree implements Serializable {
     }
     if (cur.hasChild(nodeNames[i])) {
       // node b has child sg
-      throw new StorageGroupAlreadySetException(path.getFullPath());
+      throw new StorageGroupAlreadySetException(path.getFullPath(), true);
     } else {
       StorageGroupMNode storageGroupMNode =
           new StorageGroupMNode(

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -81,7 +81,8 @@ public class MManagerBasicTest {
     try {
       manager.setStorageGroup(new PartialPath("root.laptop"));
     } catch (MetadataException e) {
-      Assert.assertEquals("root.laptop has already been set to storage group", e.getMessage());
+      Assert.assertEquals(
+          "some children of root.laptop have already been set to storage group", e.getMessage());
     }
 
     try {

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -53,6 +53,25 @@ public class MTreeTest {
   public void tearDown() throws Exception {
     EnvironmentUtils.cleanEnv();
   }
+  
+  @Test
+  public void testSetStorageGroupExceptionMessage() throws IllegalPathException {
+    MTree root = new MTree();
+    try {
+      root.setStorageGroup(new PartialPath("root.edge1.access"));
+      root.setStorageGroup(new PartialPath("root.edge1"));
+      fail("Expected exception");
+    } catch (MetadataException e) {
+      assertEquals("some children of root.edge1 have already been set to storage group", e.getMessage());
+    }
+    try {
+      root.setStorageGroup(new PartialPath("root.edge2"));
+      root.setStorageGroup(new PartialPath("root.edge2.access"));
+      fail("Expected exception");
+    } catch (MetadataException e) {
+      assertEquals("root.edge2 has already been set to storage group", e.getMessage());
+    }
+  }
 
   @Test
   public void testAddLeftNodePathWithAlias() throws MetadataException {

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -72,6 +72,12 @@ public class MTreeTest {
     } catch (MetadataException e) {
       assertEquals("root.edge2 has already been set to storage group", e.getMessage());
     }
+    try {
+      root.setStorageGroup(new PartialPath("root.edge1.access"));
+      fail("Expected exception");
+    } catch (MetadataException e) {
+      assertEquals("root.edge1.access has already been set to storage group", e.getMessage());
+    }
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -53,7 +53,7 @@ public class MTreeTest {
   public void tearDown() throws Exception {
     EnvironmentUtils.cleanEnv();
   }
-  
+
   @Test
   public void testSetStorageGroupExceptionMessage() throws IllegalPathException {
     MTree root = new MTree();
@@ -62,7 +62,8 @@ public class MTreeTest {
       root.setStorageGroup(new PartialPath("root.edge1"));
       fail("Expected exception");
     } catch (MetadataException e) {
-      assertEquals("some children of root.edge1 have already been set to storage group", e.getMessage());
+      assertEquals(
+          "some children of root.edge1 have already been set to storage group", e.getMessage());
     }
     try {
       root.setStorageGroup(new PartialPath("root.edge2"));

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -419,7 +419,8 @@ public class MTreeTest {
     try {
       root.setStorageGroup(new PartialPath("root.laptop"));
     } catch (MetadataException e) {
-      Assert.assertEquals("root.laptop has already been set to storage group", e.getMessage());
+      Assert.assertEquals(
+          "some children of root.laptop have already been set to storage group", e.getMessage());
     }
     // check timeseries
     assertFalse(root.isPathExist(new PartialPath("root.laptop.d1.s0")));


### PR DESCRIPTION
## Description
Require more clear error message for deleting and creating storage group
https://issues.apache.org/jira/browse/IOTDB-1159?jql=project%20%3D%20IOTDB%20AND%20issuetype%20%3D%20Bug%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC

