### PR TITLE
enable the client library test for all changes

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -89,7 +89,7 @@ jobs:
         run:  choco install openssl
       - name: Add Flex and Bison Path and OpenSSL
         shell: bash
-        run: cd /d/a/cpp && unzip win_flex_bison.zip && mv win_flex.exe flex.exe && mv win_bison.exe bison.exe && mv Win64OpenSSL-1_1_1k.exe openssl.exe && echo 'export PATH=/d/a/cpp:$PATH' >> ~/.bash_profile && source ~/.bash_profile
+        run: cd /d/a/cpp && unzip win_flex_bison.zip && mv win_flex.exe flex.exe && mv win_bison.exe bison.exe  && echo 'export PATH=/d/a/cpp:$PATH' >> ~/.bash_profile && source ~/.bash_profile
       - name: Test with Maven
         shell: bash
         run: source ~/.bash_profile && mvn -B clean integration-test -P compile-cpp -Dboost.include.dir=/d/a/cpp/boost_1_72_0 -Dboost.library.dir=/d/a/cpp/boost_1_72_0/stage/lib -Dtsfile.test.skip=true -Djdbc.test.skip=true -Diotdb.test.skip=true -Dtest.port.closed=true -Denforcer.skip=true -pl server,client-cpp,example/client-cpp-example -am

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -10,20 +10,10 @@ on:
     branches:
       - master
       - "rel/*"
-    paths:
-      - "client-*/**"
-      - "compile-tools/**"
-      - "thrift/**"
-      - "service-rpc/**"
   pull_request:
     branches:
       - master
       - "rel/*"
-    paths:
-      - "client-*/**"
-      - "compile-tools/**"
-      - "thrift/**"
-      - "service-rpc/**"
   # allow manually run the action:
   workflow_dispatch:
 

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -86,8 +86,7 @@ jobs:
           .\bootstrap.bat ; `
           .\b2.exe
       - name: Install OpenSSL
-        run:  Invoke-WebRequest https://slproweb.com/download/Win64OpenSSL-1_1_1k.exe -OutFile D:\a\cpp ; `
-          [Environment]::SetEnvironmentVariable("Path", $env:Path + ";D:\a\cpp", "User") ; `
+        run:  choco install openssl
       - name: Add Flex and Bison Path and OpenSSL
         shell: bash
         run: cd /d/a/cpp && unzip win_flex_bison.zip && mv win_flex.exe flex.exe && mv win_bison.exe bison.exe && mv Win64OpenSSL-1_1_1k.exe openssl.exe && echo 'export PATH=/d/a/cpp:$PATH' >> ~/.bash_profile && source ~/.bash_profile


### PR DESCRIPTION
The client library CI was enabled only when some folders have some changes:
- client-*
- thrift-*
- service-rpc

However, it is not enough because even though the client library does not change, the server's change may occur some errors.

So, in this PR, I remove the trigger constraint.