### PR TITLE
Improve Python Client:

### DIFF
--- a/client-py/pypi/README.md
+++ b/client-py/pypi/README.md
@@ -71,3 +71,22 @@ zone = session.get_time_zone()
 session.close()
 
 ```
+
+## IoTDB Testcontainer
+
+The Test Support is based on the lib `testcontainers` (https://testcontainers-python.readthedocs.io/en/latest/index.html) which you need to install in your project if you want to use the feature.
+
+To start (and stop) an IoTDB Database in a Docker container simply do:
+```
+class MyTestCase(unittest.TestCase):
+
+    def test_something(self):
+        with IoTDBContainer() as c:
+            session = Session('localhost', c.get_exposed_port(6667), 'root', 'root')
+            session.open(False)
+            result = session.execute_query_statement("SHOW TIMESERIES")
+            print(result)
+            session.close()
+```
+
+by default it will load the image `apache/iotdb:latest`, if you want a specific version just pass it like e.g. `IoTDBContainer("apache/iotdb:0.10.0")` to get version `0.10.0` running.

--- a/client-py/src/iotdb/TestContainer.py
+++ b/client-py/src/iotdb/TestContainer.py
@@ -1,0 +1,31 @@
+from os import environ
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
+
+from iotdb.Session import Session
+
+
+class IoTDBContainer(DockerContainer):
+    IOTDB_USER = environ.get("IOTDB_USER", "root")
+    IOTDB_PASSWORD = environ.get("IOTDB_PASSWORD", "root")
+
+    def _configure(self):
+        pass
+
+    @wait_container_is_ready()
+    def _connect(self):
+        session = Session(self.get_container_host_ip(), self.get_exposed_port(6667), 'root', 'root')
+        session.open(False)
+        session.close()
+
+    def __init__(self, image="apache/iotdb:latest", **kwargs):
+        super(IoTDBContainer, self).__init__(image)
+        self.port_to_expose = 6667
+        self.with_exposed_ports(self.port_to_expose)
+
+    def start(self):
+        self._configure()
+        super().start()
+        self._connect()
+        return self

--- a/client-py/src/iotdb/TestContainer.py
+++ b/client-py/src/iotdb/TestContainer.py
@@ -1,3 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 from os import environ
 
 from testcontainers.core.container import DockerContainer


### PR DESCRIPTION
* Add / Fix the insert_str_record method for type inference (sends TSInsertStringRecord)
* Add Support for python testcontainer with a specific IoTDB Container.
* Improved the readme a bit

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [x] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

python client submodule (client-py).
