### PR TITLE
[ISSUE-2730] Add the number of unseq merge times in TsFile name.

### DIFF
--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -282,6 +282,7 @@
         <appender-ref ref="stdout"/>
     </root>
     <logger level="OFF" name="io.moquette.broker.metrics.MQTTMessageLogger"/>
+    <logger level="debug" name="org.apache.iotdb.db.integration.IoTDBRemovePartitionIT"/>
     <logger level="info" name="org.apache.iotdb.db.service"/>
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">

--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -282,7 +282,7 @@
         <appender-ref ref="stdout"/>
     </root>
     <logger level="OFF" name="io.moquette.broker.metrics.MQTTMessageLogger"/>
-    <logger level="info" name="org.apache.iotdb.db.integration.IoTDBRemovePartitionIT"/>
+    <logger level="debug" name="org.apache.iotdb.db.integration.IoTDBRemovePartitionIT"/>
     <logger level="info" name="org.apache.iotdb.db.service"/>
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">

--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -282,7 +282,6 @@
         <appender-ref ref="stdout"/>
     </root>
     <logger level="OFF" name="io.moquette.broker.metrics.MQTTMessageLogger"/>
-    <logger level="debug" name="org.apache.iotdb.db.integration.IoTDBRemovePartitionIT"/>
     <logger level="info" name="org.apache.iotdb.db.service"/>
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">

--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -282,6 +282,7 @@
         <appender-ref ref="stdout"/>
     </root>
     <logger level="OFF" name="io.moquette.broker.metrics.MQTTMessageLogger"/>
+    <logger level="info" name="org.apache.iotdb.db.integration.IoTDBRemovePartitionIT"/>
     <logger level="info" name="org.apache.iotdb.db.service"/>
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -143,4 +143,12 @@ public class IoTDBConstant {
 
   // thrift
   public static final int LEFT_SIZE_IN_REQUEST = 4 * 1024 * 1024;
+
+  // change tsFile name
+  public static final int FILE_NAME_SUFFIX_INDEX = 0;
+  public static final int FILE_NAME_SUFFIX_TIME_INDEX = 0;
+  public static final int FILE_NAME_SUFFIX_VERSION_INDEX = 1;
+  public static final int FILE_NAME_SUFFIX_MERGECNT_INDEX = 2;
+  public static final int FILE_NAME_SUFFIX_UNSEQMERGECNT_INDEX = 3;
+  public static final String FILE_NAME_SUFFIX_SEPARATOR = "\\.";
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -392,18 +392,18 @@ public abstract class TsFileManagement {
           mergedFile.delete();
         }
         updateMergeModification(seqFile);
-        if (i == seqFiles.size() - 1) {
-          // FIXME if there is an exception, the the modification file will be not closed.
-          removeMergingModification();
-          isUnseqMerging = false;
-          Files.delete(mergeLog.toPath());
-        }
-      } catch (IOException e) {
-        logger.error(
-            "{} a merge task ends but cannot delete log {}", storageGroupName, mergeLog.toPath());
       } finally {
         doubleWriteUnlock(seqFile);
       }
