### PR TITLE
[ISSUE-3121] [To rel/0.12] add maven http parameter to avoid maven downloading dependencies timeout

### DIFF
--- a/.github/workflows/client-go.yml
+++ b/.github/workflows/client-go.yml
@@ -18,6 +18,9 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   unix:
     strategy:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -27,6 +27,9 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,9 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   E2E:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-unix.yml
+++ b/.github/workflows/main-unix.yml
@@ -20,6 +20,9 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   unix:
     strategy:

--- a/.github/workflows/main-win.yml
+++ b/.github/workflows/main-win.yml
@@ -20,6 +20,9 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   win:
     strategy:

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -20,6 +20,9 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a cherry-pick to rel/0.12.

see #3121 

original PR #3122 
