### PR TITLE
[Distributed] Fix stackoverflow bug caused by InsertMultiTabletPlan or InsertRowsPlan 

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
@@ -291,6 +291,7 @@ public class Coordinator {
     } catch (MetadataException e) {
       logger.error("Cannot route plan {}", plan, e);
     }
+    logger.debug("route plan {} with partitionGroup {}", plan, planGroupMap);
     return planGroupMap;
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -619,6 +619,9 @@ public class CMManager extends MManager {
     PartitionGroup partitionGroup =
         metaGroupMember.getPartitionTable().route(storageGroupName.getFullPath(), 0);
     List<String> unregisteredSeriesList = getUnregisteredSeriesList(seriesList, partitionGroup);
+    if (unregisteredSeriesList.isEmpty()) {
+      return true;
+    }
     logger.debug("Unregisterd series of {} are {}", seriesList, unregisteredSeriesList);
 
     return createTimeseries(unregisteredSeriesList, seriesList, insertPlan);

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -535,7 +535,7 @@ public class SessionExample {
                   + i
                   + ".d1 where time >= 1 and time < 10 and root.redirect"
                   + i
-                  + "d1.s1 > 1");
+                  + ".d1.s1 > 1");
       System.out.println(dataSet.getColumnNames());
       dataSet.setFetchSize(1024); // default is 10000
       while (dataSet.hasNext()) {

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -79,7 +79,6 @@ public class SessionExample {
     deleteData();
     deleteTimeseries();
     setTimeout();
-    session.close();
 
     sessionEnableRedirect = new Session(LOCAL_HOST, 6667, "root", "root");
     sessionEnableRedirect.setEnableQueryRedirection(true);
@@ -91,6 +90,7 @@ public class SessionExample {
     insertRecord4Redirect();
     query4Redirect();
     sessionEnableRedirect.close();
+    session.close();
   }
 
   private static void createTimeseries()


### PR DESCRIPTION
Suppose the cluster has just started without any data, and client perferm a InsertTablets including two Tablets with same deviceId, the cluster will try to auto-create schema for these two tablets in a `for` loop.For the first tablet, cluster will auto-create related timeseries, but for the second tablet, the `unregisteredSeriesList` is empty, and if we don't return true at this time, the cluster will create a emply createMultiTimeseriesPlan to execute, and this will cause a endless loop which finally cause stackoverflow 

![image](https://user-images.githubusercontent.com/32640567/112801466-8461c100-90a3-11eb-93be-22ddf08920c9.png)
![image](https://user-images.githubusercontent.com/32640567/112801513-8fb4ec80-90a3-11eb-918a-3fa54044f3d2.png)
![image](https://user-images.githubusercontent.com/32640567/112801559-9cd1db80-90a3-11eb-8e56-b8ee94caf9de.png)
![image](https://user-images.githubusercontent.com/32640567/112801657-becb5e00-90a3-11eb-8c83-8106b9beaada.png)

 

