### PR TITLE
[To rel/0.11] cherry-pick [ISSUE-2709,IOTDB-1178] Fix cache not cleared after unseq compaction bug, Fix windows 70,10 ci bug in unseq compaction ci

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeFileTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeFileTask.java
@@ -311,8 +311,7 @@ class MergeFileTask {
     seqFile.writeLock();
     try {
       resource.removeFileReader(seqFile);
-      ChunkMetadataCache.getInstance().remove(seqFile);
-
+      FileReaderManager.getInstance().closeFileAndRemoveReader(seqFile.getTsFilePath());
       File newMergeFile = seqFile.getTsFile();
       newMergeFile.delete();
       fsFactory.moveFile(fileWriter.getFile(), newMergeFile);
@@ -325,7 +324,6 @@ class MergeFileTask {
         ChunkCache.getInstance().clear();
         ChunkMetadataCache.getInstance().clear();
         TimeSeriesMetadataCache.getInstance().clear();
-        FileReaderManager.getInstance().closeFileAndRemoveReader(seqFile.getTsFilePath());
       }
       seqFile.writeUnlock();
     }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionCacheTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.engine.compaction;
+
+import org.apache.iotdb.db.constant.TestConstant;
+import org.apache.iotdb.db.engine.cache.ChunkCache;
+import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
+import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache.TimeSeriesMetadataCacheKey;
+import org.apache.iotdb.db.engine.compaction.TsFileManagement.CompactionMergeTask;
+import org.apache.iotdb.db.engine.compaction.level.LevelCompactionTsFileManagement;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.exception.StorageEngineException;
+import org.apache.iotdb.db.exception.metadata.IllegalPathException;
+import org.apache.iotdb.db.exception.metadata.MetadataException;
+import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
+import org.apache.iotdb.tsfile.read.common.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class LevelCompactionCacheTest extends LevelCompactionTest {
+
+  File tempSGDir;
+  boolean compactionMergeWorking = false;
+
+  @Override
+  @Before
+  public void setUp() throws IOException, WriteProcessException, MetadataException {
+    super.setUp();
+    tempSGDir = new File(TestConstant.BASE_OUTPUT_PATH.concat("tempSG"));
+    tempSGDir.mkdirs();
+  }
+
+  @Override
+  @After
+  public void tearDown() throws IOException, StorageEngineException {
+    super.tearDown();
+    FileUtils.deleteDirectory(tempSGDir);
+  }
+
+  @Test
+  public void testCompactionChunkCache() throws IllegalPathException, IOException {
+    LevelCompactionTsFileManagement levelCompactionTsFileManagement =
+        new LevelCompactionTsFileManagement(COMPACTION_TEST_SG, tempSGDir.getPath());
+    TsFileResource tsFileResource = seqResources.get(1);
+    TsFileSequenceReader reader = new TsFileSequenceReader(tsFileResource.getTsFilePath());
+    List<Path> paths = reader.getAllPaths();
+    Set<String> allSensors = new TreeSet<>();
+    for (Path path : paths) {
+      allSensors.add(path.getMeasurement());
+    }
+    ChunkMetadata firstChunkMetadata = reader.getChunkMetadataList(paths.get(0)).get(0);
+    TimeSeriesMetadataCacheKey firstTimeSeriesMetadataCacheKey =
+        new TimeSeriesMetadataCacheKey(
+            seqResources.get(1).getTsFilePath(),
+            paths.get(0).getDevice(),
+            paths.get(0).getMeasurement());
+
+    // add cache
+    ChunkCache.getInstance().get(firstChunkMetadata, reader);
+    TimeSeriesMetadataCache.getInstance().get(firstTimeSeriesMetadataCacheKey, allSensors);
+
+    levelCompactionTsFileManagement.addAll(seqResources, true);
+    levelCompactionTsFileManagement.addAll(unseqResources, false);
+    levelCompactionTsFileManagement.forkCurrentFileList(0);
+    CompactionMergeTask compactionMergeTask =
+        levelCompactionTsFileManagement
+        .new CompactionMergeTask(this::closeCompactionMergeCallBack, 0);
+    compactionMergeWorking = true;
+    compactionMergeTask.run();
+    while (compactionMergeWorking) {
+      // wait
+    }
+
+    try {
+      ChunkCache.getInstance().get(firstChunkMetadata, null);
+      fail();
+    } catch (NullPointerException e) {
+      assertTrue(true);
+    }
+
+    try {
+      TimeSeriesMetadataCache.getInstance().get(firstTimeSeriesMetadataCacheKey, new TreeSet<>());
+      fail();
+    } catch (Exception e) {
+      assertTrue(true);
+    }
+    reader.close();
+  }
+
+  /** close compaction merge callback, to release some locks */
+  private void closeCompactionMergeCallBack() {
+    this.compactionMergeWorking = false;
+  }
+}


### PR DESCRIPTION
# ISSUE-2709
## Behavior
User's query operation get invalid chunk after compaction.

## Reason
After compaction, we need to delete a file.
However, the chunk cache and timeseriesMetadata cache is also active which may be queried.
So user can get invalid chunk.

## Solution
We will clear the chunkMetadata cache and timeseriesMetadata cache after a compaction is done.

# IOTDB-1178
## Behavior
A windows ci problem about unseq compaction.
The error behaves like below (The 70,10 problem).
![image](https://user-images.githubusercontent.com/24886743/109446827-604b9980-7a7d-11eb-951f-67cdb383146d.png)

## Reason
In unseq compaction, when delete tsfile,  if tsfile is reading now,  will throw exception and then cannot delete the old file in windows system.

## Solution
As we have get the file lock, we just have to clear the TsFileSequenceReader cache before delete a tsfile.