### PR TITLE
[IOTDB-1316] Fix input format check

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
@@ -110,7 +110,7 @@ public class ImportCsv extends AbstractCsvTool {
   public static Connection getConnection(String ip, String port, String username, String password) {
     // JDBC driver name and database URL
     String driver = "org.apache.iotdb.jdbc.IoTDBDriver";
-    String url = "jdbc:iotdb://"+ip+":"+port+"/";
+    String url = "jdbc:iotdb://" + ip + ":" + port + "/";
 
     Connection connection = null;
     try {
@@ -124,24 +124,24 @@ public class ImportCsv extends AbstractCsvTool {
     return connection;
   }
 
-  public static List<String> getDatatype(String device, String ip, String port, String username, String password){
+  public static List<String> getDatatype(
+      String device, String ip, String port, String username, String password) {
     Connection connection = getConnection(ip, port, username, password);
     Statement statement = null;
-    ResultSet resultSet=null;
+    ResultSet resultSet = null;
     List<String> datatypes = new ArrayList<>();
     try {
       statement = connection.createStatement();
-      statement.execute("SHOW TIMESERIES "+device);
-      resultSet=statement.getResultSet();
-      //outputResult(statement.getResultSet());
+      statement.execute("SHOW TIMESERIES " + device);
+      resultSet = statement.getResultSet();
+      // outputResult(statement.getResultSet());
       while (resultSet.next()) {
         datatypes.add(resultSet.getString(4));
       }
-      //System.out.println(datatypes);
+      // System.out.println(datatypes);
     } catch (SQLException throwables) {
       throwables.printStackTrace();
-    }
-    finally {
+    } finally {
       try {
         statement.close();
         connection.close();
@@ -152,49 +152,42 @@ public class ImportCsv extends AbstractCsvTool {
     return datatypes;
   }
 
-  public static boolean valueCheck(String value, String device, int position, List<String> datatypes){
-    if(datatypes.get(position-1).equals("DOUBLE")){
-      try{
+  public static boolean valueCheck(
+      String value, String device, int position, List<String> datatypes) {
+    if (datatypes.get(position - 1).equals("DOUBLE")) {
+      try {
         Double.parseDouble(value);
         return true;
-      }
-      catch(NumberFormatException e) {
+      } catch (NumberFormatException e) {
         return false;
       }
-    }
-    else if(datatypes.get(position-1).equals("FLOAT")){
-      try{
+    } else if (datatypes.get(position - 1).equals("FLOAT")) {
+      try {
         Float.parseFloat(value);
         return true;
-      }
-      catch(NumberFormatException e) {
+      } catch (NumberFormatException e) {
         return false;
       }
-    }
-    else if(datatypes.get(position-1).equals("BOOLEAN")){
-        if (Boolean.parseBoolean(value)){
-          return true;
-        }
-        else if (value.equalsIgnoreCase("False")||value.equals("0")){
-          return true;
-        }
-        else {return false;}
-    }
-    else if(datatypes.get(position-1).equals("INT32")){
-      try{
+    } else if (datatypes.get(position - 1).equals("BOOLEAN")) {
+      if (Boolean.parseBoolean(value)) {
+        return true;
+      } else if (value.equalsIgnoreCase("False") || value.equals("0")) {
+        return true;
+      } else {
+        return false;
+      }
+    } else if (datatypes.get(position - 1).equals("INT32")) {
+      try {
         Integer.parseInt(value);
         return true;
-      }
-      catch(NumberFormatException e) {
+      } catch (NumberFormatException e) {
         return false;
       }
-    }
-    else if(datatypes.get(position-1).equals("INT64")){
-      try{
+    } else if (datatypes.get(position - 1).equals("INT64")) {
+      try {
         Long.parseLong(value);
         return true;
-      }
-      catch(NumberFormatException e) {
+      } catch (NumberFormatException e) {
         return false;
       }
     }
@@ -203,7 +196,8 @@ public class ImportCsv extends AbstractCsvTool {
 
   /** Data from csv To tsfile. */
   @SuppressWarnings("squid:S1135")
-  private static void loadDataFromCSV(File file, String ip, String port, String username, String password) {
+  private static void loadDataFromCSV(
+      File file, String ip, String port, String username, String password) {
     int fileLine;
     try {
       fileLine = getFileLineCount(file);
@@ -254,15 +248,15 @@ public class ImportCsv extends AbstractCsvTool {
           times.add(parseTime(cols[0], useFormatter, timeFormatter));
 
           List<String> datatypes = new ArrayList<>();
-          datatypes=getDatatype(devices.get(devices.size()-1), ip, port, username, password);
+          datatypes = getDatatype(devices.get(devices.size() - 1), ip, port, username, password);
 
           List<String> values = new ArrayList<>();
           for (int position : deviceToPositions.getValue()) {
-            boolean valid=valueCheck(cols[position], devices.get(devices.size()-1), position, datatypes);
-            if(valid==true){
+            boolean valid =
+                valueCheck(cols[position], devices.get(devices.size() - 1), position, datatypes);
+            if (valid == true) {
               values.add(cols[position]);
-            }
-            else{
+            } else {
               values.add("null");
             }
           }
@@ -422,7 +416,8 @@ public class ImportCsv extends AbstractCsvTool {
     }
   }
 
-  private static void importFromSingleFile(File file, String ip, String port, String username, String password) {
+  private static void importFromSingleFile(
+      File file, String ip, String port, String username, String password) {
     if (file.getName().endsWith(FILE_SUFFIX)) {
       loadDataFromCSV(file, ip, port, username, password);
     } else {
@@ -431,7 +426,8 @@ public class ImportCsv extends AbstractCsvTool {
     }
   }
 
-  private static void importFromDirectory(File file, String ip, String port, String username, String password) {
+  private static void importFromDirectory(
+      File file, String ip, String port, String username, String password) {
     File[] files = file.listFiles();
     if (files == null) {
       return;

--- a/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
@@ -124,7 +124,7 @@ public class ImportCsv extends AbstractCsvTool {
     return connection;
   }
 
-  public static boolean valueCheck(String value, String device, int position , String ip, String port, String username, String password){
+  public static List<String> getDatatype(String device, String ip, String port, String username, String password){
     Connection connection = getConnection(ip, port, username, password);
     Statement statement = null;
     ResultSet resultSet=null;
@@ -149,6 +149,10 @@ public class ImportCsv extends AbstractCsvTool {
         throwables.printStackTrace();
       }
     }
+    return datatypes;
+  }
+
+  public static boolean valueCheck(String value, String device, int position, List<String> datatypes){
     if(datatypes.get(position-1).equals("DOUBLE")){
       try{
         Double.parseDouble(value);
@@ -249,9 +253,12 @@ public class ImportCsv extends AbstractCsvTool {
 
           times.add(parseTime(cols[0], useFormatter, timeFormatter));
 
+          List<String> datatypes = new ArrayList<>();
+          datatypes=getDatatype(devices.get(devices.size()-1), ip, port, username, password);
+
           List<String> values = new ArrayList<>();
           for (int position : deviceToPositions.getValue()) {
-            boolean valid=valueCheck(cols[position], devices.get(devices.size()-1),position, ip, port, username, password);
+            boolean valid=valueCheck(cols[position], devices.get(devices.size()-1), position, datatypes);
             if(valid==true){
               values.add(cols[position]);
             }


### PR DESCRIPTION
## Fix input format check for import csv files
   This is used to fix the problem show in issue 1316. The new code will check the input format before import the data. If there is wrong data format, this part will be null. And the other data can import successfully.
  
  Specifically, I modified issue 1316 (https://issues.apache.org/jira/browse/IOTDB-1316)，“A sensor point value is invalid and this row can be imported successfully，but the following rows in this file are not executed”.

  In the original code, when there is a format error, such as in the example of issue 1316, in dump_ts3.csv, the format of "china" in the column of root.db1.tab1.other is wrong, and in dump_ts4.csv the format of id and age is wrong (it should be int32, but it is written as float type), the file import will stop and an error will be reported. 

  After modifying the code, when the wrong data format is encountered, the wrong data location will be replaced by null, and the data of this line and other lines can continue to be imported successfully.