### PR TITLE
[IOTDB-1260] optimize time_range query because syncMetaLeader 

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -1761,8 +1761,6 @@ public class CMManager extends MManager {
     if (withAlias) {
       alias = new ArrayList<>();
     }
-    // make sure this node knows all storage groups
-    syncMetaLeader();
 
     if (withAlias) {
       for (String path : paths) {


### PR DESCRIPTION
1. The syncMetaLeader  in CMManager.getAllpath accounts for 10 percent of the performance of the query.
2. The syncMetaLeader has been invoked in ClusterPhysicalGenerator.transformToPhysicalPlan.
3. The possibility of metadata change is small and cannot be the bottleneck of query.
Solution:
remove syncMetaLeader  in CMManager.getAllpath. 
test result:
Time_Range AVG before optimization: 139.38
Time_Ranger AVG after optimization: 110.19