### PR TITLE
[IOTDB-1357] Compaction use append chunk merge strategy when chunk is already large

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionChunkTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionChunkTest.java
@@ -120,7 +120,7 @@ public class CompactionChunkTest extends LevelCompactionTest {
       }
       for (Entry<String, Map<TsFileSequenceReader, List<ChunkMetadata>>> entry :
           measurementChunkMetadataMap.entrySet()) {
-        CompactionUtils.writeByAppendMerge(
+        CompactionUtils.writeByAppendPageMerge(
             device, compactionWriteRateLimiter, entry, targetTsfileResource, writer);
       }
       reader.close();
@@ -199,7 +199,7 @@ public class CompactionChunkTest extends LevelCompactionTest {
       }
       for (Entry<String, Map<TsFileSequenceReader, List<ChunkMetadata>>> entry :
           measurementChunkMetadataMap.entrySet()) {
-        CompactionUtils.writeByDeserializeMerge(
+        CompactionUtils.writeByDeserializePageMerge(
             device,
             compactionWriteRateLimiter,
             entry,

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMergeTest.java
@@ -35,6 +35,8 @@ import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.reader.series.SeriesRawDataBatchReader;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.BatchData;
 import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 
@@ -47,6 +49,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -210,9 +213,6 @@ public class LevelCompactionMergeTest extends LevelCompactionTest {
     long count = 0L;
     while (tsFilesReader.hasNextBatch()) {
       BatchData batchData = tsFilesReader.nextBatch();
-      for (int i = 0; i < batchData.length(); i++) {
-        System.out.println(batchData.getTimeByIndex(i));
-      }
       count += batchData.length();
     }
     assertEquals(489, count);
@@ -223,6 +223,78 @@ public class LevelCompactionMergeTest extends LevelCompactionTest {
       tsFileResource.remove();
     }
     IoTDBDescriptor.getInstance().getConfig().setMergePagePointNumberThreshold(prevPageLimit);
+  }
+
+  /** test append chunk merge, the chunk is already large than merge_chunk_point_number */
+  @Test
+  public void testCompactionAppendChunkMerge() throws IOException {
+    int prevMergeChunkPointNumberThreshold =
+        IoTDBDescriptor.getInstance().getConfig().getMergeChunkPointNumberThreshold();
+    IoTDBDescriptor.getInstance().getConfig().setMergeChunkPointNumberThreshold(1);
+
+    LevelCompactionTsFileManagement levelCompactionTsFileManagement =
+        new LevelCompactionTsFileManagement(COMPACTION_TEST_SG, tempSGDir.getPath());
+    levelCompactionTsFileManagement.addAll(seqResources, true);
+    levelCompactionTsFileManagement.addAll(unseqResources, false);
+    levelCompactionTsFileManagement.forkCurrentFileList(0);
+    CompactionMergeTask compactionMergeTask =
+        levelCompactionTsFileManagement
+        .new CompactionMergeTask(this::closeCompactionMergeCallBack, 0);
+    compactionMergeWorking = true;
+    compactionMergeTask.call();
+    while (compactionMergeWorking) {
+      // wait
+    }
+    TsFileResource newTsFileResource =
+        levelCompactionTsFileManagement.getTsFileListByTimePartition(true, 0).get(0);
+    TsFileSequenceReader tsFileSequenceReader =
+        new TsFileSequenceReader(newTsFileResource.getTsFilePath());
+    Map<String, List<ChunkMetadata>> sensorChunkMetadataListMap =
+        tsFileSequenceReader.readChunkMetadataInDevice(deviceIds[0]);
+    for (List<ChunkMetadata> chunkMetadataList : sensorChunkMetadataListMap.values()) {
+      for (ChunkMetadata chunkMetadata : chunkMetadataList) {
+        assertEquals(20, chunkMetadata.getNumOfPoints());
+      }
+    }
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setMergeChunkPointNumberThreshold(prevMergeChunkPointNumberThreshold);
+  }
+
+  /** test not append chunk merge, the chunk is smaller than merge_chunk_point_number */
+  @Test
+  public void testCompactionNoAppendChunkMerge() throws IOException {
+    int prevMergeChunkPointNumberThreshold =
+        IoTDBDescriptor.getInstance().getConfig().getMergeChunkPointNumberThreshold();
+    IoTDBDescriptor.getInstance().getConfig().setMergeChunkPointNumberThreshold(100000);
+
+    LevelCompactionTsFileManagement levelCompactionTsFileManagement =
+        new LevelCompactionTsFileManagement(COMPACTION_TEST_SG, tempSGDir.getPath());
+    levelCompactionTsFileManagement.addAll(seqResources, true);
+    levelCompactionTsFileManagement.addAll(unseqResources, false);
+    levelCompactionTsFileManagement.forkCurrentFileList(0);
+    CompactionMergeTask compactionMergeTask =
+        levelCompactionTsFileManagement
+        .new CompactionMergeTask(this::closeCompactionMergeCallBack, 0);
+    compactionMergeWorking = true;
+    compactionMergeTask.call();
+    while (compactionMergeWorking) {
+      // wait
+    }
+    TsFileResource newTsFileResource =
+        levelCompactionTsFileManagement.getTsFileListByTimePartition(true, 0).get(0);
+    TsFileSequenceReader tsFileSequenceReader =
+        new TsFileSequenceReader(newTsFileResource.getTsFilePath());
+    Map<String, List<ChunkMetadata>> sensorChunkMetadataListMap =
+        tsFileSequenceReader.readChunkMetadataInDevice(deviceIds[0]);
+    for (List<ChunkMetadata> chunkMetadataList : sensorChunkMetadataListMap.values()) {
+      for (ChunkMetadata chunkMetadata : chunkMetadataList) {
+        assertEquals(500, chunkMetadata.getNumOfPoints());
+      }
+    }
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setMergeChunkPointNumberThreshold(prevMergeChunkPointNumberThreshold);
   }
 
   /** close compaction merge callback, to release some locks */

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMergeTest.java
@@ -249,6 +249,7 @@ public class LevelCompactionMergeTest extends LevelCompactionTest {
         levelCompactionTsFileManagement.getTsFileListByTimePartition(true, 0).get(0);
     TsFileSequenceReader tsFileSequenceReader =
         new TsFileSequenceReader(newTsFileResource.getTsFilePath());
+    tsFileSequenceReader.close();
     Map<String, List<ChunkMetadata>> sensorChunkMetadataListMap =
         tsFileSequenceReader.readChunkMetadataInDevice(deviceIds[0]);
     for (List<ChunkMetadata> chunkMetadataList : sensorChunkMetadataListMap.values()) {
@@ -287,6 +288,7 @@ public class LevelCompactionMergeTest extends LevelCompactionTest {
         new TsFileSequenceReader(newTsFileResource.getTsFilePath());
     Map<String, List<ChunkMetadata>> sensorChunkMetadataListMap =
         tsFileSequenceReader.readChunkMetadataInDevice(deviceIds[0]);
+    tsFileSequenceReader.close();
     for (List<ChunkMetadata> chunkMetadataList : sensorChunkMetadataListMap.values()) {
       for (ChunkMetadata chunkMetadata : chunkMetadataList) {
         assertEquals(500, chunkMetadata.getNumOfPoints());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionMergeTest.java
@@ -249,7 +249,6 @@ public class LevelCompactionMergeTest extends LevelCompactionTest {
         levelCompactionTsFileManagement.getTsFileListByTimePartition(true, 0).get(0);
     TsFileSequenceReader tsFileSequenceReader =
         new TsFileSequenceReader(newTsFileResource.getTsFilePath());
-    tsFileSequenceReader.close();
     Map<String, List<ChunkMetadata>> sensorChunkMetadataListMap =
         tsFileSequenceReader.readChunkMetadataInDevice(deviceIds[0]);
     for (List<ChunkMetadata> chunkMetadataList : sensorChunkMetadataListMap.values()) {
@@ -257,6 +256,7 @@ public class LevelCompactionMergeTest extends LevelCompactionTest {
         assertEquals(20, chunkMetadata.getNumOfPoints());
       }
     }
+    tsFileSequenceReader.close();
     IoTDBDescriptor.getInstance()
         .getConfig()
         .setMergeChunkPointNumberThreshold(prevMergeChunkPointNumberThreshold);
@@ -288,12 +288,12 @@ public class LevelCompactionMergeTest extends LevelCompactionTest {
         new TsFileSequenceReader(newTsFileResource.getTsFilePath());
     Map<String, List<ChunkMetadata>> sensorChunkMetadataListMap =
         tsFileSequenceReader.readChunkMetadataInDevice(deviceIds[0]);
-    tsFileSequenceReader.close();
     for (List<ChunkMetadata> chunkMetadataList : sensorChunkMetadataListMap.values()) {
       for (ChunkMetadata chunkMetadata : chunkMetadataList) {
         assertEquals(500, chunkMetadata.getNumOfPoints());
       }
     }
+    tsFileSequenceReader.close();
     IoTDBDescriptor.getInstance()
         .getConfig()
         .setMergeChunkPointNumberThreshold(prevMergeChunkPointNumberThreshold);


### PR DESCRIPTION
## Problem

For level compaction (take the level compaction in sequential space as an example), the size of the merged chunk is controlled by the two parameters: seq_level_num and seq_file_num_in_each_level, that is, the original chunk is expanded by seq_file_num_in_each_level^(seq_level_num-1) times. This configuration scheme has three problems as follows:

1. When configuring, you need to know the size of a chunk originally written by the user, and configure it based on experience. This configuration method is difficult for users to configure by themselves. For each user, we also need to observe files and assist in configuration, which is very inconvenient.

2. Once the user uses the default parameters without modification or configuration errors, and the user's own scene does not need to compact too many files, it will occupy a lot of invalid disk IO, and even reduce query efficiency.

3. In some scenarios, the writing speeds of different time series are different, so according to this compaction method, a lot of chunks of different sizes will be merged in the end, and the chunks corresponding to the time series with slow writing speed will be smaller. The chunks corresponding to the time series with fast entry speed are large, resulting in uneven chunk sizes and difficult to control.

example:

Assuming that the target chunk that the user needs is 4 times the size of the original chunk, there are the following files

Level 0: file1(s1,s2,s2)+file2(s2,s2,s2) That is, file1 has 1 chunk of s1, 2 chunks of s2, and file2 has 3 chunks of s2

compact to level 1: file3(s1(1), s2(5)) The merged file has 1 chunk of s1, and 1 chunk of s2 that is 5 times the size. Suppose it and another file4(s1(1), s2(5)) to merge

compact to layer 2: file5(s1(2),s2(9)) The merged file has a chunk of s1 that is twice the size, and a chunk of s2 that is 9 times the size

It can be seen that the chunks of s2 are merged and larger, which far exceeds the chunk size required by the user, but the chunk corresponding to s1 still does not meet the requirements of the user.

## Solution

Use the configuration merge_chunk_point_number_threshold to control when merging each chunk,

If all the chunks corresponding to this sensor in the list to be merged have reached this threshold, the chunks are no longer merged, and the chunks read out are written directly to the new file.

More info about this function in [confluence](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=177047564)