### PR TITLE
optimize sync leader for meta

### DIFF
--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -171,5 +171,3 @@ max_client_pernode_permember_number=1000
 # we need to wait so much time for other connections to be released until timeout,
 # or a new connection will be created.
 wait_client_timeout_ms=5000
-
-enable_query_redirect=false

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
@@ -164,8 +164,6 @@ public class ClusterConfig {
 
   private boolean openServerRpcPort = false;
 
-  private boolean enableQueryRedirect = false;
-
   public int getSelectorNumOfClientPool() {
     return selectorNumOfClientPool;
   }
@@ -468,13 +466,5 @@ public class ClusterConfig {
 
   public void setWaitClientTimeoutMS(long waitClientTimeoutMS) {
     this.waitClientTimeoutMS = waitClientTimeoutMS;
-  }
-
-  public boolean isEnableQueryRedirect() {
-    return enableQueryRedirect;
-  }
-
-  public void setEnableQueryRedirect(boolean enableQueryRedirect) {
-    this.enableQueryRedirect = enableQueryRedirect;
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -299,11 +299,6 @@ public class ClusterDescriptor {
             properties.getProperty(
                 "wait_client_timeout_ms", String.valueOf(config.getWaitClientTimeoutMS()))));
 
-    config.setEnableQueryRedirect(
-        Boolean.parseBoolean(
-            properties.getProperty(
-                "enable_query_redirect", String.valueOf(config.isEnableQueryRedirect()))));
-
     String consistencyLevel = properties.getProperty("consistency_level");
     if (consistencyLevel != null) {
       config.setConsistencyLevel(ConsistencyLevel.getConsistencyLevel(consistencyLevel));

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/DataClusterServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/DataClusterServer.java
@@ -46,6 +46,7 @@ import org.apache.iotdb.cluster.rpc.thrift.PullSchemaRequest;
 import org.apache.iotdb.cluster.rpc.thrift.PullSchemaResp;
 import org.apache.iotdb.cluster.rpc.thrift.PullSnapshotRequest;
 import org.apache.iotdb.cluster.rpc.thrift.PullSnapshotResp;
+import org.apache.iotdb.cluster.rpc.thrift.RequestCommitIndexResponse;
 import org.apache.iotdb.cluster.rpc.thrift.SendSnapshotRequest;
 import org.apache.iotdb.cluster.rpc.thrift.SingleSeriesQueryRequest;
 import org.apache.iotdb.cluster.rpc.thrift.TSDataService;
@@ -307,7 +308,8 @@ public class DataClusterServer extends RaftServer
   }
 
   @Override
-  public void requestCommitIndex(Node header, AsyncMethodCallback<Long> resultHandler) {
+  public void requestCommitIndex(
+      Node header, AsyncMethodCallback<RequestCommitIndexResponse> resultHandler) {
     DataAsyncService service = getDataAsyncService(header, resultHandler, "Request commit index");
     if (service != null) {
       service.requestCommitIndex(header, resultHandler);
@@ -919,7 +921,7 @@ public class DataClusterServer extends RaftServer
   }
 
   @Override
-  public long requestCommitIndex(Node header) throws TException {
+  public RequestCommitIndexResponse requestCommitIndex(Node header) throws TException {
     return getDataSyncService(header).requestCommitIndex(header);
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/MetaClusterServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/MetaClusterServer.java
@@ -33,6 +33,7 @@ import org.apache.iotdb.cluster.rpc.thrift.ExecutNonQueryReq;
 import org.apache.iotdb.cluster.rpc.thrift.HeartBeatRequest;
 import org.apache.iotdb.cluster.rpc.thrift.HeartBeatResponse;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
+import org.apache.iotdb.cluster.rpc.thrift.RequestCommitIndexResponse;
 import org.apache.iotdb.cluster.rpc.thrift.SendSnapshotRequest;
 import org.apache.iotdb.cluster.rpc.thrift.StartUpStatus;
 import org.apache.iotdb.cluster.rpc.thrift.TNodeStatus;
@@ -224,7 +225,8 @@ public class MetaClusterServer extends RaftServer
   }
 
   @Override
-  public void requestCommitIndex(Node header, AsyncMethodCallback<Long> resultHandler) {
+  public void requestCommitIndex(
+      Node header, AsyncMethodCallback<RequestCommitIndexResponse> resultHandler) {
     asyncService.requestCommitIndex(header, resultHandler);
   }
 
@@ -331,7 +333,7 @@ public class MetaClusterServer extends RaftServer
   }
 
   @Override
-  public long requestCommitIndex(Node header) throws TException {
+  public RequestCommitIndexResponse requestCommitIndex(Node header) throws TException {
     return syncService.requestCommitIndex(header);
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -418,7 +418,7 @@ public abstract class RaftMember {
   }
 
   private void tryUpdateCommitIndex(long leaderTerm, long commitIndex, long commitTerm) {
-    if (term.get() == leaderTerm && logManager.getCommitLogIndex() < commitIndex) {
+    if (leaderTerm >= term.get() && logManager.getCommitLogIndex() < commitIndex) {
       // there are more local logs that can be committed, commit them in a ThreadPool so the
       // heartbeat response will not be blocked
       CommitLogTask commitLogTask = new CommitLogTask(logManager, commitIndex, commitTerm);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/service/BaseAsyncService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/service/BaseAsyncService.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.cluster.rpc.thrift.HeartBeatResponse;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.rpc.thrift.RaftService;
 import org.apache.iotdb.cluster.rpc.thrift.RaftService.AsyncClient;
+import org.apache.iotdb.cluster.rpc.thrift.RequestCommitIndexResponse;
 import org.apache.iotdb.cluster.server.NodeCharacter;
 import org.apache.iotdb.cluster.server.member.RaftMember;
 import org.apache.iotdb.cluster.utils.IOUtils;
@@ -85,10 +86,22 @@ public abstract class BaseAsyncService implements RaftService.AsyncIface {
   }
 
   @Override
-  public void requestCommitIndex(Node header, AsyncMethodCallback<Long> resultHandler) {
-    long commitIndex = member.getCommitIndex();
+  public void requestCommitIndex(
+      Node header, AsyncMethodCallback<RequestCommitIndexResponse> resultHandler) {
+    long commitIndex;
+    long commitTerm;
+    long curTerm;
+    synchronized (member.getTerm()) {
+      commitIndex = member.getLogManager().getCommitLogIndex();
+      commitTerm = member.getLogManager().getCommitLogTerm();
+      curTerm = member.getTerm().get();
+    }
+
+    RequestCommitIndexResponse response =
+        new RequestCommitIndexResponse(curTerm, commitIndex, commitTerm);
+
     if (commitIndex != Long.MIN_VALUE) {
-      resultHandler.onComplete(commitIndex);
+      resultHandler.onComplete(response);
       return;
     }
 

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterDataQueryExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterDataQueryExecutorTest.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.cluster.query;
 
 import org.apache.iotdb.cluster.common.TestUtils;
-import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
@@ -52,14 +51,12 @@ public class ClusterDataQueryExecutorTest extends BaseQueryTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    ClusterDescriptor.getInstance().getConfig().setEnableQueryRedirect(true);
   }
 
   @Override
   @After
   public void tearDown() throws Exception {
     super.tearDown();
-    ClusterDescriptor.getInstance().getConfig().setEnableQueryRedirect(false);
   }
 
   @Test

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/DataGroupMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/DataGroupMemberTest.java
@@ -48,6 +48,7 @@ import org.apache.iotdb.cluster.rpc.thrift.PullSchemaResp;
 import org.apache.iotdb.cluster.rpc.thrift.PullSnapshotRequest;
 import org.apache.iotdb.cluster.rpc.thrift.PullSnapshotResp;
 import org.apache.iotdb.cluster.rpc.thrift.RaftService.AsyncClient;
+import org.apache.iotdb.cluster.rpc.thrift.RequestCommitIndexResponse;
 import org.apache.iotdb.cluster.rpc.thrift.SendSnapshotRequest;
 import org.apache.iotdb.cluster.rpc.thrift.SingleSeriesQueryRequest;
 import org.apache.iotdb.cluster.server.NodeCharacter;
@@ -244,11 +245,11 @@ public class DataGroupMemberTest extends BaseMember {
 
                 @Override
                 public void requestCommitIndex(
-                    Node header, AsyncMethodCallback<Long> resultHandler) {
+                    Node header, AsyncMethodCallback<RequestCommitIndexResponse> resultHandler) {
                   new Thread(
                           () -> {
                             if (enableSyncLeader) {
-                              resultHandler.onComplete(-1L);
+                              resultHandler.onComplete(new RequestCommitIndexResponse());
                             } else {
                               resultHandler.onError(new TestException());
                             }

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/RaftMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/RaftMemberTest.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.cluster.log.manage.PartitionedSnapshotLogManager;
 import org.apache.iotdb.cluster.rpc.thrift.AppendEntryRequest;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.rpc.thrift.RaftService;
+import org.apache.iotdb.cluster.rpc.thrift.RequestCommitIndexResponse;
 import org.apache.iotdb.cluster.server.NodeCharacter;
 import org.apache.iotdb.cluster.server.Response;
 
@@ -178,8 +179,8 @@ public class RaftMemberTest extends BaseMember {
           }
 
           @Override
-          protected long requestCommitIdAsync() {
-            return 5;
+          protected RequestCommitIndexResponse requestCommitIdAsync() {
+            return new RequestCommitIndexResponse(5, 5, 5);
           }
 
           @Override
@@ -215,8 +216,8 @@ public class RaftMemberTest extends BaseMember {
           }
 
           @Override
-          protected long requestCommitIdAsync() {
-            return 1000L;
+          protected RequestCommitIndexResponse requestCommitIdAsync() {
+            return new RequestCommitIndexResponse(1000, 1000, 1000);
           }
 
           @Override

--- a/thrift-cluster/src/main/thrift/cluster.thrift
+++ b/thrift-cluster/src/main/thrift/cluster.thrift
@@ -58,6 +58,12 @@ struct HeartBeatResponse {
   7: optional Node header
 }
 
+struct RequestCommitIndexResponse {
+  1: required long term // leader's meta log
+  2: required long commitLogIndex  // leader's meta log
+  3: required long commitLogTerm
+}
+
 // node -> node
 struct ElectionRequest {
   1: required long term
@@ -311,7 +317,7 @@ service RaftService {
   * Ask the leader for its commit index, used to check whether the node has caught up with the
   * leader.
   **/
-  long requestCommitIndex(1:Node header)
+  RequestCommitIndexResponse requestCommitIndex(1:Node header)
 
 
   /**


### PR DESCRIPTION
## Description

In the distributed version, metadata synchronization will be performed when parsing SQL statements, which will lead to parsing time consuming up to 1 second. The main reason is that the heartbeat of the master is not received in time, which leads to the delay of the synchronization time. The root cause is that metadata and data belong to the same raft replication group, which affects the judgment of whether metadata is consistent or not.

The main idea of this pr is to reduce the time of synchronization point by getting the submitted information earlier. With weak consistency, we can get 20~30% query performance improvement.

### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
