### PR TITLE
[IOTDB-1355] Support updating aligned timeseries values when insert partially

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -173,11 +173,9 @@ public class MemTableFlushTask {
               if (dataType == TSDataType.VECTOR) {
                 if (timeDuplicatedVectorRowIndexList == null) {
                   timeDuplicatedVectorRowIndexList = new ArrayList<>();
-                  timeDuplicatedVectorRowIndexList.add(
-                      ((VectorTVList) tvPairs).getValueIndex(sortedRowIndex));
+                  timeDuplicatedVectorRowIndexList.add(tvPairs.getValueIndex(sortedRowIndex));
                 }
-                timeDuplicatedVectorRowIndexList.add(
-                    ((VectorTVList) tvPairs).getValueIndex(sortedRowIndex + 1));
+                timeDuplicatedVectorRowIndexList.add(tvPairs.getValueIndex(sortedRowIndex + 1));
               }
               continue;
             }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
@@ -527,7 +527,7 @@ public abstract class TVList {
   protected abstract TimeValuePair getTimeValuePair(
       int index, long time, Integer floatPrecision, TSEncoding encoding);
 
-  public TimeValuePair getCombinedTimeValuePairForVector(
+  public TimeValuePair getTimeValuePairForTimeDuplicatedRows(
       List<Integer> timeDuplicatedVectorRowIndexList,
       long time,
       Integer floatPrecision,
@@ -595,7 +595,7 @@ public abstract class TVList {
         TimeValuePair tvPair;
         if (getDataType() == TSDataType.VECTOR && timeDuplicatedVectorRowIndexList != null) {
           tvPair =
-              getCombinedTimeValuePairForVector(
+              getTimeValuePairForTimeDuplicatedRows(
                   timeDuplicatedVectorRowIndexList, time, floatPrecision, encoding);
         } else {
           tvPair = getTimeValuePair(cur, time, floatPrecision, encoding);

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
@@ -597,10 +597,10 @@ public abstract class TVList {
           tvPair =
               getTimeValuePairForTimeDuplicatedRows(
                   timeDuplicatedVectorRowIndexList, time, floatPrecision, encoding);
+          timeDuplicatedVectorRowIndexList = null;
         } else {
           tvPair = getTimeValuePair(cur, time, floatPrecision, encoding);
         }
-        timeDuplicatedVectorRowIndexList = null;
         cur++;
         if (tvPair.getValue() != null) {
           cachedTimeValuePair = tvPair;

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
@@ -225,6 +225,10 @@ public abstract class TVList {
     throw new UnsupportedOperationException(ERR_DATATYPE_NOT_CONSISTENT);
   }
 
+  public int getValueIndex(int index) {
+    throw new UnsupportedOperationException(ERR_DATATYPE_NOT_CONSISTENT);
+  }
+
   public abstract void sort();
 
   public long getMinTime() {
@@ -523,6 +527,14 @@ public abstract class TVList {
   protected abstract TimeValuePair getTimeValuePair(
       int index, long time, Integer floatPrecision, TSEncoding encoding);
 
+  public TimeValuePair getCombinedTimeValuePairForVector(
+      List<Integer> timeDuplicatedVectorRowIndexList,
+      long time,
+      Integer floatPrecision,
+      TSEncoding encoding) {
+    throw new UnsupportedOperationException(ERR_DATATYPE_NOT_CONSISTENT);
+  }
+
   @TestOnly
   public IPointReader getIterator() {
     return new Ite();
@@ -565,13 +577,30 @@ public abstract class TVList {
         return true;
       }
 
+      List<Integer> timeDuplicatedVectorRowIndexList = null;
       while (cur < iteSize) {
         long time = getTime(cur);
         if (isPointDeleted(time) || (cur + 1 < size() && (time == getTime(cur + 1)))) {
+          // record the time duplicated row index list for vector type
+          if (getDataType() == TSDataType.VECTOR) {
+            if (timeDuplicatedVectorRowIndexList == null) {
+              timeDuplicatedVectorRowIndexList = new ArrayList<>();
+              timeDuplicatedVectorRowIndexList.add(getValueIndex(cur));
+            }
+            timeDuplicatedVectorRowIndexList.add(getValueIndex(cur + 1));
+          }
           cur++;
           continue;
         }
-        TimeValuePair tvPair = getTimeValuePair(cur, time, floatPrecision, encoding);
+        TimeValuePair tvPair;
+        if (getDataType() == TSDataType.VECTOR && timeDuplicatedVectorRowIndexList != null) {
+          tvPair =
+              getCombinedTimeValuePairForVector(
+                  timeDuplicatedVectorRowIndexList, time, floatPrecision, encoding);
+        } else {
+          tvPair = getTimeValuePair(cur, time, floatPrecision, encoding);
+        }
+        timeDuplicatedVectorRowIndexList = null;
         cur++;
         if (tvPair.getValue() != null) {
           cachedTimeValuePair = tvPair;

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/VectorTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/VectorTVList.java
@@ -507,6 +507,27 @@ public class VectorTVList extends TVList {
     return indices.get(arrayIndex)[elementIndex];
   }
 
+  /**
+   * Get the valid original row index in a column by a given time duplicated original row index
+   * list.
+   *
+   * @param timeDuplicatedOriginRowIndexList The row index list that the time of all indexes are
+   *     same.
+   * @param columnIndex The index of a given column.
+   * @return The original row index of the latest non-null value, or the first row index if all
+   *     values in given columns are null.
+   */
+  public int getValidRowIndexForTimeDuplicatedRows(
+      List<Integer> timeDuplicatedOriginRowIndexList, int columnIndex) {
+    int validRowIndex = timeDuplicatedOriginRowIndexList.get(0);
+    for (int originRowIndex : timeDuplicatedOriginRowIndexList) {
+      if (!isValueMarked(originRowIndex, columnIndex)) {
+        validRowIndex = originRowIndex;
+      }
+    }
+    return validRowIndex;
+  }
+
   @Override
   protected void setPivotTo(int pos) {
     set(pos, pivotTime, pivotIndex);
@@ -649,15 +670,5 @@ public class VectorTVList extends TVList {
   @Override
   public TSDataType getDataType() {
     return TSDataType.VECTOR;
-  }
-
-  public int getValidRowIndex(List<Integer> originRowIndexList, int columnIndex) {
-    int validRowIndex = originRowIndexList.get(0);
-    for (int originRowIndex : originRowIndexList) {
-      if (!isValueMarked(originRowIndex, columnIndex)) {
-        validRowIndex = originRowIndex;
-      }
-    }
-    return validRowIndex;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/VectorTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/VectorTVList.java
@@ -118,15 +118,17 @@ public class VectorTVList extends TVList {
   }
 
   public Object getVector(List<Integer> timeDuplicatedIndexList) {
-    int[] timeDuplicatedIndexes = new int[values.size()];
+    int[] validIndexesForTimeDuplicatedRows = new int[values.size()];
     for (int i = 0; i < values.size(); i++) {
-      timeDuplicatedIndexes[i] = getValidRowIndexForTimeDuplicatedRows(timeDuplicatedIndexList, i);
+      validIndexesForTimeDuplicatedRows[i] =
+          getValidRowIndexForTimeDuplicatedRows(timeDuplicatedIndexList, i);
     }
     return getVectorByValueIndex(
-        timeDuplicatedIndexList.get(timeDuplicatedIndexList.size() - 1), timeDuplicatedIndexes);
+        timeDuplicatedIndexList.get(timeDuplicatedIndexList.size() - 1),
+        validIndexesForTimeDuplicatedRows);
   }
 
-  private Object getVectorByValueIndex(int valueIndex, int[] timeDuplicatedIndexes) {
+  private Object getVectorByValueIndex(int valueIndex, int[] validIndexesForTimeDuplicatedRows) {
     if (valueIndex >= size) {
       throw new ArrayIndexOutOfBoundsException(valueIndex);
     }
@@ -135,9 +137,9 @@ public class VectorTVList extends TVList {
     TsPrimitiveType[] vector = new TsPrimitiveType[values.size()];
     for (int i = 0; i < values.size(); i++) {
       List<Object> columnValues = values.get(i);
-      if (timeDuplicatedIndexes != null) {
-        arrayIndex = timeDuplicatedIndexes[i] / ARRAY_SIZE;
-        elementIndex = timeDuplicatedIndexes[i] % ARRAY_SIZE;
+      if (validIndexesForTimeDuplicatedRows != null) {
+        arrayIndex = validIndexesForTimeDuplicatedRows[i] / ARRAY_SIZE;
+        elementIndex = validIndexesForTimeDuplicatedRows[i] % ARRAY_SIZE;
       }
       if (bitMaps != null
           && bitMaps.get(i) != null
@@ -565,7 +567,7 @@ public class VectorTVList extends TVList {
   }
 
   @Override
-  public TimeValuePair getCombinedTimeValuePairForVector(
+  public TimeValuePair getTimeValuePairForTimeDuplicatedRows(
       List<Integer> indexList, long time, Integer floatPrecision, TSEncoding encoding) {
     if (this.dataTypes.size() == 1) {
       return new TimeValuePair(time, ((TsPrimitiveType) getVector(indexList)).getVector()[0]);

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/VectorTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/VectorTVList.java
@@ -650,4 +650,14 @@ public class VectorTVList extends TVList {
   public TSDataType getDataType() {
     return TSDataType.VECTOR;
   }
+
+  public int getValidRowIndex(List<Integer> originRowIndexList, int columnIndex) {
+    int validRowIndex = originRowIndexList.get(0);
+    for (int originRowIndex : originRowIndexList) {
+      if (!isValueMarked(originRowIndex, columnIndex)) {
+        validRowIndex = originRowIndex;
+      }
+    }
+    return validRowIndex;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/VectorTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/VectorTVList.java
@@ -69,8 +69,6 @@ public class VectorTVList extends TVList {
       List<Object> columnValues = values.get(i);
       if (columnValue == null) {
         markNullValue(i, arrayIndex, elementIndex);
-      } else if (isValueMarked(indices.get(arrayIndex)[elementIndex], i)) {
-        bitMaps.get(i).get(arrayIndex).unmark(elementIndex);
       }
       switch (dataTypes.get(i)) {
         case TEXT:

--- a/server/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertAlignedValuesIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertAlignedValuesIT.java
@@ -23,9 +23,9 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.sql.Connection;
@@ -38,8 +38,8 @@ import java.util.Objects;
 public class IOTDBInsertAlignedValuesIT {
   private static Connection connection;
 
-  @BeforeClass
-  public static void setUp() throws Exception {
+  @Before
+  public void setUp() throws Exception {
     EnvironmentUtils.closeStatMonitor();
     EnvironmentUtils.envSetUp();
     IoTDBDescriptor.getInstance().getConfig().setAutoCreateSchemaEnabled(true);
@@ -48,8 +48,8 @@ public class IOTDBInsertAlignedValuesIT {
         DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
   }
 
-  @AfterClass
-  public static void tearDown() throws Exception {
+  @After
+  public void tearDown() throws Exception {
     close();
     EnvironmentUtils.cleanEnv();
   }
@@ -131,6 +131,72 @@ public class IOTDBInsertAlignedValuesIT {
     Assert.assertEquals(6000, rs2.getLong(1));
     Assert.assertEquals(null, rs2.getObject(2));
     Assert.assertEquals(22.0f, rs2.getObject(3));
+    st1.close();
+  }
+
+  @Test
+  public void testUpdatingAlignedValues() throws SQLException {
+    Statement st0 = connection.createStatement();
+    st0.execute(
+        "insert into root.t1.wf01.wt01(time, (status, temperature)) values (4000, (true, 17.1))");
+    st0.execute(
+        "insert into root.t1.wf01.wt01(time, (status, temperature)) values (5000, (true, null))");
+    st0.execute(
+        "insert into root.t1.wf01.wt01(time, (status, temperature)) values (5000, (NULL, 20.1))");
+    st0.execute(
+        "insert into root.t1.wf01.wt01(time, (status, temperature)) values (6000, (null, 22))");
+    st0.close();
+
+    Statement st1 = connection.createStatement();
+
+    ResultSet rs1 = st1.executeQuery("select status from root.t1.wf01.wt01");
+    rs1.next();
+    Assert.assertEquals(true, rs1.getBoolean(2));
+    rs1.next();
+    Assert.assertEquals(true, rs1.getBoolean(2));
+    rs1.next();
+    Assert.assertEquals(null, rs1.getObject(2));
+
+    ResultSet rs2 = st1.executeQuery("select * from root.t1.wf01.wt01");
+    rs2.next();
+    Assert.assertEquals(4000, rs2.getLong(1));
+    Assert.assertEquals(true, rs2.getBoolean(2));
+    Assert.assertEquals(17.1, rs2.getFloat(3), 0.1);
+
+    rs2.next();
+    Assert.assertEquals(5000, rs2.getLong(1));
+    Assert.assertEquals(true, rs2.getObject(2));
+    Assert.assertEquals(20.1, rs2.getFloat(3), 0.1);
+
+    rs2.next();
+    Assert.assertEquals(6000, rs2.getLong(1));
+    Assert.assertEquals(null, rs2.getObject(2));
+    Assert.assertEquals(22.0f, rs2.getObject(3));
+
+    st1.execute("flush");
+    ResultSet rs3 = st1.executeQuery("select status from root.t1.wf01.wt01");
+    rs3.next();
+    Assert.assertEquals(true, rs3.getBoolean(2));
+    rs3.next();
+    Assert.assertEquals(true, rs3.getBoolean(2));
+    rs3.next();
+    Assert.assertEquals(null, rs3.getObject(2));
+
+    ResultSet rs4 = st1.executeQuery("select * from root.t1.wf01.wt01");
+    rs4.next();
+    Assert.assertEquals(4000, rs4.getLong(1));
+    Assert.assertEquals(true, rs4.getBoolean(2));
+    Assert.assertEquals(17.1, rs4.getFloat(3), 0.1);
+
+    rs4.next();
+    Assert.assertEquals(5000, rs4.getLong(1));
+    Assert.assertEquals(true, rs4.getObject(2));
+    Assert.assertEquals(20.1, rs4.getFloat(3), 0.1);
+
+    rs4.next();
+    Assert.assertEquals(6000, rs4.getLong(1));
+    Assert.assertEquals(null, rs4.getObject(2));
+    Assert.assertEquals(22.0f, rs4.getObject(3));
     st1.close();
   }
 


### PR DESCRIPTION
## Description
When insert aligned timeseries liked as below,
```
insert into root.sg.d1(time, (s1, s2, s3)) values (1, (1, 2, 3));
insert into root.sg.d1(time, (s1, s2, s3)) values (2, (1, 2, null));
insert into root.sg.d1(time, (s1, s2, s3)) values (2, (null, 2, 3));
``` 
we got the query result 
```
+-----------------------------+-------------+-------------+-------------+
|                         Time|root.sg.d1.s1|root.sg.d1.s2|root.sg.d1.s3|
+-----------------------------+-------------+-------------+-------------+
|1970-01-01T08:00:00.001+08:00|          1.0|          2.0|          3.0|
|1970-01-01T08:00:00.002+08:00|         null|          2.0|          3.0|
+-----------------------------+-------------+-------------+-------------+
```

The expected  result should be 

```
+-----------------------------+-------------+-------------+-------------+
|                         Time|root.sg.d1.s1|root.sg.d1.s2|root.sg.d1.s3|
+-----------------------------+-------------+-------------+-------------+
|1970-01-01T08:00:00.001+08:00|          1.0|          2.0|          3.0|
|1970-01-01T08:00:00.002+08:00|          1.0|          2.0|          3.0|
+-----------------------------+-------------+-------------+-------------+
```
## Solution

When traverse the sorted VectorTVList and find some rows with same timestamp, we need to use the latest non-null value as the valid value of each columns.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
