### PR TITLE
name parameters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -138,7 +138,7 @@
 * Github issue-2169 GetObject returns String for all data types
 * Github issue-2240 fix Sync failed: Socket is closed by peer
 * Github issue-2387 The deleteData method exists in Session but not in SessionPool.
-* add thrift_max_frame_size in iotdb-engine.properties
+* add rpc_max_frame_size in iotdb-engine.properties
 * Fix incorrect last result after deleting all data
 * Fix compaction recover block restart: IoTDB cannot restart until last compaction recover task finished
 * Fix compaction ignore modification file: delete does not work after compaction

--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -56,10 +56,10 @@ internal_data_port=40010
 seed_nodes=127.0.0.1:9003
 
 # whether to use thrift compressed protocol for internal communications. If you want to change
-# compression settings for external clients, please modify 'rpc_thrift_compression_enable' in
+# compression settings for external clients, please modify 'rpc_compression_enable' in
 # 'iotdb-engine.properties'.
 # WARNING: this must be consistent across all nodes in the cluster
-# rpc_thrift_compression_enable=false
+# rpc_compression_enable=false
 
 # max client connections created by thrift
 # this configuration applies separately to data/meta/client connections and thus does not control

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -161,8 +161,7 @@ public class ClusterDescriptor {
     config.setRpcThriftCompressionEnabled(
         Boolean.parseBoolean(
             properties.getProperty(
-                "rpc_thrift_compression_enable",
-                String.valueOf(config.isRpcThriftCompressionEnabled()))));
+                "rpc_compression_enable", String.valueOf(config.isRpcThriftCompressionEnabled()))));
 
     config.setConnectionTimeoutInMS(
         Integer.parseInt(

--- a/docs/UserGuide/CLI/Command-Line-Interface.md
+++ b/docs/UserGuide/CLI/Command-Line-Interface.md
@@ -87,7 +87,7 @@ Enter ```quit``` or `exit` can exit Cli. The cli will shows `quit normally`
 |-u <`username`>|string, no quotation marks|Yes|User name used for IoTDB to connect the server|-u root|
 |-maxPRC <`maxPrintRowCount`>|int|No|Set the maximum number of rows that IoTDB returns|-maxPRC 10|
 |-e <`execute`> |string|No|manipulate IoTDB in batches without entering cli input mode|-e "show storage group"|
-|-c | empty | No | If the server enables `rpc_thrift_compression_enable=true`, then cli must use `-c` | -c |
+|-c | empty | No | If the server enables `rpc_compression_enable=true`, then cli must use `-c` | -c |
 
 Following is a cli command which connects the host with IP
 10.129.187.21, rpc port 6667, username "root", password "root", and prints the timestamp in digital form. The maximum number of lines displayed on the IoTDB command line is 10.

--- a/docs/UserGuide/Cluster/Cluster-Setup.md
+++ b/docs/UserGuide/Cluster/Cluster-Setup.md
@@ -122,7 +122,7 @@ The configuration items described below are in the `iotdb-cluster.properties` fi
 
 |Name|rpc\_thrift\_compression\_enable|
 |:---:|:---|
-|Description|Whether to enable thrift compression, **Note that this parameter should be consistent with each node and with the client, and also consistent with the `rpc_thrift_compression_enable` parameter in `iotdb-engine.properties`**|
+|Description|Whether to enable thrift compression, **Note that this parameter should be consistent with each node and with the client, and also consistent with the `rpc_compression_enable` parameter in `iotdb-engine.properties`**|
 |Type| Boolean|
 |Default|false|
 |Effective| After restart system, must be changed with all other nodes|

--- a/docs/zh/UserGuide/CLI/Command-Line-Interface.md
+++ b/docs/zh/UserGuide/CLI/Command-Line-Interface.md
@@ -79,7 +79,7 @@ IoTDB> login successfully
 |-u <`username`>|string类型，不需要引号|是|IoTDB连接服务器锁使用的用户名。|-u root|
 |-maxPRC <`maxPrintRowCount`>|int类型|否|设置IoTDB返回客户端命令行中所显示的最大行数。|-maxPRC 10|
 |-e <`execute`> |string类型|否|在不进入客户端输入模式的情况下，批量操作IoTDB|-e "show storage group"|
-|-c | 空 | 否 | 如果服务器设置了 `rpc_thrift_compression_enable=true`, 则CLI必须使用 `-c` | -c |
+|-c | 空 | 否 | 如果服务器设置了 `rpc_compression_enable=true`, 则CLI必须使用 `-c` | -c |
 
 下面展示一条客户端命令，功能是连接IP为10.129.187.21的主机，端口为6667 ，用户名为root，密码为root，以数字的形式打印时间戳，IoTDB命令行显示的最大行数为10。
 

--- a/docs/zh/UserGuide/Cluster/Cluster-Setup.md
+++ b/docs/zh/UserGuide/Cluster/Cluster-Setup.md
@@ -117,7 +117,7 @@ iotdb-engines.properties配置文件中的部分内容会不再生效：
 
 |名字|rpc\_thrift\_compression\_enable|
 |:---:|:---|
-|描述|是否开启thrift压缩通信，**注意这个参数要各个节点保持一致，也要与客户端保持一致，同时也要与`iotdb-engine.properties`中`rpc_thrift_compression_enable`参数保持一致**|
+|描述|是否开启thrift压缩通信，**注意这个参数要各个节点保持一致，也要与客户端保持一致，同时也要与`iotdb-engine.properties`中`rpc_compression_enable`参数保持一致**|
 |类型| Boolean|
 |默认值|false|
 |改后生效方式|重启服务生效，需要整个集群同时更改|

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
@@ -52,5 +52,5 @@ public class Config {
   public static final String DEFAULT_BUFFER_CAPACITY = "thrift_default_buffer_capacity";
 
   /** key of thrift max frame size */
-  public static final String THRIFT_FRAME_MAX_SIZE = "thrift_max_frame_size";
+  public static final String THRIFT_FRAME_MAX_SIZE = "rpc_max_frame_size";
 }

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -41,7 +41,7 @@ rpc_address=0.0.0.0
 rpc_port=6667
 
 # Datatype: boolean
-# rpc_thrift_compression_enable=false
+# rpc_compression_enable=false
 
 # if true, a snappy based compression method will be called before sending data by the network
 # Datatype: boolean
@@ -52,11 +52,11 @@ rpc_port=6667
 
 # thrift max frame size, 64MB by default
 # Datatype: int
-# thrift_max_frame_size=67108864
+# rpc_max_frame_size=67108864
 
 # thrift init buffer size
 # Datatype: int
-# thrift_init_buffer_size=1024
+# rpc_init_buffer_size=1024
 
 ####################
 ### Write Ahead Log Configuration

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -91,11 +91,15 @@ public class IoTDBConfig {
   private String mqttPayloadFormatter = "json";
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   /** max mqtt message size. Unit: byte */
 =======
   /** max mqtt message size. 
    * Unit: byte */
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+  /** max mqtt message size. Unit: byte */
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int mqttMaxMessageSize = 1048576;
 
   /** Rpc binding address. */
@@ -137,6 +141,7 @@ public class IoTDBConfig {
   private double rejectProportion = 0.8;
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   /** If storage group increased more than this threshold, report to system. Unit: byte */
   private long storageGroupSizeReportThreshold = 16 * 1024 * 1024L;
 
@@ -147,15 +152,21 @@ public class IoTDBConfig {
 =======
   /** If storage group increased more than this threshold, report to system. 
    * Unit: byte */
+=======
+  /** If storage group increased more than this threshold, report to system. Unit: byte */
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long storageGroupSizeReportThreshold = 16 * 1024 * 1024L;
 
-  /** When inserting rejected, waiting period to check system again. 
-   * Unit: millisecond */
+  /** When inserting rejected, waiting period to check system again. Unit: millisecond */
   private int checkPeriodWhenInsertBlocked = 50;
 
+<<<<<<< HEAD
   /** When inserting rejected exceeds this, throw an exception. 
    * Unit: millisecond */
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+  /** When inserting rejected exceeds this, throw an exception. Unit: millisecond */
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int maxWaitingTimeWhenInsertBlockedInMs = 10000;
   /** Is the write ahead log enable. */
   private boolean enableWal = true;
@@ -176,12 +187,17 @@ public class IoTDBConfig {
   /**
    * The cycle when write ahead log is periodically forced to be written to disk(in milliseconds) If
 <<<<<<< HEAD
+<<<<<<< HEAD
    * set this parameter to 0 it means call channel.force(true) after every each insert. Unit:
    * millisecond
 =======
    * set this parameter to 0 it means call channel.force(true) after every each insert. 
    * Unit: millisecond
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+   * set this parameter to 0 it means call channel.force(true) after every each insert. Unit:
+   * millisecond
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long forceWalPeriodInMs = 100;
 
@@ -189,11 +205,15 @@ public class IoTDBConfig {
    * The size of the log buffer in each log node (in bytes). Due to the double buffer mechanism, if
    * WAL is enabled and the size of the inserted plan is greater than one-half of this parameter,
 <<<<<<< HEAD
+<<<<<<< HEAD
    * then the insert plan will be rejected by WAL. Unit: byte
 =======
    * then the insert plan will be rejected by WAL. 
    * Unit: byte
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+   * then the insert plan will be rejected by WAL. Unit: byte
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private int walBufferSize = 16 * 1024 * 1024;
 
@@ -216,11 +236,15 @@ public class IoTDBConfig {
    * The size of log buffer for every trigger management operation plan. If the size of a trigger
    * management operation plan is larger than this parameter, the trigger management operation plan
 <<<<<<< HEAD
+<<<<<<< HEAD
    * will be rejected by TriggerManager. Unit: byte
 =======
    * will be rejected by TriggerManager.
    * Unit: byte 
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+   * will be rejected by TriggerManager. Unit: byte
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private int tlogBufferSize = 1024 * 1024;
 
@@ -310,11 +334,15 @@ public class IoTDBConfig {
    * index structures will be counted. If the memory buffer size reaches this threshold, the indexes
    * will be flushed to the disk file. As a result, data in one series may be divided into more than
 <<<<<<< HEAD
+<<<<<<< HEAD
    * one part and indexed separately. Unit: byte
 =======
    * one part and indexed separately.
    * Unit: byte
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+   * one part and indexed separately. Unit: byte
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long indexBufferSize = 128 * 1024 * 1024L;
 
@@ -328,6 +356,7 @@ public class IoTDBConfig {
   private String indexRootFolder = "data" + File.separator + "index";
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   /** When a TsFile's file size (in byte) exceed this, the TsFile is forced closed. Unit: byte */
   private long tsFileSizeThreshold = 1L;
 
@@ -340,6 +369,12 @@ public class IoTDBConfig {
   /** When a memTable's size (in byte) exceeds this, the memtable is flushed to disk. 
    * Unit: byte */
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+  /** When a TsFile's file size (in byte) exceed this, the TsFile is forced closed. Unit: byte */
+  private long tsFileSizeThreshold = 1L;
+
+  /** When a memTable's size (in byte) exceeds this, the memtable is flushed to disk. Unit: byte */
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long memtableSizeThreshold = 1024 * 1024 * 1024L;
 
   /** When average series point number reaches this, flush the memtable to disk */
@@ -435,6 +470,7 @@ public class IoTDBConfig {
   private String ipWhiteList = "0.0.0.0/0";
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   /** Examining period of cache file reader : 100 seconds. Unit: millisecond */
   private long cacheFileReaderClearPeriod = 100000;
 
@@ -447,6 +483,12 @@ public class IoTDBConfig {
   /** the max executing time of query in ms. 
    * Unit: millisecond */
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+  /** Examining period of cache file reader : 100 seconds. Unit: millisecond */
+  private long cacheFileReaderClearPeriod = 100000;
+
+  /** the max executing time of query in ms. Unit: millisecond */
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int queryTimeoutThreshold = 60000;
 
   /** Replace implementation class of JDBC service */
@@ -458,6 +500,7 @@ public class IoTDBConfig {
   /** Is performance tracing enable. */
   private boolean enablePerformanceTracing = false;
 
+<<<<<<< HEAD
 <<<<<<< HEAD
   /** The display of stat performance interval in ms. Unit: millisecond */
   private long performanceStatDisplayInterval = 60000;
@@ -473,6 +516,12 @@ public class IoTDBConfig {
    * Unit: kilobyte 
    */
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+  /** The display of stat performance interval in ms. Unit: millisecond */
+  private long performanceStatDisplayInterval = 60000;
+
+  /** The memory used for stat performance. Unit: kilobyte */
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int performanceStatMemoryInKB = 20;
 
   /** whether use chunkBufferPool. */
@@ -550,12 +599,17 @@ public class IoTDBConfig {
   /**
    * If one merge file selection runs for more than this time, it will be ended and its current
 <<<<<<< HEAD
+<<<<<<< HEAD
    * selection will be used as final selection. When < 0, it means time is unbounded. Unit:
    * millisecond
 =======
    * selection will be used as final selection. When < 0, it means time is unbounded.
    * Unit: millisecond
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+   * selection will be used as final selection. When < 0, it means time is unbounded. Unit:
+   * millisecond
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long mergeFileSelectionTimeBudget = 30 * 1000L;
 
@@ -568,8 +622,7 @@ public class IoTDBConfig {
 
   /**
    * A global merge will be performed each such interval, that is, each storage group will be merged
-   * (if proper merge candidates can be found). 
-   * Unit: second.
+   * (if proper merge candidates can be found). Unit: second.
    */
   private long mergeIntervalSec = 0L;
 
@@ -642,6 +695,7 @@ public class IoTDBConfig {
 
   /**
 <<<<<<< HEAD
+<<<<<<< HEAD
    * default TTL for storage groups that are not set TTL by statements, in ms.
    *
    * <p>Notice: if this property is changed, previous created storage group which are not set TTL
@@ -653,6 +707,12 @@ public class IoTDBConfig {
    * will also be affected.
    * Unit: millisecond
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+   * default TTL for storage groups that are not set TTL by statements, in ms.
+   *
+   * <p>Notice: if this property is changed, previous created storage group which are not set TTL
+   * will also be affected. Unit: millisecond
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long defaultTTL = Long.MAX_VALUE;
 
@@ -671,6 +731,7 @@ public class IoTDBConfig {
   /**
    * Threshold interval time of MTree modification. If the last modification time is less than this
 <<<<<<< HEAD
+<<<<<<< HEAD
    * threshold, MTree snapshot will not be created. Default: 1 hour(3600 seconds) Unit: second
    */
   private int mtreeSnapshotThresholdTime = 3600;
@@ -686,6 +747,13 @@ public class IoTDBConfig {
    * Unit: second 
    */
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+   * threshold, MTree snapshot will not be created. Default: 1 hour(3600 seconds) Unit: second
+   */
+  private int mtreeSnapshotThresholdTime = 3600;
+
+  /** Time range for partitioning data inside each storage group. Unit: second */
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long partitionInterval = 604800;
 
   /**
@@ -744,6 +812,7 @@ public class IoTDBConfig {
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   /** time interval in minute for calculating query frequency. Unit: minute */
   private int frequencyIntervalInMinute = 1;
 
@@ -758,6 +827,12 @@ public class IoTDBConfig {
    * Unit: millisecond 
    */
 >>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
+=======
+  /** time interval in minute for calculating query frequency. Unit: minute */
+  private int frequencyIntervalInMinute = 1;
+
+  /** time cost(ms) threshold for slow query. Unit: millisecond */
+>>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long slowQueryThreshold = 5000;
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -90,16 +90,7 @@ public class IoTDBConfig {
   /** the mqtt message payload formatter. */
   private String mqttPayloadFormatter = "json";
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   /** max mqtt message size. Unit: byte */
-=======
-  /** max mqtt message size. 
-   * Unit: byte */
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-  /** max mqtt message size. Unit: byte */
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int mqttMaxMessageSize = 1048576;
 
   /** Rpc binding address. */
@@ -140,8 +131,6 @@ public class IoTDBConfig {
   /** Reject proportion for system */
   private double rejectProportion = 0.8;
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   /** If storage group increased more than this threshold, report to system. Unit: byte */
   private long storageGroupSizeReportThreshold = 16 * 1024 * 1024L;
 
@@ -149,24 +138,6 @@ public class IoTDBConfig {
   private int checkPeriodWhenInsertBlocked = 50;
 
   /** When inserting rejected exceeds this, throw an exception. Unit: millisecond */
-=======
-  /** If storage group increased more than this threshold, report to system. 
-   * Unit: byte */
-=======
-  /** If storage group increased more than this threshold, report to system. Unit: byte */
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
-  private long storageGroupSizeReportThreshold = 16 * 1024 * 1024L;
-
-  /** When inserting rejected, waiting period to check system again. Unit: millisecond */
-  private int checkPeriodWhenInsertBlocked = 50;
-
-<<<<<<< HEAD
-  /** When inserting rejected exceeds this, throw an exception. 
-   * Unit: millisecond */
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-  /** When inserting rejected exceeds this, throw an exception. Unit: millisecond */
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int maxWaitingTimeWhenInsertBlockedInMs = 10000;
   /** Is the write ahead log enable. */
   private boolean enableWal = true;
@@ -186,34 +157,15 @@ public class IoTDBConfig {
 
   /**
    * The cycle when write ahead log is periodically forced to be written to disk(in milliseconds) If
-<<<<<<< HEAD
-<<<<<<< HEAD
    * set this parameter to 0 it means call channel.force(true) after every each insert. Unit:
    * millisecond
-=======
-   * set this parameter to 0 it means call channel.force(true) after every each insert. 
-   * Unit: millisecond
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-   * set this parameter to 0 it means call channel.force(true) after every each insert. Unit:
-   * millisecond
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long forceWalPeriodInMs = 100;
 
   /**
    * The size of the log buffer in each log node (in bytes). Due to the double buffer mechanism, if
    * WAL is enabled and the size of the inserted plan is greater than one-half of this parameter,
-<<<<<<< HEAD
-<<<<<<< HEAD
    * then the insert plan will be rejected by WAL. Unit: byte
-=======
-   * then the insert plan will be rejected by WAL. 
-   * Unit: byte
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-   * then the insert plan will be rejected by WAL. Unit: byte
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private int walBufferSize = 16 * 1024 * 1024;
 
@@ -235,16 +187,7 @@ public class IoTDBConfig {
   /**
    * The size of log buffer for every trigger management operation plan. If the size of a trigger
    * management operation plan is larger than this parameter, the trigger management operation plan
-<<<<<<< HEAD
-<<<<<<< HEAD
    * will be rejected by TriggerManager. Unit: byte
-=======
-   * will be rejected by TriggerManager.
-   * Unit: byte 
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-   * will be rejected by TriggerManager. Unit: byte
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private int tlogBufferSize = 1024 * 1024;
 
@@ -333,16 +276,7 @@ public class IoTDBConfig {
    * common buffer size. With the memory-control mechanism, the occupied memory of all raw data and
    * index structures will be counted. If the memory buffer size reaches this threshold, the indexes
    * will be flushed to the disk file. As a result, data in one series may be divided into more than
-<<<<<<< HEAD
-<<<<<<< HEAD
    * one part and indexed separately. Unit: byte
-=======
-   * one part and indexed separately.
-   * Unit: byte
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-   * one part and indexed separately. Unit: byte
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long indexBufferSize = 128 * 1024 * 1024L;
 
@@ -355,26 +289,10 @@ public class IoTDBConfig {
   /** index directory. */
   private String indexRootFolder = "data" + File.separator + "index";
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   /** When a TsFile's file size (in byte) exceed this, the TsFile is forced closed. Unit: byte */
   private long tsFileSizeThreshold = 1L;
 
   /** When a memTable's size (in byte) exceeds this, the memtable is flushed to disk. Unit: byte */
-=======
-  /** When a TsFile's file size (in byte) exceed this, the TsFile is forced closed. 
-   * Unit: byte */
-  private long tsFileSizeThreshold = 1L;
-
-  /** When a memTable's size (in byte) exceeds this, the memtable is flushed to disk. 
-   * Unit: byte */
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-  /** When a TsFile's file size (in byte) exceed this, the TsFile is forced closed. Unit: byte */
-  private long tsFileSizeThreshold = 1L;
-
-  /** When a memTable's size (in byte) exceeds this, the memtable is flushed to disk. Unit: byte */
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long memtableSizeThreshold = 1024 * 1024 * 1024L;
 
   /** When average series point number reaches this, flush the memtable to disk */
@@ -469,26 +387,10 @@ public class IoTDBConfig {
 
   private String ipWhiteList = "0.0.0.0/0";
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   /** Examining period of cache file reader : 100 seconds. Unit: millisecond */
   private long cacheFileReaderClearPeriod = 100000;
 
   /** the max executing time of query in ms. Unit: millisecond */
-=======
-  /** Examining period of cache file reader : 100 seconds. 
-   * Unit: millisecond */
-  private long cacheFileReaderClearPeriod = 100000;
-
-  /** the max executing time of query in ms. 
-   * Unit: millisecond */
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-  /** Examining period of cache file reader : 100 seconds. Unit: millisecond */
-  private long cacheFileReaderClearPeriod = 100000;
-
-  /** the max executing time of query in ms. Unit: millisecond */
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int queryTimeoutThreshold = 60000;
 
   /** Replace implementation class of JDBC service */
@@ -500,28 +402,10 @@ public class IoTDBConfig {
   /** Is performance tracing enable. */
   private boolean enablePerformanceTracing = false;
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   /** The display of stat performance interval in ms. Unit: millisecond */
   private long performanceStatDisplayInterval = 60000;
 
   /** The memory used for stat performance. Unit: kilobyte */
-=======
-  /** The display of stat performance interval in ms. 
-   * Unit: millisecond 
-   */
-  private long performanceStatDisplayInterval = 60000;
-
-  /** The memory used for stat performance. 
-   * Unit: kilobyte 
-   */
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-  /** The display of stat performance interval in ms. Unit: millisecond */
-  private long performanceStatDisplayInterval = 60000;
-
-  /** The memory used for stat performance. Unit: kilobyte */
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int performanceStatMemoryInKB = 20;
 
   /** whether use chunkBufferPool. */
@@ -598,18 +482,8 @@ public class IoTDBConfig {
 
   /**
    * If one merge file selection runs for more than this time, it will be ended and its current
-<<<<<<< HEAD
-<<<<<<< HEAD
    * selection will be used as final selection. When < 0, it means time is unbounded. Unit:
    * millisecond
-=======
-   * selection will be used as final selection. When < 0, it means time is unbounded.
-   * Unit: millisecond
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-   * selection will be used as final selection. When < 0, it means time is unbounded. Unit:
-   * millisecond
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long mergeFileSelectionTimeBudget = 30 * 1000L;
 
@@ -694,25 +568,10 @@ public class IoTDBConfig {
   private int defaultFillInterval = -1;
 
   /**
-<<<<<<< HEAD
-<<<<<<< HEAD
    * default TTL for storage groups that are not set TTL by statements, in ms.
    *
    * <p>Notice: if this property is changed, previous created storage group which are not set TTL
    * will also be affected. Unit: millisecond
-=======
-   * default TTL for storage groups that are not set TTL by statements, in ms. 
-   *
-   * <p>Notice: if this property is changed, previous created storage group which are not set TTL
-   * will also be affected.
-   * Unit: millisecond
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-   * default TTL for storage groups that are not set TTL by statements, in ms.
-   *
-   * <p>Notice: if this property is changed, previous created storage group which are not set TTL
-   * will also be affected. Unit: millisecond
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long defaultTTL = Long.MAX_VALUE;
 
@@ -730,30 +589,11 @@ public class IoTDBConfig {
 
   /**
    * Threshold interval time of MTree modification. If the last modification time is less than this
-<<<<<<< HEAD
-<<<<<<< HEAD
    * threshold, MTree snapshot will not be created. Default: 1 hour(3600 seconds) Unit: second
    */
   private int mtreeSnapshotThresholdTime = 3600;
 
   /** Time range for partitioning data inside each storage group. Unit: second */
-=======
-   * threshold, MTree snapshot will not be created. Default: 1 hour(3600 seconds)
-   * Unit: second
-   */
-  private int mtreeSnapshotThresholdTime = 3600;
-
-  /** Time range for partitioning data inside each storage group. 
-   * Unit: second 
-   */
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-   * threshold, MTree snapshot will not be created. Default: 1 hour(3600 seconds) Unit: second
-   */
-  private int mtreeSnapshotThresholdTime = 3600;
-
-  /** Time range for partitioning data inside each storage group. Unit: second */
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long partitionInterval = 604800;
 
   /**
@@ -811,28 +651,10 @@ public class IoTDBConfig {
 
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   /** time interval in minute for calculating query frequency. Unit: minute */
   private int frequencyIntervalInMinute = 1;
 
   /** time cost(ms) threshold for slow query. Unit: millisecond */
-=======
-  /** time interval in minute for calculating query frequency. 
-   * Unit: minute 
-   */
-  private int frequencyIntervalInMinute = 1;
-
-  /** time cost(ms) threshold for slow query. 
-   * Unit: millisecond 
-   */
->>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
-=======
-  /** time interval in minute for calculating query frequency. Unit: minute */
-  private int frequencyIntervalInMinute = 1;
-
-  /** time cost(ms) threshold for slow query. Unit: millisecond */
->>>>>>> 1831330ed... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long slowQueryThreshold = 5000;
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -90,7 +90,12 @@ public class IoTDBConfig {
   /** the mqtt message payload formatter. */
   private String mqttPayloadFormatter = "json";
 
+<<<<<<< HEAD
   /** max mqtt message size. Unit: byte */
+=======
+  /** max mqtt message size. 
+   * Unit: byte */
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int mqttMaxMessageSize = 1048576;
 
   /** Rpc binding address. */
@@ -131,6 +136,7 @@ public class IoTDBConfig {
   /** Reject proportion for system */
   private double rejectProportion = 0.8;
 
+<<<<<<< HEAD
   /** If storage group increased more than this threshold, report to system. Unit: byte */
   private long storageGroupSizeReportThreshold = 16 * 1024 * 1024L;
 
@@ -138,6 +144,18 @@ public class IoTDBConfig {
   private int checkPeriodWhenInsertBlocked = 50;
 
   /** When inserting rejected exceeds this, throw an exception. Unit: millisecond */
+=======
+  /** If storage group increased more than this threshold, report to system. 
+   * Unit: byte */
+  private long storageGroupSizeReportThreshold = 16 * 1024 * 1024L;
+
+  /** When inserting rejected, waiting period to check system again. 
+   * Unit: millisecond */
+  private int checkPeriodWhenInsertBlocked = 50;
+
+  /** When inserting rejected exceeds this, throw an exception. 
+   * Unit: millisecond */
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int maxWaitingTimeWhenInsertBlockedInMs = 10000;
   /** Is the write ahead log enable. */
   private boolean enableWal = true;
@@ -157,15 +175,25 @@ public class IoTDBConfig {
 
   /**
    * The cycle when write ahead log is periodically forced to be written to disk(in milliseconds) If
+<<<<<<< HEAD
    * set this parameter to 0 it means call channel.force(true) after every each insert. Unit:
    * millisecond
+=======
+   * set this parameter to 0 it means call channel.force(true) after every each insert. 
+   * Unit: millisecond
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long forceWalPeriodInMs = 100;
 
   /**
    * The size of the log buffer in each log node (in bytes). Due to the double buffer mechanism, if
    * WAL is enabled and the size of the inserted plan is greater than one-half of this parameter,
+<<<<<<< HEAD
    * then the insert plan will be rejected by WAL. Unit: byte
+=======
+   * then the insert plan will be rejected by WAL. 
+   * Unit: byte
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private int walBufferSize = 16 * 1024 * 1024;
 
@@ -187,7 +215,12 @@ public class IoTDBConfig {
   /**
    * The size of log buffer for every trigger management operation plan. If the size of a trigger
    * management operation plan is larger than this parameter, the trigger management operation plan
+<<<<<<< HEAD
    * will be rejected by TriggerManager. Unit: byte
+=======
+   * will be rejected by TriggerManager.
+   * Unit: byte 
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private int tlogBufferSize = 1024 * 1024;
 
@@ -276,7 +309,12 @@ public class IoTDBConfig {
    * common buffer size. With the memory-control mechanism, the occupied memory of all raw data and
    * index structures will be counted. If the memory buffer size reaches this threshold, the indexes
    * will be flushed to the disk file. As a result, data in one series may be divided into more than
+<<<<<<< HEAD
    * one part and indexed separately. Unit: byte
+=======
+   * one part and indexed separately.
+   * Unit: byte
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long indexBufferSize = 128 * 1024 * 1024L;
 
@@ -289,10 +327,19 @@ public class IoTDBConfig {
   /** index directory. */
   private String indexRootFolder = "data" + File.separator + "index";
 
+<<<<<<< HEAD
   /** When a TsFile's file size (in byte) exceed this, the TsFile is forced closed. Unit: byte */
   private long tsFileSizeThreshold = 1L;
 
   /** When a memTable's size (in byte) exceeds this, the memtable is flushed to disk. Unit: byte */
+=======
+  /** When a TsFile's file size (in byte) exceed this, the TsFile is forced closed. 
+   * Unit: byte */
+  private long tsFileSizeThreshold = 1L;
+
+  /** When a memTable's size (in byte) exceeds this, the memtable is flushed to disk. 
+   * Unit: byte */
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long memtableSizeThreshold = 1024 * 1024 * 1024L;
 
   /** When average series point number reaches this, flush the memtable to disk */
@@ -387,10 +434,19 @@ public class IoTDBConfig {
 
   private String ipWhiteList = "0.0.0.0/0";
 
+<<<<<<< HEAD
   /** Examining period of cache file reader : 100 seconds. Unit: millisecond */
   private long cacheFileReaderClearPeriod = 100000;
 
   /** the max executing time of query in ms. Unit: millisecond */
+=======
+  /** Examining period of cache file reader : 100 seconds. 
+   * Unit: millisecond */
+  private long cacheFileReaderClearPeriod = 100000;
+
+  /** the max executing time of query in ms. 
+   * Unit: millisecond */
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int queryTimeoutThreshold = 60000;
 
   /** Replace implementation class of JDBC service */
@@ -402,10 +458,21 @@ public class IoTDBConfig {
   /** Is performance tracing enable. */
   private boolean enablePerformanceTracing = false;
 
+<<<<<<< HEAD
   /** The display of stat performance interval in ms. Unit: millisecond */
   private long performanceStatDisplayInterval = 60000;
 
   /** The memory used for stat performance. Unit: kilobyte */
+=======
+  /** The display of stat performance interval in ms. 
+   * Unit: millisecond 
+   */
+  private long performanceStatDisplayInterval = 60000;
+
+  /** The memory used for stat performance. 
+   * Unit: kilobyte 
+   */
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private int performanceStatMemoryInKB = 20;
 
   /** whether use chunkBufferPool. */
@@ -482,8 +549,13 @@ public class IoTDBConfig {
 
   /**
    * If one merge file selection runs for more than this time, it will be ended and its current
+<<<<<<< HEAD
    * selection will be used as final selection. When < 0, it means time is unbounded. Unit:
    * millisecond
+=======
+   * selection will be used as final selection. When < 0, it means time is unbounded.
+   * Unit: millisecond
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long mergeFileSelectionTimeBudget = 30 * 1000L;
 
@@ -496,7 +568,8 @@ public class IoTDBConfig {
 
   /**
    * A global merge will be performed each such interval, that is, each storage group will be merged
-   * (if proper merge candidates can be found). Unit: second.
+   * (if proper merge candidates can be found). 
+   * Unit: second.
    */
   private long mergeIntervalSec = 0L;
 
@@ -568,10 +641,18 @@ public class IoTDBConfig {
   private int defaultFillInterval = -1;
 
   /**
+<<<<<<< HEAD
    * default TTL for storage groups that are not set TTL by statements, in ms.
    *
    * <p>Notice: if this property is changed, previous created storage group which are not set TTL
    * will also be affected. Unit: millisecond
+=======
+   * default TTL for storage groups that are not set TTL by statements, in ms. 
+   *
+   * <p>Notice: if this property is changed, previous created storage group which are not set TTL
+   * will also be affected.
+   * Unit: millisecond
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
    */
   private long defaultTTL = Long.MAX_VALUE;
 
@@ -589,11 +670,22 @@ public class IoTDBConfig {
 
   /**
    * Threshold interval time of MTree modification. If the last modification time is less than this
+<<<<<<< HEAD
    * threshold, MTree snapshot will not be created. Default: 1 hour(3600 seconds) Unit: second
    */
   private int mtreeSnapshotThresholdTime = 3600;
 
   /** Time range for partitioning data inside each storage group. Unit: second */
+=======
+   * threshold, MTree snapshot will not be created. Default: 1 hour(3600 seconds)
+   * Unit: second
+   */
+  private int mtreeSnapshotThresholdTime = 3600;
+
+  /** Time range for partitioning data inside each storage group. 
+   * Unit: second 
+   */
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long partitionInterval = 604800;
 
   /**
@@ -651,10 +743,21 @@ public class IoTDBConfig {
 
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;
 
+<<<<<<< HEAD
   /** time interval in minute for calculating query frequency. Unit: minute */
   private int frequencyIntervalInMinute = 1;
 
   /** time cost(ms) threshold for slow query. Unit: millisecond */
+=======
+  /** time interval in minute for calculating query frequency. 
+   * Unit: minute 
+   */
+  private int frequencyIntervalInMinute = 1;
+
+  /** time cost(ms) threshold for slow query. 
+   * Unit: millisecond 
+   */
+>>>>>>> f8162b796... keep IoTDBConfig.java and iotdb-engine.properties consistent
   private long slowQueryThreshold = 5000;
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -151,7 +151,7 @@ public class IoTDBDescriptor {
       conf.setRpcThriftCompressionEnable(
           Boolean.parseBoolean(
               properties.getProperty(
-                  "rpc_thrift_compression_enable",
+                  "rpc_compression_enable",
                   Boolean.toString(conf.isRpcThriftCompressionEnable()))));
 
       conf.setRpcAdvancedCompressionEnable(
@@ -619,7 +619,7 @@ public class IoTDBDescriptor {
       conf.setThriftMaxFrameSize(
           Integer.parseInt(
               properties.getProperty(
-                  "thrift_max_frame_size", String.valueOf(conf.getThriftMaxFrameSize()))));
+                  "rpc_max_frame_size", String.valueOf(conf.getThriftMaxFrameSize()))));
 
       if (conf.getThriftMaxFrameSize() < IoTDBConstant.LEFT_SIZE_IN_REQUEST * 2) {
         conf.setThriftMaxFrameSize(IoTDBConstant.LEFT_SIZE_IN_REQUEST * 2);
@@ -628,7 +628,7 @@ public class IoTDBDescriptor {
       conf.setThriftDefaultBufferSize(
           Integer.parseInt(
               properties.getProperty(
-                  "thrift_init_buffer_size", String.valueOf(conf.getThriftDefaultBufferSize()))));
+                  "rpc_init_buffer_size", String.valueOf(conf.getThriftDefaultBufferSize()))));
 
       conf.setFrequencyIntervalInMinute(
           Integer.parseInt(


### PR DESCRIPTION
## Description

This PR has renamed some parameters in iotdb-cluster.properties and iotdb-engine.properties


This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
