### PR TITLE
[To rel/0.12][IOTDB-1219] A potential NPE issue in ElasticSerializableRowRecordList#applyNewMemoryControlParameters

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/udf/datastructure/row/ElasticSerializableRowRecordList.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/datastructure/row/ElasticSerializableRowRecordList.java
@@ -136,11 +136,16 @@ public class ElasticSerializableRowRecordList {
     if (!disableMemoryControl) {
       totalByteArrayLengthLimit +=
           (long) indexListOfTextFields.length * byteArrayLengthForMemoryControl;
-      for (int indexListOfTextField : indexListOfTextFields) {
-        Binary binary = (Binary) rowRecord[indexListOfTextField];
-        totalByteArrayLength += binary == null ? 0 : binary.getLength();
+
+      if (rowRecord == null) {
+        totalByteArrayLength += indexListOfTextFields.length * byteArrayLengthForMemoryControl;
+      } else {
+        for (int indexListOfTextField : indexListOfTextFields) {
+          Binary binary = (Binary) rowRecord[indexListOfTextField];
+          totalByteArrayLength += binary == null ? 0 : binary.getLength();
+        }
+        checkMemoryUsage();
       }
-      checkMemoryUsage();
     }
   }
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-1219

The bug was reported by LGTM.com:

https://lgtm.com/projects/g/apache/iotdb/snapshot/ad13f1d09d54d7f98ab09a6b3572d64e1217644c/files/server/src/main/java/org/apache/iotdb/db/query/udf/datastructure/row/ElasticSerializableRowRecordList.java?sort=name&dir=ASC&mode=heatmap

Dereferencing a variable whose value may be 'null' may cause a 'NullPointerException'.