### PR TITLE
[IOTDB-1266]SHOW TIMESERIES will only display 2000 timeseries

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -1697,7 +1697,11 @@ public class CMManager extends MManager {
     // do not use limit and offset in sub-queries unless offset is 0, otherwise the results are
     // not combinable
     if (offset != 0) {
-      plan.setLimit(0);
+      if (limit > Integer.MAX_VALUE - offset) {
+        plan.setLimit(0);
+      } else {
+        plan.setLimit(limit + offset);
+      }
       plan.setOffset(0);
     }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -1649,6 +1649,11 @@ public class CMManager extends MManager {
     // do not use limit and offset in sub-queries unless offset is 0, otherwise the results are
     // not combinable
     if (offset != 0) {
+      if (limit > Integer.MAX_VALUE - offset) {
+        plan.setLimit(0);
+      } else {
+        plan.setLimit(limit + offset);
+      }
       plan.setOffset(0);
     }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -1649,7 +1649,6 @@ public class CMManager extends MManager {
     // do not use limit and offset in sub-queries unless offset is 0, otherwise the results are
     // not combinable
     if (offset != 0) {
-      plan.setLimit(0);
       plan.setOffset(0);
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowPlan.java
@@ -51,7 +51,6 @@ public class ShowPlan extends PhysicalPlan {
     this.limit = limit;
     this.offset = offset;
     if (limit == 0) {
-      this.limit = fetchSize;
       this.hasLimit = false;
     } else {
       this.hasLimit = true;

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/ShowDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/ShowDataSet.java
@@ -28,7 +28,6 @@ import org.apache.iotdb.tsfile.read.common.RowRecord;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.utils.Binary;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,16 +42,7 @@ public abstract class ShowDataSet extends QueryDataSet {
   }
 
   @Override
-  public boolean hasNextWithoutConstraint() throws IOException {
-    if (index == result.size() && !hasLimit && result.size() == plan.getLimit()) {
-      plan.setOffset(plan.getOffset() + plan.getLimit());
-      try {
-        result = getQueryDataSet();
-        index = 0;
-      } catch (MetadataException e) {
-        throw new IOException(e);
-      }
-    }
+  public boolean hasNextWithoutConstraint() {
     return index < result.size();
   }
 

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -132,16 +132,18 @@ public abstract class Cases {
     String timeSeries;
     for (int i = 0; i < n; i++) {
       timeSeries = timeSeriesPrefix + String.valueOf(i) + timeSeriesSuffix;
-      statement.execute(String.format("create timeseries %s ", timeSeries));
+      writeStatement.execute(String.format("create timeseries %s ", timeSeries));
     }
 
-    ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES");
-    int cnt = 0;
-    while (resultSet.next()) {
-      cnt++;
+    // try to read data on each node.
+    for (Statement readStatement : readStatements) {
+      ResultSet resultSet = readStatement.executeQuery("SHOW TIMESERIES");
+      int cnt = 0;
+      while (resultSet.next()) {
+        cnt++;
+      }
+      Assert.assertEquals(n, cnt);
+      resultSet.close();
     }
-    Assert.assertEquals(n, cnt);
-
-    resultSet.close();
   }
 }

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -121,4 +121,27 @@ public abstract class Cases {
       resultSet.close();
     }
   }
+
+  // test https://issues.apache.org/jira/browse/IOTDB-1266
+  @Test
+  public void showTimeseriesRowsTest() throws SQLException {
+
+    int n = 3000;
+    String timeSeriesPrefix = "root.ln.wf01.wt";
+    String timeSeriesSuffix = ".temperature WITH DATATYPE=DOUBLE, ENCODING=RLE";
+    String timeSeries;
+    for (int i = 0; i < n; i++) {
+      timeSeries = timeSeriesPrefix + String.valueOf(i) + timeSeriesSuffix;
+      statement.execute(String.format("create timeseries %s ", timeSeries));
+    }
+
+    ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES");
+    int cnt = 0;
+    while (resultSet.next()) {
+      cnt++;
+    }
+    Assert.assertEquals(n, cnt);
+
+    resultSet.close();
+  }
 }


### PR DESCRIPTION
## Description
In current cluster version, if we have more than 2,000 timeseries, when we commend SHOW TIMESERIES, it will only display 2,000 timeseries, the same as the SHOW DEVICES...

In the default settings, if we do not set any limit, the default plan.limit will be 1000(set as the fetchsize). This is weird, because if we do not set the limit, it means that I want to fetch all the data instead of fetchsize. So I remove it.

In my opinion, hasNextWithoutConstraint() method is not correct: after I have already fetched all the timeseries, it is not necessary to do fetch again... 
For example, 
if we have 10,000 timeseries, so the result.size() should be 10,000. 
After the first display(fetch size==1000), it will only display the first 1000 timeseries, 
now the index is 1000, so it is still index < result.size() and it will keep display the rest. 

And there is the only extreme condition we need this method, if we do not set any limit value, it means that we want to fetch all the data, but if the data size is bigger than Integer.MAX_VALUE, the exceed part cannot be displayed. Then we need to do second fetch.. 

I think it is unnecessary because the user may not want to display more than Integer.MAX_VALUE timeseries...
Please correct me if I am wrong, Thanks a lot!