### PR TITLE
[ISSUE-2493] show child nodes path

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
@@ -77,6 +77,7 @@ statement
     | SHOW LATEST? TIMESERIES prefixPath? showWhereClause? limitClause? #showTimeseries
     | SHOW STORAGE GROUP prefixPath? #showStorageGroup
     | SHOW CHILD PATHS prefixPath? #showChildPaths
+    | SHOW CHILD NODES prefixPath? #showChildNodes
     | SHOW DEVICES prefixPath? (WITH STORAGE GROUP)? limitClause? #showDevices
     | SHOW MERGE #showMergeStatus
     | SHOW QUERY PROCESSLIST #showQueryProcesslist

--- a/docs/UserGuide/Operation Manual/DDL Data Definition Language.md
+++ b/docs/UserGuide/Operation Manual/DDL Data Definition Language.md
@@ -264,6 +264,59 @@ It costs 0.002s
 
 > get all paths in form of root.xx.xx.xx：show child paths root.xx.xx
 
+## Show Child Nodes
+
+```
+SHOW CHILD NODES prefixPath
+```
+
+Return all child nodes of the prefixPath.
+
+Example：
+* The timeseries used in the demonstration
+
+```
++------------------+-----+-------------+--------+--------+-----------+----+----------+
+|        timeseries|alias|storage group|dataType|encoding|compression|tags|attributes|
++------------------+-----+-------------+--------+--------+-----------+----+----------+
+|root.vehicle.d1.s1| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
+|root.vehicle.d1.s2| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
+|root.vehicle.d2.s1| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
++------------------+-----+-------------+--------+--------+-----------+----+----------+
+```
+
+* return the child nodes of root：show child paths root
+
+```
++------------+
+| child paths|
++------------+
+|root.vehicle|
++------------+
+```
+
+* return the child nodes of root.vehicle：show child paths root.vehicle
+
+```
++-----------+
+|child nodes|
++-----------+
+|         d1|
+|         d2|
++-----------+
+```
+
+* return the child nodes of root.vehicle.d1：show child nodes root.vehicle.d1
+
+```
++-----------+
+|child nodes|
++-----------+
+|         s1|
+|         s2|
++-----------+
+```
+
 ## Count Timeseries
 
 IoTDB is able to use `COUNT TIMESERIES <Path>` to count the number of timeseries in the path. SQL statements are as follows:

--- a/docs/UserGuide/Operation Manual/DDL Data Definition Language.md
+++ b/docs/UserGuide/Operation Manual/DDL Data Definition Language.md
@@ -273,48 +273,26 @@ SHOW CHILD NODES prefixPath
 Return all child nodes of the prefixPath.
 
 Example：
-* The timeseries used in the demonstration
-
-```
-+------------------+-----+-------------+--------+--------+-----------+----+----------+
-|        timeseries|alias|storage group|dataType|encoding|compression|tags|attributes|
-+------------------+-----+-------------+--------+--------+-----------+----+----------+
-|root.vehicle.d1.s1| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
-|root.vehicle.d1.s2| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
-|root.vehicle.d2.s1| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
-+------------------+-----+-------------+--------+--------+-----------+----+----------+
-```
 
 * return the child nodes of root：show child paths root
 
 ```
 +------------+
-| child paths|
+| child nodes|
 +------------+
-|root.vehicle|
+|          ln|
 +------------+
 ```
 
-* return the child nodes of root.vehicle：show child paths root.vehicle
+* return the child nodes of root.vehicle：show child paths root.ln
 
 ```
-+-----------+
-|child nodes|
-+-----------+
-|         d1|
-|         d2|
-+-----------+
-```
-
-* return the child nodes of root.vehicle.d1：show child nodes root.vehicle.d1
-
-```
-+-----------+
-|child nodes|
-+-----------+
-|         s1|
-|         s2|
-+-----------+
++------------+
+| child nodes|
++------------+
+|        wf01|
+|        wf02|
++------------+
 ```
 
 ## Count Timeseries

