### PR TITLE
[IOTDB-1247] [To rel/0.11] fix the insert blocked caused the bugs in mem control module

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,7 +33,7 @@
 * ISSUE-2639 Fix possible NPE during end query process
 * Alter IT for An error is reported and the system is suspended occasionally
 * IOTDB-1149 print error for -e param when set maxPRC<=0
-* IOTDB-1274 Fix the insert blocked caused the bugs in mem control module
+* IOTDB-1247 Fix the insert blocked caused the bugs in mem control module
 * ISSUE-2648 Last query not right when having multiple devices
 * Delete mods files after compaction
 * ISSUE-2687 fix insert NaN bug

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,7 +33,8 @@
 * ISSUE-2639 Fix possible NPE during end query process
 * Alter IT for An error is reported and the system is suspended occasionally
 * IOTDB-1149 print error for -e param when set maxPRC<=0
-* IOTDB-2648 Last query not right when having multiple devices
+* IOTDB-1274 Fix the insert blocked caused the bugs in mem control module
+* ISSUE-2648 Last query not right when having multiple devices
 * Delete mods files after compaction
 * ISSUE-2687 fix insert NaN bug
 * ISSUE-2598 Throw explicit exception when time series is unknown in where clause


### PR DESCRIPTION

There are two issues.

1. In forceAsyncFlush() method, FlushManager.getInstance().getNumberOfWorkingTasks() will always be larger than 0.
2. The forceAsyncFlush() method in SystemInfo may cause a dead lock issue. It shouldn't be in the lock of resetStorageGroupStatus.

