### PR TITLE
[ISSUE-3132] Replace the dependence repository Bintray with JFrog in compile-tool

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -90,7 +90,7 @@ jobs:
         run: mkdir D:\a\cpp ; `
           Invoke-WebRequest https://github.com/lexxmark/winflexbison/releases/download/v2.5.24/win_flex_bison-2.5.24.zip -OutFile D:\a\cpp\win_flex_bison.zip ; `
           [Environment]::SetEnvironmentVariable("Path", $env:Path + ";D:\a\cpp", "User") ; `
-          Invoke-WebRequest https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.zip -OutFile D:\a\cpp\boost_1_72_0.zip ; `
+          Invoke-WebRequest https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.zip -OutFile D:\a\cpp\boost_1_72_0.zip ; `
           Expand-Archive D:\a\cpp\boost_1_72_0.zip -DestinationPath D:\a\cpp ; `
           cd D:\a\cpp\boost_1_72_0 ; `
           .\bootstrap.bat ; `

--- a/compile-tools/pom.xml
+++ b/compile-tools/pom.xml
@@ -54,7 +54,7 @@
                 <cmake.url>https://github.com/Kitware/CMake/releases/download/v${cmake-version}/cmake-${cmake-version}-Linux-x86_64.tar.gz</cmake.url>
                 <cmake.root.dir>${project.build.directory}/cmake-${cmake-version}-Linux-x86_64/</cmake.root.dir>
                 <cmake.generator>Unix Makefiles</cmake.generator>
-                <boost.url>https://dl.bintray.com/boostorg/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
+                <boost.url>https://boostorg.jfrog.io/artifactory/main/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
                 <boost.bootstrap.executable>./bootstrap.sh</boost.bootstrap.executable>
                 <boost.build.executable>./b2</boost.build.executable>
                 <thrift.bootstrap.executable>./bootstrap.sh</thrift.bootstrap.executable>
@@ -77,7 +77,7 @@
                 <cmake.url>https://github.com/Kitware/CMake/releases/download/v${cmake-version}/cmake-${cmake-version}-Darwin-x86_64.tar.gz</cmake.url>
                 <cmake.root.dir>${project.build.directory}/cmake-${cmake-version}-Darwin-x86_64/CMake.app/Contents</cmake.root.dir>
                 <cmake.generator>Unix Makefiles</cmake.generator>
-                <boost.url>https://dl.bintray.com/boostorg/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
+                <boost.url>https://boostorg.jfrog.io/artifactory/main/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
                 <boost.bootstrap.executable>./bootstrap.sh</boost.bootstrap.executable>
                 <boost.build.executable>./b2</boost.build.executable>
                 <thrift.bootstrap.executable>./bootstrap.sh</thrift.bootstrap.executable>
@@ -105,7 +105,7 @@
                 <!--<cmake.generator>MinGW Makefiles</cmake.generator>-->
                 <cmake.generator>Visual Studio 16 2019</cmake.generator>
                 <cmake.build.type>Release</cmake.build.type>
-                <boost.url>https://dl.bintray.com/boostorg/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
+                <boost.url>https://boostorg.jfrog.io/artifactory/main/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
                 <boost.bootstrap.executable>bootstrap.bat</boost.bootstrap.executable>
                 <boost.build.executable>b2</boost.build.executable>
                 <boost.include-directory>libs/libs/boost/include/boost-${boost.version.underline-short}</boost.include-directory>


### PR DESCRIPTION
## Description

The compile-tool has a dependence `boost`, which needs to be downloaded from Bintray repository.

But since May 1st 2021, Bintray was not available and moved to JFrog. See https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/. 

Therefore, we have to update these URLs to new ones.
