### PR TITLE
[IOTDB-1430] Ensure only one vector in one MetadataIndexTree

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -93,8 +93,8 @@ public class TimeSeriesMetadataCache {
                       + RamUsageEstimator.sizeOf(value.getMeasurementId())
                       + RamUsageEstimator.shallowSizeOf(value.getStatistics())
                       + (((ChunkMetadata) value.getChunkMetadataList().get(0)).calculateRamSize()
-                      + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-                      * value.getChunkMetadataList().size()
+                              + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
+                          * value.getChunkMetadataList().size()
                       + RamUsageEstimator.shallowSizeOf(value.getChunkMetadataList());
               averageSize = ((averageSize * count) + currentSize) / (++count);
             } else if (count < 100000) {
@@ -109,8 +109,8 @@ public class TimeSeriesMetadataCache {
                       + RamUsageEstimator.sizeOf(value.getMeasurementId())
                       + RamUsageEstimator.shallowSizeOf(value.getStatistics())
                       + (((ChunkMetadata) value.getChunkMetadataList().get(0)).calculateRamSize()
-                      + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-                      * value.getChunkMetadataList().size()
+                              + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
+                          * value.getChunkMetadataList().size()
                       + RamUsageEstimator.shallowSizeOf(value.getChunkMetadataList());
               count = 1;
               currentSize = averageSize;
@@ -292,7 +292,9 @@ public class TimeSeriesMetadataCache {
                 metadata -> {
                   TimeSeriesMetadataCacheKey k =
                       new TimeSeriesMetadataCacheKey(
-                          key.filePath, key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement, metadata.getMeasurementId());
+                          key.filePath,
+                          key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement,
+                          metadata.getMeasurementId());
                   if (!lruCache.containsKey(k)) {
                     lruCache.put(k, metadata);
                   }
@@ -329,14 +331,21 @@ public class TimeSeriesMetadataCache {
       TimeSeriesMetadataCacheKey key, List<String> subSensorList, List<TimeseriesMetadata> res) {
     lock.readLock().lock();
     try {
-      TimeseriesMetadata timeseriesMetadata = lruCache.get(new TimeSeriesMetadataCacheKey(key.filePath,
-          key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement, key.measurement));
+      TimeseriesMetadata timeseriesMetadata =
+          lruCache.get(
+              new TimeSeriesMetadataCacheKey(
+                  key.filePath,
+                  key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement,
+                  key.measurement));
       if (timeseriesMetadata != null) {
         res.add(timeseriesMetadata);
         for (String subSensor : subSensorList) {
           timeseriesMetadata =
-              lruCache.get(new TimeSeriesMetadataCacheKey(key.filePath,
-                  key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement, subSensor));
+              lruCache.get(
+                  new TimeSeriesMetadataCacheKey(
+                      key.filePath,
+                      key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement,
+                      subSensor));
           if (timeseriesMetadata != null) {
             res.add(timeseriesMetadata);
           } else {
@@ -385,9 +394,7 @@ public class TimeSeriesMetadataCache {
     return lruCache.getAverageSize();
   }
 
-  /**
-   * clear LRUCache.
-   */
+  /** clear LRUCache. */
   public void clear() {
     lock.writeLock().lock();
     if (lruCache != null) {
@@ -453,9 +460,7 @@ public class TimeSeriesMetadataCache {
     }
   }
 
-  /**
-   * singleton pattern.
-   */
+  /** singleton pattern. */
   private static class TimeSeriesMetadataCacheHolder {
 
     private static final TimeSeriesMetadataCache INSTANCE = new TimeSeriesMetadataCache();

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -93,8 +93,8 @@ public class TimeSeriesMetadataCache {
                       + RamUsageEstimator.sizeOf(value.getMeasurementId())
                       + RamUsageEstimator.shallowSizeOf(value.getStatistics())
                       + (((ChunkMetadata) value.getChunkMetadataList().get(0)).calculateRamSize()
-                              + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-                          * value.getChunkMetadataList().size()
+                      + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
+                      * value.getChunkMetadataList().size()
                       + RamUsageEstimator.shallowSizeOf(value.getChunkMetadataList());
               averageSize = ((averageSize * count) + currentSize) / (++count);
             } else if (count < 100000) {
@@ -109,8 +109,8 @@ public class TimeSeriesMetadataCache {
                       + RamUsageEstimator.sizeOf(value.getMeasurementId())
                       + RamUsageEstimator.shallowSizeOf(value.getStatistics())
                       + (((ChunkMetadata) value.getChunkMetadataList().get(0)).calculateRamSize()
-                              + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-                          * value.getChunkMetadataList().size()
+                      + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
+                      * value.getChunkMetadataList().size()
                       + RamUsageEstimator.shallowSizeOf(value.getChunkMetadataList());
               count = 1;
               currentSize = averageSize;
@@ -292,7 +292,7 @@ public class TimeSeriesMetadataCache {
                 metadata -> {
                   TimeSeriesMetadataCacheKey k =
                       new TimeSeriesMetadataCacheKey(
-                          key.filePath, key.device, metadata.getMeasurementId());
+                          key.filePath, key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement, metadata.getMeasurementId());
                   if (!lruCache.containsKey(k)) {
                     lruCache.put(k, metadata);
                   }
@@ -329,12 +329,14 @@ public class TimeSeriesMetadataCache {
       TimeSeriesMetadataCacheKey key, List<String> subSensorList, List<TimeseriesMetadata> res) {
     lock.readLock().lock();
     try {
-      TimeseriesMetadata timeseriesMetadata = lruCache.get(key);
+      TimeseriesMetadata timeseriesMetadata = lruCache.get(new TimeSeriesMetadataCacheKey(key.filePath,
+          key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement, key.measurement));
       if (timeseriesMetadata != null) {
         res.add(timeseriesMetadata);
         for (String subSensor : subSensorList) {
           timeseriesMetadata =
-              lruCache.get(new TimeSeriesMetadataCacheKey(key.filePath, key.device, subSensor));
+              lruCache.get(new TimeSeriesMetadataCacheKey(key.filePath,
+                  key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement, subSensor));
           if (timeseriesMetadata != null) {
             res.add(timeseriesMetadata);
           } else {
@@ -383,7 +385,9 @@ public class TimeSeriesMetadataCache {
     return lruCache.getAverageSize();
   }
 
-  /** clear LRUCache. */
+  /**
+   * clear LRUCache.
+   */
   public void clear() {
     lock.writeLock().lock();
     if (lruCache != null) {
@@ -449,7 +453,9 @@ public class TimeSeriesMetadataCache {
     }
   }
 
-  /** singleton pattern. */
+  /**
+   * singleton pattern.
+   */
   private static class TimeSeriesMetadataCacheHolder {
 
     private static final TimeSeriesMetadataCache INSTANCE = new TimeSeriesMetadataCache();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexConstructor.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexConstructor.java
@@ -75,19 +75,15 @@ public class MetadataIndexConstructor {
             }
           }
 
-          // only add time column of vector into LEAF_MEASUREMENT node
-          if (currentIndexNode.getChildren().isEmpty()
-              || serializedTimeseriesMetadataNum + numOfValueColumns + 1
-                  > config.getMaxDegreeOfIndexNode() * 1.5) {
-            currentIndexNode.addEntry(
-                new MetadataIndexEntry(timeseriesMetadata.getMeasurementId(), out.getPosition()));
-            serializedTimeseriesMetadataNum = 0;
-          }
+          // for each vector, add time column of vector into LEAF_MEASUREMENT node
+          currentIndexNode.addEntry(
+              new MetadataIndexEntry(timeseriesMetadata.getMeasurementId(), out.getPosition()));
+          serializedTimeseriesMetadataNum = 0;
 
           timeseriesMetadata.serializeTo(out.wrapAsStream());
           serializedTimeseriesMetadataNum++;
           for (int j = 0; j < numOfValueColumns; j++) {
-            i += 1;
+            i++;
             timeseriesMetadata = entry.getValue().get(i);
             // value columns of vector should not be added into LEAF_MEASUREMENT node
             timeseriesMetadata.serializeTo(out.wrapAsStream());


### PR DESCRIPTION
Ensure there is only one vector in one MetadataIndexTree.

For example, the query process cannot determine which "s1" is queried ("vector1.s1"? "vector2.s1"?).

Unless vector1 and vector2 are in different leaf nodes in MetadataIndexTree.