+    }
+
+    try {
+      removeMergingModification();
+      isUnseqMerging = false;
+      Files.delete(mergeLog.toPath());
+    } catch (IOException e) {
+      logger.error(
+          "{} a merge task ends but cannot delete log {}", storageGroupName, mergeLog.toPath());
     }
 
     logger.info("{} a merge task ends", storageGroupName);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1239,7 +1239,7 @@ public class StorageGroupProcessor {
   }
 
   private String getNewTsFileName(long time, long version, int mergeCnt) {
-    return time + FILE_NAME_SEPARATOR + version + FILE_NAME_SEPARATOR + mergeCnt + TSFILE_SUFFIX;
+    return TsFileResource.getNewTsFileName(System.currentTimeMillis(), version, 0, 0);
   }
 
   public void syncCloseOneTsFileProcessor(boolean sequence, TsFileProcessor tsFileProcessor) {
@@ -2466,7 +2466,8 @@ public class StorageGroupProcessor {
       return tsfileName;
     }
 
-    return getNewTsFileName(preTime + ((subsequenceTime - preTime) >> 1), subsequenceVersion, 0);
+    return TsFileResource.getNewTsFileName(
+        preTime + ((subsequenceTime - preTime) >> 1), subsequenceVersion, 0, 0);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -59,6 +59,15 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_INDEX;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_MERGECNT_INDEX;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_SEPARATOR;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_TIME_INDEX;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_UNSEQMERGECNT_INDEX;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SUFFIX_VERSION_INDEX;
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
+
 @SuppressWarnings("java:S1135") // ignore todos
 public class TsFileResource {
 
@@ -752,5 +761,128 @@ public class TsFileResource {
 
   public void setTimeIndex(ITimeIndex timeIndex) {
     this.timeIndex = timeIndex;
+  }
+
+  // change tsFile name
+
+  public static String getNewTsFileName(long time, long version, int mergeCnt, int unSeqMergeCnt) {
+    return time
+        + FILE_NAME_SEPARATOR
+        + version
+        + FILE_NAME_SEPARATOR
+        + mergeCnt
+        + FILE_NAME_SEPARATOR
+        + unSeqMergeCnt
+        + TSFILE_SUFFIX;
+  }
+
+  public static TsFileName getTsFileName(String FileName) {
+    String[] fileName =
+        FileName.split(FILE_NAME_SUFFIX_SEPARATOR)[FILE_NAME_SUFFIX_INDEX].split(
+            FILE_NAME_SEPARATOR);
+    TsFileName tsFileName =
+        new TsFileName(
+            Long.parseLong(fileName[FILE_NAME_SUFFIX_TIME_INDEX]),
+            Long.parseLong(fileName[FILE_NAME_SUFFIX_VERSION_INDEX]),
+            Integer.parseInt(fileName[FILE_NAME_SUFFIX_MERGECNT_INDEX]),
+            Integer.parseInt(fileName[FILE_NAME_SUFFIX_UNSEQMERGECNT_INDEX]));
+    return tsFileName;
+  }
+
+  public static TsFileResource modifyTsFileNameUnseqMergCnt(TsFileResource tsFileResource) {
+    File tsFile = tsFileResource.getTsFile();
+    String path = tsFile.getParent();
+    TsFileName tsFileName = getTsFileName(tsFileResource.getTsFile().getName());
+    tsFileName.setUnSeqMergeCnt(tsFileName.getUnSeqMergeCnt() + 1);
+    tsFileResource.setFile(
+        new File(
+            path,
+            tsFileName.time
+                + FILE_NAME_SEPARATOR
+                + tsFileName.version
+                + FILE_NAME_SEPARATOR
+                + tsFileName.mergeCnt
+                + FILE_NAME_SEPARATOR
+                + tsFileName.unSeqMergeCnt
+                + TSFILE_SUFFIX));
+    return tsFileResource;
+  }
+
+  public static File modifyTsFileNameUnseqMergCnt(File tsFile) {
+    String path = tsFile.getParent();
+    TsFileName tsFileName = getTsFileName(tsFile.getName());
+    tsFileName.setUnSeqMergeCnt(tsFileName.getUnSeqMergeCnt() + 1);
+    return new File(
+        path,
+        tsFileName.time
+            + FILE_NAME_SEPARATOR
+            + tsFileName.version
+            + FILE_NAME_SEPARATOR
+            + tsFileName.mergeCnt
+            + FILE_NAME_SEPARATOR
+            + tsFileName.unSeqMergeCnt
+            + TSFILE_SUFFIX);
+  }
+
+  public static File modifyTsFileNameMergeCnt(File tsFile) {
+    String path = tsFile.getParent();
+    TsFileName tsFileName = getTsFileName(tsFile.getName());
+    tsFileName.setMergeCnt(tsFileName.getMergeCnt() + 1);
+    return new File(
+        path,
+        tsFileName.time
+            + FILE_NAME_SEPARATOR
+            + tsFileName.version
+            + FILE_NAME_SEPARATOR
+            + tsFileName.mergeCnt
+            + FILE_NAME_SEPARATOR
+            + tsFileName.unSeqMergeCnt
+            + TSFILE_SUFFIX);
+  }
+
+  public static class TsFileName {
+    private long time;
+    private long version;
+    private int mergeCnt;
+    private int unSeqMergeCnt;
+
+    public TsFileName(long time, long version, int mergeCnt, int unSeqMergeCnt) {
+      this.time = time;
+      this.version = version;
+      this.mergeCnt = mergeCnt;
+      this.unSeqMergeCnt = unSeqMergeCnt;
+    }
+
+    public long getTime() {
+      return time;
+    }
+
+    public long getVersion() {
+      return version;
+    }
+
+    public int getMergeCnt() {
+      return mergeCnt;
+    }
+
+    public int getUnSeqMergeCnt() {
+      return unSeqMergeCnt;
+    }
+
+    public void setTime(long time) {
+      this.time = time;
+    }
+
+    public void setVersion(long version) {
+      this.version = version;
+    }
+
+    public void setMergeCnt(int mergeCnt) {
+      this.mergeCnt = mergeCnt;
+    }
+
+    public void setUnSeqMergeCnt(int unSeqMergeCnt) {
+      this.unSeqMergeCnt = unSeqMergeCnt;
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FilePathUtils.java
@@ -251,7 +251,7 @@ public class FilePathUtils {
 
   public static long splitAndGetTsFileVersion(String tsFileName) {
     String[] names = tsFileName.split(FILE_NAME_SEPARATOR);
-    if (names.length != 3) {
+    if (names.length != 4) {
       return 0;
     }
     return Long.parseLong(names[1]);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionChunkTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionChunkTest.java
@@ -85,6 +85,8 @@ public class CompactionChunkTest extends LevelCompactionTest {
                     + 0
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 1
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + ".tsfile"));
     TsFileResource targetTsfileResource = new TsFileResource(file);
     RateLimiter compactionWriteRateLimiter = MergeManager.getINSTANCE().getMergeWriteRateLimiter();
@@ -168,6 +170,8 @@ public class CompactionChunkTest extends LevelCompactionTest {
                     + 0
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 1
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + ".tsfile"));
     TsFileResource targetTsfileResource = new TsFileResource(file);
     RateLimiter compactionWriteRateLimiter = MergeManager.getINSTANCE().getMergeWriteRateLimiter();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMoreDataTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMoreDataTest.java
@@ -101,6 +101,8 @@ public class LevelCompactionMoreDataTest extends LevelCompactionTest {
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -117,6 +119,8 @@ public class LevelCompactionMoreDataTest extends LevelCompactionTest {
                       + (10000 + i)
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -131,6 +135,8 @@ public class LevelCompactionMoreDataTest extends LevelCompactionTest {
                 unseqFileNum
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + unseqFileNum
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 0
                     + ".tsfile"));

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionRecoverTest.java
@@ -126,6 +126,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
                         + 0
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 1
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile")));
     compactionLogger.logFile(TARGET_NAME, targetTsFileResource.getTsFile());
     CompactionUtils.merge(
@@ -215,6 +217,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
                         + 0
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 1
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile")));
     compactionLogger.logFile(TARGET_NAME, targetTsFileResource.getTsFile());
     CompactionUtils.merge(
@@ -328,6 +332,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
                         + 0
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 1
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile")));
     compactionLogger.logFile(TARGET_NAME, targetTsFileResource.getTsFile());
     CompactionUtils.merge(
@@ -447,6 +453,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
                         + 0
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 1
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile")));
     compactionLogger.logFile(TARGET_NAME, targetTsFileResource.getTsFile());
     CompactionUtils.merge(
@@ -594,6 +602,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
                         + 0
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 1
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile")));
     compactionLogger.logFile(TARGET_NAME, targetTsFileResource.getTsFile());
     levelCompactionTsFileManagement.add(targetTsFileResource, true);
@@ -649,6 +659,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
                         + 0
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 1
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile")));
     compactionLogger.logFile(TARGET_NAME, targetTsFileResource.getTsFile());
     CompactionUtils.merge(

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionTest.java
@@ -132,6 +132,8 @@ abstract class LevelCompactionTest {
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -148,10 +150,12 @@ abstract class LevelCompactionTest {
                       + (10000 + i)
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
-      tsFileResource.updatePlanIndexes((long) (i + seqFileNum));
+      tsFileResource.updatePlanIndexes(i + seqFileNum);
       unseqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum * (i + 1) / unseqFileNum, 10000);
     }
@@ -164,10 +168,12 @@ abstract class LevelCompactionTest {
                     + unseqFileNum
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + ".tsfile"));
     TsFileResource tsFileResource = new TsFileResource(file);
     tsFileResource.setClosed(true);
-    tsFileResource.updatePlanIndexes((long) (seqFileNum + unseqFileNum));
+    tsFileResource.updatePlanIndexes(seqFileNum + unseqFileNum);
     unseqResources.add(tsFileResource);
     prepareFile(tsFileResource, 0, ptNum * unseqFileNum, 20000);
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionTsFileManagementTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionTsFileManagementTest.java
@@ -83,6 +83,8 @@ public class LevelCompactionTsFileManagementTest extends LevelCompactionTest {
                             + 10
                             + IoTDBConstant.FILE_NAME_SEPARATOR
                             + 0
+                            + IoTDBConstant.FILE_NAME_SEPARATOR
+                            + 0
                             + ".tsfile"))),
             false));
     assertTrue(levelCompactionTsFileManagement.contains(seqResources.get(0), false));
@@ -94,6 +96,8 @@ public class LevelCompactionTsFileManagementTest extends LevelCompactionTest {
                         10
                             + IoTDBConstant.FILE_NAME_SEPARATOR
                             + 10
+                            + IoTDBConstant.FILE_NAME_SEPARATOR
+                            + 0
                             + IoTDBConstant.FILE_NAME_SEPARATOR
                             + 0
                             + ".tsfile"))),
@@ -129,6 +133,8 @@ public class LevelCompactionTsFileManagementTest extends LevelCompactionTest {
                         + 10
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 10
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile"))),
         true);
     levelCompactionTsFileManagement.add(
@@ -140,6 +146,8 @@ public class LevelCompactionTsFileManagementTest extends LevelCompactionTest {
                         + 10
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 10
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile"))),
         false);
     assertEquals(1, levelCompactionTsFileManagement.size(true));

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/NoCompactionTsFileManagementTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/NoCompactionTsFileManagementTest.java
@@ -84,6 +84,8 @@ public class NoCompactionTsFileManagementTest extends LevelCompactionTest {
                             + 10
                             + IoTDBConstant.FILE_NAME_SEPARATOR
                             + 0
+                            + IoTDBConstant.FILE_NAME_SEPARATOR
+                            + 0
                             + ".tsfile"))),
             false));
     assertTrue(noCompactionTsFileManagement.contains(seqResources.get(0), false));
@@ -95,6 +97,8 @@ public class NoCompactionTsFileManagementTest extends LevelCompactionTest {
                         10
                             + IoTDBConstant.FILE_NAME_SEPARATOR
                             + 10
+                            + IoTDBConstant.FILE_NAME_SEPARATOR
+                            + 0
                             + IoTDBConstant.FILE_NAME_SEPARATOR
                             + 0
                             + ".tsfile"))),
