### PR TITLE
fix column type bug

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDisableAlignIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDisableAlignIT.java
@@ -410,7 +410,7 @@ public class IoTDBDisableAlignIT {
       String columnName = resultSetMetaData.getColumnName(i);
       Integer typeIndex = expectedHeaderToTypeIndexMap.get(columnName);
       if (typeIndex != null) {
-        Assert.assertEquals(expectedTypes[typeIndex], resultSetMetaData.getColumnType(1 + i / 2));
+        Assert.assertEquals(expectedTypes[typeIndex], resultSetMetaData.getColumnType(i));
       }
       actualIndexToExpectedIndexList.add(expectedHeaderToColumnIndexMap.get(columnName));
     }


### PR DESCRIPTION
the column type list now has the timestamp column if needed, so no need to recalculate index