### PR TITLE
[IOTDB-1462][To rel/0.12] Fix cross space compaction recover bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -494,7 +494,7 @@ public class StorageGroupProcessor {
               tsFileManagement::mergeEndAction,
               taskName,
               IoTDBDescriptor.getInstance().getConfig().isForceFullMerge(),
-              logicalStorageGroupName + "-" + virtualStorageGroupId);
+              logicalStorageGroupName);
       logger.info(
           "{} - {} a RecoverMergeTask {} starts...",
           logicalStorageGroupName,


### PR DESCRIPTION
# Problem
Currently, when we recover cross space compaction, We pass ${logicalStorageName}-${virtualStorageGroupId} to find its timeseries in MManager which must be empty.
# Solution
Only pass storageGroupName to MManager.