### PR TITLE
fix Flink TsFile doc url error caused by PR2813

### DIFF
--- a/site/src/main/.vuepress/config.js
+++ b/site/src/main/.vuepress/config.js
@@ -587,7 +587,7 @@ var config = {
 							['Ecosystem Integration/Hive TsFile','Hive TsFile'],
 							['Ecosystem Integration/Zeppelin-IoTDB','Zeppelin-IoTDB'],
 							['Ecosystem Integration/Flink IoTDB','Flink IoTDB'],
-							['Ecosystem Integration/Flink Tsfile','Flink Tsfile']
+							['Ecosystem Integration/Flink TsFile','Flink TsFile']
 						]
 					},
 					{
@@ -1214,7 +1214,7 @@ var config = {
 							['Ecosystem Integration/Hive TsFile','Hive TsFile'],
 							['Ecosystem Integration/Zeppelin-IoTDB','Zeppelin-IoTDB'],
 							['Ecosystem Integration/Flink IoTDB','Flink IoTDB'],
-							['Ecosystem Integration/Flink Tsfile','Flink Tsfile']
+							['Ecosystem Integration/Flink TsFile','Flink TsFile']
 						]
 					},
 					{


### PR DESCRIPTION
just a typo error, but leads to compiler error in the site module.

![image](https://user-images.githubusercontent.com/1021782/112237939-a8299f00-8c7e-11eb-8d02-ad5179b7bb74.png)
