### PR TITLE
[IOTDB-1265] fix bug: correct cluster to iotdb-cluster

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -130,7 +130,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
-            <artifactId>cluster</artifactId>
+            <artifactId>iotdb-cluster</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>

--- a/distribution/src/assembly/cluster.xml
+++ b/distribution/src/assembly/cluster.xml
@@ -29,7 +29,7 @@
     <dependencySets>
         <dependencySet>
             <includes>
-                <include>*:cluster:zip:*</include>
+                <include>*:iotdb-cluster:zip:*</include>
                 <include>*:iotdb-cli:zip:*</include>
             </includes>
             <outputDirectory>${file.separator}</outputDirectory>


### PR DESCRIPTION
## Description
### JIRA: IOTDB-1265, cluster package refactor missed necessary change

#### There was ever below change：
=============================================================
```
commit 64c11bc259cfc948286b8bf299792380766deb25
Author: wangchao316 <66939405+wangchao316@users.noreply.github.com>
Date: Tue Mar 23 20:54:44 2021 +0800

IOTDB-1255 refactor cluster package and jar name (#2892)

diff --git a/cluster/pom.xml b/cluster/pom.xml
index 1d2969321..9a15a0daa 100644
— a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -27,7 +27,7 @@
<version>0.12.0-SNAPSHOT</version>
<relativePath>../pom.xml</relativePath>
</parent>

-   <artifactId>cluster</artifactId>
+  <artifactId>iotdb-cluster</artifactId>
<name>cluster</name>
<properties>
<cluster.test.skip>false</cluster.test.skip>
```
============================================================

#### But above commit missed below 2 points' change
=============================================================
vi distribution/pom.xml
```
<dependency>
<groupId>org.apache.iotdb</groupId>
<artifactId>cluster</artifactId> //should be <artifactId>iotdb-cluster</artifactId>
<version>${project.version}</version>
<type>zip</type>
</dependency>
```
vi distribution/src/assembly/cluster.xml
```
<dependencySets>
<dependencySet>
<includes>
<include>:cluster:zip:</include> //should be <include>:iotdb-cluster:zip:</include>
<include>:iotdb-cli:zip:</include>
</includes>
```
=============================================================

When you run cmd "mvn clean pacakge",
above bug will cause final package(apache-iotdb-xxx-cluster-bin.zip) contains old files that are from cluster-xxx.zip（from Maven repo).

 