### PR TITLE
[IOTDB-1179] remove the CustomImportOrder config as we using spotless…

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -177,11 +177,6 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
-        <module name="CustomImportOrder">
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
-        </module>
         <module name="MethodParamPad"/>
         <module name="NoWhitespaceBefore">
             <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>


### PR DESCRIPTION
Remove the CustomImportOrder config as we using spotless check to ensure the code style correct.