### PR TITLE
[ISSUE-2730] Add the number of unseq merge times in TsFile name.

### DIFF
--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -282,6 +282,7 @@
         <appender-ref ref="stdout"/>
     </root>
     <logger level="OFF" name="io.moquette.broker.metrics.MQTTMessageLogger"/>
+    <logger level="debug" name="org.apache.iotdb.db.integration.IoTDBRemovePartitionIT"/>
     <logger level="info" name="org.apache.iotdb.db.service"/>
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -143,4 +143,12 @@ public class IoTDBConstant {
 
   // thrift
   public static final int LEFT_SIZE_IN_REQUEST = 4 * 1024 * 1024;
+
+  // change tsFile name
+  public static final int FILE_NAME_SUFFIX_INDEX = 0;
+  public static final int FILE_NAME_SUFFIX_TIME_INDEX = 0;
+  public static final int FILE_NAME_SUFFIX_VERSION_INDEX = 1;
+  public static final int FILE_NAME_SUFFIX_MERGECNT_INDEX = 2;
+  public static final int FILE_NAME_SUFFIX_UNSEQMERGECNT_INDEX = 3;
+  public static final String FILE_NAME_SUFFIX_SEPARATOR = "\\.";
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -607,7 +607,7 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
               compactionLogger.logFile(SOURCE_NAME, mergeResource.getTsFile());
             }
             File newLevelFile =
-                createNewTsFileName(mergeResources.get(i).get(0).getTsFile(), i + 1);
+                TsFileResource.modifyTsFileNameMergeCnt(mergeResources.get(i).get(0).getTsFile());
             compactionLogger.logSequence(sequence);
             compactionLogger.logFile(TARGET_NAME, newLevelFile);
             List<TsFileResource> toMergeTsFiles = mergeResources.get(i);
@@ -675,13 +675,6 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
           sequence,
           System.currentTimeMillis() - startTimeMillis);
     }
-  }
-
-  /** if level < maxLevel-1, the file need compaction else, the file can be merged later */
-  private File createNewTsFileName(File sourceFile, int level) {
-    String path = sourceFile.getPath();
-    String prefixPath = path.substring(0, path.lastIndexOf(FILE_NAME_SEPARATOR) + 1);
-    return new File(prefixPath + level + TSFILE_SUFFIX);
   }
 
   private List<SortedSet<TsFileResource>> newSequenceTsFileResources(Long k) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeFileTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeFileTask.java
@@ -49,12 +49,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static org.apache.iotdb.db.engine.storagegroup.TsFileResource.modifyTsFileNameUnseqMergCnt;
+
 /**
  * MergeFileTask merges the merge temporary files with the seqFiles, either move the merged chunks
  * in the temp files into the seqFiles or move the unmerged chunks into the merge temp files,
  * depending on which one is the majority.
  */
