### PR TITLE
[IoTDB-1272][to rel/0.11][Python] the session api does not infer the data as correct type

### DIFF
--- a/client-py/src/iotdb/Session.py
+++ b/client-py/src/iotdb/Session.py
@@ -26,7 +26,7 @@ from .utils.IoTDBConstants import *
 from thrift.protocol import TBinaryProtocol, TCompactProtocol
 from thrift.transport import TSocket, TTransport
 
-from .thrift.rpc.TSIService import Client, TSCreateTimeseriesReq, TSInsertRecordReq, TSInsertTabletReq, \
+from .thrift.rpc.TSIService import Client, TSCreateTimeseriesReq, TSInsertRecordReq, TSInsertStringRecordReq, TSInsertTabletReq, \
      TSExecuteStatementReq, TSOpenSessionReq, TSCreateMultiTimeseriesReq, TSCloseSessionReq, TSInsertTabletsReq, TSInsertRecordsReq
 from .thrift.rpc.ttypes import TSDeleteDataReq, TSProtocolVersion, TSSetTimeZoneReq
 
@@ -212,8 +212,8 @@ class Session(object):
     def insert_str_record(self, device_id, timestamp, measurements, string_values):
         """ special case for inserting one row of String (TEXT) value """
         data_types = [TSDataType.TEXT.value for _ in string_values]
-        request = self.gen_insert_record_req(device_id, timestamp, measurements, data_types, string_values)
-        status = self.__client.insertRecord(request)
+        request = self.gen_insert_str_record_req(device_id, timestamp, measurements, data_types, string_values)
+        status = self.__client.insertStringRecord(request)
         print("insert one record to device {} message: {}".format(device_id, status.message))
 
     def insert_record(self, device_id, timestamp, measurements, data_types, values):
@@ -291,6 +291,14 @@ class Session(object):
             return
         values_in_bytes = Session.value_to_bytes(data_types, values)
         return TSInsertRecordReq(self.__session_id, device_id, measurements, values_in_bytes, timestamp)
+
+    def gen_insert_str_record_req(self, device_id, timestamp, measurements, data_types, values):
+            if (len(values) != len(data_types)) or (len(values) != len(measurements)):
+                print("length of data types does not equal to length of values!")
+                # could raise an error here.
+                return
+            values_in_bytes = Session.value_to_bytes(data_types, values)
+            return TSInsertStringRecordReq(self.__session_id, device_id, measurements, values_in_bytes, timestamp)
 
     def gen_insert_records_req(self, device_ids, times, measurements_lst, types_lst, values_lst):
         if (len(device_ids) != len(measurements_lst)) or (len(times) != len(types_lst)) or \


### PR DESCRIPTION
IoTDB Java session API supports inferring data type, by using `InsertStringRecord`.

Python API also has a similar API, called `insert_str_record`. 

However, it does not infer the data type. Instead, it considers all values as strings.

Reason: 

the API should call `insertStringRecord`, but it calls `insertRecord` now.