### PR TITLE
[IOTDB-1348] Last plan not work in cluster mode

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
@@ -127,6 +127,7 @@ public class ClusterLastQueryExecutor extends LastQueryExecutor {
         List<Pair<Boolean, TimeValuePair>> timeValuePairs = groupFuture.get();
         for (int i = 0; i < timeValuePairs.size(); i++) {
           if (timeValuePairs.get(i) != null
+              && timeValuePairs.get(i).right != null
               && timeValuePairs.get(i).right.getTimestamp() > results.get(i).right.getTimestamp()) {
             results.get(i).right = timeValuePairs.get(i).right;
           }

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterIT.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterIT.java
@@ -97,4 +97,27 @@ public class ClusterIT {
       Assert.assertTrue(result.contains(timeseries));
     }
   }
+
+  @Test
+  public void testLast() throws SQLException {
+
+    String[] timeSeriesArray = {"root.ln.wf01.wt01.temperature WITH DATATYPE=DOUBLE, ENCODING=RLE"};
+    String[] initDataArray = {
+      "INSERT INTO root.ln.wf01.wt01(timestamp, temperature) values(100, 10.0)",
+      "INSERT INTO root.ln.wf01.wt01(timestamp, temperature) values(200, 20.0)",
+      "INSERT INTO root.ln.wf01.wt01(timestamp, temperature) values(150, 15.0)"
+    };
+
+    for (String timeSeries : timeSeriesArray) {
+      statement.execute(String.format("create timeseries %s ", timeSeries));
+    }
+    for (String initData : initDataArray) {
+      statement.execute(initData);
+    }
+    ResultSet resultSet = statement.executeQuery("select last * from root.ln.wf01.wt01;");
+    Assert.assertTrue(resultSet.next());
+    double last = Double.parseDouble(resultSet.getString(3));
+    Assert.assertEquals(20.0, last, 0.1);
+    resultSet.close();
+  }
 }

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterIT.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterIT.java
@@ -119,7 +119,7 @@ public class ClusterIT {
     Assert.assertEquals(35.71, avg, 0.1);
     resultSet.close();
   }
-  
+
   @Test
   public void testLast() throws SQLException {
 

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/SingleNodeIT.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/SingleNodeIT.java
@@ -97,4 +97,27 @@ public class SingleNodeIT {
       Assert.assertTrue(result.contains(timeseries));
     }
   }
+
+  @Test
+  public void testLast() throws SQLException {
+
+    String[] timeSeriesArray = {"root.ln.wf01.wt01.temperature WITH DATATYPE=DOUBLE, ENCODING=RLE"};
+    String[] initDataArray = {
+      "INSERT INTO root.ln.wf01.wt01(timestamp, temperature) values(100, 10.0)",
+      "INSERT INTO root.ln.wf01.wt01(timestamp, temperature) values(200, 20.0)",
+      "INSERT INTO root.ln.wf01.wt01(timestamp, temperature) values(150, 15.0)"
+    };
+
+    for (String timeSeries : timeSeriesArray) {
+      statement.execute(String.format("create timeseries %s ", timeSeries));
+    }
+    for (String initData : initDataArray) {
+      statement.execute(initData);
+    }
+    ResultSet resultSet = statement.executeQuery("select last * from root.ln.wf01.wt01;");
+    Assert.assertTrue(resultSet.next());
+    double last = Double.parseDouble(resultSet.getString(3));
+    Assert.assertEquals(20.0, last, 0.1);
+    resultSet.close();
+  }
 }

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/SingleNodeIT.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/SingleNodeIT.java
@@ -119,7 +119,7 @@ public class SingleNodeIT {
     Assert.assertEquals(35.71, avg, 0.1);
     resultSet.close();
   }
-  
+
   @Test
   public void testLast() throws SQLException {
 


### PR DESCRIPTION
![Uploading image.png…](https://issues.apache.org/jira/secure/attachment/13024829/13024829_image-2021-04-30-14-59-45-348.png)

Last plan not work in cluster mode, and I think `timeValuePairs.get(i).right` also should be judged as not null.

[jira link](https://issues.apache.org/jira/browse/IOTDB-1348)