### PR TITLE
[IOTDB-1399]Add a session interface to connect multiple nodes

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -652,5 +652,6 @@ public class SessionExample {
     nodeList.add("127.0.0.1:6668");
     Session clusterSession = new Session(nodeList, "root", "root");
     clusterSession.open();
+    clusterSession.close();
   }
 }

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -644,4 +644,13 @@ public class SessionExample {
     Session tempSession = new Session(LOCAL_HOST, 6667, "root", "root", 10000, 20000);
     tempSession.setTimeout(60000);
   }
+
+  private static void createClusterSession() throws IoTDBConnectionException {
+    ArrayList<String> nodeList = new ArrayList<>();
+    nodeList.add("127.0.0.1:6669");
+    nodeList.add("127.0.0.1:6667");
+    nodeList.add("127.0.0.1:6668");
+    Session clusterSession = new Session(nodeList, "root", "root");
+    clusterSession.open();
+  }
 }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -584,16 +584,12 @@ public class Session {
   private SessionDataSet executeStatementMayRedirect(String sql, long timeoutInMs)
       throws StatementExecutionException, IoTDBConnectionException {
     try {
-      logger.info("{} execute sql {}", defaultSessionConnection.getEndPoint(), sql);
+      logger.info("{} execute sql {}", defaultEndPoint, sql);
       return defaultSessionConnection.executeQueryStatement(sql, timeoutInMs);
     } catch (RedirectException e) {
       handleQueryRedirection(e.getEndPoint());
       if (enableQueryRedirection) {
-        logger.debug(
-            "{} redirect query {} to {}",
-            defaultSessionConnection.getEndPoint(),
-            sql,
-            e.getEndPoint());
+        logger.debug("{} redirect query {} to {}", defaultEndPoint, sql, e.getEndPoint());
         // retry
         try {
           return defaultSessionConnection.executeQueryStatement(sql, timeout);

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -253,6 +253,11 @@ public class Session {
         Config.DEFAULT_CACHE_LEADER_MODE);
   }
 
+  /**
+   * Multiple nodeUrl,If one node down, connect to the next one
+   *
+   * @param nodeUrls List<String> Multiple ip:rpcPort eg.127.0.0.1:9001
+   */
   public Session(List<String> nodeUrls, String username, String password, int fetchSize) {
     this(
         nodeUrls,
@@ -589,7 +594,7 @@ public class Session {
     } catch (RedirectException e) {
       handleQueryRedirection(e.getEndPoint());
       if (enableQueryRedirection) {
-        logger.debug("{} redirect query {} to {}", defaultEndPoint, sql, e.getEndPoint());
+        logger.debug("redirect query {} to {}", sql, e.getEndPoint());
         // retry
         try {
           return defaultSessionConnection.executeQueryStatement(sql, timeout);

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -589,12 +589,16 @@ public class Session {
   private SessionDataSet executeStatementMayRedirect(String sql, long timeoutInMs)
       throws StatementExecutionException, IoTDBConnectionException {
     try {
-      logger.info("{} execute sql {}", defaultEndPoint, sql);
+      logger.info("{} execute sql {}", defaultSessionConnection.getEndPoint(), sql);
       return defaultSessionConnection.executeQueryStatement(sql, timeoutInMs);
     } catch (RedirectException e) {
       handleQueryRedirection(e.getEndPoint());
       if (enableQueryRedirection) {
-        logger.debug("redirect query {} to {}", sql, e.getEndPoint());
+        logger.debug(
+            "{} redirect query {} to {}",
+            defaultSessionConnection.getEndPoint(),
+            sql,
+            e.getEndPoint());
         // retry
         try {
           return defaultSessionConnection.executeQueryStatement(sql, timeout);

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -253,6 +253,30 @@ public class Session {
         Config.DEFAULT_CACHE_LEADER_MODE);
   }
 
+  public Session(List<String> nodeUrls, String username, String password, int fetchSize) {
+    this(
+        nodeUrls,
+        username,
+        password,
+        fetchSize,
+        null,
+        Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
+        Config.DEFAULT_MAX_FRAME_SIZE,
+        Config.DEFAULT_CACHE_LEADER_MODE);
+  }
+
+  public Session(List<String> nodeUrls, String username, String password, ZoneId zoneId) {
+    this(
+        nodeUrls,
+        username,
+        password,
+        Config.DEFAULT_FETCH_SIZE,
+        zoneId,
+        Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
+        Config.DEFAULT_MAX_FRAME_SIZE,
+        Config.DEFAULT_CACHE_LEADER_MODE);
+  }
+
   public Session(
       List<String> nodeUrls,
       String username,
@@ -270,39 +294,6 @@ public class Session {
     this.thriftDefaultBufferSize = thriftDefaultBufferSize;
     this.thriftMaxFrameSize = thriftMaxFrameSize;
     this.enableCacheLeader = enableCacheLeader;
-  }
-
-  public synchronized void clusterOpen() throws IoTDBConnectionException {
-    clusterOpen(false);
-  }
-
-  public synchronized void clusterOpen(boolean enableRPCCompression)
-      throws IoTDBConnectionException {
-    clusterOpen(enableRPCCompression, Config.DEFAULT_CONNECTION_TIMEOUT_MS);
-  }
-
-  public synchronized void clusterOpen(boolean enableRPCCompression, int connectionTimeoutInMs)
-      throws IoTDBConnectionException {
-    if (!isClosed) {
-      return;
-    }
-
-    this.enableRPCCompression = enableRPCCompression;
-    this.connectionTimeoutInMs = connectionTimeoutInMs;
-    defaultSessionConnection = constructClusterSessionConn(this, zoneId);
-    defaultSessionConnection.setEnableRedirect(enableQueryRedirection);
-    metaSessionConnection = defaultSessionConnection;
-    isClosed = false;
-    if (enableCacheLeader || enableQueryRedirection) {
-      deviceIdToEndpoint = new HashMap<>();
-      endPointToSessionConnection = new HashMap<>();
-      endPointToSessionConnection.put(defaultEndPoint, defaultSessionConnection);
-    }
-  }
-
-  private SessionConnection constructClusterSessionConn(Session session, ZoneId zoneId)
-      throws IoTDBConnectionException {
-    return new SessionConnection(session, zoneId);
   }
 
   public void setFetchSize(int fetchSize) {
@@ -359,6 +350,9 @@ public class Session {
 
   public SessionConnection constructSessionConnection(
       Session session, EndPoint endpoint, ZoneId zoneId) throws IoTDBConnectionException {
+    if (endpoint == null) {
+      return new SessionConnection(session, zoneId);
+    }
     return new SessionConnection(session, endpoint, zoneId);
   }
 

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -74,7 +74,6 @@ public class SessionConnection {
   private long sessionId;
   private long statementId;
   private ZoneId zoneId;
-  private EndPoint endPoint;
   private List<EndPoint> endPointList = new ArrayList<>();
   private boolean enableRedirect = false;
 
@@ -84,7 +83,6 @@ public class SessionConnection {
   public SessionConnection(Session session, EndPoint endPoint, ZoneId zoneId)
       throws IoTDBConnectionException {
     this.session = session;
-    this.endPoint = endPoint;
     endPointList.add(endPoint);
     this.zoneId = zoneId == null ? ZoneId.systemDefault() : zoneId;
     init(endPoint);
@@ -161,7 +159,6 @@ public class SessionConnection {
         continue;
       }
       try {
-        this.endPoint = endPoint;
         session.defaultEndPoint = endPoint;
         init(endPoint);
       } catch (IoTDBConnectionException e) {
@@ -753,7 +750,7 @@ public class SessionConnection {
     for (int i = 1; i <= Config.RETRY_NUM; i++) {
       if (transport != null) {
         transport.close();
-        int currHostIndex = endPointList.indexOf(endPoint);
+        int currHostIndex = endPointList.indexOf(session.defaultEndPoint);
         for (int j = currHostIndex; j < endPointList.size(); j++) {
           if (j == -1) {
             continue;
@@ -761,7 +758,6 @@ public class SessionConnection {
           try {
             init(endPointList.get(j));
             flag = true;
-            this.endPoint = endPointList.get(j);
             session.defaultEndPoint = endPointList.get(j);
           } catch (IoTDBConnectionException e) {
             logger.error(
@@ -824,16 +820,16 @@ public class SessionConnection {
     this.enableRedirect = enableRedirect;
   }
 
-  public EndPoint getEndPoint() {
-    return endPoint;
+  public List<EndPoint> getEndPointList() {
+    return endPointList;
   }
 
-  public void setEndPoint(EndPoint endPoint) {
-    this.endPoint = endPoint;
+  public void setEndPointList(List<EndPoint> endPointList) {
+    this.endPointList = endPointList;
   }
 
   @Override
   public String toString() {
-    return "SessionConnection{" + " endPoint=" + endPoint + "}";
+    return "SessionConnection{" + " endPointList=" + endPointList.toString() + "}";
   }
 }

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -746,30 +746,27 @@ public class SessionConnection {
 
   private boolean reconnect() {
     boolean flag = false;
-    for (int i = Config.RETRY_NUM; i >= 0; i--) {
-      if (transport != null) {
-        transport.close();
-        int currHostIndex = endPointList.indexOf(session.defaultEndPoint);
-        for (int j = currHostIndex + 1; j < endPointList.size(); j++) {
-          session.defaultEndPoint = endPointList.get(j);
-          this.endPoint = endPointList.get(j);
-          if (currHostIndex == j) {
-            break;
-          }
-          if (j == endPointList.size() - 1) {
-            j = -1;
-          }
-          try {
-            init(endPoint);
-            flag = true;
-          } catch (IoTDBConnectionException e) {
-            logger.error("The current node may have been down {},try next node", endPoint);
-            continue;
-          }
+    if (transport != null) {
+      transport.close();
+      int currHostIndex = endPointList.indexOf(session.defaultEndPoint);
+      int tag = 0;
+      for (int j = currHostIndex; j < endPointList.size(); j++) {
+        if (tag == endPointList.size()) {
           break;
         }
-      }
-      if (flag) {
+        session.defaultEndPoint = endPointList.get(j);
+        this.endPoint = endPointList.get(j);
+        if (j == endPointList.size() - 1) {
+          j = -1;
+        }
+        tag++;
+        try {
+          init(endPoint);
+          flag = true;
+        } catch (IoTDBConnectionException e) {
+          logger.error("The current node may have been down {},try next node", endPoint);
+          continue;
+        }
         break;
       }
     }

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -751,7 +751,7 @@ public class SessionConnection {
         if (currHostIndex == endPointList.size() - 1) {
           currHostIndex = 0;
         }
-        for (int j = currHostIndex + 1; j < endPointList.size(); j++) {
+        for (int j = currHostIndex; j < endPointList.size(); j++) {
           try {
             session.defaultEndPoint = endPointList.get(j);
             init(endPointList.get(j));

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -155,9 +155,6 @@ public class SessionConnection {
 
   private void initClusterConn() throws IoTDBConnectionException {
     for (EndPoint endPoint : endPointList) {
-      if (endPoint == null) {
-        continue;
-      }
       try {
         session.defaultEndPoint = endPoint;
         init(endPoint);
@@ -752,9 +749,6 @@ public class SessionConnection {
         transport.close();
         int currHostIndex = endPointList.indexOf(session.defaultEndPoint);
         for (int j = currHostIndex; j < endPointList.size(); j++) {
-          if (j == -1) {
-            continue;
-          }
           try {
             init(endPointList.get(j));
             flag = true;

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -748,17 +748,20 @@ public class SessionConnection {
       if (transport != null) {
         transport.close();
         int currHostIndex = endPointList.indexOf(session.defaultEndPoint);
-        if (currHostIndex == endPointList.size() - 1) {
-          currHostIndex = 0;
-        }
-        for (int j = currHostIndex; j < endPointList.size(); j++) {
+        for (int j = currHostIndex + 1; j < endPointList.size(); j++) {
+          session.defaultEndPoint = endPointList.get(j);
+          if (currHostIndex == j) {
+            break;
+          }
+          if (j == endPointList.size() - 1) {
+            j = -1;
+          }
           try {
-            session.defaultEndPoint = endPointList.get(j);
-            init(endPointList.get(j));
+            init(session.defaultEndPoint);
             flag = true;
           } catch (IoTDBConnectionException e) {
             logger.error(
-                "The current node may have been down {},try next node", endPointList.get(j));
+                "The current node may have been down {},try next node", session.defaultEndPoint);
             continue;
           }
           break;

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -748,11 +748,14 @@ public class SessionConnection {
       if (transport != null) {
         transport.close();
         int currHostIndex = endPointList.indexOf(session.defaultEndPoint);
-        for (int j = currHostIndex; j < endPointList.size(); j++) {
+        if (currHostIndex == endPointList.size() - 1) {
+          currHostIndex = 0;
+        }
+        for (int j = currHostIndex + 1; j < endPointList.size(); j++) {
           try {
+            session.defaultEndPoint = endPointList.get(j);
             init(endPointList.get(j));
             flag = true;
-            session.defaultEndPoint = endPointList.get(j);
           } catch (IoTDBConnectionException e) {
             logger.error(
                 "The current node may have been down {},try next node", endPointList.get(j));

--- a/session/src/main/java/org/apache/iotdb/session/SessionUtils.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionUtils.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class SessionUtils {
@@ -161,7 +160,7 @@ public class SessionUtils {
 
   public static List<EndPoint> parseSeedNodeUrls(List<String> nodeUrls) {
     if (nodeUrls == null) {
-      return Collections.emptyList();
+      throw new NumberFormatException("nodeUrls is null");
     }
     List<EndPoint> endPointsList = new ArrayList<>();
     for (String nodeUrl : nodeUrls) {
@@ -175,15 +174,14 @@ public class SessionUtils {
     EndPoint endPoint = new EndPoint();
     String[] split = nodeUrl.split(":");
     if (split.length != 2) {
-      return null;
+      throw new NumberFormatException("NodeUrl Incorrect format");
     }
     String ip = split[0];
     try {
       int rpcPort = Integer.parseInt(split[1]);
       return endPoint.setIp(ip).setPort(rpcPort);
-    } catch (NumberFormatException e) {
-      logger.warn("parse url fail {}", nodeUrl);
+    } catch (Exception e) {
+      throw new NumberFormatException("NodeUrl Incorrect format");
     }
-    return endPoint;
   }
 }

--- a/session/src/main/java/org/apache/iotdb/session/SessionUtils.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.session;
 
+import org.apache.iotdb.service.rpc.thrift.EndPoint;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.Binary;
@@ -27,9 +28,17 @@ import org.apache.iotdb.tsfile.write.record.Tablet;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class SessionUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(SessionUtils.class);
 
   public static ByteBuffer getTimeBuffer(Tablet tablet) {
     ByteBuffer timeBuffer = ByteBuffer.allocate(tablet.getTimeBytesSize());
@@ -148,5 +157,33 @@ public class SessionUtils {
         throw new UnSupportedDataTypeException(
             String.format("Data type %s is not supported.", dataType));
     }
+  }
+
+  public static List<EndPoint> parseSeedNodeUrls(List<String> nodeUrls) {
+    if (nodeUrls == null) {
+      return Collections.emptyList();
+    }
+    List<EndPoint> endPointsList = new ArrayList<>();
+    for (String nodeUrl : nodeUrls) {
+      EndPoint endPoint = parseNodeUrl(nodeUrl);
+      endPointsList.add(endPoint);
+    }
+    return endPointsList;
+  }
+
+  private static EndPoint parseNodeUrl(String nodeUrl) {
+    EndPoint endPoint = new EndPoint();
+    String[] split = nodeUrl.split(":");
+    if (split.length != 2) {
+      return null;
+    }
+    String ip = split[0];
+    try {
+      int rpcPort = Integer.parseInt(split[1]);
+      return endPoint.setIp(ip).setPort(rpcPort);
+    } catch (NumberFormatException e) {
+      logger.warn("parse url fail {}", nodeUrl);
+    }
+    return endPoint;
   }
 }

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionComplexIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionComplexIT.java
@@ -897,7 +897,7 @@ public class IoTDBSessionComplexIT {
     nodeList.add("127.0.0.1:6667");
     nodeList.add("127.0.0.1:6668");
     session = new Session(nodeList, "root", "root");
-    session.clusterOpen();
+    session.open();
 
     session.setStorageGroup("root.sg1");
 

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionComplexIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionComplexIT.java
@@ -889,4 +889,24 @@ public class IoTDBSessionComplexIT {
 
     session.close();
   }
+
+  @Test
+  public void testSessionCluster() throws IoTDBConnectionException, StatementExecutionException {
+    ArrayList<String> nodeList = new ArrayList<>();
+    nodeList.add("127.0.0.1:6669");
+    nodeList.add("127.0.0.1:6667");
+    nodeList.add("127.0.0.1:6668");
+    session = new Session(nodeList, "root", "root");
+    session.clusterOpen();
+
+    session.setStorageGroup("root.sg1");
+
+    createTimeseries();
+    insertByStr();
+
+    insertViaSQL();
+    queryByDevice("root.sg1.d1");
+
+    session.close();
+  }
 }

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionComplexIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionComplexIT.java
@@ -909,4 +909,19 @@ public class IoTDBSessionComplexIT {
 
     session.close();
   }
+
+  @Test
+  public void testErrorSessionCluster() throws IoTDBConnectionException {
+    ArrayList<String> nodeList = new ArrayList<>();
+    // test Format error
+    nodeList.add("127.0.0.16669");
+    nodeList.add("127.0.0.1:6667");
+    session = new Session(nodeList, "root", "root");
+    try {
+      session.open();
+    } catch (Exception e) {
+      Assert.assertEquals("NodeUrl Incorrect format", e.getMessage());
+    }
+    session.close();
+  }
 }

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterSessionSimpleIT.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterSessionSimpleIT.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.sql;
+
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.session.Session;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.NoProjectNameDockerComposeContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClusterSessionSimpleIT {
+
+  private static Logger node1Logger = LoggerFactory.getLogger("iotdb-server_1");
+  private static Logger node2Logger = LoggerFactory.getLogger("iotdb-server_2");
+  private static Logger node3Logger = LoggerFactory.getLogger("iotdb-server_3");
+
+  private Session session;
+
+  @Rule
+  public DockerComposeContainer environment =
+      new NoProjectNameDockerComposeContainer(
+              "3nodes", new File("src/test/resources/3nodes/docker-compose.yaml"))
+          .withExposedService("iotdb-server_1", 6667, Wait.forListeningPort())
+          .withLogConsumer("iotdb-server_1", new Slf4jLogConsumer(node1Logger))
+          .withExposedService("iotdb-server_2", 6667, Wait.forListeningPort())
+          .withLogConsumer("iotdb-server_2", new Slf4jLogConsumer(node2Logger))
+          .withExposedService("iotdb-server_3", 6667, Wait.forListeningPort())
+          .withLogConsumer("iotdb-server_3", new Slf4jLogConsumer(node3Logger))
+          .withLocalCompose(true);
+
+  protected DockerComposeContainer getContainer() {
+    return environment;
+  }
+
+  @Test
+  public void testSessionCluster() throws IoTDBConnectionException, StatementExecutionException {
+    List<String> stringList = new ArrayList<>();
+    Integer service1Port = getContainer().getServicePort("iotdb-server_1", 6667);
+    Integer service2Port = getContainer().getServicePort("iotdb-server_2", 6667);
+    Integer service3Port = getContainer().getServicePort("iotdb-server_3", 6667);
+    stringList.add("localhost:" + service1Port);
+    stringList.add("localhost:" + service2Port);
+    stringList.add("localhost:" + service3Port);
+    session = new Session(stringList, "root", "root");
+    session.clusterOpen();
+    session.setStorageGroup("root.sg1");
+    session.createTimeseries(
+        "root.sg1.d1.s1", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
+
+    session.createTimeseries(
+        "root.sg1.d2.s1", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
+    String deviceId = "root.sg1.d1";
+    List<String> measurements = new ArrayList<>();
+    measurements.add("s1");
+    measurements.add("s2");
+
+    for (long time = 0; time < 100; time++) {
+      List<String> values = new ArrayList<>();
+      values.add("1");
+      values.add("2");
+      session.insertRecord(deviceId, time, measurements, values);
+    }
+    session.close();
+  }
+}

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterSessionSimpleIT.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterSessionSimpleIT.java
@@ -80,17 +80,6 @@ public class ClusterSessionSimpleIT {
 
     session.createTimeseries(
         "root.sg1.d2.s1", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
-    String deviceId = "root.sg1.d1";
-    List<String> measurements = new ArrayList<>();
-    measurements.add("s1");
-    measurements.add("s2");
-
-    for (long time = 0; time < 100; time++) {
-      List<String> values = new ArrayList<>();
-      values.add("1");
-      values.add("2");
-      session.insertRecord(deviceId, time, measurements, values);
-    }
     session.close();
   }
 }

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterSessionSimpleIT.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/ClusterSessionSimpleIT.java
@@ -73,7 +73,7 @@ public class ClusterSessionSimpleIT {
     stringList.add("localhost:" + service2Port);
     stringList.add("localhost:" + service3Port);
     session = new Session(stringList, "root", "root");
-    session.clusterOpen();
+    session.open();
     session.setStorageGroup("root.sg1");
     session.createTimeseries(
         "root.sg1.d1.s1", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);


### PR DESCRIPTION
While the cluster is running, the coordinator node may go down, which may cause the session to be unable to read or write properly.i add a session interface to connect multiple nodes.Users can now define a list that contains multiple servers that can be connected. When one of the servers goes down, try again. If it fails, connect to the next one. If all the nodes in the list fail, an exception will be thrown.