### PR TITLE
Extract the common codes to one utils class  & Reduce the content of debug log printing of the InsertRowsPlan

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -122,7 +122,6 @@ import org.apache.iotdb.db.utils.FileLoaderUtils;
 import org.apache.iotdb.db.utils.UpgradeUtils;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
-import org.apache.iotdb.service.rpc.thrift.TSStatus;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.exception.filter.QueryFilterOptimizationException;
 import org.apache.iotdb.tsfile.file.metadata.ChunkGroupMetadata;
@@ -1181,21 +1180,17 @@ public class PlanExecutor implements IPlanExecutor {
 
   @Override
   public void insert(InsertRowsPlan plan) throws QueryProcessException {
-    boolean allSuccess = true;
     for (int i = 0; i < plan.getInsertRowPlanList().size(); i++) {
       if (plan.getResults().containsKey(i)) {
-        allSuccess = false;
         continue;
       }
       try {
         insert(plan.getInsertRowPlanList().get(i));
-        plan.getResults().put(i, RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS));
       } catch (QueryProcessException e) {
         plan.getResults().put(i, RpcUtils.getStatus(e.getErrorCode(), e.getMessage()));
-        allSuccess = false;
       }
-      if (!allSuccess) {
-        throw new BatchProcessException(plan.getResults().values().toArray(new TSStatus[0]));
+      if (!plan.getResults().isEmpty()) {
+        throw new BatchProcessException(plan.getFailingStatus());
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
+import org.apache.iotdb.db.utils.StatusUtils;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 
 import java.io.DataOutputStream;
@@ -208,12 +209,16 @@ public class InsertRowsPlan extends InsertPlan {
   @Override
   public String toString() {
     return "InsertRowsPlan{"
-        + " insertRowPlanIndexList="
-        + insertRowPlanIndexList
-        + ", insertRowPlanList="
-        + insertRowPlanList
+        + " insertRowPlanIndexList's size="
+        + insertRowPlanIndexList.size()
+        + ", insertRowPlanList's size="
+        + insertRowPlanList.size()
         + ", results="
         + results
         + "}";
+  }
+
+  public TSStatus[] getFailingStatus() {
+    return StatusUtils.getFailingStatus(results, insertRowPlanList.size());
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateMultiTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateMultiTimeSeriesPlan.java
@@ -22,7 +22,7 @@ import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
-import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.db.utils.StatusUtils;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -33,7 +33,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -141,15 +140,7 @@ public class CreateMultiTimeSeriesPlan extends PhysicalPlan {
   }
 
   public TSStatus[] getFailingStatus() {
-    if (results.isEmpty()) {
-      return new TSStatus[0];
-    }
-    TSStatus[] failingStatus = new TSStatus[paths.size()];
-    Arrays.fill(failingStatus, RpcUtils.SUCCESS_STATUS);
-    for (Map.Entry<Integer, TSStatus> status : results.entrySet()) {
-      failingStatus[status.getKey()] = status.getValue();
-    }
-    return failingStatus;
+    return StatusUtils.getFailingStatus(results, paths.size());
   }
 
   public void setResults(Map<Integer, TSStatus> results) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteTimeSeriesPlan.java
@@ -22,14 +22,13 @@ import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
-import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.db.utils.StatusUtils;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -102,14 +101,6 @@ public class DeleteTimeSeriesPlan extends PhysicalPlan {
   }
 
   public TSStatus[] getFailingStatus() {
-    if (results.isEmpty()) {
-      return new TSStatus[0];
-    }
-    TSStatus[] failingStatus = new TSStatus[deletePathList.size()];
-    Arrays.fill(failingStatus, RpcUtils.SUCCESS_STATUS);
-    for (Map.Entry<Integer, TSStatus> status : results.entrySet()) {
-      failingStatus[status.getKey()] = status.getValue();
-    }
-    return failingStatus;
+    return StatusUtils.getFailingStatus(results, deletePathList.size());
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -1143,7 +1143,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           req.deviceIds.get(0),
           req.getTimestamps().get(0));
     }
-    boolean checkAllSuccess = true;
+    boolean allCheckSuccess = true;
     InsertRowsPlan insertRowsPlan = new InsertRowsPlan();
     for (int i = 0; i < req.deviceIds.size(); i++) {
       try {
@@ -1156,11 +1156,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         TSStatus status = checkAuthority(plan, req.getSessionId());
         if (status != null) {
           insertRowsPlan.getResults().put(i, status);
-          checkAllSuccess = false;
+          allCheckSuccess = false;
         }
         insertRowsPlan.addOneInsertRowPlan(plan, i);
       } catch (Exception e) {
-        checkAllSuccess = false;
+        allCheckSuccess = false;
         insertRowsPlan
             .getResults()
             .put(
@@ -1172,16 +1172,16 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     TSStatus tsStatus = executeNonQueryPlan(insertRowsPlan);
 
     return judgeFinalTsStatus(
-        checkAllSuccess, tsStatus, insertRowsPlan.getResults(), req.deviceIds.size());
+        allCheckSuccess, tsStatus, insertRowsPlan.getResults(), req.deviceIds.size());
   }
 
   private TSStatus judgeFinalTsStatus(
-      boolean checkAllSuccess,
+      boolean allCheckSuccess,
       TSStatus executeTsStatus,
       Map<Integer, TSStatus> checkTsStatus,
       int totalRowCount) {
 
-    if (checkAllSuccess) {
+    if (allCheckSuccess) {
       return executeTsStatus;
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -1143,7 +1143,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           req.deviceIds.get(0),
           req.getTimestamps().get(0));
     }
-    boolean allSuccess = true;
+    boolean checkAllSuccess = true;
     InsertRowsPlan insertRowsPlan = new InsertRowsPlan();
     for (int i = 0; i < req.deviceIds.size(); i++) {
       try {
@@ -1156,11 +1156,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         TSStatus status = checkAuthority(plan, req.getSessionId());
         if (status != null) {
           insertRowsPlan.getResults().put(i, status);
-          allSuccess = false;
+          checkAllSuccess = false;
         }
         insertRowsPlan.addOneInsertRowPlan(plan, i);
       } catch (Exception e) {
-        allSuccess = false;
+        checkAllSuccess = false;
         insertRowsPlan
             .getResults()
             .put(
@@ -1172,16 +1172,16 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     TSStatus tsStatus = executeNonQueryPlan(insertRowsPlan);
 
     return judgeFinalTsStatus(
-        allSuccess, tsStatus, insertRowsPlan.getResults(), req.deviceIds.size());
+        checkAllSuccess, tsStatus, insertRowsPlan.getResults(), req.deviceIds.size());
   }
 
   private TSStatus judgeFinalTsStatus(
-      boolean allSuccess,
+      boolean checkAllSuccess,
       TSStatus executeTsStatus,
       Map<Integer, TSStatus> checkTsStatus,
       int totalRowCount) {
 
-    if (allSuccess) {
+    if (checkAllSuccess) {
       return executeTsStatus;
     }
 
@@ -1252,7 +1252,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           req.getTimestamps().get(0));
     }
 
-    boolean allSuccess = true;
+    boolean allCheckSuccess = true;
     InsertRowsPlan insertRowsPlan = new InsertRowsPlan();
     for (int i = 0; i < req.deviceIds.size(); i++) {
       InsertRowPlan plan = new InsertRowPlan();
@@ -1266,6 +1266,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         TSStatus status = checkAuthority(plan, req.getSessionId());
         if (status != null) {
           insertRowsPlan.getResults().put(i, status);
+          allCheckSuccess = false;
         }
         insertRowsPlan.addOneInsertRowPlan(plan, i);
       } catch (Exception e) {
@@ -1275,13 +1276,13 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
                 i,
                 onNPEOrUnexpectedException(
                     e, "inserting string records", TSStatusCode.INTERNAL_SERVER_ERROR));
-        allSuccess = false;
+        allCheckSuccess = false;
       }
     }
     TSStatus tsStatus = executeNonQueryPlan(insertRowsPlan);
 
     return judgeFinalTsStatus(
-        allSuccess, tsStatus, insertRowsPlan.getResults(), req.deviceIds.size());
+        allCheckSuccess, tsStatus, insertRowsPlan.getResults(), req.deviceIds.size());
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/StatusUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/StatusUtils.java
@@ -26,6 +26,12 @@ import java.util.Arrays;
 import java.util.Map;
 
 public class StatusUtils {
+  private StatusUtils() {}
+
+  /**
+   * @param statusMap index -> status
+   * @param size the total number of status to generate
+   */
   public static TSStatus[] getFailingStatus(Map<Integer, TSStatus> statusMap, int size) {
     if (statusMap == null || statusMap.isEmpty()) {
       return new TSStatus[0];

--- a/server/src/main/java/org/apache/iotdb/db/utils/StatusUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/StatusUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.utils;
+
+import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class StatusUtils {
+  public static TSStatus[] getFailingStatus(Map<Integer, TSStatus> statusMap, int size) {
+    if (statusMap == null || statusMap.isEmpty()) {
+      return new TSStatus[0];
+    }
+    TSStatus[] failingStatus = new TSStatus[size];
+    Arrays.fill(failingStatus, RpcUtils.SUCCESS_STATUS);
+    for (Map.Entry<Integer, TSStatus> status : statusMap.entrySet()) {
+      failingStatus[status.getKey()] = status.getValue();
+    }
+    return failingStatus;
+  }
+}


### PR DESCRIPTION
1. Extract the common codes to one utils class (which is used to judge the final status when whose plan have multi rows)
2. Reduce the content of debug log printing of the InsertRowsPlan(which is too big when the bug log level is enabled, reduce the write throughput. In our test, we use the insertRecords interface to the performance,  the performance was 300,000 points/s before modification and it became 3.4 million points/s after modification).