@@ -129,6 +133,8 @@ public class NoCompactionTsFileManagementTest extends LevelCompactionTest {
                         + 10
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 10
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile"))),
         true);
     noCompactionTsFileManagement.add(
@@ -140,6 +146,8 @@ public class NoCompactionTsFileManagementTest extends LevelCompactionTest {
                         + 10
                         + IoTDBConstant.FILE_NAME_SEPARATOR
                         + 10
+                        + IoTDBConstant.FILE_NAME_SEPARATOR
+                        + 0
                         + ".tsfile"))),
         false);
     noCompactionTsFileManagement.forkCurrentFileList(0);

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -115,6 +116,7 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
                     + 0
                     + ".tsfile"));
     TsFileResource largeUnseqTsFileResource = new TsFileResource(file);
+    unseqResources.add(largeUnseqTsFileResource);
     largeUnseqTsFileResource.setClosed(true);
     largeUnseqTsFileResource.setMinPlanIndex(10);
     largeUnseqTsFileResource.setMaxPlanIndex(10);
@@ -135,10 +137,10 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
       newTimeIndex.updateStartTime(device, timeIndex.getStartTime(device));
     }
     secondTsFileResource.setTimeIndex(newTimeIndex);
-    unseqResources.clear();
-    unseqResources.add(largeUnseqTsFileResource);
 
