### PR TITLE
[IOTDB-1221] Compaction module: chunk metadata lists returned by the getMeasurementChunkMetadataListMapIterator method are not lexicographically ordered by the measurement names

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -1262,8 +1262,8 @@ public class TsFileSequenceReader implements AutoCloseable {
    *     always larger than the last measurement of the linked hashmap of the previous iteration in
    *     lexicographic order.
    */
-  public Iterator<LinkedHashMap<String, List<ChunkMetadata>>>
-      getMeasurementChunkMetadataListMapIterator(String device) throws IOException {
+  public Iterator<Map<String, List<ChunkMetadata>>> getMeasurementChunkMetadataListMapIterator(
+      String device) throws IOException {
     readFileMetadata();
 
     MetadataIndexNode metadataIndexNode = tsFileMetaData.getMetadataIndex();
@@ -1271,7 +1271,7 @@ public class TsFileSequenceReader implements AutoCloseable {
         getMetadataAndEndOffset(metadataIndexNode, device, true, true);
 
     if (metadataIndexPair == null) {
-      return new Iterator<LinkedHashMap<String, List<ChunkMetadata>>>() {
+      return new Iterator<Map<String, List<ChunkMetadata>>>() {
 
         @Override
         public boolean hasNext() {
@@ -1289,7 +1289,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     ByteBuffer buffer = readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right);
     collectEachLeafMeasurementNodeOffsetRange(buffer, queue);
 
-    return new Iterator<LinkedHashMap<String, List<ChunkMetadata>>>() {
+    return new Iterator<Map<String, List<ChunkMetadata>>>() {
 
       @Override
       public boolean hasNext() {

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -142,7 +141,7 @@ public class MeasurementChunkMetadataListMapIteratorTest {
             expectedDeviceMeasurementChunkMetadataListMap.get(device);
 
         Map<String, List<ChunkMetadata>> actual = new HashMap<>();
-        Iterator<LinkedHashMap<String, List<ChunkMetadata>>> iterator =
+        Iterator<Map<String, List<ChunkMetadata>>> iterator =
             fileReader.getMeasurementChunkMetadataListMapIterator(device);
         while (iterator.hasNext()) {
           Map<String, List<ChunkMetadata>> next = iterator.next();
@@ -178,7 +177,7 @@ public class MeasurementChunkMetadataListMapIteratorTest {
 
     try (TsFileSequenceReader fileReader = new TsFileSequenceReader(FILE_PATH)) {
       for (String device : fileReader.getAllDevices()) {
-        Iterator<LinkedHashMap<String, List<ChunkMetadata>>> iterator =
+        Iterator<Map<String, List<ChunkMetadata>>> iterator =
             fileReader.getMeasurementChunkMetadataListMapIterator(device);
 
         String lastMeasurement = null;

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
@@ -183,8 +183,7 @@ public class MeasurementChunkMetadataListMapIteratorTest {
 
         String lastMeasurement = null;
         while (iterator.hasNext()) {
-          LinkedHashMap<String, List<ChunkMetadata>> next = iterator.next();
-          for (String measurement : next.keySet()) {
+          for (String measurement : iterator.next().keySet()) {
             if (lastMeasurement != null) {
               Assert.assertTrue(lastMeasurement.compareTo(measurement) < 0);
             }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -59,45 +60,65 @@ public class MeasurementChunkMetadataListMapIteratorTest {
 
   @Test
   public void test0() throws IOException {
-    test(1, 1);
+    testCorrectness(1, 1);
+    testSequentiality(1, 1);
   }
 
   @Test
   public void test1() throws IOException {
-    test(1, 10);
+    testCorrectness(1, 10);
+    testSequentiality(1, 10);
   }
 
   @Test
   public void test2() throws IOException {
-    test(2, 1);
+    testCorrectness(2, 1);
+    testSequentiality(2, 1);
   }
 
   @Test
   public void test3() throws IOException {
-    test(2, 2);
+    testCorrectness(2, 2);
+    testSequentiality(2, 2);
   }
 
   @Test
   public void test4() throws IOException {
-    test(2, 100);
+    testCorrectness(2, 100);
+    testSequentiality(2, 100);
   }
 
   @Test
   public void test5() throws IOException {
-    test(50, 2);
+    testCorrectness(50, 2);
+    testSequentiality(50, 2);
   }
 
   @Test
   public void test6() throws IOException {
-    test(50, 50);
+    testCorrectness(50, 50);
+    testSequentiality(50, 50);
   }
 
   @Test
   public void test7() throws IOException {
-    test(50, 100);
+    testCorrectness(50, 100);
+    testSequentiality(50, 100);
   }
 
-  public void test(int deviceNum, int measurementNum) throws IOException {
+  @Test
+  public void test8() throws IOException {
+    testCorrectness(33, 733);
+    testSequentiality(33, 733);
+  }
+
+  @Test
+  public void test9() throws IOException {
+    testCorrectness(733, 33);
+    testSequentiality(733, 33);
+  }
+
+  public void testCorrectness(int deviceNum, int measurementNum) throws IOException {
     FileGenerator.generateFile(10000, deviceNum, measurementNum);
 
     try (TsFileSequenceReader fileReader = new TsFileSequenceReader(FILE_PATH)) {
@@ -121,7 +142,7 @@ public class MeasurementChunkMetadataListMapIteratorTest {
             expectedDeviceMeasurementChunkMetadataListMap.get(device);
 
         Map<String, List<ChunkMetadata>> actual = new HashMap<>();
-        Iterator<Map<String, List<ChunkMetadata>>> iterator =
+        Iterator<LinkedHashMap<String, List<ChunkMetadata>>> iterator =
             fileReader.getMeasurementChunkMetadataListMapIterator(device);
         while (iterator.hasNext()) {
           Map<String, List<ChunkMetadata>> next = iterator.next();
@@ -130,14 +151,14 @@ public class MeasurementChunkMetadataListMapIteratorTest {
           }
         }
 
-        check(expected, actual);
+        checkCorrectness(expected, actual);
       }
     }
 
     FileGenerator.after();
   }
 
-  private void check(
+  private void checkCorrectness(
       Map<String, List<ChunkMetadata>> expected, Map<String, List<ChunkMetadata>> actual) {
     Assert.assertEquals(expected.keySet(), actual.keySet());
     for (String measurement : expected.keySet()) {
@@ -150,5 +171,29 @@ public class MeasurementChunkMetadataListMapIteratorTest {
             expectedChunkMetadataList.get(i).toString(), actualChunkMetadataList.get(i).toString());
       }
     }
+  }
+
+  public void testSequentiality(int deviceNum, int measurementNum) throws IOException {
+    FileGenerator.generateFile(10000, deviceNum, measurementNum);
+
+    try (TsFileSequenceReader fileReader = new TsFileSequenceReader(FILE_PATH)) {
+      for (String device : fileReader.getAllDevices()) {
+        Iterator<LinkedHashMap<String, List<ChunkMetadata>>> iterator =
+            fileReader.getMeasurementChunkMetadataListMapIterator(device);
+
+        String lastMeasurement = null;
+        while (iterator.hasNext()) {
+          LinkedHashMap<String, List<ChunkMetadata>> next = iterator.next();
+          for (String measurement : next.keySet()) {
+            if (lastMeasurement != null) {
+              Assert.assertTrue(lastMeasurement.compareTo(measurement) < 0);
+            }
+            lastMeasurement = measurement;
+          }
+        }
+      }
+    }
+
+    FileGenerator.after();
   }
 }


### PR DESCRIPTION
Chunk metadata lists returned by the `getMeasurementChunkMetadataListMapIterator` method are not lexicographically ordered by the measurement names, which will cause compaction errors.

JIRA: https://issues.apache.org/jira/browse/IOTDB-1221
