### PR TITLE
[IOTDB-1226]download calcite-core's dependency penhato from public.nexus.pentaho.org rather than spring.io

### DIFF
--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -168,17 +168,13 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <!-- org.pentaho:pentaho-aggdesigner-algorithm is in repo.spring.io and we have to claim
-    to use https-->
-    <!-- Please note the notice in https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020
-    Anonymous access using /libs-snapshot or /libs-milestone in the pom.xml, or with
-    these configured in a remote repository, should replace them with /snapshot and /milestone, 
-    respectively.-->
+    <!-- org.pentaho:pentaho-aggdesigner-algorithm is removed from  repo.spring.io and we have to claim
+    to use https://public.nexus.pentaho.org or http://conjars.org/repo  -->
     <repositories>
         <repository>
             <id>for_pentaho</id>
-            <name>spring.io</name>
-            <url>https://repo.spring.io/milestone</url>
+            <name>public.nexus.pentaho.org</name>
+            <url>https://public.nexus.pentaho.org/repository/proxy-public-3rd-party-release</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>


### PR DESCRIPTION
Pentaho is dependent on calcite-core 1.10 (by hive), but it is always downloaded failed from spring.io repo.

see:

 

Error: Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.7.0:process (process-resource-bundles) on project hive-connector: Execution process-resource-bundles of goal org.apache.maven.plugins:maven-remote-resources-plugin:1.7.0:process failed: Error resolving project artifact: Could not transfer artifact org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom for project org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde: Connection timed out (Read failed) -> [Help 1]

 



The solution is change another repo, e.g.,

1. https://public.nexus.pentaho.org/repository/proxy-public-3rd-party-release

2.  http://conjars.org/repo

 

BTW, calcite 1.26 does not depend on it anymore.