### PR TITLE
[To rel/0.12] Fix upgrade tool cannot close file reader

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileRewriteTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileRewriteTool.java
@@ -41,6 +41,7 @@ import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.BatchData;
 import org.apache.iotdb.tsfile.read.reader.page.PageReader;
 import org.apache.iotdb.tsfile.utils.Binary;
+import org.apache.iotdb.tsfile.v2.read.TsFileSequenceReaderForV2;
 import org.apache.iotdb.tsfile.write.chunk.ChunkWriterImpl;
 import org.apache.iotdb.tsfile.write.chunk.IChunkWriter;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
@@ -98,6 +99,23 @@ public class TsFileRewriteTool implements AutoCloseable {
     oldTsFile = resourceToBeRewritten.getTsFile();
     String file = oldTsFile.getAbsolutePath();
     reader = new TsFileSequenceReader(file);
+    partitionWriterMap = new HashMap<>();
+    if (FSFactoryProducer.getFSFactory().getFile(file + ModificationFile.FILE_SUFFIX).exists()) {
+      oldModification = (List<Modification>) resourceToBeRewritten.getModFile().getModifications();
+      modsIterator = oldModification.iterator();
+      fileModificationMap = new HashMap<>();
+    }
+  }
+
+  public TsFileRewriteTool(TsFileResource resourceToBeRewritten, boolean needReaderForV2)
+      throws IOException {
+    oldTsFile = resourceToBeRewritten.getTsFile();
+    String file = oldTsFile.getAbsolutePath();
+    if (needReaderForV2) {
+      reader = new TsFileSequenceReaderForV2(file);
+    } else {
+      reader = new TsFileSequenceReader(file);
+    }
     partitionWriterMap = new HashMap<>();
     if (FSFactoryProducer.getFSFactory().getFile(file + ModificationFile.FILE_SUFFIX).exists()) {
       oldModification = (List<Modification>) resourceToBeRewritten.getModFile().getModifications();

--- a/server/src/main/java/org/apache/iotdb/db/tools/upgrade/TsFileOnlineUpgradeTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/upgrade/TsFileOnlineUpgradeTool.java
@@ -61,9 +61,7 @@ public class TsFileOnlineUpgradeTool extends TsFileRewriteTool {
    * @throws IOException If some I/O error occurs
    */
   public TsFileOnlineUpgradeTool(TsFileResource resourceToBeUpgraded) throws IOException {
-    super(resourceToBeUpgraded);
-    String file = oldTsFile.getAbsolutePath();
-    reader = new TsFileSequenceReaderForV2(file);
+    super(resourceToBeUpgraded, true);
   }
 
   /**


### PR DESCRIPTION
## Description

When we upgrade the 0.11 TsFiles to 0.12, the speed of upgrading become low with time.

The log of `lsof` command shows there are many upgraded and deleted old files not closed.
```
java    18179 root *595r   REG               8,33       3507  15460871 /data3/backup_iotdb/apache-iotdb-0.11.3/data/data/sequence/root.ko.trans.26/0/upgrade/1616135911533-6009-0.tsfile (deleted)
java    18179 root *596r   REG               8,33      13885  15446568 /data3/backup_iotdb/apache-iotdb-0.11.3/data/data/sequence/root.ko.trans.26/0/upgrade/1616135908452-5988-0.tsfile (deleted)
java    18179 root *597r   REG               8,33      19028  15446569 /data3/backup_iotdb/apache-iotdb-0.11.3/data/data/sequence/root.ko.trans.26/0/upgrade/1616135909755-6003-0.tsfile (deleted)
java    18179 root *598r   REG               8,33      11344  15401392 /data3/backup_iotdb/apache-iotdb-0.11.3/data/data/sequence/root.ko.trans.26/0/upgrade/1616135919608-6054-1.tsfile (deleted)
java    18179 root *599r   REG               8,33       9547  15457531 /data3/backup_iotdb/apache-iotdb-0.11.3/data/data/sequence/root.ko.trans.26/0/upgrade/1616135925248-6115-0.tsfile (deleted)
java    18179 root *600r   REG               8,33      19141  15457504 /data3/backup_iotdb/apache-iotdb-0.11.3/data/data/sequence/root.ko.trans.26/0/upgrade/1616135912014-6018-0.tsfile (deleted)
java    18179 root *601r   REG               8,33      19135  15457510 /data3/backup_iotdb/apache-iotdb-0.11.3/data/data/sequence/root.ko.trans.26/0/upgrade/1616135914048-6041-0.tsfile (deleted)
```

Therefore, the reason of slow upgrading is that too may file readers opened in memory.