### PR TITLE
[ISSUE-2905] Fix Files.deleteIfExists() doesn't work for HDFS file

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -254,7 +254,9 @@ public class TsFileResource {
     }
     File src = fsFactory.getFile(file + RESOURCE_SUFFIX + TEMP_SUFFIX);
     File dest = fsFactory.getFile(file + RESOURCE_SUFFIX);
-    Files.deleteIfExists(dest.toPath());
+    if (dest.exists()) {
+      dest.delete();
+    }
     fsFactory.moveFile(src, dest);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -254,9 +254,7 @@ public class TsFileResource {
     }
     File src = fsFactory.getFile(file + RESOURCE_SUFFIX + TEMP_SUFFIX);
     File dest = fsFactory.getFile(file + RESOURCE_SUFFIX);
-    if (dest.exists()) {
-      dest.delete();
-    }
+    fsFactory.deleteIfExists(dest);
     fsFactory.moveFile(src, dest);
   }
 
@@ -461,14 +459,13 @@ public class TsFileResource {
   /** Remove the data file, its resource file, and its modification file physically. */
   public void remove() {
     try {
-      Files.deleteIfExists(file.toPath());
+      fsFactory.deleteIfExists(file);
     } catch (IOException e) {
       logger.error("TsFile {} cannot be deleted: {}", file, e.getMessage());
     }
     removeResourceFile();
     try {
-      Files.deleteIfExists(
-          fsFactory.getFile(file.getPath() + ModificationFile.FILE_SUFFIX).toPath());
+      fsFactory.deleteIfExists(fsFactory.getFile(file.getPath() + ModificationFile.FILE_SUFFIX));
     } catch (IOException e) {
       logger.error("ModificationFile {} cannot be deleted: {}", file, e.getMessage());
     }
@@ -476,7 +473,7 @@ public class TsFileResource {
 
   public void removeResourceFile() {
     try {
-      Files.deleteIfExists(fsFactory.getFile(file.getPath() + RESOURCE_SUFFIX).toPath());
+      fsFactory.deleteIfExists(fsFactory.getFile(file.getPath() + RESOURCE_SUFFIX));
     } catch (IOException e) {
       logger.error("TsFileResource {} cannot be deleted: {}", file, e.getMessage());
     }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fsFactory/FSFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fsFactory/FSFactory.java
@@ -24,6 +24,7 @@ import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 
 public interface FSFactory {
@@ -128,4 +129,11 @@ public interface FSFactory {
    * @return list of files
    */
   File[] listFilesByPrefix(String fileFolder, String prefix);
+
+  /**
+   * delete the file if it exists
+   *
+   * @param file local file or HDFS file
+   */
+  boolean deleteIfExists(File file) throws IOException;
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fsFactory/HDFSFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fsFactory/HDFSFactory.java
@@ -229,4 +229,9 @@ public class HDFSFactory implements FSFactory {
       return null;
     }
   }
+
+  @Override
+  public boolean deleteIfExists(File file) {
+    return file.delete();
+  }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fsFactory/LocalFSFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fsFactory/LocalFSFactory.java
@@ -34,6 +34,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 
 public class LocalFSFactory implements FSFactory {
 
@@ -130,5 +131,10 @@ public class LocalFSFactory implements FSFactory {
   @Override
   public File[] listFilesByPrefix(String fileFolder, String prefix) {
     return new File(fileFolder).listFiles(file -> file.getName().startsWith(prefix));
+  }
+
+  @Override
+  public boolean deleteIfExists(File file) throws IOException {
+    return Files.deleteIfExists(file.toPath());
   }
 }


### PR DESCRIPTION
Cluster module introduce `Files.deleteIfExists(file.toPath())` in tsfile resource, but `toPath()` method returns `java.nio.file.Path` which doesn't work for HDFS file, and result in failure of storing tsfiles in HDFS.