### PR TITLE
update configuration items

### DIFF
--- a/docs/zh/UserGuide/Appendix/Config Manual.md
+++ b/docs/zh/UserGuide/Appendix/Config Manual.md
@@ -153,7 +153,7 @@
 |名字| time\_encoder |
 |:---:|:---|
 |描述| 时间列编码方式|
-|类型|枚举String: “TS_2DIFF”,“PLAIN”,“RLE”,“,“RLE””|
+|类型|枚举String: “TS_2DIFF”,“PLAIN”,“RLE”|
 |默认值| TS_2DIFF |
 |改后生效方式|触发生效|
 
@@ -162,7 +162,7 @@
 |名字| value\_encoder |
 |:---:|:---|
 |描述| value列编码方式|
-|类型|枚举String: “TS_2DIFF”,“PLAIN”,“RLE”,“,“RLE””|
+|类型|枚举String: “TS_2DIFF”,“PLAIN”,“RLE”|
 |默认值| PLAIN |
 |改后生效方式|触发生效|
 


### PR DESCRIPTION
按照当前手册和0.12内配置文件对比，添加部分了解的参数。剩余其他参数可能需要规划其他参数类型。所以未敢添加。
当前版本不包含配置参数如下表

####################
### Web Page Configuration
####################
enable_metric_service=false
metrics_port=8181
query_cache_size_in_metric=50
####################
### Storage Engine Configuration
####################
concurrent_query_thread=0
chunk_buffer_pool_enable=false
batch_size=100000
enable_mtree_snapshot=false
mtree_snapshot_threshold_time=3600
virtual_storage_group_num = 1
time_index_level=DEVICE_TIME_INDEX
####################
### Memory Control Configuration
####################
write_read_schema_free_memory_proportion=4:3:1:2
primitive_array_size=128
flush_proportion=0.4
buffered_arrays_memory_proportion=0.6
reject_proportion=0.8
storage_group_report_threshold=16777216
max_deduplicated_path_num=1000
check_period_when_insert_blocked=50
max_waiting_time_when_insert_blocked=10000
estimated_series_size=300
io_task_queue_size_for_flushing=10
####################
### Upgrade Configurations
####################
upgrade_thread_num=1
####################
### Query Configurations
####################
default_fill_interval=-1
####################
### Merge Configurations
####################
compaction_strategy=LEVEL_COMPACTION
enable_unseq_compaction=true
seq_file_num_in_each_level=6
seq_level_num=3
unseq_file_num_in_each_level=10
unseq_level_num=1
merge_chunk_point_number=100000
merge_page_point_number=100
merge_chunk_subthread_num=4
merge_fileSelection_time_budget=30000
merge_memory_budget=2147483648
continue_merge_after_reboot=false
force_full_merge=false
compaction_thread_num=10
merge_write_throughput_mb_per_sec=8
query_time_threshold=60000
####################
### Metadata Cache Configuration
####################
meta_data_cache_enable=true
chunk_timeseriesmeta_free_memory_proportion=1:2:3:4
metadata_node_cache_size=300000
####################
### LAST Cache Configuration
####################
enable_last_cache=true
####################
### Statistics Monitor configuration
####################
enable_monitor_series_write=false
####################
### WAL Direct Buffer Pool Configuration
####################
wal_pool_trim_interval_ms=10000
max_wal_bytebuffer_num_for_each_partition=6
####################
### External sort Configuration
####################
enable_external_sort=true
external_sort_threshold=1000
####################
### Sync Server Configuration
####################
is_sync_enable=false
sync_server_port=5555
ip_white_list=0.0.0.0/0
####################
### performance statistic configuration
####################
enable_performance_stat=false
performance_stat_display_interval=60000
performance_stat_memory_in_kb=20
enable_performance_tracing=false
tracing_dir=data/tracing
####################
### Configurations for watermark module
####################
watermark_module_opened=false
watermark_secret_key=IoTDB*2019@Beijing
watermark_bit_string=100101110100
watermark_method=GroupBasedLSBMethod(embed_row_cycle=2,embed_lsb_num=5)
####################
### Configurations for tsfile-format
####################
frequency_interval_in_minute=1
slow_query_threshold=5000
debug_state=false
####################
### MQTT Broker Configuration
####################
enable_mqtt_service=false
mqtt_host=0.0.0.0
mqtt_port=1883
mqtt_handler_pool_size=1
mqtt_payload_formatter=json
mqtt_max_message_size=1048576
####################
### UDF Query Configuration
####################
udf_initial_byte_array_length_for_memory_control=48
udf_memory_budget_in_mb=30.0
udf_reader_transformer_collector_memory_proportion=1:1:1
udf_root_dir=ext\\udf
 index_root_dir=data/index
enable_index=false
concurrent_index_build_thread=0
default_index_window_range=10
index_buffer_size=134217728