-class MergeFileTask {
+public class MergeFileTask {
 
   private static final Logger logger = LoggerFactory.getLogger(MergeFileTask.class);
 
@@ -201,6 +203,37 @@ class MergeFileTask {
       seqFile.serialize();
       mergeLogger.logFileMergeEnd();
       logger.debug("{} moved merged chunks of {} to the old file", taskName, seqFile);
+
+      newFileWriter.getFile().delete();
+      // change tsFile name
+      File nextMergeVersionFile = modifyTsFileNameUnseqMergCnt(seqFile.getTsFile());
+      if (!nextMergeVersionFile.exists()) {
+        fsFactory.moveFile(seqFile.getTsFile(), nextMergeVersionFile);
+      } else {
+        nextMergeVersionFile.delete();
+        fsFactory.moveFile(seqFile.getTsFile(), nextMergeVersionFile);
+      }
+      if (!fsFactory
+          .getFile(nextMergeVersionFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX)
+          .exists()) {
+        fsFactory.moveFile(
+            fsFactory.getFile(
+                seqFile.getTsFile().getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX),
+            fsFactory.getFile(
+                nextMergeVersionFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX));
+
+      } else {
+        fsFactory
+            .getFile(nextMergeVersionFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX)
+            .delete();
+        fsFactory.moveFile(
+            fsFactory.getFile(
+                seqFile.getTsFile().getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX),
+            fsFactory.getFile(
+                nextMergeVersionFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX));
+      }
+
+      seqFile.setFile(nextMergeVersionFile);
     } catch (Exception e) {
       restoreOldFile(seqFile);
       throw e;
@@ -330,17 +363,43 @@ class MergeFileTask {
     fileWriter.endFile();
 
     updatePlanIndexes(seqFile);
-    seqFile.serialize();
     mergeLogger.logFileMergeEnd();
     logger.debug("{} moved unmerged chunks of {} to the new file", taskName, seqFile);
 
     seqFile.writeLock();
     try {
+      seqFile.serialize();
+      resource.removeFileReader(seqFile);
       FileReaderManager.getInstance().closeFileAndRemoveReader(seqFile.getTsFilePath());
-      File newMergeFile = seqFile.getTsFile();
-      newMergeFile.delete();
-      fsFactory.moveFile(fileWriter.getFile(), newMergeFile);
-      seqFile.setFile(newMergeFile);
+
+      // change tsFile name
+      seqFile.getTsFile().delete();
+      File nextMergeVersionFile = modifyTsFileNameUnseqMergCnt(seqFile.getTsFile());
+      if (!nextMergeVersionFile.exists()) {
+        fsFactory.moveFile(fileWriter.getFile(), nextMergeVersionFile);
+      } else {
+        nextMergeVersionFile.delete();
+        fsFactory.moveFile(fileWriter.getFile(), nextMergeVersionFile);
+      }
+      if (!fsFactory
+          .getFile(nextMergeVersionFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX)
+          .exists()) {
+        fsFactory.moveFile(
+            fsFactory.getFile(
+                seqFile.getTsFile().getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX),
+            fsFactory.getFile(
+                nextMergeVersionFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX));
+      } else {
+        fsFactory
+            .getFile(nextMergeVersionFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX)
+            .delete();
+        fsFactory.moveFile(
+            fsFactory.getFile(
+                seqFile.getTsFile().getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX),
+            fsFactory.getFile(
+                nextMergeVersionFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX));
+      }
+      seqFile.setFile(nextMergeVersionFile);
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
     } finally {

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeTask.java
@@ -233,7 +233,7 @@ public class MergeTask implements Callable<Void> {
     }
 
     File logFile = new File(storageGroupSysDir, MergeLogger.MERGE_LOG_NAME);
-    if (executeCallback) {
+    if (!executeCallback) {
       // make sure merge.log is not deleted until unseqFiles are cleared so that when system
       // reboots, the undeleted files can be deleted again
       callback.call(resource.getSeqFiles(), resource.getUnseqFiles(), logFile);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1239,7 +1239,7 @@ public class StorageGroupProcessor {
   }
 
   private String getNewTsFileName(long time, long version, int mergeCnt) {
-    return time + FILE_NAME_SEPARATOR + version + FILE_NAME_SEPARATOR + mergeCnt + TSFILE_SUFFIX;
+    return TsFileResource.getNewTsFileName(System.currentTimeMillis(), version, 0, 0);
   }
 
   public void syncCloseOneTsFileProcessor(boolean sequence, TsFileProcessor tsFileProcessor) {
@@ -2466,7 +2466,8 @@ public class StorageGroupProcessor {
       return tsfileName;
     }
 
-    return getNewTsFileName(preTime + ((subsequenceTime - preTime) >> 1), subsequenceVersion, 0);
+    return TsFileResource.getNewTsFileName(
+        preTime + ((subsequenceTime - preTime) >> 1), subsequenceVersion, 0, 0);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -59,6 +59,15 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_INDEX;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_MERGECNT_INDEX;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_SEPARATOR;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_TIME_INDEX;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_UNSEQMERGECNT_INDEX;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_VERSION_INDEX;
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
+
 @SuppressWarnings("java:S1135") // ignore todos
 public class TsFileResource {
 
@@ -753,5 +762,128 @@ public class TsFileResource {
 
   public void setTimeIndex(ITimeIndex timeIndex) {
     this.timeIndex = timeIndex;
+  }
+
+  // change tsFile name
+
+  public static File modifyTsFileNameMergeCnt(File tsFile) {
+    String path = tsFile.getParent();
+    TsFileName tsFileName = getTsFileName(tsFile.getName());
+    tsFileName.setMergeCnt(tsFileName.getMergeCnt() + 1);
+    return new File(
+        path,
+        tsFileName.time
+            + FILE_NAME_SEPARATOR
+            + tsFileName.version
+            + FILE_NAME_SEPARATOR
+            + tsFileName.mergeCnt
+            + FILE_NAME_SEPARATOR
+            + tsFileName.unSeqMergeCnt
+            + TSFILE_SUFFIX);
+  }
+
+  public static String getNewTsFileName(long time, long version, int mergeCnt, int unSeqMergeCnt) {
+    return time
+        + FILE_NAME_SEPARATOR
+        + version
+        + FILE_NAME_SEPARATOR
+        + mergeCnt
+        + FILE_NAME_SEPARATOR
+        + unSeqMergeCnt
+        + TSFILE_SUFFIX;
+  }
+
+  public static TsFileName getTsFileName(String FileName) {
+    String[] fileName =
+        FileName.split(FILE_NAME_SUFFIX_SEPARATOR)[FILE_NAME_SUFFIX_INDEX].split(
+            FILE_NAME_SEPARATOR);
+    TsFileName tsFileName =
+        new TsFileName(
+            Long.parseLong(fileName[FILE_NAME_SUFFIX_TIME_INDEX]),
+            Long.parseLong(fileName[FILE_NAME_SUFFIX_VERSION_INDEX]),
+            Integer.parseInt(fileName[FILE_NAME_SUFFIX_MERGECNT_INDEX]),
+            Integer.parseInt(fileName[FILE_NAME_SUFFIX_UNSEQMERGECNT_INDEX]));
+    return tsFileName;
+  }
+
+  public static TsFileResource modifyTsFileNameUnseqMergCnt(TsFileResource tsFileResource) {
+    File tsFile = tsFileResource.getTsFile();
+    String path = tsFile.getParent();
+    TsFileName tsFileName = getTsFileName(tsFileResource.getTsFile().getName());
+    tsFileName.setUnSeqMergeCnt(tsFileName.getUnSeqMergeCnt() + 1);
+    tsFileResource.setFile(
+        new File(
+            path,
+            tsFileName.time
+                + FILE_NAME_SEPARATOR
+                + tsFileName.version
+                + FILE_NAME_SEPARATOR
+                + tsFileName.mergeCnt
+                + FILE_NAME_SEPARATOR
+                + tsFileName.unSeqMergeCnt
+                + TSFILE_SUFFIX));
+    return tsFileResource;
+  }
+
+  public static File modifyTsFileNameUnseqMergCnt(File tsFile) {
+    String path = tsFile.getParent();
+    TsFileName tsFileName = getTsFileName(tsFile.getName());
+    tsFileName.setUnSeqMergeCnt(tsFileName.getUnSeqMergeCnt() + 1);
+    return new File(
+        path,
+        tsFileName.time
+            + FILE_NAME_SEPARATOR
+            + tsFileName.version
+            + FILE_NAME_SEPARATOR
+            + tsFileName.mergeCnt
+            + FILE_NAME_SEPARATOR
+            + tsFileName.unSeqMergeCnt
+            + TSFILE_SUFFIX);
+  }
+
+  public static class TsFileName {
+    private long time;
+    private long version;
+    private int mergeCnt;
+    private int unSeqMergeCnt;
+
+    public TsFileName(long time, long version, int mergeCnt, int unSeqMergeCnt) {
+      this.time = time;
+      this.version = version;
+      this.mergeCnt = mergeCnt;
+      this.unSeqMergeCnt = unSeqMergeCnt;
+    }
+
+    public long getTime() {
+      return time;
+    }
+
+    public long getVersion() {
+      return version;
+    }
+
+    public int getMergeCnt() {
+      return mergeCnt;
+    }
+
+    public int getUnSeqMergeCnt() {
+      return unSeqMergeCnt;
+    }
+
+    public void setTime(long time) {
+      this.time = time;
+    }
+
+    public void setVersion(long version) {
+      this.version = version;
+    }
+
+    public void setMergeCnt(int mergeCnt) {
+      this.mergeCnt = mergeCnt;
+    }
+
+    public void setUnSeqMergeCnt(int unSeqMergeCnt) {
+      this.unSeqMergeCnt = unSeqMergeCnt;
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
@@ -251,7 +251,7 @@ public class FilePathUtils {
 
   public static long splitAndGetTsFileVersion(String tsFileName) {
     String[] names = tsFileName.split(FILE_NAME_SEPARATOR);
-    if (names.length != 3) {
+    if (names.length != 4) {
       return 0;
     }
     return Long.parseLong(names[1]);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMoreDataTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMoreDataTest.java
@@ -101,6 +101,8 @@ public class LevelCompactionMoreDataTest extends LevelCompactionTest {
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -117,6 +119,8 @@ public class LevelCompactionMoreDataTest extends LevelCompactionTest {
                       + (10000 + i)
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -131,6 +135,8 @@ public class LevelCompactionMoreDataTest extends LevelCompactionTest {
                 unseqFileNum
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + unseqFileNum
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 0
                     + ".tsfile"));

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionTest.java
@@ -132,6 +132,8 @@ abstract class LevelCompactionTest {
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -148,6 +150,8 @@ abstract class LevelCompactionTest {
                       + (10000 + i)
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -162,6 +166,8 @@ abstract class LevelCompactionTest {
                 unseqFileNum
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + unseqFileNum
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 0
                     + ".tsfile"));

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeOverLapTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeOverLapTest.java
@@ -83,6 +83,8 @@ public class MergeOverLapTest extends MergeTest {
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -100,6 +102,8 @@ public class MergeOverLapTest extends MergeTest {
                       + (10000 + i)
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -114,6 +118,8 @@ public class MergeOverLapTest extends MergeTest {
                 unseqFileNum
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + unseqFileNum
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 0
                     + ".tsfile"));
@@ -192,7 +198,7 @@ public class MergeOverLapTest extends MergeTest {
                 + TsFileConstant.PATH_SEPARATOR
                 + measurementSchemas[0].getMeasurementId());
     List<TsFileResource> resources = new ArrayList<>();
-    resources.add(seqResources.get(0));
+    resources.add(seqResources.get(1));
     IBatchReader tsFilesReader =
         new SeriesRawDataBatchReader(
             path,

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.iotdb.db.engine.storagegroup.TsFileResource.modifyTsFileNameUnseqMergCnt;
 import static org.junit.Assert.assertEquals;
 
 public class MergeTaskTest extends MergeTest {
@@ -88,7 +89,7 @@ public class MergeTaskTest extends MergeTest {
                 + TsFileConstant.PATH_SEPARATOR
                 + measurementSchemas[0].getMeasurementId());
     List<TsFileResource> list = new ArrayList<>();
-    list.add(seqResources.get(0));
+    list.add(modifyTsFileNameUnseqMergCnt(seqResources.get(0)));
     IBatchReader tsFilesReader =
         new SeriesRawDataBatchReader(
             path,
@@ -199,7 +200,7 @@ public class MergeTaskTest extends MergeTest {
                 + TsFileConstant.PATH_SEPARATOR
                 + measurementSchemas[0].getMeasurementId());
     List<TsFileResource> list = new ArrayList<>();
-    list.add(seqResources.get(0));
+    list.add(modifyTsFileNameUnseqMergCnt(seqResources.get(0)));
     IBatchReader tsFilesReader =
         new SeriesRawDataBatchReader(
             path,
@@ -240,7 +241,7 @@ public class MergeTaskTest extends MergeTest {
                 + TsFileConstant.PATH_SEPARATOR
                 + measurementSchemas[0].getMeasurementId());
     List<TsFileResource> resources = new ArrayList<>();
-    resources.add(seqResources.get(0));
+    resources.add(modifyTsFileNameUnseqMergCnt(seqResources.get(0)));
     IBatchReader tsFilesReader =
         new SeriesRawDataBatchReader(
             path,
@@ -324,7 +325,7 @@ public class MergeTaskTest extends MergeTest {
                 + TsFileConstant.PATH_SEPARATOR
                 + measurementSchemas[0].getMeasurementId());
     List<TsFileResource> list = new ArrayList<>();
-    list.add(seqResources.get(0));
+    list.add(modifyTsFileNameUnseqMergCnt(seqResources.get(0)));
     IBatchReader tsFilesReader =
         new SeriesRawDataBatchReader(
             path,
@@ -364,7 +365,7 @@ public class MergeTaskTest extends MergeTest {
                 + TsFileConstant.PATH_SEPARATOR
                 + measurementSchemas[0].getMeasurementId());
     List<TsFileResource> list = new ArrayList<>();
-    list.add(seqResources.get(2));
+    list.add(modifyTsFileNameUnseqMergCnt(seqResources.get(2)));
     IBatchReader tsFilesReader =
         new SeriesRawDataBatchReader(
             path,
@@ -452,7 +453,7 @@ public class MergeTaskTest extends MergeTest {
         count++;
       }
     }
-    assertEquals(70, count);
+    assertEquals(50, count);
     tsFilesReader.close();
   }
 
@@ -479,7 +480,7 @@ public class MergeTaskTest extends MergeTest {
                 + TsFileConstant.PATH_SEPARATOR
                 + measurementSchemas[0].getMeasurementId());
     List<TsFileResource> resources = new ArrayList<>();
-    resources.add(seqResources.get(2));
+    resources.add(modifyTsFileNameUnseqMergCnt(seqResources.get(2)));
     IBatchReader tsFilesReader =
         new SeriesRawDataBatchReader(
             path,

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTest.java
@@ -134,6 +134,8 @@ abstract class MergeTest {
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -152,6 +154,8 @@ abstract class MergeTest {
                       + (10000 + i)
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -168,6 +172,8 @@ abstract class MergeTest {
                 unseqFileNum
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + unseqFileNum
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 0
                     + ".tsfile"));

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBRemovePartitionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBRemovePartitionIT.java
@@ -20,6 +20,19 @@
 package org.apache.iotdb.db.integration;
 
 import org.apache.iotdb.db.engine.StorageEngine;
+import org.apache.iotdb.db.engine.compaction.TsFileManagement;
+import org.apache.iotdb.db.engine.compaction.level.LevelCompactionTsFileManagement;
+import org.apache.iotdb.db.engine.flush.MemTableFlushTask;
+import org.apache.iotdb.db.engine.merge.manage.MergeResource;
+import org.apache.iotdb.db.engine.merge.selector.MaxFileMergeFileSelector;
+import org.apache.iotdb.db.engine.merge.selector.MaxSeriesMergeFileSelector;
+import org.apache.iotdb.db.engine.merge.task.MergeFileTask;
+import org.apache.iotdb.db.engine.merge.task.MergeMultiChunkTask;
+import org.apache.iotdb.db.engine.merge.task.MergeMultiChunkTask.MergeChunkHeapTask;
+import org.apache.iotdb.db.engine.merge.task.MergeTask;
+import org.apache.iotdb.db.engine.storagegroup.StorageGroupProcessor;
+import org.apache.iotdb.db.engine.storagegroup.TsFileProcessor;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
@@ -28,7 +41,11 @@ import org.apache.iotdb.jdbc.Config;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -44,8 +61,35 @@ public class IoTDBRemovePartitionIT {
 
   private static int partitionInterval = 100;
 
+  private void setLoggerLevel(Class clazz, String loggerLevelNew)
+      throws NoSuchMethodException, ClassNotFoundException, InvocationTargetException,
+          IllegalAccessException {
+    Logger loggerInterface = LoggerFactory.getLogger(clazz);
+    Class<?> levelLogBackClass = Class.forName("ch.qos.logback.classic.Level");
+    Method toLevelMethod = levelLogBackClass.getDeclaredMethod("toLevel", String.class);
+    Object traceLevel = toLevelMethod.invoke(null, loggerLevelNew);
+    Method loggerSetLevelMethod =
+        loggerInterface.getClass().getDeclaredMethod("setLevel", levelLogBackClass);
+    loggerSetLevelMethod.invoke(loggerInterface, traceLevel);
+  }
+
   @Before
   public void setUp() throws Exception {
+    setLoggerLevel(StorageEngine.class, "DEBUG");
+    setLoggerLevel(MemTableFlushTask.class, "DEBUG");
+    setLoggerLevel(StorageGroupProcessor.class, "DEBUG");
+    setLoggerLevel(MergeResource.class, "DEBUG");
+    setLoggerLevel(TsFileProcessor.class, "DEBUG");
+    setLoggerLevel(TsFileResource.class, "DEBUG");
+    setLoggerLevel(LevelCompactionTsFileManagement.class, "DEBUG");
+    setLoggerLevel(TsFileManagement.class, "DEBUG");
+    setLoggerLevel(MaxFileMergeFileSelector.class, "DEBUG");
+    setLoggerLevel(MaxSeriesMergeFileSelector.class, "DEBUG");
+    setLoggerLevel(MergeMultiChunkTask.class, "DEBUG");
+    setLoggerLevel(MergeChunkHeapTask.class, "DEBUG");
+    setLoggerLevel(MergeFileTask.class, "DEBUG");
+    setLoggerLevel(MergeTask.class, "DEBUG");
+
     EnvironmentUtils.closeStatMonitor();
     EnvironmentUtils.envSetUp();
     StorageEngine.setEnablePartition(true);
@@ -58,6 +102,21 @@ public class IoTDBRemovePartitionIT {
     StorageEngine.setEnablePartition(false);
     StorageEngine.setTimePartitionInterval(-1);
     EnvironmentUtils.cleanEnv();
+
+    setLoggerLevel(StorageEngine.class, "ERROR");
+    setLoggerLevel(MemTableFlushTask.class, "ERROR");
+    setLoggerLevel(StorageGroupProcessor.class, "ERROR");
+    setLoggerLevel(MergeResource.class, "ERROR");
+    setLoggerLevel(TsFileProcessor.class, "ERROR");
+    setLoggerLevel(TsFileResource.class, "ERROR");
+    setLoggerLevel(LevelCompactionTsFileManagement.class, "ERROR");
+    setLoggerLevel(TsFileManagement.class, "ERROR");
+    setLoggerLevel(MaxFileMergeFileSelector.class, "ERROR");
+    setLoggerLevel(MaxSeriesMergeFileSelector.class, "ERROR");
+    setLoggerLevel(MergeMultiChunkTask.class, "ERROR");
+    setLoggerLevel(MergeChunkHeapTask.class, "ERROR");
+    setLoggerLevel(MergeFileTask.class, "ERROR");
+    setLoggerLevel(MergeTask.class, "ERROR");
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/sync/receiver/load/FileLoaderTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/receiver/load/FileLoaderTest.java
@@ -120,6 +120,8 @@ public class FileLoaderTest {
                 + IoTDBConstant.FILE_NAME_SEPARATOR
                 + rand
                 + IoTDBConstant.FILE_NAME_SEPARATOR
+                + "0"
+                + IoTDBConstant.FILE_NAME_SEPARATOR
                 + "0.tsfile";
 
         File syncFile = new File(fileName);
@@ -243,6 +245,8 @@ public class FileLoaderTest {
                 + (time + i * 100 + j)
                 + IoTDBConstant.FILE_NAME_SEPARATOR
                 + rand
+                + IoTDBConstant.FILE_NAME_SEPARATOR
+                + "0"
                 + IoTDBConstant.FILE_NAME_SEPARATOR
                 + "0.tsfile";
 


### PR DESCRIPTION
## Description
Hi all :
I have submitted a pr for [ISSUE-2730](https://github.com/apache/iotdb/issues/2730), please take a look.
This issue about add the number of unseq merge times in TsFile name.

The modules involved are as follows:
   1、server/engine/merge
   2、server/engine/storagegroup

### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
