### PR TITLE
[IOTDB-1189] [Distributed]optimize thread pool client close

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncClientPool.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncClientPool.java
@@ -107,7 +107,7 @@ public class SyncClientPool {
           logger.warn(
               "Cannot get an available client after {}ms, create a new one",
               WAIT_CLIENT_TIMEOUT_MS);
-          nodeClientNumMap.put(node, nodeClientNum + 1);
+          nodeClientNumMap.computeIfPresent(node, (n, oldValue) -> oldValue + 1);
           return createClient(node, nodeClientNum);
         }
       } catch (InterruptedException e) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncDataClient.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncDataClient.java
@@ -31,6 +31,7 @@ import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransportException;
 
+import java.io.Closeable;
 import java.net.SocketException;
 
 /**
@@ -39,7 +40,7 @@ import java.net.SocketException;
  */
 // the two classes does not share a common parent and Java does not allow multiple extension
 @SuppressWarnings("common-java:DuplicatedBlocks")
-public class SyncDataClient extends Client {
+public class SyncDataClient extends Client implements Closeable {
 
   Node node;
   SyncClientPool pool;
@@ -82,6 +83,12 @@ public class SyncDataClient extends Client {
         inputProtocol.getTransport().close();
       }
     }
+  }
+
+  /** put the client to pool, instead of close client. */
+  @Override
+  public void close() {
+    putBack();
   }
 
   public static class FactorySync implements SyncClientFactory {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncMetaClient.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncMetaClient.java
@@ -29,13 +29,15 @@ import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransportException;
 
+import java.io.Closeable;
+
 /**
  * Notice: Because a client will be returned to a pool immediately after a successful request, you
  * should not cache it anywhere else or there may be conflicts.
  */
 // the two classes does not share a common parent and Java does not allow multiple extension
 @SuppressWarnings("common-java:DuplicatedBlocks")
-public class SyncMetaClient extends Client {
+public class SyncMetaClient extends Client implements Closeable {
 
   Node node;
   SyncClientPool pool;
@@ -64,6 +66,12 @@ public class SyncMetaClient extends Client {
     } else {
       getInputProtocol().getTransport().close();
     }
+  }
+
+  /** put the client to pool, instead of close client. */
+  @Override
+  public void close() {
+    putBack();
   }
 
   public static class FactorySync implements SyncClientFactory {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
@@ -34,7 +34,6 @@ import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.member.DataGroupMember;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.exception.StorageEngineException;
@@ -254,16 +253,12 @@ public class ClusterPlanExecutor extends PlanExecutor {
               SyncClientAdaptor.getPathCount(
                   client, partitionGroup.getHeader(), pathsToQuery, level);
         } else {
-          SyncDataClient syncDataClient = null;
-          try {
-            syncDataClient =
-                metaGroupMember
-                    .getClientProvider()
-                    .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+          try (SyncDataClient syncDataClient =
+              metaGroupMember
+                  .getClientProvider()
+                  .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
             syncDataClient.setTimeout(RaftServer.getReadOperationTimeoutMS());
             count = syncDataClient.getPathCount(partitionGroup.getHeader(), pathsToQuery, level);
-          } finally {
-            ClientUtils.putBackSyncClient(syncDataClient);
           }
         }
         logger.debug(
@@ -360,16 +355,12 @@ public class ClusterPlanExecutor extends PlanExecutor {
               SyncClientAdaptor.getNodeList(
                   client, group.getHeader(), schemaPattern.getFullPath(), level);
         } else {
-          SyncDataClient syncDataClient = null;
-          try {
-            syncDataClient =
-                metaGroupMember
-                    .getClientProvider()
-                    .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+          try (SyncDataClient syncDataClient =
+              metaGroupMember
+                  .getClientProvider()
+                  .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
             paths =
                 syncDataClient.getNodeList(group.getHeader(), schemaPattern.getFullPath(), level);
-          } finally {
-            ClientUtils.putBackSyncClient(syncDataClient);
           }
         }
         if (paths != null) {
@@ -473,16 +464,12 @@ public class ClusterPlanExecutor extends PlanExecutor {
           nextChildren =
               SyncClientAdaptor.getNextChildren(client, group.getHeader(), path.getFullPath());
         } else {
-          SyncDataClient syncDataClient = null;
-          try {
-            syncDataClient =
-                metaGroupMember
-                    .getClientProvider()
-                    .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+          try (SyncDataClient syncDataClient =
+              metaGroupMember
+                  .getClientProvider()
+                  .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
             nextChildren =
                 syncDataClient.getChildNodePathInNextLevel(group.getHeader(), path.getFullPath());
-          } finally {
-            ClientUtils.putBackSyncClient(syncDataClient);
           }
         }
         if (nextChildren != null) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/aggregate/ClusterAggregator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/aggregate/ClusterAggregator.java
@@ -35,7 +35,6 @@ import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.member.DataGroupMember;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.PartialPath;
@@ -271,15 +270,12 @@ public class ClusterAggregator {
       // each buffer is an AggregationResult
       resultBuffers = SyncClientAdaptor.getAggrResult(client, request);
     } else {
-      SyncDataClient syncDataClient = null;
-      try {
-        syncDataClient =
-            metaGroupMember
-                .getClientProvider()
-                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+      try (SyncDataClient syncDataClient =
+          metaGroupMember
+              .getClientProvider()
+              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
+
         resultBuffers = syncDataClient.getAggrResult(request);
-      } finally {
-        ClientUtils.putBackSyncClient(syncDataClient);
       }
     }
     return resultBuffers;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterPreviousFill.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterPreviousFill.java
@@ -32,7 +32,6 @@ import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.handlers.caller.PreviousFillHandler;
 import org.apache.iotdb.cluster.server.member.DataGroupMember;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.cluster.utils.PartitionUtils.Intervals;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
@@ -241,12 +240,11 @@ public class ClusterPreviousFill extends PreviousFill {
   private ByteBuffer remoteSyncPreviousFill(
       Node node, PreviousFillRequest request, PreviousFillArguments arguments) {
     ByteBuffer byteBuffer = null;
-    SyncDataClient syncDataClient = null;
-    try {
-      syncDataClient =
-          metaGroupMember
-              .getClientProvider()
-              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+    try (SyncDataClient syncDataClient =
+        metaGroupMember
+            .getClientProvider()
+            .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
+
       byteBuffer = syncDataClient.previousFill(request);
     } catch (Exception e) {
       logger.error(
@@ -255,8 +253,6 @@ public class ClusterPreviousFill extends PreviousFill {
           arguments.getPath(),
           node,
           e);
-    } finally {
-      ClientUtils.putBackSyncClient(syncDataClient);
     }
     return byteBuffer;
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutor.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.query.aggregation.AggregateResult;
 import org.apache.iotdb.db.query.dataset.groupby.GroupByExecutor;
 import org.apache.iotdb.db.utils.SerializeUtils;
@@ -85,16 +84,13 @@ public class RemoteGroupByExecutor implements GroupByExecutor {
             SyncClientAdaptor.getGroupByResult(
                 client, header, executorId, curStartTime, curEndTime);
       } else {
-        SyncDataClient syncDataClient = null;
-        try {
-          syncDataClient =
-              metaGroupMember
-                  .getClientProvider()
-                  .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
+        try (SyncDataClient syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS())) {
+
           aggrBuffers =
               syncDataClient.getGroupByResult(header, executorId, curStartTime, curEndTime);
-        } finally {
-          ClientUtils.putBackSyncClient(syncDataClient);
         }
       }
     } catch (TException e) {
@@ -133,16 +129,13 @@ public class RemoteGroupByExecutor implements GroupByExecutor {
             SyncClientAdaptor.peekNextNotNullValue(
                 client, header, executorId, nextStartTime, nextEndTime);
       } else {
-        SyncDataClient syncDataClient = null;
-        try {
-          syncDataClient =
-              metaGroupMember
-                  .getClientProvider()
-                  .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS());
+        try (SyncDataClient syncDataClient =
+            metaGroupMember
+                .getClientProvider()
+                .getSyncDataClient(source, RaftServer.getReadOperationTimeoutMS())) {
+
           aggrBuffer =
               syncDataClient.peekNextNotNullValue(header, executorId, nextStartTime, nextEndTime);
-        } finally {
-          ClientUtils.putBackSyncClient(syncDataClient);
         }
       }
     } catch (TException e) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
@@ -30,7 +30,6 @@ import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.member.DataGroupMember;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.cluster.utils.ClusterQueryUtils;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
@@ -258,12 +257,11 @@ public class ClusterLastQueryExecutor extends LastQueryExecutor {
     }
 
     private ByteBuffer lastSync(Node node, QueryContext context) throws TException {
-      SyncDataClient syncDataClient = null;
-      try {
-        syncDataClient =
-            metaGroupMember
-                .getClientProvider()
-                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+      try (SyncDataClient syncDataClient =
+          metaGroupMember
+              .getClientProvider()
+              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
+
         return syncDataClient.last(
             new LastQueryRequest(
                 PartialPath.toStringList(seriesPaths),
@@ -272,8 +270,6 @@ public class ClusterLastQueryExecutor extends LastQueryExecutor {
                 queryPlan.getDeviceToMeasurements(),
                 group.getHeader(),
                 syncDataClient.getNode()));
-      } finally {
-        ClientUtils.putBackSyncClient(syncDataClient);
       }
     }
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
@@ -39,7 +39,6 @@ import org.apache.iotdb.cluster.rpc.thrift.SingleSeriesQueryRequest;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.member.DataGroupMember;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.cluster.utils.ClusterQueryUtils;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.exception.StorageEngineException;
@@ -657,15 +656,12 @@ public class ClusterReaderFactory {
               .getAsyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
       executorId = SyncClientAdaptor.getGroupByExecutor(client, request);
     } else {
-      SyncDataClient syncDataClient = null;
-      try {
-        syncDataClient =
-            metaGroupMember
-                .getClientProvider()
-                .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
+      try (SyncDataClient syncDataClient =
+          metaGroupMember
+              .getClientProvider()
+              .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
+
         executorId = syncDataClient.getGroupByExecutor(request);
-      } finally {
-        ClientUtils.putBackSyncClient(syncDataClient);
       }
     }
     return executorId;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/DataSourceInfo.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/DataSourceInfo.java
@@ -29,7 +29,6 @@ import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.rpc.thrift.SingleSeriesQueryRequest;
 import org.apache.iotdb.cluster.server.RaftServer;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.utils.SerializeUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.filter.TimeFilter;
@@ -155,12 +154,13 @@ public class DataSourceInfo {
 
   private Long applyForReaderIdSync(Node node, boolean byTimestamp, long timestamp)
       throws TException {
-    SyncDataClient client =
+
+    Long newReaderId;
+    try (SyncDataClient client =
         this.metaGroupMember
             .getClientProvider()
-            .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
-    Long newReaderId;
-    try {
+            .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
+
       if (byTimestamp) {
         newReaderId = client.querySingleSeriesByTimestamp(request);
       } else {
@@ -176,8 +176,6 @@ public class DataSourceInfo {
         newReaderId = client.querySingleSeries(request);
       }
       return newReaderId;
-    } finally {
-      ClientUtils.putBackSyncClient(client);
     }
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
@@ -31,7 +31,6 @@ import org.apache.iotdb.cluster.query.RemoteQueryContext;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.server.handlers.caller.GenericHandler;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
@@ -315,14 +314,10 @@ public class ClientServer extends TSServiceImpl {
                       queriedNode, RaftServer.getReadOperationTimeoutMS());
               client.endQuery(header, coordinator.getThisNode(), queryId, handler);
             } else {
-              SyncDataClient syncDataClient = null;
-              try {
-                syncDataClient =
-                    coordinator.getSyncDataClient(
-                        queriedNode, RaftServer.getReadOperationTimeoutMS());
+              try (SyncDataClient syncDataClient =
+                  coordinator.getSyncDataClient(
+                      queriedNode, RaftServer.getReadOperationTimeoutMS())) {
                 syncDataClient.endQuery(header, coordinator.getThisNode(), queryId);
-              } finally {
-                ClientUtils.putBackSyncClient(syncDataClient);
               }
             }
           } catch (IOException | TException e) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/PullSnapshotHintService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/PullSnapshotHintService.java
@@ -122,11 +122,12 @@ public class PullSnapshotHintService {
   }
 
   private boolean sendHintSync(Node receiver, PullSnapshotHint hint) throws TException {
-    SyncDataClient syncDataClient = (SyncDataClient) member.getSyncClient(receiver);
-    if (syncDataClient == null) {
-      return false;
+    try (SyncDataClient syncDataClient = (SyncDataClient) member.getSyncClient(receiver)) {
+      if (syncDataClient == null) {
+        return false;
+      }
+      return syncDataClient.onSnapshotApplied(hint.header, hint.slots);
     }
-    return syncDataClient.onSnapshotApplied(hint.header, hint.slots);
   }
 
   private static class PullSnapshotHint {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/service/BaseSyncService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/service/BaseSyncService.java
@@ -19,8 +19,6 @@
 
 package org.apache.iotdb.cluster.server.service;
 
-import org.apache.iotdb.cluster.client.sync.SyncDataClient;
-import org.apache.iotdb.cluster.client.sync.SyncMetaClient;
 import org.apache.iotdb.cluster.exception.LeaderUnknownException;
 import org.apache.iotdb.cluster.exception.UnknownLogTypeException;
 import org.apache.iotdb.cluster.rpc.thrift.AppendEntriesRequest;
@@ -34,6 +32,7 @@ import org.apache.iotdb.cluster.rpc.thrift.RaftService;
 import org.apache.iotdb.cluster.rpc.thrift.RaftService.Client;
 import org.apache.iotdb.cluster.server.NodeCharacter;
 import org.apache.iotdb.cluster.server.member.RaftMember;
+import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.cluster.utils.IOUtils;
 import org.apache.iotdb.cluster.utils.StatusUtils;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
@@ -111,17 +110,9 @@ public abstract class BaseSyncService implements RaftService.Iface {
       client.getInputProtocol().getTransport().close();
       throw e;
     } finally {
-      putBackSyncClient(client);
+      ClientUtils.putBackSyncClient(client);
     }
     return commitIndex;
-  }
-
-  void putBackSyncClient(Client client) {
-    if (client instanceof SyncDataClient) {
-      ((SyncDataClient) client).putBack();
-    } else {
-      ((SyncMetaClient) client).putBack();
-    }
   }
 
   @Override
@@ -160,7 +151,7 @@ public abstract class BaseSyncService implements RaftService.Iface {
           client.getInputProtocol().getTransport().close();
           throw e;
         } finally {
-          putBackSyncClient(client);
+          ClientUtils.putBackSyncClient(client);
         }
         return status;
       } else {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/service/DataSyncService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/service/DataSyncService.java
@@ -38,6 +38,7 @@ import org.apache.iotdb.cluster.rpc.thrift.SendSnapshotRequest;
 import org.apache.iotdb.cluster.rpc.thrift.SingleSeriesQueryRequest;
 import org.apache.iotdb.cluster.rpc.thrift.TSDataService;
 import org.apache.iotdb.cluster.server.member.DataGroupMember;
+import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
@@ -108,7 +109,7 @@ public class DataSyncService extends BaseSyncService implements TSDataService.If
         client.getInputProtocol().getTransport().close();
         throw e;
       } finally {
-        putBackSyncClient(client);
+        ClientUtils.putBackSyncClient(client);
       }
       return pullSnapshotResp;
     } else {
@@ -136,7 +137,7 @@ public class DataSyncService extends BaseSyncService implements TSDataService.If
         client.getInputProtocol().getTransport().close();
         throw te;
       } finally {
-        putBackSyncClient(client);
+        ClientUtils.putBackSyncClient(client);
       }
       return pullSchemaResp;
     } catch (MetadataException e) {
@@ -164,7 +165,7 @@ public class DataSyncService extends BaseSyncService implements TSDataService.If
         client.getInputProtocol().getTransport().close();
         throw te;
       } finally {
-        putBackSyncClient(client);
+        ClientUtils.putBackSyncClient(client);
       }
       return pullSchemaResp;
     } catch (IllegalPathException e) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/service/MetaSyncService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/service/MetaSyncService.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.cluster.rpc.thrift.TSMetaService;
 import org.apache.iotdb.cluster.server.NodeCharacter;
 import org.apache.iotdb.cluster.server.Response;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
+import org.apache.iotdb.cluster.utils.ClientUtils;
 import org.apache.iotdb.cluster.utils.ClusterUtils;
 
 import org.apache.thrift.TException;
@@ -114,7 +115,7 @@ public class MetaSyncService extends BaseSyncService implements TSMetaService.If
         client.getInputProtocol().getTransport().close();
         logger.warn("Cannot connect to node {}", node, e);
       } finally {
-        putBackSyncClient(client);
+        ClientUtils.putBackSyncClient(client);
       }
     }
     return null;
@@ -177,7 +178,7 @@ public class MetaSyncService extends BaseSyncService implements TSMetaService.If
         client.getInputProtocol().getTransport().close();
         logger.warn("Cannot connect to node {}", node, e);
       } finally {
-        putBackSyncClient(client);
+        ClientUtils.putBackSyncClient(client);
       }
     }
     return null;

--- a/cluster/src/test/java/org/apache/iotdb/cluster/client/sync/SyncDataClientTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/client/sync/SyncDataClientTest.java
@@ -72,4 +72,55 @@ public class SyncDataClientTest {
       listenThread.join();
     }
   }
+
+  @Test
+  public void testTryClose() throws IOException, InterruptedException {
+    Node node = new Node();
+    node.setDataPort(40010).setInternalIp("localhost").setClientIp("localhost");
+    ServerSocket serverSocket = new ServerSocket(node.getDataPort());
+    Thread listenThread =
+        new Thread(
+            () -> {
+              while (!Thread.interrupted()) {
+                try {
+                  serverSocket.accept();
+                } catch (IOException e) {
+                  return;
+                }
+              }
+            });
+    listenThread.start();
+
+    try {
+      SyncClientPool syncClientPool = new SyncClientPool(new FactorySync(new Factory()));
+      SyncDataClient clientOut;
+      try (SyncDataClient clientIn = (SyncDataClient) syncClientPool.getClient(node)) {
+        assertEquals(node, clientIn.getNode());
+        clientIn.setTimeout(1000);
+        clientOut = clientIn;
+        assertEquals(1000, clientIn.getTimeout());
+      }
+      assertTrue(clientOut.getInputProtocol().getTransport().isOpen());
+
+      try (SyncDataClient newClient = (SyncDataClient) syncClientPool.getClient(node)) {
+        assertEquals(clientOut, newClient);
+        assertEquals(
+            "DataClient{node=ClusterNode{ internalIp='localhost', metaPort=0, nodeIdentifier=0,"
+                + " dataPort=40010, clientPort=0, clientIp='localhost'}}",
+            newClient.toString());
+      }
+
+      try (SyncDataClient clientIn =
+          new SyncDataClient(
+              new TBinaryProtocol(new TSocket(node.getInternalIp(), node.getDataPort())))) {
+        clientOut = clientIn;
+      }
+      // client without a belong pool will be closed after putBack()
+      assertFalse(clientOut.getInputProtocol().getTransport().isOpen());
+    } finally {
+      serverSocket.close();
+      listenThread.interrupt();
+      listenThread.join();
+    }
+  }
 }

--- a/cluster/src/test/java/org/apache/iotdb/cluster/client/sync/SyncMetaClientTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/client/sync/SyncMetaClientTest.java
@@ -64,4 +64,51 @@ public class SyncMetaClientTest {
       listenThread.join();
     }
   }
+
+  @Test
+  public void testTryClose() throws IOException, InterruptedException {
+    Node node = new Node();
+    node.setMetaPort(9003).setInternalIp("localhost").setClientIp("localhost");
+    ServerSocket serverSocket = new ServerSocket(node.getMetaPort());
+    Thread listenThread =
+        new Thread(
+            () -> {
+              while (!Thread.interrupted()) {
+                try {
+                  serverSocket.accept();
+                } catch (IOException e) {
+                  return;
+                }
+              }
+            });
+    listenThread.start();
+
+    try {
+      SyncClientPool syncClientPool = new SyncClientPool(new FactorySync(new Factory()));
+      SyncMetaClient clientOut;
+      try (SyncMetaClient clientIn = (SyncMetaClient) syncClientPool.getClient(node); ) {
+        assertEquals(node, clientIn.getNode());
+        clientOut = clientIn;
+      }
+
+      try (SyncMetaClient newClientIn = (SyncMetaClient) syncClientPool.getClient(node)) {
+        assertEquals(node, newClientIn.getNode());
+        assertEquals(clientOut, newClientIn);
+      }
+      assertTrue(clientOut.getInputProtocol().getTransport().isOpen());
+
+      try (SyncMetaClient clientIn =
+          new SyncMetaClient(
+              new TBinaryProtocol(new TSocket(node.getInternalIp(), node.getDataPort())))) {
+        clientOut = clientIn;
+      }
+
+      // client without a belong pool will be closed after putBack()
+      assertFalse(clientOut.getInputProtocol().getTransport().isOpen());
+    } finally {
+      serverSocket.close();
+      listenThread.interrupt();
+      listenThread.join();
+    }
+  }
 }


### PR DESCRIPTION
Currently, the thread pool is used to manage inter-cluster communication access. The connection is obtained from the connection pool. After the connection is used, the connection is returned to the connection pool. After the connection is used, the interface must be called to put the connection back to the connection pool. This requires that the connection must be closed in finally.
Therefore, the connection usage is optimized here. Use try() to obtain the closed connection（push to thread pool）.

1. interface Closeable and close method. if call close , will put client to pool.
2. use try() syntax,  will put client to pool.This is the common method of closing connections for thread pools. For example, common-pool.jar.
3. In case the connection is not put back into the connection pool after the connection is completed.
