### PR TITLE
[To rel/0.12] fix versionInfo NPE when query upgrading 0.11 tsfile

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/v2/file/metadata/TsFileMetadataV2.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/v2/file/metadata/TsFileMetadataV2.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 
 public class TsFileMetadataV2 {
@@ -40,6 +41,7 @@ public class TsFileMetadataV2 {
       ByteBuffer buffer, List<Pair<Long, Long>> versionInfo) {
     TsFileMetadata fileMetaData = new TsFileMetadata();
 
+    List<Pair<Long, Long>> tmpVersionInfo = new ArrayList<>();
     // metadataIndex
     fileMetaData.setMetadataIndex(MetadataIndexNodeV2.deserializeFrom(buffer));
     // totalChunkNum
@@ -52,9 +54,10 @@ public class TsFileMetadataV2 {
     for (int i = 0; i < versionSize; i++) {
       long versionPos = ReadWriteIOUtils.readLong(buffer);
       long version = ReadWriteIOUtils.readLong(buffer);
-      versionInfo.add(new Pair<>(versionPos, version));
+      tmpVersionInfo.add(new Pair<>(versionPos, version));
     }
 
+    versionInfo = tmpVersionInfo;
     // metaOffset
     long metaOffset = ReadWriteIOUtils.readLong(buffer);
     fileMetaData.setMetaOffset(metaOffset);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/v2/file/metadata/TsFileMetadataV2.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/v2/file/metadata/TsFileMetadataV2.java
@@ -35,13 +35,12 @@ public class TsFileMetadataV2 {
    * deserialize data from the buffer.
    *
    * @param buffer -buffer use to deserialize
-   * @return -a instance of TsFileMetaData
+   * @return -a pair of TsFileMetaData and VersionInfo
    */
-  public static TsFileMetadata deserializeFrom(
-      ByteBuffer buffer, List<Pair<Long, Long>> versionInfo) {
+  public static Pair<TsFileMetadata, List<Pair<Long, Long>>> deserializeFrom(ByteBuffer buffer) {
     TsFileMetadata fileMetaData = new TsFileMetadata();
 
-    List<Pair<Long, Long>> tmpVersionInfo = new ArrayList<>();
+    List<Pair<Long, Long>> versionInfo = new ArrayList<>();
     // metadataIndex
     fileMetaData.setMetadataIndex(MetadataIndexNodeV2.deserializeFrom(buffer));
     // totalChunkNum
@@ -54,10 +53,9 @@ public class TsFileMetadataV2 {
     for (int i = 0; i < versionSize; i++) {
       long versionPos = ReadWriteIOUtils.readLong(buffer);
       long version = ReadWriteIOUtils.readLong(buffer);
-      tmpVersionInfo.add(new Pair<>(versionPos, version));
+      versionInfo.add(new Pair<>(versionPos, version));
     }
 
-    versionInfo = tmpVersionInfo;
     // metaOffset
     long metaOffset = ReadWriteIOUtils.readLong(buffer);
     fileMetaData.setMetaOffset(metaOffset);
@@ -73,6 +71,6 @@ public class TsFileMetadataV2 {
           BloomFilter.buildBloomFilter(bytes, filterSize, hashFunctionSize));
     }
 
-    return fileMetaData;
+    return new Pair<>(fileMetaData, versionInfo);
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/v2/read/TsFileSequenceReaderForV2.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/v2/read/TsFileSequenceReaderForV2.java
@@ -146,9 +146,10 @@ public class TsFileSequenceReaderForV2 extends TsFileSequenceReader implements A
   @Override
   public TsFileMetadata readFileMetadata() throws IOException {
     if (tsFileMetaData == null || versionInfo == null) {
-      tsFileMetaData =
-          TsFileMetadataV2.deserializeFrom(
-              readData(fileMetadataPos, fileMetadataSize), versionInfo);
+      Pair<TsFileMetadata, List<Pair<Long, Long>>> pair =
+          TsFileMetadataV2.deserializeFrom(readData(fileMetadataPos, fileMetadataSize));
+      tsFileMetaData = pair.left;
+      versionInfo = pair.right;
     }
     return tsFileMetaData;
   }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/v2/read/TsFileSequenceReaderForV2.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/v2/read/TsFileSequenceReaderForV2.java
@@ -145,8 +145,7 @@ public class TsFileSequenceReaderForV2 extends TsFileSequenceReader implements A
    */
   @Override
   public TsFileMetadata readFileMetadata() throws IOException {
-    if (tsFileMetaData == null) {
-      versionInfo = new ArrayList<>();
+    if (tsFileMetaData == null || versionInfo == null) {
       tsFileMetaData =
           TsFileMetadataV2.deserializeFrom(
               readData(fileMetadataPos, fileMetadataSize), versionInfo);


### PR DESCRIPTION
<img width="954" alt="Screen Shot 2021-05-13 at 11 38 09 AM" src="https://user-images.githubusercontent.com/25913899/118074016-bd4dbf00-b3df-11eb-9b7e-896dc9ba5f27.png">

The reason is the versionInfo may be not thread safe. Two threads can deserialize it concurrently.