### PR TITLE
Remove the broken cached leader connection & optimize the insertRecords method in session

### DIFF
--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
@@ -95,6 +95,22 @@ public class RpcUtils {
     }
   }
 
+  public static void verifySuccessWithRedirectionForMultiDevices(
+      TSStatus status, List<String> devices) throws StatementExecutionException, RedirectException {
+    verifySuccess(status);
+    if (status.getCode() == TSStatusCode.MULTIPLE_ERROR.getStatusCode()) {
+      Map<String, EndPoint> deviceEndPointMap = new HashMap<>();
+      List<TSStatus> statusSubStatus = status.getSubStatus();
+      for (int i = 0; i < statusSubStatus.size(); i++) {
+        TSStatus subStatus = statusSubStatus.get(i);
+        if (subStatus.isSetRedirectNode()) {
+          deviceEndPointMap.put(devices.get(i), subStatus.getRedirectNode());
+        }
+      }
+      throw new RedirectException(deviceEndPointMap);
+    }
+  }
+
   public static void verifySuccessWithRedirectionForInsertTablets(
       TSStatus status, TSInsertTabletsReq req)
       throws StatementExecutionException, RedirectException {

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.service.rpc.thrift.EndPoint;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
 import org.apache.iotdb.service.rpc.thrift.TSIService;
-import org.apache.iotdb.service.rpc.thrift.TSInsertTabletsReq;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 
 import java.lang.reflect.Proxy;
@@ -105,23 +104,6 @@ public class RpcUtils {
         TSStatus subStatus = statusSubStatus.get(i);
         if (subStatus.isSetRedirectNode()) {
           deviceEndPointMap.put(devices.get(i), subStatus.getRedirectNode());
-        }
-      }
-      throw new RedirectException(deviceEndPointMap);
-    }
-  }
-
-  public static void verifySuccessWithRedirectionForInsertTablets(
-      TSStatus status, TSInsertTabletsReq req)
-      throws StatementExecutionException, RedirectException {
-    verifySuccess(status);
-    if (status.getCode() == TSStatusCode.MULTIPLE_ERROR.getStatusCode()) {
-      Map<String, EndPoint> deviceEndPointMap = new HashMap<>();
-      List<TSStatus> statusSubStatus = status.getSubStatus();
-      for (int i = 0; i < statusSubStatus.size(); i++) {
-        TSStatus subStatus = statusSubStatus.get(i);
-        if (subStatus.isSetRedirectNode()) {
-          deviceEndPointMap.put(req.getDeviceIds().get(i), subStatus.getRedirectNode());
         }
       }
       throw new RedirectException(deviceEndPointMap);

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -59,6 +59,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -690,17 +691,22 @@ public class Session {
     // remove the cached broken leader session
     if (enableCacheLeader) {
       EndPoint endPoint = null;
-      for (Map.Entry<EndPoint, SessionConnection> entry : endPointToSessionConnection.entrySet()) {
+      for (Iterator<Entry<EndPoint, SessionConnection>> it =
+              endPointToSessionConnection.entrySet().iterator();
+          it.hasNext(); ) {
+        Map.Entry<EndPoint, SessionConnection> entry = it.next();
         if (entry.getValue().equals(sessionConnection)) {
           endPoint = entry.getKey();
-          endPointToSessionConnection.remove(endPoint);
+          it.remove();
           break;
         }
       }
 
-      for (Map.Entry<String, EndPoint> entry : deviceIdToEndpoint.entrySet()) {
+      for (Iterator<Entry<String, EndPoint>> it = deviceIdToEndpoint.entrySet().iterator();
+          it.hasNext(); ) {
+        Map.Entry<String, EndPoint> entry = it.next();
         if (entry.getValue().equals(endPoint)) {
-          deviceIdToEndpoint.remove(entry.getKey());
+          it.remove();
         }
       }
     }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -685,16 +685,16 @@ public class Session {
     }
   }
 
+  // TODO https://issues.apache.org/jira/browse/IOTDB-1399
   private void removeBrokenSessionConnection(String deviceId) {
     // remove the cached broken leader session
     if (enableCacheLeader) {
       EndPoint endPoint = deviceIdToEndpoint.remove(deviceId);
       removeBrokenSessionConnection(endPoint);
     }
-    // TODO how to deal with the defaultSessionConnection? maybe we can mark the session as broken,
-    //  however, it still needs the upper called layer to switch the connect node.
   }
 
+  // TODO https://issues.apache.org/jira/browse/IOTDB-1399
   private void removeBrokenSessionConnection(EndPoint endPoint) {
     // remove the cached broken leader session
     if (enableCacheLeader) {
@@ -705,8 +705,6 @@ public class Session {
       }
       endPointToSessionConnection.remove(endPoint);
     }
-    // TODO how to deal with the defaultSessionConnection? maybe we can mark the session as broken,
-    //  however, it still needs the upper called layer to switch the connect node.
   }
 
   private void handleMetaRedirection(String storageGroup, RedirectException e)

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -553,7 +553,8 @@ public class SessionConnection {
       throws IoTDBConnectionException, StatementExecutionException, RedirectException {
     request.setSessionId(sessionId);
     try {
-      RpcUtils.verifySuccessWithRedirectionForInsertTablets(client.insertTablets(request), request);
+      RpcUtils.verifySuccessWithRedirectionForMultiDevices(
+          client.insertTablets(request), request.getDeviceIds());
     } catch (TException e) {
       if (reconnect()) {
         try {

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -475,7 +475,8 @@ public class SessionConnection {
       throws IoTDBConnectionException, StatementExecutionException, RedirectException {
     request.setSessionId(sessionId);
     try {
-      RpcUtils.verifySuccessWithRedirection(client.insertRecords(request));
+      RpcUtils.verifySuccessWithRedirectionForMultiDevices(
+          client.insertRecords(request), request.getDeviceIds());
     } catch (TException e) {
       if (reconnect()) {
         try {
@@ -494,7 +495,8 @@ public class SessionConnection {
       throws IoTDBConnectionException, StatementExecutionException, RedirectException {
     request.setSessionId(sessionId);
     try {
-      RpcUtils.verifySuccessWithRedirection(client.insertStringRecords(request));
+      RpcUtils.verifySuccessWithRedirectionForMultiDevices(
+          client.insertStringRecords(request), request.getDeviceIds());
     } catch (TException e) {
       if (reconnect()) {
         try {
@@ -789,5 +791,10 @@ public class SessionConnection {
 
   public void setEndPoint(EndPoint endPoint) {
     this.endPoint = endPoint;
+  }
+
+  @Override
+  public String toString() {
+    return "SessionConnection{" + " endPoint=" + endPoint + "}";
   }
 }

--- a/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
@@ -836,8 +836,8 @@ public class SessionCacheLeaderUT {
     }
 
     // set connection as broken, due to we enable the cache leader, when we called
-// ((MockSession) session). getLastConstructedSessionConnection(), the session's endpoint has been changed to
-    // EndPoint(ip:127.0.0.1, port:55562)
+    // ((MockSession) session).getLastConstructedSessionConnection(), the session's endpoint has
+    // been changed to EndPoint(ip:127.0.0.1, port:55562)
     Assert.assertEquals(
         "MockSessionConnection{ endPoint=EndPoint(ip:127.0.0.1, port:55562)}",
         ((MockSession) session).getLastConstructedSessionConnection().toString());
@@ -990,8 +990,8 @@ public class SessionCacheLeaderUT {
     // set the session connection as broken
     ((MockSession) session).getLastConstructedSessionConnection().setConnectionBroken(true);
     // set connection as broken, due to we enable the cache leader, when we called
-// ((MockSession) session). getLastConstructedSessionConnection(), the session's endpoint has been changed to
-    // EndPoint(ip:127.0.0.1, port:55562)
+    // ((MockSession) session).getLastConstructedSessionConnection(), the session's endpoint has
+    // been changed to EndPoint(ip:127.0.0.1, port:55562)
     Assert.assertEquals(
         "MockSessionConnection{ endPoint=EndPoint(ip:127.0.0.1, port:55562)}",
         ((MockSession) session).getLastConstructedSessionConnection().toString());

--- a/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
@@ -836,7 +836,7 @@ public class SessionCacheLeaderUT {
     }
 
     // set connection as broken, due to we enable the cache leader, when we called
-    // ((MockSession) session).getMockSessionConnection(), the session's endpoint have changed to
+// ((MockSession) session). getLastConstructedSessionConnection(), the session's endpoint has been changed to
     // EndPoint(ip:127.0.0.1, port:55562)
     Assert.assertEquals(
         "MockSessionConnection{ endPoint=EndPoint(ip:127.0.0.1, port:55562)}",

--- a/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
@@ -990,7 +990,7 @@ public class SessionCacheLeaderUT {
     // set the session connection as broken
     ((MockSession) session).getLastConstructedSessionConnection().setConnectionBroken(true);
     // set connection as broken, due to we enable the cache leader, when we called
-    // ((MockSession) session).getMockSessionConnection(), the session's endpoint have changed to
+// ((MockSession) session). getLastConstructedSessionConnection(), the session's endpoint has been changed to
     // EndPoint(ip:127.0.0.1, port:55562)
     Assert.assertEquals(
         "MockSessionConnection{ endPoint=EndPoint(ip:127.0.0.1, port:55562)}",

--- a/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
@@ -724,7 +724,7 @@ public class SessionCacheLeaderUT {
     assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
     assertNull(session.deviceIdToEndpoint);
     assertNull(session.endPointToSessionConnection);
-    ((MockSession) session).getMockSessionConnection().setConnectionBroken(true);
+    ((MockSession) session).getLastConstructedSessionConnection().setConnectionBroken(true);
 
     List<String> allDeviceIds =
         new ArrayList<String>() {
@@ -840,8 +840,8 @@ public class SessionCacheLeaderUT {
     // EndPoint(ip:127.0.0.1, port:55562)
     Assert.assertEquals(
         "MockSessionConnection{ endPoint=EndPoint(ip:127.0.0.1, port:55562)}",
-        ((MockSession) session).getMockSessionConnection().toString());
-    ((MockSession) session).getMockSessionConnection().setConnectionBroken(true);
+        ((MockSession) session).getLastConstructedSessionConnection().toString());
+    ((MockSession) session).getLastConstructedSessionConnection().setConnectionBroken(true);
     try {
       session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
     } catch (IoTDBConnectionException e) {
@@ -875,7 +875,7 @@ public class SessionCacheLeaderUT {
     assertNull(session.endPointToSessionConnection);
 
     // set the session connection as broken
-    ((MockSession) session).getMockSessionConnection().setConnectionBroken(true);
+    ((MockSession) session).getLastConstructedSessionConnection().setConnectionBroken(true);
     List<String> allDeviceIds =
         new ArrayList<String>() {
           {
@@ -988,13 +988,13 @@ public class SessionCacheLeaderUT {
     }
 
     // set the session connection as broken
-    ((MockSession) session).getMockSessionConnection().setConnectionBroken(true);
+    ((MockSession) session).getLastConstructedSessionConnection().setConnectionBroken(true);
     // set connection as broken, due to we enable the cache leader, when we called
     // ((MockSession) session).getMockSessionConnection(), the session's endpoint have changed to
     // EndPoint(ip:127.0.0.1, port:55562)
     Assert.assertEquals(
         "MockSessionConnection{ endPoint=EndPoint(ip:127.0.0.1, port:55562)}",
-        ((MockSession) session).getMockSessionConnection().toString());
+        ((MockSession) session).getLastConstructedSessionConnection().toString());
 
     for (long row = 0; row < 10; row++) {
       int row1 = tablet1.rowSize++;
@@ -1073,7 +1073,7 @@ public class SessionCacheLeaderUT {
 
   static class MockSession extends Session {
 
-    private MockSessionConnection mockSessionConnection;
+    private MockSessionConnection lastConstructedSessionConnection;
 
     public MockSession(String host, int rpcPort, boolean enableCacheLeader) {
       super(
@@ -1091,12 +1091,12 @@ public class SessionCacheLeaderUT {
     @Override
     public SessionConnection constructSessionConnection(
         Session session, EndPoint endpoint, ZoneId zoneId) {
-      mockSessionConnection = new MockSessionConnection(session, endpoint, zoneId);
-      return mockSessionConnection;
+      lastConstructedSessionConnection = new MockSessionConnection(session, endpoint, zoneId);
+      return lastConstructedSessionConnection;
     }
 
-    public MockSessionConnection getMockSessionConnection() {
-      return mockSessionConnection;
+    public MockSessionConnection getLastConstructedSessionConnection() {
+      return lastConstructedSessionConnection;
     }
   }
 

--- a/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.tsfile.write.record.Tablet;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.ZoneId;
@@ -47,6 +48,7 @@ import java.util.Random;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 public class SessionCacheLeaderUT {
 
@@ -309,6 +311,7 @@ public class SessionCacheLeaderUT {
         timestamps.clear();
       }
     }
+
     session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
     deviceIds.clear();
     measurementsList.clear();
@@ -709,6 +712,338 @@ public class SessionCacheLeaderUT {
     session.close();
   }
 
+  @Test
+  public void testInsertRecordsWithSessionBroken() throws StatementExecutionException {
+    // without leader cache
+    session = new MockSession("127.0.0.1", 55560, false);
+    try {
+      session.open();
+    } catch (IoTDBConnectionException e) {
+      fail(e.getMessage());
+    }
+    assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
+    assertNull(session.deviceIdToEndpoint);
+    assertNull(session.endPointToSessionConnection);
+    ((MockSession) session).getMockSessionConnection().setConnectionBroken(true);
+
+    List<String> allDeviceIds =
+        new ArrayList<String>() {
+          {
+            add("root.sg1.d1");
+            add("root.sg2.d1");
+            add("root.sg3.d1");
+            add("root.sg4.d1");
+          }
+        };
+    List<String> measurements = new ArrayList<>();
+    measurements.add("s1");
+    measurements.add("s2");
+    measurements.add("s3");
+
+    List<String> deviceIds = new ArrayList<>();
+    List<List<String>> measurementsList = new ArrayList<>();
+    List<List<Object>> valuesList = new ArrayList<>();
+    List<Long> timestamps = new ArrayList<>();
+    List<List<TSDataType>> typesList = new ArrayList<>();
+
+    for (long time = 0; time < 500; time++) {
+      List<Object> values = new ArrayList<>();
+      List<TSDataType> types = new ArrayList<>();
+      values.add(1L);
+      values.add(2L);
+      values.add(3L);
+      types.add(TSDataType.INT64);
+      types.add(TSDataType.INT64);
+      types.add(TSDataType.INT64);
+      deviceIds.add(allDeviceIds.get((int) (time % allDeviceIds.size())));
+      measurementsList.add(measurements);
+      valuesList.add(values);
+      typesList.add(types);
+      timestamps.add(time);
+
+      if (time != 0 && time % 100 == 0) {
+        try {
+          session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
+        } catch (IoTDBConnectionException e) {
+          Assert.assertEquals(
+              "the session connection = EndPoint(ip:127.0.0.1, port:55560) is broken",
+              e.getMessage());
+        }
+        deviceIds.clear();
+        measurementsList.clear();
+        valuesList.clear();
+        timestamps.clear();
+      }
+    }
+
+    try {
+      session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
+    } catch (IoTDBConnectionException e) {
+      Assert.assertEquals(
+          "the session connection = EndPoint(ip:127.0.0.1, port:55560) is broken", e.getMessage());
+    }
+    deviceIds.clear();
+    measurementsList.clear();
+    valuesList.clear();
+    timestamps.clear();
+
+    assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
+    assertNull(session.deviceIdToEndpoint);
+    assertNull(session.endPointToSessionConnection);
+    try {
+      session.close();
+    } catch (IoTDBConnectionException e) {
+      Assert.assertEquals(
+          "the session connection = EndPoint(ip:127.0.0.1, port:55560) is broken", e.getMessage());
+    }
+
+    // with leader cache
+    // reset connection
+    session = new MockSession("127.0.0.1", 55560, true);
+    try {
+      session.open();
+    } catch (IoTDBConnectionException e) {
+      Assert.fail(e.getMessage());
+    }
+    assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
+    assertEquals(0, session.deviceIdToEndpoint.size());
+    assertEquals(1, session.endPointToSessionConnection.size());
+    for (long time = 0; time < 500; time++) {
+      List<Object> values = new ArrayList<>();
+      List<TSDataType> types = new ArrayList<>();
+      values.add(1L);
+      values.add(2L);
+      values.add(3L);
+      types.add(TSDataType.INT64);
+      types.add(TSDataType.INT64);
+      types.add(TSDataType.INT64);
+      deviceIds.add(allDeviceIds.get((int) (time % allDeviceIds.size())));
+      measurementsList.add(measurements);
+      valuesList.add(values);
+      typesList.add(types);
+      timestamps.add(time);
+      if (time != 0 && time % 100 == 0) {
+        try {
+          session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
+        } catch (IoTDBConnectionException e) {
+          Assert.fail(e.getMessage());
+        }
+        deviceIds.clear();
+        measurementsList.clear();
+        valuesList.clear();
+        timestamps.clear();
+      }
+    }
+
+    // set connection as broken, due to we enable the cache leader, when we called
+    // ((MockSession) session).getMockSessionConnection(), the session's endpoint have changed to
+    // EndPoint(ip:127.0.0.1, port:55562)
+    Assert.assertEquals(
+        "MockSessionConnection{ endPoint=EndPoint(ip:127.0.0.1, port:55562)}",
+        ((MockSession) session).getMockSessionConnection().toString());
+    ((MockSession) session).getMockSessionConnection().setConnectionBroken(true);
+    try {
+      session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
+    } catch (IoTDBConnectionException e) {
+      Assert.assertEquals(
+          "the session connection = EndPoint(ip:127.0.0.1, port:55562) is broken", e.getMessage());
+    }
+    assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
+    assertEquals(3, session.deviceIdToEndpoint.size());
+    for (Map.Entry<String, EndPoint> endPointMap : session.deviceIdToEndpoint.entrySet()) {
+      assertEquals(getDeviceIdBelongedEndpoint(endPointMap.getKey()), endPointMap.getValue());
+    }
+    assertEquals(3, session.endPointToSessionConnection.size());
+    try {
+      session.close();
+    } catch (IoTDBConnectionException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testInsertTabletsWithSessionBroken() throws StatementExecutionException {
+    // without leader cache
+    session = new MockSession("127.0.0.1", 55560, false);
+    try {
+      session.open();
+    } catch (IoTDBConnectionException e) {
+      Assert.fail(e.getMessage());
+    }
+    assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
+    assertNull(session.deviceIdToEndpoint);
+    assertNull(session.endPointToSessionConnection);
+
+    // set the session connection as broken
+    ((MockSession) session).getMockSessionConnection().setConnectionBroken(true);
+    List<String> allDeviceIds =
+        new ArrayList<String>() {
+          {
+            add("root.sg1.d1");
+            add("root.sg2.d1");
+            add("root.sg3.d1");
+            add("root.sg4.d1");
+          }
+        };
+    List<IMeasurementSchema> schemaList = new ArrayList<>();
+    schemaList.add(new MeasurementSchema("s1", TSDataType.INT64));
+    schemaList.add(new MeasurementSchema("s2", TSDataType.INT64));
+    schemaList.add(new MeasurementSchema("s3", TSDataType.INT64));
+
+    Tablet tablet1 = new Tablet(allDeviceIds.get(1), schemaList, 100);
+    Tablet tablet2 = new Tablet(allDeviceIds.get(2), schemaList, 100);
+    Tablet tablet3 = new Tablet(allDeviceIds.get(3), schemaList, 100);
+
+    Map<String, Tablet> tabletMap = new HashMap<>();
+    tabletMap.put(allDeviceIds.get(1), tablet1);
+    tabletMap.put(allDeviceIds.get(2), tablet2);
+    tabletMap.put(allDeviceIds.get(3), tablet3);
+
+    long timestamp = System.currentTimeMillis();
+    for (long row = 0; row < 100; row++) {
+      int row1 = tablet1.rowSize++;
+      int row2 = tablet2.rowSize++;
+      int row3 = tablet3.rowSize++;
+      tablet1.addTimestamp(row1, timestamp);
+      tablet2.addTimestamp(row2, timestamp);
+      tablet3.addTimestamp(row3, timestamp);
+      for (int i = 0; i < 3; i++) {
+        long value = new Random().nextLong();
+        tablet1.addValue(schemaList.get(i).getMeasurementId(), row1, value);
+        tablet2.addValue(schemaList.get(i).getMeasurementId(), row2, value);
+        tablet3.addValue(schemaList.get(i).getMeasurementId(), row3, value);
+      }
+      if (tablet1.rowSize == tablet1.getMaxRowNumber()) {
+        try {
+          session.insertTablets(tabletMap, true);
+        } catch (IoTDBConnectionException e) {
+          assertEquals(
+              "the session connection = EndPoint(ip:127.0.0.1, port:55560) is broken",
+              e.getMessage());
+        }
+        tablet1.reset();
+        tablet2.reset();
+        tablet3.reset();
+      }
+      timestamp++;
+    }
+
+    if (tablet1.rowSize != 0) {
+      try {
+        session.insertTablets(tabletMap, true);
+      } catch (IoTDBConnectionException e) {
+        Assert.fail(e.getMessage());
+      }
+
+      tablet1.reset();
+      tablet2.reset();
+      tablet3.reset();
+    }
+
+    assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
+    assertNull(session.deviceIdToEndpoint);
+    assertNull(session.endPointToSessionConnection);
+    try {
+      session.close();
+    } catch (IoTDBConnectionException e) {
+      Assert.fail(e.getMessage());
+    }
+
+    // with leader cache
+    // rest the session connection
+    session = new MockSession("127.0.0.1", 55560, true);
+    try {
+      session.open();
+    } catch (IoTDBConnectionException e) {
+      Assert.fail(e.getMessage());
+    }
+    assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
+    assertEquals(0, session.deviceIdToEndpoint.size());
+    assertEquals(1, session.endPointToSessionConnection.size());
+
+    for (long row = 0; row < 100; row++) {
+      int row1 = tablet1.rowSize++;
+      int row2 = tablet2.rowSize++;
+      int row3 = tablet3.rowSize++;
+      tablet1.addTimestamp(row1, timestamp);
+      tablet2.addTimestamp(row2, timestamp);
+      tablet3.addTimestamp(row3, timestamp);
+      for (int i = 0; i < 3; i++) {
+        long value = new Random().nextLong();
+        tablet1.addValue(schemaList.get(i).getMeasurementId(), row1, value);
+        tablet2.addValue(schemaList.get(i).getMeasurementId(), row2, value);
+        tablet3.addValue(schemaList.get(i).getMeasurementId(), row3, value);
+      }
+      if (tablet1.rowSize == tablet1.getMaxRowNumber()) {
+        try {
+          session.insertTablets(tabletMap, true);
+        } catch (IoTDBConnectionException e) {
+          Assert.fail(e.getMessage());
+        }
+        tablet1.reset();
+        tablet2.reset();
+        tablet3.reset();
+      }
+      timestamp++;
+    }
+
+    // set the session connection as broken
+    ((MockSession) session).getMockSessionConnection().setConnectionBroken(true);
+    // set connection as broken, due to we enable the cache leader, when we called
+    // ((MockSession) session).getMockSessionConnection(), the session's endpoint have changed to
+    // EndPoint(ip:127.0.0.1, port:55562)
+    Assert.assertEquals(
+        "MockSessionConnection{ endPoint=EndPoint(ip:127.0.0.1, port:55562)}",
+        ((MockSession) session).getMockSessionConnection().toString());
+
+    for (long row = 0; row < 10; row++) {
+      int row1 = tablet1.rowSize++;
+      int row2 = tablet2.rowSize++;
+      int row3 = tablet3.rowSize++;
+      tablet1.addTimestamp(row1, timestamp);
+      tablet2.addTimestamp(row2, timestamp);
+      tablet3.addTimestamp(row3, timestamp);
+      for (int i = 0; i < 3; i++) {
+        long value = new Random().nextLong();
+        tablet1.addValue(schemaList.get(i).getMeasurementId(), row1, value);
+        tablet2.addValue(schemaList.get(i).getMeasurementId(), row2, value);
+        tablet3.addValue(schemaList.get(i).getMeasurementId(), row3, value);
+      }
+      if (tablet1.rowSize == tablet1.getMaxRowNumber()) {
+        try {
+          session.insertTablets(tabletMap, true);
+        } catch (IoTDBConnectionException e) {
+          Assert.fail(e.getMessage());
+        }
+        tablet1.reset();
+        tablet2.reset();
+        tablet3.reset();
+      }
+      timestamp++;
+    }
+    try {
+      session.insertTablets(tabletMap, true);
+    } catch (IoTDBConnectionException e) {
+      Assert.assertEquals(
+          "the session connection = EndPoint(ip:127.0.0.1, port:55562) is broken", e.getMessage());
+    }
+    tablet1.reset();
+    tablet2.reset();
+    tablet3.reset();
+
+    assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
+    assertEquals(2, session.deviceIdToEndpoint.size());
+    for (Map.Entry<String, EndPoint> endPointEntry : session.deviceIdToEndpoint.entrySet()) {
+      assertEquals(getDeviceIdBelongedEndpoint(endPointEntry.getKey()), endPointEntry.getValue());
+    }
+    assertEquals(3, session.endPointToSessionConnection.size());
+    try {
+      session.close();
+    } catch (IoTDBConnectionException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
   private void addLine(
       List<Long> times,
       List<List<String>> measurements,
@@ -738,6 +1073,8 @@ public class SessionCacheLeaderUT {
 
   static class MockSession extends Session {
 
+    private MockSessionConnection mockSessionConnection;
+
     public MockSession(String host, int rpcPort, boolean enableCacheLeader) {
       super(
           host,
@@ -754,69 +1091,132 @@ public class SessionCacheLeaderUT {
     @Override
     public SessionConnection constructSessionConnection(
         Session session, EndPoint endpoint, ZoneId zoneId) {
-      return new MockSessionConnection(session, endpoint, zoneId);
+      mockSessionConnection = new MockSessionConnection(session, endpoint, zoneId);
+      return mockSessionConnection;
+    }
+
+    public MockSessionConnection getMockSessionConnection() {
+      return mockSessionConnection;
     }
   }
 
   static class MockSessionConnection extends SessionConnection {
 
+    private EndPoint endPoint;
+    private boolean connectionBroken;
+    private IoTDBConnectionException ioTDBConnectionException;
+
     public MockSessionConnection(Session session, EndPoint endPoint, ZoneId zoneId) {
       super();
+      this.endPoint = endPoint;
+      ioTDBConnectionException =
+          new IoTDBConnectionException(
+              String.format("the session connection = %s is broken", endPoint.toString()));
     }
 
     @Override
     public void close() {}
 
     @Override
-    protected void setStorageGroup(String storageGroup) throws RedirectException {
+    protected void setStorageGroup(String storageGroup)
+        throws RedirectException, IoTDBConnectionException {
+      if (isConnectionBroken()) {
+        throw ioTDBConnectionException;
+      }
       throw new RedirectException(endpoints.get(1));
     }
 
     @Override
-    protected void deleteStorageGroups(List<String> storageGroups) throws RedirectException {
+    protected void deleteStorageGroups(List<String> storageGroups)
+        throws RedirectException, IoTDBConnectionException {
+      if (isConnectionBroken()) {
+        throw ioTDBConnectionException;
+      }
       throw new RedirectException(endpoints.get(1));
     }
 
     @Override
-    protected void insertRecord(TSInsertRecordReq request) throws RedirectException {
+    protected void insertRecord(TSInsertRecordReq request)
+        throws RedirectException, IoTDBConnectionException {
+      if (isConnectionBroken()) {
+        throw ioTDBConnectionException;
+      }
       throw new RedirectException(getDeviceIdBelongedEndpoint(request.prefixPath));
     }
 
     @Override
-    protected void insertRecord(TSInsertStringRecordReq request) throws RedirectException {
+    protected void insertRecord(TSInsertStringRecordReq request)
+        throws RedirectException, IoTDBConnectionException {
+      if (isConnectionBroken()) {
+        throw ioTDBConnectionException;
+      }
       throw new RedirectException(getDeviceIdBelongedEndpoint(request.deviceId));
     }
 
     @Override
-    protected void insertRecords(TSInsertRecordsReq request) throws RedirectException {
-      throw new RedirectException(getDeviceIdBelongedEndpoint(request.deviceIds.get(0)));
+    protected void insertRecords(TSInsertRecordsReq request)
+        throws RedirectException, IoTDBConnectionException {
+      if (isConnectionBroken()) {
+        throw ioTDBConnectionException;
+      }
+      throw getRedirectException(request.getDeviceIds());
     }
 
     @Override
-    protected void insertRecords(TSInsertStringRecordsReq request) throws RedirectException {
-      throw new RedirectException(getDeviceIdBelongedEndpoint(request.deviceIds.get(0)));
+    protected void insertRecords(TSInsertStringRecordsReq request)
+        throws RedirectException, IoTDBConnectionException {
+      if (isConnectionBroken()) {
+        throw ioTDBConnectionException;
+      }
+      throw getRedirectException(request.getDeviceIds());
     }
 
     @Override
     protected void insertRecordsOfOneDevice(TSInsertRecordsOfOneDeviceReq request)
-        throws RedirectException {
+        throws RedirectException, IoTDBConnectionException {
+      if (isConnectionBroken()) {
+        throw ioTDBConnectionException;
+      }
       throw new RedirectException(getDeviceIdBelongedEndpoint(request.deviceId));
     }
 
     @Override
-    protected void insertTablet(TSInsertTabletReq request) throws RedirectException {
+    protected void insertTablet(TSInsertTabletReq request)
+        throws RedirectException, IoTDBConnectionException {
+      if (isConnectionBroken()) {
+        throw ioTDBConnectionException;
+      }
       throw new RedirectException(getDeviceIdBelongedEndpoint(request.prefixPath));
     }
 
     @Override
-    protected void insertTablets(TSInsertTabletsReq request) throws RedirectException {
-      Map<String, EndPoint> deviceEndPointMap = new HashMap<>();
-      for (int i = 0; i < request.getDeviceIds().size(); i++) {
-        deviceEndPointMap.put(
-            request.getDeviceIds().get(i),
-            getDeviceIdBelongedEndpoint(request.getDeviceIds().get(i)));
+    protected void insertTablets(TSInsertTabletsReq request)
+        throws RedirectException, IoTDBConnectionException {
+      if (isConnectionBroken()) {
+        throw ioTDBConnectionException;
       }
-      throw new RedirectException(deviceEndPointMap);
+      throw getRedirectException(request.getDeviceIds());
+    }
+
+    private RedirectException getRedirectException(List<String> deviceIds) {
+      Map<String, EndPoint> deviceEndPointMap = new HashMap<>();
+      for (String deviceId : deviceIds) {
+        deviceEndPointMap.put(deviceId, getDeviceIdBelongedEndpoint(deviceId));
+      }
+      return new RedirectException(deviceEndPointMap);
+    }
+
+    public boolean isConnectionBroken() {
+      return connectionBroken;
+    }
+
+    public void setConnectionBroken(boolean connectionBroken) {
+      this.connectionBroken = connectionBroken;
+    }
+
+    @Override
+    public String toString() {
+      return "MockSessionConnection{" + " endPoint=" + endPoint + "}";
     }
   }
 }


### PR DESCRIPTION
1. remove the broken session when enable cache leader
2. optimize the `insertRecords` method in session, which we can insert all the devices of data in one session connection, in the previous degien, if some of the devices belong to one session connection, we send to the server per device per connection. 