### PR TITLE
Make the Wal buffer pool parameters to be configurable

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -420,6 +420,7 @@ enable_monitor_series_write=false
 wal_pool_trim_interval_ms=10000
 
 # the max number of wal bytebuffer can be allocated for each time partition, if there is no unseq data you can set it to 4.
+# it should be an even number
 max_wal_bytebuffer_num_for_each_partition=8
 
 ####################

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -421,7 +421,7 @@ wal_pool_trim_interval_ms=10000
 
 # the max number of wal bytebuffer can be allocated for each time partition, if there is no unseq data you can set it to 4.
 # it should be an even number
-max_wal_bytebuffer_num_for_each_partition=8
+max_wal_bytebuffer_num_for_each_partition=6
 
 ####################
 ### External sort Configuration

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -414,6 +414,15 @@ enable_stat_monitor=false
 enable_monitor_series_write=false
 
 ####################
+### WAL Direct Buffer Pool Configuration
+####################
+# the interval to trim the wal pool
+wal_pool_trim_interval_ms=10000
+
+# the max number of wal bytebuffer can be allocated for each time partition, if there is no unseq data you can set it to 4.
+max_wal_bytebuffer_num_for_each_partition=8
+
+####################
 ### External sort Configuration
 ####################
 # Is external sort enable

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -18,6 +18,11 @@
  */
 package org.apache.iotdb.db.conf;
 
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
+
+import java.io.File;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
 import org.apache.iotdb.db.engine.compaction.CompactionStrategy;
 import org.apache.iotdb.db.engine.merge.selector.MergeFileStrategy;
