### PR TITLE
[To rel/0.12] Fix continuous compaction run into dead loop when unseq compaction cannot select candidates

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -192,7 +192,7 @@ public abstract class TsFileManagement {
     }
   }
 
-  public synchronized void merge(
+  public synchronized boolean merge(
       boolean fullMerge,
       List<TsFileResource> seqMergeList,
       List<TsFileResource> unSeqMergeList,
@@ -204,7 +204,7 @@ public abstract class TsFileManagement {
             storageGroupName,
             (System.currentTimeMillis() - mergeStartTime));
       }
-      return;
+      return false;
     }
     // wait until seq merge has finished
     while (isSeqMerging) {
@@ -213,7 +213,7 @@ public abstract class TsFileManagement {
       } catch (InterruptedException e) {
         logger.error("{} [Compaction] shutdown", storageGroupName, e);
         Thread.currentThread().interrupt();
-        return;
+        return false;
       }
     }
     isUnseqMerging = true;
@@ -221,13 +221,13 @@ public abstract class TsFileManagement {
     if (seqMergeList.isEmpty()) {
       logger.info("{} no seq files to be merged", storageGroupName);
       isUnseqMerging = false;
-      return;
+      return false;
     }
 
     if (unSeqMergeList.isEmpty()) {
       logger.info("{} no unseq files to be merged", storageGroupName);
       isUnseqMerging = false;
-      return;
+      return false;
     }
 
     long budget = IoTDBDescriptor.getInstance().getConfig().getMergeMemoryBudget();
@@ -241,7 +241,7 @@ public abstract class TsFileManagement {
         logger.info(
             "{} cannot select merge candidates under the budget {}", storageGroupName, budget);
         isUnseqMerging = false;
-        return;
+        return false;
       }
       // avoid pending tasks holds the metadata and streams
       mergeResource.clear();
@@ -278,9 +278,10 @@ public abstract class TsFileManagement {
             mergeFiles[0].size(),
             mergeFiles[1].size());
       }
-
+      return true;
     } catch (MergeException | IOException e) {
       logger.error("{} cannot select file for merge", storageGroupName, e);
+      return false;
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -600,12 +600,12 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
     if (enableUnseqCompaction
         && unseqLevelNum <= 1
         && forkedUnSequenceTsFileResources.get(0).size() > 0) {
-      isMergeExecutedInCurrentTask = true;
-      merge(
-          isForceFullMerge,
-          getTsFileListByTimePartition(true, timePartition),
-          forkedUnSequenceTsFileResources.get(0),
-          Long.MAX_VALUE);
+      isMergeExecutedInCurrentTask =
+          merge(
+              isForceFullMerge,
+              getTsFileListByTimePartition(true, timePartition),
+              forkedUnSequenceTsFileResources.get(0),
+              Long.MAX_VALUE);
     } else {
       isMergeExecutedInCurrentTask =
           merge(
@@ -651,11 +651,12 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
             // do not merge current unseq file level to upper level and just merge all of them to
             // seq file
             isSeqMerging = false;
-            merge(
-                isForceFullMerge,
-                getTsFileListByTimePartition(true, timePartition),
-                mergeResources.get(i),
-                Long.MAX_VALUE);
+            isMergeExecutedInCurrentTask =
+                merge(
+                    isForceFullMerge,
+                    getTsFileListByTimePartition(true, timePartition),
+                    mergeResources.get(i),
+                    Long.MAX_VALUE);
           } else {
             compactionLogger = new CompactionLogger(storageGroupDir, storageGroupName);
             // log source file list and target file for recover


### PR DESCRIPTION
Currently, if the unseq compaction cannot select candidates for merge, it will always run again in the same unseq file list in the continuous compaction process. So we have to avoid continuous compaction if the unseq file cannot be selected to be merged.