### PR TITLE
[IOTDB-1267] optimize ServerTimeGenerator IExpression parameter

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterDataQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterDataQueryExecutor.java
@@ -38,7 +38,6 @@ import org.apache.iotdb.db.query.executor.RawDataQueryExecutor;
 import org.apache.iotdb.db.query.reader.series.IReaderByTimestamp;
 import org.apache.iotdb.db.query.reader.series.ManagedSeriesReader;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.GlobalTimeExpression;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
@@ -200,11 +199,9 @@ public class ClusterDataQueryExecutor extends RawDataQueryExecutor {
   }
 
   @Override
-  protected TimeGenerator getTimeGenerator(
-      IExpression queryExpression, QueryContext context, RawDataQueryPlan rawDataQueryPlan)
+  protected TimeGenerator getTimeGenerator(QueryContext context, RawDataQueryPlan rawDataQueryPlan)
       throws StorageEngineException {
-    return new ClusterTimeGenerator(
-        queryExpression, context, metaGroupMember, rawDataQueryPlan, false);
+    return new ClusterTimeGenerator(context, metaGroupMember, rawDataQueryPlan, false);
   }
 
   @Override
@@ -214,8 +211,7 @@ public class ClusterDataQueryExecutor extends RawDataQueryExecutor {
       if (hasValueFilter) {
         // 1. check time Generator has local data
         ClusterTimeGenerator clusterTimeGenerator =
-            new ClusterTimeGenerator(
-                queryPlan.getExpression(), context, metaGroupMember, queryPlan, true);
+            new ClusterTimeGenerator(context, metaGroupMember, queryPlan, true);
         if (clusterTimeGenerator.isHasLocalReader()) {
           this.hasLocalReader = true;
           this.endPoint = null;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/aggregate/ClusterAggregateExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/aggregate/ClusterAggregateExecutor.java
@@ -85,7 +85,7 @@ public class ClusterAggregateExecutor extends AggregationExecutor {
   @Override
   protected TimeGenerator getTimeGenerator(QueryContext context, RawDataQueryPlan rawDataQueryPlan)
       throws StorageEngineException {
-    return new ClusterTimeGenerator(expression, context, metaMember, rawDataQueryPlan, false);
+    return new ClusterTimeGenerator(context, metaMember, rawDataQueryPlan, false);
   }
 
   @Override

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/ClusterGroupByVFilterDataSet.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/ClusterGroupByVFilterDataSet.java
@@ -33,7 +33,6 @@ import org.apache.iotdb.db.query.dataset.groupby.GroupByWithValueFilterDataSet;
 import org.apache.iotdb.db.query.filter.TsFileFilter;
 import org.apache.iotdb.db.query.reader.series.IReaderByTimestamp;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.read.query.timegenerator.TimeGenerator;
 
 import java.util.ArrayList;
@@ -60,10 +59,9 @@ public class ClusterGroupByVFilterDataSet extends GroupByWithValueFilterDataSet 
   }
 
   @Override
-  protected TimeGenerator getTimeGenerator(
-      IExpression expression, QueryContext context, RawDataQueryPlan rawDataQueryPlan)
+  protected TimeGenerator getTimeGenerator(QueryContext context, RawDataQueryPlan rawDataQueryPlan)
       throws StorageEngineException {
-    return new ClusterTimeGenerator(expression, context, metaGroupMember, rawDataQueryPlan, false);
+    return new ClusterTimeGenerator(context, metaGroupMember, rawDataQueryPlan, false);
   }
 
   @Override

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterTimeGenerator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterTimeGenerator.java
@@ -58,7 +58,6 @@ public class ClusterTimeGenerator extends ServerTimeGenerator {
 
   /** Constructor of EngineTimeGenerator. */
   public ClusterTimeGenerator(
-      IExpression expression,
       QueryContext context,
       MetaGroupMember metaGroupMember,
       RawDataQueryPlan rawDataQueryPlan,
@@ -70,9 +69,10 @@ public class ClusterTimeGenerator extends ServerTimeGenerator {
     try {
       readerFactory.syncMetaGroup();
       if (onlyCheckLocalData) {
-        whetherHasLocalDataGroup(expression, metaGroupMember, queryPlan.isAscending());
+        whetherHasLocalDataGroup(
+            queryPlan.getExpression(), metaGroupMember, queryPlan.isAscending());
       } else {
-        constructNode(expression);
+        constructNode(queryPlan.getExpression());
       }
     } catch (IOException | CheckConsistencyException e) {
       throw new StorageEngineException(e);

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/reader/ClusterTimeGeneratorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/reader/ClusterTimeGeneratorTest.java
@@ -62,7 +62,7 @@ public class ClusterTimeGeneratorTest extends BaseQueryTest {
       dataQueryPlan.addDeduplicatedPaths(new PartialPath(TestUtils.getTestSeries(1, 1)));
 
       ClusterTimeGenerator timeGenerator =
-          new ClusterTimeGenerator(expression, context, testMetaMember, dataQueryPlan, false);
+          new ClusterTimeGenerator(context, testMetaMember, dataQueryPlan, false);
       for (int i = 3; i <= 8; i++) {
         assertTrue(timeGenerator.hasNext());
         assertEquals(i, timeGenerator.next());

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
@@ -39,7 +39,6 @@ import org.apache.iotdb.db.utils.TestOnly;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
-import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.read.query.timegenerator.TimeGenerator;
 import org.apache.iotdb.tsfile.utils.Pair;
 
@@ -81,8 +80,7 @@ public class GroupByWithValueFilterDataSet extends GroupByEngineDataSet {
   /** init reader and aggregate function. */
   protected void initGroupBy(QueryContext context, GroupByTimePlan groupByTimePlan)
       throws StorageEngineException, QueryProcessException {
-    this.timestampGenerator =
-        getTimeGenerator(groupByTimePlan.getExpression(), context, groupByTimePlan);
+    this.timestampGenerator = getTimeGenerator(context, groupByTimePlan);
     this.allDataReaderList = new ArrayList<>();
     this.groupByTimePlan = groupByTimePlan;
 
@@ -100,10 +98,9 @@ public class GroupByWithValueFilterDataSet extends GroupByEngineDataSet {
     }
   }
 
-  protected TimeGenerator getTimeGenerator(
-      IExpression expression, QueryContext context, RawDataQueryPlan queryPlan)
+  protected TimeGenerator getTimeGenerator(QueryContext context, RawDataQueryPlan queryPlan)
       throws StorageEngineException {
-    return new ServerTimeGenerator(expression, context, queryPlan);
+    return new ServerTimeGenerator(context, queryPlan);
   }
 
   protected IReaderByTimestamp getReaderByTime(

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
@@ -390,7 +390,7 @@ public class AggregationExecutor {
 
   protected TimeGenerator getTimeGenerator(QueryContext context, RawDataQueryPlan queryPlan)
       throws StorageEngineException {
-    return new ServerTimeGenerator(expression, context, queryPlan);
+    return new ServerTimeGenerator(context, queryPlan);
   }
 
   protected IReaderByTimestamp getReaderByTime(

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/RawDataQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/RawDataQueryExecutor.java
@@ -36,7 +36,6 @@ import org.apache.iotdb.db.query.reader.series.SeriesRawDataBatchReader;
 import org.apache.iotdb.db.query.reader.series.SeriesReaderByTimestamp;
 import org.apache.iotdb.db.query.timegenerator.ServerTimeGenerator;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.GlobalTimeExpression;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
@@ -146,8 +145,7 @@ public class RawDataQueryExecutor {
       return dataSet;
     }
 
-    TimeGenerator timestampGenerator =
-        getTimeGenerator(queryPlan.getExpression(), context, queryPlan);
+    TimeGenerator timestampGenerator = getTimeGenerator(context, queryPlan);
     List<Boolean> cached =
         markFilterdPaths(
             queryPlan.getExpression(),
@@ -204,10 +202,9 @@ public class RawDataQueryExecutor {
         queryPlan.isAscending());
   }
 
-  protected TimeGenerator getTimeGenerator(
-      IExpression expression, QueryContext context, RawDataQueryPlan queryPlan)
+  protected TimeGenerator getTimeGenerator(QueryContext context, RawDataQueryPlan queryPlan)
       throws StorageEngineException {
-    return new ServerTimeGenerator(expression, context, queryPlan);
+    return new ServerTimeGenerator(context, queryPlan);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/UDTFQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/UDTFQueryExecutor.java
@@ -58,8 +58,7 @@ public class UDTFQueryExecutor extends RawDataQueryExecutor {
 
   public QueryDataSet executeWithValueFilterAlignByTime(QueryContext context)
       throws StorageEngineException, QueryProcessException, IOException {
-    TimeGenerator timestampGenerator =
-        getTimeGenerator(udtfPlan.getExpression(), context, udtfPlan);
+    TimeGenerator timestampGenerator = getTimeGenerator(context, udtfPlan);
     List<Boolean> cached =
         markFilterdPaths(
             udtfPlan.getExpression(),
@@ -90,8 +89,7 @@ public class UDTFQueryExecutor extends RawDataQueryExecutor {
 
   public QueryDataSet executeWithValueFilterNonAlign(QueryContext context)
       throws QueryProcessException, StorageEngineException, IOException {
-    TimeGenerator timestampGenerator =
-        getTimeGenerator(udtfPlan.getExpression(), context, udtfPlan);
+    TimeGenerator timestampGenerator = getTimeGenerator(context, udtfPlan);
     List<Boolean> cached =
         markFilterdPaths(
             udtfPlan.getExpression(),

--- a/server/src/main/java/org/apache/iotdb/db/query/timegenerator/ServerTimeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/timegenerator/ServerTimeGenerator.java
@@ -58,13 +58,12 @@ public class ServerTimeGenerator extends TimeGenerator {
   }
 
   /** Constructor of EngineTimeGenerator. */
-  public ServerTimeGenerator(
-      IExpression expression, QueryContext context, RawDataQueryPlan queryPlan)
+  public ServerTimeGenerator(QueryContext context, RawDataQueryPlan queryPlan)
       throws StorageEngineException {
     this.context = context;
     this.queryPlan = queryPlan;
     try {
-      serverConstructNode(expression);
+      serverConstructNode(queryPlan.getExpression());
     } catch (IOException e) {
       throw new StorageEngineException(e);
     }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
+import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.timegenerator.ServerTimeGenerator;
@@ -188,7 +189,7 @@ public class IoTDBEngineTimeGeneratorIT {
   /** value >= 14 && time > 500 */
   @Test
   public void testOneSeriesWithValueAndTimeFilter()
-      throws IOException, StorageEngineException, IllegalPathException {
+      throws IOException, StorageEngineException, IllegalPathException, QueryProcessException {
     // System.out.println("Test >>> root.vehicle.d0.s0 >= 14 && time > 500");
 
     PartialPath pd0s0 =
@@ -202,8 +203,8 @@ public class IoTDBEngineTimeGeneratorIT {
     List<PartialPath> paths = new ArrayList<>();
     paths.add(pd0s0);
     queryPlan.setDeduplicatedPaths(paths);
-    ServerTimeGenerator timeGenerator =
-        new ServerTimeGenerator(singleSeriesExpression, TEST_QUERY_CONTEXT, queryPlan);
+    queryPlan.setExpression(singleSeriesExpression);
+    ServerTimeGenerator timeGenerator = new ServerTimeGenerator(TEST_QUERY_CONTEXT, queryPlan);
 
     int cnt = 0;
     while (timeGenerator.hasNext()) {
@@ -218,7 +219,7 @@ public class IoTDBEngineTimeGeneratorIT {
   /** root.vehicle.d1.s0 >= 5, and d1.s0 has no data */
   @Test
   public void testEmptySeriesWithValueFilter()
-      throws IOException, StorageEngineException, IllegalPathException {
+      throws IOException, StorageEngineException, IllegalPathException, QueryProcessException {
     // System.out.println("Test >>> root.vehicle.d1.s0 >= 5");
 
     PartialPath pd1s0 =
@@ -230,9 +231,8 @@ public class IoTDBEngineTimeGeneratorIT {
     List<PartialPath> paths = new ArrayList<>();
     paths.add(pd1s0);
     queryPlan.setDeduplicatedPaths(paths);
-
-    ServerTimeGenerator timeGenerator =
-        new ServerTimeGenerator(singleSeriesExpression, TEST_QUERY_CONTEXT, queryPlan);
+    queryPlan.setExpression(singleSeriesExpression);
+    ServerTimeGenerator timeGenerator = new ServerTimeGenerator(TEST_QUERY_CONTEXT, queryPlan);
 
     int cnt = 0;
     while (timeGenerator.hasNext()) {
@@ -244,7 +244,7 @@ public class IoTDBEngineTimeGeneratorIT {
   /** root.vehicle.d0.s0 >= 5 && root.vehicle.d0.s2 >= 11.5 || time > 900 */
   @Test
   public void testMultiSeriesWithValueFilterAndTimeFilter()
-      throws IOException, StorageEngineException, IllegalPathException {
+      throws IOException, StorageEngineException, IllegalPathException, QueryProcessException {
     System.out.println(
         "Test >>> root.vehicle.d0.s0 >= 5 && root.vehicle.d0.s2 >= 11.5 || time > 900");
 
@@ -269,8 +269,8 @@ public class IoTDBEngineTimeGeneratorIT {
     paths.add(pd0s0);
     paths.add(pd0s2);
     queryPlan.setDeduplicatedPaths(paths);
-    ServerTimeGenerator timeGenerator =
-        new ServerTimeGenerator(andExpression, TEST_QUERY_CONTEXT, queryPlan);
+    queryPlan.setExpression(andExpression);
+    ServerTimeGenerator timeGenerator = new ServerTimeGenerator(TEST_QUERY_CONTEXT, queryPlan);
     int cnt = 0;
     while (timeGenerator.hasNext()) {
       long time = timeGenerator.next();


### PR DESCRIPTION
More, in public ServerTimeGenerator(IExpression expression, QueryContext context, RawDataQueryPlan queryPlan) , we should remove IExpression expression, and use queryPlan.getExpression instead.