### PR TITLE
[IOTDB-1232][IOTDB-1313] Fix lossing time precision when import csv with unsupported timestamp format

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
@@ -57,18 +57,6 @@ public abstract class AbstractCsvTool {
       new String[] {"default", "long", "number", "timestamp"};
   protected static final String[] STRING_TIME_FORMAT =
       new String[] {
-        "yyyy-MM-dd HH:mm:ss",
-        "yyyy/MM/dd HH:mm:ss",
-        "yyyy.MM.dd HH:mm:ss",
-        "yyyy-MM-dd'T'HH:mm:ss",
-        "yyyy/MM/dd'T'HH:mm:ss",
-        "yyyy.MM.dd'T'HH:mm:ss",
-        "yyyy-MM-dd HH:mm:ssZZ",
-        "yyyy/MM/dd HH:mm:ssZZ",
-        "yyyy.MM.dd HH:mm:ssZZ",
-        "yyyy-MM-dd'T'HH:mm:ssZZ",
-        "yyyy/MM/dd'T'HH:mm:ssZZ",
-        "yyyy.MM.dd'T'HH:mm:ssZZ",
         "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
         "yyyy/MM/dd HH:mm:ss.SSS",
         "yyyy-MM-dd HH:mm:ss.SSS",
@@ -82,6 +70,18 @@ public abstract class AbstractCsvTool {
         "yyyy.MM.dd HH:mm:ss.SSSZZ",
         "yyyy-MM-dd'T'HH:mm:ss.SSSZZ",
         "yyyy/MM/dd'T'HH:mm:ss.SSSZZ",
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy/MM/dd HH:mm:ss",
+        "yyyy.MM.dd HH:mm:ss",
+        "yyyy-MM-dd'T'HH:mm:ss",
+        "yyyy/MM/dd'T'HH:mm:ss",
+        "yyyy.MM.dd'T'HH:mm:ss",
+        "yyyy-MM-dd HH:mm:ssZZ",
+        "yyyy/MM/dd HH:mm:ssZZ",
+        "yyyy.MM.dd HH:mm:ssZZ",
+        "yyyy-MM-dd'T'HH:mm:ssZZ",
+        "yyyy/MM/dd'T'HH:mm:ssZZ",
+        "yyyy.MM.dd'T'HH:mm:ssZZ",
       };
   protected static String host;
   protected static String port;

--- a/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
@@ -54,12 +54,7 @@ public abstract class AbstractCsvTool {
   protected static final String TIME_ZONE_NAME = "timeZone";
   protected static final int MAX_HELP_CONSOLE_WIDTH = 92;
   protected static final String[] NUMBER_TIME_FORMAT =
-      new String[] {
-        "default",
-        "long",
-        "number",
-        "timestamp"
-      };
+      new String[] {"default", "long", "number", "timestamp"};
   protected static final String[] STRING_TIME_FORMAT =
       new String[] {
         "yyyy-MM-dd HH:mm:ss",

--- a/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
@@ -53,7 +53,7 @@ public abstract class AbstractCsvTool {
   protected static final String TIME_ZONE_ARGS = "tz";
   protected static final String TIME_ZONE_NAME = "timeZone";
   protected static final int MAX_HELP_CONSOLE_WIDTH = 92;
-  protected static final String[] NUMBER_TIME_FORMAT =
+  protected static final String[] TIME_FORMAT =
       new String[] {"default", "long", "number", "timestamp"};
   protected static final String[] STRING_TIME_FORMAT =
       new String[] {
@@ -127,7 +127,7 @@ public abstract class AbstractCsvTool {
   }
 
   protected static boolean checkTimeFormat() {
-    for (String format : NUMBER_TIME_FORMAT) {
+    for (String format : TIME_FORMAT) {
       if (timeFormat.equals(format)) {
         return true;
       }

--- a/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
@@ -53,12 +53,15 @@ public abstract class AbstractCsvTool {
   protected static final String TIME_ZONE_ARGS = "tz";
   protected static final String TIME_ZONE_NAME = "timeZone";
   protected static final int MAX_HELP_CONSOLE_WIDTH = 92;
-  protected static final String[] SUPPORT_TIME_FORMAT =
+  protected static final String[] NUMBER_TIME_FORMAT =
       new String[] {
         "default",
         "long",
         "number",
-        "timestamp",
+        "timestamp"
+      };
+  protected static final String[] STRING_TIME_FORMAT =
+      new String[] {
         "yyyy-MM-dd HH:mm:ss",
         "yyyy/MM/dd HH:mm:ss",
         "yyyy.MM.dd HH:mm:ss",
@@ -129,7 +132,12 @@ public abstract class AbstractCsvTool {
   }
 
   protected static boolean checkTimeFormat() {
-    for (String format : SUPPORT_TIME_FORMAT) {
+    for (String format : NUMBER_TIME_FORMAT) {
+      if (timeFormat.equals(format)) {
+        return true;
+      }
+    }
+    for (String format : STRING_TIME_FORMAT) {
       if (timeFormat.equals(format)) {
         return true;
       }

--- a/cli/src/main/java/org/apache/iotdb/tool/ExportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ExportCsv.java
@@ -312,7 +312,7 @@ public class ExportCsv extends AbstractCsvTool {
         break;
       case "timestamp":
       case "long":
-      case "nubmer":
+      case "number":
         bw.write(time + ",");
         break;
       default:

--- a/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
@@ -33,8 +33,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -57,8 +55,6 @@ public class ImportCsv extends AbstractCsvTool {
   private static final String FILE_ARGS = "f";
   private static final String FILE_NAME = "file or folder";
   private static final String FILE_SUFFIX = "csv";
-  private static final Logger logger = LoggerFactory.getLogger(ImportCsv.class);
-  private static final String TIME_TYPE = "It isn't a {} time type";
 
   private static final String TSFILEDB_CLI_PREFIX = "ImportCsv";
   private static final String ILLEGAL_PATH_ARGUMENT = "Path parameter is null";
@@ -249,9 +245,6 @@ public class ImportCsv extends AbstractCsvTool {
   }
 
   private static SimpleDateFormat formatterInit(String time) {
-    SimpleDateFormat format1 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-    SimpleDateFormat format2 = new SimpleDateFormat("yyy-MM-dd HH:mm:ss");
-    SimpleDateFormat format3 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
     try {
       Long.parseLong(time);
@@ -260,25 +253,14 @@ public class ImportCsv extends AbstractCsvTool {
       // do nothing
     }
 
-    try {
-      format1.parse(time).getTime();
-      return format1;
-    } catch (java.text.ParseException ignored) {
-      // do nothing
-    }
-
-    try {
-      format2.parse(time).getTime();
-      return format2;
-    } catch (java.text.ParseException ignored) {
-      // do nothing
-    }
-
-    try {
-      format3.parse(time).getTime();
-      return format3;
-    } catch (java.text.ParseException ignored) {
-      // do nothing
+    for (String timeFormat : STRING_TIME_FORMAT) {
+      SimpleDateFormat format = new SimpleDateFormat(timeFormat);
+      try {
+        format.parse(time).getTime();
+        return format;
+      } catch (java.text.ParseException ignored) {
+        // do nothing
+      }
     }
     return null;
   }


### PR DESCRIPTION
## Description
https://issues.apache.org/jira/browse/IOTDB-1313

This bug is about when import CSV with timestamp format `yyyy-MM-dd'T'HH:mm:ss.SSS`, the importCsv tool will treat it as `yyyy-MM-dd'T'HH:mm:ss`. It will cause the time precision lost. 

This PR is adding all formats supported in exportCsv tool.

This PR also solved https://issues.apache.org/jira/browse/IOTDB-1232。