### PR TITLE
[To Vector] Move BitMaps to the end of the ValueBuffer

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
@@ -157,8 +157,8 @@ public class InsertTabletPlan extends InsertPlan {
     writeMeasurements(stream);
     writeDataTypes(stream);
     writeTimes(stream);
-    writeBitMaps(stream);
     writeValues(stream);
+    writeBitMaps(stream);
   }
 
   private void writeMeasurements(DataOutputStream stream) throws IOException {
@@ -207,7 +207,6 @@ public class InsertTabletPlan extends InsertPlan {
   }
 
   private void writeBitMaps(DataOutputStream stream) throws IOException {
-    stream.writeBoolean(bitMaps != null);
     if (bitMaps != null) {
       for (BitMap bitMap : bitMaps) {
         if (bitMap == null) {
@@ -243,8 +242,8 @@ public class InsertTabletPlan extends InsertPlan {
     writeMeasurements(buffer);
     writeDataTypes(buffer);
     writeTimes(buffer);
-    writeBitMaps(buffer);
     writeValues(buffer);
+    writeBitMaps(buffer);
   }
 
   private void writeMeasurements(ByteBuffer buffer) {
@@ -292,7 +291,6 @@ public class InsertTabletPlan extends InsertPlan {
   }
 
   private void writeBitMaps(ByteBuffer buffer) {
-    buffer.put(BytesUtils.boolToByte(bitMaps != null));
     if (bitMaps != null) {
       for (BitMap bitMap : bitMaps) {
         if (bitMap == null) {
@@ -461,9 +459,9 @@ public class InsertTabletPlan extends InsertPlan {
     times = QueryDataSetUtils.readTimesFromBuffer(buffer, rows);
     updateTimesCache();
 
-    bitMaps = QueryDataSetUtils.readBitMapsFromBuffer(buffer, dataTypeSize, rows);
     columns = QueryDataSetUtils.readValuesFromBuffer(buffer, dataTypes, dataTypeSize, rows);
     this.index = buffer.getLong();
+    bitMaps = QueryDataSetUtils.readBitMapsFromBuffer(buffer, dataTypeSize, rows);
   }
 
   public void setDataTypes(List<Integer> dataTypes) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
@@ -157,8 +157,8 @@ public class InsertTabletPlan extends InsertPlan {
     writeMeasurements(stream);
     writeDataTypes(stream);
     writeTimes(stream);
-    writeValues(stream);
     writeBitMaps(stream);
+    writeValues(stream);
   }
 
   private void writeMeasurements(DataOutputStream stream) throws IOException {
@@ -207,6 +207,7 @@ public class InsertTabletPlan extends InsertPlan {
   }
 
   private void writeBitMaps(DataOutputStream stream) throws IOException {
+    stream.writeBoolean(bitMaps != null);
     if (bitMaps != null) {
       for (BitMap bitMap : bitMaps) {
         if (bitMap == null) {
@@ -242,8 +243,8 @@ public class InsertTabletPlan extends InsertPlan {
     writeMeasurements(buffer);
     writeDataTypes(buffer);
     writeTimes(buffer);
-    writeValues(buffer);
     writeBitMaps(buffer);
+    writeValues(buffer);
   }
 
   private void writeMeasurements(ByteBuffer buffer) {
@@ -291,6 +292,7 @@ public class InsertTabletPlan extends InsertPlan {
   }
 
   private void writeBitMaps(ByteBuffer buffer) {
+    buffer.put(BytesUtils.boolToByte(bitMaps != null));
     if (bitMaps != null) {
       for (BitMap bitMap : bitMaps) {
         if (bitMap == null) {
@@ -459,9 +461,9 @@ public class InsertTabletPlan extends InsertPlan {
     times = QueryDataSetUtils.readTimesFromBuffer(buffer, rows);
     updateTimesCache();
 
+    bitMaps = QueryDataSetUtils.readBitMapsFromBuffer(buffer, dataTypeSize, rows);
     columns = QueryDataSetUtils.readValuesFromBuffer(buffer, dataTypes, dataTypeSize, rows);
     this.index = buffer.getLong();
-    bitMaps = QueryDataSetUtils.readBitMapsFromBuffer(buffer, dataTypeSize, rows);
   }
 
   public void setDataTypes(List<Integer> dataTypes) {

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -1633,11 +1633,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       InsertTabletPlan insertTabletPlan =
           new InsertTabletPlan(new PartialPath(req.deviceId), req.measurements);
       insertTabletPlan.setTimes(QueryDataSetUtils.readTimesFromBuffer(req.timestamps, req.size));
-      insertTabletPlan.setBitMaps(
-          QueryDataSetUtils.readBitMapsFromBuffer(req.values, req.types.size(), req.size));
       insertTabletPlan.setColumns(
           QueryDataSetUtils.readValuesFromBuffer(
               req.values, req.types, req.types.size(), req.size));
+      insertTabletPlan.setBitMaps(
+          QueryDataSetUtils.readBitMapsFromBuffer(req.values, req.types.size(), req.size));
       insertTabletPlan.setRowCount(req.size);
       insertTabletPlan.setDataTypes(req.types);
 
@@ -1677,15 +1677,15 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         new InsertTabletPlan(new PartialPath(req.deviceIds.get(i)), req.measurementsList.get(i));
     insertTabletPlan.setTimes(
         QueryDataSetUtils.readTimesFromBuffer(req.timestampsList.get(i), req.sizeList.get(i)));
-    insertTabletPlan.setBitMaps(
-        QueryDataSetUtils.readBitMapsFromBuffer(
-            req.valuesList.get(i), req.measurementsList.get(i).size(), req.sizeList.get(i)));
     insertTabletPlan.setColumns(
         QueryDataSetUtils.readValuesFromBuffer(
             req.valuesList.get(i),
             req.typesList.get(i),
             req.measurementsList.get(i).size(),
             req.sizeList.get(i)));
+    insertTabletPlan.setBitMaps(
+        QueryDataSetUtils.readBitMapsFromBuffer(
+            req.valuesList.get(i), req.measurementsList.get(i).size(), req.sizeList.get(i)));
     insertTabletPlan.setRowCount(req.sizeList.get(i));
     insertTabletPlan.setDataTypes(req.typesList.get(i));
     return insertTabletPlan;

--- a/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
@@ -185,7 +185,7 @@ public class QueryDataSetUtils {
   }
 
   public static BitMap[] readBitMapsFromBuffer(ByteBuffer buffer, int columns, int size) {
-    if (!buffer.hasRemaining()) {
+    if (!buffer.hasRemaining() || !BytesUtils.byteToBool(buffer.get())) {
       return null;
     }
     BitMap[] bitMaps = new BitMap[columns];

--- a/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
@@ -185,7 +185,7 @@ public class QueryDataSetUtils {
   }
 
   public static BitMap[] readBitMapsFromBuffer(ByteBuffer buffer, int columns, int size) {
-    if (!BytesUtils.byteToBool(buffer.get())) {
+    if (!buffer.hasRemaining()) {
       return null;
     }
     BitMap[] bitMaps = new BitMap[columns];

--- a/session/src/main/java/org/apache/iotdb/session/SessionUtils.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionUtils.java
@@ -43,21 +43,6 @@ public class SessionUtils {
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public static ByteBuffer getValueBuffer(Tablet tablet) {
     ByteBuffer valueBuffer = ByteBuffer.allocate(tablet.getTotalValueOccupation());
-    boolean hasBitMaps = tablet.bitMaps != null;
-    valueBuffer.put(BytesUtils.boolToByte(hasBitMaps));
-    if (hasBitMaps) {
-      for (BitMap bitMap : tablet.bitMaps) {
-        boolean columnHasNull = bitMap != null && !bitMap.isAllUnmarked();
-        valueBuffer.put(BytesUtils.boolToByte(columnHasNull));
-
-        if (columnHasNull) {
-          byte[] bytes = bitMap.getByteArray();
-          for (int j = 0; j < tablet.rowSize / Byte.SIZE + 1; j++) {
-            valueBuffer.put(bytes[j]);
-          }
-        }
-      }
-    }
     int indexOfValues = 0;
     for (int i = 0; i < tablet.getSchemas().size(); i++) {
       IMeasurementSchema schema = tablet.getSchemas().get(i);
@@ -69,6 +54,18 @@ public class SessionUtils {
           getValueBufferOfDataType(
               schema.getValueTSDataTypeList().get(j), tablet, indexOfValues, valueBuffer);
           indexOfValues++;
+        }
+      }
+    }
+    if (tablet.bitMaps != null) {
+      for (BitMap bitMap : tablet.bitMaps) {
+        boolean columnHasNull = bitMap != null && !bitMap.isAllUnmarked();
+        valueBuffer.put(BytesUtils.boolToByte(columnHasNull));
+        if (columnHasNull) {
+          byte[] bytes = bitMap.getByteArray();
+          for (int j = 0; j < tablet.rowSize / Byte.SIZE + 1; j++) {
+            valueBuffer.put(bytes[j]);
+          }
         }
       }
     }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
@@ -284,18 +284,6 @@ public class Tablet {
   /** @return total bytes of values */
   public int getTotalValueOccupation() {
     int valueOccupation = 0;
-    // marker byte
-    valueOccupation++;
-    // bitmap size
-    if (bitMaps != null) {
-      for (BitMap bitMap : bitMaps) {
-        // marker byte
-        valueOccupation++;
-        if (bitMap != null && !bitMap.isAllUnmarked()) {
-          valueOccupation += rowSize / Byte.SIZE + 1;
-        }
-      }
-    }
     int columnIndex = 0;
     for (int i = 0; i < schemas.size(); i++) {
       IMeasurementSchema schema = schemas.get(i);
@@ -307,6 +295,16 @@ public class Tablet {
           TSDataType dataType = schema.getValueTSDataTypeList().get(j);
           valueOccupation += calOccupationOfOneColumn(dataType, columnIndex);
           columnIndex++;
+        }
+      }
+    }
+    // add bitmap size if the tablet has bitMaps
+    if (bitMaps != null) {
+      for (BitMap bitMap : bitMaps) {
+        // marker byte
+        valueOccupation++;
+        if (bitMap != null && !bitMap.isAllUnmarked()) {
+          valueOccupation += rowSize / Byte.SIZE + 1;
         }
       }
     }


### PR DESCRIPTION
## Description
Move BitMaps to the end of the ValueBuffer to keep the compatibility of the other languages clients. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
