### PR TITLE
Optimize Field 'START_TIME' is never used  in  IoTDBConstant.java

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -75,7 +75,6 @@ public class IoTDBConstant {
   public static final String COLUMN_TAGS = "tags";
   public static final String COLUMN_ATTRIBUTES = "attributes";
   public static final String QUERY_ID = "queryId";
-  public static final String START_TIME = "startTime";
   public static final String STATEMENT = "statement";
 
   public static final String COLUMN_ROLE = "role";


### PR DESCRIPTION
Field 'START_TIME' is never used

Update IoTDBConstant.java
