### PR TITLE
[IOTDB-1387]  Fix Without Null ALL doesn't take effect in align by device clause

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
@@ -248,6 +248,7 @@ public class AlignByDeviceDataSet extends QueryDataSet {
     Field deviceField = new Field(TSDataType.TEXT);
     deviceField.setBinaryV(new Binary(currentDevice.getFullPath()));
     rowRecord.addField(deviceField);
+    rowRecord.resetNullFlag();
 
     List<Field> measurementFields = originRowRecord.getFields();
     Map<String, Field> currentColumnMap = new HashMap<>();

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
@@ -248,7 +248,8 @@ public class AlignByDeviceDataSet extends QueryDataSet {
     Field deviceField = new Field(TSDataType.TEXT);
     deviceField.setBinaryV(new Binary(currentDevice.getFullPath()));
     rowRecord.addField(deviceField);
-    // device field should not be considered as a value field it should affect the WITHOUT NULL judgement
+    // device field should not be considered as a value field it should affect the WITHOUT NULL
+    // judgement
     rowRecord.resetNullFlag();
 
     List<Field> measurementFields = originRowRecord.getFields();

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
@@ -248,6 +248,7 @@ public class AlignByDeviceDataSet extends QueryDataSet {
     Field deviceField = new Field(TSDataType.TEXT);
     deviceField.setBinaryV(new Binary(currentDevice.getFullPath()));
     rowRecord.addField(deviceField);
+    // device field should not be considered as a value field it should affect the WITHOUT NULL judgement
     rowRecord.resetNullFlag();
 
     List<Field> measurementFields = originRowRecord.getFields();

--- a/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
@@ -70,6 +70,7 @@ public class QueryDataSetUtils {
         // filter rows whose columns are null according to the rule
         if ((queryDataSet.isWithoutAllNull() && rowRecord.isAllNull())
             || (queryDataSet.isWithoutAnyNull() && rowRecord.hasNullField())) {
+          queryDataSet.decreaseAlreadyReturnedRowNum();
           i--;
           continue;
         }

--- a/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
@@ -70,6 +70,7 @@ public class QueryDataSetUtils {
         // filter rows whose columns are null according to the rule
         if ((queryDataSet.isWithoutAllNull() && rowRecord.isAllNull())
             || (queryDataSet.isWithoutAnyNull() && rowRecord.hasNullField())) {
+          // if the current RowRecord doesn't satisfy, we should also decrease AlreadyReturnedRowNum
           queryDataSet.decreaseAlreadyReturnedRowNum();
           i--;
           continue;

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBWithoutAllNullIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBWithoutAllNullIT.java
@@ -18,21 +18,23 @@
  */
 package org.apache.iotdb.db.integration;
 
-import static org.apache.iotdb.db.constant.TestConstant.TIMESTAMP_STR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.utils.EnvironmentUtils;
-import org.apache.iotdb.jdbc.Config;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import static org.apache.iotdb.db.constant.TestConstant.TIMESTAMP_STR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class IoTDBWithoutAllNullIT {
 
@@ -192,7 +194,7 @@ public class IoTDBWithoutAllNullIT {
   public void withoutAllNullTest4() {
     String[] retArray1 = new String[] {"11,root.testWithoutAllNull.d1,24,true,55.5"};
     try (Connection connection =
-        DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+            DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
       boolean hasResultSet =
           statement.execute(
@@ -207,7 +209,7 @@ public class IoTDBWithoutAllNullIT {
               resultSet.getString(TIMESTAMP_STR)
                   + ","
                   + resultSet.getString("Device")
-                  +","
+                  + ","
                   + resultSet.getString("last_value(s1)")
                   + ","
                   + resultSet.getString("last_value(s2)")
@@ -228,7 +230,7 @@ public class IoTDBWithoutAllNullIT {
   public void withoutAllNullTest5() {
     String[] retArray1 = new String[] {"6,root.testWithoutAllNull.d1,20,true,null"};
     try (Connection connection =
-        DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+            DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
       boolean hasResultSet =
           statement.execute(
@@ -243,7 +245,7 @@ public class IoTDBWithoutAllNullIT {
               resultSet.getString(TIMESTAMP_STR)
                   + ","
                   + resultSet.getString("Device")
-                  +","
+                  + ","
                   + resultSet.getString("last_value(s1)")
                   + ","
                   + resultSet.getString("last_value(s2)")

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBWithoutAllNullIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBWithoutAllNullIT.java
@@ -18,23 +18,21 @@
  */
 package org.apache.iotdb.db.integration;
 
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.utils.EnvironmentUtils;
-import org.apache.iotdb.jdbc.Config;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.apache.iotdb.db.constant.TestConstant.TIMESTAMP_STR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
-
-import static org.apache.iotdb.db.constant.TestConstant.TIMESTAMP_STR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class IoTDBWithoutAllNullIT {
 
@@ -179,6 +177,78 @@ public class IoTDBWithoutAllNullIT {
                   + resultSet.getString("last_value(root.testWithoutAllNull.d1.s2)")
                   + ","
                   + resultSet.getString("last_value(root.testWithoutAllNull.d1.s3)");
+          assertEquals(retArray1[cnt], ans);
+          cnt++;
+        }
+        assertEquals(retArray1.length, cnt);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void withoutAllNullTest4() {
+    String[] retArray1 = new String[] {"11,root.testWithoutAllNull.d1,24,true,55.5"};
+    try (Connection connection =
+        DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      boolean hasResultSet =
+          statement.execute(
+              "select last_value(*) from root.testWithoutAllNull.d1 GROUP BY([1, 21), 5ms) WITHOUT NULL ALL LIMIT 1 OFFSET 1 ALIGN BY DEVICE");
+
+      assertTrue(hasResultSet);
+      int cnt;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        cnt = 0;
+        while (resultSet.next()) {
+          String ans =
+              resultSet.getString(TIMESTAMP_STR)
+                  + ","
+                  + resultSet.getString("Device")
+                  +","
+                  + resultSet.getString("last_value(s1)")
+                  + ","
+                  + resultSet.getString("last_value(s2)")
+                  + ","
+                  + resultSet.getString("last_value(s3)");
+          assertEquals(retArray1[cnt], ans);
+          cnt++;
+        }
+        assertEquals(retArray1.length, cnt);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void withoutAllNullTest5() {
+    String[] retArray1 = new String[] {"6,root.testWithoutAllNull.d1,20,true,null"};
+    try (Connection connection =
+        DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      boolean hasResultSet =
+          statement.execute(
+              "select last_value(*) from root.testWithoutAllNull.d1 GROUP BY([1, 21), 5ms) ORDER BY TIME DESC WITHOUT NULL ALL LIMIT 1 OFFSET 1 ALIGN BY DEVICE");
+
+      assertTrue(hasResultSet);
+      int cnt;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        cnt = 0;
+        while (resultSet.next()) {
+          String ans =
+              resultSet.getString(TIMESTAMP_STR)
+                  + ","
+                  + resultSet.getString("Device")
+                  +","
+                  + resultSet.getString("last_value(s1)")
+                  + ","
+                  + resultSet.getString("last_value(s2)")
+                  + ","
+                  + resultSet.getString("last_value(s3)");
           assertEquals(retArray1[cnt], ans);
           cnt++;
         }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/RowRecord.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/RowRecord.java
@@ -94,4 +94,9 @@ public class RowRecord {
   public boolean isAllNull() {
     return allNull;
   }
+
+  public void resetNullFlag() {
+    hasNullField = false;
+    allNull = true;
+  }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/QueryDataSet.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/QueryDataSet.java
@@ -194,4 +194,8 @@ public abstract class QueryDataSet {
   public void setWithoutAllNull(boolean withoutAllNull) {
     this.withoutAllNull = withoutAllNull;
   }
+
+  public void decreaseAlreadyReturnedRowNum() {
+    alreadyReturnedRowNum--;
+  }
 }


### PR DESCRIPTION
## Description

The details can be seen in JIRA.

## Reasons

Align by device always have one device column which will never be null. While using WITHOUT NULL clause, we shouldn't take device column into consideration.

## Solution

Reset the null state in RowRecord after add the device column. Also decrease the alreadyReturnedRowNum field in QueryDataset while the current RowRecord doesn't satisify the without null constraint.
