### PR TITLE
Use switch case in enums class 

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/CompressionType.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/CompressionType.java
@@ -58,12 +58,26 @@ public enum CompressionType {
    * @return CompressionType
    */
   public static CompressionType deserialize(byte compressor) {
-    for (CompressionType compressionType : CompressionType.values()) {
-      if (compressor == compressionType.index) {
-        return compressionType;
-      }
+    switch (compressor) {
+      case 0:
+        return CompressionType.UNCOMPRESSED;
+      case 1:
+        return CompressionType.SNAPPY;
+      case 2:
+        return CompressionType.GZIP;
+      case 3:
+        return CompressionType.LZO;
+      case 4:
+        return CompressionType.SDT;
+      case 5:
+        return CompressionType.PAA;
+      case 6:
+        return CompressionType.PLA;
+      case 7:
+        return CompressionType.LZ4;
+      default:
+        throw new IllegalArgumentException("Invalid input: " + compressor);
     }
-    throw new IllegalArgumentException("Invalid input: " + compressor);
   }
 
   public static int getSerializedSize() {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/MetadataIndexNodeType.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/MetadataIndexNodeType.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.tsfile.file.metadata.enums;
 
+import org.apache.iotdb.tsfile.file.metadata.MetadataIndexNode;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -57,13 +59,18 @@ public enum MetadataIndexNodeType {
    * @return MetadataIndexNodeType
    */
   public static MetadataIndexNodeType deserialize(byte i) {
-    for (MetadataIndexNodeType metadataIndexNodeType : MetadataIndexNodeType.values()) {
-      if (i == metadataIndexNodeType.type) {
-        return metadataIndexNodeType;
-      }
+    switch (i) {
+      case 0:
+        return MetadataIndexNodeType.INTERNAL_DEVICE;
+      case 1:
+        return MetadataIndexNodeType.LEAF_DEVICE;
+      case 2:
+        return MetadataIndexNodeType.INTERNAL_MEASUREMENT;
+      case 3:
+        return MetadataIndexNodeType.LEAF_MEASUREMENT;
+      default:
+        throw new IllegalArgumentException("Invalid input: " + i);
     }
-
-    throw new IllegalArgumentException("Invalid input: " + i);
   }
 
   public static MetadataIndexNodeType deserializeFrom(ByteBuffer buffer) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/MetadataIndexNodeType.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/MetadataIndexNodeType.java
@@ -19,8 +19,6 @@
 
 package org.apache.iotdb.tsfile.file.metadata.enums;
 
-import org.apache.iotdb.tsfile.file.metadata.MetadataIndexNode;
-
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/TSDataType.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/TSDataType.java
@@ -60,13 +60,22 @@ public enum TSDataType {
   }
 
   private static TSDataType getTsDataType(byte type) {
-    for (TSDataType tsDataType : TSDataType.values()) {
-      if (type == tsDataType.type) {
-        return tsDataType;
-      }
+    switch (type) {
+      case 0:
+        return TSDataType.BOOLEAN;
+      case 1:
+        return TSDataType.INT32;
+      case 2:
+        return TSDataType.INT64;
+      case 3:
+        return TSDataType.FLOAT;
+      case 4:
+        return TSDataType.DOUBLE;
+      case 5:
+        return TSDataType.TEXT;
+      default:
+        throw new IllegalArgumentException("Invalid input: " + type);
     }
-
-    throw new IllegalArgumentException("Invalid input: " + type);
   }
 
   public static TSDataType deserializeFrom(ByteBuffer buffer) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/TSEncoding.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/TSEncoding.java
@@ -46,13 +46,28 @@ public enum TSEncoding {
   }
 
   private static TSEncoding getTsEncoding(byte encoding) {
-    for (TSEncoding tsEncoding : TSEncoding.values()) {
-      if (encoding == tsEncoding.type) {
-        return tsEncoding;
-      }
+    switch (encoding) {
+      case 0:
+        return TSEncoding.PLAIN;
+      case 1:
+        return TSEncoding.PLAIN_DICTIONARY;
+      case 2:
+        return TSEncoding.RLE;
+      case 3:
+        return TSEncoding.DIFF;
+      case 4:
+        return TSEncoding.TS_2DIFF;
+      case 5:
+        return TSEncoding.BITMAP;
+      case 6:
+        return TSEncoding.GORILLA_V1;
+      case 7:
+        return TSEncoding.REGULAR;
+      case 8:
+        return TSEncoding.GORILLA;
+      default:
+        throw new IllegalArgumentException("Invalid input: " + encoding);
     }
-
-    throw new IllegalArgumentException("Invalid input: " + encoding);
   }
 
   public static int getSerializedSize() {


### PR DESCRIPTION
## Description
Fix bad smell code, it is not necessary to use for loop to find enums type. It can use switch case to reduce complexity from O(n) ->O(1)...
