### PR TITLE
Enable coveralls check for commit pushed into master branch

### DIFF
--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -51,7 +51,7 @@ jobs:
         # we do not compile client-cpp for saving time, it is tested in client.yml
         run: mvn -B clean compile post-integration-test -Dtest.port.closed=true -Pcode-coverage -P '!testcontainer'
       - name: Code Coverage (Coveralls)
-        if: ${{ success() && (github.event_name == 'pull_request_target')}}
+        if: ${{ success() && (github.event_name == 'pull_request_target' || github.event_name == 'push')}}
         run: |
           mvn -B post-integration-test -Pcode-coverage -pl code-coverage
           mvn -B coveralls:report \


### PR DESCRIPTION
## Description
Currently coveralls doesn't check the commit pushed into master branch.
<img width="364" alt="Screen Shot 2021-06-05 at 6 35 33 PM" src="https://user-images.githubusercontent.com/25913899/120888779-d1768c00-c62c-11eb-87ac-88429de53bc3.png">


This PR is for fixing it.