### PR TITLE
Delete vector data bug

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
@@ -42,7 +42,6 @@ import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
-import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertMultiTabletPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowsPlan;
@@ -162,7 +161,7 @@ public class Coordinator {
    */
   private TSStatus processNonPartitionedDataPlan(PhysicalPlan plan) {
     try {
-      if (plan instanceof DeleteTimeSeriesPlan || plan instanceof DeletePlan) {
+      if (plan instanceof DeleteTimeSeriesPlan) {
         // as delete related plans may have abstract paths (paths with wildcards), we convert
         // them to full paths so the executor nodes will not need to query the metadata holders,
         // eliminating the risk that when they are querying the metadata holders, the timeseries

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -305,6 +305,9 @@ public abstract class AbstractMemTable implements IMemTable {
       }
       IWritableMemChunk vectorMemChunk =
           memTableMap.get(deviceId).get(partialVectorSchema.getMeasurementId());
+      if (vectorMemChunk == null) {
+        return null;
+      }
 
       List<String> measurementIdList = partialVectorSchema.getValueMeasurementIdList();
       List<Integer> columns = new ArrayList<>();


### PR DESCRIPTION
# Reproduction:
- stand-alone:
insert some vector data to root.ln
delete from root.*
select * from root.ln
500 NPE occurs
 - Reason: The delete logic and vector don't coordinate well
- cluster:
insert some vector data to root.ln
delete from root.*
select * from root.ln
data still exists
 - Reason:  Vector does not currently support single column deletion