### PR TITLE
Fix the sketch tool in new tsfile format

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
@@ -116,7 +116,9 @@ public class TsFileSketchTool {
                     + String.format("%20s", "")
                     + " \t"
                     + chunkMetadata.getStatistics());
-            printlnBoth(pw, String.format("%20s", "") + "|\t\t[marker] " + chunk.getHeader().getChunkType());
+            printlnBoth(
+                pw,
+                String.format("%20s", "") + "|\t\t[marker] " + chunk.getHeader().getChunkType());
             nextChunkGroupHeaderPos =
                 chunkMetadata.getOffsetOfChunkHeader()
                     + chunk.getHeader().getSerializedSize()

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
@@ -116,12 +116,12 @@ public class TsFileSketchTool {
                     + String.format("%20s", "")
                     + " \t"
                     + chunkMetadata.getStatistics());
-            printlnBoth(pw, String.format("%20s", "") + "|\t\t[marker] 1");
+            printlnBoth(pw, String.format("%20s", "") + "|\t\t[marker] " + chunk.getHeader().getChunkType());
             nextChunkGroupHeaderPos =
                 chunkMetadata.getOffsetOfChunkHeader()
                     + chunk.getHeader().getSerializedSize()
                     + chunk.getHeader().getDataSize()
-                    - 1;
+                    + 17; // skip the PlanIndex
           }
 
           printlnBoth(pw, str1 + "\t[Chunk Group] of " + chunkGroupMetadata.getDevice() + " ends");

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/LocalTsFileInput.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/LocalTsFileInput.java
@@ -144,6 +144,7 @@ public class LocalTsFileInput implements TsFileInput {
     int varIntLength = ReadWriteForEncodingUtils.varIntSize(strLength);
     byte[] bytes = new byte[strLength];
     channel.read(strBuffer, offset + varIntLength);
+    strBuffer.flip();
     strBuffer.get(bytes, 0, strLength);
     return new String(bytes, 0, strLength);
   }


### PR DESCRIPTION
## Problems
The tsfile format has been changed, but the tsfile sketch tool is not updated yet. While using the SketchTool to analyze a new format tsfile will throw Exception like the following:
![image](https://user-images.githubusercontent.com/16079446/110078738-2652fe00-7dc3-11eb-9844-80be0ea98511.png)

## Reasons
* The new tsfile format has added a new structure called PlanIndex after each chunk group which is used by distributed iotdb, while scanning the tsfile in tsfile sketch tool, we should skip it.
* While reading data from ByteBuffer, I forgot to flip it.

## Solutions
* skip the PlanIndex after each chunk group which occupys 17 bytes
* flip the ByteBuffer.