### PR TITLE
[To rel/0.11] Bump logback-classic and logback-core from 1.1.11 to 1.2.3

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -294,8 +294,8 @@ org.slf4j:jcl-over-slf4j:1.7.25
 EPL 1.0
 ------------
 com.h2database:h2-mvstore:1.4.199
-ch.qos.logback:logback-classic:1.1.11
-ch.qos.logback:logback-core:1.1.11
+ch.qos.logback:logback-classic:1.2.3
+ch.qos.logback:logback-core:1.2.3
 
 
 CDDL 1.1

--- a/grafana/pom.xml
+++ b/grafana/pom.xml
@@ -165,7 +165,7 @@
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                         <resource>META-INF/spring.schemas</resource>
                                     </transformer>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <mainClass>${start-class}</mainClass>
                                     </transformer>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -223,7 +223,7 @@
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>
-                                                <ignore />
+                                                <ignore/>
                                             </action>
                                         </pluginExecution>
                                     </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <hive2.version>2.3.6</hive2.version>
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.12</slf4j.version>
-        <logback.version>1.1.11</logback.version>
+        <logback.version>1.2.3</logback.version>
         <joda.version>2.9.9</joda.version>
         <spark.version>2.4.3</spark.version>
         <flink.version>1.11.1</flink.version>
@@ -139,7 +139,7 @@
         <sonar.exclusions>**/generated-sources</sonar.exclusions>
         <!-- By default, the argLine is empty-->
         <gson.version>2.8.6</gson.version>
-        <argLine />
+        <argLine/>
     </properties>
     <!--
         if we claim dependencies in dependencyManagement, then we do not claim
@@ -603,7 +603,7 @@
                         <id>enforce-version-convergence</id>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                         <goals>
@@ -649,7 +649,7 @@
                                 </requireJavaVersion>
                                 <!-- Disabled for now as it breaks the ability to build single modules -->
                                 <!--reactorModuleConvergence/-->
-                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies" />
+                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
The versions of logback-classic and logback-core on rel/0.12 and master branches are the newest stable version (1.2.3).