### PR TITLE
[To rel/0.11][ISSUE-3132] Replace the dependence repository Bintray with JFrog in compile-tool 

### DIFF
--- a/compile-tools/pom.xml
+++ b/compile-tools/pom.xml
@@ -54,7 +54,7 @@
                 <cmake.url>https://github.com/Kitware/CMake/releases/download/v${cmake-version}/cmake-${cmake-version}-Linux-x86_64.tar.gz</cmake.url>
                 <cmake.root.dir>${project.build.directory}/cmake-${cmake-version}-Linux-x86_64/</cmake.root.dir>
                 <cmake.generator>Unix Makefiles</cmake.generator>
-                <boost.url>https://dl.bintray.com/boostorg/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
+                <boost.url>https://boostorg.jfrog.io/artifactory/main/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
                 <boost.bootstrap.executable>./bootstrap.sh</boost.bootstrap.executable>
                 <boost.build.executable>./b2</boost.build.executable>
                 <thrift.bootstrap.executable>./bootstrap.sh</thrift.bootstrap.executable>
@@ -77,7 +77,7 @@
                 <cmake.url>https://github.com/Kitware/CMake/releases/download/v${cmake-version}/cmake-${cmake-version}-Darwin-x86_64.tar.gz</cmake.url>
                 <cmake.root.dir>${project.build.directory}/cmake-${cmake-version}-Darwin-x86_64/CMake.app/Contents</cmake.root.dir>
                 <cmake.generator>Unix Makefiles</cmake.generator>
-                <boost.url>https://dl.bintray.com/boostorg/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
+                <boost.url>https://boostorg.jfrog.io/artifactory/main/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
                 <boost.bootstrap.executable>./bootstrap.sh</boost.bootstrap.executable>
                 <boost.build.executable>./b2</boost.build.executable>
                 <thrift.bootstrap.executable>./bootstrap.sh</thrift.bootstrap.executable>
@@ -104,7 +104,7 @@
                 <!--<cmake.generator>MinGW Makefiles</cmake.generator>-->
                 <cmake.generator>Visual Studio 16 2019</cmake.generator>
                 <cmake.build.type>Release</cmake.build.type>
-                <boost.url>https://dl.bintray.com/boostorg/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
+                <boost.url>https://boostorg.jfrog.io/artifactory/main/release/${boost.version}/source/boost_${boost.version.underline}.zip</boost.url>
                 <boost.bootstrap.executable>bootstrap.bat</boost.bootstrap.executable>
                 <boost.build.executable>b2</boost.build.executable>
                 <boost.include-directory>libs/libs/boost/include/boost-${boost.version.underline-short}</boost.include-directory>


### PR DESCRIPTION
## Description
cherry pick from #3133 