-    MergeResource resource = new MergeResource(seqResources, unseqResources);
+    List<TsFileResource> newUnseqResources = new ArrayList<>();
+    newUnseqResources.add(largeUnseqTsFileResource);
+    MergeResource resource = new MergeResource(seqResources, newUnseqResources);
     IMergeFileSelector mergeFileSelector = new MaxFileMergeFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
     assertEquals(0, result.length);
@@ -166,6 +168,7 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
                     + 0
                     + ".tsfile"));
     TsFileResource largeUnseqTsFileResource = new TsFileResource(file);
+    unseqResources.add(largeUnseqTsFileResource);
     largeUnseqTsFileResource.setClosed(true);
     largeUnseqTsFileResource.setMinPlanIndex(10);
     largeUnseqTsFileResource.setMaxPlanIndex(10);
@@ -186,11 +189,12 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
       newTimeIndex.updateStartTime(device, timeIndex.getStartTime(device));
     }
     secondTsFileResource.setTimeIndex(newTimeIndex);
-    unseqResources.clear();
-    unseqResources.add(largeUnseqTsFileResource);
+    List<TsFileResource> newUnseqResources = new ArrayList<>();
+    newUnseqResources.add(largeUnseqTsFileResource);
 
     long timeLowerBound = System.currentTimeMillis() - Long.MAX_VALUE;
