### PR TITLE
[ISSUE-3277][To rel/0.11] Fix TotalSeriesNumber in MManager counted twice when recovering 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -216,16 +216,11 @@ public class MManager {
 
       isRecovering = true;
       int lineNumber = initFromLog(logFile);
-      List<PartialPath> storageGroups = mtree.getAllStorageGroupPaths();
-      for (PartialPath sg : storageGroups) {
-        MNode node = mtree.getNodeByPath(sg);
-        totalSeriesNumber.addAndGet(node.getMeasurementMNodeCount());
-      }
 
       logWriter = new MLogWriter(config.getSchemaDir(), MetadataConstant.METADATA_LOG);
       logWriter.setLineNumber(lineNumber);
       isRecovering = false;
-    } catch (IOException | MetadataException e) {
+    } catch (IOException e) {
       mtree = new MTree();
       logger.error("Cannot read MTree from file, using an empty new one", e);
     }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -516,7 +516,7 @@ public class MManagerBasicTest {
   }
 
   @Test
-  public void testTotalSeriesNumber() {
+  public void testTotalSeriesNumber() throws Exception {
     MManager manager = IoTDB.metaManager;
 
     try {
@@ -558,6 +558,8 @@ public class MManagerBasicTest {
           CompressionType.GZIP,
           null);
 
+      assertEquals(6, manager.getTotalSeriesNumber());
+      EnvironmentUtils.restartDaemon();
       assertEquals(6, manager.getTotalSeriesNumber());
       manager.deleteTimeseries(new PartialPath("root.laptop.d2.s1"));
       assertEquals(5, manager.getTotalSeriesNumber());


### PR DESCRIPTION
## Description
Fix #3277 