@@ -31,15 +36,8 @@ import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
 
 public class IoTDBConfig {
 
@@ -166,6 +164,10 @@ public class IoTDBConfig {
    * then the insert plan will be rejected by WAL.
    */
   private int walBufferSize = 16 * 1024 * 1024;
+
+  private int maxWalBytebufferNumForEachPartition = 8;
+
+  private long walPoolTrimIntervalInMS = 10_000;
 
   private int estimatedSeriesSize = 300;
 
@@ -1142,6 +1144,22 @@ public class IoTDBConfig {
 
   public void setWalBufferSize(int walBufferSize) {
     this.walBufferSize = walBufferSize;
+  }
+
+  public int getMaxWalBytebufferNumForEachPartition() {
+    return maxWalBytebufferNumForEachPartition;
+  }
+
+  public void setMaxWalBytebufferNumForEachPartition(int maxWalBytebufferNumForEachPartition) {
+    this.maxWalBytebufferNumForEachPartition = maxWalBytebufferNumForEachPartition;
+  }
+
+  public long getWalPoolTrimIntervalInMS() {
+    return walPoolTrimIntervalInMS;
+  }
+
+  public void setWalPoolTrimIntervalInMS(long walPoolTrimIntervalInMS) {
+    this.walPoolTrimIntervalInMS = walPoolTrimIntervalInMS;
   }
 
   public int getEstimatedSeriesSize() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -18,11 +18,6 @@
  */
 package org.apache.iotdb.db.conf;
 
-import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
-
-import java.io.File;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
 import org.apache.iotdb.db.engine.compaction.CompactionStrategy;
 import org.apache.iotdb.db.engine.merge.selector.MergeFileStrategy;
@@ -36,8 +31,15 @@ import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
 
 public class IoTDBConfig {
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -167,7 +167,7 @@ public class IoTDBConfig {
    */
   private int walBufferSize = 16 * 1024 * 1024;
 
-  private int maxWalBytebufferNumForEachPartition = 8;
+  private int maxWalBytebufferNumForEachPartition = 6;
 
   private long walPoolTrimIntervalInMS = 10_000;
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -260,13 +260,6 @@ public class IoTDBDescriptor {
 
       conf.setWalDir(properties.getProperty("wal_dir", conf.getWalDir()));
 
-      int walBufferSize =
-          Integer.parseInt(
-              properties.getProperty("wal_buffer_size", Integer.toString(conf.getWalBufferSize())));
-      if (walBufferSize > 0) {
-        conf.setWalBufferSize(walBufferSize);
-      }
-
       int mlogBufferSize =
           Integer.parseInt(
               properties.getProperty(
@@ -819,6 +812,27 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "enable_discard_out_of_order_data",
                 Boolean.toString(conf.isEnableDiscardOutOfOrderData()))));
+
+    int walBufferSize =
+        Integer.parseInt(
+            properties.getProperty("wal_buffer_size", Integer.toString(conf.getWalBufferSize())));
+    if (walBufferSize > 0) {
+      conf.setWalBufferSize(walBufferSize);
+    }
+
+    int maxWalBytebufferNumForEachPartition =
+        Integer.parseInt(
+            properties.getProperty("max_wal_bytebuffer_num_for_each_partition", Integer.toString(conf.getMaxWalBytebufferNumForEachPartition())));
+    if (maxWalBytebufferNumForEachPartition > 0) {
+      conf.setMaxWalBytebufferNumForEachPartition(maxWalBytebufferNumForEachPartition);
+    }
+
+    long poolTrimIntervalInMS =
+        Integer.parseInt(
+            properties.getProperty("wal_pool_trim_interval_ms", Long.toString(conf.getWalPoolTrimIntervalInMS())));
+    if (poolTrimIntervalInMS > 0) {
+      conf.setWalPoolTrimIntervalInMS(poolTrimIntervalInMS);
+    }
   }
 
   private void loadAutoCreateSchemaProps(Properties properties) {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -822,14 +822,17 @@ public class IoTDBDescriptor {
 
     int maxWalBytebufferNumForEachPartition =
         Integer.parseInt(
-            properties.getProperty("max_wal_bytebuffer_num_for_each_partition", Integer.toString(conf.getMaxWalBytebufferNumForEachPartition())));
+            properties.getProperty(
+                "max_wal_bytebuffer_num_for_each_partition",
+                Integer.toString(conf.getMaxWalBytebufferNumForEachPartition())));
     if (maxWalBytebufferNumForEachPartition > 0) {
       conf.setMaxWalBytebufferNumForEachPartition(maxWalBytebufferNumForEachPartition);
     }
 
     long poolTrimIntervalInMS =
         Integer.parseInt(
-            properties.getProperty("wal_pool_trim_interval_ms", Long.toString(conf.getWalPoolTrimIntervalInMS())));
+            properties.getProperty(
+                "wal_pool_trim_interval_ms", Long.toString(conf.getWalPoolTrimIntervalInMS())));
     if (poolTrimIntervalInMS > 0) {
       conf.setWalPoolTrimIntervalInMS(poolTrimIntervalInMS);
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -18,38 +18,6 @@
  */
 package org.apache.iotdb.db.engine.storagegroup;
 
-import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
-import static org.apache.iotdb.db.engine.merge.task.MergeTask.MERGE_SUFFIX;
-import static org.apache.iotdb.db.engine.storagegroup.TsFileResource.TEMP_SUFFIX;
-import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -109,8 +77,42 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
+
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
+import static org.apache.iotdb.db.engine.merge.task.MergeTask.MERGE_SUFFIX;
+import static org.apache.iotdb.db.engine.storagegroup.TsFileResource.TEMP_SUFFIX;
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 
 /**
  * For sequence data, a StorageGroupProcessor has some TsFileProcessors, in which there is only one
@@ -272,7 +274,8 @@ public class StorageGroupProcessor {
     synchronized (walByteBufferPool) {
       long startTime = System.nanoTime();
       int MAX_WAL_BYTEBUFFER_NUM =
-          config.getConcurrentWritingTimePartition() * config.getMaxWalBytebufferNumForEachPartition();
+          config.getConcurrentWritingTimePartition()
+              * config.getMaxWalBytebufferNumForEachPartition();
       while (walByteBufferPool.isEmpty() && currentWalPoolSize + 2 > MAX_WAL_BYTEBUFFER_NUM) {
         try {
           walByteBufferPool.wait();
@@ -284,7 +287,8 @@ public class StorageGroupProcessor {
               virtualStorageGroupId,
               e);
         }
-        logger.info("Waiting {} ms for wal direct byte buffer.",
+        logger.info(
+            "Waiting {} ms for wal direct byte buffer.",
             (System.nanoTime() - startTime) / 1_000_000);
       }
       // If the queue is not empty, it must have at least two.


### PR DESCRIPTION
## Problem
After adding the Wal Buffer Pool, the writing test with unseq data became 50% slower than before.

## Reasons
Before, as the descriptions of the design document(https://cwiki.apache.org/confluence/display/IOTDB/DirectByteBuffer+Pool+for+WAL) the default number of wal buffer for each time partition in each storage group is 4. 2 for seq and another 2 for unseq. However, if we have unseq data, then seq occupy 2 wal buffer, unseq occupy 2 wal buffer, now the wal buffer pool wil be empty. While one tsfile is closing,  it won't put the wal buffer back to the pool until the closing is finished. So the writing operation coming later will be blocked until the closing tsfile put its wal buffer back.

## Solutions
Now, I make the max wal buffer number for each time partition to be configurable in iotdb-engine.properties and it can be modified without need to restart iotdb, just change the config file and execute the load configuration command.
The default number of wal buffer for each time partition is changed from 4 to 6 in this version. Even if new writing operation comes while the tsfile is closing, it won't be blocked, because there are still wal buffer in the pool.

Actually, if the file closing operation is very slow, it will happen that more than one tsfile are closing together, the later writing will still be blocked. In this case, you will see the 'Waiting {} ms for wal direct byte buffer.' logs printed. If you have enough memory, you can change the `max_wal_bytebuffer_num_for_each_partition` to be higher, like 8, 10, 12 or 16.