### PR TITLE
Disable pull_request_target for sonar check since it cannot load any PR revision information

### DIFF
--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -51,7 +51,7 @@ jobs:
         # we do not compile client-cpp for saving time, it is tested in client.yml
         run: mvn -B clean post-integration-test -Dtest.port.closed=true -Pcode-coverage -P '!testcontainer'
       - name: Code Coverage (Coveralls)
-        if: ${{ success() }}
+        if: ${{ success() && (github.event_name == 'pull_request_target')}}
         run: |
           mvn -B post-integration-test -Pcode-coverage -pl code-coverage
           mvn -B coveralls:report \

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -71,6 +71,4 @@ jobs:
           -Dsonar.projectKey=apache_incubator-iotdb \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONARCLOUD_TOKEN }} \
-          -Dsonar.pullrequest.key=$PR_NUMBER \
-          -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }} \
           -DskipTests -pl '!distribution' -am

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -10,6 +10,13 @@ on:
       - "rel/*"
     paths-ignore:
       - "docs/**"
+  pull_request:
+    branches:
+      - master
+      - "rel/*"
+      - cluster_new
+    paths-ignore:
+      - "docs/**"
   pull_request_target:
     branches:
       - master
@@ -54,7 +61,7 @@ jobs:
           -DrepoToken=${{ secrets.COVERALL_TOKEN }} \
           -Pcode-coverage
       - name: SonarCloud Report
-        if: ${{ success() }}
+        if: ${{ success() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'apache/iotdb' || github.event_name == 'push')}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}


### PR DESCRIPTION
## Description

I find out the sonar cannot load any information after I use `pull_request_target` instead of `pull_request`, but the coverall works well.
Therefore I'm going to revert the sonar check logic and keep the coverall one.
<img width="969" alt="Screen Shot 2021-06-02 at 6 01 37 PM" src="https://user-images.githubusercontent.com/25913899/120461574-b1e12880-c3cc-11eb-8ee0-0040e2fd189f.png">
