### PR TITLE
[IOTDB-1425]Privilege controller does not support some operators

### DIFF
--- a/docs/UserGuide/Administration-Management/Administration.md
+++ b/docs/UserGuide/Administration-Management/Administration.md
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
         http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,8 +23,8 @@
 
 IoTDB provides users with account privilege management operations, so as to ensure data security.
 
-We will show you basic user privilege management operations through the following specific examples. Detailed SQL syntax and usage details can be found in [SQL Documentation](../Appendix/SQL-Reference.md). 
-At the same time, in the JAVA programming environment, you can use the [Java JDBC](../API/Programming-JDBC.md) to execute privilege management statements in a single or batch mode. 
+We will show you basic user privilege management operations through the following specific examples. Detailed SQL syntax and usage details can be found in [SQL Documentation](../Appendix/SQL-Reference.md).
+At the same time, in the JAVA programming environment, you can use the [Java JDBC](../API/Programming-JDBC.md) to execute privilege management statements in a single or batch mode.
 
 ## Basic Concepts
 
@@ -125,6 +125,7 @@ At the same time, changes to roles are immediately reflected on all users who ow
 |privilege Name|Interpretation|
 |:---|:---|
 |SET\_STORAGE\_GROUP|set storage groups; path dependent|
+|DELETE\_STORAGE\_GROUP|delete storage groups; path dependent|
 |CREATE\_TIMESERIES|create timeseries; path dependent|
 |INSERT\_TIMESERIES|insert data; path dependent|
 |READ\_TIMESERIES|query data; path dependent|

