### PR TITLE
[IOTDB-1174] optimize mergechunks thread number

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
@@ -264,6 +264,13 @@ public class MergeMultiChunkTask {
         IoTDBDescriptor.getInstance().getConfig().getMergeChunkSubThreadNum();
     MetaListEntry[] metaListEntries = new MetaListEntry[currMergingPaths.size()];
     PriorityQueue<Integer>[] chunkIdxHeaps = new PriorityQueue[mergeChunkSubTaskNum];
+
+    // if merge path is smaller than mergeChunkSubTaskNum, will use merge path number.
+    // so thread are not wasted.
+    if (currMergingPaths.size() < mergeChunkSubTaskNum) {
+      mergeChunkSubTaskNum = currMergingPaths.size();
+    }
+
     for (int i = 0; i < mergeChunkSubTaskNum; i++) {
       chunkIdxHeaps[i] = new PriorityQueue<>();
     }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMergeIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMergeIT.java
@@ -39,9 +39,9 @@ import java.sql.Statement;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class IoTDBMergeTest {
+public class IoTDBMergeIT {
 
-  private static final Logger logger = LoggerFactory.getLogger(IoTDBMergeTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(IoTDBMergeIT.class);
   private long prevPartitionInterval;
   private CompactionStrategy prevTsFileManagementStrategy;
 
@@ -380,7 +380,7 @@ public class IoTDBMergeTest {
       }
       // it is uncertain whether the sub tasks are created at this time point, and we are only
       // sure that the main task is created
-      assertEquals(5, cnt);
+      assertEquals(4, cnt);
     }
   }
 }

--- a/server/src/test/resources/logback.xml
+++ b/server/src/test/resources/logback.xml
@@ -45,7 +45,7 @@
     <logger name="org.eclipse.jetty.util.thread.QueuedThreadPool" level="DEBUG"/>
     <logger name="org.apache.iotdb.db.service.MetricsService" level="INFO"/>
     <logger name="org.apache.iotdb.db.engine.flush.FlushManager" level="INFO"/>
-    <logger name="org.apache.iotdb.db.integration.IoTDBMergeTest" level="INFO"/>
+    <logger name="org.apache.iotdb.db.integration.IoTDBMergeIT" level="INFO"/>
     <logger name="org.apache.iotdb.db.service.RegisterManager" level="INFO"/>
     <logger name="org.apache.iotdb.db.service.IoTDB" level="WARN"/>
     <logger name="org.apache.iotdb.db.service.RPCService" level="INFO"/>


### PR DESCRIPTION
if merge path is smaller than mergeChunkSubTaskNum, will use merge path number.
so threads are not wasted.