-    MergeResource mergeResource = new MergeResource(seqResources, unseqResources, timeLowerBound);
+    MergeResource mergeResource =
+        new MergeResource(seqResources, newUnseqResources, timeLowerBound);
     assertEquals(5, mergeResource.getSeqFiles().size());
     assertEquals(1, mergeResource.getUnseqFiles().size());
     mergeResource.clear();

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeOverLapTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeOverLapTest.java
@@ -83,6 +83,8 @@ public class MergeOverLapTest extends MergeTest {
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -100,6 +102,8 @@ public class MergeOverLapTest extends MergeTest {
                       + (10000 + i)
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -114,6 +118,8 @@ public class MergeOverLapTest extends MergeTest {
                 unseqFileNum
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + unseqFileNum
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 0
                     + ".tsfile"));

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
@@ -146,6 +146,7 @@ public class MergeTaskTest extends MergeTest {
     smallUnseqTsFileResource.setMaxPlanIndex(10);
     smallUnseqTsFileResource.setVersion(10);
     prepareFile(smallUnseqTsFileResource, 0, 50, 0);
+    unseqResources.add(smallUnseqTsFileResource);
 
     // remove all data of first file
     for (String deviceId : deviceIds) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTest.java
@@ -134,6 +134,8 @@ abstract class MergeTest {
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
       tsFileResource.setClosed(true);
@@ -150,6 +152,8 @@ abstract class MergeTest {
                   (10000 + i)
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + (10000 + i)
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + 0
                       + ".tsfile"));
@@ -170,6 +174,8 @@ abstract class MergeTest {
                     + unseqFileNum
                     + IoTDBConstant.FILE_NAME_SEPARATOR
                     + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
                     + ".tsfile"));
     TsFileResource tsFileResource = new TsFileResource(file);
     tsFileResource.setClosed(true);
@@ -183,9 +189,11 @@ abstract class MergeTest {
   private void removeFiles() throws IOException {
     for (TsFileResource tsFileResource : seqResources) {
       tsFileResource.remove();
+      tsFileResource.getModFile().remove();
     }
     for (TsFileResource tsFileResource : unseqResources) {
       tsFileResource.remove();
+      tsFileResource.getModFile().remove();
     }
 
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBRemovePartitionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBRemovePartitionIT.java
@@ -64,6 +64,7 @@ public class IoTDBRemovePartitionIT {
     StorageEngine.setEnablePartition(false);
     StorageEngine.setTimePartitionInterval(-1);
     EnvironmentUtils.cleanEnv();
+
     ch.qos.logback.classic.Logger rootLogger =
         (ch.qos.logback.classic.Logger)
             LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);


### PR DESCRIPTION
## Description
Hi all :
I have submitted a pr for [ISSUE-2730](https://github.com/apache/iotdb/issues/2730), please take a look.
This issue about add the number of unseq merge times in TsFile name.

The modules involved are as follows:
   1、server/engine/merge
   2、server/engine/storagegroup
### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
