### PR TITLE
[To rel/0.11] Automatically close the dataset while there is no more data

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
@@ -21,8 +21,15 @@ package org.apache.iotdb.jdbc;
 
 import static org.apache.iotdb.rpc.IoTDBRpcDataSet.START_INDEX;
 import static org.apache.iotdb.rpc.IoTDBRpcDataSet.TIMESTAMP_STR;
-import static org.apache.iotdb.rpc.IoTDBRpcDataSet.VALUE_IS_NULL;
 
+import java.nio.ByteBuffer;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
@@ -34,11 +41,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.BytesUtils;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.thrift.TException;
-
-import java.nio.ByteBuffer;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.*;
 
 public class IoTDBNonAlignJDBCResultSet extends AbstractIoTDBJDBCResultSet {
 
@@ -121,9 +123,12 @@ public class IoTDBNonAlignJDBCResultSet extends AbstractIoTDBJDBCResultSet {
       }
       if (!resp.hasResultSet) {
         ioTDBRpcDataSet.emptyResultSet = true;
+        close();
       } else {
         tsQueryNonAlignDataSet = resp.getNonAlignQueryDataSet();
         if (tsQueryNonAlignDataSet == null) {
+          ioTDBRpcDataSet.emptyResultSet = true;
+          close();
           return false;
         }
       }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -192,13 +192,26 @@ public class IoTDBRpcDataSet {
       return true;
     }
     if (emptyResultSet) {
-      return false;
+      try {
+        close();
+        return false;
+      } catch (TException e) {
+        throw new IoTDBConnectionException(
+            "Cannot close dataset, because of network connection: {} ", e);
+      }
     }
-    if (fetchResults()) {
+    if (fetchResults() && hasCachedResults()) {
       constructOneRow();
       return true;
+    } else {
+      try {
+        close();
+        return false;
+      } catch (TException e) {
+        throw new IoTDBConnectionException(
+            "Cannot close dataset, because of network connection: {} ", e);
+      }
     }
-    return false;
   }
 
   public boolean fetchResults() throws StatementExecutionException, IoTDBConnectionException {
@@ -210,6 +223,7 @@ public class IoTDBRpcDataSet {
       RpcUtils.verifySuccess(resp.getStatus());
       if (!resp.hasResultSet) {
         emptyResultSet = true;
+        close();
       } else {
         tsQueryDataSet = resp.getQueryDataSet();
       }


### PR DESCRIPTION
Some users may forget to close the dataset manually after iterating the dataset which will cause resource leaky. We can automatically close it for users while there is no more data.
