### PR TITLE
Update the SeedUrl Format Exception Info when using cluster mode

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/exception/BadSeedUrlFormatException.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/exception/BadSeedUrlFormatException.java
@@ -25,7 +25,7 @@ public class BadSeedUrlFormatException extends Exception {
     super(
         String.format(
             "Seed url %s has bad format, which should be "
-                + "{IP/DomainName}:{metaPort}:{dataPort}:{clientPort}",
+                + "{IP/DomainName}:{metaPort}",
             seedUrl));
   }
 }


### PR DESCRIPTION
## Description
When we start the IoTDB server in cluster mode, the SeedUrl format reminder Info is wrong, should has two parameter.