### PR TITLE
[To Vector] Fix get buffer size bug when values contain TEXT data

### DIFF
--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
@@ -381,7 +381,8 @@ public class IoTDBSessionSimpleIT {
     schemaList.add(new MeasurementSchema("s0", TSDataType.INT64));
     schemaList.add(
         new VectorMeasurementSchema(
-            new String[] {"s1", "s2", "s3"}, new TSDataType[] {TSDataType.INT64, TSDataType.INT32, TSDataType.TEXT}));
+            new String[] {"s1", "s2", "s3"},
+            new TSDataType[] {TSDataType.INT64, TSDataType.INT32, TSDataType.TEXT}));
     schemaList.add(new MeasurementSchema("s4", TSDataType.INT32));
 
     Tablet tablet = new Tablet("root.sg1.d1", schemaList);
@@ -401,9 +402,7 @@ public class IoTDBSessionSimpleIT {
           rowIndex,
           new SecureRandom().nextInt());
       tablet.addValue(
-          schemaList.get(1).getValueMeasurementIdList().get(2),
-          rowIndex,
-          new Binary("test"));
+          schemaList.get(1).getValueMeasurementIdList().get(2), rowIndex, new Binary("test"));
       tablet.addValue(schemaList.get(2).getMeasurementId(), rowIndex, new SecureRandom().nextInt());
       timestamp++;
     }

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
@@ -381,8 +381,8 @@ public class IoTDBSessionSimpleIT {
     schemaList.add(new MeasurementSchema("s0", TSDataType.INT64));
     schemaList.add(
         new VectorMeasurementSchema(
-            new String[] {"s1", "s2"}, new TSDataType[] {TSDataType.INT64, TSDataType.INT32}));
-    schemaList.add(new MeasurementSchema("s3", TSDataType.INT32));
+            new String[] {"s1", "s2", "s3"}, new TSDataType[] {TSDataType.INT64, TSDataType.INT32, TSDataType.TEXT}));
+    schemaList.add(new MeasurementSchema("s4", TSDataType.INT32));
 
     Tablet tablet = new Tablet("root.sg1.d1", schemaList);
     long timestamp = System.currentTimeMillis();
@@ -400,6 +400,10 @@ public class IoTDBSessionSimpleIT {
           schemaList.get(1).getValueMeasurementIdList().get(1),
           rowIndex,
           new SecureRandom().nextInt());
+      tablet.addValue(
+          schemaList.get(1).getValueMeasurementIdList().get(2),
+          rowIndex,
+          new Binary("test"));
       tablet.addValue(schemaList.get(2).getMeasurementId(), rowIndex, new SecureRandom().nextInt());
       timestamp++;
     }
@@ -416,6 +420,7 @@ public class IoTDBSessionSimpleIT {
       Assert.assertEquals(10L, rowRecord.getFields().get(1).getLongV());
       Assert.assertEquals(10L, rowRecord.getFields().get(2).getLongV());
       Assert.assertEquals(10L, rowRecord.getFields().get(3).getLongV());
+      Assert.assertEquals(10L, rowRecord.getFields().get(4).getLongV());
     }
     session.close();
   }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
@@ -296,20 +296,24 @@ public class Tablet {
         }
       }
     }
+    int columnIndex = 0;
     for (int i = 0; i < schemas.size(); i++) {
       IMeasurementSchema schema = schemas.get(i);
       if (schema instanceof MeasurementSchema) {
-        valueOccupation += calOccupationOfOneColumn(schema.getType(), i);
+        valueOccupation += calOccupationOfOneColumn(schema.getType(), columnIndex);
+        columnIndex++;
       } else {
-        for (TSDataType dataType : schema.getValueTSDataTypeList()) {
-          valueOccupation += calOccupationOfOneColumn(dataType, i);
+        for (int j = 0; j < schema.getValueTSDataTypeList().size(); j++) {
+          TSDataType dataType = schema.getValueTSDataTypeList().get(j);
+          valueOccupation += calOccupationOfOneColumn(dataType, columnIndex);
+          columnIndex++;
         }
       }
     }
     return valueOccupation;
   }
 
-  private int calOccupationOfOneColumn(TSDataType dataType, int i) {
+  private int calOccupationOfOneColumn(TSDataType dataType, int columnIndex) {
     int valueOccupation = 0;
     switch (dataType) {
       case BOOLEAN:
@@ -325,7 +329,7 @@ public class Tablet {
         break;
       case TEXT:
         valueOccupation += rowSize * 4;
-        Binary[] binaries = (Binary[]) values[i];
+        Binary[] binaries = (Binary[]) values[columnIndex];
         for (int rowIndex = 0; rowIndex < rowSize; rowIndex++) {
           valueOccupation += binaries[rowIndex].getLength();
         }


### PR DESCRIPTION
## Description
The calOccupationOfOneColumn method in Tablet should use column index instead of the measurementSchema index.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
