### PR TITLE
Add TsFileSequenceReader getChunkMetadataList method return empty if path not exists

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
@@ -136,7 +136,7 @@ public class MergeResource {
   public List<ChunkMetadata> queryChunkMetadata(PartialPath path, TsFileResource seqFile)
       throws IOException {
     TsFileSequenceReader sequenceReader = getFileReader(seqFile);
-    return sequenceReader.getChunkMetadataList(path);
+    return sequenceReader.getChunkMetadataListReturnEmptyIfPathNotExists(path);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/utils/MergeUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/MergeUtils.java
@@ -142,7 +142,8 @@ public class MergeUtils {
     List<Path> paths = collectFileSeries(sequenceReader);
 
     for (Path path : paths) {
-      List<ChunkMetadata> chunkMetadataList = sequenceReader.getChunkMetadataList(path);
+      List<ChunkMetadata> chunkMetadataList =
+          sequenceReader.getChunkMetadataListReturnEmptyIfPathNotExists(path);
       totalChunkNum += chunkMetadataList.size();
       maxChunkNum = chunkMetadataList.size() > maxChunkNum ? chunkMetadataList.size() : maxChunkNum;
     }
@@ -191,11 +192,11 @@ public class MergeUtils {
       TsFileSequenceReader tsFileReader,
       MergeResource resource,
       TsFileResource tsFileResource,
-      PriorityQueue<MetaListEntry> chunkMetaHeap)
-      throws IOException {
+      PriorityQueue<MetaListEntry> chunkMetaHeap) {
     for (int i = 0; i < paths.size(); i++) {
       PartialPath path = paths.get(i);
-      List<ChunkMetadata> metaDataList = tsFileReader.getChunkMetadataList(path);
+      List<ChunkMetadata> metaDataList =
+          tsFileReader.getChunkMetadataListReturnEmptyIfPathNotExists(path);
       if (metaDataList.isEmpty()) {
         continue;
       }

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
@@ -34,7 +34,11 @@ import org.apache.iotdb.db.query.reader.series.SeriesRawDataBatchReader;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
 import org.apache.iotdb.tsfile.read.common.BatchData;
+import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.reader.IBatchReader;
+import org.apache.iotdb.tsfile.write.TsFileWriter;
+import org.apache.iotdb.tsfile.write.record.TSRecord;
+import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.apache.commons.io.FileUtils;
@@ -499,5 +503,76 @@ public class MergeTaskTest extends MergeTest {
       }
     }
     tsFilesReader.close();
+  }
+
+  @Test
+  public void testMergeWithFileWithoutSomeSensor() throws Exception {
+    File file =
+        new File(
+            TestConstant.BASE_OUTPUT_PATH.concat(
+                10
+                    + "unseq"
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 10
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 10
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource unseqTsFileResourceWithoutSomeSensor = new TsFileResource(file);
+    unseqTsFileResourceWithoutSomeSensor.setClosed(true);
+    unseqTsFileResourceWithoutSomeSensor.setMinPlanIndex(10);
+    unseqTsFileResourceWithoutSomeSensor.setMaxPlanIndex(10);
+    unseqTsFileResourceWithoutSomeSensor.setVersion(10);
+    prepareFileWithLastSensor(unseqTsFileResourceWithoutSomeSensor, 0, 50, 0);
+    unseqResources.add(unseqTsFileResourceWithoutSomeSensor);
+
+    List<TsFileResource> testSeqResources = seqResources.subList(0, 1);
+    List<TsFileResource> testUnseqResources = new ArrayList<>();
+    testUnseqResources.add(unseqTsFileResourceWithoutSomeSensor);
+    MergeTask mergeTask =
+        new MergeTask(
+            new MergeResource(testSeqResources, testUnseqResources),
+            tempSGDir.getPath(),
+            (k, v, l) -> {
+              assertEquals(99, k.get(0).getEndTime("root.mergeTest.device1"));
+            },
+            "test",
+            false,
+            1,
+            MERGE_TEST_SG);
+    mergeTask.call();
+  }
+
+  private void prepareFileWithLastSensor(
+      TsFileResource tsFileResource, long timeOffset, long ptNum, long valueOffset)
+      throws IOException, WriteProcessException {
+    TsFileWriter fileWriter = new TsFileWriter(tsFileResource.getTsFile());
+    for (int i = 0; i < deviceIds.length - 1; i++) {
+      for (int j = 0; j < measurementSchemas.length - 1; j++) {
+        fileWriter.registerTimeseries(
+            new Path(deviceIds[i], measurementSchemas[j].getMeasurementId()),
+            measurementSchemas[j]);
+      }
+    }
+    for (long i = timeOffset; i < timeOffset + ptNum; i++) {
+      for (int j = 0; j < deviceNum - 1; j++) {
+        TSRecord record = new TSRecord(i, deviceIds[j]);
+        for (int k = 0; k < measurementNum - 1; k++) {
+          record.addTuple(
+              DataPoint.getDataPoint(
+                  measurementSchemas[k].getType(),
+                  measurementSchemas[k].getMeasurementId(),
+                  String.valueOf(i + valueOffset)));
+        }
+        fileWriter.write(record);
+        tsFileResource.updateStartTime(deviceIds[j], i);
+        tsFileResource.updateEndTime(deviceIds[j], i);
+      }
+      if ((i + 1) % flushInterval == 0) {
+        fileWriter.flushAllChunkGroups();
+      }
+    }
+    fileWriter.close();
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -1163,6 +1163,20 @@ public class TsFileSequenceReader implements AutoCloseable {
   }
 
   /**
+   * get ChunkMetaDatas of given path return empty if path not exists
+   *
+   * @param path timeseries path
+   * @return List of ChunkMetaData
+   */
+  public List<ChunkMetadata> getChunkMetadataListReturnEmptyIfPathNotExists(Path path) {
+    try {
+      return getChunkMetadataList(path);
+    } catch (IOException e) {
+      return Collections.emptyList();
+    }
+  }
+
+  /**
    * get ChunkMetaDatas in given TimeseriesMetaData
    *
    * @return List of ChunkMetaData


### PR DESCRIPTION
## Behavior
Unseq compaction failed if some path not in the file, throw error like below.
![4111617881357_ pic_hd](https://user-images.githubusercontent.com/24886743/116500138-7a202600-a8e0-11eb-8c84-b3a371a36367.jpg)

## Reason
The getChunkMetadataList now throw Exception if there is not the path in the file.

## Solution
Add a method getChunkMetadataListReturnEmptyIfPathNotExists and use it.