### PR TITLE
Enable sonar-coveralls for pr from fork repos

### DIFF
--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -10,7 +10,7 @@ on:
       - "rel/*"
     paths-ignore:
       - "docs/**"
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - "rel/*"
@@ -43,7 +43,7 @@ jobs:
         # we do not compile client-cpp for saving time, it is tested in client.yml
         run: mvn -B clean post-integration-test -Dtest.port.closed=true -Pcode-coverage
       - name: Code Coverage (Coveralls)
-        if: ${{ success() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'apache/iotdb' || github.event_name == 'push') }}
+        if: ${{ success() }}
         run: |
           mvn -B post-integration-test -Pcode-coverage -pl code-coverage
           mvn -B coveralls:report \
@@ -53,7 +53,7 @@ jobs:
           -DrepoToken=${{ secrets.COVERALL_TOKEN }} \
           -Pcode-coverage
       - name: SonarCloud Report
-        if: ${{ success() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'apache/iotdb' || github.event_name == 'push') }}
+        if: ${{ success() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
@@ -63,4 +63,6 @@ jobs:
           -Dsonar.projectKey=apache_incubator-iotdb \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONARCLOUD_TOKEN }} \
+          -Dsonar.pullrequest.branch=$BRANCH_NAME \
+          -Dsonar.pullrequest.key=$PR_NUMBER \
           -DskipTests -pl '!distribution' -am


### PR DESCRIPTION
## Description
Enable sonar-coveralls check for pr from fork repos according to [this article](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target).

I'm going to merge this pr directly, and test by a pr from my fork repos to see if this change is effective. 
If not, I'll revert this.