### PR TITLE
[IoTDB-1331] Add transformPath for CMManger

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -81,6 +81,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.TimeseriesSchema;
 import org.apache.iotdb.tsfile.write.schema.VectorMeasurementSchema;
 
@@ -263,6 +264,20 @@ public class CMManager extends MManager {
   @Override
   public IMeasurementSchema getSeriesSchema(PartialPath fullPath) throws MetadataException {
     return super.getSeriesSchema(fullPath, getMeasurementMNode(fullPath));
+  }
+
+  /**
+   * Transform the PartialPath to VectorPartialPath if it is a sub sensor of one vector. otherwise,
+   * we don't change it.
+   */
+  @Override
+  public PartialPath transformPath(PartialPath partialPath) throws MetadataException {
+    MeasurementMNode node = getMeasurementMNode(partialPath);
+    if (node.getSchema() instanceof MeasurementSchema) {
+      return partialPath;
+    } else {
+      return toVectorPath(partialPath, node.getName());
+    }
   }
 
   private MeasurementMNode getMeasurementMNode(PartialPath fullPath) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1190,7 +1190,7 @@ public class MManager {
   }
 
   /**
-   * transform the PartialPath to VectorPartialPath if it is a sub sensor of one vector otherwise,
+   * Transform the PartialPath to VectorPartialPath if it is a sub sensor of one vector. otherwise,
    * we don't change it.
    */
   public PartialPath transformPath(PartialPath partialPath) throws MetadataException {
@@ -1198,11 +1198,16 @@ public class MManager {
     if (node.getSchema() instanceof MeasurementSchema) {
       return partialPath;
     } else {
-      List<PartialPath> subSensorsPathList = new ArrayList<>();
-      subSensorsPathList.add(partialPath);
-      return new VectorPartialPath(
-          partialPath.getDevice() + "." + node.getName(), subSensorsPathList);
+      return toVectorPath(partialPath, node.getName());
     }
+  }
+
+  /** Convert the PartialPath to VectorPartialPath. */
+  protected VectorPartialPath toVectorPath(PartialPath partialPath, String name)
+      throws MetadataException {
+    List<PartialPath> subSensorsPathList = new ArrayList<>();
+    subSensorsPathList.add(partialPath);
+    return new VectorPartialPath(partialPath.getDevice() + "." + name, subSensorsPathList);
   }
 
   /**

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterIT.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterIT.java
@@ -97,4 +97,26 @@ public class ClusterIT {
       Assert.assertTrue(result.contains(timeseries));
     }
   }
+
+  @Test
+  public void testAgg() throws SQLException {
+
+    String[] timeSeriesArray = {"root.ln.wf01.wt01.temperature WITH DATATYPE=FLOAT, ENCODING=RLE"};
+    String[] initDataArray = {
+      "INSERT INTO root.ln.wf01.wt01(timestamp,temperature) values(200,20.71)",
+      "INSERT INTO root.ln.wf01.wt01(timestamp,temperature) values(220,50.71)"
+    };
+
+    for (String timeSeries : timeSeriesArray) {
+      statement.execute(String.format("create timeseries %s ", timeSeries));
+    }
+    for (String initData : initDataArray) {
+      statement.execute(initData);
+    }
+    ResultSet resultSet = statement.executeQuery("select avg(temperature) from root.ln.wf01.wt01;");
+    Assert.assertTrue(resultSet.next());
+    double avg = resultSet.getDouble(1);
+    Assert.assertEquals(35.71, avg, 0.1);
+    resultSet.close();
+  }
 }

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/SingleNodeIT.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/SingleNodeIT.java
@@ -97,4 +97,26 @@ public class SingleNodeIT {
       Assert.assertTrue(result.contains(timeseries));
     }
   }
+
+  @Test
+  public void testAgg() throws SQLException {
+
+    String[] timeSeriesArray = {"root.ln.wf01.wt01.temperature WITH DATATYPE=FLOAT, ENCODING=RLE"};
+    String[] initDataArray = {
+      "INSERT INTO root.ln.wf01.wt01(timestamp,temperature) values(200,20.71)",
+      "INSERT INTO root.ln.wf01.wt01(timestamp,temperature) values(220,50.71)"
+    };
+
+    for (String timeSeries : timeSeriesArray) {
+      statement.execute(String.format("create timeseries %s ", timeSeries));
+    }
+    for (String initData : initDataArray) {
+      statement.execute(initData);
+    }
+    ResultSet resultSet = statement.executeQuery("select avg(temperature) from root.ln.wf01.wt01;");
+    Assert.assertTrue(resultSet.next());
+    double avg = resultSet.getDouble(1);
+    Assert.assertEquals(35.71, avg, 0.1);
+    resultSet.close();
+  }
 }


### PR DESCRIPTION
Fix the following bug:
```
IoTDB> select avg(temperature) from root.ln.wf01.wt01;
Msg: 411: Error occurred in query process: Path [root.ln.wf01.wt01.temperature] does not exist
```
In this PR only add overide the method `transformPath` in CMManger.