### PR TITLE
simplify the Avg formula on removing redundant operations

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/AvgAggrResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/AvgAggrResult.java
@@ -78,9 +78,7 @@ public class AvgAggrResult extends AggregateResult {
     } else {
       sum = statistics.getSumDoubleValue();
     }
-    avg =
-        avg * ((double) preCnt / cnt)
-            + ((double) statistics.getCount() / cnt) * sum / statistics.getCount();
+    avg = (avg * preCnt + sum) / cnt;
   }
 
   @Override
@@ -131,7 +129,7 @@ public class AvgAggrResult extends AggregateResult {
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in aggregation AVG : %s", type));
     }
-    avg = avg * ((double) cnt / (cnt + 1)) + val * (1.0 / (cnt + 1));
+    avg = (avg * cnt + val) / (cnt + 1);
     cnt++;
   }
 
@@ -164,9 +162,7 @@ public class AvgAggrResult extends AggregateResult {
       // avoid two empty results producing an NaN
       return;
     }
-    avg =
-        avg * ((double) cnt / (cnt + anotherAvg.cnt))
-            + anotherAvg.avg * ((double) anotherAvg.cnt / (cnt + anotherAvg.cnt));
+    avg = (avg * cnt + anotherAvg.avg * anotherAvg.cnt) / (cnt + anotherAvg.cnt);
     cnt += anotherAvg.cnt;
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
@@ -271,7 +271,6 @@ public class IOTDBGroupByInnerIntervalIT {
         }
         assertEquals(retArray1.length, cnt);
       }
-
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
@@ -95,6 +95,8 @@ public class IOTDBGroupByInnerIntervalIT {
             + "values(29, 50.5, false, 550)",
       };
 
+  private static final double DETLA = 1e-6;
+
   private static final String TIMESTAMP_STR = "Time";
 
   @Before
