### PR TITLE
[IOTDB-1356] Separate unseq_file_num_in_each_level from selecting candidate file in unseq compaction

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -401,6 +401,13 @@ timestamp_precision=ms
 # Datatype: int
 # unseq_level_num=1
 
+# Works when compaction_strategy is LEVEL_COMPACTION.
+# The max open file num in each unseq compaction task.
+# We use the unseq file num as the open file num
+# This parameters have to be much smaller than the permitted max open file num of each process controlled by operator system(65535 in most system)
+# Datatype: int
+# max_open_file_num_in_each_unseq_compaction=2000
+
 # Works when the compaction_strategy is LEVEL_COMPACTION.
 # When the average point number of chunks in the target file reaches this, merge the file to the top level.
 # During a merge, if a chunk with less number of points than this parameter, the chunk will be

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -347,6 +347,14 @@ public class IoTDBConfig {
   /** Works when the compaction_strategy is LEVEL_COMPACTION. The max num of unseq level. */
   private int unseqLevelNum = 1;
 
+  /**
+   * Works when compaction_strategy is LEVEL_COMPACTION. The max open file num in each unseq
+   * compaction task. We use the unseq file num as the open file num # This parameters have to be
+   * much smaller than the permitted max open file num of each process controlled by operator
+   * system(65535 in most system).
+   */
+  private int maxOpenFileNumInEachUnseqCompaction = 2000;
+
   /** whether to cache meta data(ChunkMetaData and TsFileMetaData) or not. */
   private boolean metaDataCacheEnable = true;
 
@@ -1518,6 +1526,14 @@ public class IoTDBConfig {
 
   public void setUnseqLevelNum(int unseqLevelNum) {
     this.unseqLevelNum = unseqLevelNum;
+  }
+
+  public int getMaxOpenFileNumInEachUnseqCompaction() {
+    return maxOpenFileNumInEachUnseqCompaction;
+  }
+
+  public void setMaxOpenFileNumInEachUnseqCompaction(int maxOpenFileNumInEachUnseqCompaction) {
+    this.maxOpenFileNumInEachUnseqCompaction = maxOpenFileNumInEachUnseqCompaction;
   }
 
   public int getMergeChunkSubThreadNum() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -342,6 +342,12 @@ public class IoTDBDescriptor {
               properties.getProperty(
                   "unseq_level_num", Integer.toString(conf.getUnseqLevelNum()))));
 
+      conf.setUnseqLevelNum(
+          Integer.parseInt(
+              properties.getProperty(
+                  "max_open_file_num_in_each_unseq_compaction",
+                  Integer.toString(conf.getMaxOpenFileNumInEachUnseqCompaction()))));
+
       conf.setUnseqFileNumInEachLevel(
           Integer.parseInt(
               properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -342,7 +342,7 @@ public class IoTDBDescriptor {
               properties.getProperty(
                   "unseq_level_num", Integer.toString(conf.getUnseqLevelNum()))));
 
-      conf.setUnseqLevelNum(
+      conf.setMaxOpenFileNumInEachUnseqCompaction(
           Integer.parseInt(
               properties.getProperty(
                   "max_open_file_num_in_each_unseq_compaction",

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -76,6 +76,8 @@ public abstract class TsFileManagement {
   protected boolean isMergeExecutedInCurrentTask = false;
 
   protected boolean isForceFullMerge = IoTDBDescriptor.getInstance().getConfig().isForceFullMerge();
+  private final int maxOpenFileNumInEachUnseqCompaction =
+      IoTDBDescriptor.getInstance().getConfig().getMaxOpenFileNumInEachUnseqCompaction();
 
   public TsFileManagement(String storageGroupName, String storageGroupDir) {
     this.storageGroupName = storageGroupName;
@@ -228,6 +230,14 @@ public abstract class TsFileManagement {
       logger.info("{} no unseq files to be merged", storageGroupName);
       isUnseqMerging = false;
       return;
+    }
+
+    if (unSeqMergeList.size() > maxOpenFileNumInEachUnseqCompaction) {
+      logger.info(
+          "{} too much unseq files to be merged, reduce it to {}",
+          storageGroupName,
+          maxOpenFileNumInEachUnseqCompaction);
+      unSeqMergeList = unSeqMergeList.subList(0, maxOpenFileNumInEachUnseqCompaction);
     }
 
     long budget = IoTDBDescriptor.getInstance().getConfig().getMergeMemoryBudget();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -237,7 +237,9 @@ public abstract class TsFileManagement {
           "{} too much unseq files to be merged, reduce it to {}",
           storageGroupName,
           maxOpenFileNumInEachUnseqCompaction);
-      unSeqMergeList = unSeqMergeList.subList(0, maxOpenFileNumInEachUnseqCompaction);
+      unSeqMergeList =
+          unSeqMergeList.subList(
+              unSeqMergeList.size() - maxOpenFileNumInEachUnseqCompaction, unSeqMergeList.size());
     }
 
     long budget = IoTDBDescriptor.getInstance().getConfig().getMergeMemoryBudget();


### PR DESCRIPTION
Currently, unseq_file_num_in_each_level will impact the max selected file num in unseq compaction. This is not intuition.

Need to optimize the compaction candidate selecting process, according to the merge_memory_budget, max_selecting_merge_file_num, max open file num in system.