### PR TITLE
[To rel/0.12] Fix upgrade tool cannot load old tsfile if time partition enabled in 0.11

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
@@ -241,6 +241,14 @@ public class IoTDBConfigCheck {
       System.exit(-1);
     }
 
+    // virtual storage group num can only set to 1 when upgrading from old version
+    if (!virtualStorageGroupNum.equals("1")) {
+      logger.error(
+          "virtual storage group num cannot set to {} when upgrading from old version, "
+              + "please set to 1 and restart",
+          virtualStorageGroupNum);
+      System.exit(-1);
+    }
     try (FileOutputStream tmpFOS = new FileOutputStream(tmpPropertiesFile.toString())) {
       properties.setProperty(PARTITION_INTERVAL_STRING, String.valueOf(partitionInterval));
       properties.setProperty(TSFILE_FILE_SYSTEM_STRING, tsfileFileSystem);


### PR DESCRIPTION
## Description

### Reproduce

1. change the configs in 0.11

```
# whether enable data partition. If disabled, all data belongs to partition 0
enable_partition=true

# time range for partitioning data inside each storage group, the unit is second
partition_interval=1
```
2. start 0.11 iotdb, execute these statements.
```
IoTDB> insert into root.sg.d1(time,s1,s2) values(1001,1,2)
Msg: The statement is executed successfully.
IoTDB> insert into root.sg.d1(time,s1,s2) values(2001,1,2)
Msg: The statement is executed successfully.
IoTDB> flush
```

The tsfile file paths looks like
```
$ tree data
data
├── sequence
│   └── root.sg
│       ├── 1
│       │   ├── 1620653607439-1-0.tsfile
│       │   └── 1620653607439-1-0.tsfile.resource
│       └── 2
│           ├── 1620653626029-1-0.tsfile
│           └── 1620653626029-1-0.tsfile.resource
└── unsequence

```

3. Move the data files 0.12 and start server with same partition configs.
4. Execute `Select * from root` and get empty result set.


### Reason
In 0.12, we introduce the virtual storage group, and there should be a directory names `0` under the storage group directory.

The upgrade tool should move all files of each partition to this virtual storage group directory before upgrading, otherwise, the server cannot load the old files. 

There is no problem if time partition disabled in 0.11. The reason is a directory names `0` under the storage group folder exists.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
