### PR TITLE
Fix compaction lock with query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -135,11 +135,11 @@ public abstract class TsFileManagement {
   /** fork current TsFile list (call this before merge) */
   public abstract void forkCurrentFileList(long timePartition) throws IOException;
 
-  protected void readLock() {
+  public void readLock() {
     compactionMergeLock.readLock().lock();
   }
 
-  protected void readUnLock() {
+  public void readUnLock() {
     compactionMergeLock.readLock().unlock();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1606,10 +1606,14 @@ public class StorageGroupProcessor {
   }
 
   public void readLock() {
+    // apply read lock for SG insert lock to prevent inconsistent with concurrently writing memtable
     insertLock.readLock().lock();
+    // apply read lock for TsFileResource list
+    tsFileManagement.readLock();
   }
 
   public void readUnlock() {
+    tsFileManagement.readUnLock();
     insertLock.readLock().unlock();
   }
 


### PR DESCRIPTION
## Problem

When Level compaction is ending(delete file in resource list and delete file in disk). The query may get a tsfile resource from resource list. However, it may be deleted by the compaction ending process later, then the query process cannot read data from the deleted resource. Whichmay cause a ci problem like below.
![3501622863945_ pic_hd](https://user-images.githubusercontent.com/24886743/120881886-e7715600-c606-11eb-8861-cd6f0495f186.jpg)

## Solution

Get the tsfileResource list's read lock in TsFileManagament before trying to lock each tsfile and after locking all the tsfiles, we then unlock the tsfileResource list's read lock in TsFileManagament.