### PR TITLE
[To rel/0.11] Add explain sql support

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
@@ -20,7 +20,7 @@
 grammar SqlBase;
 
 singleStatement
-    : statement EOF
+    : EXPLAIN? statement EOF
     ;
 
 /*
@@ -1185,6 +1185,11 @@ DESC
 ASC
     : A S C
     ;
+
+EXPLAIN
+    : E X P L A I N
+    ;
+
 //============================
 // End of the keywords list
 //============================

--- a/grafana/pom.xml
+++ b/grafana/pom.xml
@@ -165,7 +165,7 @@
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                         <resource>META-INF/spring.schemas</resource>
                                     </transformer>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <mainClass>${start-class}</mainClass>
                                     </transformer>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -223,7 +223,7 @@
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>
-                                                <ignore />
+                                                <ignore/>
                                             </action>
                                         </pluginExecution>
                                     </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <sonar.exclusions>**/generated-sources</sonar.exclusions>
         <!-- By default, the argLine is empty-->
         <gson.version>2.8.6</gson.version>
-        <argLine />
+        <argLine/>
     </properties>
     <!--
         if we claim dependencies in dependencyManagement, then we do not claim
@@ -599,7 +599,7 @@
                         <id>enforce-version-convergence</id>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                         <goals>
@@ -645,7 +645,7 @@
                                 </requireJavaVersion>
                                 <!-- Disabled for now as it breaks the ability to build single modules -->
                                 <!--reactorModuleConvergence/-->
