### PR TITLE
[IOTDB-1350]FIx log Compression time

### DIFF
--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -26,7 +26,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILEERROR">
         <file>${IOTDB_HOME}/logs/log_error.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-error-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-error-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>512MB</totalSizeCap>
@@ -45,7 +45,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILEWARN">
         <file>${IOTDB_HOME}/logs/log_warn.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-warn-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-warn-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>512MB</totalSizeCap>
@@ -64,7 +64,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILEINFO">
         <file>${IOTDB_HOME}/logs/log_info.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-info-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-info-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>5GB</totalSizeCap>
@@ -83,7 +83,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILEDEBUG">
         <file>${IOTDB_HOME}/logs/log_debug.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-debug-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-debug-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>5GB</totalSizeCap>
@@ -102,7 +102,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILETRACE">
         <file>${IOTDB_HOME}/logs/log_trace.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-trace-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-trace-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>5GB</totalSizeCap>
@@ -132,7 +132,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILEALL">
         <file>${IOTDB_HOME}/logs/log_all.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-all-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-all-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>5GB</totalSizeCap>
@@ -149,7 +149,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_COST_MEASURE">
         <file>${IOTDB_HOME}/logs/log_measure.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-measure-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-measure-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>512MB</totalSizeCap>
@@ -166,7 +166,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="SYNC">
         <file>${IOTDB_HOME}/logs/log_sync.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-sync-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-sync-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>512MB</totalSizeCap>
@@ -183,7 +183,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="AUDIT">
         <file>${IOTDB_HOME}/logs/log_audit.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-audit-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-audit-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>512MB</totalSizeCap>
@@ -200,7 +200,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="QUERY_DEBUG">
         <file>${IOTDB_HOME}/logs/log_query_debug.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-query-debug-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-query-debug-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>512MB</totalSizeCap>
@@ -217,7 +217,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="SLOW_SQL">
         <file>${IOTDB_HOME}/logs/log_slow_sql.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-slow-sql-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-slow-sql-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>512MB</totalSizeCap>
@@ -234,7 +234,7 @@
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="QUERY_FREQUENCY">
         <file>${IOTDB_HOME}/logs/log_query_frequency.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-query-frequency-%d{yyyyMMdd-HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${IOTDB_HOME}/logs/log-query-frequency-%d{yyyyMMdd}.%i.log.gz</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>168</maxHistory>
             <totalSizeCap>512MB</totalSizeCap>


### PR DESCRIPTION
Logs are compressed every hour. There are many compressed packages in a day, and the size of each compressed package is small. Therefore, logs are compressed by day and size.