### PR TITLE
[To rel/0.12] Fix upgrade NPE and DeadLock

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/upgrade/UpgradeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/upgrade/UpgradeTask.java
@@ -61,13 +61,8 @@ public class UpgradeTask extends WrappedRunnable {
         logger.info("find upgraded file for {}", upgradeResource.getTsFile());
         upgradedResources = findUpgradedFiles();
       }
-      upgradeResource.writeLock();
-      try {
-        upgradeResource.setUpgradedResources(upgradedResources);
-        upgradeResource.getUpgradeTsFileResourceCallBack().call(upgradeResource);
-      } finally {
-        upgradeResource.writeUnlock();
-      }
+      upgradeResource.setUpgradedResources(upgradedResources);
+      upgradeResource.getUpgradeTsFileResourceCallBack().call(upgradeResource);
       UpgradeSevice.setCntUpgradeFileNum(UpgradeSevice.getCntUpgradeFileNum() - 1);
       logger.info(
           "Upgrade completes, file path:{} , the remaining upgraded file num: {}",

--- a/server/src/main/java/org/apache/iotdb/db/engine/upgrade/UpgradeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/upgrade/UpgradeTask.java
@@ -63,12 +63,12 @@ public class UpgradeTask extends WrappedRunnable {
       }
       upgradeResource.setUpgradedResources(upgradedResources);
       upgradeResource.getUpgradeTsFileResourceCallBack().call(upgradeResource);
-      UpgradeSevice.setCntUpgradeFileNum(UpgradeSevice.getCntUpgradeFileNum() - 1);
+      UpgradeSevice.getTotalUpgradeFileNum().getAndAdd(-1);
       logger.info(
           "Upgrade completes, file path:{} , the remaining upgraded file num: {}",
           oldTsfilePath,
-          UpgradeSevice.getCntUpgradeFileNum());
-      if (UpgradeSevice.getCntUpgradeFileNum() == 0) {
+          UpgradeSevice.getTotalUpgradeFileNum().get());
+      if (UpgradeSevice.getTotalUpgradeFileNum().get() == 0) {
         logger.info("Start delete empty tmp folders");
         clearTmpFolders(DirectoryManager.getInstance().getAllSequenceFileFolders());
         clearTmpFolders(DirectoryManager.getInstance().getAllUnSequenceFileFolders());

--- a/server/src/main/java/org/apache/iotdb/db/service/UpgradeSevice.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/UpgradeSevice.java
@@ -39,7 +39,7 @@ public class UpgradeSevice implements IService {
   private static final UpgradeSevice INSTANCE = new UpgradeSevice();
   private ExecutorService upgradeThreadPool;
   private AtomicInteger threadCnt = new AtomicInteger();
-  private static int cntUpgradeFileNum;
+  private static AtomicInteger cntUpgradeFileNum = new AtomicInteger();
 
   private UpgradeSevice() {}
 
@@ -58,7 +58,7 @@ public class UpgradeSevice implements IService {
             updateThreadNum, r -> new Thread(r, "UpgradeThread-" + threadCnt.getAndIncrement()));
     UpgradeLog.createUpgradeLog();
     countUpgradeFiles();
-    if (cntUpgradeFileNum == 0) {
+    if (cntUpgradeFileNum.get() == 0) {
       stop();
       return;
     }
@@ -82,22 +82,8 @@ public class UpgradeSevice implements IService {
     return ServiceType.UPGRADE_SERVICE;
   }
 
-  public static void setCntUpgradeFileNum(int cntUpgradeFileNum) {
-    UpgradeUtils.getCntUpgradeFileLock().writeLock().lock();
-    try {
-      UpgradeSevice.cntUpgradeFileNum = cntUpgradeFileNum;
-    } finally {
-      UpgradeUtils.getCntUpgradeFileLock().writeLock().unlock();
-    }
-  }
-
-  public static int getCntUpgradeFileNum() {
-    UpgradeUtils.getCntUpgradeFileLock().readLock().lock();
-    try {
-      return cntUpgradeFileNum;
-    } finally {
-      UpgradeUtils.getCntUpgradeFileLock().readLock().unlock();
-    }
+  public static AtomicInteger getTotalUpgradeFileNum() {
+    return cntUpgradeFileNum;
   }
 
   public void submitUpgradeTask(UpgradeTask upgradeTask) {
@@ -105,7 +91,7 @@ public class UpgradeSevice implements IService {
   }
 
   private static void countUpgradeFiles() {
-    cntUpgradeFileNum = StorageEngine.getInstance().countUpgradeFiles();
+    cntUpgradeFileNum.addAndGet(StorageEngine.getInstance().countUpgradeFiles());
     logger.info("finish counting upgrading files, total num:{}", cntUpgradeFileNum);
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
@@ -294,7 +294,8 @@ public class ChunkWriterImpl implements IChunkWriter {
       if (numOfPages == 0) { // record the firstPageStatistics
         this.firstPageStatistics = pageWriter.getStatistics();
         this.sizeWithoutStatistic = pageWriter.writePageHeaderAndDataIntoBuff(pageBuffer, true);
-      } else if (numOfPages == 1) { // put the firstPageStatistics into pageBuffer
+      } else if (numOfPages == 1
+          && firstPageStatistics != null) { // put the firstPageStatistics into pageBuffer
         byte[] b = pageBuffer.toByteArray();
         pageBuffer.reset();
         pageBuffer.write(b, 0, this.sizeWithoutStatistic);


### PR DESCRIPTION
## Description
### Fix A NPE appears when upgrade 0.11 TsFiles

![3541622733489_ pic_hd](https://user-images.githubusercontent.com/25913899/120737661-101f2000-c521-11eb-8b15-22655daf70fd.jpg)


### Fix deadLock when counting upgrade files with multiple upgrade threads
```
"UpgradeThread-64" #364 prio=5 os_prio=0 tid=0x00007f06c478b800 nid=0x5eff waiting on condition [0x00007efa873f2000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x00007efcd37218c8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
	at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
	at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1067)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1127)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)

   Locked ownable synchronizers:
	- None

"UpgradeThread-63" #363 prio=5 os_prio=0 tid=0x00007f06c478a000 nid=0x5efe waiting on condition [0x00007efa874f3000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x00007efcd37218c8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
	at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
	at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1067)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1127)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)

   Locked ownable synchronizers:
	- None
```