### PR TITLE
[To rel/0.12] Update force full merge config

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -374,7 +374,7 @@ timestamp_precision=ms
 # When set to true, all unseq merges becomes full merge (the whole SeqFiles are re-written despite how
 # much they are overflowed). This may increase merge overhead depending on how much the SeqFiles
 # are overflowed.
-# force_full_merge=false
+# force_full_merge=true
 
 # How many threads will be set up to perform compaction, 10 by default.
 # Set to 1 when less than or equal to 0.

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -482,7 +482,7 @@ public class IoTDBConfig {
    * despite how much they are overflowed). This may increase merge overhead depending on how much
    * the SeqFiles are overflowed.
    */
-  private boolean forceFullMerge = false;
+  private boolean forceFullMerge = true;
 
   /** The limit of compaction merge can reach per second */
   private int mergeWriteThroughputMbPerSec = 8;


### PR DESCRIPTION
cherry pick #3194
Currently, we use inplace merge to speed up unseq compaction. However, there are some case that too much unseq data appended to one seq file which may make some seq file too large. So we change the default merge strategy to full merge instead.