### PR TITLE
[IOTDB-1181] Upgrade jetty jar to fix CVE-2020-27216

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <org.slf4j.version>1.7.25</org.slf4j.version>
         <guava.version>24.1.1</guava.version>
         <jline.version>2.14.5</jline.version>
-        <jetty.version>9.4.24.v20191120</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
         <metrics.version>3.2.6</metrics.version>
         <javax.xml.bind.version>2.4.0-b180725.0427</javax.xml.bind.version>
         <felix.version>5.1.1</felix.version>


### PR DESCRIPTION
current  jetty version is 9.4.24.v20191120,  which have a high loopholes CVE-2020-27216， we can use 9.4.35.v20201120 version