### PR TITLE
[Distributed] minor improve the concurrency problem caused by the checking apply thread and the compact entries thread

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/LogCatchUpTask.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/LogCatchUpTask.java
@@ -266,7 +266,7 @@ public class LogCatchUpTask implements Callable<Boolean> {
     }
     // do append entries
     if (logger.isInfoEnabled()) {
-      logger.info("{}: sending {} logs to {}", raftMember.getName(), node, logList.size());
+      logger.info("{}: sending {} logs to {}", raftMember.getName(), logList.size(), node);
     }
     if (ClusterDescriptor.getInstance().getConfig().isUseAsyncServer()) {
       abort = !appendEntriesAsync(logList, request);
@@ -274,7 +274,7 @@ public class LogCatchUpTask implements Callable<Boolean> {
       abort = !appendEntriesSync(logList, request);
     }
     if (!abort && logger.isInfoEnabled()) {
-      logger.info("{}: sent {} logs to {}", raftMember.getName(), node, logList.size());
+      logger.info("{}: sent {} logs to {}", raftMember.getName(), logList.size(), node);
     }
     logList.clear();
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
@@ -208,13 +208,19 @@ public class CommittedEntryManager {
       throw new EntryUnavailableException(compactIndex, getLastIndex());
     }
     int index = (int) (compactIndex - dummyIndex);
+    for (int i = 1; i <= index; i++) {
+      entryTotalMemSize -= entries.get(i).getByteSize();
+    }
+    // The following two lines of code should be tightly linked,
+    // because the check apply thread will read the entry also, and there will be concurrency
+    // problems,
+    // but please rest assured that we have done concurrency security check in the check apply
+    // thread.
+    // They are put together just to reduce the probability of concurrency.
     entries.set(
         0,
         new EmptyContentLog(
             entries.get(index).getCurrLogIndex(), entries.get(index).getCurrLogTerm()));
-    for (int i = 1; i <= index; i++) {
-      entryTotalMemSize -= entries.get(i).getByteSize();
-    }
     entries.subList(1, index + 1).clear();
   }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6237070/114516816-56b67380-9c70-11eb-9bc1-88f4185d3339.png)

There are so many checks apply thread warnings, even though, we have handled the issue, it is better to reduce it.
Reduce the concurrency problem caused by the check apply thread and the compact entries thread.
