### PR TITLE
[ISSUE-3316] Fix constructing firstChunkMetaDatahasNextChunk logic in hasNextChunk()

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
@@ -320,13 +320,16 @@ public class SeriesReader {
       /*
        * first time series metadata is already unpacked, consume cached ChunkMetadata
        */
-      if (!cachedChunkMetadata.isEmpty()) {
+      while (!cachedChunkMetadata.isEmpty()) {
         firstChunkMetadata = cachedChunkMetadata.peek();
         unpackAllOverlappedTsFilesToTimeSeriesMetadata(
             orderUtils.getOverlapCheckTime(firstChunkMetadata.getStatistics()));
         unpackAllOverlappedTimeSeriesMetadataToCachedChunkMetadata(
             orderUtils.getOverlapCheckTime(firstChunkMetadata.getStatistics()), false);
-        firstChunkMetadata = cachedChunkMetadata.poll();
+        if (firstChunkMetadata.equals(cachedChunkMetadata.peek())) {
+          firstChunkMetadata = cachedChunkMetadata.poll();
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
After PR #3317，the logic I modified seems still be something wrong. After updating firstChunkMetaData, we need to unpack overlappedTimeSeriesMetaData using it again.