### PR TITLE
[IOTDB-1390] Fix unseq compaction loss data bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
@@ -195,6 +195,16 @@ public class MergeMultiChunkTask {
     mergeLogger.logTSEnd();
   }
 
+  private String getMaxSensor(List<PartialPath> sensors) {
+    String maxSensor = sensors.get(0).getMeasurement();
+    for (int i = 1; i < sensors.size(); i++) {
+      if (maxSensor.compareTo(sensors.get(i).getMeasurement()) < 0) {
+        maxSensor = sensors.get(i).getMeasurement();
+      }
+    }
+    return maxSensor;
+  }
+
   private void pathsMergeOneFile(int seqFileIdx, IPointReader[] unseqReaders) throws IOException {
     TsFileResource currTsFile = resource.getSeqFiles().get(seqFileIdx);
     String deviceId = currMergingPaths.get(0).getDevice();
@@ -238,7 +248,7 @@ public class MergeMultiChunkTask {
       return;
     }
 
-    String lastSensor = currMergingPaths.get(currMergingPaths.size() - 1).getMeasurement();
+    String lastSensor = getMaxSensor(currMergingPaths);
     String currSensor = null;
     Map<String, List<ChunkMetadata>> measurementChunkMetadataListMap = new TreeMap<>();
     // find all sensor to merge in order, if exceed, then break
@@ -455,7 +465,6 @@ public class MergeMultiChunkTask {
       IChunkWriter chunkWriter,
       TsFileResource currFile)
       throws IOException {
-
     int unclosedChunkPoint = lastUnclosedChunkPoint;
     boolean chunkModified =
         (currMeta.getDeleteIntervalList() != null && !currMeta.getDeleteIntervalList().isEmpty());

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
@@ -215,12 +215,15 @@ public class MergeTaskTest extends MergeTest {
             null,
             null,
             true);
+    long count = 0L;
     while (tsFilesReader.hasNextBatch()) {
       BatchData batchData = tsFilesReader.nextBatch();
-      for (int i = 0; i < batchData.length(); i++) {
-        assertEquals(batchData.getTimeByIndex(i) + 20000.0, batchData.getDoubleByIndex(i), 0.001);
+      for (int t = 0; t < batchData.length(); t++) {
+        assertEquals(batchData.getTimeByIndex(t) + 20000.0, batchData.getDoubleByIndex(t), 0.001);
+        count++;
       }
     }
+    assertEquals(100, count);
     tsFilesReader.close();
   }
 


### PR DESCRIPTION
## Behavior
set compaction_strategy = LEVEL_COMPACTION

use the `data` to recover the IoTDB. After Recovery, it will merge the unseq data automatically. After unseq compaction, the data of some sensor in seq file loss.

use the following SQL to check data status before and after unseq compaction.

select Channel96 from root.*.J053102.T034.V1 where time >= 2021-05-18 22:32:27 and time <= 2021-05-18 22:32:37;
![9FC2321FEC32B5D6D27ECF043C05AF93](https://user-images.githubusercontent.com/24886743/119324996-03920080-bcb3-11eb-9d9a-5722b575c7b6.jpg)
<img width="799" alt="73AA84209157A758BAF4153BB569FB1D" src="https://user-images.githubusercontent.com/24886743/119325013-068cf100-bcb3-11eb-9130-2088ed3e773d.png">

## Reason
Unseq compaction filter sensor by lexicographic order. However, the input sensor list may be not in lexicographic order.

## Solution
Ignore the condition of lexicographic order and use traditional filter means.