### PR TITLE
[To rel/0.11] Fix unseq compaction file selector conflicts with time partition bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -55,9 +55,7 @@ public abstract class TsFileManagement {
   protected String storageGroupName;
   protected String storageGroupDir;
 
-  /**
-   * Serialize queries, delete resource files, compaction cleanup files
-   */
+  /** Serialize queries, delete resource files, compaction cleanup files */
   private final ReadWriteLock compactionMergeLock = new ReentrantReadWriteLock();
 
   public volatile boolean isUnseqMerging = false;
@@ -67,6 +65,7 @@ public abstract class TsFileManagement {
    * be invisible at this moment, without this, deletion/update during merge could be lost.
    */
   public ModificationFile mergingModification;
+
   private long mergeStartTime;
 
   public TsFileManagement(String storageGroupName, String storageGroupDir) {
@@ -75,68 +74,49 @@ public abstract class TsFileManagement {
   }
 
   /**
-   * get the TsFile list in sequence
+   * get the TsFile list in sequence, not recommend to use this method, use
+   * getTsFileListByTimePartition instead
    */
   public abstract List<TsFileResource> getTsFileList(boolean sequence);
 
-  /**
-   * get the TsFile list iterator in sequence
-   */
+  /** get the TsFile list in sequence by time partition */
+  public abstract List<TsFileResource> getTsFileListByTimePartition(
+      boolean sequence, long timePartition);
+
+  /** get the TsFile list iterator in sequence */
   public abstract Iterator<TsFileResource> getIterator(boolean sequence);
 
-  /**
-   * remove one TsFile from list
-   */
+  /** remove one TsFile from list */
   public abstract void remove(TsFileResource tsFileResource, boolean sequence);
 
-  /**
-   * remove some TsFiles from list
-   */
+  /** remove some TsFiles from list */
   public abstract void removeAll(List<TsFileResource> tsFileResourceList, boolean sequence);
 
-  /**
-   * add one TsFile to list
-   */
+  /** add one TsFile to list */
   public abstract void add(TsFileResource tsFileResource, boolean sequence);
 
-  /**
-   * add one TsFile to list for recover
-   */
+  /** add one TsFile to list for recover */
   public abstract void addRecover(TsFileResource tsFileResource, boolean sequence);
 
-  /**
-   * add some TsFiles to list
-   */
+  /** add some TsFiles to list */
   public abstract void addAll(List<TsFileResource> tsFileResourceList, boolean sequence);
 
-  /**
-   * is one TsFile contained in list
-   */
+  /** is one TsFile contained in list */
   public abstract boolean contains(TsFileResource tsFileResource, boolean sequence);
 
-  /**
-   * clear list
-   */
+  /** clear list */
   public abstract void clear();
 
-  /**
-   * is the list empty
-   */
+  /** is the list empty */
   public abstract boolean isEmpty(boolean sequence);
 
-  /**
-   * return TsFile list size
-   */
+  /** return TsFile list size */
   public abstract int size(boolean sequence);
 
-  /**
-   * recover TsFile list
-   */
+  /** recover TsFile list */
   public abstract void recover();
 
-  /**
-   * fork current TsFile list (call this before merge)
-   */
+  /** fork current TsFile list (call this before merge) */
   public abstract void forkCurrentFileList(long timePartition) throws IOException;
 
   public void readLock() {
@@ -166,8 +146,8 @@ public abstract class TsFileManagement {
     private CloseCompactionMergeCallBack closeCompactionMergeCallBack;
     private long timePartitionId;
 
-    public CompactionMergeTask(CloseCompactionMergeCallBack closeCompactionMergeCallBack,
-        long timePartitionId) {
+    public CompactionMergeTask(
+        CloseCompactionMergeCallBack closeCompactionMergeCallBack, long timePartitionId) {
       this.closeCompactionMergeCallBack = closeCompactionMergeCallBack;
       this.timePartitionId = timePartitionId;
     }
@@ -194,11 +174,16 @@ public abstract class TsFileManagement {
     }
   }
 
-  public void merge(boolean fullMerge, List<TsFileResource> seqMergeList,
-      List<TsFileResource> unSeqMergeList, long dataTTL) {
+  public void merge(
+      boolean fullMerge,
+      List<TsFileResource> seqMergeList,
+      List<TsFileResource> unSeqMergeList,
+      long dataTTL) {
     if (isUnseqMerging) {
       if (logger.isInfoEnabled()) {
-        logger.info("{} Last merge is ongoing, currently consumed time: {}ms", storageGroupName,
+        logger.info(
+            "{} Last merge is ongoing, currently consumed time: {}ms",
+            storageGroupName,
             (System.currentTimeMillis() - mergeStartTime));
       }
       return;
@@ -235,8 +220,8 @@ public abstract class TsFileManagement {
     try {
       List[] mergeFiles = fileSelector.select();
       if (mergeFiles.length == 0) {
-        logger.info("{} cannot select merge candidates under the budget {}", storageGroupName,
-            budget);
+        logger.info(
+            "{} cannot select merge candidates under the budget {}", storageGroupName, budget);
         isUnseqMerging = false;
         return;
       }
@@ -255,15 +240,25 @@ public abstract class TsFileManagement {
       }
 
       mergeStartTime = System.currentTimeMillis();
-      MergeTask mergeTask = new MergeTask(mergeResource, storageGroupDir,
-          this::mergeEndAction, taskName, fullMerge, fileSelector.getConcurrentMergeNum(),
-          storageGroupName);
-      mergingModification = new ModificationFile(
-          storageGroupDir + File.separator + MERGING_MODIFICATION_FILE_NAME);
+      MergeTask mergeTask =
+          new MergeTask(
+              mergeResource,
+              storageGroupDir,
+              this::mergeEndAction,
+              taskName,
+              fullMerge,
+              fileSelector.getConcurrentMergeNum(),
+              storageGroupName);
+      mergingModification =
+          new ModificationFile(storageGroupDir + File.separator + MERGING_MODIFICATION_FILE_NAME);
       MergeManager.getINSTANCE().submitMainTask(mergeTask);
       if (logger.isInfoEnabled()) {
-        logger.info("{} submits a merge task {}, merging {} seqFiles, {} unseqFiles",
-            storageGroupName, taskName, mergeFiles[0].size(), mergeFiles[1].size());
+        logger.info(
+            "{} submits a merge task {}, merging {} seqFiles, {} unseqFiles",
+            storageGroupName,
+            taskName,
+            mergeFiles[0].size(),
+            mergeFiles[1].size());
       }
 
     } catch (MergeException | IOException e) {
@@ -283,9 +278,7 @@ public abstract class TsFileManagement {
     }
   }
 
-  /**
-   * acquire the write locks of the resource , the merge lock and the compaction lock
-   */
+  /** acquire the write locks of the resource , the merge lock and the compaction lock */
   private void doubleWriteLock(TsFileResource seqFile) {
     boolean fileLockGot;
     boolean compactionLockGot;
@@ -307,9 +300,7 @@ public abstract class TsFileManagement {
     }
   }
 
-  /**
-   * release the write locks of the resource , the merge lock and the compaction lock
-   */
+  /** release the write locks of the resource , the merge lock and the compaction lock */
   private void doubleWriteUnlock(TsFileResource seqFile) {
     writeUnlock();
     seqFile.writeUnlock();
@@ -351,13 +342,16 @@ public abstract class TsFileManagement {
         try {
           seqFile.getModFile().close();
         } catch (IOException e) {
-          logger
-              .error("Cannot close the ModificationFile {}", seqFile.getModFile().getFilePath(), e);
+          logger.error(
+              "Cannot close the ModificationFile {}", seqFile.getModFile().getFilePath(), e);
         }
       }
     } catch (IOException e) {
-      logger.error("{} cannot clean the ModificationFile of {} after merge", storageGroupName,
-          seqFile.getTsFile(), e);
+      logger.error(
+          "{} cannot clean the ModificationFile of {} after merge",
+          storageGroupName,
+          seqFile.getTsFile(),
+          e);
     }
   }
 
@@ -372,8 +366,8 @@ public abstract class TsFileManagement {
     }
   }
 
-  public void mergeEndAction(List<TsFileResource> seqFiles, List<TsFileResource> unseqFiles,
-      File mergeLog) {
+  public void mergeEndAction(
+      List<TsFileResource> seqFiles, List<TsFileResource> unseqFiles, File mergeLog) {
     logger.info("{} a merge task is ending...", storageGroupName);
 
     if (unseqFiles.isEmpty()) {
@@ -392,14 +386,14 @@ public abstract class TsFileManagement {
       try {
         updateMergeModification(seqFile);
         if (i == seqFiles.size() - 1) {
-          //FIXME if there is an exception, the the modification file will be not closed.
+          // FIXME if there is an exception, the the modification file will be not closed.
           removeMergingModification();
           isUnseqMerging = false;
           Files.delete(mergeLog.toPath());
         }
       } catch (IOException e) {
-        logger.error("{} a merge task ends but cannot delete log {}", storageGroupName,
-            mergeLog.toPath());
+        logger.error(
+            "{} a merge task ends but cannot delete log {}", storageGroupName, mergeLog.toPath());
       } finally {
         doubleWriteUnlock(seqFile);
       }
@@ -410,10 +404,8 @@ public abstract class TsFileManagement {
 
   // ({systemTime}-{versionNum}-{mergeNum}.tsfile)
   public static int compareFileName(File o1, File o2) {
-    String[] items1 = o1.getName().replace(TSFILE_SUFFIX, "")
-        .split(FILE_NAME_SEPARATOR);
-    String[] items2 = o2.getName().replace(TSFILE_SUFFIX, "")
-        .split(FILE_NAME_SEPARATOR);
+    String[] items1 = o1.getName().replace(TSFILE_SUFFIX, "").split(FILE_NAME_SEPARATOR);
+    String[] items2 = o2.getName().replace(TSFILE_SUFFIX, "").split(FILE_NAME_SEPARATOR);
     long ver1 = Long.parseLong(items1[0]);
     long ver2 = Long.parseLong(items2[0]);
     int cmp = Long.compare(ver1, ver2);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -169,24 +169,42 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
     }
   }
 
+  @Deprecated
   @Override
   public List<TsFileResource> getTsFileList(boolean sequence) {
     List<TsFileResource> result = new ArrayList<>();
     if (sequence) {
       synchronized (sequenceTsFileResources) {
-        for (List<SortedSet<TsFileResource>> sequenceTsFileList :
-            sequenceTsFileResources.values()) {
-          for (int i = sequenceTsFileList.size() - 1; i >= 0; i--) {
-            result.addAll(sequenceTsFileList.get(i));
-          }
+        for (long timePartition : sequenceTsFileResources.keySet()) {
+          result.addAll(getTsFileListByTimePartition(true, timePartition));
         }
       }
     } else {
       synchronized (unSequenceTsFileResources) {
-        for (List<List<TsFileResource>> unSequenceTsFileList : unSequenceTsFileResources.values()) {
-          for (int i = unSequenceTsFileList.size() - 1; i >= 0; i--) {
-            result.addAll(unSequenceTsFileList.get(i));
-          }
+        for (long timePartition : unSequenceTsFileResources.keySet()) {
+          result.addAll(getTsFileListByTimePartition(false, timePartition));
+        }
+      }
+    }
+    return result;
+  }
+
+  public List<TsFileResource> getTsFileListByTimePartition(boolean sequence, long timePartition) {
+    List<TsFileResource> result = new ArrayList<>();
+    if (sequence) {
+      synchronized (sequenceTsFileResources) {
+        List<SortedSet<TsFileResource>> sequenceTsFileList =
+            sequenceTsFileResources.get(timePartition);
+        for (int i = sequenceTsFileList.size() - 1; i >= 0; i--) {
+          result.addAll(sequenceTsFileList.get(i));
+        }
+      }
+    } else {
+      synchronized (unSequenceTsFileResources) {
+        List<List<TsFileResource>> unSequenceTsFileList =
+            unSequenceTsFileResources.get(timePartition);
+        for (int i = unSequenceTsFileList.size() - 1; i >= 0; i--) {
+          result.addAll(unSequenceTsFileList.get(i));
         }
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/no/NoCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/no/NoCompactionTsFileManagement.java
@@ -20,8 +20,12 @@
 package org.apache.iotdb.db.engine.compaction.no;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.iotdb.db.engine.compaction.TsFileManagement;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
@@ -32,30 +36,46 @@ public class NoCompactionTsFileManagement extends TsFileManagement {
 
   private static final Logger logger = LoggerFactory.getLogger(NoCompactionTsFileManagement.class);
   // includes sealed and unsealed sequence TsFiles
-  private TreeSet<TsFileResource> sequenceFileTreeSet = new TreeSet<>(
-      (o1, o2) -> {
-        try {
-          int rangeCompare = Long.compare(Long.parseLong(o1.getTsFile().getParentFile().getName()),
-              Long.parseLong(o2.getTsFile().getParentFile().getName()));
-          return rangeCompare == 0 ? compareFileName(o1.getTsFile(), o2.getTsFile()) : rangeCompare;
-        } catch (NumberFormatException e) {
-          return compareFileName(o1.getTsFile(), o2.getTsFile());
-        }
-      });
+  private final Map<Long, TreeSet<TsFileResource>> sequenceFileTreeSetMap = new TreeMap<>();
 
   // includes sealed and unsealed unSequence TsFiles
-  private List<TsFileResource> unSequenceFileList = new ArrayList<>();
+  private final Map<Long, List<TsFileResource>> unSequenceFileListMap = new TreeMap<>();
 
   public NoCompactionTsFileManagement(String storageGroupName, String storageGroupDir) {
     super(storageGroupName, storageGroupDir);
   }
 
+  @Deprecated
   @Override
   public List<TsFileResource> getTsFileList(boolean sequence) {
+    List<TsFileResource> result = new ArrayList<>();
     if (sequence) {
-      return new ArrayList<>(sequenceFileTreeSet);
+      synchronized (sequenceFileTreeSetMap) {
+        for (TreeSet<TsFileResource> tsFileResourceTreeSet : sequenceFileTreeSetMap.values()) {
+          result.addAll(tsFileResourceTreeSet);
+        }
+      }
     } else {
-      return unSequenceFileList;
+      synchronized (unSequenceFileListMap) {
+        for (List<TsFileResource> tsFileResourceList : unSequenceFileListMap.values()) {
+          result.addAll(tsFileResourceList);
+        }
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public List<TsFileResource> getTsFileListByTimePartition(boolean sequence, long timePartition) {
+    if (sequence) {
+      synchronized (sequenceFileTreeSetMap) {
+        return new ArrayList<>(sequenceFileTreeSetMap.getOrDefault(timePartition, new TreeSet<>()));
+      }
+    } else {
+      synchronized (unSequenceFileListMap) {
+        return new ArrayList<>(
+            unSequenceFileListMap.getOrDefault(timePartition, Collections.emptyList()));
+      }
     }
   }
 
@@ -67,27 +87,79 @@ public class NoCompactionTsFileManagement extends TsFileManagement {
   @Override
   public void remove(TsFileResource tsFileResource, boolean sequence) {
     if (sequence) {
-      sequenceFileTreeSet.remove(tsFileResource);
+      synchronized (sequenceFileTreeSetMap) {
+        TreeSet<TsFileResource> sequenceFileTreeSet =
+            sequenceFileTreeSetMap.get(tsFileResource.getTimePartition());
+        sequenceFileTreeSet.remove(tsFileResource);
+      }
     } else {
-      unSequenceFileList.remove(tsFileResource);
+      synchronized (unSequenceFileListMap) {
+        List<TsFileResource> unSequenceFileList =
+            unSequenceFileListMap.get(tsFileResource.getTimePartition());
+        unSequenceFileList.remove(tsFileResource);
+      }
     }
   }
 
   @Override
   public void removeAll(List<TsFileResource> tsFileResourceList, boolean sequence) {
-    if (sequence) {
-      sequenceFileTreeSet.removeAll(tsFileResourceList);
-    } else {
-      unSequenceFileList.removeAll(tsFileResourceList);
+    if (tsFileResourceList.size() > 0) {
+      tsFileResourceList.sort((o1, o2) -> (int) (o1.getTimePartition() - o2.getTimePartition()));
+      if (sequence) {
+        synchronized (sequenceFileTreeSetMap) {
+          long currTimePartition = tsFileResourceList.get(0).getTimePartition();
+          int startIndex = 0;
+          for (int i = 1; i < tsFileResourceList.size(); i++) {
+            TsFileResource tsFileResource = tsFileResourceList.get(i);
+            if (tsFileResource.getTimePartition() != currTimePartition) {
+              sequenceFileTreeSetMap
+                  .get(currTimePartition)
+                  .removeAll(tsFileResourceList.subList(startIndex, i));
+              currTimePartition = tsFileResource.getTimePartition();
+              startIndex = i;
+            }
+          }
+          sequenceFileTreeSetMap
+              .get(currTimePartition)
+              .removeAll(tsFileResourceList.subList(startIndex, tsFileResourceList.size()));
+        }
+      } else {
+        synchronized (unSequenceFileListMap) {
+          long currTimePartition = tsFileResourceList.get(0).getTimePartition();
+          int startIndex = 0;
+          for (int i = 1; i < tsFileResourceList.size(); i++) {
+            TsFileResource tsFileResource = tsFileResourceList.get(i);
+            if (tsFileResource.getTimePartition() != currTimePartition) {
+              unSequenceFileListMap
+                  .get(currTimePartition)
+                  .removeAll(tsFileResourceList.subList(startIndex, i));
+              currTimePartition = tsFileResource.getTimePartition();
+              startIndex = i;
+            }
+          }
+          unSequenceFileListMap
+              .get(currTimePartition)
+              .removeAll(tsFileResourceList.subList(startIndex, tsFileResourceList.size()));
+        }
+      }
     }
   }
 
   @Override
   public void add(TsFileResource tsFileResource, boolean sequence) {
+    long timePartitionId = tsFileResource.getTimePartition();
     if (sequence) {
-      sequenceFileTreeSet.add(tsFileResource);
+      synchronized (sequenceFileTreeSetMap) {
+        sequenceFileTreeSetMap
+            .computeIfAbsent(timePartitionId, this::newSequenceTsFileResources)
+            .add(tsFileResource);
+      }
     } else {
-      unSequenceFileList.add(tsFileResource);
+      synchronized (unSequenceFileListMap) {
+        unSequenceFileListMap
+            .computeIfAbsent(timePartitionId, this::newUnSequenceTsFileResources)
+            .add(tsFileResource);
+      }
     }
   }
 
@@ -98,44 +170,73 @@ public class NoCompactionTsFileManagement extends TsFileManagement {
 
   @Override
   public void addAll(List<TsFileResource> tsFileResourceList, boolean sequence) {
-    if (sequence) {
-      sequenceFileTreeSet.addAll(tsFileResourceList);
-    } else {
-      unSequenceFileList.addAll(tsFileResourceList);
+    for (TsFileResource tsFileResource : tsFileResourceList) {
+      add(tsFileResource, sequence);
     }
   }
 
   @Override
   public boolean contains(TsFileResource tsFileResource, boolean sequence) {
     if (sequence) {
-      return sequenceFileTreeSet.contains(tsFileResource);
+      synchronized (sequenceFileTreeSetMap) {
+        return sequenceFileTreeSetMap
+            .getOrDefault(tsFileResource.getTimePartition(), newSequenceTsFileResources(0L))
+            .contains(tsFileResource);
+      }
     } else {
-      return unSequenceFileList.contains(tsFileResource);
+      synchronized (unSequenceFileListMap) {
+        return unSequenceFileListMap
+            .getOrDefault(tsFileResource.getTimePartition(), new ArrayList<>())
+            .contains(tsFileResource);
+      }
     }
   }
 
   @Override
   public void clear() {
-    sequenceFileTreeSet.clear();
-    unSequenceFileList.clear();
+    sequenceFileTreeSetMap.clear();
+    unSequenceFileListMap.clear();
   }
 
   @Override
   public boolean isEmpty(boolean sequence) {
     if (sequence) {
-      return sequenceFileTreeSet.isEmpty();
+      synchronized (sequenceFileTreeSetMap) {
+        for (Set<TsFileResource> sequenceFileTreeSet : sequenceFileTreeSetMap.values()) {
+          if (!sequenceFileTreeSet.isEmpty()) {
+            return false;
+          }
+        }
+      }
     } else {
-      return unSequenceFileList.isEmpty();
+      synchronized (unSequenceFileListMap) {
+        for (List<TsFileResource> unSequenceFileList : unSequenceFileListMap.values()) {
+          if (!unSequenceFileList.isEmpty()) {
+            return false;
+          }
+        }
+      }
     }
+    return true;
   }
 
   @Override
   public int size(boolean sequence) {
+    int result = 0;
     if (sequence) {
-      return sequenceFileTreeSet.size();
+      synchronized (sequenceFileTreeSetMap) {
+        for (Set<TsFileResource> sequenceFileTreeSet : sequenceFileTreeSetMap.values()) {
+          result += sequenceFileTreeSet.size();
+        }
+      }
     } else {
-      return unSequenceFileList.size();
+      synchronized (unSequenceFileListMap) {
+        for (List<TsFileResource> unSequenceFileList : unSequenceFileListMap.values()) {
+          result += unSequenceFileList.size();
+        }
+      }
     }
+    return result;
   }
 
   @Override
@@ -151,5 +252,13 @@ public class NoCompactionTsFileManagement extends TsFileManagement {
   @Override
   protected void merge(long timePartition) {
     logger.info("{} no merge logic", storageGroupName);
+  }
+
+  private TreeSet<TsFileResource> newSequenceTsFileResources(Long k) {
+    return new TreeSet<>((o1, o2) -> compareFileName(o1.getTsFile(), o2.getTsFile()));
+  }
+
+  private List<TsFileResource> newUnSequenceTsFileResources(Long k) {
+    return new ArrayList<>();
   }
 }


### PR DESCRIPTION
## Behavior
A ci bug behave like below:
![image](https://user-images.githubusercontent.com/24886743/112608587-761e6580-8e55-11eb-8860-e1ebd2d9dc3f.png)

## Reason

The problem happens in LevelCompaction. The compaction process get all seq files to merge with unseq files in one time partition t1. And the unseq compaction may select seq files which is not in time partition t1. This operation may destroy the time partition structure.

this is a cherry-pick of PR #2920 

## Solution 1
Just submit seq files in time partition t1 for unseq compaction in `LevelCompactionTsFileManagement`.
We changed the management of the `TsFileResourceList` to groups by time partition in `NoCompactionTsFileManagement`.
We deprecated the `getTsFileList()` method.

## Solution 2 (not implemented)
Make unseq compaction not select seq files exceed end time of each unseq file.
We cannot implement this by adding condition `unseqEndTime >= seqStartTime` in `selectOverlappedFile`. Reason: 
Case there are
-  a seq file file1 with time range (0-6099),
- a seq file file2 with time range (6300-6399), 
- a seq file file3 with time range (7300-7399), 
- a seq file file4 with time range (8300-8399), 
- a seq file file5 with time range (9300-9399), 
- an unseq file file6 with time range (7000-7099), 
- an unseq file file7 with time range (8000-8099), 
- an unseq file file8 with time range (9000-9099), 
- an unseq file file9 with time range (0-100). 

For unseq file file6, it does not satisfy the condition `unseqStartTime <= seqEndTime` for file1, file2.
And for file3, the unseq file file6 will satisfy the condition `unseqEndTime >= seqStartTime` which is filtered.
So we can just select only an unseq file file6. 
This also applies to the next two files.
And when we check unseq file file9, seq file file1 will be selected.
Then we just select seq file file1, unseq file file6 file7 file8 file9. When they merge, will get a file with time range (0-9099), which is wrong.