### PR TITLE
[IOTDB-1059] Support sql statement insert without timestamp

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
@@ -587,7 +587,6 @@ nodeNameWithoutStar
     | PREVIOUSUNTILLAST
     | METADATA
     | TIMESERIES
-    | TIMESTAMP
     | PROPERTY
     | WITH
     | DATATYPE
@@ -642,7 +641,6 @@ nodeNameWithoutStar
     | DISABLE
     | ALIGN
     | COMPRESSION
-    | TIME
     | ATTRIBUTES
     | TAGS
     | RENAME

--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
@@ -374,7 +374,7 @@ comparisonOperator
     ;
 
 insertColumnsSpec
-    : LR_BRACKET (TIMESTAMP|TIME) (COMMA measurementName)+ RR_BRACKET
+    : LR_BRACKET (TIMESTAMP|TIME)? (COMMA? measurementName)+ RR_BRACKET
     ;
 measurementName
     : nodeNameWithoutStar
@@ -388,6 +388,7 @@ insertValuesSpec
 insertMultiValue
     : LR_BRACKET dateFormat (COMMA measurementValue)+ RR_BRACKET
     | LR_BRACKET INT (COMMA measurementValue)+ RR_BRACKET
+    | LR_BRACKET (measurementValue COMMA?)+ RR_BRACKET
     ;
 
 measurementValue

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.qp.physical.crud;
 
