### PR TITLE
[Cluster] Fix query multiple subSensors for multiple device timeout bug in cluster

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -230,13 +230,14 @@ public class CMManager extends MManager {
                 null, measurementSchema.getMeasurementId(), measurementSchema, null);
         if (measurementSchema instanceof VectorMeasurementSchema) {
           for (String subSensorId : measurementSchema.getValueMeasurementIdList()) {
-            cacheMeta(new PartialPath(path.getDevice(), subSensorId), measurementMNode);
+            cacheMeta(new PartialPath(path.getDevice(), subSensorId), measurementMNode, false);
           }
           cacheMeta(
               new PartialPath(path.getDevice(), measurementSchema.getMeasurementId()),
-              measurementMNode);
+              measurementMNode,
+              true);
         } else {
-          cacheMeta(path, measurementMNode);
+          cacheMeta(path, measurementMNode, true);
         }
         return measurementMNode.getDataType(path.getMeasurement());
       } else {
@@ -290,7 +291,7 @@ public class CMManager extends MManager {
           MeasurementMNode measurementMNode =
               new MeasurementMNode(
                   null, measurementSchema.getMeasurementId(), measurementSchema, null);
-          cacheMeta(fullPath, measurementMNode);
+          cacheMeta(fullPath, measurementMNode, true);
           node = measurementMNode;
         } else {
           throw e;
@@ -370,13 +371,20 @@ public class CMManager extends MManager {
       // take care, the pulled schema's measurement Id is only series name
       MeasurementMNode measurementMNode =
           new MeasurementMNode(null, schema.getMeasurementId(), schema, null);
-      cacheMeta(deviceId.concatNode(schema.getMeasurementId()), measurementMNode);
+      cacheMeta(deviceId.concatNode(schema.getMeasurementId()), measurementMNode, true);
     }
     logger.debug("Pulled {}/{} schemas from remote", schemas.size(), measurementList.length);
   }
 
+  /*
+  do not set FullPath for Vector subSensor
+   */
   @Override
-  public void cacheMeta(PartialPath seriesPath, MeasurementMNode measurementMNode) {
+  public void cacheMeta(
+      PartialPath seriesPath, MeasurementMNode measurementMNode, boolean needSetFullPath) {
+    if (needSetFullPath) {
+      measurementMNode.setFullPath(seriesPath.getFullPath());
+    }
     cacheLock.writeLock().lock();
     mRemoteMetaCache.put(seriesPath, measurementMNode);
     cacheLock.writeLock().unlock();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -2054,7 +2054,8 @@ public class MManager {
    * if the path is in local mtree, nothing needed to do (because mtree is in the memory); Otherwise
    * cache the path to mRemoteSchemaCache
    */
-  public void cacheMeta(PartialPath path, MeasurementMNode measurementMNode) {
+  public void cacheMeta(
+      PartialPath path, MeasurementMNode measurementMNode, boolean needSetFullPath) {
     // do nothing
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
@@ -353,6 +353,10 @@ public class MNode implements Serializable {
     this.addChild(newChildNode.getName(), newChildNode);
   }
 
+  public void setFullPath(String fullPath) {
+    this.fullPath = fullPath;
+  }
+
   public Template getUpperTemplate() {
     MNode cur = this;
     while (cur != null) {

--- a/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
@@ -120,7 +120,7 @@ public class SchemaUtils {
 
     MeasurementMNode measurementMNode =
         new MeasurementMNode(null, path.getMeasurement(), measurementSchema, null);
-    IoTDB.metaManager.cacheMeta(path, measurementMNode);
+    IoTDB.metaManager.cacheMeta(path, measurementMNode, true);
   }
 
   public static List<TSDataType> getSeriesTypesByPaths(Collection<PartialPath> paths)


### PR DESCRIPTION
This bug is because we don't set FullPath for MeasurementMnode to distinguish them. 
The logic here is new since the aligned timeseries pr were merged and may require further refactoring later