### PR TITLE
[IOTDB-1188][To rel/0.11]Fix IoTDB 0.11 unable to delete data bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1504,7 +1504,7 @@ public class StorageGroupProcessor {
    * Delete data whose timestamp <= 'timestamp' and belongs to the time series
    * deviceId.measurementId.
    *
-   * @param path the timeseries path of the to be deleted.
+   * @param path the timeseries path to be deleted.
    * @param startTime the startTime of delete range.
    * @param endTime the endTime of delete range.
    */
@@ -1522,18 +1522,6 @@ public class StorageGroupProcessor {
     try {
       Set<PartialPath> devicePaths = IoTDB.metaManager.getDevices(path.getDevicePath());
       for (PartialPath device : devicePaths) {
-        Long lastUpdateTime = null;
-        for (Map<String, Long> latestTimeMap : latestTimeForEachDevice.values()) {
-          Long curTime = latestTimeMap.get(device.getFullPath());
-          if (curTime != null && (lastUpdateTime == null || lastUpdateTime < curTime)) {
-            lastUpdateTime = curTime;
-          }
-        }
-        // There is no tsfile data, the delete operation is invalid
-        if (lastUpdateTime == null) {
-          logger.debug("No device {} in SG {}, deletion invalid", device, storageGroupName);
-          return;
-        }
         // delete Last cache record if necessary
         tryToDeleteLastCache(device, path, startTime, endTime);
       }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
@@ -313,6 +313,31 @@ public class IoTDBDeletionIT {
     }
   }
 
+  @Test
+  public void testDeletionWithNullSeries() throws SQLException {
+    try (Connection connection = DriverManager
+            .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root",
+                    "root");
+         Statement statement = connection.createStatement()) {
+      statement.execute("SET STORAGE GROUP TO root.sg");
+      statement.execute("CREATE TIMESERIES root.sg.d1.s0 WITH DATATYPE=INT32,"
+              + " ENCODING=PLAIN");
+      statement.execute("CREATE TIMESERIES root.sg.d2.s0 WITH DATATYPE=INT32,"
+              + " ENCODING=PLAIN");
+      statement.execute("CREATE TIMESERIES root.sg.d3.s0 WITH DATATYPE=INT32,"
+              + " ENCODING=PLAIN");
+      statement.execute("CREATE TIMESERIES root.sg.d4.s0 WITH DATATYPE=INT32,"
+              + " ENCODING=PLAIN");
+      statement.execute("INSERT INTO root.sg.d2(timestamp,s0) VALUES(100, 32)");
+
+      statement.execute("delete from root.sg.d2 where time <= 300");
+      try (ResultSet resultSet = statement.executeQuery("select * from root.sg.d2")) {
+        // Delete successful
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+
   private static void prepareSeries() {
     try (Connection connection = DriverManager
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root",


### PR DESCRIPTION
## Description
Check JIRA issue: https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-1188?filter=allopenissues
This bug has been fixed in master branch. So only 0.11 release versions have this bug.

## Reason 
The bug occurs when the delete path is not a full timeseries path but a device path.
If any device path contains no data, delete code will falsely return. In this way, the devices that truly contain data will not be deleted.
