### PR TITLE
[IOTDB-1433] [To rel/0.11] Fix bug in getMetadataAndEndOffset when querying non-exist device

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -771,7 +771,7 @@ public class TsFileSequenceReader implements AutoCloseable {
             metadataIndex.getChildIndexEntry(name, false);
         ByteBuffer buffer = readData(childIndexEntry.left.getOffset(), childIndexEntry.right);
         return getMetadataAndEndOffset(
-            MetadataIndexNode.deserializeFrom(buffer), name, type, false);
+            MetadataIndexNode.deserializeFrom(buffer), name, type, exactSearch);
       }
     } catch (BufferOverflowException e) {
       logger.error(

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
@@ -151,6 +151,10 @@ public class MeasurementChunkMetadataListMapIteratorTest {
         }
 
         checkCorrectness(expected, actual);
+
+        // test not exist device
+        iterator = fileReader.getMeasurementChunkMetadataListMapIterator("dd");
+        Assert.assertFalse(iterator.hasNext());
       }
     }
 


### PR DESCRIPTION
See as PR #3391 