### PR TITLE
IOTDB-854  Limit the memory foorprint of the committed log cache

### DIFF
--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -101,6 +101,11 @@ min_num_of_logs_in_mem=1000
 # memory footprint
 max_num_of_logs_in_mem=2000
 
+# maximum memory size of committed logs in memory, when reached, a log deletion will be triggered.
+# Increasing the number will reduce the chance to use snapshot in catch-ups, but will also increase
+# memory footprint, default is 512MB
+max_memory_size_for_raft_log=536870912
+
 # deletion check period of the submitted log
 log_deletion_check_interval_second=-1
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
@@ -65,6 +65,7 @@ public class ClusterConfig {
   /** max number of committed logs in memory */
   private int maxNumOfLogsInMem = 1000;
 
+  /** max memory size of committed logs in memory, default 512M */
   private long maxMemorySizeForRaftLog = 536870912;
 
   /** deletion check period of the submitted log */

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
@@ -65,6 +65,8 @@ public class ClusterConfig {
   /** max number of committed logs in memory */
   private int maxNumOfLogsInMem = 1000;
 
+  private long maxMemorySizeForRaftLog = 536870912;
+
   /** deletion check period of the submitted log */
   private int logDeleteCheckIntervalSecond = -1;
 
@@ -379,6 +381,14 @@ public class ClusterConfig {
 
   public void setMaxRaftLogIndexSizeInMemory(int maxRaftLogIndexSizeInMemory) {
     this.maxRaftLogIndexSizeInMemory = maxRaftLogIndexSizeInMemory;
+  }
+
+  public long getMaxMemorySizeForRaftLog() {
+    return maxMemorySizeForRaftLog;
+  }
+
+  public void setMaxMemorySizeForRaftLog(long maxMemorySizeForRaftLog) {
+    this.maxMemorySizeForRaftLog = maxMemorySizeForRaftLog;
   }
 
   public int getMaxRaftLogPersistDataSizePerFile() {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -200,6 +200,12 @@ public class ClusterDescriptor {
             properties.getProperty(
                 "max_num_of_logs_in_mem", String.valueOf(config.getMaxNumOfLogsInMem()))));
 
+    config.setMaxMemorySizeForRaftLog(
+        Long.parseLong(
+            properties.getProperty(
+                "max_memory_size_for_raft_log",
+                String.valueOf(config.getMaxMemorySizeForRaftLog()))));
+
     config.setLogDeleteCheckIntervalSecond(
         Integer.parseInt(
             properties.getProperty(

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/Log.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/Log.java
@@ -45,7 +45,7 @@ public abstract class Log implements Comparable<Log> {
   private long createTime;
   private long enqueueTime;
 
-  private int byteSize;
+  private int byteSize = 0;
 
   public abstract ByteBuffer serialize();
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/Log.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/Log.java
@@ -45,6 +45,8 @@ public abstract class Log implements Comparable<Log> {
   private long createTime;
   private long enqueueTime;
 
+  private int byteSize;
+
   public abstract ByteBuffer serialize();
 
   public abstract void deserialize(ByteBuffer buffer);
@@ -131,5 +133,13 @@ public abstract class Log implements Comparable<Log> {
 
   public void setEnqueueTime(long enqueueTime) {
     this.enqueueTime = enqueueTime;
+  }
+
+  public long getByteSize() {
+    return byteSize;
+  }
+
+  public void setByteSize(int byteSize) {
+    this.byteSize = byteSize;
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/LogDispatcher.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/LogDispatcher.java
@@ -92,7 +92,11 @@ public class LogDispatcher {
   public void offer(SendLogRequest log) {
     // do serialization here to avoid taking LogManager for too long
     if (!nodeLogQueues.isEmpty()) {
-      log.serializedLogFuture = serializationService.submit(() -> log.getLog().serialize());
+      log.serializedLogFuture = serializationService.submit(() -> {
+        ByteBuffer byteBuffer = log.getLog().serialize();
+        log.getLog().setByteSize(byteBuffer.array().length);
+        return byteBuffer;
+      });
     }
     for (int i = 0; i < nodeLogQueues.size(); i++) {
       BlockingQueue<SendLogRequest> nodeLogQueue = nodeLogQueues.get(i);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/LogDispatcher.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/LogDispatcher.java
@@ -92,11 +92,13 @@ public class LogDispatcher {
   public void offer(SendLogRequest log) {
     // do serialization here to avoid taking LogManager for too long
     if (!nodeLogQueues.isEmpty()) {
-      log.serializedLogFuture = serializationService.submit(() -> {
-        ByteBuffer byteBuffer = log.getLog().serialize();
-        log.getLog().setByteSize(byteBuffer.array().length);
-        return byteBuffer;
-      });
+      log.serializedLogFuture =
+          serializationService.submit(
+              () -> {
+                ByteBuffer byteBuffer = log.getLog().serialize();
+                log.getLog().setByteSize(byteBuffer.array().length);
+                return byteBuffer;
+              });
     }
     for (int i = 0; i < nodeLogQueues.size(); i++) {
       BlockingQueue<SendLogRequest> nodeLogQueue = nodeLogQueues.get(i);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
@@ -41,6 +41,8 @@ public class CommittedEntryManager {
   // memory cache for logs which have been persisted in disk.
   private List<Log> entries;
 
+  private long entryTotalMemSize;
+
   /**
    * Note that it is better to use applyingSnapshot to update dummy entry immediately after this
    * instance is created.
@@ -48,6 +50,7 @@ public class CommittedEntryManager {
   CommittedEntryManager(int maxNumOfLogInMem) {
     entries = Collections.synchronizedList(new ArrayList<>(maxNumOfLogInMem));
     entries.add(new EmptyContentLog(-1, -1));
+    entryTotalMemSize = 0;
   }
 
   /**
@@ -209,6 +212,9 @@ public class CommittedEntryManager {
         0,
         new EmptyContentLog(
             entries.get(index).getCurrLogIndex(), entries.get(index).getCurrLogTerm()));
+    for (int i = 1; i <= index; i++) {
+      entryTotalMemSize -= entries.get(i).getByteSize();
+    }
     entries.subList(1, index + 1).clear();
   }
 
@@ -225,6 +231,9 @@ public class CommittedEntryManager {
     }
     long offset = appendingEntries.get(0).getCurrLogIndex() - getDummyIndex();
     if (entries.size() - offset == 0) {
+      for (int i = 0; i < appendingEntries.size(); i++) {
+        entryTotalMemSize += appendingEntries.get(i).getByteSize();
+      }
       entries.addAll(appendingEntries);
     } else if (entries.size() - offset > 0) {
       throw new TruncateCommittedEntryException(
@@ -245,5 +254,30 @@ public class CommittedEntryManager {
   @TestOnly
   List<Log> getAllEntries() {
     return entries;
+  }
+
+  public long getEntryTotalMemSize() {
+    return entryTotalMemSize;
+  }
+
+  public void setEntryTotalMemSize(long entryTotalMemSize) {
+    this.entryTotalMemSize = entryTotalMemSize;
+  }
+
+  /**
+   * check how many logs could be reserved in memory.
+   *
+   * @param maxMemSize the max memory size for old committed log
+   * @return max num to reserve old committed log
+   */
+  public int maxLogNumShouldReserve(long maxMemSize) {
+    long totalSize = 0;
+    for (int i = entries.size() - 1; i >= 1; i--) {
+      if (totalSize + entries.get(i).getByteSize() > maxMemSize) {
+        return entries.size() - 1 - i;
+      }
+      totalSize += entries.get(i).getByteSize();
+    }
+    return entries.size();
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
@@ -278,6 +278,6 @@ public class CommittedEntryManager {
       }
       totalSize += entries.get(i).getByteSize();
     }
-    return entries.size();
+    return entries.size() - 1;
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
@@ -585,10 +585,10 @@ public abstract class RaftLogManager {
           .clear();
     }
     try {
-      boolean needCompactedLog = false;
+      boolean needToCompactLog = false;
       int numToReserveForNew = minNumOfLogsInMem;
       if (committedEntryManager.getTotalSize() + entries.size() > maxNumOfLogsInMem) {
-        needCompactedLog = true;
+        needToCompactLog = true;
         numToReserveForNew = maxNumOfLogsInMem - entries.size();
       }
 
@@ -598,12 +598,12 @@ public abstract class RaftLogManager {
       }
       int sizeToReserveForNew = minNumOfLogsInMem;
       if (newEntryMemSize + committedEntryManager.getEntryTotalMemSize() > maxLogMemSize) {
-        needCompactedLog = true;
+        needToCompactLog = true;
         sizeToReserveForNew =
             committedEntryManager.maxLogNumShouldReserve(maxLogMemSize - newEntryMemSize);
       }
 
-      if (needCompactedLog) {
+      if (needToCompactLog) {
         int numForNew = Math.min(numToReserveForNew, sizeToReserveForNew);
         int sizeToReserveForConfig = minNumOfLogsInMem;
         startTime = Statistic.RAFT_SENDER_COMMIT_DELETE_EXCEEDING_LOGS.getOperationStartTime();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.cluster.log.Snapshot;
 import org.apache.iotdb.cluster.log.StableEntryManager;
 import org.apache.iotdb.cluster.server.monitor.Timer.Statistic;
 import org.apache.iotdb.db.utils.TestOnly;
+import org.apache.iotdb.tsfile.utils.RamUsageEstimator;
 
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.slf4j.Logger;
@@ -595,10 +596,11 @@ public abstract class RaftLogManager {
       long newEntryMemSize = 0;
       for (Log entry : entries) {
         if (entry.getByteSize() == 0) {
-          logger.info(
+          logger.debug(
               "{} should not go here, must be send to the follower, "
-                  + "so the log has been serialized exclude single node",
+                  + "so the log has been serialized exclude single node mode",
               entry);
+          entry.setByteSize((int) RamUsageEstimator.sizeOf(entry));
         }
         newEntryMemSize += entry.getByteSize();
       }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
@@ -595,11 +595,12 @@ public abstract class RaftLogManager {
       long newEntryMemSize = 0;
       for (Log entry : entries) {
         if (entry.getByteSize() == 0) {
-          logger.warn("{} should not go here, must be send to the follower, so the log has been serialized", entry);
-          newEntryMemSize += entry.serialize().array().length;
-        } else {
-          newEntryMemSize += entry.getByteSize();
+          logger.info(
+              "{} should not go here, must be send to the follower, "
+                  + "so the log has been serialized exclude single node",
+              entry);
         }
+        newEntryMemSize += entry.getByteSize();
       }
       int sizeToReserveForNew = minNumOfLogsInMem;
       if (newEntryMemSize + committedEntryManager.getEntryTotalMemSize() > maxLogMemSize) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
@@ -594,7 +594,12 @@ public abstract class RaftLogManager {
 
       long newEntryMemSize = 0;
       for (Log entry : entries) {
-        newEntryMemSize += entry.getByteSize();
+        if (entry.getByteSize() == 0) {
+          logger.warn("{} should not go here, must be send to the follower, so the log has been serialized", entry);
+          newEntryMemSize += entry.serialize().array().length;
+        } else {
+          newEntryMemSize += entry.getByteSize();
+        }
       }
       int sizeToReserveForNew = minNumOfLogsInMem;
       if (newEntryMemSize + committedEntryManager.getEntryTotalMemSize() > maxLogMemSize) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -536,7 +536,7 @@ public abstract class RaftMember {
     for (ByteBuffer buffer : request.getEntries()) {
       buffer.mark();
       Log log;
-      logByteSize = buffer.limit() - buffer.position();
+      logByteSize = buffer.array().length;
       try {
         log = LogParser.getINSTANCE().parse(buffer);
         log.setByteSize(logByteSize);
@@ -953,6 +953,7 @@ public abstract class RaftMember {
 
       log.setPlan(plan);
       plan.setIndex(log.getCurrLogIndex());
+      log.setByteSize(log.serialize().array().length);
       logManager.append(log);
     }
     Timer.Statistic.RAFT_SENDER_APPEND_LOG.calOperationCostTimeFromStart(startTime);
@@ -986,6 +987,7 @@ public abstract class RaftMember {
       log.setCurrLogIndex(logManager.getLastLogIndex() + 1);
       log.setPlan(plan);
       plan.setIndex(log.getCurrLogIndex());
+      log.setByteSize(log.serialize().array().length);
 
       startTime = Timer.Statistic.RAFT_SENDER_APPEND_LOG_V2.getOperationStartTime();
       logManager.append(log);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -508,7 +508,9 @@ public abstract class RaftMember {
     }
 
     long startTime = Timer.Statistic.RAFT_RECEIVER_LOG_PARSE.getOperationStartTime();
+    int logByteSize = request.getEntry().length;
     Log log = LogParser.getINSTANCE().parse(request.entry);
+    log.setByteSize(logByteSize);
     Timer.Statistic.RAFT_RECEIVER_LOG_PARSE.calOperationCostTimeFromStart(startTime);
 
     long result = appendEntry(request.prevLogIndex, request.prevLogTerm, request.leaderCommit, log);
@@ -529,12 +531,15 @@ public abstract class RaftMember {
 
     long response;
     List<Log> logs = new ArrayList<>();
+    int logByteSize = 0;
     long startTime = Timer.Statistic.RAFT_RECEIVER_LOG_PARSE.getOperationStartTime();
     for (ByteBuffer buffer : request.getEntries()) {
       buffer.mark();
       Log log;
+      logByteSize = buffer.limit() - buffer.position();
       try {
         log = LogParser.getINSTANCE().parse(buffer);
+        log.setByteSize(logByteSize);
       } catch (BufferUnderflowException e) {
         buffer.reset();
         throw e;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -536,7 +536,7 @@ public abstract class RaftMember {
     for (ByteBuffer buffer : request.getEntries()) {
       buffer.mark();
       Log log;
-      logByteSize = buffer.array().length;
+      logByteSize = buffer.limit() - buffer.position();
       try {
         log = LogParser.getINSTANCE().parse(buffer);
         log.setByteSize(logByteSize);
@@ -1572,7 +1572,6 @@ public abstract class RaftMember {
       // single node group, no followers
       long startTime = Timer.Statistic.RAFT_SENDER_COMMIT_LOG.getOperationStartTime();
       logger.debug(MSG_LOG_IS_ACCEPTED, name, log);
-      log.setByteSize(log.serialize().array().length);
       commitLog(log);
       Timer.Statistic.RAFT_SENDER_COMMIT_LOG.calOperationCostTimeFromStart(startTime);
       return true;

--- a/cluster/src/test/java/org/apache/iotdb/cluster/common/TestUtils.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/common/TestUtils.java
@@ -126,6 +126,7 @@ public class TestUtils {
       Log log = new LargeTestLog();
       log.setCurrLogIndex(i);
       log.setCurrLogTerm(i);
+      log.setByteSize(8192);
       logList.add(log);
     }
     return logList;


### PR DESCRIPTION
## Description
see https://issues.apache.org/jira/browse/IOTDB-854

limit the total  size of raftlog in memory.

### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
