### PR TITLE
[To rel/0.11] cherry-pick [ISSUE-2746] Fix data overlapped bug after unseq compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
@@ -74,8 +74,11 @@ public class MergeResource {
         .collect(Collectors.toList());
   }
 
+  /** If returns true, it means to participate in the merge */
   private boolean filterResource(TsFileResource res) {
-    return res.getTsFile().exists() && !res.isDeleted() && res.stillLives(timeLowerBound);
+    return res.getTsFile().exists()
+        && !res.isDeleted()
+        && (!res.isClosed() || res.stillLives(timeLowerBound));
   }
 
   public MergeResource(Collection<TsFileResource> seqFiles, List<TsFileResource> unseqFiles,

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
@@ -211,7 +211,6 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
   }
 
   private void selectOverlappedSeqFiles(TsFileResource unseqFile) {
-
     int tmpSelectedNum = 0;
     for (Entry<String, Integer> deviceStartTimeEntry : unseqFile.getDeviceToIndexMap().entrySet()) {
       String deviceId = deviceStartTimeEntry.getKey();
@@ -225,7 +224,8 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
         if (seqSelected[i] || !seqFile.getDeviceToIndexMap().containsKey(deviceId)) {
           continue;
         }
-        long seqEndTime = seqFile.getEndTime(deviceId);
+        // the open file's endTime is Long.MIN_VALUE, this will make the file be filtered below
+        long seqEndTime = seqFile.isClosed() ? seqFile.getEndTime(deviceId) : Long.MAX_VALUE;
         if (unseqEndTime <= seqEndTime) {
           // the unseqFile overlaps current seqFile
           tmpSelectedSeqFiles.add(i);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -400,6 +400,7 @@ public class TsFileResource {
     return startTimes[index];
   }
 
+  /** open file's end time is Long.MIN_VALUE */
   public long getEndTime(String deviceId) {
     if (!deviceToIndex.containsKey(deviceId)) {
       return Long.MIN_VALUE;
@@ -891,5 +892,9 @@ public class TsFileResource {
   public boolean isPlanIndexOverlap(TsFileResource another) {
     return another.maxPlanIndex >= this.minPlanIndex &&
            another.minPlanIndex <= this.maxPlanIndex;
+  }
+
+  public void setTimeIndex(ITimeIndex timeIndex) {
+    this.timeIndex = timeIndex;
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
@@ -19,16 +19,26 @@
 
 package org.apache.iotdb.db.engine.merge;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.util.List;
+import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.engine.merge.manage.MergeResource;
-import org.apache.iotdb.db.engine.merge.selector.MaxFileMergeFileSelector;
 import org.apache.iotdb.db.engine.merge.selector.IMergeFileSelector;
+import org.apache.iotdb.db.engine.merge.selector.MaxFileMergeFileSelector;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.timeindex.ITimeIndex;
 import org.apache.iotdb.db.exception.MergeException;
+import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
 
 public class MaxFileMergeFileSelectorTest extends MergeTest {
 
@@ -78,8 +88,111 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
     List[] result = mergeFileSelector.select();
     List<TsFileResource> seqSelected = result[0];
     List<TsFileResource> unseqSelected = result[1];
-    assertEquals(seqResources.subList(0, 3), seqSelected);
-    assertEquals(unseqResources.subList(0, 3), unseqSelected);
+    assertEquals(seqResources.subList(0, 4), seqSelected);
+    assertEquals(unseqResources.subList(0, 4), unseqSelected);
     resource.clear();
+  }
+
+  /**
+   * test unseq merge select with the following files: {0seq-0-0-0.tsfile 0-100 1seq-1-1-0.tsfile
+   * 100-200 2seq-2-2-0.tsfile 200-300 3seq-3-3-0.tsfile 300-400 4seq-4-4-0.tsfile 400-500}
+   * {10unseq-10-10-0.tsfile 0-500}
+   */
+  @Test
+  public void testFileOpenSelection()
+      throws MergeException, IOException, WriteProcessException, NoSuchFieldException,
+          IllegalAccessException {
+    File file =
+        new File(
+            TestConstant.BASE_OUTPUT_PATH.concat(
+                10
+                    + "unseq"
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 10
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 10
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource largeUnseqTsFileResource = new TsFileResource(file);
+    largeUnseqTsFileResource.setClosed(true);
+    largeUnseqTsFileResource.setMinPlanIndex(10);
+    largeUnseqTsFileResource.setMaxPlanIndex(10);
+    largeUnseqTsFileResource.setVersion(10);
+    prepareFile(largeUnseqTsFileResource, 0, seqFileNum * ptNum, 0);
+
+    // update the second file's status to open
+    TsFileResource secondTsFileResource = seqResources.get(1);
+    secondTsFileResource.setClosed(false);
+    Set<String> devices = secondTsFileResource.getDevices();
+    // update the end time of the file to Long.MIN_VALUE, so we can simulate a real open file
+    Field timeIndexField = TsFileResource.class.getDeclaredField("timeIndex");
+    timeIndexField.setAccessible(true);
+    ITimeIndex timeIndex = (ITimeIndex) timeIndexField.get(secondTsFileResource);
+    ITimeIndex newTimeIndex =
+        IoTDBDescriptor.getInstance().getConfig().getTimeIndexLevel().getTimeIndex();
+    for (String device : devices) {
+      newTimeIndex.updateStartTime(device, timeIndex.getStartTime(device));
+    }
+    secondTsFileResource.setTimeIndex(newTimeIndex);
+    unseqResources.clear();
+    unseqResources.add(largeUnseqTsFileResource);
+
+    MergeResource resource = new MergeResource(seqResources, unseqResources);
+    IMergeFileSelector mergeFileSelector = new MaxFileMergeFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    assertEquals(0, result.length);
+    resource.clear();
+  }
+
+  /**
+   * test unseq merge select with the following files: {0seq-0-0-0.tsfile 0-100 1seq-1-1-0.tsfile
+   * 100-200 2seq-2-2-0.tsfile 200-300 3seq-3-3-0.tsfile 300-400 4seq-4-4-0.tsfile 400-500}
+   * {10unseq-10-10-0.tsfile 0-500}
+   */
+  @Test
+  public void testFileOpenSelectionFromCompaction()
+      throws IOException, WriteProcessException, NoSuchFieldException, IllegalAccessException {
+    File file =
+        new File(
+            TestConstant.BASE_OUTPUT_PATH.concat(
+                10
+                    + "unseq"
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 10
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 10
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource largeUnseqTsFileResource = new TsFileResource(file);
+    largeUnseqTsFileResource.setClosed(true);
+    largeUnseqTsFileResource.setMinPlanIndex(10);
+    largeUnseqTsFileResource.setMaxPlanIndex(10);
+    largeUnseqTsFileResource.setVersion(10);
+    prepareFile(largeUnseqTsFileResource, 0, seqFileNum * ptNum, 0);
+
+    // update the second file's status to open
+    TsFileResource secondTsFileResource = seqResources.get(1);
+    secondTsFileResource.setClosed(false);
+    Set<String> devices = secondTsFileResource.getDevices();
+    // update the end time of the file to Long.MIN_VALUE, so we can simulate a real open file
+    Field timeIndexField = TsFileResource.class.getDeclaredField("timeIndex");
+    timeIndexField.setAccessible(true);
+    ITimeIndex timeIndex = (ITimeIndex) timeIndexField.get(secondTsFileResource);
+    ITimeIndex newTimeIndex =
+        IoTDBDescriptor.getInstance().getConfig().getTimeIndexLevel().getTimeIndex();
+    for (String device : devices) {
+      newTimeIndex.updateStartTime(device, timeIndex.getStartTime(device));
+    }
+    secondTsFileResource.setTimeIndex(newTimeIndex);
+    unseqResources.clear();
+    unseqResources.add(largeUnseqTsFileResource);
+
+    long timeLowerBound = System.currentTimeMillis() - Long.MAX_VALUE;
+    MergeResource mergeResource = new MergeResource(seqResources, unseqResources, timeLowerBound);
+    assertEquals(5, mergeResource.getSeqFiles().size());
+    assertEquals(1, mergeResource.getUnseqFiles().size());
+    mergeResource.clear();
   }
 }


### PR DESCRIPTION
## Behavior
Unseq compaction causes the overlap of seq files which lead to out-of-order query.
The query behaves like below.
![image](https://user-images.githubusercontent.com/24886743/109408656-66cb0a00-79c6-11eb-85b2-45ccb21ba4f5.png)

## Reason
The unseq compaction selector tries to find unseq files which overlap with some unsealed files.

However, the unsealed file's endTime is always Long.MIN_VALUE which will be ignored because [Long.MIN_VALUE, Long.MIN_VALUE) never overlap with other files .

As a result, the unseq compaction can not select an overlapped file if the file is unsealed. In this case, the unseq file's remaining data will be appended to the end of the last sealed seq file which is overlapped with the unsealed file.

## Solution
When selecting the overlapped seq files with an unseq file, if we encounter an unsealed seq file, the unseq file will be excluded from this unseq merge task.