--- a/docs/zh/UserGuide/Operation Manual/DDL Data Definition Language.md
+++ b/docs/zh/UserGuide/Operation Manual/DDL Data Definition Language.md
@@ -271,6 +271,59 @@ SHOW CHILD PATHS prefixPath
 +---------------+
 ```
 
+## 查看子节点
+
+```
+SHOW CHILD NODES prefixPath
+```
+
+可以查看此前缀路径的下一层的所有节点。
+
+示例：
+* 演示所用序列
+
+```
++------------------+-----+-------------+--------+--------+-----------+----+----------+
+|        timeseries|alias|storage group|dataType|encoding|compression|tags|attributes|
++------------------+-----+-------------+--------+--------+-----------+----+----------+
+|root.vehicle.d1.s1| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
+|root.vehicle.d1.s2| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
+|root.vehicle.d2.s1| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
++------------------+-----+-------------+--------+--------+-----------+----+----------+
+```
+
+* 查询 root 的下一层：show child paths root
+
+```
++------------+
+| child paths|
++------------+
+|root.vehicle|
++------------+
+```
+
+* 查询 root.vehicle的下一层 ：show child paths root.vehicle
+
+```
++-----------+
+|child nodes|
++-----------+
+|         d1|
+|         d2|
++-----------+
+```
+
+* 查询 root.vehicl.d1的下一层 ：show child nodes root.vehicle.d1
+
+```
++-----------+
+|child nodes|
++-----------+
+|         s1|
+|         s2|
++-----------+
+```
+
 ## 统计时间序列总数
 
 IoTDB支持使用`COUNT TIMESERIES<Path>`来统计一条路径中的时间序列个数。SQL语句如下所示：

--- a/docs/zh/UserGuide/Operation Manual/DDL Data Definition Language.md
+++ b/docs/zh/UserGuide/Operation Manual/DDL Data Definition Language.md
@@ -280,48 +280,26 @@ SHOW CHILD NODES prefixPath
 可以查看此前缀路径的下一层的所有节点。
 
 示例：
-* 演示所用序列
-
-```
-+------------------+-----+-------------+--------+--------+-----------+----+----------+
-|        timeseries|alias|storage group|dataType|encoding|compression|tags|attributes|
-+------------------+-----+-------------+--------+--------+-----------+----+----------+
-|root.vehicle.d1.s1| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
-|root.vehicle.d1.s2| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
-|root.vehicle.d2.s1| null| root.vehicle| BOOLEAN|   PLAIN|     SNAPPY|null|      null|
-+------------------+-----+-------------+--------+--------+-----------+----+----------+
-```
 
 * 查询 root 的下一层：show child paths root
 
 ```
 +------------+
-| child paths|
+| child nodes|
 +------------+
-|root.vehicle|
+|          ln|
 +------------+
 ```
 
-* 查询 root.vehicle的下一层 ：show child paths root.vehicle
+* 查询 root.vehicle的下一层 ：show child paths root.ln
 
 ```