@@ -116,10 +118,10 @@ public class IOTDBGroupByInnerIntervalIT {
         new String[] {
           "1,3,6.6,2.2",
           "6,3,23.1,7.7",
-          "11,3,36.599999999999994,12.2",
-          "16,2,35.400000000000006,17.700000000000003",
+          "11,3,36.6,12.2",
+          "16,2,35.4,17.7",
           "21,2,45.5,22.75",
-          "26,3,90.9,30.299999999999997"
+          "26,3,90.9,30.3"
         };
 
     try (Connection connection =
@@ -144,7 +146,7 @@ public class IOTDBGroupByInnerIntervalIT {
                   + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
                   + ","
                   + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
-          assertEquals(retArray1[cnt], ans);
+          assertEquals(retArray1[cnt], ans, DETLA);
           cnt++;
         }
         assertEquals(retArray1.length, cnt);
@@ -162,10 +164,10 @@ public class IOTDBGroupByInnerIntervalIT {
         new String[] {
           "1,1,3.3,3.3",
           "6,3,23.1,7.7",
-          "11,3,36.599999999999994,12.2",
-          "16,2,35.400000000000006,17.700000000000003",
+          "11,3,36.6,12.2",
+          "16,2,35.4,17.7",
           "21,2,45.5,22.75",
-          "26,3,90.9,30.299999999999997"
+          "26,3,90.9,30.3"
         };
 
     try (Connection connection =
@@ -190,7 +192,7 @@ public class IOTDBGroupByInnerIntervalIT {
                   + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
                   + ","
                   + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
-          assertEquals(retArray1[cnt], ans);
+          assertEquals(retArray1[cnt], ans, DETLA);
           cnt++;
         }
         assertEquals(retArray1.length, cnt);
@@ -198,11 +200,11 @@ public class IOTDBGroupByInnerIntervalIT {
 
       String[] retArray2 =
           new String[] {
-            "26,3,90.9,30.299999999999997",
+            "26,3,90.9,30.3",
             "21,2,45.5,22.75",
-            "16,2,35.400000000000006,17.700000000000003",
+            "16,2,35.4,17.7",
             "11,3,36.6,12.2",
-            "6,3,23.1,7.699999999999999",
+            "6,3,23.1,7.7",
             "1,1,3.3,3.3",
           };
       hasResultSet =
@@ -223,7 +225,7 @@ public class IOTDBGroupByInnerIntervalIT {
                   + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
                   + ","
                   + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
-          assertEquals(retArray2[cnt], ans);
+          assertEquals(retArray2[cnt], ans, DETLA);
           cnt++;
         }
         assertEquals(retArray2.length, cnt);
@@ -240,10 +242,10 @@ public class IOTDBGroupByInnerIntervalIT {
         new String[] {
           "1,0,0.0,null",
           "6,3,23.1,7.7",
-          "11,3,36.599999999999994,12.2",
-          "16,2,35.400000000000006,17.700000000000003",
+          "11,3,36.6,12.2",
+          "16,2,35.4,17.7",
           "21,2,45.5,22.75",
-          "26,3,90.9,30.299999999999997"
+          "26,3,90.9,30.3"
         };
 
     try (Connection connection =
@@ -268,7 +270,7 @@ public class IOTDBGroupByInnerIntervalIT {
                   + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
                   + ","
                   + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
-          assertEquals(retArray1[cnt], ans);
+          assertEquals(retArray1[cnt], ans, DETLA);
           cnt++;
         }
         assertEquals(retArray1.length, cnt);

--- a/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
@@ -228,8 +228,8 @@ public class IOTDBGroupByInnerIntervalIT {
 
   @Test
   public void countSumAvgInnerIntervalTestWithTimeFilter() {
+    String retArray = "1,0,0.0,null";
     double[][] retArray1 = {
-      {1.0, 0.0, 0.0, 0.0},
       {6.0, 3.0, 23.1, 7.7},
       {11.0, 3.0, 36.6, 12.2},
       {16.0, 2.0, 35.4, 17.7},
@@ -245,10 +245,20 @@ public class IOTDBGroupByInnerIntervalIT {
               "select count(temperature), sum(temperature), avg(temperature) from "
                   + "root.ln.wf01.wt01 where time > 3"
                   + " GROUP BY ([1, 30), 3ms, 5ms)");
-
       assertTrue(hasResultSet);
       int cnt;
       try (ResultSet resultSet = statement.getResultSet()) {
+        String res =
+            resultSet.getString(TIMESTAMP_STR)
+                + ","
+                + resultSet.getString(TIMESTAMP_STR)
+                + ","
+                + resultSet.getString(count("root.ln.wf01.wt01.temperature"))
+                + ","
+                + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
+                + ","
+                + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
+        assertEquals(retArray, res);
         cnt = 0;
         while (resultSet.next()) {
           double[] ans = new double[4];

--- a/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
@@ -248,17 +248,17 @@ public class IOTDBGroupByInnerIntervalIT {
       assertTrue(hasResultSet);
       int cnt;
       try (ResultSet resultSet = statement.getResultSet()) {
-        String res =
-            resultSet.getString(TIMESTAMP_STR)
-                + ","
-                + resultSet.getString(TIMESTAMP_STR)
-                + ","
-                + resultSet.getString(count("root.ln.wf01.wt01.temperature"))
-                + ","
-                + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
-                + ","
-                + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
-        assertEquals(retArray, res);
+        if (resultSet.next()) {
+          String res =
+              resultSet.getString(TIMESTAMP_STR)
+                  + ","
+                  + resultSet.getString(count("root.ln.wf01.wt01.temperature"))
+                  + ","
+                  + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
+                  + ","
+                  + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
+          assertEquals(retArray, res);
+        }
         cnt = 0;
         while (resultSet.next()) {
           double[] ans = new double[4];

--- a/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByInnerIntervalIT.java
@@ -114,15 +114,14 @@ public class IOTDBGroupByInnerIntervalIT {
 
   @Test
   public void countSumAvgInnerIntervalTest() {
-    String[] retArray1 =
-        new String[] {
-          "1,3,6.6,2.2",
-          "6,3,23.1,7.7",
-          "11,3,36.6,12.2",
-          "16,2,35.4,17.7",
-          "21,2,45.5,22.75",
-          "26,3,90.9,30.3"
-        };
+    double[][] retArray1 = {
+      {1.0, 3.0, 6.6, 2.2},
+      {6.0, 3.0, 23.1, 7.7},
+      {11.0, 3.0, 36.6, 12.2},
+      {16.0, 2.0, 35.4, 17.7},
+      {21.0, 2.0, 45.5, 22.75},
+      {26.0, 3.0, 90.9, 30.3}
+    };
 
     try (Connection connection =
             DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
@@ -138,15 +137,13 @@ public class IOTDBGroupByInnerIntervalIT {
       try (ResultSet resultSet = statement.getResultSet()) {
         cnt = 0;
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(count("root.ln.wf01.wt01.temperature"))
-                  + ","
-                  + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
-                  + ","
-                  + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
-          assertEquals(retArray1[cnt], ans, DETLA);
+          double[] ans = new double[4];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(count("root.ln.wf01.wt01.temperature")));
+          ans[2] = Double.valueOf(resultSet.getString(sum("root.ln.wf01.wt01.temperature")));
+          ans[3] = Double.valueOf(resultSet.getString(avg("root.ln.wf01.wt01.temperature")));
+          assertArrayEquals(retArray1[cnt], ans, DETLA);
+
           cnt++;
         }
         assertEquals(retArray1.length, cnt);
@@ -160,15 +157,14 @@ public class IOTDBGroupByInnerIntervalIT {
 
   @Test
   public void countSumAvgInnerIntervalTestWithValueFilter() {
-    String[] retArray1 =
-        new String[] {
-          "1,1,3.3,3.3",
-          "6,3,23.1,7.7",
-          "11,3,36.6,12.2",
-          "16,2,35.4,17.7",
-          "21,2,45.5,22.75",
-          "26,3,90.9,30.3"
-        };
+    double[][] retArray1 = {
+      {1.0, 1.0, 3.3, 3.3},
+      {6.0, 3.0, 23.1, 7.7},
+      {11.0, 3.0, 36.6, 12.2},
+      {16.0, 2.0, 35.4, 17.7},
+      {21.0, 2.0, 45.5, 22.75},
+      {26.0, 3.0, 90.9, 30.3}
+    };
 
     try (Connection connection =
             DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
@@ -184,29 +180,26 @@ public class IOTDBGroupByInnerIntervalIT {
       try (ResultSet resultSet = statement.getResultSet()) {
         cnt = 0;
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(count("root.ln.wf01.wt01.temperature"))
-                  + ","
-                  + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
-                  + ","
-                  + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
-          assertEquals(retArray1[cnt], ans, DETLA);
+          double[] ans = new double[4];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(count("root.ln.wf01.wt01.temperature")));
+          ans[2] = Double.valueOf(resultSet.getString(sum("root.ln.wf01.wt01.temperature")));
+          ans[3] = Double.valueOf(resultSet.getString(avg("root.ln.wf01.wt01.temperature")));
+          assertArrayEquals(retArray1[cnt], ans, DETLA);
           cnt++;
         }
         assertEquals(retArray1.length, cnt);
       }
 
-      String[] retArray2 =
-          new String[] {
-            "26,3,90.9,30.3",
-            "21,2,45.5,22.75",
-            "16,2,35.4,17.7",
-            "11,3,36.6,12.2",
-            "6,3,23.1,7.7",
-            "1,1,3.3,3.3",
-          };
+      double[][] retArray2 = {
+        {26.0, 3.0, 90.9, 30.3},
+        {21.0, 2.0, 45.5, 22.75},
+        {16.0, 2.0, 35.4, 17.7},
+        {11.0, 3.0, 36.6, 12.2},
+        {6.0, 3.0, 23.1, 7.7},
+        {1.0, 1.0, 3.3, 3.3}
+      };
+
       hasResultSet =
           statement.execute(
               "select count(temperature), sum(temperature), avg(temperature) from "
@@ -217,15 +210,12 @@ public class IOTDBGroupByInnerIntervalIT {
       try (ResultSet resultSet = statement.getResultSet()) {
         cnt = 0;
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(count("root.ln.wf01.wt01.temperature"))
-                  + ","
-                  + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
-                  + ","
-                  + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
-          assertEquals(retArray2[cnt], ans, DETLA);
+          double[] ans = new double[4];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(count("root.ln.wf01.wt01.temperature")));
+          ans[2] = Double.valueOf(resultSet.getString(sum("root.ln.wf01.wt01.temperature")));
+          ans[3] = Double.valueOf(resultSet.getString(avg("root.ln.wf01.wt01.temperature")));
+          assertArrayEquals(retArray2[cnt], ans, DETLA);
           cnt++;
         }
         assertEquals(retArray2.length, cnt);
@@ -238,15 +228,14 @@ public class IOTDBGroupByInnerIntervalIT {
 
   @Test
   public void countSumAvgInnerIntervalTestWithTimeFilter() {
-    String[] retArray1 =
-        new String[] {
-          "1,0,0.0,null",
-          "6,3,23.1,7.7",
-          "11,3,36.6,12.2",
-          "16,2,35.4,17.7",
-          "21,2,45.5,22.75",
-          "26,3,90.9,30.3"
-        };
+    double[][] retArray1 = {
+      {1.0, 0.0, 0.0, 0.0},
+      {6.0, 3.0, 23.1, 7.7},
+      {11.0, 3.0, 36.6, 12.2},
+      {16.0, 2.0, 35.4, 17.7},
+      {21.0, 2.0, 45.5, 22.75},
+      {26.0, 3.0, 90.9, 30.3}
+    };
 
     try (Connection connection =
             DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
@@ -262,15 +251,12 @@ public class IOTDBGroupByInnerIntervalIT {
       try (ResultSet resultSet = statement.getResultSet()) {
         cnt = 0;
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(count("root.ln.wf01.wt01.temperature"))
-                  + ","
-                  + resultSet.getString(sum("root.ln.wf01.wt01.temperature"))
-                  + ","
-                  + resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
-          assertEquals(retArray1[cnt], ans, DETLA);
+          double[] ans = new double[4];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(count("root.ln.wf01.wt01.temperature")));
+          ans[2] = Double.valueOf(resultSet.getString(sum("root.ln.wf01.wt01.temperature")));
+          ans[3] = Double.valueOf(resultSet.getString(avg("root.ln.wf01.wt01.temperature")));
+          assertArrayEquals(retArray1[cnt], ans, DETLA);
           cnt++;
         }
         assertEquals(retArray1.length, cnt);

--- a/server/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
@@ -732,13 +732,11 @@ public class IoTDBAggregationIT {
 
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(sum(d0s0))
-                  + ","
-                  + resultSet.getString(avg(d0s2));
-          Assert.assertEquals(retArray[cnt], ans);
+          double[] ans = new double[3];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(sum(d0s0)));
+          ans[2] = Double.valueOf(resultSet.getString(avg(d0s2)));
+          assertArrayEquals(retArray[cnt], ans, DETLA);
           cnt++;
         }
         Assert.assertEquals(2, cnt);
@@ -754,13 +752,11 @@ public class IoTDBAggregationIT {
       cnt = 0;
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(sum(d0s0))
-                  + ","
-                  + resultSet.getString(avg(d0s2));
-          Assert.assertEquals(retArray[cnt], ans);
+          double[] ans = new double[3];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(sum(d0s0)));
+          ans[2] = Double.valueOf(resultSet.getString(avg(d0s2)));
+          assertArrayEquals(retArray[cnt], ans, DETLA);
           cnt++;
         }
         Assert.assertEquals(1, cnt);
@@ -918,7 +914,7 @@ public class IoTDBAggregationIT {
 
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
-          double[] ans = new double[5];
+          double[] ans = new double[7];
           ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
           ans[1] = Double.valueOf(resultSet.getString(sum(d0s2)));
           ans[2] = Double.valueOf(resultSet.getString(count(d0s0)));

--- a/server/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
@@ -45,6 +45,7 @@ import static org.apache.iotdb.db.constant.TestConstant.max_value;
 import static org.apache.iotdb.db.constant.TestConstant.min_time;
 import static org.apache.iotdb.db.constant.TestConstant.min_value;
 import static org.apache.iotdb.db.constant.TestConstant.sum;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
 
 public class IoTDBAggregationIT {
@@ -695,8 +696,11 @@ public class IoTDBAggregationIT {
 
   @Test
   public void avgSumTest() {
-    String[] retArray =
-        new String[] {"0,1.4508E7,7250.374812593702", "0,626750.0,1250.9980039920158"};
+    double[][] retArray = {
+      {0.0, 1.4508E7, 7250.374812593702},
+      {0.0, 626750.0, 1250.9980039920158}
+    };
+
     try (Connection connection =
             DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
@@ -710,13 +714,11 @@ public class IoTDBAggregationIT {
       int cnt = 0;
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(sum(d0s0))
-                  + ","
-                  + resultSet.getString(avg(d0s2));
-          Assert.assertEquals(retArray[cnt], ans, DETLA);
+          double[] ans = new double[3];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(sum(d0s0)));
+          ans[2] = Double.valueOf(resultSet.getString(avg(d0s2)));
+          assertArrayEquals(retArray[cnt], ans, DETLA);
           cnt++;
         }
         Assert.assertEquals(1, cnt);
@@ -836,13 +838,13 @@ public class IoTDBAggregationIT {
   /** test aggregation query with more than one functions on one series */
   @Test
   public void mergeAggrOnOneSeriesTest() {
-    String[] retArray =
-        new String[] {
-          "0,1.4508E7,7250.374812593702,7250.374812593702,1.4508E7",
-          "0,626750.0,1250.9980039920158,1250.9980039920158,626750.0",
-          "0,1.4508E7,2001,7250.374812593702,7250.374812593702",
-          "0,1.4508E7,2001,7250.374812593702,7250.374812593702,2001,1.4508E7"
-        };
+    double[][] retArray = {
+      {0.0, 1.4508E7, 7250.374812593702, 7250.374812593702, 1.4508E7},
+      {0.0, 626750.0, 1250.9980039920158, 1250.9980039920158, 626750.0},
+      {0.0, 1.4508E7, 2001, 7250.374812593702, 7250.374812593702},
+      {0.0, 1.4508E7, 2001, 7250.374812593702, 7250.374812593702, 2001, 1.4508E7}
+    };
+
     try (Connection connection =
             DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
@@ -856,17 +858,13 @@ public class IoTDBAggregationIT {
       int cnt = 0;
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(sum(d0s0))
-                  + ","
-                  + resultSet.getString(avg(d0s2))
-                  + ","
-                  + resultSet.getString(avg(d0s0))
-                  + ","
-                  + resultSet.getString(sum(d0s2));
-          Assert.assertEquals(retArray[cnt], ans, DETLA);
+          double[] ans = new double[5];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(sum(d0s0)));
+          ans[2] = Double.valueOf(resultSet.getString(avg(d0s2)));
+          ans[3] = Double.valueOf(resultSet.getString(avg(d0s0)));
+          ans[4] = Double.valueOf(resultSet.getString(sum(d0s2)));
+          assertArrayEquals(retArray[cnt], ans, DETLA);
           cnt++;
         }
         Assert.assertEquals(1, cnt);
@@ -880,17 +878,13 @@ public class IoTDBAggregationIT {
 
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(sum(d0s0))
-                  + ","
-                  + resultSet.getString(avg(d0s2))
-                  + ","
-                  + resultSet.getString(avg(d0s0))
-                  + ","
-                  + resultSet.getString(sum(d0s2));
-          Assert.assertEquals(retArray[cnt], ans);
+          double[] ans = new double[5];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(sum(d0s0)));
+          ans[2] = Double.valueOf(resultSet.getString(avg(d0s2)));
+          ans[3] = Double.valueOf(resultSet.getString(avg(d0s0)));
+          ans[4] = Double.valueOf(resultSet.getString(sum(d0s2)));
+          assertArrayEquals(retArray[cnt], ans, DETLA);
           cnt++;
         }
         Assert.assertEquals(2, cnt);
@@ -904,17 +898,13 @@ public class IoTDBAggregationIT {
 
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(sum(d0s0))
-                  + ","
-                  + resultSet.getString(count(d0s0))
-                  + ","
-                  + resultSet.getString(avg(d0s2))
-                  + ","
-                  + resultSet.getString(avg(d0s0));
-          Assert.assertEquals(retArray[cnt], ans);
+          double[] ans = new double[5];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(sum(d0s0)));
+          ans[2] = Double.valueOf(resultSet.getString(count(d0s0)));
+          ans[3] = Double.valueOf(resultSet.getString(avg(d0s2)));
+          ans[4] = Double.valueOf(resultSet.getString(avg(d0s0)));
+          assertArrayEquals(retArray[cnt], ans, DETLA);
           cnt++;
         }
         Assert.assertEquals(3, cnt);
@@ -928,21 +918,15 @@ public class IoTDBAggregationIT {
 
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
-          String ans =
-              resultSet.getString(TIMESTAMP_STR)
-                  + ","
-                  + resultSet.getString(sum(d0s2))
-                  + ","
-                  + resultSet.getString(count(d0s0))
-                  + ","
-                  + resultSet.getString(avg(d0s2))
-                  + ","
-                  + resultSet.getString(avg(d0s1))
-                  + ","
-                  + resultSet.getString(count(d0s2))
-                  + ","
-                  + resultSet.getString(sum(d0s0));
-          Assert.assertEquals(retArray[cnt], ans);
+          double[] ans = new double[5];
+          ans[0] = Double.valueOf(resultSet.getString(TIMESTAMP_STR));
+          ans[1] = Double.valueOf(resultSet.getString(sum(d0s2)));
+          ans[2] = Double.valueOf(resultSet.getString(count(d0s0)));
+          ans[3] = Double.valueOf(resultSet.getString(avg(d0s2)));
+          ans[4] = Double.valueOf(resultSet.getString(avg(d0s1)));
+          ans[5] = Double.valueOf(resultSet.getString(count(d0s2)));
+          ans[6] = Double.valueOf(resultSet.getString(sum(d0s0)));
+          assertArrayEquals(retArray[cnt], ans, DETLA);
           cnt++;
         }
         Assert.assertEquals(4, cnt);

--- a/server/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
@@ -49,6 +49,7 @@ import static org.junit.Assert.fail;
 
 public class IoTDBAggregationIT {
 
+  private static final double DETLA = 1e-6;
   private static final String TIMESTAMP_STR = "Time";
   private static final String TEMPERATURE_STR = "root.ln.wf01.wt01.temperature";
 
@@ -715,7 +716,7 @@ public class IoTDBAggregationIT {
                   + resultSet.getString(sum(d0s0))
                   + ","
                   + resultSet.getString(avg(d0s2));
-          Assert.assertEquals(retArray[cnt], ans);
+          Assert.assertEquals(retArray[cnt], ans, DETLA);
           cnt++;
         }
         Assert.assertEquals(1, cnt);
@@ -865,7 +866,7 @@ public class IoTDBAggregationIT {
                   + resultSet.getString(avg(d0s0))
                   + ","
                   + resultSet.getString(sum(d0s2));
-          Assert.assertEquals(retArray[cnt], ans);
+          Assert.assertEquals(retArray[cnt], ans, DETLA);
           cnt++;
         }
         Assert.assertEquals(1, cnt);


### PR DESCRIPTION
## Description

I did serval improvements of the AVG function:

The formula to calculate AVG function is complex, it can be simplified. I removed reduncdant operations.
When we calculate the AVG, the result value will transfer into Double type. in Java, the calculation of double type will always cause the loss of accuracy. And in our test case, there are lots of values which are loss of accuracy. I try to fix it by using assertEquals(double expected, double actual, double delta)