--- a/server/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
@@ -117,6 +117,8 @@ public class AuthorityChecker {
         return PrivilegeType.REVOKE_USER_ROLE.ordinal();
       case SET_STORAGE_GROUP:
         return PrivilegeType.SET_STORAGE_GROUP.ordinal();
+      case DELETE_STORAGE_GROUP:
+        return PrivilegeType.DELETE_STORAGE_GROUP.ordinal();
       case CREATE_TIMESERIES:
         return PrivilegeType.CREATE_TIMESERIES.ordinal();
       case DELETE_TIMESERIES:
@@ -138,6 +140,7 @@ public class AuthorityChecker {
       case INSERT:
       case LOADDATA:
       case CREATE_INDEX:
+      case ALTER_TIMESERIES:
         return PrivilegeType.INSERT_TIMESERIES.ordinal();
       case LIST_ROLE:
       case LIST_ROLE_USERS:

--- a/server/src/main/java/org/apache/iotdb/db/auth/entity/PrivilegeType.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/entity/PrivilegeType.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.auth.entity;
 /** This enum class contains all available privileges in IoTDB. */
 public enum PrivilegeType {
   SET_STORAGE_GROUP,
+  DELETE_STORAGE_GROUP,
   INSERT_TIMESERIES,
   @Deprecated
   UPDATE_TIMESERIES,

--- a/server/src/main/java/org/apache/iotdb/db/utils/AuthUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/AuthUtils.java
@@ -135,6 +135,7 @@ public class AuthUtils {
       switch (type) {
         case READ_TIMESERIES:
         case SET_STORAGE_GROUP:
+        case DELETE_STORAGE_GROUP:
         case CREATE_TIMESERIES:
         case DELETE_TIMESERIES:
         case INSERT_TIMESERIES:
@@ -147,6 +148,7 @@ public class AuthUtils {
       switch (type) {
         case READ_TIMESERIES:
         case SET_STORAGE_GROUP:
+        case DELETE_STORAGE_GROUP:
         case CREATE_TIMESERIES:
         case DELETE_TIMESERIES:
         case INSERT_TIMESERIES:

--- a/server/src/test/java/org/apache/iotdb/db/auth/authorizer/LocalFileAuthorizerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/auth/authorizer/LocalFileAuthorizerTest.java
@@ -88,20 +88,20 @@ public class LocalFileAuthorizerTest {
   @Test
   public void testUserPermission() throws AuthException {
     authorizer.createUser(user.getName(), user.getPassword());
-    authorizer.grantPrivilegeToUser(user.getName(), nodeName, 1);
+    authorizer.grantPrivilegeToUser(user.getName(), nodeName, 2);
     try {
-      authorizer.grantPrivilegeToUser(user.getName(), nodeName, 1);
+      authorizer.grantPrivilegeToUser(user.getName(), nodeName, 2);
     } catch (AuthException e) {
       assertEquals("User user already has INSERT_TIMESERIES on root.laptop.d1", e.getMessage());
     }
     try {
-      authorizer.grantPrivilegeToUser("error", nodeName, 1);
+      authorizer.grantPrivilegeToUser("error", nodeName, 2);
     } catch (AuthException e) {
       assertEquals("No such user error", e.getMessage());
     }
 
     try {
-      authorizer.grantPrivilegeToUser("root", nodeName, 1);
+      authorizer.grantPrivilegeToUser("root", nodeName, 2);
     } catch (AuthException e) {
       Assert.assertEquals(
           "Invalid operation, administrator already has all privileges", e.getMessage());
@@ -113,9 +113,9 @@ public class LocalFileAuthorizerTest {
       assertEquals("Invalid privilegeId 100", e.getMessage());
     }
 
-    authorizer.revokePrivilegeFromUser(user.getName(), nodeName, 1);
+    authorizer.revokePrivilegeFromUser(user.getName(), nodeName, 2);
     try {
-      authorizer.revokePrivilegeFromUser(user.getName(), nodeName, 1);
+      authorizer.revokePrivilegeFromUser(user.getName(), nodeName, 2);
     } catch (AuthException e) {
       assertEquals("User user does not have INSERT_TIMESERIES on root.laptop.d1", e.getMessage());
     }
@@ -128,13 +128,13 @@ public class LocalFileAuthorizerTest {
 
     try {
       authorizer.deleteUser(user.getName());
-      authorizer.revokePrivilegeFromUser(user.getName(), nodeName, 1);
+      authorizer.revokePrivilegeFromUser(user.getName(), nodeName, 2);
     } catch (AuthException e) {
       assertEquals("No such user user", e.getMessage());
     }
 
     try {
-      authorizer.revokePrivilegeFromUser("root", "root", 1);
+      authorizer.revokePrivilegeFromUser("root", "root", 2);
     } catch (AuthException e) {
       Assert.assertEquals(
           "Invalid operation, administrator must have all privileges", e.getMessage());
@@ -160,26 +160,26 @@ public class LocalFileAuthorizerTest {
   @Test
   public void testRolePermission() throws AuthException {
     authorizer.createRole(roleName);
-    authorizer.grantPrivilegeToRole(roleName, nodeName, 1);
+    authorizer.grantPrivilegeToRole(roleName, nodeName, 2);
     try {
-      authorizer.grantPrivilegeToRole(roleName, nodeName, 1);
+      authorizer.grantPrivilegeToRole(roleName, nodeName, 2);
     } catch (AuthException e) {
       assertEquals("Role role already has INSERT_TIMESERIES on root.laptop.d1", e.getMessage());
     }
-    authorizer.revokePrivilegeFromRole(roleName, nodeName, 1);
+    authorizer.revokePrivilegeFromRole(roleName, nodeName, 2);
     try {
-      authorizer.revokePrivilegeFromRole(roleName, nodeName, 1);
+      authorizer.revokePrivilegeFromRole(roleName, nodeName, 2);
     } catch (AuthException e) {
       assertEquals("Role role does not have INSERT_TIMESERIES on root.laptop.d1", e.getMessage());
     }
     authorizer.deleteRole(roleName);
     try {
-      authorizer.revokePrivilegeFromRole(roleName, nodeName, 1);
+      authorizer.revokePrivilegeFromRole(roleName, nodeName, 2);
     } catch (AuthException e) {
       assertEquals("No such role role", e.getMessage());
     }
     try {
-      authorizer.grantPrivilegeToRole(roleName, nodeName, 1);
+      authorizer.grantPrivilegeToRole(roleName, nodeName, 2);
     } catch (AuthException e) {
       assertEquals("No such role role", e.getMessage());
     }

--- a/server/src/test/java/org/apache/iotdb/db/auth/entity/PathPrivilegeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/auth/entity/PathPrivilegeTest.java
@@ -29,11 +29,11 @@ public class PathPrivilegeTest {
   public void testPathPrivilege() {
     PathPrivilege pathPrivilege = new PathPrivilege();
     pathPrivilege.setPath("root.ln");
-    pathPrivilege.setPrivileges(Collections.singleton(1));
+    pathPrivilege.setPrivileges(Collections.singleton(2));
     Assert.assertEquals("root.ln : INSERT_TIMESERIES", pathPrivilege.toString());
     PathPrivilege pathPrivilege1 = new PathPrivilege();
     pathPrivilege1.setPath("root.sg");
-    pathPrivilege1.setPrivileges(Collections.singleton(1));
+    pathPrivilege1.setPrivileges(Collections.singleton(2));
     Assert.assertNotEquals(pathPrivilege, pathPrivilege1);
     pathPrivilege.deserialize(pathPrivilege1.serialize());
     Assert.assertEquals("root.sg : INSERT_TIMESERIES", pathPrivilege.toString());

--- a/server/src/test/java/org/apache/iotdb/db/auth/entity/RoleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/auth/entity/RoleTest.java
@@ -30,7 +30,7 @@ public class RoleTest {
     Role role = new Role("role");
     PathPrivilege pathPrivilege = new PathPrivilege("root.ln");
     role.setPrivilegeList(Collections.singletonList(pathPrivilege));
-    role.setPrivileges("root.ln", Collections.singleton(1));
+    role.setPrivileges("root.ln", Collections.singleton(2));
     Assert.assertEquals(
         "Role{name='role', privilegeList=[root.ln : INSERT_TIMESERIES]}", role.toString());
     Role role1 = new Role("role1");

--- a/server/src/test/java/org/apache/iotdb/db/auth/entity/UserTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/auth/entity/UserTest.java
@@ -30,7 +30,7 @@ public class UserTest {
     User user = new User("user", "password");
     PathPrivilege pathPrivilege = new PathPrivilege("root.ln");
     user.setPrivilegeList(Collections.singletonList(pathPrivilege));
-    user.setPrivileges("root.ln", Collections.singleton(1));
+    user.setPrivileges("root.ln", Collections.singleton(2));
     Assert.assertEquals(
         "User{name='user', password='password', privilegeList=[root.ln : INSERT_TIMESERIES], roleList=[], useWaterMark=false, lastActiveTime=0}",
         user.toString());

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
@@ -180,7 +180,7 @@ public class PhysicalPlanTest {
   @Test
   public void testAuthor() throws QueryProcessException {
     String sql =
-        "grant role xm privileges 'SET_STORAGE_GROUP','DELETE_TIMESERIES' on root.vehicle.d1.s1";
+        "grant role xm privileges 'SET_STORAGE_GROUP','DELETE_STORAGE_GROUP','DELETE_TIMESERIES' on root.vehicle.d1.s1";
     Planner processor = new Planner();
     AuthorPlan plan = (AuthorPlan) processor.parseSQLToPhysicalPlan(sql);
     assertEquals(
@@ -188,7 +188,7 @@ public class PhysicalPlanTest {
             + "roleName: xm\n"
             + "password: null\n"
             + "newPassword: null\n"
-            + "permissions: [0, 5]\n"
+            + "permissions: [0, 1, 6]\n"
             + "nodeName: root.vehicle.d1.s1\n"
             + "authorType: GRANT_ROLE",
         plan.toString());


### PR DESCRIPTION
## Description


### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
