### PR TITLE
[IOTDB-1256] Jackson have loopholes CVE-2020-25649

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <!-- keep consistent with client-cpp/tools/thrift/pom.xml-->
         <thrift.version>0.13.0</thrift.version>
         <airline.version>0.8</airline.version>
-        <jackson.version>2.10.0</jackson.version>
+        <jackson.version>2.11.0</jackson.version>
         <antlr4.version>4.8-1</antlr4.version>
         <common.cli.version>1.3.1</common.cli.version>
         <common.codec.version>1.13</common.codec.version>


### PR DESCRIPTION
Jackson 2.10.0  have loopholes CVE-2020-25649， so need upgrate to 2.11.0.