### PR TITLE
[rel/0.12] wait for clear cache

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -230,6 +230,7 @@ com.fasterxml.jackson.core:jackson-databind:2.10.0
 javax.inject:javax.inject:1
 net.jpountz.lz4:1.3.0
 com.github.stephenc.jcip:jcip-annotations:1.0-1
+com.github.ben-manes.caffeine:caffeine:2.9.1
 org.eclipse.jetty:jetty-http:9.4.24.v20191120
 org.eclipse.jetty:jetty-io:9.4.24.v20191120
 org.eclipse.jetty:jetty-security:9.4.24.v20191120


### PR DESCRIPTION
## Description
The Caffeine cache's `invalidateAll()` + `cleanUp()` methods may not clear the cache immediately, so the `lruCache.estimatedSize() == 0` may return false after we clear the cache.

## Solution

Wait 1 minutes for the clear cache processing.