### PR TITLE
[IOTDB-1412] Unclear exception message thrown when executing empty InsertTabletPlan

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1179,6 +1179,9 @@ public class PlanExecutor implements IPlanExecutor {
   @Override
   public void insert(InsertRowsOfOneDevicePlan insertRowsOfOneDevicePlan)
       throws QueryProcessException {
+    if (insertRowsOfOneDevicePlan.getRowPlans().length == 0) {
+      return;
+    }
     try {
       for (InsertRowPlan plan : insertRowsOfOneDevicePlan.getRowPlans()) {
         plan.setMeasurementMNodes(new MeasurementMNode[plan.getMeasurements().length]);
@@ -1302,6 +1305,9 @@ public class PlanExecutor implements IPlanExecutor {
 
   @Override
   public void insertTablet(InsertTabletPlan insertTabletPlan) throws QueryProcessException {
+    if (insertTabletPlan.getRowCount() == 0) {
+      return;
+    }
     try {
       insertTabletPlan.setMeasurementMNodes(
           new MeasurementMNode[insertTabletPlan.getMeasurements().length]);


### PR DESCRIPTION
When the system executes an empty InsertTabletPlan, the system will throw the following error which is unclear:

![image](https://user-images.githubusercontent.com/30497621/120263155-b672e780-c2cd-11eb-824a-40bce3d0eb5f.png)

Empty insertTabletPlan / insertRowsOfOneDevicePlan are now handled properly in PlanExecutor.