-import java.util.Set;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
@@ -51,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class InsertRowPlan extends InsertPlan {
 
@@ -588,12 +588,12 @@ public class InsertRowPlan extends InsertPlan {
     List measurementList = Arrays.asList(this.measurements);
     try {
       Set<String> schemaSet = IoTDB.metaManager.getChildNodeInNextLevel(this.deviceId);
-      checkTimeseries("time",schemaSet,measurementList);
-      checkTimeseries("TIME",schemaSet,measurementList);
-      checkTimeseries("timestamp",schemaSet,measurementList);
-      checkTimeseries("TIMESTAMP",schemaSet,measurementList);
+      checkTimeseries("time", schemaSet, measurementList);
+      checkTimeseries("TIME", schemaSet, measurementList);
+      checkTimeseries("timestamp", schemaSet, measurementList);
+      checkTimeseries("TIMESTAMP", schemaSet, measurementList);
     } catch (MetadataException e) {
-        e.printStackTrace();
+      e.printStackTrace();
     }
     if (values == null) {
       throw new QueryProcessException("Values are null");
@@ -608,10 +608,10 @@ public class InsertRowPlan extends InsertPlan {
     }
   }
 
-  public void checkTimeseries(String timeseries,Set<String> schemaSet,List measurementList)
+  public void checkTimeseries(String timeseries, Set<String> schemaSet, List measurementList)
       throws QueryProcessException {
     if (measurementList.contains(timeseries)) {
-      if (!schemaSet.contains(timeseries)){
+      if (!schemaSet.contains(timeseries)) {
         throw new QueryProcessException("Should create timeseries first");
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
@@ -582,12 +582,6 @@ public class InsertRowPlan extends InsertPlan {
   @Override
   public void checkIntegrity() throws QueryProcessException {
     super.checkIntegrity();
-    if (this.measurements.length == 1) {
-      if (this.measurements[0].equalsIgnoreCase("time")
-          || this.measurements[0].equalsIgnoreCase("timestamp")) {
-        throw new QueryProcessException("Should insert non-time column");
-      }
-    }
     if (values == null) {
       throw new QueryProcessException("Values are null");
     }

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -1763,8 +1763,13 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
       long timestamp;
       if (insertMultiValues.get(i).dateFormat() != null) {
         timestamp = parseTimeFormat(insertMultiValues.get(i).dateFormat().getText());
-      } else {
+      } else if (insertMultiValues.get(i).INT() != null) {
         timestamp = Long.parseLong(insertMultiValues.get(i).INT().getText());
+      } else {
+        if (insertMultiValues.size() != 1) {
+          throw new SQLParserException("need timestamps when insert multi rows");
+        }
+        timestamp = System.currentTimeMillis();
       }
       timeArray[i] = timestamp;
       List<MeasurementValueContext> values = insertMultiValues.get(i).measurementValue();

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -1768,7 +1768,7 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
       } else if (insertMultiValues.size() != 1) {
         throw new SQLParserException("need timestamps when insert multi rows");
       } else {
-        timestamp = parseTimeFormat("now()");
+        timestamp = parseTimeFormat(SQLConstant.NOW_FUNC);
       }
       timeArray[i] = timestamp;
       List<MeasurementValueContext> values = insertMultiValues.get(i).measurementValue();

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -1768,21 +1768,7 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
       } else if (insertMultiValues.size() != 1) {
         throw new SQLParserException("need timestamps when insert multi rows");
       } else {
-        String timePrecision = IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision();
-        long startupNano = IoTDBDescriptor.getInstance().getConfig().getStartUpNanosecond();
-        switch (timePrecision) {
-          case "ns":
-            timestamp =
-                System.currentTimeMillis() * 1000_000
-                    + (System.nanoTime() - startupNano) % 1000_000;
-            break;
-          case "us":
-            timestamp =
-                System.currentTimeMillis() * 1000 + (System.nanoTime() - startupNano) / 1000 % 1000;
-            break;
-          default:
-            timestamp = System.currentTimeMillis();
-        }
+        timestamp = parseTimeFormat("now()");
       }
       timeArray[i] = timestamp;
       List<MeasurementValueContext> values = insertMultiValues.get(i).measurementValue();

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -1767,17 +1767,18 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
         timestamp = Long.parseLong(insertMultiValues.get(i).INT().getText());
       } else if (insertMultiValues.size() != 1) {
         throw new SQLParserException("need timestamps when insert multi rows");
-      } else{
+      } else {
         String timePrecision = IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision();
         long startupNano = IoTDBDescriptor.getInstance().getConfig().getStartUpNanosecond();
         switch (timePrecision) {
           case "ns":
-            timestamp = System.currentTimeMillis() * 1000_000
-                + (System.nanoTime() - startupNano) % 1000_000;
+            timestamp =
+                System.currentTimeMillis() * 1000_000
+                    + (System.nanoTime() - startupNano) % 1000_000;
             break;
           case "us":
-            timestamp = System.currentTimeMillis() * 1000
-                + (System.nanoTime() - startupNano) / 1000 % 1000;
+            timestamp =
+                System.currentTimeMillis() * 1000 + (System.nanoTime() - startupNano) / 1000 % 1000;
             break;
           default:
             timestamp = System.currentTimeMillis();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertWithoutTimeIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertWithoutTimeIT.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iotdb.db.integration;
 
 import org.apache.iotdb.db.utils.EnvironmentUtils;

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertWithoutTimeIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertWithoutTimeIT.java
@@ -87,9 +87,9 @@ public class IoTDBInsertWithoutTimeIT {
   @Test
   public void testInsertWithoutTime() throws SQLException {
     Statement st0 = connection.createStatement();
-    st0.execute("insert into root.t1.wf01.wt01(time, status, temperature) values (1, true, 22)");
+    st0.execute("insert into root.t1.wf01.wt01(time, status, temperature) values (1, true, 11)");
     st0.execute(
-        "insert into root.t1.wf01.wt01(time, status, temperature) values (2, false, 33),(3, true, 44)");
+        "insert into root.t1.wf01.wt01(time, status, temperature) values (2, false, 22),(3, true, 33)");
     st0.execute("insert into root.t1.wf01.wt01(status, temperature) values (true, 10)");
     st0.execute("insert into root.t1.wf01.wt01(status) values (false)");
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertWithoutTimeIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertWithoutTimeIT.java
@@ -85,12 +85,13 @@ public class IoTDBInsertWithoutTimeIT {
   }
 
   @Test
-  public void testInsertWithoutTime() throws SQLException {
+  public void testInsertWithoutTime() throws SQLException, InterruptedException {
     Statement st0 = connection.createStatement();
     st0.execute("insert into root.t1.wf01.wt01(time, status, temperature) values (1, true, 11)");
     st0.execute(
         "insert into root.t1.wf01.wt01(time, status, temperature) values (2, false, 22),(3, true, 33)");
     st0.execute("insert into root.t1.wf01.wt01(status, temperature) values (true, 10)");
+    Thread.sleep(3);
     st0.execute("insert into root.t1.wf01.wt01(status) values (false)");
 
     Statement st1 = connection.createStatement();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertWithoutTimeIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertWithoutTimeIT.java
@@ -1,0 +1,109 @@
+package org.apache.iotdb.db.integration;
+
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** @Author: Architect @Date: 2021-07-13 16:32 */
+public class IoTDBInsertWithoutTimeIT {
+  private static List<String> sqls = new ArrayList<>();
+  private static Connection connection;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvironmentUtils.closeStatMonitor();
+    initCreateSQLStatement();
+    EnvironmentUtils.envSetUp();
+    insertData();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    close();
+    EnvironmentUtils.cleanEnv();
+  }
+
+  private static void close() {
+    if (Objects.nonNull(connection)) {
+      try {
+        connection.close();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  private static void initCreateSQLStatement() {
+    sqls.add("SET STORAGE GROUP TO root.t1");
+    sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN");
+    sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.temperature WITH DATATYPE=FLOAT, ENCODING=RLE");
+  }
+
+  private static void insertData() throws ClassNotFoundException, SQLException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    connection =
+        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+    Statement statement = connection.createStatement();
+
+    for (String sql : sqls) {
+      statement.execute(sql);
+    }
+
+    statement.close();
+  }
+
+  @Test
+  public void testInsertWithoutTime() throws SQLException {
+    Statement st0 = connection.createStatement();
+    st0.execute("insert into root.t1.wf01.wt01(time, status, temperature) values (1, true, 22)");
+    st0.execute(
+        "insert into root.t1.wf01.wt01(time, status, temperature) values (2, false, 33),(3, true, 44)");
+    st0.execute("insert into root.t1.wf01.wt01(status, temperature) values (true, 10)");
+    st0.execute("insert into root.t1.wf01.wt01(status) values (false)");
+
+    Statement st1 = connection.createStatement();
+    ResultSet rs1 = st1.executeQuery("select count(status) from root.t1.wf01.wt01");
+    rs1.next();
+    long countStatus = rs1.getLong(1);
+    Assert.assertEquals(countStatus, 5L);
+
+    st1.close();
+  }
+
+  @Test(expected = Exception.class)
+  public void testInsertWithTimesColumns() throws SQLException {
+    Statement st1 = connection.createStatement();
+    st1.execute("insert into root.t1.wf01.wt01(time) values (1)");
+  }
+
+  @Test(expected = Exception.class)
+  public void testInsertMultiRow() throws SQLException {
+    Statement st1 = connection.createStatement();
+    st1.execute("insert into root.t1.wf01.wt01(status) values (false),(true)");
+  }
+
+  @Test(expected = Exception.class)
+  public void testInsertWithMultiTimesColumns1() throws SQLException {
+    Statement st1 = connection.createStatement();
+    st1.execute("insert into root.t1.wf01.wt01(time,time) values(1,1)");
+  }
+
+  @Test(expected = Exception.class)
+  public void testInsertWithMultiTimesColumns2() throws SQLException {
+    Statement st1 = connection.createStatement();
+    st1.execute("insert into root.t1.wf01.wt01(time,status,time) values(1,false,1)");
+  }
+}


### PR DESCRIPTION
## Description
1.This PR support users insert data without timestamp, the server use the current system timestamp to pair with the data points.

2.When the timeseries named with time/timestamp/TIME/TIMESTAMP,  it will throw exception.

3.It doesn't support insert mult rows and will throw SQLParserException
 
![image](https://user-images.githubusercontent.com/35786966/117251816-ba028280-ae77-11eb-8b51-8d479760c594.png)


### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
