### PR TITLE
split csv bug when has null value

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
@@ -435,6 +435,9 @@ public class ImportCsv extends AbstractCsvTool {
         nextNode(path, nodes, '\'');
       }
     }
+    if (path.charAt(path.length() - 1) == ',') {
+      nodes.add("");
+    }
     if (startIndex <= path.length() - 1) {
       nodes.add(path.substring(startIndex));
     }


### PR DESCRIPTION
will throw ArrayOutOfIndexError when a value is null 
ie.
time,root.fit.d4.s1,root.fit.d4.s2,root.fit.d4.s3,root.fit.d4.s4,root.fit.d4.s5
2,-2147054108,-9221527177961516032,3.40034e+34,1.7978729221545312e+304,
3,-2147054108,-9221527177961516032,3.40034e+34,1.7978729221545312e+304,1