### PR TITLE
Fix monitor bug caused by virtual storage group name

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/FlushManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/FlushManager.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iotdb.db.engine.flush;
 
+import static java.io.File.separator;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
 import org.apache.iotdb.db.concurrent.WrappedRunnable;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -31,11 +34,8 @@ import org.apache.iotdb.db.monitor.StatMonitor;
 import org.apache.iotdb.db.service.IService;
 import org.apache.iotdb.db.service.JMXService;
 import org.apache.iotdb.db.service.ServiceType;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class FlushManager implements FlushManagerMBean, IService {
 
@@ -110,7 +110,8 @@ public class FlushManager implements FlushManagerMBean, IService {
       // update stat monitor cache to system during each flush()
       if (config.isEnableStatMonitor() && config.isEnableMonitorSeriesWrite()) {
         try {
-          StatMonitor.getInstance().saveStatValue(tsFileProcessor.getStorageGroupName());
+          StatMonitor.getInstance()
+              .saveStatValue(tsFileProcessor.getStorageGroupName().split(separator)[0]);
         } catch (StorageEngineException | MetadataException e) {
           LOGGER.error("Inserting monitor series data error.", e);
         }

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/FlushManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/FlushManager.java
@@ -18,9 +18,6 @@
  */
 package org.apache.iotdb.db.engine.flush;
 
-import static java.io.File.separator;
-
-import java.util.concurrent.ConcurrentLinkedDeque;
 import org.apache.iotdb.db.concurrent.WrappedRunnable;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -34,8 +31,13 @@ import org.apache.iotdb.db.monitor.StatMonitor;
 import org.apache.iotdb.db.service.IService;
 import org.apache.iotdb.db.service.JMXService;
 import org.apache.iotdb.db.service.ServiceType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import static java.io.File.separator;
 
 public class FlushManager implements FlushManagerMBean, IService {
 

--- a/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
@@ -18,13 +18,6 @@
  */
 package org.apache.iotdb.db.monitor;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -54,8 +47,17 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.write.record.TSRecord;
 import org.apache.iotdb.tsfile.write.record.datapoint.LongDataPoint;
+
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class StatMonitor implements StatMonitorMBean, IService {
 

--- a/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
@@ -18,6 +18,13 @@
  */
 package org.apache.iotdb.db.monitor;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -40,23 +47,15 @@ import org.apache.iotdb.db.service.IService;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.service.JMXService;
 import org.apache.iotdb.db.service.ServiceType;
+import org.apache.iotdb.db.utils.TestOnly;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.write.record.TSRecord;
 import org.apache.iotdb.tsfile.write.record.datapoint.LongDataPoint;
-
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 public class StatMonitor implements StatMonitorMBean, IService {
 
@@ -204,6 +203,7 @@ public class StatMonitor implements StatMonitorMBean, IService {
     globalSeriesValue.set(2, globalSeriesValue.get(2) + 1);
   }
 
+  @TestOnly
   public void close() {
     config.setEnableStatMonitor(false);
     config.setEnableMonitorSeriesWrite(false);

--- a/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
@@ -98,6 +98,7 @@ public class StatMonitor implements StatMonitorMBean, IService {
   /** Generate tsRecords for stat parameters and insert them into StorageEngine. */
   public void saveStatValue(String storageGroupName)
       throws MetadataException, StorageEngineException {
+    logger.error("start save value at " + storageGroupName);
     long insertTime = System.currentTimeMillis();
     // update monitor series of storage group
     PartialPath storageGroupSeries = getStorageGroupMonitorSeries(storageGroupName);

--- a/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
@@ -98,7 +98,6 @@ public class StatMonitor implements StatMonitorMBean, IService {
   /** Generate tsRecords for stat parameters and insert them into StorageEngine. */
   public void saveStatValue(String storageGroupName)
       throws MetadataException, StorageEngineException {
-    logger.error("start save value at " + storageGroupName);
     long insertTime = System.currentTimeMillis();
     // update monitor series of storage group
     PartialPath storageGroupSeries = getStorageGroupMonitorSeries(storageGroupName);

--- a/server/src/test/java/org/apache/iotdb/db/monitor/IoTDBStatMonitorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/monitor/IoTDBStatMonitorTest.java
@@ -18,12 +18,6 @@
  */
 package org.apache.iotdb.db.monitor;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.Statement;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
@@ -31,12 +25,20 @@ import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
 
 /** This is a integration test for StatMonitor. */
 public class IoTDBStatMonitorTest {

--- a/server/src/test/java/org/apache/iotdb/db/monitor/IoTDBStatMonitorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/monitor/IoTDBStatMonitorTest.java
@@ -73,6 +73,9 @@ public class IoTDBStatMonitorTest {
   @After
   public void tearDown() throws IOException, StorageEngineException {
     // reset setEnableStatMonitor to false
+    config.setEnableStatMonitor(false);
+    config.setEnableMonitorSeriesWrite(false);
+
     statMonitor.close();
     EnvironmentUtils.cleanEnv();
   }

--- a/server/src/test/java/org/apache/iotdb/db/monitor/IoTDBStatMonitorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/monitor/IoTDBStatMonitorTest.java
@@ -83,6 +83,7 @@ public class IoTDBStatMonitorTest {
   @Test
   public void completeTest() throws Exception {
     getValueInMemoryTest();
+    statMonitor.saveStatValue("root.sg");
     saveStatValueTest();
 
     // restart server
@@ -120,9 +121,6 @@ public class IoTDBStatMonitorTest {
             DriverManager.getConnection(
                 Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
-      // flush to save statistics
-      statement.execute("flush");
-
       boolean hasResult = statement.execute("select TOTAL_POINTS from root.stats.\"root.sg\"");
       Assert.assertTrue(hasResult);
 

--- a/server/src/test/java/org/apache/iotdb/db/monitor/IoTDBStatMonitorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/monitor/IoTDBStatMonitorTest.java
@@ -18,6 +18,12 @@
  */
 package org.apache.iotdb.db.monitor;
 
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
@@ -25,20 +31,12 @@ import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.Statement;
 
 /** This is a integration test for StatMonitor. */
 public class IoTDBStatMonitorTest {
@@ -113,12 +111,13 @@ public class IoTDBStatMonitorTest {
   }
 
   private void saveStatValueTest() throws MetadataException, StorageEngineException {
-    statMonitor.saveStatValue(STORAGE_GROUP_NAME);
-
     try (Connection connection =
             DriverManager.getConnection(
                 Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
+      // flush to save statistics
+      statement.execute("flush");
+
       boolean hasResult = statement.execute("select TOTAL_POINTS from root.stats.\"root.sg\"");
       Assert.assertTrue(hasResult);
 


### PR DESCRIPTION
Currently, tsfile processor has storage group name with virtual storage group name. But it will cause path problem in stat monitor module which need logical storage group name. This PR fix this issue.