### PR TITLE
[IOTDB-1255] refactor cluster package and jar name

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -27,7 +27,7 @@
         <version>0.12.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>cluster</artifactId>
+    <artifactId>iotdb-cluster</artifactId>
     <name>cluster</name>
     <properties>
         <cluster.test.skip>false</cluster.test.skip>


### PR DESCRIPTION
We should use statistical naming throughout the project, for jar names, and zip names.

current， cluster package-name is cluster-*.zip, and cluster-*.jar

solution：
![image](https://user-images.githubusercontent.com/66939405/112138724-d373a600-8c0c-11eb-8446-2cf9046d8290.png)

