### PR TITLE
[ISSUE-2741] getObject method in JDBC should return an Object

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBJDBCResultSet.java
@@ -443,7 +443,7 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
 
   @Override
   public Object getObject(String columnName) throws SQLException {
-    return getValueByName(columnName);
+    return getObjectByName(columnName);
   }
 
   @Override
@@ -1121,4 +1121,6 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
   abstract void checkRecord() throws SQLException;
 
   abstract String getValueByName(String columnName) throws SQLException;
+
+  abstract Object getObjectByName(String columnName) throws SQLException;
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
@@ -104,6 +104,15 @@ public class IoTDBJDBCResultSet extends AbstractIoTDBJDBCResultSet {
     }
   }
 
+  @Override
+  protected Object getObjectByName(String columnName) throws SQLException {
+    try {
+      return ioTDBRpcDataSet.getObjectByName(columnName);
+    } catch (StatementExecutionException e) {
+      throw new SQLException(e.getMessage());
+    }
+  }
+
   public boolean isIgnoreTimeStamp() {
     return ioTDBRpcDataSet.ignoreTimeStamp;
   }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
@@ -248,4 +248,26 @@ public class IoTDBNonAlignJDBCResultSet extends AbstractIoTDBJDBCResultSet {
     return ioTDBRpcDataSet.getString(
         index, ioTDBRpcDataSet.columnTypeDeduplicatedList.get(index), ioTDBRpcDataSet.values);
   }
+
+  @Override
+  protected Object getObjectByName(String columnName) throws SQLException {
+    checkRecord();
+    if (columnName.startsWith(TIMESTAMP_STR)) {
+      String column = columnName.substring(TIMESTAMP_STR_LENGTH);
+      int index = ioTDBRpcDataSet.columnOrdinalMap.get(column) - START_INDEX;
+      if (times[index] == null || times[index].length == 0) {
+        return null;
+      }
+      return BytesUtils.bytesToLong(times[index]);
+    }
+    int index = ioTDBRpcDataSet.columnOrdinalMap.get(columnName) - START_INDEX;
+    if (index < 0
+        || index >= ioTDBRpcDataSet.values.length
+        || ioTDBRpcDataSet.values[index] == null
+        || ioTDBRpcDataSet.values[index].length < 1) {
+      return null;
+    }
+    return ioTDBRpcDataSet.getObject(
+        index, ioTDBRpcDataSet.columnTypeDeduplicatedList.get(index), ioTDBRpcDataSet.values);
+  }
 }

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
@@ -370,34 +370,34 @@ public class IoTDBJDBCResultSetTest {
 
   private void constructObjectList(List<Object> standardObject) {
     Object[][] input = {
-        {
-          2L, 2.22F, 40000L, null, 2.22F,
-        },
-        {
-          3L, 3.33F, null, null, 3.33F,
-        },
-        {
-          4L, 4.44F, null, null, 4.44F,
-        },
-        {
-          50L, null, 50000L, null, null,
-        },
-        {
-          100L, null, 199L, null, null,
-        },
-        {
-          101L, null, 199L, null, null,
-        },
-        {
-          103L, null, 199L, null, null,
-        },
-        {
-          105L, 11.11F, 199L, 33333, 11.11F,
-        },
-        {
-          1000L, 1000.11F, 55555L, 22222, 1000.11F,
-        }
-      };
+      {
+        2L, 2.22F, 40000L, null, 2.22F,
+      },
+      {
+        3L, 3.33F, null, null, 3.33F,
+      },
+      {
+        4L, 4.44F, null, null, 4.44F,
+      },
+      {
+        50L, null, 50000L, null, null,
+      },
+      {
+        100L, null, 199L, null, null,
+      },
+      {
+        101L, null, 199L, null, null,
+      },
+      {
+        103L, null, 199L, null, null,
+      },
+      {
+        105L, 11.11F, 199L, 33333, 11.11F,
+      },
+      {
+        1000L, 1000.11F, 55555L, 22222, 1000.11F,
+      }
+    };
     for (Object[] row : input) {
       standardObject.addAll(Arrays.asList(row));
     }

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
@@ -47,6 +47,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -210,6 +211,7 @@ public class IoTDBJDBCResultSetTest {
       // check fetched result
       int colCount = resultSetMetaData.getColumnCount();
       StringBuilder resultStr = new StringBuilder();
+      List<Object> resultObjectList = new ArrayList<>();
       for (int i = 1; i < colCount + 1; i++) { // meta title
         resultStr.append(resultSetMetaData.getColumnName(i)).append(",");
       }
@@ -217,6 +219,7 @@ public class IoTDBJDBCResultSetTest {
       while (resultSet.next()) { // data
         for (int i = 1; i <= colCount; i++) {
           resultStr.append(resultSet.getString(i)).append(",");
+          resultObjectList.add(resultSet.getObject(i));
         }
         resultStr.append("\n");
         fetchResultsResp.hasResultSet = false; // at the second time to fetch
@@ -233,6 +236,12 @@ public class IoTDBJDBCResultSetTest {
               + "105,11.11,199,33333,11.11,\n"
               + "1000,1000.11,55555,22222,1000.11,\n"; // Note the LIMIT&OFFSET clause takes effect
       Assert.assertEquals(standard, resultStr.toString());
+      List<Object> standardObject = new ArrayList<>();
+      constructObjectList(standardObject);
+      Assert.assertEquals(standardObject.size(), resultObjectList.size());
+      for (int i = 0; i < standardObject.size(); i++) {
+        Assert.assertEquals(standardObject.get(i), resultObjectList.get(i));
+      }
     }
 
     // The client get TSQueryDataSet at the first request
@@ -357,5 +366,40 @@ public class IoTDBJDBCResultSetTest {
     tsQueryDataSet.setBitmapList(bitmapList);
     tsQueryDataSet.setValueList(valueList);
     return tsQueryDataSet;
+  }
+
+  private void constructObjectList(List<Object> standardObject) {
+    Object[][] input = {
+        {
+          2L, 2.22F, 40000L, null, 2.22F,
+        },
+        {
+          3L, 3.33F, null, null, 3.33F,
+        },
+        {
+          4L, 4.44F, null, null, 4.44F,
+        },
+        {
+          50L, null, 50000L, null, null,
+        },
+        {
+          100L, null, 199L, null, null,
+        },
+        {
+          101L, null, 199L, null, null,
+        },
+        {
+          103L, null, 199L, null, null,
+        },
+        {
+          105L, 11.11F, 199L, 33333, 11.11F,
+        },
+        {
+          1000L, 1000.11F, 55555L, 22222, 1000.11F,
+        }
+      };
+    for (Object[] row : input) {
+      standardObject.addAll(Arrays.asList(row));
+    }
   }
 }


### PR DESCRIPTION
#2741
Currently, the getObject method in JDBC returns a String which does not match the JDBC standard.

In this PR, I re-implement this method by calling `IoTDBRpcDataSet.getObjectByName` and `IoTDBRpcDataSet.getObject` method directly to get the Object result.

