### PR TITLE
[IOTDB-1252] optimize test mult-times perform

### DIFF
--- a/cluster/src/test/java/org/apache/iotdb/cluster/common/TestAsyncDataClient.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/common/TestAsyncDataClient.java
@@ -31,8 +31,8 @@ import org.apache.iotdb.cluster.rpc.thrift.PreviousFillRequest;
 import org.apache.iotdb.cluster.rpc.thrift.PullSchemaRequest;
 import org.apache.iotdb.cluster.rpc.thrift.PullSchemaResp;
 import org.apache.iotdb.cluster.rpc.thrift.SingleSeriesQueryRequest;
+import org.apache.iotdb.cluster.server.member.BaseMember;
 import org.apache.iotdb.cluster.server.member.DataGroupMember;
-import org.apache.iotdb.cluster.server.member.MemberTest;
 import org.apache.iotdb.cluster.server.service.DataAsyncService;
 import org.apache.iotdb.cluster.utils.IOUtils;
 import org.apache.iotdb.cluster.utils.StatusUtils;
@@ -173,7 +173,7 @@ public class TestAsyncDataClient extends AsyncDataClient {
 
   @Override
   public void appendEntry(AppendEntryRequest request, AsyncMethodCallback<Long> resultHandler) {
-    new Thread(() -> resultHandler.onComplete(MemberTest.dummyResponse.get())).start();
+    new Thread(() -> resultHandler.onComplete(BaseMember.dummyResponse.get())).start();
   }
 
   @Override

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/BaseQueryTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/BaseQueryTest.java
@@ -20,7 +20,7 @@
 package org.apache.iotdb.cluster.query;
 
 import org.apache.iotdb.cluster.common.TestUtils;
-import org.apache.iotdb.cluster.server.member.MemberTest;
+import org.apache.iotdb.cluster.server.member.BaseMember;
 import org.apache.iotdb.cluster.server.monitor.NodeStatusManager;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.CompactionStrategy;
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertNull;
  * allNodes: node0, node1... node9 localNode: node0 pathList: root.sg0.s0, root.sg0.s1...
  * root.sg0.s9 (all double type)
  */
-public class BaseQueryTest extends MemberTest {
+public class BaseQueryTest extends BaseMember {
 
   List<PartialPath> pathList;
   List<TSDataType> dataTypes;

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/DataGroupMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/DataGroupMemberTest.java
@@ -118,7 +118,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class DataGroupMemberTest extends MemberTest {
+public class DataGroupMemberTest extends BaseMember {
 
   private DataGroupMember dataGroupMember;
   private Map<Integer, FileSnapshot> snapshotMap;

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/MetaGroupMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/MetaGroupMemberTest.java
@@ -137,7 +137,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class MetaGroupMemberTest extends MemberTest {
+public class MetaGroupMemberTest extends BaseMember {
 
   private DataClusterServer dataClusterServer;
   protected boolean mockDataClusterServer;

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/RaftMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/RaftMemberTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.cluster.server.member;
+
+import org.apache.iotdb.cluster.common.TestAsyncDataClient;
+import org.apache.iotdb.cluster.common.TestDataGroupMember;
+import org.apache.iotdb.cluster.common.TestPartitionedLogManager;
+import org.apache.iotdb.cluster.common.TestUtils;
+import org.apache.iotdb.cluster.config.ClusterDescriptor;
+import org.apache.iotdb.cluster.config.ConsistencyLevel;
+import org.apache.iotdb.cluster.exception.CheckConsistencyException;
+import org.apache.iotdb.cluster.log.manage.PartitionedSnapshotLogManager;
+import org.apache.iotdb.cluster.rpc.thrift.AppendEntryRequest;
+import org.apache.iotdb.cluster.rpc.thrift.Node;
+import org.apache.iotdb.cluster.rpc.thrift.RaftService;
+import org.apache.iotdb.cluster.server.NodeCharacter;
+import org.apache.iotdb.cluster.server.Response;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+public class RaftMemberTest extends BaseMember {
+  @Test
+  public void testsyncLeaderStrongConsistencyCheckFalse() {
+    // 1. write request : Strong consistency level with syncLeader false
+    DataGroupMember dataGroupMemberWithWriteStrongConsistencyFalse =
+        newDataGroupMemberWithSyncLeaderFalse(TestUtils.getNode(0), false);
+    ClusterDescriptor.getInstance()
+        .getConfig()
+        .setConsistencyLevel(ConsistencyLevel.STRONG_CONSISTENCY);
+    try {
+      dataGroupMemberWithWriteStrongConsistencyFalse.waitUntilCatchUp(
+          new RaftMember.StrongCheckConsistency());
+    } catch (CheckConsistencyException e) {
+      Assert.assertNotNull(e);
+      Assert.assertEquals(CheckConsistencyException.CHECK_STRONG_CONSISTENCY_EXCEPTION, e);
+    }
+  }
+
+  @Test
+  public void testsyncLeaderStrongConsistencyCheckTrue() {
+    // 1. write request : Strong consistency level with syncLeader false
+    DataGroupMember dataGroupMemberWithWriteStrongConsistencyTrue =
+        newDataGroupMemberWithSyncLeaderTrue(TestUtils.getNode(0), false);
+    ClusterDescriptor.getInstance()
+        .getConfig()
+        .setConsistencyLevel(ConsistencyLevel.STRONG_CONSISTENCY);
+    try {
+
+      PartitionedSnapshotLogManager partitionedSnapshotLogManager =
+          Mockito.mock(PartitionedSnapshotLogManager.class);
+      Mockito.when(partitionedSnapshotLogManager.getMaxHaveAppliedCommitIndex()).thenReturn(1000L);
+      dataGroupMemberWithWriteStrongConsistencyTrue.setLogManager(partitionedSnapshotLogManager);
+
+      dataGroupMemberWithWriteStrongConsistencyTrue.waitUntilCatchUp(
+          new RaftMember.StrongCheckConsistency());
+    } catch (CheckConsistencyException e) {
+      Assert.fail();
+    }
+  }
+
+  @Test
+  public void testsyncLeaderMidConsistencyCheckFalse() {
+    // 1. write request : Strong consistency level with syncLeader false
+    DataGroupMember dataGroupMemberWithWriteStrongConsistencyFalse =
+        newDataGroupMemberWithSyncLeaderFalse(TestUtils.getNode(0), false);
+    ClusterDescriptor.getInstance()
+        .getConfig()
+        .setConsistencyLevel(ConsistencyLevel.MID_CONSISTENCY);
+    ClusterDescriptor.getInstance().getConfig().setMaxReadLogLag(1);
+    try {
+
+      PartitionedSnapshotLogManager partitionedSnapshotLogManager =
+          Mockito.mock(PartitionedSnapshotLogManager.class);
+      Mockito.when(partitionedSnapshotLogManager.getMaxHaveAppliedCommitIndex()).thenReturn(-2L);
+      dataGroupMemberWithWriteStrongConsistencyFalse.setLogManager(partitionedSnapshotLogManager);
+
+      dataGroupMemberWithWriteStrongConsistencyFalse.waitUntilCatchUp(
+          new RaftMember.MidCheckConsistency());
+    } catch (CheckConsistencyException e) {
+      Assert.assertEquals(CheckConsistencyException.CHECK_MID_CONSISTENCY_EXCEPTION, e);
+    }
+  }
+
+  @Test
+  public void testsyncLeaderMidConsistencyCheckTrue() {
+    // 1. write request : Strong consistency level with syncLeader false
+    DataGroupMember dataGroupMemberWithWriteStrongConsistencyTrue =
+        newDataGroupMemberWithSyncLeaderTrue(TestUtils.getNode(0), false);
+    ClusterDescriptor.getInstance()
+        .getConfig()
+        .setConsistencyLevel(ConsistencyLevel.MID_CONSISTENCY);
+    ClusterDescriptor.getInstance().getConfig().setMaxReadLogLag(500);
+    try {
+
+      PartitionedSnapshotLogManager partitionedSnapshotLogManager =
+          Mockito.mock(PartitionedSnapshotLogManager.class);
+      Mockito.when(partitionedSnapshotLogManager.getMaxHaveAppliedCommitIndex()).thenReturn(600L);
+      dataGroupMemberWithWriteStrongConsistencyTrue.setLogManager(partitionedSnapshotLogManager);
+
+      dataGroupMemberWithWriteStrongConsistencyTrue.waitUntilCatchUp(
+          new RaftMember.MidCheckConsistency());
+    } catch (CheckConsistencyException e) {
+      Assert.fail();
+    }
+  }
+
+  @Test
+  public void testsyncLeaderWeakConsistencyCheckFalse() {
+    // 1. write request : Strong consistency level with syncLeader false
+    DataGroupMember dataGroupMemberWithWriteStrongConsistencyFalse =
+        newDataGroupMemberWithSyncLeaderFalse(TestUtils.getNode(0), false);
+    ClusterDescriptor.getInstance()
+        .getConfig()
+        .setConsistencyLevel(ConsistencyLevel.WEAK_CONSISTENCY);
+    ClusterDescriptor.getInstance().getConfig().setMaxReadLogLag(1);
+    try {
+
+      PartitionedSnapshotLogManager partitionedSnapshotLogManager =
+          Mockito.mock(PartitionedSnapshotLogManager.class);
+      Mockito.when(partitionedSnapshotLogManager.getMaxHaveAppliedCommitIndex()).thenReturn(-2L);
+      dataGroupMemberWithWriteStrongConsistencyFalse.setLogManager(partitionedSnapshotLogManager);
+
+      dataGroupMemberWithWriteStrongConsistencyFalse.waitUntilCatchUp(null);
+    } catch (CheckConsistencyException e) {
+      Assert.fail();
+    }
+  }
+
+  @Test
+  public void testsyncLeaderWeakConsistencyCheckTrue() {
+    // 1. write request : Strong consistency level with syncLeader false
+    DataGroupMember dataGroupMemberWithWriteStrongConsistencyTrue =
+        newDataGroupMemberWithSyncLeaderTrue(TestUtils.getNode(0), false);
+    ClusterDescriptor.getInstance()
+        .getConfig()
+        .setConsistencyLevel(ConsistencyLevel.WEAK_CONSISTENCY);
+    ClusterDescriptor.getInstance().getConfig().setMaxReadLogLag(500);
+    try {
+
+      PartitionedSnapshotLogManager partitionedSnapshotLogManager =
+          Mockito.mock(PartitionedSnapshotLogManager.class);
+      Mockito.when(partitionedSnapshotLogManager.getMaxHaveAppliedCommitIndex()).thenReturn(600L);
+      dataGroupMemberWithWriteStrongConsistencyTrue.setLogManager(partitionedSnapshotLogManager);
+
+      dataGroupMemberWithWriteStrongConsistencyTrue.waitUntilCatchUp(null);
+    } catch (CheckConsistencyException e) {
+      Assert.fail();
+    }
+  }
+
+  private DataGroupMember newDataGroupMemberWithSyncLeaderFalse(Node node, boolean syncLeader) {
+    DataGroupMember newMember =
+        new TestDataGroupMember(node, partitionTable.getHeaderGroup(node)) {
+
+          @Override
+          public boolean syncLeader(RaftMember.CheckConsistency checkConsistency) {
+            return syncLeader;
+          }
+
+          @Override
+          protected long requestCommitIdAsync() {
+            return 5;
+          }
+
+          @Override
+          public long appendEntry(AppendEntryRequest request) {
+            return Response.RESPONSE_AGREE;
+          }
+
+          @Override
+          public RaftService.AsyncClient getAsyncClient(Node node) {
+            try {
+              return new TestAsyncDataClient(node, dataGroupMemberMap);
+            } catch (IOException e) {
+              return null;
+            }
+          }
+        };
+    newMember.setThisNode(node);
+    newMember.setMetaGroupMember(testMetaMember);
+    newMember.setLeader(node);
+    newMember.setCharacter(NodeCharacter.LEADER);
+    newMember.setLogManager(new TestPartitionedLogManager());
+    newMember.setAppendLogThreadPool(testThreadPool);
+    return newMember;
+  }
+
+  private DataGroupMember newDataGroupMemberWithSyncLeaderTrue(Node node, boolean syncLeader) {
+    DataGroupMember newMember =
+        new TestDataGroupMember(node, partitionTable.getHeaderGroup(node)) {
+
+          @Override
+          public boolean syncLeader(RaftMember.CheckConsistency checkConsistency) {
+            return syncLeader;
+          }
+
+          @Override
+          protected long requestCommitIdAsync() {
+            return 1000L;
+          }
+
+          @Override
+          public long appendEntry(AppendEntryRequest request) {
+            return Response.RESPONSE_AGREE;
+          }
+
+          @Override
+          public RaftService.AsyncClient getAsyncClient(Node node) {
+            try {
+              return new TestAsyncDataClient(node, dataGroupMemberMap);
+            } catch (IOException e) {
+              return null;
+            }
+          }
+        };
+    newMember.setThisNode(node);
+    newMember.setMetaGroupMember(testMetaMember);
+    newMember.setLeader(node);
+    newMember.setCharacter(NodeCharacter.LEADER);
+    newMember.setLogManager(new TestPartitionedLogManager());
+    newMember.setAppendLogThreadPool(testThreadPool);
+    return newMember;
+  }
+}


### PR DESCRIPTION
Currently, we use MemberTest as the base class and reuse some of its methods. If one test-class extends the MemberTest , the test case of the MemberTest class is executed again when the test case of the subclass is executed. As a result, some tests in the MemberTest class are executed multiple times, increasing the test case execution time
![image](https://user-images.githubusercontent.com/66939405/112108087-baf29400-8bea-11eb-8e73-2f4be32df19c.png)
Solution:
1. test case extract in MemberTest.
2. MemberTest rename a basemember class，which can not add new test case.