### PR TITLE
cluster bug - fix privilege check

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -590,18 +590,18 @@ public class CMManager extends MManager {
           getStorageGroups(
               Collections.singletonList(
                   new PartialPath(((SetDeviceTemplatePlan) plan).getPrefixPath()))));
-    } else {
+    } else if (plan instanceof CreateMultiTimeSeriesPlan) {
       List<PartialPath> paths = new ArrayList<>();
-      if (plan instanceof CreateMultiTimeSeriesPlan) {
-        CreateMultiTimeSeriesPlan multiPlan = (CreateMultiTimeSeriesPlan) plan;
-        for (int i = 0; i < multiPlan.getPaths().size(); i++) {
-          // sgs are created or no permission to create
-          if (!multiPlan.getResults().containsKey(i)) {
-            paths.add(multiPlan.getPaths().get(i));
-          }
+      CreateMultiTimeSeriesPlan multiPlan = (CreateMultiTimeSeriesPlan) plan;
+      for (int i = 0; i < multiPlan.getPaths().size(); i++) {
+        // sgs are created or no permission to create
+        if (!multiPlan.getResults().containsKey(i)) {
+          paths.add(multiPlan.getPaths().get(i));
         }
       }
       storageGroups.addAll(getStorageGroups(paths));
+    } else {
+      storageGroups.addAll(getStorageGroups(plan.getPaths()));
     }
 
     // create storage groups

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -591,11 +591,11 @@ public class CMManager extends MManager {
               Collections.singletonList(
                   new PartialPath(((SetDeviceTemplatePlan) plan).getPrefixPath()))));
     } else {
-      // check permission for each sg
       List<PartialPath> paths = new ArrayList<>();
       if (plan instanceof CreateMultiTimeSeriesPlan) {
         CreateMultiTimeSeriesPlan multiPlan = (CreateMultiTimeSeriesPlan) plan;
         for (int i = 0; i < multiPlan.getPaths().size(); i++) {
+          // sgs are created or no permission to create
           if (!multiPlan.getResults().containsKey(i)) {
             paths.add(multiPlan.getPaths().get(i));
           }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -591,7 +591,17 @@ public class CMManager extends MManager {
               Collections.singletonList(
                   new PartialPath(((SetDeviceTemplatePlan) plan).getPrefixPath()))));
     } else {
-      storageGroups.addAll(getStorageGroups(plan.getPaths()));
+      // check permission for each sg
+      List<PartialPath> paths = new ArrayList<>();
+      if (plan instanceof CreateMultiTimeSeriesPlan) {
+        CreateMultiTimeSeriesPlan multiPlan = (CreateMultiTimeSeriesPlan) plan;
+        for (int i = 0; i < multiPlan.getPaths().size(); i++) {
+          if (!multiPlan.getResults().containsKey(i)) {
+            paths.add(multiPlan.getPaths().get(i));
+          }
+        }
+      }
+      storageGroups.addAll(getStorageGroups(paths));
     }
 
     // create storage groups

--- a/cluster/src/test/java/org/apache/iotdb/cluster/integration/SingleNodeTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/integration/SingleNodeTest.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.Session;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -122,10 +123,9 @@ public class SingleNodeTest extends BaseSingleNodeTest {
                 + "No permissions for this operation CREATE_TIMESERIES for SQL: \"create timeseries root.sg2.d1.s1 with datatype=int32\""
                 + System.lineSeparator(),
             e.getMessage());
-        System.out.println(e.getMessage());
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      Assert.fail(e.getMessage());
     }
   }
 }

--- a/cluster/src/test/java/org/apache/iotdb/cluster/integration/SingleNodeTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/integration/SingleNodeTest.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.cluster.integration;
 
 import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.jdbc.Config;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.Session;
@@ -28,9 +29,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -92,5 +97,35 @@ public class SingleNodeTest extends BaseSingleNodeTest {
     assertTrue(session.checkTimeseriesExists("root.sg1.d1.t1"));
     assertFalse(session.checkTimeseriesExists("root.sg1.d1.t2"));
     assertFalse(session.checkTimeseriesExists("root.sg1.d1.t3"));
+  }
+
+  @Test
+  public void testUserPrivilege() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("create user user1 \"1234\"");
+      try (Connection connection1 =
+              DriverManager.getConnection(
+                  Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "user1", "1234");
+          Statement userStatement = connection1.createStatement()) {
+        userStatement.addBatch("create timeseries root.sg1.d1.s1 with datatype=int32");
+        userStatement.addBatch("create timeseries root.sg2.d1.s1 with datatype=int32");
+        userStatement.executeBatch();
+      } catch (Exception e) {
+        assertEquals(
+            System.lineSeparator()
+                + "No permissions for this operation CREATE_TIMESERIES for SQL: \"create timeseries root.sg1.d1.s1 with datatype=int32\""
+                + System.lineSeparator()
+                + "No permissions for this operation CREATE_TIMESERIES for SQL: \"create timeseries root.sg2.d1.s1 with datatype=int32\""
+                + System.lineSeparator(),
+            e.getMessage());
+        System.out.println(e.getMessage());
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/BatchPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/BatchPlan.java
@@ -19,6 +19,10 @@
 
 package org.apache.iotdb.db.qp.physical;
 
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+import java.util.Map;
+
 /** BatchPlan contains multiple sub-plans. */
 public interface BatchPlan {
 
@@ -50,4 +54,11 @@ public interface BatchPlan {
    * @return how many sub-plans are in the plan.
    */
   int getBatchSize();
+
+  /**
+   * Return execution status for each path
+   *
+   * @return execution status for each path
+   */
+  Map<Integer, TSStatus> getResults();
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
@@ -23,13 +23,16 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
 import org.apache.iotdb.db.qp.physical.BatchPlan;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class InsertRowsOfOneDevicePlan extends InsertPlan implements BatchPlan {
@@ -177,6 +180,10 @@ public class InsertRowsOfOneDevicePlan extends InsertPlan implements BatchPlan {
       isExecuted = new boolean[getBatchSize()];
     }
     return isExecuted[i];
+  }
+
+  public Map<Integer, TSStatus> getResults() {
+    return Collections.emptyMap();
   }
 
   @Override


### PR DESCRIPTION
This PR fixed the following 2 bugs:
1. For user who does not have CREATE_TIMESERIES privilege, JDBC executeBatch() interface shows execution success, though the unauthorized timeseries are not created.
2. if enabled auto-create schema, CMManager creates SGs for all paths ignoring privilege check. 

Now fixed as:
```
Exception in thread "main" java.sql.BatchUpdateException: 
No permissions for this operation CREATE_TIMESERIES for SQL: "CREATE TIMESERIES root.sg4.d1.s1 WITH DATATYPE=INT64"
No permissions for this operation CREATE_TIMESERIES for SQL: "CREATE TIMESERIES root.sg7.d1.s1 WITH DATATYPE=INT64"
No permissions for this operation CREATE_TIMESERIES for SQL: "CREATE TIMESERIES root.sg8.d1.s1 WITH DATATYPE=INT64"

	at org.apache.iotdb.jdbc.IoTDBStatement.executeBatchSQL(IoTDBStatement.java:355)
	at org.apache.iotdb.jdbc.IoTDBStatement.executeBatch(IoTDBStatement.java:308)
	at org.apache.iotdb.JDBCExample.main(JDBCExample.java:43)
```
