### PR TITLE
[IOTDB-1251] optimize route intervals

### DIFF
--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutorTest.java
@@ -76,7 +76,7 @@ public class RemoteGroupByExecutorTest extends BaseQueryTest {
       for (int i = 0; i < groupByExecutors.size(); i++) {
         GroupByExecutor groupByExecutor = groupByExecutors.get(i);
         Object[] answers;
-        if (i == 1) {
+        if (groupByExecutors.size() == 1) {
           // a series is only managed by one group
           List<AggregateResult> aggregateResults;
           answers = new Object[] {5.0, 2.0, 10.0, 0.0, 4.0, 4.0, 0.0, 4.0, 0.0};
@@ -138,7 +138,7 @@ public class RemoteGroupByExecutorTest extends BaseQueryTest {
       for (int i = 0; i < groupByExecutors.size(); i++) {
         GroupByExecutor groupByExecutor = groupByExecutors.get(i);
         Object[] answers;
-        if (i == 1) {
+        if (groupByExecutors.size() == 1) {
           // a series is only managed by one group
           List<AggregateResult> aggregateResults;
           answers = new Object[] {2.0, 3.5, 7.0, 3.0, 4.0, 4.0, 3.0, 4.0, 3.0};

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/MetaGroupMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/MetaGroupMemberTest.java
@@ -67,6 +67,7 @@ import org.apache.iotdb.cluster.server.monitor.NodeStatusManager;
 import org.apache.iotdb.cluster.server.service.MetaAsyncService;
 import org.apache.iotdb.cluster.utils.ClusterUtils;
 import org.apache.iotdb.cluster.utils.Constants;
+import org.apache.iotdb.cluster.utils.PartitionUtils;
 import org.apache.iotdb.cluster.utils.StatusUtils;
 import org.apache.iotdb.db.auth.AuthException;
 import org.apache.iotdb.db.auth.authorizer.IAuthorizer;
@@ -1318,6 +1319,38 @@ public class MetaGroupMemberTest extends MemberTest {
 
     assertEquals(Response.RESPONSE_CLUSTER_TOO_SMALL, (long) resultRef.get());
     assertTrue(testMetaMember.getAllNodes().contains(TestUtils.getNode(10)));
+  }
+
+  @Test
+  public void testRouteIntervalsDisablePartition()
+      throws IllegalPathException, StorageEngineException {
+    boolean isEablePartition = StorageEngine.isEnablePartition();
+    StorageEngine.setEnablePartition(false);
+    testMetaMember.setCharacter(LEADER);
+    testMetaMember.setLeader(testMetaMember.getThisNode());
+    PartitionUtils.Intervals intervals = new PartitionUtils.Intervals();
+    intervals.addInterval(Long.MIN_VALUE, Long.MAX_VALUE);
+
+    List<PartitionGroup> partitionGroups =
+        testMetaMember.routeIntervals(intervals, new PartialPath(TestUtils.getTestSg(0)));
+    assertEquals(1, partitionGroups.size());
+    StorageEngine.setEnablePartition(isEablePartition);
+  }
+
+  @Test
+  public void testRouteIntervalsEnablePartition()
+      throws IllegalPathException, StorageEngineException {
+    boolean isEablePartition = StorageEngine.isEnablePartition();
+    StorageEngine.setEnablePartition(true);
+    testMetaMember.setCharacter(LEADER);
+    testMetaMember.setLeader(testMetaMember.getThisNode());
+    PartitionUtils.Intervals intervals = new PartitionUtils.Intervals();
+    intervals.addInterval(Long.MIN_VALUE, Long.MAX_VALUE);
+
+    List<PartitionGroup> partitionGroups =
+        testMetaMember.routeIntervals(intervals, new PartialPath(TestUtils.getTestSg(0)));
+    assertTrue(partitionGroups.size() > 1);
+    StorageEngine.setEnablePartition(isEablePartition);
   }
 
   private void doRemoveNode(AtomicReference<Long> resultRef, Node nodeToRemove) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -92,6 +92,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 public class StorageEngine implements IService {
+  private static final Logger logger = LoggerFactory.getLogger(StorageEngine.class);
 
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static final long TTL_CHECK_INTERVAL = 60 * 1000L;
@@ -105,7 +106,6 @@ public class StorageEngine implements IService {
   private static boolean enablePartition =
       IoTDBDescriptor.getInstance().getConfig().isEnablePartition();
 
-  private final Logger logger;
   /**
    * a folder (system/storage_groups/ by default) that persist system info. Each Storage Processor
    * will have a subfolder under the systemDir.
@@ -126,7 +126,6 @@ public class StorageEngine implements IService {
   private List<FlushListener> customFlushListeners = new ArrayList<>();
 
   private StorageEngine() {
-    logger = LoggerFactory.getLogger(StorageEngine.class);
     systemDir = FilePathUtils.regularizePath(config.getSystemDir()) + "storage_groups";
 
     // build time Interval to divide time partition
@@ -190,7 +189,6 @@ public class StorageEngine implements IService {
     return enablePartition ? time / timePartitionInterval : 0;
   }
 
-  @TestOnly
   public static boolean isEnablePartition() {
     return enablePartition;
   }


### PR DESCRIPTION
When data is not partitioned, all data of a sequence is stored in partition 0. Therefore, during the query, we only need to route to partition 0 regardless of the interval. Therefore, partition calculation is not performed.
This reduces the time spent on partition calculation and routing to other partitions.
Current problems:
1. When
firstLB == Long.MIN_VALUE || lastUB == Long.MAX_VALUE
route all partiongroup.
2. For other time conditions, partition calculation is performed.