### PR TITLE
[IOTDB-1204] set parameter in iotdb-cluster.properties

### DIFF
--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -162,5 +162,7 @@ max_read_log_lag=1000
 # Max number of clients in a ClientPool of a member for one node.
 max_client_pernode_permember_number=1000
 
-# If the number of connections created for a node exceeds  `max_client_pernode_permember_number`, we need to wait so much time for other connections to be released until timeout, or a new connection will be created.
+# If the number of connections created for a node exceeds  `max_client_pernode_permember_number`,
+# we need to wait so much time for other connections to be released until timeout,
+# or a new connection will be created.
 wait_client_timeout_ms=5000

--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -158,3 +158,10 @@ max_number_of_logs_per_fetch_on_disk=1000
 # When consistency level is set to mid, query will fail if the log lag exceeds max_read_log_lag
 # This default value is 1000
 max_read_log_lag=1000
+
+# Max number of clients in a ClientPool of a member for one node.
+max_client_pernode_permember_number=1000
+
+# Wait for some timeout, if the old client is not released
+# A new client is created
+wait_client_timeout_ms=5000

--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -162,6 +162,5 @@ max_read_log_lag=1000
 # Max number of clients in a ClientPool of a member for one node.
 max_client_pernode_permember_number=1000
 
-# Wait for some timeout, if the old client is not released
-# A new client is created
+# If the number of connections created for a node exceeds  `max_client_pernode_permember_number`, we need to wait so much time for other connections to be released until timeout, or a new connection will be created.
 wait_client_timeout_ms=5000

--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncClientPool.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncClientPool.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SyncClientPool {
 
   private static final Logger logger = LoggerFactory.getLogger(SyncClientPool.class);
-  private static final long WAIT_CLIENT_TIMEOUT_MS = 5 * 1000L;
+  private long waitClientTimeoutMS;
   private int maxConnectionForEachNode;
   private Map<ClusterNode, Deque<Client>> clientCaches = new ConcurrentHashMap<>();
   private Map<ClusterNode, Integer> nodeClientNumMap = new ConcurrentHashMap<>();
@@ -46,6 +46,7 @@ public class SyncClientPool {
 
   public SyncClientPool(SyncClientFactory syncClientFactory) {
     this.syncClientFactory = syncClientFactory;
+    this.waitClientTimeoutMS = ClusterDescriptor.getInstance().getConfig().getWaitClientTimeoutMS();
     this.maxConnectionForEachNode =
         ClusterDescriptor.getInstance().getConfig().getMaxClientPerNodePerMember();
   }
@@ -112,12 +113,11 @@ public class SyncClientPool {
     long waitStart = System.currentTimeMillis();
     while (clientStack.isEmpty()) {
       try {
-        this.wait(WAIT_CLIENT_TIMEOUT_MS);
+        this.wait(waitClientTimeoutMS);
         if (clientStack.isEmpty()
-            && System.currentTimeMillis() - waitStart >= WAIT_CLIENT_TIMEOUT_MS) {
+            && System.currentTimeMillis() - waitStart >= waitClientTimeoutMS) {
           logger.warn(
-              "Cannot get an available client after {}ms, create a new one",
-              WAIT_CLIENT_TIMEOUT_MS);
+              "Cannot get an available client after {}ms, create a new one", waitClientTimeoutMS);
           Client client = syncClientFactory.getSyncClient(clusterNode, this);
           nodeClientNumMap.computeIfPresent(clusterNode, (n, oldValue) -> oldValue + 1);
           return client;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
@@ -71,6 +71,9 @@ public class ClusterConfig {
   /** max number of clients in a ClientPool of a member for one node. */
   private int maxClientPerNodePerMember = 1000;
 
+  /** Wait for some timeout, if the old client is not released A new client is created */
+  private long waitClientTimeoutMS = 5 * 1000L;
+
   /**
    * ClientPool will have so many selector threads (TAsyncClientManager) to distribute to its
    * clients.
@@ -440,5 +443,13 @@ public class ClusterConfig {
 
   public void setOpenServerRpcPort(boolean openServerRpcPort) {
     this.openServerRpcPort = openServerRpcPort;
+  }
+
+  public long getWaitClientTimeoutMS() {
+    return waitClientTimeoutMS;
+  }
+
+  public void setWaitClientTimeoutMS(long waitClientTimeoutMS) {
+    this.waitClientTimeoutMS = waitClientTimeoutMS;
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
@@ -71,7 +71,11 @@ public class ClusterConfig {
   /** max number of clients in a ClientPool of a member for one node. */
   private int maxClientPerNodePerMember = 1000;
 
-  /** Wait for some timeout, if the old client is not released A new client is created */
+  /**
+   * If the number of connections created for a node exceeds `max_client_pernode_permember_number`,
+   * we need to wait so much time for other connections to be released until timeout, or a new
+   * connection will be created.
+   */
   private long waitClientTimeoutMS = 5 * 1000L;
 
   /**

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -282,6 +282,17 @@ public class ClusterDescriptor {
         Long.parseLong(
             properties.getProperty("max_read_log_lag", String.valueOf(config.getMaxReadLogLag()))));
 
+    config.setMaxClientPerNodePerMember(
+        Integer.parseInt(
+            properties.getProperty(
+                "max_client_pernode_permember_number",
+                String.valueOf(config.getMaxClientPerNodePerMember()))));
+
+    config.setWaitClientTimeoutMS(
+        Long.parseLong(
+            properties.getProperty(
+                "wait_client_timeout_ms", String.valueOf(config.getWaitClientTimeoutMS()))));
+
     String consistencyLevel = properties.getProperty("consistency_level");
     if (consistencyLevel != null) {
       config.setConsistencyLevel(ConsistencyLevel.getConsistencyLevel(consistencyLevel));


### PR DESCRIPTION
The WAIT_CLIENT_TIMEOUT_MS and maxConnectionForEachNode
parameter controls the connection generation speed and affects cluster link access. Therefore, it can be configured in the iotdb-cluster file.