### PR TITLE
fix index out of bound when VectorTimeSeriesMetadata is not find in memory

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
@@ -181,7 +181,7 @@ public class FileLoaderUtils {
                       .collect(Collectors.toList()),
                   allSensors,
                   context.isDebug());
-      if (timeSeriesMetadata != null) {
+      if (timeSeriesMetadata != null && !timeSeriesMetadata.isEmpty()) {
         timeSeriesMetadata
             .get(0)
             .setChunkMetadataLoader(


### PR DESCRIPTION
1. start  the `master` branch IoTDBServer
2. use `VectorSessionExample` to insert data:
```
    createTemplate();
    insertTabletWithAlignedTimeseriesMethod1();
    insertTabletWithAlignedTimeseriesMethod2();
```
3. use cli to select .
```
select * from root.*;
```

4.the error result like this:
```
[[INTERNAL_SERVER_ERROR] Exception occurred while executing executeQueryStatement. Index: 0][500] 500: [INTERNAL_SERVER_ERROR] Exception occurred while executing executeQueryStatement. Index: 0
```