### PR TITLE
[IOTDB-1419][To rel/0.11] remove redundant clearCompactionStatus

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionMergeTaskPoolManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionMergeTaskPoolManager.java
@@ -139,6 +139,14 @@ public class CompactionMergeTaskPoolManager implements IService {
     return ServiceType.COMPACTION_SERVICE;
   }
 
+  public synchronized void clearCompactionStatus(String storageGroupName) {
+    // for test
+    if (sgCompactionStatus == null) {
+      sgCompactionStatus = new ConcurrentHashMap<>();
+    }
+    sgCompactionStatus.put(storageGroupName, false);
+  }
+
   public synchronized void submitTask(StorageGroupCompactionTask storageGroupCompactionTask)
       throws RejectedExecutionException {
     if (pool != null && !pool.isTerminated()) {
@@ -147,8 +155,8 @@ public class CompactionMergeTaskPoolManager implements IService {
       if (isCompacting) {
         return;
       }
-      storageGroupCompactionTask.setSgCompactionStatus(sgCompactionStatus);
       sgCompactionStatus.put(storageGroup, true);
+      storageGroupCompactionTask.setSgCompactionStatus(sgCompactionStatus);
       pool.submit(storageGroupCompactionTask);
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -181,10 +181,8 @@ public abstract class TsFileManagement {
     @Override
     public void run() {
       recover();
-      // in recover logic, we do not have to start next compaction task, and in this case the param
-      // time partition is useless, we can just pass 0L
+      // in recover logic, the param time partition is useless, we can just pass 0L
       closeCompactionMergeCallBack.call(false, 0L);
-      clearCompactionStatus();
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -702,6 +702,7 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
           logger.error("{} Compaction log close fail", storageGroupName + COMPACTION_LOG_NAME);
         }
       }
+      isMergeExecutedInCurrentTask = false;
       restoreCompaction();
       logger.error("Error occurred in Compaction Merge thread", e);
     } finally {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
@@ -256,8 +256,8 @@ public class CompactionUtils {
       throws IOException, IllegalPathException {
     Map<String, TsFileSequenceReader> tsFileSequenceReaderMap = new HashMap<>();
     Map<String, List<Modification>> modificationCache = new HashMap<>();
+    RestorableTsFileIOWriter writer = new RestorableTsFileIOWriter(targetResource.getTsFile());
     try {
-      RestorableTsFileIOWriter writer = new RestorableTsFileIOWriter(targetResource.getTsFile());
       RateLimiter compactionWriteRateLimiter =
           MergeManager.getINSTANCE().getMergeWriteRateLimiter();
       Set<String> tsFileDevicesMap =
@@ -402,9 +402,9 @@ public class CompactionUtils {
       }
       targetResource.setHistoricalVersions(historicalVersions);
       targetResource.serialize();
-      writer.endFile();
       targetResource.close();
     } finally {
+      writer.endFile();
       for (TsFileSequenceReader reader : tsFileSequenceReaderMap.values()) {
         reader.close();
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
@@ -402,9 +402,10 @@ public class CompactionUtils {
       }
       targetResource.setHistoricalVersions(historicalVersions);
       targetResource.serialize();
+      writer.endFile();
       targetResource.close();
     } finally {
-      writer.endFile();
+      writer.close();
       for (TsFileSequenceReader reader : tsFileSequenceReaderMap.values()) {
         reader.close();
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1882,12 +1882,7 @@ public class StorageGroupProcessor {
     logger.info("{} submit a compaction merge task", storageGroupName);
     try {
       // fork and filter current tsfile, then commit then to compaction merge
-      tsFileManagement.readLock();
-      try {
-        tsFileManagement.forkCurrentFileList(timePartition);
-      } finally {
-        tsFileManagement.readUnLock();
-      }
+      tsFileManagement.forkCurrentFileList(timePartition);
       tsFileManagement.setForceFullMerge(fullMerge);
       tsFileManagement
           .new CompactionOnePartitionUtil(this::closeCompactionMergeCallBack, timePartition)

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1895,12 +1895,12 @@ public class StorageGroupProcessor {
 
   /** close recover compaction merge callback, to start continuous compaction */
   private void closeCompactionRecoverCallBack(boolean isMerge, long timePartitionId) {
-    logger.info(
-        "{} recover finished, submit continuous compaction task", storageGroupName);
+    CompactionMergeTaskPoolManager.getInstance().clearCompactionStatus(storageGroupName);
     if (IoTDBDescriptor.getInstance().getConfig().isEnableContinuousCompaction()) {
+      logger.info(
+          "{} recover finished, submit continuous compaction task", storageGroupName);
       CompactionMergeTaskPoolManager.getInstance()
           .submitTask(new CompactionAllPartitionTask(storageGroupName));
-      new CompactionAllPartitionTask(storageGroupName).run();
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
@@ -159,7 +159,7 @@ public class TsFileRecoverPerformer {
   private void recoverResourceFromFile() throws IOException {
     try {
       tsFileResource.deserialize();
-    } catch (IOException e) {
+    } catch (Exception e) {
       logger.warn("Cannot deserialize TsFileResource {}, construct it using "
           + "TsFileSequenceReader", tsFileResource.getTsFile(), e);
       recoverResourceFromReader();


### PR DESCRIPTION
Currently, recover process cannot execute the continuous compaction every time, as the clearCompactionStatus may set compaction working status to false even the recover of compaction is the finished.
So we remove redundant clearCompactionStatus and synchronous to trigger the later continuous compaction.
Moreover, the PR also expands the Exception to be catched to log more error.