### PR TITLE
[IOTDB-1301] snappy compatible arm64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
         <metrics.version>3.2.6</metrics.version>
         <javax.xml.bind.version>2.4.0-b180725.0427</javax.xml.bind.version>
         <felix.version>5.1.1</felix.version>
+        <snappy.version>1.1.8.4</snappy.version>
         <!-- URL of the ASF SonarQube server -->
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>apache</sonar.organization>
@@ -448,7 +449,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.7.2</version>
+                <version>${snappy.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.thrift</groupId>


### PR DESCRIPTION
Snappy must be compatible with the ARM server. 1.8.0 and later versions are compatible with ARM.