### PR TITLE
Fix query one sensor in a vector from memtable

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -315,17 +315,6 @@ public abstract class AbstractMemTable implements IMemTable {
       // get sorted tv list is synchronized so different query can get right sorted list reference
       TVList vectorTvListCopy = vectorMemChunk.getSortedTvListForQuery(columns);
       int curSize = vectorTvListCopy.size();
-      // return normal ReadOnlyMemChunk for query one measurement in vector
-      if (columns.size() == 1) {
-        return new ReadOnlyMemChunk(
-            measurementIdList.get(0),
-            partialVectorSchema.getValueTSDataTypeList().get(0),
-            partialVectorSchema.getValueTSEncodingList().get(0),
-            vectorTvListCopy,
-            null,
-            curSize,
-            deletionList);
-      }
       return new ReadOnlyMemChunk(partialVectorSchema, vectorTvListCopy, curSize, deletionList);
     } else {
       if (!checkPath(deviceId, measurement)) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/querycontext/ReadOnlyMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/querycontext/ReadOnlyMemChunk.java
@@ -186,41 +186,10 @@ public class ReadOnlyMemChunk {
       while (iterator.hasNextTimeValuePair()) {
         TimeValuePair timeValuePair = iterator.nextTimeValuePair();
         timeStatistics.update(timeValuePair.getTimestamp());
-        for (int i = 0; i < schema.getValueTSDataTypeList().size(); i++) {
-          if (timeValuePair.getValue().getVector()[i] == null) {
-            continue;
-          }
-          switch (schema.getValueTSDataTypeList().get(i)) {
-            case BOOLEAN:
-              valueStatistics[i].update(
-                  timeValuePair.getTimestamp(),
-                  timeValuePair.getValue().getVector()[i].getBoolean());
-              break;
-            case TEXT:
-              valueStatistics[i].update(
-                  timeValuePair.getTimestamp(),
-                  timeValuePair.getValue().getVector()[i].getBinary());
-              break;
-            case FLOAT:
-              valueStatistics[i].update(
-                  timeValuePair.getTimestamp(), timeValuePair.getValue().getVector()[i].getFloat());
-              break;
-            case INT32:
-              valueStatistics[i].update(
-                  timeValuePair.getTimestamp(), timeValuePair.getValue().getVector()[i].getInt());
-              break;
-            case INT64:
-              valueStatistics[i].update(
-                  timeValuePair.getTimestamp(), timeValuePair.getValue().getVector()[i].getLong());
-              break;
-            case DOUBLE:
-              valueStatistics[i].update(
-                  timeValuePair.getTimestamp(),
-                  timeValuePair.getValue().getVector()[i].getDouble());
-              break;
-            default:
-              throw new QueryProcessException("Unsupported data type:" + dataType);
-          }
+        if (schema.getValueTSDataTypeList().size() == 1) {
+          updateValueStatisticsForSingleColumn(schema, valueStatistics, timeValuePair);
+        } else {
+          updateValueStatistics(schema, valueStatistics, timeValuePair);
         }
       }
     }
@@ -233,6 +202,76 @@ public class ReadOnlyMemChunk {
     vectorChunkMetadata.setChunkLoader(new MemChunkLoader(this));
     vectorChunkMetadata.setVersion(Long.MAX_VALUE);
     cachedMetaData = vectorChunkMetadata;
+  }
+
+  // When query one measurement in a Vector, the timeValuePair is not a vector type
+  private void updateValueStatisticsForSingleColumn(
+      IMeasurementSchema schema, Statistics[] valueStatistics, TimeValuePair timeValuePair)
+      throws QueryProcessException {
+    switch (schema.getValueTSDataTypeList().get(0)) {
+      case BOOLEAN:
+        valueStatistics[0].update(
+            timeValuePair.getTimestamp(), timeValuePair.getValue().getBoolean());
+        break;
+      case TEXT:
+        valueStatistics[0].update(
+            timeValuePair.getTimestamp(), timeValuePair.getValue().getBinary());
+        break;
+      case FLOAT:
+        valueStatistics[0].update(
+            timeValuePair.getTimestamp(), timeValuePair.getValue().getFloat());
+        break;
+      case INT32:
+        valueStatistics[0].update(timeValuePair.getTimestamp(), timeValuePair.getValue().getInt());
+        break;
+      case INT64:
+        valueStatistics[0].update(timeValuePair.getTimestamp(), timeValuePair.getValue().getLong());
+        break;
+      case DOUBLE:
+        valueStatistics[0].update(
+            timeValuePair.getTimestamp(), timeValuePair.getValue().getDouble());
+        break;
+      default:
+        throw new QueryProcessException("Unsupported data type:" + dataType);
+    }
+  }
+
+  private void updateValueStatistics(
+      IMeasurementSchema schema, Statistics[] valueStatistics, TimeValuePair timeValuePair)
+      throws QueryProcessException {
+    for (int i = 0; i < schema.getValueTSDataTypeList().size(); i++) {
+      if (timeValuePair.getValue().getVector()[i] == null) {
+        continue;
+      }
+      switch (schema.getValueTSDataTypeList().get(i)) {
+        case BOOLEAN:
+          valueStatistics[i].update(
+              timeValuePair.getTimestamp(), timeValuePair.getValue().getVector()[i].getBoolean());
+          break;
+        case TEXT:
+          valueStatistics[i].update(
+              timeValuePair.getTimestamp(), timeValuePair.getValue().getVector()[i].getBinary());
+          break;
+        case FLOAT:
+          valueStatistics[i].update(
+              timeValuePair.getTimestamp(), timeValuePair.getValue().getVector()[i].getFloat());
+          break;
+        case INT32:
+          valueStatistics[i].update(
+              timeValuePair.getTimestamp(), timeValuePair.getValue().getVector()[i].getInt());
+          break;
+        case INT64:
+          valueStatistics[i].update(
+              timeValuePair.getTimestamp(), timeValuePair.getValue().getVector()[i].getLong());
+          break;
+        case DOUBLE:
+          valueStatistics[i].update(
+              timeValuePair.getTimestamp(), timeValuePair.getValue().getVector()[i].getDouble());
+          break;
+        default:
+          throw new QueryProcessException("Unsupported data type:" + dataType);
+      }
+    }
   }
 
   public TSDataType getDataType() {

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/MemPageReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/MemPageReader.java
@@ -19,6 +19,8 @@
 package org.apache.iotdb.db.query.reader.chunk;
 
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.VectorChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.common.BatchData;
@@ -45,8 +47,15 @@ public class MemPageReader implements IPageReader {
 
   @Override
   public BatchData getAllSatisfiedPageData(boolean ascending) throws IOException {
-    BatchData batchData =
-        BatchDataFactory.createBatchData(chunkMetadata.getDataType(), ascending, false);
+    TSDataType dataType;
+    if (chunkMetadata instanceof VectorChunkMetadata
+        && ((VectorChunkMetadata) chunkMetadata).getValueChunkMetadataList().size() == 1) {
+      dataType =
+          ((VectorChunkMetadata) chunkMetadata).getValueChunkMetadataList().get(0).getDataType();
+    } else {
+      dataType = chunkMetadata.getDataType();
+    }
+    BatchData batchData = BatchDataFactory.createBatchData(dataType, ascending, false);
     while (timeValuePairIterator.hasNextTimeValuePair()) {
       TimeValuePair timeValuePair = timeValuePairIterator.nextTimeValuePair();
       if (valueFilter == null

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/VectorChunkMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/VectorChunkMetadata.java
@@ -128,9 +128,7 @@ public class VectorChunkMetadata implements IChunkMetadata {
 
   @Override
   public TSDataType getDataType() {
-    return valueChunkMetadataList.size() == 1
-        ? valueChunkMetadataList.get(0).getDataType()
-        : timeChunkMetadata.getDataType();
+    return timeChunkMetadata.getDataType();
   }
 
   @Override

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/VectorChunkMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/VectorChunkMetadata.java
@@ -128,7 +128,9 @@ public class VectorChunkMetadata implements IChunkMetadata {
 
   @Override
   public TSDataType getDataType() {
-    return timeChunkMetadata.getDataType();
+    return valueChunkMetadataList.size() == 1
+        ? valueChunkMetadataList.get(0).getDataType()
+        : timeChunkMetadata.getDataType();
   }
 
   @Override


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/25913899/115892618-e71f6000-a489-11eb-8614-1a7f56400a52.png)



Solution:
1. ReadOnlyMemChunk for query one measurement in vector should be vector type.
2. ValueStatistics  updating logic for one column vector should be different to other vector types

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
