### PR TITLE
fix import csv split by comma bug

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
@@ -424,38 +424,21 @@ public class ImportCsv extends AbstractCsvTool {
 
   public static String[] splitCsvLine(String path) {
     List<String> nodes = new ArrayList<>();
-    startIndex = 0;
-    for (i = 0; i < path.length(); i++) {
-      if (path.charAt(i) == ',') {
-        nodes.add(path.substring(startIndex, i));
-        startIndex = i + 1;
-      } else if (path.charAt(i) == '"') {
-        nextNode(path, nodes, '"');
+    int start = 0;
+    boolean singleQuotes = false;
+    boolean doubleQuotes = false;
+    // split by comma if the comma is followed by an even number of quotes
+    for (int i = 0; i < path.length(); i++) {
+      if (path.charAt(i) == '\"') {
+        doubleQuotes = !doubleQuotes; // toggle state
       } else if (path.charAt(i) == '\'') {
-        nextNode(path, nodes, '\'');
+        singleQuotes = !singleQuotes;
+      } else if (path.charAt(i) == ',' && (!singleQuotes && !doubleQuotes)) {
+        nodes.add(path.substring(start, i));
+        start = i + 1;
       }
     }
-    if (path.charAt(path.length() - 1) == ',') {
-      nodes.add("");
-    }
-    if (startIndex <= path.length() - 1) {
-      nodes.add(path.substring(startIndex));
-    }
+    nodes.add(path.substring(start));
     return nodes.toArray(new String[0]);
-  }
-
-  public static void nextNode(String path, List<String> nodes, char enclose) {
-    int endIndex = path.indexOf(enclose, i + 1);
-    // if a double quotes with escape character
-    while (endIndex != -1 && path.charAt(endIndex - 1) == '\\') {
-      endIndex = path.indexOf(enclose, endIndex + 1);
-    }
-    if (endIndex != -1 && (endIndex == path.length() - 1 || path.charAt(endIndex + 1) == ',')) {
-      nodes.add(path.substring(startIndex + 1, endIndex));
-      i = endIndex + 1;
-      startIndex = endIndex + 2;
-    } else {
-      throw new IllegalArgumentException("Illegal csv line" + path);
-    }
   }
 }

--- a/cli/src/test/java/org/apache/iotdb/tool/CsvLineSplitTest.java
+++ b/cli/src/test/java/org/apache/iotdb/tool/CsvLineSplitTest.java
@@ -26,8 +26,8 @@ public class CsvLineSplitTest {
   @Test
   public void testSplit() {
     Assert.assertArrayEquals(
-        new String[] {"", "a", "b", "c", "\\\""}, ImportCsv.splitCsvLine(",a,b,c,\"\\\"\""));
+        new String[] {"", "a", "b", "c", "\\\""}, ImportCsv.splitCsvLine(",a,b,c,\\\""));
     Assert.assertArrayEquals(
-        new String[] {"", "a", "b", "\\'"}, ImportCsv.splitCsvLine(",a,b,\"\\'\""));
+        new String[] {"", "a", "b", "\\'"}, ImportCsv.splitCsvLine(",a,b,\\'"));
   }
 }

--- a/cli/src/test/java/org/apache/iotdb/tool/CsvLineSplitTest.java
+++ b/cli/src/test/java/org/apache/iotdb/tool/CsvLineSplitTest.java
@@ -29,5 +29,12 @@ public class CsvLineSplitTest {
         new String[] {"", "a", "b", "c", "\\\""}, ImportCsv.splitCsvLine(",a,b,c,\\\""));
     Assert.assertArrayEquals(
         new String[] {"", "a", "b", "\\'"}, ImportCsv.splitCsvLine(",a,b,\\'"));
+    Assert.assertArrayEquals(
+        new String[] {"", "a\",\"a", "\"a,,\"", "'"}, ImportCsv.splitCsvLine(",a\",\"a,\"a,,\",'"));
+    Assert.assertArrayEquals(
+        new String[] {"True", "a=\",\"a''"}, ImportCsv.splitCsvLine("True,a=\",\"a''"));
+    Assert.assertArrayEquals(
+        new String[] {"True", "\"a=,,,a=z//z'a\""},
+        ImportCsv.splitCsvLine("True,\"a=,,,a=z//z'a\""));
   }
 }


### PR DESCRIPTION
previously when ImportCSV tool read csv files, single or double quotes are not allowed inside a string (ie ad"bcd). 
This pr changes the csv splitting method. now it allows quotes or commas inside a string value. 
 
csv file as following:
time,root.fit.d6.s5,root.fit.d6.s6
1,True,
4,True,aapovpba=","akava'',vava=z//z'nnn
6,True,aapovpba=','akavavava=z//z'nnn
7,True,"aapovpba=,,,akavavava=z//z'nnn"

after import csv, query result:
![image](https://user-images.githubusercontent.com/68632589/119316860-0c320900-bcaa-11eb-8f87-504c875202c6.png)
