### PR TITLE
Skip testContainer in unix and sonar workflow to accelerate CI

### DIFF
--- a/.github/workflows/main-unix.yml
+++ b/.github/workflows/main-unix.yml
@@ -52,4 +52,4 @@ jobs:
       - name: IT/UT Test
         shell: bash
         # we do not compile client-cpp for saving time, it is tested in client.yml
-        run:  mvn -B clean post-integration-test -Dtest.port.closed=true
+        run:  mvn -B clean post-integration-test -Dtest.port.closed=true -P '!testcontainer'

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2-
       - name: IT/UT Test
         # we do not compile client-cpp for saving time, it is tested in client.yml
-        run: mvn -B clean post-integration-test -Dtest.port.closed=true -Pcode-coverage
+        run: mvn -B clean post-integration-test -Dtest.port.closed=true -Pcode-coverage -DskipTests -P '!testcontainer'
       - name: Code Coverage (Coveralls)
         if: ${{ success() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'apache/iotdb' || github.event_name == 'push') }}
         run: |

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2-
       - name: IT/UT Test
         # we do not compile client-cpp for saving time, it is tested in client.yml
-        run: mvn -B clean post-integration-test -Dtest.port.closed=true -Pcode-coverage -DskipTests -P '!testcontainer'
+        run: mvn -B clean post-integration-test -Dtest.port.closed=true -Pcode-coverage -P '!testcontainer'
       - name: Code Coverage (Coveralls)
         if: ${{ success() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'apache/iotdb' || github.event_name == 'push') }}
         run: |

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -23,7 +23,6 @@ on:
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   PR_NUMBER: ${{ github.event.number }}
-  BRANCH_NAME: $GITHUB_REF
 
 jobs:
   ubuntu:
@@ -65,6 +64,7 @@ jobs:
           -Dsonar.projectKey=apache_incubator-iotdb \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONARCLOUD_TOKEN }} \
-          -Dsonar.pullrequest.branch=$BRANCH_NAME \
+          -Dsonar.pullrequest.branch=$GITHUB_HEAD_REF \
+          -Dsonar.pullrequest.base=$GITHUB_BASE_REF \
           -Dsonar.pullrequest.key=$PR_NUMBER \
           -DskipTests -pl '!distribution' -am

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -23,6 +23,7 @@ on:
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   PR_NUMBER: ${{ github.event.number }}
+  BRANCH_NAME: $GITHUB_REF
 
 jobs:
   ubuntu:


### PR DESCRIPTION
## Description

The CI runs very slow right now. Especially the sonar tests takes over one hour.
Since we have the e2e workflow runs the testContainer tests, it's not necessary to run these test in unix and sonar CI again.