### PR TITLE
[IOTDB-1339] optimize TimeoutChangeableTSnappyFramedTransport

### DIFF
--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcTransportFactory.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcTransportFactory.java
@@ -19,8 +19,6 @@
 
 package org.apache.iotdb.rpc;
 
-import org.apache.iotdb.rpc.TimeoutChangeableTFastFramedTransport.Factory;
-
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportFactory;
 
@@ -37,8 +35,12 @@ public class RpcTransportFactory extends TTransportFactory {
   static {
     INSTANCE =
         USE_SNAPPY
-            ? new RpcTransportFactory(new TimeoutChangeableTSnappyFramedTransport.Factory())
-            : new RpcTransportFactory(new Factory(thriftDefaultBufferSize, thriftMaxFrameSize));
+            ? new RpcTransportFactory(
+                new TimeoutChangeableTSnappyFramedTransport.Factory(
+                    thriftDefaultBufferSize, thriftMaxFrameSize))
+            : new RpcTransportFactory(
+                new TimeoutChangeableTFastFramedTransport.Factory(
+                    thriftDefaultBufferSize, thriftMaxFrameSize));
   }
 
   private TTransportFactory inner;

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTFastFramedTransport.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTFastFramedTransport.java
@@ -30,8 +30,9 @@ public class TimeoutChangeableTFastFramedTransport extends TElasticFramedTranspo
 
   private TSocket underlyingSocket;
 
-  public TimeoutChangeableTFastFramedTransport(TSocket underlying) {
-    super(underlying);
+  public TimeoutChangeableTFastFramedTransport(
+      TSocket underlying, int thriftDefaultBufferSize, int thriftMaxFrameSize) {
+    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize);
     this.underlyingSocket = underlying;
   }
 
@@ -58,7 +59,8 @@ public class TimeoutChangeableTFastFramedTransport extends TElasticFramedTranspo
     @Override
     public TTransport getTransport(TTransport trans) {
       if (trans instanceof TSocket) {
-        return new TimeoutChangeableTFastFramedTransport((TSocket) trans);
+        return new TimeoutChangeableTFastFramedTransport(
+            (TSocket) trans, thriftDefaultBufferSize, thriftMaxFrameSize);
       } else {
         return new TElasticFramedTransport(trans, thriftDefaultBufferSize, thriftMaxFrameSize);
       }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTSnappyFramedTransport.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTSnappyFramedTransport.java
@@ -30,8 +30,9 @@ public class TimeoutChangeableTSnappyFramedTransport extends TSnappyElasticFrame
 
   private TSocket underlyingSocket;
 
-  public TimeoutChangeableTSnappyFramedTransport(TSocket underlying) {
-    super(underlying);
+  public TimeoutChangeableTSnappyFramedTransport(
+      TSocket underlying, int thriftDefaultBufferSize, int thriftMaxFrameSize) {
+    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize);
     this.underlyingSocket = underlying;
   }
 
@@ -58,7 +59,8 @@ public class TimeoutChangeableTSnappyFramedTransport extends TSnappyElasticFrame
     @Override
     public TTransport getTransport(TTransport trans) {
       if (trans instanceof TSocket) {
-        return new TimeoutChangeableTSnappyFramedTransport((TSocket) trans);
+        return new TimeoutChangeableTSnappyFramedTransport(
+            (TSocket) trans, thriftDefaultBufferSize, thriftMaxFrameSize);
       } else {
         return new TSnappyElasticFramedTransport(
             trans, thriftDefaultBufferSize, thriftMaxFrameSize);

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTSnappyFramedTransport.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTSnappyFramedTransport.java
@@ -46,12 +46,22 @@ public class TimeoutChangeableTSnappyFramedTransport extends TSnappyElasticFrame
   }
 
   public static class Factory extends TTransportFactory {
+
+    private final int thriftDefaultBufferSize;
+    protected final int thriftMaxFrameSize;
+
+    public Factory(int thriftDefaultBufferSize, int thriftMaxFrameSize) {
+      this.thriftDefaultBufferSize = thriftDefaultBufferSize;
+      this.thriftMaxFrameSize = thriftMaxFrameSize;
+    }
+
     @Override
     public TTransport getTransport(TTransport trans) {
       if (trans instanceof TSocket) {
         return new TimeoutChangeableTSnappyFramedTransport((TSocket) trans);
       } else {
-        return new TSnappyElasticFramedTransport(trans);
+        return new TSnappyElasticFramedTransport(
+            trans, thriftDefaultBufferSize, thriftMaxFrameSize);
       }
     }
   }


### PR DESCRIPTION
TimeoutChangeableTSnappyFramedTransport do not use thriftDefaultBufferSize and thriftMaxFrameSize.  