-+-----------+
-|child nodes|
-+-----------+
-|         d1|
-|         d2|
-+-----------+
-```
-
-* 查询 root.vehicl.d1的下一层 ：show child nodes root.vehicle.d1
-
-```
-+-----------+
-|child nodes|
-+-----------+
-|         s1|
-|         s2|
-+-----------+
++------------+
+| child nodes|
++------------+
+|        wf01|
+|        wf02|
++------------+
 ```
 
 ## 统计时间序列总数

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -68,6 +68,7 @@ public class IoTDBConstant {
   public static final String COLUMN_TIMESERIES_ENCODING = "encoding";
   public static final String COLUMN_TIMESERIES_COMPRESSION = "compression";
   public static final String COLUMN_CHILD_PATHS = "child paths";
+  public static final String COLUMN_CHILD_NODES = "child nodes";
   public static final String COLUMN_DEVICES = "devices";
   public static final String COLUMN_COLUMN = "column";
   public static final String COLUMN_COUNT = "count";

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1018,6 +1018,18 @@ public class MManager {
   }
 
   /**
+   * Get child node in the next level of the given path.
+   *
+   * <p>e.g., MTree has [root.sg1.d1.s1, root.sg1.d1.s2, root.sg1.d2.s1] given path = root.sg1,
+   * return [d1, d2] given path = root.sg.d1 return [s1,s2]
+   *
+   * @return All child nodes of given seriesPath.
+   */
+  public Set<String> getChildNodeInNextLevel(PartialPath path) throws MetadataException {
+    return mtree.getChildNodeInNextLevel(path);
+  }
+
+  /**
    * Check whether the path exists.
    *
    * @param path a full path or a prefix path

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1011,6 +1011,7 @@ public class MManager {
    * <p>e.g., MTree has [root.sg1.d1.s1, root.sg1.d1.s2, root.sg1.d2.s1] given path = root.sg1,
    * return [root.sg1.d1, root.sg1.d2]
    *
+   * @param path The given path
    * @return All child nodes' seriesPath(s) of given seriesPath.
    */
   public Set<String> getChildNodePathInNextLevel(PartialPath path) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -1109,6 +1109,7 @@ public class MTree implements Serializable {
    * <p>e.g., MTree has [root.sg1.d1.s1, root.sg1.d1.s2, root.sg1.d2.s1] given path = root.sg1,
    * return [root.sg1.d1, root.sg1.d2]
    *
+   * @param path The given path
    * @return All child nodes' seriesPath(s) of given seriesPath.
    */
   Set<String> getChildNodePathInNextLevel(PartialPath path) throws MetadataException {
@@ -1179,6 +1180,7 @@ public class MTree implements Serializable {
    * <p>e.g., MTree has [root.sg1.d1.s1, root.sg1.d1.s2, root.sg1.d2.s1] given path = root.sg1.d1
    * return [s1, s2]
    *
+   * @param partial Path
    * @return All child nodes' seriesPath(s) of given seriesPath.
    */
   Set<String> getChildNodeInNextLevel(PartialPath path) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -1171,6 +1171,76 @@ public class MTree implements Serializable {
   }
 
   /**
+   * Get child node in the next level of the given path.
+   *
+   * <p>e.g., MTree has [root.sg1.d1.s1, root.sg1.d1.s2, root.sg1.d2.s1] given path = root.sg1,
+   * return [d1, d2]
+   *
+   * <p>e.g., MTree has [root.sg1.d1.s1, root.sg1.d1.s2, root.sg1.d2.s1] given path = root.sg1.d1
+   * return [s1, s2]
+   *
+   * @return All child nodes' seriesPath(s) of given seriesPath.
+   */
+  Set<String> getChildNodeInNextLevel(PartialPath path) throws MetadataException {
+    String[] nodes = path.getNodes();
+    if (nodes.length == 0 || !nodes[0].equals(root.getName())) {
+      throw new IllegalPathException(path.getFullPath());
+    }
+    Set<String> childNodes = new TreeSet<>();
+    findChildNodeInNextLevel(root, nodes, 1, "", childNodes, nodes.length + 1);
+    return childNodes;
+  }
+
+  /**
+   * Traverse the MTree to match all child node path in next level
+   *
+   * @param node the current traversing node
+   * @param nodes split the prefix path with '.'
+   * @param idx the current index of array nodes
+   * @param parent store the node string having traversed
+   * @param res store all matched device names
+   * @param length expected length of path
+   */
+  @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
+  private void findChildNodeInNextLevel(
+      MNode node, String[] nodes, int idx, String parent, Set<String> res, int length) {
+    if (node == null) {
+      return;
+    }
+    String nodeReg = MetaUtils.getNodeRegByIdx(idx, nodes);
+    if (!nodeReg.contains(PATH_WILDCARD)) {
+      if (idx == length) {
+        res.add(node.getName());
+      } else {
+        findChildNodeInNextLevel(
+            node.getChild(nodeReg),
+            nodes,
+            idx + 1,
+            parent + node.getName() + PATH_SEPARATOR,
+            res,
+            length);
+      }
+    } else {
+      if (node.getChildren().size() > 0) {
+        for (MNode child : node.getChildren().values()) {
+          if (!Pattern.matches(nodeReg.replace("*", ".*"), child.getName())) {
+            continue;
+          }
+          if (idx == length) {
+            res.add(node.getName());
+          } else {
+            findChildNodeInNextLevel(
+                child, nodes, idx + 1, parent + node.getName() + PATH_SEPARATOR, res, length);
+          }
+        }
+      } else if (idx == length) {
+        String nodeName = node.getName();
+        res.add(nodeName);
+      }
+    }
+  }
+
+  /**
    * Get all devices under give path
    *
    * @return a list contains all distinct devices names

--- a/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
@@ -170,6 +170,8 @@ public class SQLConstant {
   public static final int TOK_QUERY_PROCESSLIST = 97;
   public static final int TOK_KILL_QUERY = 98;
 
+  public static final int TOK_CHILD_NODES = 99;
+
   public static final Map<Integer, String> tokenSymbol = new HashMap<>();
   public static final Map<Integer, String> tokenNames = new HashMap<>();
   public static final Map<Integer, Integer> reverseWords = new HashMap<>();

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -90,6 +90,7 @@ import org.apache.iotdb.db.qp.physical.sys.MergePlan;
 import org.apache.iotdb.db.qp.physical.sys.OperateFilePlan;
 import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
 import org.apache.iotdb.db.qp.physical.sys.SetTTLPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowChildNodesPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowChildPathsPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowDevicesPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowFunctionsPlan;
@@ -147,6 +148,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_CANCELLED;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_CHILD_NODES;
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_CHILD_PATHS;
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_COLUMN;
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_COUNT;
@@ -481,6 +483,8 @@ public class PlanExecutor implements IPlanExecutor {
         return processShowDevices((ShowDevicesPlan) showPlan);
       case CHILD_PATH:
         return processShowChildPaths((ShowChildPathsPlan) showPlan);
+      case CHILD_NODE:
+        return processShowChildNodes((ShowChildNodesPlan) showPlan);
       case COUNT_TIMESERIES:
         return processCountTimeSeries((CountPlan) showPlan);
       case COUNT_NODE_TIMESERIES:
@@ -629,6 +633,28 @@ public class PlanExecutor implements IPlanExecutor {
 
   protected Set<String> getPathNextChildren(PartialPath path) throws MetadataException {
     return IoTDB.metaManager.getChildNodePathInNextLevel(path);
+  }
+
+  private QueryDataSet processShowChildNodes(ShowChildNodesPlan showChildNodesPlan)
+      throws MetadataException {
+    // getNodeNextChildren
+    Set<String> childNodesList = getNodeNextChildren(showChildNodesPlan.getPath());
+    ListDataSet listDataSet =
+        new ListDataSet(
+            Collections.singletonList(new PartialPath(COLUMN_CHILD_NODES, false)),
+            Collections.singletonList(TSDataType.TEXT));
+    for (String s : childNodesList) {
+      RowRecord record = new RowRecord(0);
+      Field field = new Field(TSDataType.TEXT);
+      field.setBinaryV(new Binary(s));
+      record.addField(field);
+      listDataSet.putRecord(record);
+    }
+    return listDataSet;
+  }
+
+  protected Set<String> getNodeNextChildren(PartialPath path) throws MetadataException {
+    return IoTDB.metaManager.getChildNodeInNextLevel(path);
   }
 
   protected List<PartialPath> getStorageGroupNames(PartialPath path) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/ShowChildNodesOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/ShowChildNodesOperator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.iotdb.db.qp.logical.sys;
+
+import org.apache.iotdb.db.metadata.PartialPath;
+
+public class ShowChildNodesOperator extends ShowOperator {
+
+  private PartialPath path;
+
+  public ShowChildNodesOperator(int tokenIntType, PartialPath path) {
+    super(tokenIntType);
+    this.path = path;
+  }
+
+  public PartialPath getPath() {
+    return path;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowChildNodesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowChildNodesPlan.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.iotdb.db.qp.physical.sys;
+
+import org.apache.iotdb.db.metadata.PartialPath;
+
+public class ShowChildNodesPlan extends ShowPlan {
+
+  // the path could be a prefix path with wildcard
+  private PartialPath prefixPath;
+
+  public ShowChildNodesPlan(ShowContentType showContentType, PartialPath prefixPath) {
+    super(showContentType);
+    this.prefixPath = prefixPath;
+    canBeSplit = false;
+  }
+
+  @Override
+  public PartialPath getPath() {
+    return this.prefixPath;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowPlan.java
@@ -107,6 +107,7 @@ public class ShowPlan extends PhysicalPlan {
     TIMESERIES,
     STORAGE_GROUP,
     CHILD_PATH,
+    CHILD_NODE,
     DEVICES,
     COUNT_TIMESERIES,
     COUNT_NODE_TIMESERIES,

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -61,6 +61,7 @@ import org.apache.iotdb.db.qp.logical.sys.MoveFileOperator;
 import org.apache.iotdb.db.qp.logical.sys.RemoveFileOperator;
 import org.apache.iotdb.db.qp.logical.sys.SetStorageGroupOperator;
 import org.apache.iotdb.db.qp.logical.sys.SetTTLOperator;
+import org.apache.iotdb.db.qp.logical.sys.ShowChildNodesOperator;
 import org.apache.iotdb.db.qp.logical.sys.ShowChildPathsOperator;
 import org.apache.iotdb.db.qp.logical.sys.ShowDevicesOperator;
 import org.apache.iotdb.db.qp.logical.sys.ShowFunctionsOperator;
@@ -169,6 +170,7 @@ import org.apache.iotdb.db.qp.sql.SqlBaseParser.SequenceClauseContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.SetStorageGroupContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.SetTTLStatementContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.ShowAllTTLStatementContext;
+import org.apache.iotdb.db.qp.sql.SqlBaseParser.ShowChildNodesContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.ShowChildPathsContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.ShowDevicesContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.ShowFlushTaskInfoContext;
@@ -779,6 +781,17 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
     } else {
       return new ShowChildPathsOperator(
           SQLConstant.TOK_CHILD_PATHS, new PartialPath(SQLConstant.getSingleRootArray()));
+    }
+  }
+
+  @Override
+  public Operator visitShowChildNodes(ShowChildNodesContext ctx) {
+    if (ctx.prefixPath() != null) {
+      return new ShowChildNodesOperator(
+          SQLConstant.TOK_CHILD_NODES, parsePrefixPath(ctx.prefixPath()));
+    } else {
+      return new ShowChildNodesOperator(
+          SQLConstant.TOK_CHILD_NODES, new PartialPath(SQLConstant.getSingleRootArray()));
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -56,6 +56,7 @@ import org.apache.iotdb.db.qp.logical.sys.MoveFileOperator;
 import org.apache.iotdb.db.qp.logical.sys.RemoveFileOperator;
 import org.apache.iotdb.db.qp.logical.sys.SetStorageGroupOperator;
 import org.apache.iotdb.db.qp.logical.sys.SetTTLOperator;
+import org.apache.iotdb.db.qp.logical.sys.ShowChildNodesOperator;
 import org.apache.iotdb.db.qp.logical.sys.ShowChildPathsOperator;
 import org.apache.iotdb.db.qp.logical.sys.ShowDevicesOperator;
 import org.apache.iotdb.db.qp.logical.sys.ShowFunctionsOperator;
@@ -100,6 +101,7 @@ import org.apache.iotdb.db.qp.physical.sys.MergePlan;
 import org.apache.iotdb.db.qp.physical.sys.OperateFilePlan;
 import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
 import org.apache.iotdb.db.qp.physical.sys.SetTTLPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowChildNodesPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowChildPathsPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowDevicesPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowFunctionsPlan;
@@ -312,6 +314,9 @@ public class PhysicalGenerator {
           case SQLConstant.TOK_CHILD_PATHS:
             return new ShowChildPathsPlan(
                 ShowContentType.CHILD_PATH, ((ShowChildPathsOperator) operator).getPath());
+          case SQLConstant.TOK_CHILD_NODES:
+            return new ShowChildNodesPlan(
+                ShowContentType.CHILD_NODE, ((ShowChildNodesOperator) operator).getPath());
           case SQLConstant.TOK_QUERY_PROCESSLIST:
             return new ShowQueryProcesslistPlan(ShowContentType.QUERY_PROCESSLIST);
           case SQLConstant.TOK_SHOW_FUNCTIONS:

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
@@ -368,6 +368,41 @@ public class IoTDBMetadataFetchIT {
   }
 
   @Test
+  public void showChildNodes() throws SQLException, ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      String[] sqls = new String[] {"show child nodes root.ln"};
+      String[] standards = new String[] {"wf01,\n"};
+      for (int n = 0; n < sqls.length; n++) {
+        String sql = sqls[n];
+        String standard = standards[n];
+        StringBuilder builder = new StringBuilder();
+        try {
+          boolean hasResultSet = statement.execute(sql);
+          if (hasResultSet) {
+            try (ResultSet resultSet = statement.getResultSet()) {
+              ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+              while (resultSet.next()) {
+                for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+                  builder.append(resultSet.getString(i)).append(",");
+                }
+                builder.append("\n");
+              }
+            }
+          }
+          Assert.assertEquals(standard, builder.toString());
+        } catch (SQLException e) {
+          logger.error("showChildNodes() failed", e);
+          fail(e.getMessage());
+        }
+      }
+    }
+  }
+
+  @Test
   public void showCountTimeSeries() throws SQLException, ClassNotFoundException {
     Class.forName(Config.JDBC_DRIVER_NAME);
     try (Connection connection =

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -34,7 +34,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -450,6 +452,47 @@ public class MManagerBasicTest {
       assertTrue(manager.getStorageGroupByPath(new PartialPath("root.vehicle1.device2")).isEmpty());
       assertTrue(manager.getStorageGroupByPath(new PartialPath("root.vehicle1.device3")).isEmpty());
       assertFalse(manager.getStorageGroupByPath(new PartialPath("root.vehicle1.device")).isEmpty());
+    } catch (MetadataException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testShowChildNodesWithGivenPrefix() {
+    MManager manager = IoTDB.metaManager;
+    try {
+      manager.setStorageGroup(new PartialPath("root.laptop"));
+      manager.createTimeseries(
+          new PartialPath("root.laptop.d1.s1"),
+          TSDataType.INT32,
+          TSEncoding.PLAIN,
+          CompressionType.GZIP,
+          null);
+      manager.createTimeseries(
+          new PartialPath("root.laptop.d2.s1"),
+          TSDataType.INT32,
+          TSEncoding.PLAIN,
+          CompressionType.GZIP,
+          null);
+      manager.createTimeseries(
+          new PartialPath("root.laptop.d1.s2"),
+          TSDataType.INT32,
+          TSEncoding.PLAIN,
+          CompressionType.GZIP,
+          null);
+      Set<String> nodes = new HashSet<>(Arrays.asList("s1", "s2"));
+      Set<String> nodes2 = new HashSet<>(Arrays.asList("laptop"));
+      Set<String> nodes3 = new HashSet<>(Arrays.asList("d1", "d2"));
+      Set<String> nexLevelNodes1 =
+          manager.getChildNodeInNextLevel(new PartialPath("root.laptop.d1"));
+      Set<String> nexLevelNodes2 = manager.getChildNodeInNextLevel(new PartialPath("root"));
+      Set<String> nexLevelNodes3 = manager.getChildNodeInNextLevel(new PartialPath("root.laptop"));
+      // usual condition
+      assertEquals(nodes, nexLevelNodes1);
+      assertEquals(nodes2, nexLevelNodes2);
+      assertEquals(nodes3, nexLevelNodes3);
+
     } catch (MetadataException e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -34,8 +34,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -368,6 +371,39 @@ public class MTreeTest {
     } catch (MetadataException e) {
       e.printStackTrace();
       fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetAllChildNodeNamesByPath() {
+    MTree root = new MTree();
+    try {
+      root.setStorageGroup(new PartialPath("root.a.d0"));
+      root.createTimeseries(
+          new PartialPath("root.a.d0.s0"),
+          TSDataType.INT32,
+          TSEncoding.RLE,
+          TSFileDescriptor.getInstance().getConfig().getCompressor(),
+          Collections.emptyMap(),
+          null);
+      root.createTimeseries(
+          new PartialPath("root.a.d0.s1"),
+          TSDataType.INT32,
+          TSEncoding.RLE,
+          TSFileDescriptor.getInstance().getConfig().getCompressor(),
+          Collections.emptyMap(),
+          null);
+
+      // getChildNodeByPath
+      Set<String> result1 = root.getChildNodeInNextLevel(new PartialPath("root.a.d0"));
+      Set<String> result2 = root.getChildNodeInNextLevel(new PartialPath("root.a"));
+      Set<String> result3 = root.getChildNodeInNextLevel(new PartialPath("root"));
+      assertEquals(result1, new HashSet<>(Arrays.asList("s0", "s1")));
+      assertEquals(result2, new HashSet<>(Arrays.asList("d0")));
+      assertEquals(result3, new HashSet<>(Arrays.asList("a")));
+
+    } catch (MetadataException e1) {
+      e1.printStackTrace();
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -393,15 +393,25 @@ public class MTreeTest {
           TSFileDescriptor.getInstance().getConfig().getCompressor(),
           Collections.emptyMap(),
           null);
+      root.createTimeseries(
+          new PartialPath("root.a.d5"),
+          TSDataType.INT32,
+          TSEncoding.RLE,
+          TSFileDescriptor.getInstance().getConfig().getCompressor(),
+          Collections.emptyMap(),
+          null);
 
       // getChildNodeByPath
       Set<String> result1 = root.getChildNodeInNextLevel(new PartialPath("root.a.d0"));
       Set<String> result2 = root.getChildNodeInNextLevel(new PartialPath("root.a"));
       Set<String> result3 = root.getChildNodeInNextLevel(new PartialPath("root"));
       assertEquals(result1, new HashSet<>(Arrays.asList("s0", "s1")));
-      assertEquals(result2, new HashSet<>(Arrays.asList("d0")));
+      assertEquals(result2, new HashSet<>(Arrays.asList("d0", "d5")));
       assertEquals(result3, new HashSet<>(Arrays.asList("a")));
 
+      // if child node is nll   will return  null HashSet
+      Set<String> result5 = root.getChildNodeInNextLevel(new PartialPath("root.a.d5"));
+      assertEquals(result5, new HashSet<>(Arrays.asList()));
     } catch (MetadataException e1) {
       e1.printStackTrace();
     }

--- a/server/src/test/java/org/apache/iotdb/db/qp/PlannerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/PlannerTest.java
@@ -211,6 +211,13 @@ public class PlannerTest {
     }
   }
 
+  @Test
+  public void parseShowChildNodeToPhysicalPlan() throws Exception {
+    String showChildNodesStatement = "show child nodes root.vehicle1.device1";
+    PhysicalPlan plan14 = processor.parseSQLToPhysicalPlan(showChildNodesStatement);
+    assertEquals(OperatorType.SHOW, plan14.getOperatorType());
+  }
+
   @Test(expected = ParseCancellationException.class)
   public void parseErrorSQLToPhysicalPlan() throws QueryProcessException {
     String createTSStatement =


### PR DESCRIPTION
## Description
Hi all :
        I have submitted a pr for  [ISSUE-2493](https://github.com/apache/iotdb/issues/2493), please take a look.
        This issue about add SQL syntax for metadata queries  

The modules involved are as follows:
&ensp;&ensp;&ensp;1、antlr
&ensp;&ensp;&ensp;2、server/query planner 
&ensp;&ensp;&ensp;3、server/metadata
The local test results are as follows:

![image](https://user-images.githubusercontent.com/13831999/109014240-eae37000-76ee-11eb-8d67-9036c744f936.png)


### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
