### PR TITLE
[IOTDB-1371] Fix NPE when creating aligned timeseries and inserting with mismatched data type

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/sink/LocalIoTDBSinkTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sink/LocalIoTDBSinkTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.sink;
 
+import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.sink.local.LocalIoTDBConfiguration;
 import org.apache.iotdb.db.sink.local.LocalIoTDBEvent;
 import org.apache.iotdb.db.sink.local.LocalIoTDBHandler;
@@ -191,7 +192,7 @@ public class LocalIoTDBSinkTest {
     }
   }
 
-  @Test(expected = ClassCastException.class)
+  @Test(expected = QueryProcessException.class)
   public void onEventWithWrongType1() throws Exception {
     LocalIoTDBHandler localIoTDBHandler = new LocalIoTDBHandler();
     localIoTDBHandler.open(


### PR DESCRIPTION
When creating aligned timeseries and inserting with mismatched data type, the MNode will be null and a NullPointerException would be thrown.