### PR TITLE
[IOTDB-1236] Improve jdbc performance for creating timeseries in cluster module

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -553,14 +553,8 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         }
 
         if (physicalPlan.getOperatorType().equals(OperatorType.INSERT)) {
-          if (lastOperatorType == null || OperatorType.INSERT == lastOperatorType) {
-            insertRowsPlan =
-                executeList.size() > 0
-                    ? (InsertRowsPlan) executeList.get(executeList.size() - 1)
-                    : new InsertRowsPlan();
-            if (lastOperatorType == null) {
-              executeList.add(insertRowsPlan);
-            }
+          if (OperatorType.INSERT == lastOperatorType) {
+            insertRowsPlan = (InsertRowsPlan) executeList.get(executeList.size() - 1);
           } else {
             insertRowsPlan = new InsertRowsPlan();
             executeList.add(insertRowsPlan);
@@ -576,14 +570,8 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
             executeList = new ArrayList();
           }
         } else if (physicalPlan.getOperatorType().equals(OperatorType.CREATE_TIMESERIES)) {
-          if (lastOperatorType == null || OperatorType.CREATE_TIMESERIES == lastOperatorType) {
-            multiPlan =
-                executeList.size() > 0
-                    ? (CreateMultiTimeSeriesPlan) executeList.get(executeList.size() - 1)
-                    : new CreateMultiTimeSeriesPlan();
-            if (lastOperatorType == null) {
-              executeList.add(multiPlan);
-            }
+          if (OperatorType.CREATE_TIMESERIES == lastOperatorType) {
+            multiPlan = (CreateMultiTimeSeriesPlan) executeList.get(executeList.size() - 1);
           } else {
             multiPlan = new CreateMultiTimeSeriesPlan();
             executeList.add(multiPlan);

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -509,19 +509,17 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     multiPlan.getAlias().add(alias);
   }
 
-  private boolean executeBatchList(ArrayList executeList, List<TSStatus> result) {
+  private boolean executeBatchList(List executeList, List<TSStatus> result) {
     boolean isAllSuccessful = true;
-    if (executeList.size() > 0) {
-      for (int j = 0; j < executeList.size(); j++) {
-        Object planObject = executeList.get(j);
-        if (InsertRowsPlan.class.isInstance(planObject)) {
-          if (!executeInsertRowsPlan((InsertRowsPlan) planObject, result)) {
-            isAllSuccessful = false;
-          }
-        } else if (CreateMultiTimeSeriesPlan.class.isInstance(planObject)) {
-          if (!executeMultiTimeSeriesPlan((CreateMultiTimeSeriesPlan) planObject, result)) {
-            isAllSuccessful = false;
-          }
+    for (int j = 0; j < executeList.size(); j++) {
+      Object planObject = executeList.get(j);
+      if (InsertRowsPlan.class.isInstance(planObject)) {
+        if (!executeInsertRowsPlan((InsertRowsPlan) planObject, result)) {
+          isAllSuccessful = false;
+        }
+      } else if (CreateMultiTimeSeriesPlan.class.isInstance(planObject)) {
+        if (!executeMultiTimeSeriesPlan((CreateMultiTimeSeriesPlan) planObject, result)) {
+          isAllSuccessful = false;
         }
       }
     }
@@ -539,7 +537,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
 
     InsertRowsPlan insertRowsPlan;
     int index = 0;
-    ArrayList executeList = new ArrayList();
+    List executeList = new ArrayList();
     OperatorType lastOperatorType = null;
     CreateMultiTimeSeriesPlan multiPlan;
     for (int i = 0; i < req.getStatements().size(); i++) {
@@ -567,7 +565,6 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
             if (!executeBatchList(executeList, result)) {
               isAllSuccessful = false;
             }
-            executeList = new ArrayList();
           }
         } else if (physicalPlan.getOperatorType().equals(OperatorType.CREATE_TIMESERIES)) {
           if (OperatorType.CREATE_TIMESERIES == lastOperatorType) {
@@ -585,7 +582,6 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
             if (!executeBatchList(executeList, result)) {
               isAllSuccessful = false;
             }
-            executeList = new ArrayList();
           }
         } else {
           lastOperatorType = physicalPlan.getOperatorType();
@@ -593,7 +589,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
             if (!executeBatchList(executeList, result)) {
               isAllSuccessful = false;
             }
-            executeList = new ArrayList();
+            executeList.clear();
           }
           long t2 = System.currentTimeMillis();
           TSExecuteStatementResp resp = executeUpdateStatement(physicalPlan, req.getSessionId());

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -447,7 +447,85 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         result.set(startIndex + entry.getKey(), entry.getValue());
       }
     }
-    return tsStatus.equals(RpcUtils.SUCCESS_STATUS);
+    return tsStatus.getCode() == RpcUtils.SUCCESS_STATUS.getCode();
+  }
+
+  private boolean executeMultiTimeSeriesPlan(
+      CreateMultiTimeSeriesPlan multiPlan, List<TSStatus> result) {
+    long t1 = System.currentTimeMillis();
+    TSStatus tsStatus = executeNonQueryPlan(multiPlan);
+    Measurement.INSTANCE.addOperationLatency(Operation.EXECUTE_ROWS_PLAN_IN_BATCH, t1);
+
+    int startIndex = result.size();
+    if (startIndex > 0) {
+      startIndex = startIndex - 1;
+    }
+    for (int k = 0; k < multiPlan.getPaths().size(); k++) {
+      result.add(RpcUtils.SUCCESS_STATUS);
+    }
+    if (tsStatus.subStatus != null) {
+      for (Entry<Integer, TSStatus> entry : multiPlan.getResults().entrySet()) {
+        result.set(startIndex + entry.getKey(), entry.getValue());
+      }
+    }
+    return tsStatus.getCode() == RpcUtils.SUCCESS_STATUS.getCode();
+  }
+
+  private void initMultiTimeSeriesPlan(CreateMultiTimeSeriesPlan multiPlan) {
+    if (multiPlan.getPaths() == null) {
+      List<PartialPath> paths = new ArrayList<>();
+      List<TSDataType> tsDataTypes = new ArrayList<>();
+      List<TSEncoding> tsEncodings = new ArrayList<>();
+      List<CompressionType> tsCompressionTypes = new ArrayList<>();
+      List<Map<String, String>> tagsList = new ArrayList<>();
+      List<Map<String, String>> attributesList = new ArrayList<>();
+      List<String> aliasList = new ArrayList<>();
+      multiPlan.setPaths(paths);
+      multiPlan.setDataTypes(tsDataTypes);
+      multiPlan.setEncodings(tsEncodings);
+      multiPlan.setCompressors(tsCompressionTypes);
+      multiPlan.setTags(tagsList);
+      multiPlan.setAttributes(attributesList);
+      multiPlan.setAlias(aliasList);
+    }
+  }
+
+  private void setMultiTimeSeriesPlan(
+      CreateMultiTimeSeriesPlan multiPlan, CreateTimeSeriesPlan createTimeSeriesPlan) {
+    PartialPath path = createTimeSeriesPlan.getPath();
+    TSDataType type = createTimeSeriesPlan.getDataType();
+    TSEncoding encoding = createTimeSeriesPlan.getEncoding();
+    CompressionType compressor = createTimeSeriesPlan.getCompressor();
+    Map<String, String> tags = createTimeSeriesPlan.getTags();
+    Map<String, String> attributes = createTimeSeriesPlan.getAttributes();
+    String alias = createTimeSeriesPlan.getAlias();
+
+    multiPlan.getPaths().add(path);
+    multiPlan.getDataTypes().add(type);
+    multiPlan.getEncodings().add(encoding);
+    multiPlan.getCompressors().add(compressor);
+    multiPlan.getTags().add(tags);
+    multiPlan.getAttributes().add(attributes);
+    multiPlan.getAlias().add(alias);
+  }
+
+  private boolean executeBatchList(ArrayList executeList, List<TSStatus> result) {
+    boolean isAllSuccessful = true;
+    if (executeList.size() > 0) {
+      for (int j = 0; j < executeList.size(); j++) {
+        Object planObject = executeList.get(j);
+        if (InsertRowsPlan.class.isInstance(planObject)) {
+          if (!executeInsertRowsPlan((InsertRowsPlan) planObject, result)) {
+            isAllSuccessful = false;
+          }
+        } else if (CreateMultiTimeSeriesPlan.class.isInstance(planObject)) {
+          if (!executeMultiTimeSeriesPlan((CreateMultiTimeSeriesPlan) planObject, result)) {
+            isAllSuccessful = false;
+          }
+        }
+      }
+    }
+    return isAllSuccessful;
   }
 
   @Override
@@ -459,18 +537,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       return RpcUtils.getStatus(TSStatusCode.NOT_LOGIN_ERROR);
     }
 
-    InsertRowsPlan insertRowsPlan = new InsertRowsPlan();
+    InsertRowsPlan insertRowsPlan;
     int index = 0;
-
-    CreateMultiTimeSeriesPlan multiPlan = new CreateMultiTimeSeriesPlan();
-    List<PartialPath> paths = new ArrayList<>();
-    List<TSDataType> tsDataTypes = new ArrayList<>();
-    List<TSEncoding> tsEncodings = new ArrayList<>();
-    List<CompressionType> tsCompressionTypes = new ArrayList<>();
-    List<Map<String, String>> tagsList = new ArrayList<>();
-    List<Map<String, String>> attributesList = new ArrayList<>();
-    List<String> aliasList = new ArrayList<>();
-
+    ArrayList executeList = new ArrayList();
+    OperatorType lastOperatorType = null;
+    CreateMultiTimeSeriesPlan multiPlan;
     for (int i = 0; i < req.getStatements().size(); i++) {
       String statement = req.getStatements().get(i);
       try {
@@ -482,37 +553,59 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         }
 
         if (physicalPlan.getOperatorType().equals(OperatorType.INSERT)) {
+          if (lastOperatorType == null || OperatorType.INSERT == lastOperatorType) {
+            insertRowsPlan =
+                executeList.size() > 0
+                    ? (InsertRowsPlan) executeList.get(executeList.size() - 1)
+                    : new InsertRowsPlan();
+            if (lastOperatorType == null) {
+              executeList.add(insertRowsPlan);
+            }
+          } else {
+            insertRowsPlan = new InsertRowsPlan();
+            executeList.add(insertRowsPlan);
+            index = 0;
+          }
+          lastOperatorType = OperatorType.INSERT;
           insertRowsPlan.addOneInsertRowPlan((InsertRowPlan) physicalPlan, index);
           index++;
-          if (i == req.getStatements().size() - 1
-              && !executeInsertRowsPlan(insertRowsPlan, result)) {
-            isAllSuccessful = false;
-          }
-        } else if (physicalPlan.getOperatorType().equals(OperatorType.CREATE_TIMESERIES)) {
-
-          CreateTimeSeriesPlan createTimeSeriesPlan = (CreateTimeSeriesPlan) physicalPlan;
-          PartialPath path = createTimeSeriesPlan.getPath();
-          TSDataType type = createTimeSeriesPlan.getDataType();
-          TSEncoding encoding = createTimeSeriesPlan.getEncoding();
-          CompressionType compressor = createTimeSeriesPlan.getCompressor();
-          Map<String, String> tags = createTimeSeriesPlan.getTags();
-          Map<String, String> attributes = createTimeSeriesPlan.getAttributes();
-          String alias = createTimeSeriesPlan.getAlias();
-
-          paths.add(path);
-          tsDataTypes.add(type);
-          tsEncodings.add(encoding);
-          tsCompressionTypes.add(compressor);
-          tagsList.add(tags);
-          attributesList.add(attributes);
-          aliasList.add(alias);
-        } else {
-          if (insertRowsPlan.getRowCount() > 0) {
-            if (!executeInsertRowsPlan(insertRowsPlan, result)) {
+          if (i == req.getStatements().size() - 1) {
+            if (!executeBatchList(executeList, result)) {
               isAllSuccessful = false;
             }
-            index = 0;
-            insertRowsPlan = new InsertRowsPlan();
+            executeList = new ArrayList();
+          }
+        } else if (physicalPlan.getOperatorType().equals(OperatorType.CREATE_TIMESERIES)) {
+          if (lastOperatorType == null || OperatorType.CREATE_TIMESERIES == lastOperatorType) {
+            multiPlan =
+                executeList.size() > 0
+                    ? (CreateMultiTimeSeriesPlan) executeList.get(executeList.size() - 1)
+                    : new CreateMultiTimeSeriesPlan();
+            if (lastOperatorType == null) {
+              executeList.add(multiPlan);
+            }
+          } else {
+            multiPlan = new CreateMultiTimeSeriesPlan();
+            executeList.add(multiPlan);
+          }
+          lastOperatorType = OperatorType.CREATE_TIMESERIES;
+          initMultiTimeSeriesPlan(multiPlan);
+
+          CreateTimeSeriesPlan createTimeSeriesPlan = (CreateTimeSeriesPlan) physicalPlan;
+          setMultiTimeSeriesPlan(multiPlan, createTimeSeriesPlan);
+          if (i == req.getStatements().size() - 1) {
+            if (!executeBatchList(executeList, result)) {
+              isAllSuccessful = false;
+            }
+            executeList = new ArrayList();
+          }
+        } else {
+          lastOperatorType = physicalPlan.getOperatorType();
+          if (executeList.size() > 0) {
+            if (!executeBatchList(executeList, result)) {
+              isAllSuccessful = false;
+            }
+            executeList = new ArrayList();
           }
           long t2 = System.currentTimeMillis();
           TSExecuteStatementResp resp = executeUpdateStatement(physicalPlan, req.getSessionId());
@@ -523,6 +616,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           }
         }
       } catch (Exception e) {
+        LOGGER.error("Error occurred when executing executeBatchStatement: ", e);
         TSStatus status = tryCatchQueryException(e);
         if (status != null) {
           result.add(status);
@@ -534,30 +628,6 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         }
       }
     }
-    if (paths.size() > 0) {
-      multiPlan.setPaths(paths);
-      multiPlan.setDataTypes(tsDataTypes);
-      multiPlan.setEncodings(tsEncodings);
-      multiPlan.setCompressors(tsCompressionTypes);
-      multiPlan.setTags(tagsList);
-      multiPlan.setAttributes(attributesList);
-      multiPlan.setAlias(aliasList);
-      TSStatus status = executeNonQueryPlan(multiPlan);
-      if (status.code != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-        int startIndex = result.size();
-        if (startIndex > 0) {
-          startIndex = startIndex - 1;
-        }
-        for (int i = 0; i < paths.size(); i++) {
-          result.add(RpcUtils.SUCCESS_STATUS);
-        }
-        for (Entry<Integer, TSStatus> entry : multiPlan.getResults().entrySet()) {
-          result.set(startIndex + entry.getKey(), entry.getValue());
-        }
-        isAllSuccessful = false;
-      }
-    }
-
     Measurement.INSTANCE.addOperationLatency(Operation.EXECUTE_JDBC_BATCH, t1);
     return isAllSuccessful
         ? RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS, "Execute batch statements successfully")

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBExecuteBatchIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBExecuteBatchIT.java
@@ -26,7 +26,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 import static org.junit.Assert.assertEquals;
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBExecuteBatchIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBExecuteBatchIT.java
@@ -26,11 +26,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -70,6 +66,124 @@ public class IoTDBExecuteBatchIT {
       while (resultSet.next()) {
         assertEquals(timestamps[count], resultSet.getString("Time"));
         assertEquals(values[count], resultSet.getString("root.ln.wf01.wt01.temperature"));
+        count++;
+      }
+    } catch (SQLException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testJDBCExecuteBatchForCreateMultiTimeSeriesPlan() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.setFetchSize(100);
+      statement.addBatch(
+          "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600000,1.2)");
+      statement.addBatch(
+          "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600001,2.3)");
+      statement.addBatch("delete timeseries root.ln.wf01.wt01");
+      statement.addBatch(
+          "create timeseries root.turbine.d1.s1(s1) with datatype=boolean, encoding=plain , compression=snappy tags(tag1=v1, tag2=v2) attributes(attr1=v3, attr2=v4)");
+      statement.addBatch(
+          "create timeseries root.turbine.d1.s2(s2) with datatype=float, encoding=rle, compression=uncompressed tags(tag1=v5, tag2=v6) attributes(attr1=v7, attr2=v8) ");
+      statement.addBatch(
+          "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600002,3.4)");
+      statement.addBatch(
+          "create timeseries root.turbine.d1.s3 with datatype=boolean, encoding=rle");
+      statement.executeBatch();
+      statement.clearBatch();
+      ResultSet resultSet = statement.executeQuery("select * from root.ln.wf01.wt01");
+      String[] timestamps = {"1509465600002"};
+      String[] values = {"3.4"};
+      int count = 0;
+      while (resultSet.next()) {
+        assertEquals(timestamps[count], resultSet.getString("Time"));
+        assertEquals(values[count], resultSet.getString("root.ln.wf01.wt01.temperature"));
+        count++;
+      }
+      ResultSet timeSeriesResultSetForS1 =
+          statement.executeQuery("SHOW TIMESERIES root.turbine.d1.s1");
+      count = 0;
+      String[] key_s1 = {
+        "timeseries",
+        "alias",
+        "storage",
+        "group",
+        "dataType",
+        "encoding",
+        "compression",
+        "tags",
+        "attributes"
+      };
+      String[] value_s1 = {
+        "root.turbine.d1.s1",
+        "s1",
+        "root.turbine",
+        "BOOLEAN",
+        "PLAIN",
+        "SNAPPY",
+        "{\"tag1\":\"v1\",\"tag2\":\"v2\"}",
+        "{\"attr2\":\"v3\",\"attr1\":\"v4\"}"
+      };
+
+      while (timeSeriesResultSetForS1.next()) {
+        assertEquals(value_s1[count], timeSeriesResultSetForS1.getString(key_s1[count]));
+        count++;
+      }
+
+      ResultSet timeSeriesResultSetForS2 =
+          statement.executeQuery("SHOW TIMESERIES root.turbine.d1.s2");
+      count = 0;
+      String[] key_s2 = {
+        "timeseries",
+        "alias",
+        "storage",
+        "group",
+        "dataType",
+        "encoding",
+        "compression",
+        "tags",
+        "attributes"
+      };
+      String[] value_s2 = {
+        "root.turbine.d1.s2",
+        "s2",
+        "root.turbine",
+        "FLOAT",
+        "RLE",
+        "UNCOMPRESSED",
+        "{\"tag1\":\"v5\",\"tag2\":\"v6\"}",
+        "{\"attr2\":\"v7\",\"attr1\":\"v8\"}"
+      };
+      while (timeSeriesResultSetForS2.next()) {
+        assertEquals(value_s2[count], timeSeriesResultSetForS2.getString(key_s2[count]));
+        count++;
+      }
+
+      count = 0;
+      String[] key_s3 = {
+        "timeseries",
+        "alias",
+        "storage",
+        "group",
+        "dataType",
+        "encoding",
+        "compression",
+        "tags",
+        "attributes"
+      };
+      String[] value_s3 = {
+        "root.turbine.d1.s3", "null", "root.turbine", "BOOLEAN", "RLE", "SNAPPY", "null", "null"
+      };
+      ResultSet timeSeriesResultSetForS3 =
+          statement.executeQuery("SHOW TIMESERIES root.turbine.d1.s3");
+
+      while (timeSeriesResultSetForS3.next()) {
+        assertEquals(value_s3[count], timeSeriesResultSetForS3.getString(key_s3[count]));
         count++;
       }
     } catch (SQLException e) {


### PR DESCRIPTION
Jira: 
https://issues.apache.org/jira/browse/IOTDB-1236

Improve jdbc performance for creating timeseries in cluster module

Refer to InsertRowsPlan to judge the type of operation specifically, and execute CreateMultiTimeSeriesPlan without affecting the execution sequence
1. Determine the type of operation
2. Assemble batch objects
3. If it is not INSERT and CREATE_TIMESERIES operations, start to execute the operation queue in order

reference
https://github.com/apache/iotdb/pull/2725

