### PR TITLE
[IOTDB-1456] Fix Error occurred while executing delete timeseries statement

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
@@ -38,6 +38,7 @@ import org.apache.iotdb.db.qp.executor.PlanExecutor;
 import org.apache.iotdb.db.qp.physical.BatchPlan;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
+import org.apache.iotdb.db.qp.physical.sys.DeleteTimeSeriesPlan;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
@@ -94,6 +95,7 @@ abstract class BaseApplier implements LogApplier {
   private void handleBatchProcessException(BatchProcessException e, PhysicalPlan plan)
       throws QueryProcessException, StorageEngineException, StorageGroupNotSetException {
     TSStatus[] failingStatus = e.getFailingStatus();
+    boolean needThrow = false;
     for (int i = 0; i < failingStatus.length; i++) {
       TSStatus status = failingStatus[i];
       // skip succeeded plans in later execution
@@ -101,6 +103,16 @@ abstract class BaseApplier implements LogApplier {
           && status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()
           && plan instanceof BatchPlan) {
         ((BatchPlan) plan).setIsExecuted(i);
+      }
+
+      if (plan instanceof DeleteTimeSeriesPlan) {
+        if (status != null && status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+          if (status.getCode() == TSStatusCode.TIMESERIES_NOT_EXIST.getStatusCode()) {
+            logger.info("{} doesn't exist, it may has been deleted.", plan.getPaths().get(i));
+          } else {
+            needThrow = true;
+          }
+        }
       }
     }
     boolean needRetry = false;
@@ -118,7 +130,10 @@ abstract class BaseApplier implements LogApplier {
       executeAfterSync(plan);
       return;
     }
-    throw e;
+
+    if (!(plan instanceof DeleteTimeSeriesPlan) || needThrow) {
+      throw e;
+    }
   }
 
   private void executeAfterSync(PhysicalPlan plan)

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.qp.physical.sys.CreateFunctionPlan;
 import org.apache.iotdb.db.qp.physical.sys.DropFunctionPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowFunctionsPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowPlan;
+import org.apache.iotdb.rpc.BatchExecutionException;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.Session;
@@ -140,6 +141,23 @@ public abstract class Cases {
       double last = Double.parseDouble(resultSet.getString(3));
       Assert.assertEquals(25.0, last, 0.1);
       resultSet.close();
+    }
+
+    // test https://issues.apache.org/jira/browse/IOTDB-1457
+    initDataArray =
+        new String[] {
+          "INSERT INTO root.ln.wf011.wt0110(timestamp, temperature) values(250, 10.0)",
+          "INSERT INTO root.ln.wf011.wt0111(timestamp, temperature) values(300, 20.0)",
+          "INSERT INTO root.ln.wf011.wt0112(timestamp, temperature) values(350, 25.0)"
+        };
+
+    for (String initData : initDataArray) {
+      writeStatement.execute(initData);
+    }
+    try {
+      session.executeNonQueryStatement(" delete from root.ln.wf011.*");
+    } catch (StatementExecutionException | IoTDBConnectionException e) {
+      Assert.assertFalse(e instanceof BatchExecutionException);
     }
 
     // test dictionary encoding


### PR DESCRIPTION
Error was thrown in cluster mode when executing delete timeseries statement.
It happended frequently in the condition that ReplicateNum greater than node count.
It seems that batch exception is not handled correctly, timeseries does not exist exception should be skipped when delete timeseries plan is executing.


More details in https://issues.apache.org/jira/browse/IOTDB-1456