### PR TITLE
[IOTDB-1315] fix for time format error in csv export

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
@@ -71,6 +71,7 @@ public abstract class AbstractCsvTool {
         "yyyy-MM-dd'T'HH:mm:ssZZ",
         "yyyy/MM/dd'T'HH:mm:ssZZ",
         "yyyy.MM.dd'T'HH:mm:ssZZ",
+        "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
         "yyyy/MM/dd HH:mm:ss.SSS",
         "yyyy-MM-dd HH:mm:ss.SSS",
         "yyyy.MM.dd HH:mm:ss.SSS",


### PR DESCRIPTION
## Fix the time format problem in csv export. 
This is used to fix the problem in issue [IOTDB-1315], together with the time format problem in Windows system.

### Add time format  yyyy-MM-dd'T'HH:mm:ss.SSSZ
First, I solved the problem that the time format yyyy-MM-dd'T'HH:mm:ss.SSSZ was not written in AbstractCsvTool.java. The modified file involves AbstractCsvTool.java. I've added this time format to 'SUPPORT_TIME_FORMAT'.

### Fix the time format problem (time format with ' or space) in Windows system
  Second, in further debugging, I found that, due to the difference in command line reading between different operating systems of Linux and Windows, not only "-tf yyyy-MM-dd\'T\'HH:mm:ss.SSSZ" will be considered as a format error under Windows, but also other time formats with spaces and ' will have format errors because of the way of adding' \ '.
The method to correct this problem is as follows:
  In Windows operating system, the entering of time format string with ' in command line should be changed from \ 'to direct ', such as chaning from "yyyy-MM-dd\'T\'HH:mm:ss.SSSZ" to "yyyy-MM-dd'T'HH:mm:ss.SSSZ"; The time format string with space input from the command line can be exported normally if it is included in double quotation marks (""). For example, -tf "yyyy-MM-dd HH:mm:ss".