### PR TITLE
[To rel/0.11] Fix continuous compaction run into dead loop when unseq compaction cannot select candidates

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -570,12 +570,12 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
     if (enableUnseqCompaction
         && unseqLevelNum <= 1
         && forkedUnSequenceTsFileResources.get(0).size() > 0) {
-      isMergeExecutedInCurrentTask = true;
-      merge(
-          isForceFullMerge,
-          getTsFileListByTimePartition(true, timePartition),
-          forkedUnSequenceTsFileResources.get(0),
-          Long.MAX_VALUE);
+      isMergeExecutedInCurrentTask =
+          merge(
+              isForceFullMerge,
+              getTsFileListByTimePartition(true, timePartition),
+              forkedUnSequenceTsFileResources.get(0),
+              Long.MAX_VALUE);
     } else {
       isMergeExecutedInCurrentTask =
           merge(
@@ -620,7 +620,11 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
             // do not merge current unseq file level to upper level and just merge all of them to
             // seq file
             isSeqMerging = false;
-            merge(isForceFullMerge, getTsFileListByTimePartition(true, timePartition), mergeResources.get(i), Long.MAX_VALUE);
+            isMergeExecutedInCurrentTask = merge(
+                isForceFullMerge,
+                getTsFileListByTimePartition(true, timePartition),
+                mergeResources.get(i),
+                Long.MAX_VALUE);
           } else {
             CompactionLogger compactionLogger =
                 new CompactionLogger(storageGroupDir, storageGroupName);


### PR DESCRIPTION
Currently, if the unseq compaction cannot select candidates for merge, it will always run again in the same unseq file list in the continuous compaction process. So we have to avoid continuous compaction if the unseq file cannot be selected to be merged.