-                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies" />
+                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
                             </rules>
                         </configuration>
                     </execution>

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/ChunkCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/ChunkCache.java
@@ -84,6 +84,11 @@ public class ChunkCache {
   }
 
   public Chunk get(ChunkMetadata chunkMetaData, TsFileSequenceReader reader) throws IOException {
+    return get(chunkMetaData, reader, false);
+  }
+
+  public Chunk get(ChunkMetadata chunkMetaData, TsFileSequenceReader reader, boolean debug)
+      throws IOException {
     if (!CACHE_ENABLE) {
       Chunk chunk = reader.readMemChunk(chunkMetaData);
       return new Chunk(chunk.getHeader(), chunk.getData().duplicate(),
@@ -118,7 +123,7 @@ public class ChunkCache {
       }
     }
 
-    if (config.isDebugOn()) {
+    if (debug) {
       DEBUG_LOGGER.info("get chunk from cache whose meta data is: " + chunkMetaData);
     }
     return new Chunk(chunk.getHeader(), chunk.getData().duplicate(), chunk.getDeleteIntervalList());

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/ChunkMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/ChunkMetadataCache.java
@@ -102,11 +102,16 @@ public class ChunkMetadataCache {
     return ChunkMetadataCacheSingleton.INSTANCE;
   }
 
+  public List<ChunkMetadata> get(String filePath, Path seriesPath,
+      TimeseriesMetadata timeseriesMetadata) throws IOException {
+    return get(filePath, seriesPath, timeseriesMetadata, false);
+  }
+
   /**
    * get {@link ChunkMetadata}. THREAD SAFE.
    */
   public List<ChunkMetadata> get(String filePath, Path seriesPath,
-      TimeseriesMetadata timeseriesMetadata) throws IOException {
+      TimeseriesMetadata timeseriesMetadata, boolean debug) throws IOException {
     if (timeseriesMetadata == null) {
       return Collections.emptyList();
     }
@@ -144,7 +149,7 @@ public class ChunkMetadataCache {
         lock.writeLock().unlock();
       }
     }
-    if (config.isDebugOn()) {
+    if (debug) {
       DEBUG_LOGGER.info(
           "Chunk meta data list size: " + chunkMetadataList.size() + " key is: " + key.getString());
       chunkMetadataList.forEach(c -> DEBUG_LOGGER.info(c.toString()));

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -106,8 +106,13 @@ public class TimeSeriesMetadataCache {
     return TimeSeriesMetadataCache.TimeSeriesMetadataCacheHolder.INSTANCE;
   }
 
-  @SuppressWarnings("squid:S1860") // Suppress synchronize warning
   public TimeseriesMetadata get(TimeSeriesMetadataCacheKey key, Set<String> allSensors)
+      throws IOException {
+    return get(key, allSensors, false);
+  }
+
+  @SuppressWarnings("squid:S1860") // Suppress synchronize warning
+  public TimeseriesMetadata get(TimeSeriesMetadataCacheKey key, Set<String> allSensors, boolean debug)
       throws IOException {
     if (!CACHE_ENABLE) {
       // bloom filter part
@@ -134,7 +139,7 @@ public class TimeSeriesMetadataCache {
       cacheHitNum.incrementAndGet();
       printCacheLog(true);
     } else {
-      if (config.isDebugOn()) {
+      if (debug) {
         DEBUG_LOGGER.info(
             "Cache miss: " + key.device + "." + key.measurement + " metadata in file: "
                 + key.filePath);
@@ -159,7 +164,7 @@ public class TimeSeriesMetadataCache {
           TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
           BloomFilter bloomFilter = reader.readBloomFilter();
           if (bloomFilter != null && !bloomFilter.contains(path.getFullPath())) {
-            if (config.isDebugOn()) {
+            if (debug) {
               DEBUG_LOGGER.info("TimeSeries meta data {} is filter by bloomFilter!", key);
             }
             return null;
@@ -185,12 +190,12 @@ public class TimeSeriesMetadataCache {
       }
     }
     if (timeseriesMetadata == null) {
-      if (config.isDebugOn()) {
+      if (debug) {
         DEBUG_LOGGER.info("The file doesn't have this time series {}", key);
       }
       return null;
     } else {
-      if (config.isDebugOn()) {
+      if (debug) {
         DEBUG_LOGGER.info(
             "Get timeseries: {}. {} metadata in file: {} from cache: {}",
             key.device, key.measurement, key.filePath, timeseriesMetadata);

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -198,7 +198,7 @@ public class TimeSeriesMetadataCache {
       if (debug) {
         DEBUG_LOGGER.info(
             "Get timeseries: {}. {} metadata in file: {} from cache: {}",
-            key.device, key.measurement, key.filePath, timeseriesMetadata.toString());
+            key.device, key.measurement, key.filePath, timeseriesMetadata);
       }
       return new TimeseriesMetadata(timeseriesMetadata);
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -198,7 +198,7 @@ public class TimeSeriesMetadataCache {
       if (debug) {
         DEBUG_LOGGER.info(
             "Get timeseries: {}. {} metadata in file: {} from cache: {}",
-            key.device, key.measurement, key.filePath, timeseriesMetadata);
+            key.device, key.measurement, key.filePath, timeseriesMetadata.toString());
       }
       return new TimeseriesMetadata(timeseriesMetadata);
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/modification/Modification.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/modification/Modification.java
@@ -94,4 +94,13 @@ public abstract class Modification {
   public int hashCode() {
     return Objects.hash(type, path, versionNum);
   }
+
+  @Override
+  public String toString() {
+    return "Modification{" +
+        "type=" + type +
+        ", path=" + path +
+        ", versionNum=" + versionNum +
+        '}';
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1601,6 +1601,8 @@ public class StorageGroupProcessor {
       tsFileResource.getModFile().write(deletion);
       // remember to close mod file
       tsFileResource.getModFile().close();
+      logger.info("[Deletion] Deletion with path:{}, time:{}-{} written into mods file.",
+              deletion.getPath(), deletion.getStartTime(), deletion.getEndTime());
 
       tsFileResource.updatePlanIndexes(planIndex);
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1415,7 +1415,7 @@ public class StorageGroupProcessor {
       boolean isSeq)
       throws MetadataException {
 
-    if (config.isDebugOn()) {
+    if (context.isDebug()) {
       DEBUG_LOGGER
           .info("Path: {}.{}, get tsfile list: {} isSeq: {} timefilter: {}", deviceId.getFullPath(),
               measurementId, tsFileResources, isSeq, (timeFilter == null ? "null" : timeFilter));
@@ -1429,7 +1429,7 @@ public class StorageGroupProcessor {
     context.setQueryTimeLowerBound(timeLowerBound);
 
     for (TsFileResource tsFileResource : tsFileResources) {
-      if (!isTsFileResourceSatisfied(tsFileResource, deviceId.getFullPath(), timeFilter, isSeq)) {
+      if (!isTsFileResourceSatisfied(tsFileResource, deviceId.getFullPath(), timeFilter, isSeq, context.isDebug())) {
         continue;
       }
       closeQueryLock.readLock().lock();
@@ -1450,7 +1450,7 @@ public class StorageGroupProcessor {
     }
     // for upgrade files and old files must be closed
     for (TsFileResource tsFileResource : upgradeTsFileResources) {
-      if (!isTsFileResourceSatisfied(tsFileResource, deviceId.getFullPath(), timeFilter, isSeq)) {
+      if (!isTsFileResourceSatisfied(tsFileResource, deviceId.getFullPath(), timeFilter, isSeq, context.isDebug())) {
         continue;
       }
       closeQueryLock.readLock().lock();
@@ -1467,9 +1467,9 @@ public class StorageGroupProcessor {
    * @return true if the device is contained in the TsFile and it lives beyond TTL
    */
   private boolean isTsFileResourceSatisfied(TsFileResource tsFileResource, String deviceId,
-      Filter timeFilter, boolean isSeq) {
+      Filter timeFilter, boolean isSeq, boolean debug) {
     if (!tsFileResource.containsDevice(deviceId)) {
-      if (config.isDebugOn()) {
+      if (debug) {
         DEBUG_LOGGER.info("Path: {} file {} is not satisfied because of no device!", deviceId,
             tsFileResource);
       }
@@ -1482,7 +1482,7 @@ public class StorageGroupProcessor {
         : Long.MAX_VALUE;
 
     if (!isAlive(endTime)) {
-      if (config.isDebugOn()) {
+      if (debug) {
         DEBUG_LOGGER
             .info("Path: {} file {} is not satisfied because of ttl!", deviceId, tsFileResource);
       }
@@ -1491,7 +1491,7 @@ public class StorageGroupProcessor {
 
     if (timeFilter != null) {
       boolean res = timeFilter.satisfyStartEndTime(startTime, endTime);
-      if (config.isDebugOn() && !res) {
+      if (debug && !res) {
         DEBUG_LOGGER.info("Path: {} file {} is not satisfied because of time filter!", deviceId,
             tsFileResource);
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1524,6 +1524,7 @@ public class StorageGroupProcessor {
       for (PartialPath device : devicePaths) {
         // delete Last cache record if necessary
         tryToDeleteLastCache(device, path, startTime, endTime);
+        DEBUG_LOGGER.info("Delete last cache for path: " + path + " with deletion interval: " + startTime + " to " + endTime);
       }
 
       // write log to impacted working TsFileProcessors

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -393,11 +393,15 @@ public class TsFileProcessor {
         for (PartialPath device : devicePaths) {
           workMemTable.delete(deletion.getPath(), device, deletion.getStartTime(),
               deletion.getEndTime());
+          logger.info("[Deletion] Delete in-memory data with deletion path: {}, time:{}-{}.",
+                  deletion.getPath(), deletion.getStartTime(), deletion.getEndTime());
         }
       }
       // flushing memTables are immutable, only record this deletion in these memTables for query
       for (IMemTable memTable : flushingMemTables) {
         memTable.delete(deletion);
+        logger.info("[Deletion] delete flushing memtable with deletion path: {}, time:{}-{}",
+                deletion.getPath(), deletion.getStartTime(), deletion.getEndTime());
       }
     } finally {
       flushQueryLock.writeLock().unlock();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MeasurementMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MeasurementMNode.java
@@ -29,12 +29,16 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Represents an MNode which has a Measurement or Sensor attached to it.
  */
 public class MeasurementMNode extends MNode {
 
   private static final long serialVersionUID = -1199657856921206435L;
+  private static final Logger DEBUG_LOGGER = LoggerFactory.getLogger("QUERY_DEBUG");
 
   /**
    * measurement's Schema for one timeseries represented by current leaf node
@@ -82,12 +86,14 @@ public class MeasurementMNode extends MNode {
       if (!highPriorityUpdate || latestFlushedTime <= timeValuePair.getTimestamp()) {
         cachedLastValuePair =
             new TimeValuePair(timeValuePair.getTimestamp(), timeValuePair.getValue());
+        DEBUG_LOGGER.info("[MeasurementMNode] Last cache for path: " + fullPath + " is set to: " + timeValuePair.getTimestamp());
       }
     } else if (timeValuePair.getTimestamp() > cachedLastValuePair.getTimestamp()
         || (timeValuePair.getTimestamp() == cachedLastValuePair.getTimestamp()
         && highPriorityUpdate)) {
       cachedLastValuePair.setTimestamp(timeValuePair.getTimestamp());
       cachedLastValuePair.setValue(timeValuePair.getValue());
+      DEBUG_LOGGER.info("[MeasurementMNode] Last cache for path: " + fullPath + " is set to: " + timeValuePair.getTimestamp());
     }
   }
 
@@ -98,6 +104,7 @@ public class MeasurementMNode extends MNode {
 
   public void resetCache() {
     cachedLastValuePair = null;
+    DEBUG_LOGGER.info("[MeasurementMNode] Last cache for path: " + fullPath + " is set to null");
   }
 
   public long getOffset() {

--- a/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
@@ -45,9 +45,7 @@ import java.util.Set;
 
 import static org.apache.iotdb.db.conf.IoTDBConstant.TIME;
 
-/**
- * provide a integration method for other user.
- */
+/** provide a integration method for other user. */
 public class Planner {
 
   protected LogicalGenerator logicalGenerator;
@@ -57,44 +55,43 @@ public class Planner {
   }
 
   @TestOnly
-  public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr)
-      throws QueryProcessException {
+  public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr) throws QueryProcessException {
     return parseSQLToPhysicalPlan(sqlStr, ZoneId.systemDefault(), 1024);
   }
 
-  /**
-   * @param fetchSize this parameter only take effect when it is a query plan
-   */
+  /** @param fetchSize this parameter only take effect when it is a query plan */
   public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr, ZoneId zoneId, int fetchSize)
       throws QueryProcessException {
     Operator operator = logicalGenerator.generate(sqlStr, zoneId);
-    int maxDeduplicatedPathNum = QueryResourceManager.getInstance()
-        .getMaxDeduplicatedPathNum(fetchSize);
+    int maxDeduplicatedPathNum =
+        QueryResourceManager.getInstance().getMaxDeduplicatedPathNum(fetchSize);
     if (operator instanceof SFWOperator && ((SFWOperator) operator).isLastQuery()) {
-      // Dataset of last query actually has only three columns, so we shouldn't limit the path num while constructing logical plan
-      // To avoid overflowing because logicalOptimize function may do maxDeduplicatedPathNum + 1, we set it to Integer.MAX_VALUE - 1
+      // Dataset of last query actually has only three columns, so we shouldn't limit the path num
+      // while constructing logical plan
+      // To avoid overflowing because logicalOptimize function may do maxDeduplicatedPathNum + 1, we
+      // set it to Integer.MAX_VALUE - 1
       maxDeduplicatedPathNum = Integer.MAX_VALUE - 1;
     }
     operator = logicalOptimize(operator, maxDeduplicatedPathNum);
     PhysicalGenerator physicalGenerator = new PhysicalGenerator();
-    return physicalGenerator.transformToPhysicalPlan(operator, fetchSize);
+    PhysicalPlan physicalPlan = physicalGenerator.transformToPhysicalPlan(operator, fetchSize);
+    physicalPlan.setDebug(operator.isDebug());
+    return physicalPlan;
   }
 
-  /**
-   * convert raw data query to physical plan directly
-   */
+  /** convert raw data query to physical plan directly */
   public PhysicalPlan rawDataQueryReqToPhysicalPlan(TSRawDataQueryReq rawDataQueryReq)
       throws QueryProcessException, IllegalPathException {
     List<String> paths = rawDataQueryReq.getPaths();
     long startTime = rawDataQueryReq.getStartTime();
     long endTime = rawDataQueryReq.getEndTime();
 
-    //construct query operator and set its global time filter
+    // construct query operator and set its global time filter
     QueryOperator queryOp = new QueryOperator(SQLConstant.TOK_QUERY);
     FromOperator fromOp = new FromOperator(SQLConstant.TOK_FROM);
     SelectOperator selectOp = new SelectOperator(SQLConstant.TOK_SELECT);
 
-    //iterate the path list and add it to from operator
+    // iterate the path list and add it to from operator
     for (String p : paths) {
       PartialPath path = new PartialPath(p);
       fromOp.addPrefixTablePath(path);
@@ -104,7 +101,7 @@ public class Planner {
     queryOp.setSelectOperator(selectOp);
     queryOp.setFromOperator(fromOp);
 
-    //set time filter operator
+    // set time filter operator
     FilterOperator filterOp = new FilterOperator(SQLConstant.KW_AND);
     PartialPath timePath = new PartialPath(TIME);
     filterOp.setSinglePath(timePath);
@@ -113,26 +110,32 @@ public class Planner {
     filterOp.setIsSingle(true);
     filterOp.setPathSet(pathSet);
 
-    BasicFunctionOperator left = new BasicFunctionOperator(SQLConstant.GREATERTHANOREQUALTO,
-        timePath, Long.toString(startTime));
-    BasicFunctionOperator right = new BasicFunctionOperator(SQLConstant.LESSTHAN, timePath,
-        Long.toString(endTime));
+    BasicFunctionOperator left =
+        new BasicFunctionOperator(
+            SQLConstant.GREATERTHANOREQUALTO, timePath, Long.toString(startTime));
+    BasicFunctionOperator right =
+        new BasicFunctionOperator(SQLConstant.LESSTHAN, timePath, Long.toString(endTime));
     filterOp.addChildOperator(left);
     filterOp.addChildOperator(right);
 
     queryOp.setFilterOperator(filterOp);
 
-    int maxDeduplicatedPathNum = QueryResourceManager.getInstance()
-        .getMaxDeduplicatedPathNum(rawDataQueryReq.fetchSize);
+    int maxDeduplicatedPathNum =
+        QueryResourceManager.getInstance().getMaxDeduplicatedPathNum(rawDataQueryReq.fetchSize);
     if (queryOp.isLastQuery()) {
-      // Dataset of last query actually has only three columns, so we shouldn't limit the path num while constructing logical plan
-      // To avoid overflowing because logicalOptimize function may do maxDeduplicatedPathNum + 1, we set it to Integer.MAX_VALUE - 1
+      // Dataset of last query actually has only three columns, so we shouldn't limit the path num
+      // while constructing logical plan
+      // To avoid overflowing because logicalOptimize function may do maxDeduplicatedPathNum + 1, we
+      // set it to Integer.MAX_VALUE - 1
       maxDeduplicatedPathNum = Integer.MAX_VALUE - 1;
     }
     SFWOperator op = (SFWOperator) logicalOptimize(queryOp, maxDeduplicatedPathNum);
 
     PhysicalGenerator physicalGenerator = new PhysicalGenerator();
-    return physicalGenerator.transformToPhysicalPlan(op, rawDataQueryReq.fetchSize);
+    PhysicalPlan physicalPlan =
+        physicalGenerator.transformToPhysicalPlan(op, rawDataQueryReq.fetchSize);
+    physicalPlan.setDebug(op.isDebug());
+    return physicalPlan;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/Operator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/Operator.java
@@ -20,21 +20,22 @@ package org.apache.iotdb.db.qp.logical;
 
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 
-/**
- * This class is a superclass of all operator.
- */
+/** This class is a superclass of all operator. */
 public abstract class Operator {
 
   // operator type in int format
   protected int tokenIntType;
   // operator type in String format
   protected String tokenName;
+  // flag of "explain"
+  protected boolean isDebug;
 
   protected OperatorType operatorType = OperatorType.NULL;
 
   public Operator(int tokenIntType) {
     this.tokenIntType = tokenIntType;
     this.tokenName = SQLConstant.tokenNames.get(tokenIntType);
+    this.isDebug = false;
   }
 
   public OperatorType getType() {
@@ -57,26 +58,92 @@ public abstract class Operator {
     this.operatorType = operatorType;
   }
 
+  public boolean isDebug() {
+    return isDebug;
+  }
+
+  public void setDebug(boolean debug) {
+    isDebug = debug;
+  }
+
   @Override
   public String toString() {
     return tokenName;
   }
 
-  /**
-   * If you want to add new OperatorType, you must add it in the last.
-   */
+  /** If you want to add new OperatorType, you must add it in the last. */
   public enum OperatorType {
-    SFW, JOIN, UNION, FILTER, GROUPBYTIME, ORDERBY, LIMIT, SELECT, SEQTABLESCAN, HASHTABLESCAN,
-    MERGEJOIN, FILEREAD, NULL, TABLESCAN, UPDATE, INSERT, BATCHINSERT, DELETE, BASIC_FUNC, IN, QUERY, MERGEQUERY,
-    AGGREGATION, AUTHOR, FROM, FUNC, LOADDATA, METADATA, INDEX, INDEXQUERY, FILL,
-    SET_STORAGE_GROUP, CREATE_TIMESERIES, DELETE_TIMESERIES, CREATE_USER, DELETE_USER, MODIFY_PASSWORD,
-    GRANT_USER_PRIVILEGE, REVOKE_USER_PRIVILEGE, GRANT_USER_ROLE, REVOKE_USER_ROLE, CREATE_ROLE,
-    DELETE_ROLE, GRANT_ROLE_PRIVILEGE, REVOKE_ROLE_PRIVILEGE, LIST_USER, LIST_ROLE,
-    LIST_USER_PRIVILEGE, LIST_ROLE_PRIVILEGE, LIST_USER_ROLES, LIST_ROLE_USERS,
-    GRANT_WATERMARK_EMBEDDING, REVOKE_WATERMARK_EMBEDDING,
-    TTL, DELETE_STORAGE_GROUP, LOAD_CONFIGURATION, SHOW, LOAD_FILES, REMOVE_FILE, MOVE_FILE, LAST, GROUP_BY_FILL,
-    ALTER_TIMESERIES, FLUSH, MERGE, FULL_MERGE, CLEAR_CACHE,
-    SHOW_MERGE_STATUS, CREATE_SCHEMA_SNAPSHOT, TRACING, DELETE_PARTITION,
+    SFW,
+    JOIN,
+    UNION,
+    FILTER,
+    GROUPBYTIME,
+    ORDERBY,
+    LIMIT,
+    SELECT,
+    SEQTABLESCAN,
+    HASHTABLESCAN,
+    MERGEJOIN,
+    FILEREAD,
+    NULL,
+    TABLESCAN,
+    UPDATE,
+    INSERT,
+    BATCHINSERT,
+    DELETE,
+    BASIC_FUNC,
+    IN,
+    QUERY,
+    MERGEQUERY,
+    AGGREGATION,
+    AUTHOR,
+    FROM,
+    FUNC,
+    LOADDATA,
+    METADATA,
+    INDEX,
+    INDEXQUERY,
+    FILL,
+    SET_STORAGE_GROUP,
+    CREATE_TIMESERIES,
+    DELETE_TIMESERIES,
+    CREATE_USER,
+    DELETE_USER,
+    MODIFY_PASSWORD,
+    GRANT_USER_PRIVILEGE,
+    REVOKE_USER_PRIVILEGE,
+    GRANT_USER_ROLE,
+    REVOKE_USER_ROLE,
+    CREATE_ROLE,
+    DELETE_ROLE,
+    GRANT_ROLE_PRIVILEGE,
+    REVOKE_ROLE_PRIVILEGE,
+    LIST_USER,
+    LIST_ROLE,
+    LIST_USER_PRIVILEGE,
+    LIST_ROLE_PRIVILEGE,
+    LIST_USER_ROLES,
+    LIST_ROLE_USERS,
+    GRANT_WATERMARK_EMBEDDING,
+    REVOKE_WATERMARK_EMBEDDING,
+    TTL,
+    DELETE_STORAGE_GROUP,
+    LOAD_CONFIGURATION,
+    SHOW,
+    LOAD_FILES,
+    REMOVE_FILE,
+    MOVE_FILE,
+    LAST,
+    GROUP_BY_FILL,
+    ALTER_TIMESERIES,
+    FLUSH,
+    MERGE,
+    FULL_MERGE,
+    CLEAR_CACHE,
+    SHOW_MERGE_STATUS,
+    CREATE_SCHEMA_SNAPSHOT,
+    TRACING,
+    DELETE_PARTITION,
     CREATE_MULTI_TIMESERIES,
     BATCH_INSERT_ONE_DEVICE,
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -63,6 +63,8 @@ public abstract class PhysicalPlan {
   // a bridge from a cluster raft log to a physical plan
   protected long index;
 
+  private boolean debug;
+
   /**
    * whether the plan can be split into more than one Plans. Only used in the cluster mode.
    */
@@ -169,6 +171,14 @@ public abstract class PhysicalPlan {
 
   public void setLoginUserName(String loginUserName) {
     this.loginUserName = loginUserName;
+  }
+
+  public boolean isDebug() {
+    return debug;
+  }
+
+  public void setDebug(boolean debug) {
+    this.debug = debug;
   }
 
   public static class Factory {

--- a/server/src/main/java/org/apache/iotdb/db/query/context/QueryContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/context/QueryContext.java
@@ -50,11 +50,22 @@ public class QueryContext {
 
   private long queryTimeLowerBound = Long.MIN_VALUE;
 
+  private boolean debug;
+
   public QueryContext() {
   }
 
   public QueryContext(long queryId) {
     this.queryId = queryId;
+  }
+
+  public QueryContext(long queryId, boolean debug) {
+    this.queryId = queryId;
+    this.debug = debug;
+  }
+
+  public boolean isDebug() {
+    return debug;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
@@ -74,7 +74,7 @@ public class GroupByWithValueFilterDataSet extends GroupByEngineDataSet {
   }
 
   public GroupByWithValueFilterDataSet(long queryId, GroupByTimePlan groupByTimePlan) {
-    super(new QueryContext(queryId), groupByTimePlan);
+    super(new QueryContext(queryId, groupByTimePlan.isDebug()), groupByTimePlan);
     this.allDataReaderList = new ArrayList<>();
     this.timeStampFetchSize = IoTDBDescriptor.getInstance().getConfig().getBatchSize();
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -54,11 +54,15 @@ import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.Pair;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class LastQueryExecutor {
 
   private List<PartialPath> selectedSeries;
   private List<TSDataType> dataTypes;
   private IExpression expression;
+  private static final Logger DEBUG_LOGGER = LoggerFactory.getLogger("QUERY_DEBUG");
   private static final boolean lastCacheEnabled =
           IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled();
 
@@ -158,6 +162,7 @@ public class LastQueryExecutor {
           resultContainer.get(i).left = true;
           if (lastCacheEnabled) {
             cacheAccessors.get(i).write(resultContainer.get(i).right);
+            DEBUG_LOGGER.info("[LastQueryExecutor] Update last cache for path: " + seriesPaths + " with timestamp: " + resultContainer.get(i).right.getTimestamp());
           }
         }
       }

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/metadata/DiskChunkMetadataLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/metadata/DiskChunkMetadataLoader.java
@@ -87,7 +87,7 @@ public class DiskChunkMetadataLoader implements IChunkMetadataLoader {
         context.getPathModifications(resource.getModFile(), seriesPath);
 
     if (context.isDebug()) {
-      DEBUG_LOGGER.info("Modifications file Path: {} ", resource.getTsFilePath());
+      DEBUG_LOGGER.info("Modifications size is {} for file Path: {} ", pathModifications.size(), resource.getTsFilePath());
       pathModifications.forEach(c -> DEBUG_LOGGER.info(c.toString()));
     }
 
@@ -96,10 +96,8 @@ public class DiskChunkMetadataLoader implements IChunkMetadataLoader {
     }
 
     if (context.isDebug()) {
-      if (context.isDebug()) {
-        DEBUG_LOGGER.info("After modification Chunk meta data list is: ");
-        chunkMetadataList.forEach(c -> DEBUG_LOGGER.info(c.toString()));
-      }
+      DEBUG_LOGGER.info("After modification Chunk meta data list is: ");
+      chunkMetadataList.forEach(c -> DEBUG_LOGGER.info(c.toString()));
     }
 
     for (ChunkMetadata data : chunkMetadataList) {

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -767,7 +767,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       if (costTime >= config.getSlowQueryThreshold()) {
         SLOW_SQL_LOGGER.info("Cost: " + costTime + " ms, sql is " + statement);
       }
-      if (config.isDebugOn()) {
+      if (plan.isDebug()) {
         SLOW_SQL_LOGGER.info("ChunkCache used memory proportion: " + ChunkCache.getInstance()
             .getUsedMemoryProportion() + "\nChunkMetadataCache used memory proportion: "
             + ChunkMetadataCache.getInstance().getUsedMemoryProportion()
@@ -1113,14 +1113,14 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       throws QueryProcessException, QueryFilterOptimizationException, StorageEngineException,
       IOException, MetadataException, SQLException, TException, InterruptedException {
 
-    QueryContext context = genQueryContext(queryId);
+    QueryContext context = genQueryContext(queryId, physicalPlan.isDebug());
     QueryDataSet queryDataSet = executor.processQuery(physicalPlan, context);
     queryId2DataSet.put(queryId, queryDataSet);
     return queryDataSet;
   }
 
-  protected QueryContext genQueryContext(long queryId) {
-    return new QueryContext(queryId);
+  protected QueryContext genQueryContext(long queryId, boolean debug) {
+    return new QueryContext(queryId, debug);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
@@ -94,7 +94,7 @@ public class FileLoaderUtils {
       }
       timeSeriesMetadata = TimeSeriesMetadataCache.getInstance()
           .get(new TimeSeriesMetadataCache.TimeSeriesMetadataCacheKey(resource.getTsFilePath(),
-              seriesPath.getDevice(), seriesPath.getMeasurement()), allSensors);
+              seriesPath.getDevice(), seriesPath.getMeasurement()), allSensors, context.isDebug());
       if (timeSeriesMetadata != null) {
         timeSeriesMetadata.setChunkMetadataLoader(
             new DiskChunkMetadataLoader(resource, seriesPath, context, filter));

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/TimeseriesMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/TimeseriesMetadata.java
@@ -169,4 +169,16 @@ public class TimeseriesMetadata implements Accountable {
   public boolean isSeq() {
     return isSeq;
   }
+
+  @Override
+  public String toString() {
+    return "TimeseriesMetadata{" +
+        "measurementId='" + measurementId + '\'' +
+        ", dataType=" + dataType +
+        ", statistics=" + statistics +
+        ", modified=" + modified +
+        ", ramSize=" + ramSize +
+        ", isSeq=" + isSeq +
+        '}';
+  }
 }


### PR DESCRIPTION
## Description
In this pr, we support explain sql to print the query execute plan in logs. This function can be useful while some bugs happened online and we can collect some information.

## Usage
explain + the query sql, like the following:
```
explain select s1 from root.sg1.d1
```
