### PR TITLE
[IOTDB-1238] Make aligned timeseries MeasurementMNode name start with "$#$"

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -109,6 +109,7 @@ public class IoTDBConstant {
 
   public static final String PATH_WILDCARD = "*";
   public static final String TIME = "time";
+  public static final String ALIGN_TIMESERIES_PREFIX = "$#$";
 
   // sdt parameters
   public static final String LOSS = "loss";

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1092,12 +1092,7 @@ public class MManager {
 
   public IMeasurementSchema getSeriesSchema(PartialPath device, String measurement)
       throws MetadataException {
-    MNode node = mtree.getNodeByPath(device);
-    MNode leaf = node.getChild(measurement);
-    if (leaf != null) {
-      return ((MeasurementMNode) leaf).getSchema();
-    }
-    return null;
+    return getSeriesSchema(new PartialPath(device.getFullPath(), measurement));
   }
 
   /**
@@ -1110,9 +1105,7 @@ public class MManager {
    *     measurements = ["2", "0"]
    */
   public IMeasurementSchema getSeriesSchema(PartialPath fullPath) throws MetadataException {
-    MNode node = mtree.getNodeByPath(fullPath.getDevicePath());
-    MNode leaf = node.getChild(fullPath.getMeasurement());
-
+    MNode leaf = mtree.getNodeByPath(fullPath);
     if (fullPath instanceof VectorPartialPath) {
       List<PartialPath> measurements = ((VectorPartialPath) fullPath).getSubSensorsPathList();
       String[] measurementIndices = new String[measurements.size()];

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -302,11 +302,13 @@ public class MTree implements Serializable {
     }
     MNode cur = root;
     boolean hasSetStorageGroup = false;
+    StorageGroupMNode storageGroupMNode = null;
     // e.g, devicePath = root.sg.d1, create internal nodes and set cur to d1 node
     for (int i = 1; i < deviceNodeNames.length; i++) {
       String nodeName = deviceNodeNames[i];
       if (cur instanceof StorageGroupMNode) {
         hasSetStorageGroup = true;
+        storageGroupMNode = (StorageGroupMNode) cur;
       }
       if (!cur.hasChild(nodeName)) {
         if (!hasSetStorageGroup) {
@@ -316,8 +318,12 @@ public class MTree implements Serializable {
       }
       cur = cur.getChild(nodeName);
     }
-
-    String leafName = measurements.get(0) + ".align";
+    int alignedTimeseriesIndex = 0;
+    if (storageGroupMNode != null) {
+      alignedTimeseriesIndex = storageGroupMNode.getAlignedTimeseriesIndex();
+      storageGroupMNode.addAlignedTimeseriesIndex();
+    }
+    String leafName = IoTDBConstant.ALIGN_TIMESERIES_PREFIX + alignedTimeseriesIndex;
 
     // synchronize check and add, we need addChild and add Alias become atomic operation
     // only write on mtree will be synchronized

--- a/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogWriter.java
@@ -193,7 +193,8 @@ public class MLogWriter implements AutoCloseable {
       childSize = node.getChildren().size();
     }
     StorageGroupMNodePlan plan =
-        new StorageGroupMNodePlan(node.getName(), node.getDataTTL(), childSize);
+        new StorageGroupMNodePlan(
+            node.getName(), node.getDataTTL(), childSize, node.getAlignedTimeseriesIndex());
     putLog(plan);
   }
 
@@ -425,7 +426,10 @@ public class MLogWriter implements AutoCloseable {
                 CompressionType.values()[Integer.parseInt(words[5])]));
       case "1":
         return new StorageGroupMNodePlan(
-            words[1], Long.parseLong(words[2]), Integer.parseInt(words[3]));
+            words[1],
+            Long.parseLong(words[2]),
+            Integer.parseInt(words[3]),
+            words.length == 5 ? Integer.parseInt(words[4]) : 0);
       case "0":
         return new MNodePlan(words[1], Integer.parseInt(words[2]));
       default:

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/StorageGroupMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/StorageGroupMNode.java
@@ -33,9 +33,18 @@ public class StorageGroupMNode extends MNode {
    */
   private long dataTTL;
 
+  private int alignedTimeseriesIndex;
+
   public StorageGroupMNode(MNode parent, String name, long dataTTL) {
     super(parent, name);
     this.dataTTL = dataTTL;
+    this.alignedTimeseriesIndex = 0;
+  }
+
+  public StorageGroupMNode(MNode parent, String name, long dataTTL, int alignedTimeseriesIndex) {
+    super(parent, name);
+    this.dataTTL = dataTTL;
+    this.alignedTimeseriesIndex = alignedTimeseriesIndex;
   }
 
   public long getDataTTL() {
@@ -46,6 +55,14 @@ public class StorageGroupMNode extends MNode {
     this.dataTTL = dataTTL;
   }
 
+  public int getAlignedTimeseriesIndex() {
+    return alignedTimeseriesIndex;
+  }
+
+  public void addAlignedTimeseriesIndex() {
+    this.alignedTimeseriesIndex++;
+  }
+
   @Override
   public void serializeTo(MLogWriter logWriter) throws IOException {
     serializeChildren(logWriter);
@@ -54,10 +71,15 @@ public class StorageGroupMNode extends MNode {
   }
 
   public static StorageGroupMNode deserializeFrom(StorageGroupMNodePlan plan) {
-    return new StorageGroupMNode(null, plan.getName(), plan.getDataTTL());
+    return new StorageGroupMNode(
+        null, plan.getName(), plan.getDataTTL(), plan.getAlignedTimeseriesIndex());
   }
 
   public static StorageGroupMNode deserializeFrom(String[] nodeInfo) {
-    return new StorageGroupMNode(null, nodeInfo[1], Long.valueOf(nodeInfo[2]));
+    return new StorageGroupMNode(
+        null,
+        nodeInfo[1],
+        Long.parseLong(nodeInfo[2]),
+        nodeInfo.length == 4 ? Integer.parseInt(nodeInfo[3]) : 0);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StorageGroupMNodePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StorageGroupMNodePlan.java
@@ -32,15 +32,19 @@ import java.util.Objects;
 public class StorageGroupMNodePlan extends MNodePlan {
   private long dataTTL;
 
+  private int alignedTimeseriesIndex;
+
   public StorageGroupMNodePlan() {
     super(false, Operator.OperatorType.STORAGE_GROUP_MNODE);
   }
 
-  public StorageGroupMNodePlan(String name, long dataTTL, int childSize) {
+  public StorageGroupMNodePlan(
+      String name, long dataTTL, int childSize, int alignedTimeseriesIndex) {
     super(false, Operator.OperatorType.STORAGE_GROUP_MNODE);
     this.name = name;
     this.dataTTL = dataTTL;
     this.childSize = childSize;
+    this.alignedTimeseriesIndex = alignedTimeseriesIndex;
   }
 
   @Override
@@ -56,12 +60,21 @@ public class StorageGroupMNodePlan extends MNodePlan {
     this.dataTTL = dataTTL;
   }
 
+  public int getAlignedTimeseriesIndex() {
+    return alignedTimeseriesIndex;
+  }
+
+  public void setAlignedTimeseriesIndex(int alignedTimeseriesIndex) {
+    this.alignedTimeseriesIndex = alignedTimeseriesIndex;
+  }
+
   @Override
   public void serialize(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.STORAGE_GROUP_MNODE.ordinal());
     putString(buffer, name);
     buffer.putLong(dataTTL);
     buffer.putInt(childSize);
+    buffer.putInt(alignedTimeseriesIndex);
 
     buffer.putLong(index);
   }
@@ -72,6 +85,7 @@ public class StorageGroupMNodePlan extends MNodePlan {
     putString(stream, name);
     stream.writeLong(dataTTL);
     stream.writeInt(childSize);
+    stream.writeInt(alignedTimeseriesIndex);
 
     stream.writeLong(index);
   }
@@ -81,12 +95,25 @@ public class StorageGroupMNodePlan extends MNodePlan {
     name = readString(buffer);
     dataTTL = buffer.getLong();
     childSize = buffer.getInt();
+    if (buffer.hasRemaining()) {
+      alignedTimeseriesIndex = buffer.getInt();
+    } else {
+      alignedTimeseriesIndex = 0;
+    }
     index = buffer.getLong();
   }
 
   @Override
   public String toString() {
-    return "StorageGroupMNode{" + name + "," + dataTTL + "," + childSize + "}";
+    return "StorageGroupMNode{"
+        + name
+        + ","
+        + dataTTL
+        + ","
+        + childSize
+        + ","
+        + alignedTimeseriesIndex
+        + "}";
   }
 
   @Override
@@ -100,11 +127,12 @@ public class StorageGroupMNodePlan extends MNodePlan {
     StorageGroupMNodePlan that = (StorageGroupMNodePlan) o;
     return Objects.equals(name, that.name)
         && Objects.equals(dataTTL, that.dataTTL)
-        && Objects.equals(childSize, that.childSize);
+        && Objects.equals(childSize, that.childSize)
+        && Objects.equals(alignedTimeseriesIndex, that.alignedTimeseriesIndex);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, dataTTL, childSize);
+    return Objects.hash(name, dataTTL, childSize, alignedTimeseriesIndex);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -272,6 +272,16 @@ public class MManagerBasicTest {
     assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.s1")));
     assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.s2")));
     assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.s3")));
+    try {
+      assertEquals(
+          1,
+          manager
+              .getStorageGroupNodeByStorageGroupPath(new PartialPath("root.laptop"))
+              .getAlignedTimeseriesIndex());
+    } catch (MetadataException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
 
     try {
       manager.deleteTimeseries(new PartialPath("root.laptop.d1.s2"));
@@ -331,6 +341,16 @@ public class MManagerBasicTest {
     assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.s0")));
     assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.s2")));
     assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.s4")));
+    try {
+      assertEquals(
+          2,
+          manager
+              .getStorageGroupNodeByStorageGroupPath(new PartialPath("root.laptop"))
+              .getAlignedTimeseriesIndex());
+    } catch (MetadataException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
   }
 
   @Test

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/DefaultDeviceTemplateTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/DefaultDeviceTemplateTest.java
@@ -50,7 +50,7 @@ public class DefaultDeviceTemplateTest {
       MeasurementSchema s1 = new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.PLAIN);
       MeasurementSchema s2 = new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.PLAIN);
 
-      List<MeasurementSchema> schemaList = new ArrayList<>();
+      List<IMeasurementSchema> schemaList = new ArrayList<>();
       schemaList.add(s1);
       schemaList.add(s2);
 


### PR DESCRIPTION
`MeasurementMNode` with aligned timeseries should have specific name. For example, starting with `$#$`