### PR TITLE
[To rel/0.12] Fix `merge` command cannot execute compaction task bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -220,7 +220,7 @@ public class StorageGroupProcessor {
   /**
    * time partition id -> version controller which assigns a version for each MemTable and
    * deletion/update such that after they are persisted, the order of insertions, deletions and
-   * updates can be re-determined.
+   * updates can be re-determined. Will be empty if there are not MemTables in memory.
    */
   private HashMap<Long, VersionController> timePartitionIdVersionControllerMap = new HashMap<>();
   /**
@@ -2067,7 +2067,7 @@ public class StorageGroupProcessor {
   public void merge(boolean isFullMerge) {
     writeLock();
     try {
-      for (long timePartitionId : timePartitionIdVersionControllerMap.keySet()) {
+      for (long timePartitionId : partitionLatestFlushedTimeForEachDevice.keySet()) {
         executeCompaction(timePartitionId, isFullMerge);
       }
     } finally {


### PR DESCRIPTION
## Behavior
1. Set IoTDB params like below:
```java
enableMemControl: false
memtableSizeThreshold: 1*1024*1024L
```
2. Use SessionExample to write data util there are too much TsFile that cannot be compacted immediately like figure-1.
![image](https://user-images.githubusercontent.com/24886743/117613375-6656a880-b199-11eb-95d2-ec6ac8863c63.png)
3. open cli and use `merge` command to execute compaction task.

Problem: Nothing happens after `merge` command.

## Reason
The member variable timePartitionIdVersionControllerMap will be empty if there are no Memtables in memory. So the `merge` command cannot find timePartitionId to execute compaction bug.

## Solution
1. use `partitionLatestFlushedTimeForEachDevice` instead.