### PR TITLE
[IOTDB-1186] Remove redundant sync meta leader in query process for cluster module

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/ClusterMain.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/ClusterMain.java
@@ -260,7 +260,7 @@ public class ClusterMain {
           @Override
           public int calculateSlotByTime(String storageGroupName, long timestamp, int maxSlotNum) {
             int sgSerialNum = extractSerialNumInSGName(storageGroupName) % k;
-            if (sgSerialNum > 0) {
+            if (sgSerialNum >= 0) {
               return maxSlotNum / k * sgSerialNum;
             } else {
               return defaultStrategy.calculateSlotByTime(storageGroupName, timestamp, maxSlotNum);
@@ -271,7 +271,7 @@ public class ClusterMain {
           public int calculateSlotByPartitionNum(
               String storageGroupName, long partitionId, int maxSlotNum) {
             int sgSerialNum = extractSerialNumInSGName(storageGroupName) % k;
-            if (sgSerialNum > 0) {
+            if (sgSerialNum >= 0) {
               return maxSlotNum / k * sgSerialNum;
             } else {
               return defaultStrategy.calculateSlotByPartitionNum(

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterDataQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterDataQueryExecutor.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.cluster.query;
 
+import org.apache.iotdb.cluster.exception.CheckConsistencyException;
 import org.apache.iotdb.cluster.exception.EmptyIntervalException;
 import org.apache.iotdb.cluster.query.reader.ClusterReaderFactory;
 import org.apache.iotdb.cluster.query.reader.ClusterTimeGenerator;
@@ -63,6 +64,13 @@ public class ClusterDataQueryExecutor extends RawDataQueryExecutor {
     Filter timeFilter = null;
     if (queryPlan.getExpression() != null) {
       timeFilter = ((GlobalTimeExpression) queryPlan.getExpression()).getFilter();
+    }
+
+    // make sure the partition table is new
+    try {
+      metaGroupMember.syncLeaderWithConsistencyCheck(false);
+    } catch (CheckConsistencyException e) {
+      throw new StorageEngineException(e);
     }
 
     List<ManagedSeriesReader> readersOfSelectedSeries = new ArrayList<>();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
@@ -85,6 +85,10 @@ public class ClusterReaderFactory {
     this.metaGroupMember = metaGroupMember;
   }
 
+  public void syncMetaGroup() throws CheckConsistencyException {
+    metaGroupMember.syncLeaderWithConsistencyCheck(false);
+  }
+
   /**
    * Create an IReaderByTimestamp that can read the data of "path" by timestamp in the whole
    * cluster. This will query every group and merge the result from them.
@@ -216,12 +220,6 @@ public class ClusterReaderFactory {
       QueryContext context,
       boolean ascending)
       throws StorageEngineException, EmptyIntervalException {
-    // make sure the partition table is new
-    try {
-      metaGroupMember.syncLeaderWithConsistencyCheck(false);
-    } catch (CheckConsistencyException e) {
-      throw new StorageEngineException(e);
-    }
     // find the groups that should be queried using the timeFilter
     List<PartitionGroup> partitionGroups = metaGroupMember.routeFilter(timeFilter, path);
     logger.debug(

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterTimeGenerator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterTimeGenerator.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.cluster.query.reader;
 
+import org.apache.iotdb.cluster.exception.CheckConsistencyException;
 import org.apache.iotdb.cluster.metadata.CMManager;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
 import org.apache.iotdb.db.exception.StorageEngineException;
@@ -51,8 +52,9 @@ public class ClusterTimeGenerator extends ServerTimeGenerator {
     this.queryPlan = rawDataQueryPlan;
     this.readerFactory = new ClusterReaderFactory(metaGroupMember);
     try {
+      readerFactory.syncMetaGroup();
       constructNode(expression);
-    } catch (IOException e) {
+    } catch (IOException | CheckConsistencyException e) {
       throw new StorageEngineException(e);
     }
   }


### PR DESCRIPTION
see [1186](https://issues.apache.org/jira/browse/IOTDB-1186).