### PR TITLE
[IOTDB-1277] Flink IoTDB source 

### DIFF
--- a/docs/UserGuide/Ecosystem Integration/Flink IoTDB.md
+++ b/docs/UserGuide/Ecosystem Integration/Flink IoTDB.md
@@ -21,14 +21,14 @@
 
 ## IoTDB-Flink-Connector 
 
-IoTDB integration for [Apache Flink](https://flink.apache.org/). This module includes the iotdb sink that allows a flink job to write events into timeseries.
+IoTDB integration for [Apache Flink](https://flink.apache.org/). This module includes the IoTDB sink that allows a flink job to write events into timeseries, and the IoTDB source allowing reading data from IoTDB.
 
 ### IoTDBSink
 
-To use the `IoTDBSink`,  you need construct an instance of it by specifying `IoTDBOptions` and `IoTSerializationSchema` instances.
+To use the `IoTDBSink`,  you need construct an instance of it by specifying `IoTDBSinkOptions` and `IoTSerializationSchema` instances.
 The `IoTDBSink` send only one event after another by default, but you can change to batch by invoking `withBatchSize(int)`. 
 
-### Example
+#### Example
 
 This example shows a case that sends data to a IoTDB server from a Flink job:
 
@@ -54,7 +54,7 @@ public class FlinkIoTDBSink {
     // run the flink job on local mini cluster
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-    IoTDBOptions options = new IoTDBOptions();
+    IoTDBSinkOptions options = new IoTDBSinkOptions();
     options.setHost("127.0.0.1");
     options.setPort(6667);
     options.setUser("root");
@@ -65,7 +65,7 @@ public class FlinkIoTDBSink {
     // here.
     options.setTimeseriesOptionList(
         Lists.newArrayList(
-            new IoTDBOptions.TimeseriesOption(
+            new IoTDBSinkOptions.TimeseriesOption(
                 "root.sg.d1.s1", TSDataType.DOUBLE, TSEncoding.GORILLA, CompressionType.SNAPPY)));
 
     IoTSerializationSchema serializationSchema = new DefaultIoTSerializationSchema();
@@ -118,7 +118,100 @@ public class FlinkIoTDBSink {
 
 
 
-### Usage
+#### Usage
 
 * Launch the IoTDB server.
 * Run `org.apache.iotdb.flink.FlinkIoTDBSink.java` to run the flink job on local mini cluster.
+
+### IoTDBSource
+To use the `IoTDBSource`, you need to construct an instance of `IoTDBSource` by specifying `IoTDBSourceOptions`
+and implementing the abstract method `convert()` in `IoTDBSource`. The `convert` methods defines how 
+you want the row data to be transformed.
+
+#### Example
+This example shows a case where data are read from IoTDB.
+```java
+import org.apache.iotdb.flink.options.IoTDBSourceOptions;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.session.Session;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.common.RowRecord;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FlinkIoTDBSource {
+
+  static final String LOCAL_HOST = "127.0.0.1";
+  static final String ROOT_SG1_D1_S1 = "root.sg1.d1.s1";
+  static final String ROOT_SG1_D1 = "root.sg1.d1";
+
+  public static void main(String[] args) throws Exception {
+    prepareData();
+
+    // run the flink job on local mini cluster
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+    IoTDBSourceOptions ioTDBSourceOptions =
+        new IoTDBSourceOptions("127.0.0.1", 6667, "root", "root",
+            "select s1 from " + ROOT_SG1_D1 + " align by device");
+
+    env.addSource(
+        new IoTDBSource<RowRecord>(ioTDBSourceOptions) {
+          @Override
+          public RowRecord convert(RowRecord rowRecord) {
+            return rowRecord;
+          }
+        })
+        .name("sensor-source")
+        .print()
+        .setParallelism(2);
+    env.execute();
+  }
+
+  /**
+   * Write some data to IoTDB
+   */
+  private static void prepareData() throws IoTDBConnectionException, StatementExecutionException {
+    Session session = new Session(LOCAL_HOST, 6667, "root", "root");
+    session.open(false);
+    try {
+      session.setStorageGroup("root.sg1");
+      if (!session.checkTimeseriesExists(ROOT_SG1_D1_S1)) {
+        session.createTimeseries(
+            ROOT_SG1_D1_S1, TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
+        List<String> measurements = new ArrayList<>();
+        List<TSDataType> types = new ArrayList<>();
+        measurements.add("s1");
+        measurements.add("s2");
+        measurements.add("s3");
+        types.add(TSDataType.INT64);
+        types.add(TSDataType.INT64);
+        types.add(TSDataType.INT64);
+
+        for (long time = 0; time < 100; time++) {
+          List<Object> values = new ArrayList<>();
+          values.add(1L);
+          values.add(2L);
+          values.add(3L);
+          session.insertRecord(ROOT_SG1_D1, time, measurements, types, values);
+        }
+      }
+    } catch (StatementExecutionException e) {
+      if (e.getStatusCode() != TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode()) {
+        throw e;
+      }
+    }
+  }
+}
+```
+
+#### Usage
+Launch the IoTDB server.
+Run org.apache.iotdb.flink.FlinkIoTDBSource.java to run the flink job on local mini cluster.

--- a/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSink.java
+++ b/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSink.java
@@ -17,6 +17,7 @@
  */
 package org.apache.iotdb.flink;
 
+import org.apache.iotdb.flink.options.IoTDBSinkOptions;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -35,7 +36,7 @@ public class FlinkIoTDBSink {
     // run the flink job on local mini cluster
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-    IoTDBOptions options = new IoTDBOptions();
+    IoTDBSinkOptions options = new IoTDBSinkOptions();
     options.setHost("127.0.0.1");
     options.setPort(6667);
     options.setUser("root");
@@ -46,7 +47,7 @@ public class FlinkIoTDBSink {
     // here.
     options.setTimeseriesOptionList(
         Lists.newArrayList(
-            new IoTDBOptions.TimeseriesOption(
+            new IoTDBSinkOptions.TimeseriesOption(
                 "root.sg.d1.s1", TSDataType.DOUBLE, TSEncoding.GORILLA, CompressionType.SNAPPY)));
 
     IoTSerializationSchema serializationSchema = new DefaultIoTSerializationSchema();

--- a/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSource.java
+++ b/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSource.java
@@ -45,7 +45,12 @@ public class FlinkIoTDBSource {
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
     IoTDBSourceOptions ioTDBSourceOptions =
-        new IoTDBSourceOptions("127.0.0.1", 6667, "root", "root", "select s1 from " + ROOT_SG1_D1);
+        new IoTDBSourceOptions(
+            "127.0.0.1",
+            6667,
+            "root",
+            "root",
+            "select s1 from " + ROOT_SG1_D1 + " align by device");
 
     env.addSource(
             new IoTDBSource<RowRecord>(ioTDBSourceOptions) {

--- a/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSource.java
+++ b/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSource.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iotdb.flink;
+
+import org.apache.iotdb.flink.options.IoTDBSourceOptions;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.session.Session;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.common.RowRecord;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FlinkIoTDBSource {
+
+  static final String LOCAL_HOST = "127.0.0.1";
+  static final String ROOT_SG1_D1_S1 = "root.sg1.d1.s1";
+  static final String ROOT_SG1_D1 = "root.sg1.d1";
+
+  public static void main(String[] args) throws Exception {
+    prepareData();
+
+    // run the flink job on local mini cluster
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+    IoTDBSourceOptions ioTDBSourceOptions =
+        new IoTDBSourceOptions("127.0.0.1", 6667, "root", "root", "select s1 from " + ROOT_SG1_D1);
+
+    env.addSource(
+            new IoTDBSource<RowRecord>(ioTDBSourceOptions) {
+              @Override
+              public RowRecord convert(RowRecord rowRecord) {
+                return rowRecord;
+              }
+            })
+        .name("sensor-source")
+        .print()
+        .setParallelism(2);
+    env.execute();
+  }
+
+  /** Write some data to IoTDB */
+  private static void prepareData() throws IoTDBConnectionException, StatementExecutionException {
+    Session session = new Session(LOCAL_HOST, 6667, "root", "root");
+    session.open(false);
+    try {
+      session.setStorageGroup("root.sg1");
+      if (!session.checkTimeseriesExists(ROOT_SG1_D1_S1)) {
+        session.createTimeseries(
+            ROOT_SG1_D1_S1, TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
+        List<String> measurements = new ArrayList<>();
+        List<TSDataType> types = new ArrayList<>();
+        measurements.add("s1");
+        measurements.add("s2");
+        measurements.add("s3");
+        types.add(TSDataType.INT64);
+        types.add(TSDataType.INT64);
+        types.add(TSDataType.INT64);
+
+        for (long time = 0; time < 100; time++) {
+          List<Object> values = new ArrayList<>();
+          values.add(1L);
+          values.add(2L);
+          values.add(3L);
+          session.insertRecord(ROOT_SG1_D1, time, measurements, types, values);
+        }
+      }
+    } catch (StatementExecutionException e) {
+      if (e.getStatusCode() != TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode()) {
+        throw e;
+      }
+    }
+  }
+}

--- a/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSource.java
+++ b/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSource.java
@@ -18,10 +18,6 @@
 
 package org.apache.iotdb.flink;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.types.Row;
 import org.apache.iotdb.flink.options.IoTDBSourceOptions;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
@@ -31,6 +27,11 @@ import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class FlinkIoTDBSource {
 
@@ -46,22 +47,16 @@ public class FlinkIoTDBSource {
 
     IoTDBSourceOptions ioTDBSourceOptions =
         new IoTDBSourceOptions(
-            LOCAL_HOST,
-            6667,
-            "root",
-            "root",
-            "select s1 from " + ROOT_SG1_D1 + " align by device");
+            LOCAL_HOST, 6667, "root", "root", "select s1 from " + ROOT_SG1_D1 + " align by device");
 
-    IoTDBSource<RowRecord> source = new IoTDBSource<RowRecord>(ioTDBSourceOptions) {
-      @Override
-      public RowRecord convert(RowRecord rowRecord) {
-        return rowRecord;
-      }
-    };
-    env.addSource(source)
-        .name("sensor-source")
-        .print()
-        .setParallelism(2);
+    IoTDBSource<RowRecord> source =
+        new IoTDBSource<RowRecord>(ioTDBSourceOptions) {
+          @Override
+          public RowRecord convert(RowRecord rowRecord) {
+            return rowRecord;
+          }
+        };
+    env.addSource(source).name("sensor-source").print().setParallelism(2);
     env.execute();
   }
 

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.iotdb.flink;
 
+import org.apache.iotdb.flink.options.IoTDBSinkOptions;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.pool.SessionPool;
@@ -50,9 +51,9 @@ public class IoTDBSink<IN> extends RichSinkFunction<IN> {
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LoggerFactory.getLogger(IoTDBSink.class);
 
-  private IoTDBOptions options;
+  private IoTDBSinkOptions options;
   private IoTSerializationSchema<IN> serializationSchema;
-  private Map<String, IoTDBOptions.TimeseriesOption> timeseriesOptionMap;
+  private Map<String, IoTDBSinkOptions.TimeseriesOption> timeseriesOptionMap;
   private transient SessionPool pool;
   private transient ScheduledExecutorService scheduledExecutor;
 
@@ -61,12 +62,12 @@ public class IoTDBSink<IN> extends RichSinkFunction<IN> {
   private List<Event> batchList;
   private int sessionPoolSize = 2;
 
-  public IoTDBSink(IoTDBOptions options, IoTSerializationSchema<IN> schema) {
+  public IoTDBSink(IoTDBSinkOptions options, IoTSerializationSchema<IN> schema) {
     this.options = options;
     this.serializationSchema = schema;
     this.batchList = new LinkedList<>();
     this.timeseriesOptionMap = new HashMap<>();
-    for (IoTDBOptions.TimeseriesOption timeseriesOption : options.getTimeseriesOptionList()) {
+    for (IoTDBSinkOptions.TimeseriesOption timeseriesOption : options.getTimeseriesOptionList()) {
       timeseriesOptionMap.put(timeseriesOption.getPath(), timeseriesOption);
     }
   }
@@ -94,7 +95,7 @@ public class IoTDBSink<IN> extends RichSinkFunction<IN> {
       }
     }
 
-    for (IoTDBOptions.TimeseriesOption option : options.getTimeseriesOptionList()) {
+    for (IoTDBSinkOptions.TimeseriesOption option : options.getTimeseriesOptionList()) {
       if (!pool.checkTimeseriesExists(option.getPath())) {
         pool.createTimeseries(
             option.getPath(), option.getDataType(), option.getEncoding(), option.getCompressor());
@@ -191,7 +192,7 @@ public class IoTDBSink<IN> extends RichSinkFunction<IN> {
         && measurements.size() == values.size()) {
       for (int i = 0; i < measurements.size(); i++) {
         String measurement = device + TsFileConstant.PATH_SEPARATOR + measurements.get(i);
-        IoTDBOptions.TimeseriesOption timeseriesOption = timeseriesOptionMap.get(measurement);
+        IoTDBSinkOptions.TimeseriesOption timeseriesOption = timeseriesOptionMap.get(measurement);
         if (timeseriesOption != null && TSDataType.TEXT.equals(timeseriesOption.getDataType())) {
           // The TEXT data type should be covered by " or '
           values.set(i, "'" + values.get(i) + "'");

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
@@ -70,9 +70,7 @@ public abstract class IoTDBSource<T> extends RichSourceFunction<T> {
   public void cancel() {
     try {
       dataSet.closeOperationHandle();
-    } catch (StatementExecutionException e) {
-      e.printStackTrace();
-    } catch (IoTDBConnectionException e) {
+    } catch (StatementExecutionException | IoTDBConnectionException e) {
       e.printStackTrace();
     }
   }

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
@@ -1,0 +1,71 @@
+package org.apache.iotdb.flink;
+
+import org.apache.iotdb.flink.options.IoTDBSourceOptions;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.session.Session;
+import org.apache.iotdb.session.SessionDataSet;
+import org.apache.iotdb.tsfile.read.common.RowRecord;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class IoTDBSource<T> extends RichSourceFunction<T> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IoTDBSource.class);
+  private static final long serialVersionUID = 1L;
+  private IoTDBSourceOptions sourceOptions;
+
+  private transient Session session;
+  SessionDataSet dataSet;
+
+  public IoTDBSource(IoTDBSourceOptions ioTDBSourceOptions) {
+    this.sourceOptions = ioTDBSourceOptions;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    initSession();
+  }
+
+  public abstract T convert(RowRecord rowRecord);
+
+  @Override
+  public void run(SourceContext<T> sourceContext) throws Exception {
+    dataSet = session.executeQueryStatement(sourceOptions.getSql());
+    dataSet.setFetchSize(1024); // default is 10000
+    while (dataSet.hasNext()) {
+      sourceContext.collect(convert(dataSet.next()));
+    }
+    dataSet.closeOperationHandle();
+  }
+
+  @Override
+  public void cancel() {
+    try {
+      dataSet.closeOperationHandle();
+    } catch (StatementExecutionException e) {
+      e.printStackTrace();
+    } catch (IoTDBConnectionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    session.close();
+  }
+
+  void initSession() throws Exception {
+    session =
+        new Session(
+            sourceOptions.getHost(),
+            sourceOptions.getPort(),
+            sourceOptions.getUser(),
+            sourceOptions.getPassword());
+  }
+}

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
@@ -90,5 +90,6 @@ public abstract class IoTDBSource<T> extends RichSourceFunction<T> {
             sourceOptions.getPort(),
             sourceOptions.getUser(),
             sourceOptions.getPassword());
+    session.open();
   }
 }

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
@@ -59,7 +59,7 @@ public abstract class IoTDBSource<T> extends RichSourceFunction<T> {
   @Override
   public void run(SourceContext<T> sourceContext) throws Exception {
     dataSet = session.executeQueryStatement(sourceOptions.getSql());
-    dataSet.setFetchSize(1024); // default is 10000
+    dataSet.setFetchSize(sourceOptions.getFetchSize());
     while (dataSet.hasNext()) {
       sourceContext.collect(convert(dataSet.next()));
     }
@@ -78,6 +78,11 @@ public abstract class IoTDBSource<T> extends RichSourceFunction<T> {
   @Override
   public void close() throws Exception {
     super.close();
+    try {
+      dataSet.closeOperationHandle();
+    } catch (StatementExecutionException | IoTDBConnectionException e) {
+      e.printStackTrace();
+    }
     session.close();
   }
 

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.iotdb.flink;
 
 import org.apache.iotdb.flink.options.IoTDBSourceOptions;
@@ -31,6 +48,11 @@ public abstract class IoTDBSource<T> extends RichSourceFunction<T> {
     initSession();
   }
 
+  /**
+   * Convert raw data (in form of RowRecord) extracted from IoTDB to user-defined data type
+   * @param rowRecord, row record from IoTDB
+   * @return object in user-defined form
+   */
   public abstract T convert(RowRecord rowRecord);
 
   @Override

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSource.java
@@ -50,6 +50,7 @@ public abstract class IoTDBSource<T> extends RichSourceFunction<T> {
 
   /**
    * Convert raw data (in form of RowRecord) extracted from IoTDB to user-defined data type
+   *
    * @param rowRecord, row record from IoTDB
    * @return object in user-defined form
    */

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBOptions.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBOptions.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iotdb.flink.options;
+
+import java.io.Serializable;
+
+public class IoTDBOptions implements Serializable {
+
+  protected String host;
+  protected int port;
+  protected String user;
+  protected String password;
+
+  public IoTDBOptions(String host, int port, String user, String password) {
+    this.host = host;
+    this.port = port;
+    this.user = user;
+    this.password = password;
+  }
+
+  public IoTDBOptions() {}
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public void setUser(String user) {
+    this.user = user;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+}

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBOptions.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBOptions.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.iotdb.flink.options;
 
 import java.io.Serializable;

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSinkOptions.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSinkOptions.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.iotdb.flink;
+package org.apache.iotdb.flink.options;
 
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -26,61 +26,23 @@ import java.io.Serializable;
 import java.util.List;
 
 /** IoTDBOptions describes the configuration related information for IoTDB and timeseries. */
-public class IoTDBOptions implements Serializable {
-  private String host;
-  private int port;
-  private String user;
-  private String password;
+public class IoTDBSinkOptions extends IoTDBOptions {
+
   private String storageGroup;
   private List<TimeseriesOption> timeseriesOptionList;
 
-  public IoTDBOptions() {}
+  public IoTDBSinkOptions() {}
 
-  public IoTDBOptions(
+  public IoTDBSinkOptions(
       String host,
       int port,
       String user,
       String password,
       String storageGroup,
       List<TimeseriesOption> timeseriesOptionList) {
-    this.host = host;
-    this.port = port;
-    this.user = user;
-    this.password = password;
+    super(host, port, user, password);
     this.storageGroup = storageGroup;
     this.timeseriesOptionList = timeseriesOptionList;
-  }
-
-  public String getHost() {
-    return host;
-  }
-
-  public void setHost(String host) {
-    this.host = host;
-  }
-
-  public int getPort() {
-    return port;
-  }
-
-  public void setPort(int port) {
-    this.port = port;
-  }
-
-  public String getUser() {
-    return user;
-  }
-
-  public void setUser(String user) {
-    this.user = user;
-  }
-
-  public String getPassword() {
-    return password;
-  }
-
-  public void setPassword(String password) {
-    this.password = password;
   }
 
   public String getStorageGroup() {
@@ -100,6 +62,7 @@ public class IoTDBOptions implements Serializable {
   }
 
   public static class TimeseriesOption implements Serializable {
+
     private String path;
     private TSDataType dataType = TSDataType.TEXT;
     private TSEncoding encoding = TSEncoding.PLAIN;

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSourceOptions.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSourceOptions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iotdb.flink.options;
+
+public class IoTDBSourceOptions extends IoTDBOptions {
+  private String sql;
+
+  public IoTDBSourceOptions(String host, int port, String user, String password, String sql) {
+    super(host, port, user, password);
+    this.sql = sql;
+  }
+
+  public String getSql() {
+    return sql;
+  }
+
+  public void setSql(String sql) {
+    this.sql = sql;
+  }
+}

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSourceOptions.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSourceOptions.java
@@ -19,10 +19,17 @@ package org.apache.iotdb.flink.options;
 
 public class IoTDBSourceOptions extends IoTDBOptions {
   private String sql;
+  private int fetchSize;
 
   public IoTDBSourceOptions(String host, int port, String user, String password, String sql) {
+    this(host, port, user, password, sql, 1024);
+  }
+
+  public IoTDBSourceOptions(
+      String host, int port, String user, String password, String sql, int fetchSIze) {
     super(host, port, user, password);
     this.sql = sql;
+    this.fetchSize = fetchSIze;
   }
 
   public String getSql() {
@@ -31,5 +38,13 @@ public class IoTDBSourceOptions extends IoTDBOptions {
 
   public void setSql(String sql) {
     this.sql = sql;
+  }
+
+  public int getFetchSize() {
+    return fetchSize;
+  }
+
+  public void setFetchSize(int fetchSize) {
+    this.fetchSize = fetchSize;
   }
 }

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSourceOptions.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSourceOptions.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.iotdb.flink.options;
 
 public class IoTDBSourceOptions extends IoTDBOptions {

--- a/flink-iotdb-connector/src/test/java/org/apache/iotdb/flink/DefaultIoTSerializationSchemaTest.java
+++ b/flink-iotdb-connector/src/test/java/org/apache/iotdb/flink/DefaultIoTSerializationSchemaTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.iotdb.flink;
 
+import org.apache.iotdb.flink.options.IoTDBSinkOptions;
+
 import com.google.common.collect.Lists;
 import org.junit.Test;
 
@@ -30,9 +32,9 @@ public class DefaultIoTSerializationSchemaTest {
 
   @Test
   public void serialize() {
-    IoTDBOptions options = new IoTDBOptions();
+    IoTDBSinkOptions options = new IoTDBSinkOptions();
     options.setTimeseriesOptionList(
-        Lists.newArrayList(new IoTDBOptions.TimeseriesOption("root.sg.D01.temperature")));
+        Lists.newArrayList(new IoTDBSinkOptions.TimeseriesOption("root.sg.D01.temperature")));
     DefaultIoTSerializationSchema serializationSchema = new DefaultIoTSerializationSchema();
 
     Map<String, String> tuple = new HashMap();

--- a/flink-iotdb-connector/src/test/java/org/apache/iotdb/flink/IoTDBSinkBatchInsertTest.java
+++ b/flink-iotdb-connector/src/test/java/org/apache/iotdb/flink/IoTDBSinkBatchInsertTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.iotdb.flink;
 
+import org.apache.iotdb.flink.options.IoTDBSinkOptions;
 import org.apache.iotdb.session.pool.SessionPool;
 
 import com.google.common.collect.Lists;
@@ -40,9 +41,9 @@ public class IoTDBSinkBatchInsertTest {
 
   @Before
   public void setUp() {
-    IoTDBOptions options = new IoTDBOptions();
+    IoTDBSinkOptions options = new IoTDBSinkOptions();
     options.setTimeseriesOptionList(
-        Lists.newArrayList(new IoTDBOptions.TimeseriesOption("root.sg.D01.temperature")));
+        Lists.newArrayList(new IoTDBSinkOptions.TimeseriesOption("root.sg.D01.temperature")));
     ioTDBSink = new IoTDBSink(options, new DefaultIoTSerializationSchema());
     ioTDBSink.withBatchSize(3);
 

--- a/flink-iotdb-connector/src/test/java/org/apache/iotdb/flink/IoTDBSinkBatchTimerTest.java
+++ b/flink-iotdb-connector/src/test/java/org/apache/iotdb/flink/IoTDBSinkBatchTimerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.iotdb.flink;
 
+import org.apache.iotdb.flink.options.IoTDBSinkOptions;
 import org.apache.iotdb.session.pool.SessionPool;
 
 import com.google.common.collect.Lists;
@@ -40,9 +41,9 @@ public class IoTDBSinkBatchTimerTest {
 
   @Before
   public void setUp() {
-    IoTDBOptions options = new IoTDBOptions();
+    IoTDBSinkOptions options = new IoTDBSinkOptions();
     options.setTimeseriesOptionList(
-        Lists.newArrayList(new IoTDBOptions.TimeseriesOption("root.sg.D01.temperature")));
+        Lists.newArrayList(new IoTDBSinkOptions.TimeseriesOption("root.sg.D01.temperature")));
     ioTDBSink = new IoTDBSink(options, new DefaultIoTSerializationSchema());
     ioTDBSink.withBatchSize(3);
     ioTDBSink.withFlushIntervalMs(1000);

--- a/flink-iotdb-connector/src/test/java/org/apache/iotdb/flink/IoTDBSinkInsertTest.java
+++ b/flink-iotdb-connector/src/test/java/org/apache/iotdb/flink/IoTDBSinkInsertTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.iotdb.flink;
 
+import org.apache.iotdb.flink.options.IoTDBSinkOptions;
 import org.apache.iotdb.session.pool.SessionPool;
 
 import com.google.common.collect.Lists;
@@ -39,9 +40,9 @@ public class IoTDBSinkInsertTest {
 
   @Before
   public void setUp() throws Exception {
-    IoTDBOptions options = new IoTDBOptions();
+    IoTDBSinkOptions options = new IoTDBSinkOptions();
     options.setTimeseriesOptionList(
-        Lists.newArrayList(new IoTDBOptions.TimeseriesOption("root.sg.D01.temperature")));
+        Lists.newArrayList(new IoTDBSinkOptions.TimeseriesOption("root.sg.D01.temperature")));
     ioTDBSink = new IoTDBSink(options, new DefaultIoTSerializationSchema());
 
     pool = mock(SessionPool.class);


### PR DESCRIPTION
## Description
This pull request implements IoTDBSource in flink scenario.

### Options 
Now there are two types of options, one for IoTDBSink, another for IoTDBSource. I extracted common attributes to a super class, IoTDBOptions, and made the original one to be IoTDBSinkOptions, and created a new IoTDBSourceOptions.

### IoTDBSource
I implemented IoTDBSource, which reads data from IoTDB and organizes results in form of any user-defined data type. For the latter part, an abstract mathod called `convert()` is given so that whoever use it can determine the way they like to organize the results.
