### PR TITLE
[IOTDB-1433] [To rel/0.12] Fix bug in getMetadataAndEndOffset when querying non-exist device

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -732,7 +732,7 @@ public class TsFileSequenceReader implements AutoCloseable {
             metadataIndex.getChildIndexEntry(name, false);
         ByteBuffer buffer = readData(childIndexEntry.left.getOffset(), childIndexEntry.right);
         return getMetadataAndEndOffset(
-            MetadataIndexNode.deserializeFrom(buffer), name, isDeviceLevel, false);
+            MetadataIndexNode.deserializeFrom(buffer), name, isDeviceLevel, exactSearch);
       }
     } catch (BufferOverflowException e) {
       logger.error("Something error happened while deserializing MetadataIndex of file {}", file);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
@@ -153,8 +153,7 @@ public class MeasurementChunkMetadataListMapIteratorTest {
         checkCorrectness(expected, actual);
 
         // test not exist device
-        Iterator<Map<String, List<ChunkMetadata>>> iterator =
-            fileReader.getMeasurementChunkMetadataListMapIterator("dd");
+        iterator = fileReader.getMeasurementChunkMetadataListMapIterator("dd");
         Assert.assertFalse(iterator.hasNext());
       }
     }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
@@ -151,6 +151,11 @@ public class MeasurementChunkMetadataListMapIteratorTest {
         }
 
         checkCorrectness(expected, actual);
+
+        // test not exist device
+        Iterator<Map<String, List<ChunkMetadata>>> iterator =
+            fileReader.getMeasurementChunkMetadataListMapIterator("dd");
+        Assert.assertFalse(iterator.hasNext());
       }
     }
 


### PR DESCRIPTION
See as PR #3391 