### PR TITLE
[To rel/0.12] [IOTDB-1456] Fix Error occurred while executing delete timeseries statement

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
@@ -37,6 +37,7 @@ import org.apache.iotdb.db.qp.executor.PlanExecutor;
 import org.apache.iotdb.db.qp.physical.BatchPlan;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
+import org.apache.iotdb.db.qp.physical.sys.DeleteTimeSeriesPlan;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -93,6 +94,7 @@ abstract class BaseApplier implements LogApplier {
   private void handleBatchProcessException(BatchProcessException e, PhysicalPlan plan)
       throws QueryProcessException, StorageEngineException, StorageGroupNotSetException {
     TSStatus[] failingStatus = e.getFailingStatus();
+    boolean needThrow = false;
     for (int i = 0; i < failingStatus.length; i++) {
       TSStatus status = failingStatus[i];
       // skip succeeded plans in later execution
@@ -100,6 +102,16 @@ abstract class BaseApplier implements LogApplier {
           && status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()
           && plan instanceof BatchPlan) {
         ((BatchPlan) plan).setIsExecuted(i);
+      }
+
+      if (plan instanceof DeleteTimeSeriesPlan) {
+        if (status != null && status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+          if (status.getCode() != TSStatusCode.TIMESERIES_NOT_EXIST.getStatusCode()) {
+            logger.info("{} doesn't exist, it may has been deleted.", plan.getPaths().get(i));
+          } else {
+            needThrow = true;
+          }
+        }
       }
     }
     boolean needRetry = false;
@@ -116,7 +128,10 @@ abstract class BaseApplier implements LogApplier {
       executeAfterSync(plan);
       return;
     }
-    throw e;
+
+    if (!(plan instanceof DeleteTimeSeriesPlan) || needThrow) {
+      throw e;
+    }
   }
 
   private void executeAfterSync(PhysicalPlan plan)


### PR DESCRIPTION
Error was thrown in cluster mode when executing delete timeseries statement.
It happended frequently in the condition that ReplicateNum greater than node count.
It seems that batch exception is not handled correctly, timeseries does not exist exception should be skipped when delete timeseries plan is executing.

More details in https://issues.apache.org/jira/browse/IOTDB-1456