### PR TITLE
JDBC bug - check authority for execute batch

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -322,19 +322,19 @@ public class IoTDBStatement implements Statement {
     TSStatus execResp = client.executeBatchStatement(execReq);
     int[] result = new int[batchSQLList.size()];
     boolean allSuccess = true;
-    String message = "\n";
+    StringBuilder message = new StringBuilder("\n");
     for (int i = 0; i < result.length; i++) {
       if (execResp.getCode() == TSStatusCode.MULTIPLE_ERROR.getStatusCode()) {
         result[i] = execResp.getSubStatus().get(i).code;
         if (result[i] != TSStatusCode.SUCCESS_STATUS.getStatusCode()
             && result[i] != TSStatusCode.NEED_REDIRECTION.getStatusCode()) {
           allSuccess = false;
-          message +=
+          message.append(
               execResp.getSubStatus().get(i).message
                   + " for SQL: \""
                   + batchSQLList.get(i)
                   + "\""
-                  + "\n";
+                  + "\n");
         }
       } else {
         allSuccess =
@@ -342,11 +342,12 @@ public class IoTDBStatement implements Statement {
                 && (execResp.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()
                     || execResp.getCode() == TSStatusCode.NEED_REDIRECTION.getStatusCode());
         result[i] = execResp.getCode();
-        message = execResp.getMessage();
+        message.setLength(0);
+        message.append(execResp.getMessage());
       }
     }
     if (!allSuccess) {
-      throw new BatchUpdateException(message, result);
+      throw new BatchUpdateException(message.toString(), result);
     }
     return result;
   }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -333,7 +333,7 @@ public class IoTDBStatement implements Statement {
               execResp.getSubStatus().get(i).message
                   + " for SQL: \""
                   + batchSQLList.get(i)
-                  + "\" "
+                  + "\""
                   + "\n";
         }
       } else {

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -322,14 +322,19 @@ public class IoTDBStatement implements Statement {
     TSStatus execResp = client.executeBatchStatement(execReq);
     int[] result = new int[batchSQLList.size()];
     boolean allSuccess = true;
-    String message = "";
+    String message = "\n";
     for (int i = 0; i < result.length; i++) {
       if (execResp.getCode() == TSStatusCode.MULTIPLE_ERROR.getStatusCode()) {
         result[i] = execResp.getSubStatus().get(i).code;
         if (result[i] != TSStatusCode.SUCCESS_STATUS.getStatusCode()
             && result[i] != TSStatusCode.NEED_REDIRECTION.getStatusCode()) {
           allSuccess = false;
-          message = execResp.getSubStatus().get(i).message;
+          message +=
+              execResp.getSubStatus().get(i).message
+                  + " for SQL: \""
+                  + batchSQLList.get(i)
+                  + "\" "
+                  + "\n";
         }
       } else {
         allSuccess =

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1245,9 +1245,9 @@ public class PlanExecutor implements IPlanExecutor {
       } catch (QueryProcessException e) {
         plan.getResults().put(i, RpcUtils.getStatus(e.getErrorCode(), e.getMessage()));
       }
-      if (!plan.getResults().isEmpty()) {
-        throw new BatchProcessException(plan.getFailingStatus());
-      }
+    }
+    if (!plan.getResults().isEmpty()) {
+      throw new BatchProcessException(plan.getFailingStatus());
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -569,16 +569,16 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
             executeList.add(insertRowsPlan);
             index = 0;
           }
-          lastOperatorType = OperatorType.INSERT;
-          insertRowsPlan.addOneInsertRowPlan((InsertRowPlan) physicalPlan, index);
-          index++;
 
           TSStatus status = checkAuthority(physicalPlan, req.getSessionId());
           if (status != null) {
-            insertRowsPlan.getResults().put(i, status);
-            result.add(status);
+            insertRowsPlan.getResults().put(index, status);
             isAllSuccessful = false;
           }
+
+          lastOperatorType = OperatorType.INSERT;
+          insertRowsPlan.addOneInsertRowPlan((InsertRowPlan) physicalPlan, index);
+          index++;
 
           if (i == req.getStatements().size() - 1) {
             if (!executeBatchList(executeList, result)) {
@@ -592,15 +592,15 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
             multiPlan = new CreateMultiTimeSeriesPlan();
             executeList.add(multiPlan);
           }
-          lastOperatorType = OperatorType.CREATE_TIMESERIES;
-          initMultiTimeSeriesPlan(multiPlan);
 
           TSStatus status = checkAuthority(physicalPlan, req.getSessionId());
           if (status != null) {
             multiPlan.getResults().put(i, status);
-            result.add(status);
             isAllSuccessful = false;
           }
+
+          lastOperatorType = OperatorType.CREATE_TIMESERIES;
+          initMultiTimeSeriesPlan(multiPlan);
 
           CreateTimeSeriesPlan createTimeSeriesPlan = (CreateTimeSeriesPlan) physicalPlan;
           setMultiTimeSeriesPlan(multiPlan, createTimeSeriesPlan);

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -572,6 +572,14 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           lastOperatorType = OperatorType.INSERT;
           insertRowsPlan.addOneInsertRowPlan((InsertRowPlan) physicalPlan, index);
           index++;
+
+          TSStatus status = checkAuthority(physicalPlan, req.getSessionId());
+          if (status != null) {
+            insertRowsPlan.getResults().put(i, status);
+            result.add(status);
+            isAllSuccessful = false;
+          }
+
           if (i == req.getStatements().size() - 1) {
             if (!executeBatchList(executeList, result)) {
               isAllSuccessful = false;
@@ -586,6 +594,13 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           }
           lastOperatorType = OperatorType.CREATE_TIMESERIES;
           initMultiTimeSeriesPlan(multiPlan);
+
+          TSStatus status = checkAuthority(physicalPlan, req.getSessionId());
+          if (status != null) {
+            multiPlan.getResults().put(i, status);
+            result.add(status);
+            isAllSuccessful = false;
+          }
 
           CreateTimeSeriesPlan createTimeSeriesPlan = (CreateTimeSeriesPlan) physicalPlan;
           setMultiTimeSeriesPlan(multiPlan, createTimeSeriesPlan);

--- a/server/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
@@ -33,6 +33,9 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -1069,6 +1072,48 @@ public class IoTDBAuthorizationIT {
               e.getMessage());
         }
       }
+    }
+  }
+
+  @Test
+  public void testExecuteBatchWithPrivilege1() throws ClassNotFoundException, SQLException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection adminCon =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement adminStmt = adminCon.createStatement()) {
+      adminStmt.execute("CREATE USER tempuser 'temppw'");
+      adminStmt.execute("GRANT USER tempuser PRIVILEGES 'INSERT_TIMESERIES' on root.sg1");
+
+      try (Connection userCon =
+              DriverManager.getConnection(
+                  Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "tempuser", "temppw");
+          Statement userStatement = userCon.createStatement()) {
+        userStatement.addBatch("insert into root.sg1.d1(timestamp,s1) values (1,1)");
+        userStatement.addBatch("insert into root.sg2.d1(timestamp,s1) values (2,1)");
+        userStatement.addBatch("insert into root.sg1.d1(timestamp,s2) values (3,1)");
+        userStatement.addBatch("insert into root.sg2.d1(timestamp,s1) values (4,1)");
+        try {
+          userStatement.executeBatch();
+        } catch (BatchUpdateException e) {
+          System.out.println(e.getMessage());
+          assertEquals(
+              "\nNo permissions for this operation INSERT for SQL: \"insert into root.sg2.d1(timestamp,s1) values (2,1)\"\n"
+                  + "No permissions for this operation INSERT for SQL: \"insert into root.sg2.d1(timestamp,s1) values (4,1)\"\n",
+              e.getMessage());
+        }
+      }
+      ResultSet resultSet = adminStmt.executeQuery("select * from root");
+      String[] expected = new String[] {"1, 1.0", "1, null", "3, null", "3, 1.0"};
+      List<String> expectedList = new ArrayList<>();
+      Collections.addAll(expectedList, expected);
+      List<String> result = new ArrayList<>();
+      while (resultSet.next()) {
+        result.add(resultSet.getString("Time") + ", " + resultSet.getString("root.sg1.d1.s1"));
+        result.add(resultSet.getString("Time") + ", " + resultSet.getString("root.sg1.d1.s2"));
+      }
+      assertEquals(expected.length, result.size());
+      assertTrue(expectedList.containsAll(result));
     }
   }
 }


### PR DESCRIPTION
1. when user does not have "create timeseries" privilege, JDBC allows user to create timeseries using executeBatch() interface. this adds authority check
2. when multiple errors occur, JDBC only shows user the last error message. this adds all error message with its SQL. 
![image](https://user-images.githubusercontent.com/68632589/115985369-2959b600-a5de-11eb-9b4c-81af85d0f3fd.png)
