### PR TITLE
[IOTDB-1258] jcl-over-slf4j have security vulnerabilities CVE-2018-8088

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <common.collections.version>3.2.2</common.collections.version>
         <common.lang3.version>3.8.1</common.lang3.version>
         <common.logging.version>1.1.3</common.logging.version>
-        <org.slf4j.version>1.7.25</org.slf4j.version>
+        <org.slf4j.version>1.7.30</org.slf4j.version>
         <guava.version>24.1.1</guava.version>
         <jline.version>2.14.5</jline.version>
         <jetty.version>9.4.35.v20201120</jetty.version>


### PR DESCRIPTION
jcl-over-slf4j 1.7.25 have a Security Vulnerabilities, which CVSS be greater than 9.8. so need ugrade 1.7.30