### PR TITLE
[Distributed]Lowering the logging level from debug to trace when serializing meta 

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
@@ -813,7 +813,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   private void serializeMeta(LogManagerMeta meta) {
     File tempMetaFile = SystemFileFactory.INSTANCE.getFile(logDir + LOG_META_TMP);
     tempMetaFile.getParentFile().mkdirs();
-    logger.debug("Serializing log meta into {}", tempMetaFile.getPath());
+    logger.trace("Serializing log meta into {}", tempMetaFile.getPath());
     try (FileOutputStream tempMetaFileOutputStream = new FileOutputStream(tempMetaFile)) {
       ReadWriteIOUtils.write(minAvailableVersion, tempMetaFileOutputStream);
       ReadWriteIOUtils.write(maxAvailableVersion, tempMetaFileOutputStream);
@@ -835,7 +835,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
 
     // rebuild meta stream
     this.meta = meta;
-    logger.debug("Serialized log meta into {}", tempMetaFile.getPath());
+    logger.trace("Serialized log meta into {}", tempMetaFile.getPath());
   }
 
   @Override


### PR DESCRIPTION
The debug log outputs some useless log when serializing meta, which make it harder to find the usage info when debugging the code, so I think we can lower the debug level to trace.

![image](https://user-images.githubusercontent.com/6237070/114806663-b11e1400-9dd7-11eb-8d6c-02695c6bb07d.png)
