### PR TITLE
[Distributed] fix the plan index miss 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletPlan.java
@@ -240,8 +240,6 @@ public class InsertMultiTabletPlan extends InsertPlan {
     buffer.put((byte) type);
     buffer.putInt(insertTabletPlanList.size());
     for (InsertTabletPlan insertTabletPlan : insertTabletPlanList) {
-      // use the InsertMultiTabletPlan's index as the sub InsertTabletPlan's index
-      insertTabletPlan.setIndex(super.index);
       insertTabletPlan.subSerialize(buffer);
     }
 
@@ -257,8 +255,6 @@ public class InsertMultiTabletPlan extends InsertPlan {
     stream.writeByte((byte) type);
     stream.writeInt(insertTabletPlanList.size());
     for (InsertTabletPlan insertTabletPlan : insertTabletPlanList) {
-      // use the InsertMultiTabletPlan's index as the sub InsertTabletPlan's index
-      insertTabletPlan.setIndex(super.index);
       insertTabletPlan.subSerialize(stream);
     }
 
@@ -282,6 +278,14 @@ public class InsertMultiTabletPlan extends InsertPlan {
     this.parentInsertTabletPlanIndexList = new ArrayList<>(tmpParentInsetTablePlanIndexListSize);
     for (int i = 0; i < tmpParentInsetTablePlanIndexListSize; i++) {
       this.parentInsertTabletPlanIndexList.add(buffer.getInt());
+    }
+  }
+
+  @Override
+  public void setIndex(long index) {
+    for (InsertTabletPlan insertTabletPlan : insertTabletPlanList) {
+      // use the InsertMultiTabletPlan's index as the sub InsertTabletPlan's index
+      insertTabletPlan.setIndex(super.index);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletPlan.java
@@ -240,6 +240,8 @@ public class InsertMultiTabletPlan extends InsertPlan {
     buffer.put((byte) type);
     buffer.putInt(insertTabletPlanList.size());
     for (InsertTabletPlan insertTabletPlan : insertTabletPlanList) {
+      // use the InsertMultiTabletPlan's index as the sub InsertTabletPlan's index
+      insertTabletPlan.setIndex(super.index);
       insertTabletPlan.subSerialize(buffer);
     }
 
@@ -255,6 +257,8 @@ public class InsertMultiTabletPlan extends InsertPlan {
     stream.writeByte((byte) type);
     stream.writeInt(insertTabletPlanList.size());
     for (InsertTabletPlan insertTabletPlan : insertTabletPlanList) {
+      // use the InsertMultiTabletPlan's index as the sub InsertTabletPlan's index
+      insertTabletPlan.setIndex(super.index);
       insertTabletPlan.subSerialize(stream);
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletPlan.java
@@ -283,9 +283,10 @@ public class InsertMultiTabletPlan extends InsertPlan {
 
   @Override
   public void setIndex(long index) {
+    super.setIndex(index);
     for (InsertTabletPlan insertTabletPlan : insertTabletPlanList) {
       // use the InsertMultiTabletPlan's index as the sub InsertTabletPlan's index
-      insertTabletPlan.setIndex(super.index);
+      insertTabletPlan.setIndex(index);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
@@ -101,8 +101,6 @@ public class InsertRowsOfOneDevicePlan extends InsertPlan {
 
     stream.writeInt(rowPlans.length);
     for (InsertRowPlan plan : rowPlans) {
-      // use the InsertRowsOfOneDevicePlan's index as the sub InsertRowPlan's index
-      plan.setIndex(super.index);
       stream.writeLong(plan.getTime());
       plan.serializeMeasurementsAndValues(stream);
     }
@@ -116,8 +114,6 @@ public class InsertRowsOfOneDevicePlan extends InsertPlan {
     putString(buffer, deviceId.getFullPath());
     buffer.putInt(rowPlans.length);
     for (InsertRowPlan plan : rowPlans) {
-      // use the InsertRowsOfOneDevicePlan's index as the sub InsertRowPlan's index
-      plan.setIndex(super.index);
       buffer.putLong(plan.getTime());
       plan.serializeMeasurementsAndValues(buffer);
     }
@@ -132,6 +128,14 @@ public class InsertRowsOfOneDevicePlan extends InsertPlan {
       rowPlans[i].setDeviceId(deviceId);
       rowPlans[i].setTime(buffer.getLong());
       rowPlans[i].deserializeMeasurementsAndValues(buffer);
+    }
+  }
+
+  @Override
+  public void setIndex(long index) {
+    for (InsertRowPlan plan : rowPlans) {
+      // use the InsertRowsOfOneDevicePlan's index as the sub InsertRowPlan's index
+      plan.setIndex(super.index);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
@@ -133,9 +133,10 @@ public class InsertRowsOfOneDevicePlan extends InsertPlan {
 
   @Override
   public void setIndex(long index) {
+    super.setIndex(index);
     for (InsertRowPlan plan : rowPlans) {
       // use the InsertRowsOfOneDevicePlan's index as the sub InsertRowPlan's index
-      plan.setIndex(super.index);
+      plan.setIndex(index);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
@@ -101,6 +101,8 @@ public class InsertRowsOfOneDevicePlan extends InsertPlan {
 
     stream.writeInt(rowPlans.length);
     for (InsertRowPlan plan : rowPlans) {
+      // use the InsertRowsOfOneDevicePlan's index as the sub InsertRowPlan's index
+      plan.setIndex(super.index);
       stream.writeLong(plan.getTime());
       plan.serializeMeasurementsAndValues(stream);
     }
@@ -114,6 +116,8 @@ public class InsertRowsOfOneDevicePlan extends InsertPlan {
     putString(buffer, deviceId.getFullPath());
     buffer.putInt(rowPlans.length);
     for (InsertRowPlan plan : rowPlans) {
+      // use the InsertRowsOfOneDevicePlan's index as the sub InsertRowPlan's index
+      plan.setIndex(super.index);
       buffer.putLong(plan.getTime());
       plan.serializeMeasurementsAndValues(buffer);
     }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public class InsertRowsPlan extends InsertPlan {
+
   /**
    * Suppose there is an InsertRowsPlan, which contains 5 InsertRowPlans,
    * insertRowPlanList={InsertRowPlan_0, InsertRowPlan_1, InsertRowPlan_2, InsertRowPlan_3,
@@ -148,6 +149,8 @@ public class InsertRowsPlan extends InsertPlan {
     buffer.put((byte) type);
     buffer.putInt(insertRowPlanList.size());
     for (InsertRowPlan insertRowPlan : insertRowPlanList) {
+      // use the InsertRowsPlan's index as the sub InsertRowPlan's index
+      insertRowPlan.setIndex(super.index);
       insertRowPlan.subSerialize(buffer);
     }
     for (Integer index : insertRowPlanIndexList) {
@@ -161,6 +164,8 @@ public class InsertRowsPlan extends InsertPlan {
     stream.writeByte((byte) type);
     stream.writeInt(insertRowPlanList.size());
     for (InsertRowPlan insertRowPlan : insertRowPlanList) {
+      // use the InsertRowsPlan's index as the sub InsertRowPlan's index
+      insertRowPlan.setIndex(super.index);
       insertRowPlan.subSerialize(stream);
     }
     for (Integer index : insertRowPlanIndexList) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
@@ -149,8 +149,6 @@ public class InsertRowsPlan extends InsertPlan {
     buffer.put((byte) type);
     buffer.putInt(insertRowPlanList.size());
     for (InsertRowPlan insertRowPlan : insertRowPlanList) {
-      // use the InsertRowsPlan's index as the sub InsertRowPlan's index
-      insertRowPlan.setIndex(super.index);
       insertRowPlan.subSerialize(buffer);
     }
     for (Integer index : insertRowPlanIndexList) {
@@ -164,8 +162,6 @@ public class InsertRowsPlan extends InsertPlan {
     stream.writeByte((byte) type);
     stream.writeInt(insertRowPlanList.size());
     for (InsertRowPlan insertRowPlan : insertRowPlanList) {
-      // use the InsertRowsPlan's index as the sub InsertRowPlan's index
-      insertRowPlan.setIndex(super.index);
       insertRowPlan.subSerialize(stream);
     }
     for (Integer index : insertRowPlanIndexList) {
@@ -186,6 +182,14 @@ public class InsertRowsPlan extends InsertPlan {
 
     for (int i = 0; i < size; i++) {
       insertRowPlanIndexList.add(buffer.getInt());
+    }
+  }
+
+  @Override
+  public void setIndex(long index) {
+    for (InsertRowPlan insertRowPlan : insertRowPlanList) {
+      // use the InsertRowsPlan's index as the sub InsertRowPlan's index
+      insertRowPlan.setIndex(super.index);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
@@ -187,9 +187,10 @@ public class InsertRowsPlan extends InsertPlan {
 
   @Override
   public void setIndex(long index) {
+    super.setIndex(index);
     for (InsertRowPlan insertRowPlan : insertRowPlanList) {
       // use the InsertRowsPlan's index as the sub InsertRowPlan's index
-      insertRowPlan.setIndex(super.index);
+      insertRowPlan.setIndex(index);
     }
   }
 


### PR DESCRIPTION
**[phenomenon]**
The plan index is always zero when we use insertRecords interface to test the cluster.
![image](https://user-images.githubusercontent.com/6237070/114812351-648c0600-9de2-11eb-9046-7f6af26fab48.png)

**[After resloved]**
After the bug was resolved, we can see that the plan index is not zero.
![image](https://user-images.githubusercontent.com/6237070/114812144-05c68c80-9de2-11eb-8e90-ddb6c4ba38be.png)


 **[Reason]**
the plan index is not set in the sub plans when we split the InsertRowsPlan, InertMultiTabletPlans and InsertRowsOfOneDevicePlan
