### PR TITLE
[IOTDB-1354] fix errors in SlotPartitionTableTest

### DIFF
--- a/cluster/src/test/java/org/apache/iotdb/cluster/partition/SlotPartitionTableTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/partition/SlotPartitionTableTest.java
@@ -63,7 +63,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,7 +117,6 @@ public class SlotPartitionTableTest {
     prevReplicaNum = ClusterDescriptor.getInstance().getConfig().getReplicationNum();
     ClusterDescriptor.getInstance().getConfig().setReplicationNum(replica_size);
     tables = new SlotPartitionTable[20];
-    mManager = new MManager[20];
 
     // suppose there are 40 storage groups and each node maintains two of them.
     String[] storageNames = new String[40];
@@ -138,11 +136,6 @@ public class SlotPartitionTableTest {
       storageNames[i + 20] = String.format("root.sg.l2.l3.l4.%d", i + 20);
       node = localTable.routeToHeaderByTime(storageNames[i + 20], 0);
       nodeSGs[node.getMetaPort() - 30000].add(storageNames[i + 20]);
-    }
-    for (int i = 0; i < 20; i++) {
-      mManager[i] = MManagerWhiteBox.newMManager("target/schemas/mlog_" + i);
-      initMockMManager(i, mManager[i], storageNames, nodeSGs[i]);
-      Whitebox.setInternalState(tables[i], "mManager", mManager[i]);
     }
   }
 
@@ -225,7 +218,7 @@ public class SlotPartitionTableTest {
 
     assertEquals(
         new Node(
-            "localhost", 30000 + last, last, 40000 + last, Constants.RPC_PORT + start, "localhost"),
+            "localhost", 30000 + last, last, 40000 + last, Constants.RPC_PORT + last, "localhost"),
         group.get(replica_size - 1));
   }
 


### PR DESCRIPTION
When running the Tests using `mvn test`, SlotPartitionTableTest will be skipped:
```
[INFO] Running org.apache.iotdb.cluster.partition.SlotPartitionTableTest
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.014 s - in org.apache.iotdb.cluster.partition.SlotPartitionTableTest
```
I do not know why, but that is why we never find this failed test...

When running the test in IDEA, all tests will fail, because the snapets:

```       
 for (int i = 0; i < 20; i++) {
          mManager[i] = MManagerWhiteBox.newMManager("target/schemas/mlog_" + i);
          initMockMManager(i, mManager[i], storageNames, nodeSGs[i]);
          Whitebox.setInternalState(tables[i], "mManager", mManager[i]);
        }
```

`assertGetHeaderGroup` has another error:
```
    assertEquals(
        new Node(
            "localhost", 30000 + last, last, 40000 + last, Constants.RPC_PORT + start, "localhost"),
        group.get(replica_size - 1));
```
It is obvious that the PRC_PORT should be `Constants.RPC_PORT + last`