### PR TITLE
[IOTDB-1352]fix cluster_info_public_port  parameter not set in cluster/src/test/resources/

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/MetaClusterServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/MetaClusterServer.java
@@ -102,7 +102,6 @@ public class MetaClusterServer extends RaftServer
     member.start();
     // JMX based DBA API
     registerManager.register(ClusterMonitor.INSTANCE);
-
   }
 
   /** Also stops the IoTDB instance, the MetaGroupMember and the ClusterMonitor. */

--- a/cluster/src/test/resources/node1conf/iotdb-cluster.properties
+++ b/cluster/src/test/resources/node1conf/iotdb-cluster.properties
@@ -19,6 +19,7 @@
 internal_ip=127.0.0.1
 internal_meta_port=9003
 internal_data_port=40010
+cluster_info_public_port=6567
 seed_nodes=127.0.0.1:9003,127.0.0.1:9005,127.0.0.1:9007
 default_replica_num=1
 consistency_level=mid

--- a/cluster/src/test/resources/node2conf/iotdb-cluster.properties
+++ b/cluster/src/test/resources/node2conf/iotdb-cluster.properties
@@ -19,6 +19,7 @@
 internal_ip=127.0.0.1
 internal_meta_port=9005
 internal_data_port=40012
+cluster_info_public_port=6568
 seed_nodes=127.0.0.1:9003,127.0.0.1:9005,127.0.0.1:9007
 default_replica_num=1
 consistency_level=mid

--- a/cluster/src/test/resources/node3conf/iotdb-cluster.properties
+++ b/cluster/src/test/resources/node3conf/iotdb-cluster.properties
@@ -19,6 +19,7 @@
 internal_ip=127.0.0.1
 internal_meta_port=9007
 internal_data_port=40014
+cluster_info_public_port=6569
 seed_nodes=127.0.0.1:9003,127.0.0.1:9005,127.0.0.1:9007
 default_replica_num=1
 consistency_level=mid


### PR DESCRIPTION
after add `cluster_info_public_port`, we need to set them as different ports in our cluster/src/test/resources.