### PR TITLE
[IOTDB-1235] Refactor createMultiTimeseries

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -1339,7 +1339,7 @@ public class MTree implements Serializable {
         tsRow[2] = schema.getValueTSDataTypeList().get(i).toString();
         tsRow[3] = schema.getValueTSEncodingList().get(i).toString();
         tsRow[4] = schema.getCompressor().toString();
-        tsRow[5] = "0";
+        tsRow[5] = "-1";
         tsRow[6] =
             needLast
                 ? String.valueOf(getLastTimeStamp((MeasurementMNode) node, queryContext))

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateMultiTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateMultiTimeSeriesPlan.java
@@ -152,6 +152,7 @@ public class CreateMultiTimeSeriesPlan extends PhysicalPlan {
     int type = PhysicalPlanType.CREATE_MULTI_TIMESERIES.ordinal();
     stream.write(type);
     stream.writeInt(paths.size());
+    stream.writeInt(dataTypes.size()); // size of datatypes, encodings for aligned timeseries
 
     for (PartialPath path : paths) {
       putString(stream, path.getFullPath());
@@ -209,6 +210,7 @@ public class CreateMultiTimeSeriesPlan extends PhysicalPlan {
     int type = PhysicalPlanType.CREATE_MULTI_TIMESERIES.ordinal();
     buffer.put((byte) type);
     buffer.putInt(paths.size());
+    buffer.putInt(dataTypes.size()); // size of datatypes, encodings for aligned timeseries
 
     for (PartialPath path : paths) {
       putString(buffer, path.getFullPath());
@@ -264,16 +266,17 @@ public class CreateMultiTimeSeriesPlan extends PhysicalPlan {
   @Override
   public void deserialize(ByteBuffer buffer) throws IllegalPathException {
     int totalSize = buffer.getInt();
+    int dataTypeSize = buffer.getInt();
     paths = new ArrayList<>(totalSize);
     for (int i = 0; i < totalSize; i++) {
       paths.add(new PartialPath(readString(buffer)));
     }
     dataTypes = new ArrayList<>(totalSize);
-    for (int i = 0; i < totalSize; i++) {
+    for (int i = 0; i < dataTypeSize; i++) {
       dataTypes.add(TSDataType.values()[buffer.get()]);
     }
     encodings = new ArrayList<>(totalSize);
-    for (int i = 0; i < totalSize; i++) {
+    for (int i = 0; i < dataTypeSize; i++) {
       encodings.add(TSEncoding.values()[buffer.get()]);
     }
     compressors = new ArrayList<>(totalSize);

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -1655,8 +1655,8 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
 
       CreateMultiTimeSeriesPlan multiPlan = new CreateMultiTimeSeriesPlan();
       List<PartialPath> paths = new ArrayList<>(req.paths.size());
-      List<TSDataType> dataTypes = new ArrayList<>(req.paths.size());
-      List<TSEncoding> encodings = new ArrayList<>(req.paths.size());
+      List<TSDataType> dataTypes = new ArrayList<>(req.dataTypes.size());
+      List<TSEncoding> encodings = new ArrayList<>(req.dataTypes.size());
       List<CompressionType> compressors = new ArrayList<>(req.paths.size());
       List<String> alias = null;
       if (req.measurementAliasList != null) {
@@ -1687,8 +1687,6 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         }
 
         paths.add(new PartialPath(req.paths.get(i)));
-        dataTypes.add(TSDataType.values()[req.dataTypes.get(i)]);
-        encodings.add(TSEncoding.values()[req.encodings.get(i)]);
         compressors.add(CompressionType.values()[req.compressors.get(i)]);
         if (alias != null) {
           alias.add(req.measurementAliasList.get(i));
@@ -1702,6 +1700,10 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         if (attributes != null) {
           attributes.add(req.attributesList.get(i));
         }
+      }
+      for (int i = 0; i < req.dataTypes.size(); i++) {
+        dataTypes.add(TSDataType.values()[req.dataTypes.get(i)]);
+        encodings.add(TSEncoding.values()[req.encodings.get(i)]);
       }
 
       multiPlan.setPaths(paths);

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanSerializeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanSerializeTest.java
@@ -255,6 +255,32 @@ public class PhysicalPlanSerializeTest {
   }
 
   @Test
+  public void createMuSerializeTest3() throws IOException, IllegalPathException {
+    // same as:
+    // create timeseries root.sg.d1.s0 with datatype=DOUBLE, encoding=GORILLA, compression=SNAPPY
+    // create aligned timeseries root.sg.d1.(s1 INT64, s2 DOUBLE, s3 INT64)
+    // with encoding=(GORILLA, GORILLA, GORILLA), compression=SNAPPY
+    CreateMultiTimeSeriesPlan plan = new CreateMultiTimeSeriesPlan();
+    plan.setPaths(
+        Arrays.asList(new PartialPath("root.sg.d1.s0"), new PartialPath("root.sg.d1.(s1,s2,s3)")));
+    plan.setDataTypes(
+        Arrays.asList(TSDataType.DOUBLE, TSDataType.INT64, TSDataType.DOUBLE, TSDataType.INT64));
+    plan.setEncodings(
+        Arrays.asList(
+            TSEncoding.GORILLA, TSEncoding.GORILLA, TSEncoding.GORILLA, TSEncoding.GORILLA));
+    plan.setCompressors(Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
+    plan.setProps(null);
+    plan.setTags(null);
+    plan.setAttributes(null);
+    plan.setAlias(null);
+
+    PhysicalPlan result = testTwoSerializeMethodAndDeserialize(plan);
+
+    Assert.assertEquals(OperatorType.CREATE_MULTI_TIMESERIES, result.getOperatorType());
+    Assert.assertEquals(plan, result);
+  }
+
+  @Test
   public void AlterTimeSeriesPlanSerializeTest() throws IOException, IllegalPathException {
     AlterTimeSeriesPlan alterTimeSeriesPlan =
         new AlterTimeSeriesPlan(

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -438,13 +438,13 @@ public class Session {
 
     request.setPaths(paths);
 
-    List<Integer> dataTypeOrdinals = new ArrayList<>(paths.size());
+    List<Integer> dataTypeOrdinals = new ArrayList<>(dataTypes.size());
     for (TSDataType dataType : dataTypes) {
       dataTypeOrdinals.add(dataType.ordinal());
     }
     request.setDataTypes(dataTypeOrdinals);
 
-    List<Integer> encodingOrdinals = new ArrayList<>(paths.size());
+    List<Integer> encodingOrdinals = new ArrayList<>(dataTypes.size());
     for (TSEncoding encoding : encodings) {
       encodingOrdinals.add(encoding.ordinal());
     }


### PR DESCRIPTION
For cluster, `createMultiTimeseries` is used for auto create schema.

Here is an example:
```
private static void createMultiTimeseries()
      throws IoTDBConnectionException, StatementExecutionException {

    List<String> paths = new ArrayList<>();
    paths.add("root.sg1.d1.(s0,s1,s2)");
    paths.add("root.sg1.d1.s3");

    List<TSDataType> tsDataTypes = new ArrayList<>();
    tsDataTypes.add(TSDataType.INT64);
    tsDataTypes.add(TSDataType.DOUBLE);
    tsDataTypes.add(TSDataType.FLOAT);
    tsDataTypes.add(TSDataType.INT64);

    List<TSEncoding> tsEncodings = new ArrayList<>();
    tsEncodings.add(TSEncoding.RLE);
    tsEncodings.add(TSEncoding.RLE);
    tsEncodings.add(TSEncoding.RLE);
    tsEncodings.add(TSEncoding.RLE);

    List<CompressionType> compressionTypes = new ArrayList<>();
    compressionTypes.add(CompressionType.SNAPPY);
    compressionTypes.add(CompressionType.SNAPPY);

    session.createMultiTimeseries(
        paths, tsDataTypes, tsEncodings, compressionTypes, null, null, null, null);

    // show timeseries
    SessionDataSet dataSet = session.executeQueryStatement("show timeseries");
    while (dataSet.hasNext()) {
      System.out.println(dataSet.next());
    }
  }
```