### PR TITLE
[IOTDB-1262] The test fails to be executed independently

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
@@ -198,8 +198,12 @@ public class IoTDBEngineTimeGeneratorIT {
 
     SingleSeriesExpression singleSeriesExpression =
         new SingleSeriesExpression(pd0s0, FilterFactory.and(valueGtEq, timeGt));
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
+    List<PartialPath> paths = new ArrayList<>();
+    paths.add(pd0s0);
+    queryPlan.setDeduplicatedPaths(paths);
     ServerTimeGenerator timeGenerator =
-        new ServerTimeGenerator(singleSeriesExpression, TEST_QUERY_CONTEXT, new RawDataQueryPlan());
+        new ServerTimeGenerator(singleSeriesExpression, TEST_QUERY_CONTEXT, queryPlan);
 
     int cnt = 0;
     while (timeGenerator.hasNext()) {


### PR DESCRIPTION
The test fails to be executed independently

![image](https://user-images.githubusercontent.com/1021782/113096818-7f7a4a00-9228-11eb-9c23-e9dd41ea0f3f.png)

Reason:

This test uses an empty `queryPlan`. However, `SeriesRawDataBatchReader` may need to use the path from the queryPlan.

```
return new SeriesRawDataBatchReader(
        path,
        queryPlan.getAllMeasurementsInDevice(path.getDevice()), \\called `allSensors`
        dataType,
        context,
        queryDataSource,
        timeFilter,
        valueFilter,
        null,
        queryPlan.isAscending());
```

The current logic is: if we can find the `path` in `TimeSeriesMetadataCache`, then we do not need to use `allSensors`.  If not, we have to check `allSensors`.

When running the whole IT test, `TimeSeriesMetadataCache` is not empty and the `path` exists in it, so even though  `allSensors` is empty, it does not take any side effect. 
But when run the IT independently,  `TimeSeriesMetadataCache` is empty and then we will search the `path` in `allSensors`, which is also empty...

But for this case, it is clear that we should not generate an empty queryPlan, and this PR fixes it using this way.

More, in `public ServerTimeGenerator(IExpression expression, QueryContext context, RawDataQueryPlan queryPlan)` , we should remove `IExpression expression`, and use `queryPlan.getExpression` instead.

After change:

![image](https://user-images.githubusercontent.com/66939405/112918552-b290e080-9137-11eb-9c38-4f5e3a2ce2d6.png)


