### PR TITLE
[IOTDB-1437]Fix the tsfile sketch tool NPE

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
@@ -135,9 +135,6 @@ public class TsFileSketchTool {
               // skip the PlanIndex
               nextChunkGroupHeaderPos += 16;
               break;
-            default:
-              System.out.println("error occurred, unknown marker=" + marker);
-              return;
           }
 
           printlnBoth(pw, str1 + "\t[Chunk Group] of " + chunkGroupMetadata.getDevice() + " ends");

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.tools;
 
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.header.ChunkGroupHeader;
 import org.apache.iotdb.tsfile.file.metadata.ChunkGroupMetadata;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
@@ -122,8 +123,21 @@ public class TsFileSketchTool {
             nextChunkGroupHeaderPos =
                 chunkMetadata.getOffsetOfChunkHeader()
                     + chunk.getHeader().getSerializedSize()
-                    + chunk.getHeader().getDataSize()
-                    + 17; // skip the PlanIndex
+                    + chunk.getHeader().getDataSize();
+          }
+          reader.position(nextChunkGroupHeaderPos);
+          byte marker = reader.readMarker();
+          switch (marker) {
+            case MetaMarker.CHUNK_GROUP_HEADER:
+              // do nothing
+              break;
+            case MetaMarker.OPERATION_INDEX_RANGE:
+              // skip the PlanIndex
+              nextChunkGroupHeaderPos += 16;
+              break;
+            default:
+              System.out.println("error occurred, unknown marker=" + marker);
+              return;
           }
 
           printlnBoth(pw, str1 + "\t[Chunk Group] of " + chunkGroupMetadata.getDevice() + " ends");

--- a/server/src/test/java/org/apache/iotdb/db/tools/TsFileSketchToolTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/tools/TsFileSketchToolTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.tools;
+
+import java.nio.file.Files;
+import org.apache.commons.io.FileUtils;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.write.TsFileWriter;
+import org.apache.iotdb.tsfile.write.record.Tablet;
+import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+import org.apache.iotdb.tsfile.write.schema.Schema;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TsFileSketchToolTest {
+  String path = "test.tsfile";
+  String sketchOut = "sketch.out";
+  String device = "root.device_0";
+
+  @Before
+  public void setUp() throws Exception {
+    try {
+      File f = FSFactoryProducer.getFSFactory().getFile(path);
+      if (f.exists() && !f.delete()) {
+        throw new RuntimeException("can not delete " + f.getAbsolutePath());
+      }
+
+      Schema schema = new Schema();
+
+      String sensorPrefix = "sensor_";
+      // the number of rows to include in the tablet
+      int rowNum = 1000000;
+      // the number of values to include in the tablet
+      int sensorNum = 10;
+
+      List<IMeasurementSchema> measurementSchemas = new ArrayList<>();
+      // add measurements into file schema (all with INT64 data type)
+      for (int i = 0; i < sensorNum; i++) {
+        IMeasurementSchema measurementSchema =
+            new MeasurementSchema(sensorPrefix + (i + 1), TSDataType.INT64, TSEncoding.TS_2DIFF);
+        measurementSchemas.add(measurementSchema);
+        schema.registerTimeseries(
+            new Path(device, sensorPrefix + (i + 1)),
+            new MeasurementSchema(sensorPrefix + (i + 1), TSDataType.INT64, TSEncoding.TS_2DIFF));
+      }
+
+      // add measurements into TSFileWriter
+      try (TsFileWriter tsFileWriter = new TsFileWriter(f, schema)) {
+
+        // construct the tablet
+        Tablet tablet = new Tablet(device, measurementSchemas);
+
+        long[] timestamps = tablet.timestamps;
+        Object[] values = tablet.values;
+
+        long timestamp = 1;
+        long value = 1000000L;
+
+        for (int r = 0; r < rowNum; r++, value++) {
+          int row = tablet.rowSize++;
+          timestamps[row] = timestamp++;
+          for (int i = 0; i < sensorNum; i++) {
+            long[] sensor = (long[]) values[i];
+            sensor[row] = value;
+          }
+          // write Tablet to TsFile
+          if (tablet.rowSize == tablet.getMaxRowNumber()) {
+            tsFileWriter.write(tablet);
+            tablet.reset();
+          }
+        }
+        // write Tablet to TsFile
+        if (tablet.rowSize != 0) {
+          tsFileWriter.write(tablet);
+          tablet.reset();
+        }
+      }
+    } catch (Exception e) {
+      throw new Exception("meet error in TsFileWrite with tablet", e);
+    }
+  }
+
+  @Test
+  public void tsFileSketchToolTest() {
+    TsFileSketchTool tool = new TsFileSketchTool();
+    String args[] = new String[2];
+    args[0] = path;
+    args[1] = sketchOut;
+    try {
+      tool.main(args);
+    } catch (IOException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @After
+  public void tearDown(){
+    try {
+      FileUtils.forceDelete(new File(path));
+      FileUtils.forceDelete(new File(sketchOut));
+    } catch (IOException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/tools/TsFileSketchToolTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/tools/TsFileSketchToolTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.iotdb.db.tools;
 
-import java.nio.file.Files;
-import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
@@ -31,6 +29,7 @@ import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.Schema;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -123,7 +122,7 @@ public class TsFileSketchToolTest {
   }
 
   @After
-  public void tearDown(){
+  public void tearDown() {
     try {
       FileUtils.forceDelete(new File(path));
       FileUtils.forceDelete(new File(sketchOut));

--- a/site/src/main/.vuepress/theme/global-components/Contributor.vue
+++ b/site/src/main/.vuepress/theme/global-components/Contributor.vue
@@ -291,7 +291,7 @@
         {
           avatar:'/img/contributor-avatar/user.svg',
           name: 'Stefanie Zhao',
-          role: 'PPMC, Committer',
+          role: 'PMC, Committer',
           id: 'zhaoxinyi',
           date: '2018/11/18'
         },


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IOTDB-1437

**Reason**
When parsing, `PlanIndex` is parsed after each chunk group.

**Solution** 
Not all ChunkGroups are followed by a `PlanIndex` , which should be judged according to the marker.