### PR TITLE
[IOTDB-1317] Log CatchUp always failed du to not check the follower's match index

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/CatchUpTask.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/CatchUpTask.java
@@ -133,6 +133,10 @@ public class CatchUpTask implements Runnable {
             logsInDisk.get(0).getCurrLogIndex());
         logs = logsInDisk;
         index = findLastMatchIndex(logs);
+        // the follower's matchIndex may have been updated
+        if (index == -1) {
+          return false;
+        }
       } else {
         logger.info(
             "{}, Cannot find matched of {} within [{}, {}] in disk",

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/CatchUpTask.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/CatchUpTask.java
@@ -114,26 +114,34 @@ public class CatchUpTask implements Runnable {
 
     int index = findLastMatchIndex(logs);
     if (index == -1) {
-      logger.info("Cannot find matched of {} within [{}, {}] in memory", node, lo, hi);
-      if (judgeUseLogsInDiskToCatchUp()) {
-        long startIndex = peer.getMatchIndex() + 1;
-        long endIndex = raftMember.getLogManager().getCommitLogIndex();
-        List<Log> logsInDisk = getLogsInStableEntryManager(startIndex, endIndex);
-        if (!logsInDisk.isEmpty()) {
-          logger.info(
-              "{}, found {} logs in disk to catch up {} , startIndex={}, endIndex={}, memoryFirstIndex={}, getFirstLogIndex={}",
-              name,
-              logsInDisk.size(),
-              node,
-              startIndex,
-              endIndex,
-              localFirstIndex,
-              logsInDisk.get(0).getCurrLogIndex());
-          logs = logsInDisk;
-          return true;
-        }
+      logger.info("{}, Cannot find matched of {} within [{}, {}] in memory", name, node, lo, hi);
+      if (!judgeUseLogsInDiskToCatchUp()) {
+        return false;
       }
-      return false;
+      long startIndex = peer.getMatchIndex() + 1;
+      long endIndex = raftMember.getLogManager().getCommitLogIndex();
+      List<Log> logsInDisk = getLogsInStableEntryManager(startIndex, endIndex);
+      if (!logsInDisk.isEmpty()) {
+        logger.info(
+            "{}, found {} logs in disk to catch up {} , startIndex={}, endIndex={}, memoryFirstIndex={}, getFirstLogIndex={}",
+            name,
+            logsInDisk.size(),
+            node,
+            startIndex,
+            endIndex,
+            localFirstIndex,
+            logsInDisk.get(0).getCurrLogIndex());
+        logs = logsInDisk;
+        index = findLastMatchIndex(logs);
+      } else {
+        logger.info(
+            "{}, Cannot find matched of {} within [{}, {}] in disk",
+            name,
+            node,
+            startIndex,
+            endIndex);
+        return false;
+      }
     }
     long newMatchedIndex = logs.get(index).getCurrLogIndex() - 1;
     if (newMatchedIndex > lastLogIndex) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IOTDB-1317

When the follower lags behind the leader, it will catch up with the leader through the log. When it can't find the logs to catch up with in the memory of the leader, it will go to the file on the local disk to find the satisfied logs. The logs found are between the old match index and the commit index saved by the leader. However, at this time, the match index of the follower may have been updated and the old match index of the follower may have been deleted (in order to prevent a large number of logs from being kept on disk, there is a log deletion mechanism). So at this time, if you send the above logs to the follower, the follower will fail to find the matching log. At this time, this storage group will appear to write stuck phenomenon.

The solution is to re-check the match index of the follower after reading the log from the disk.

