### PR TITLE
[IOTDB-1462] fix cross space compaction recover use wrong storage group name bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -485,7 +485,7 @@ public class StorageGroupProcessor {
               tsFileManagement::mergeEndAction,
               taskName,
               IoTDBDescriptor.getInstance().getConfig().isForceFullMerge(),
-              logicalStorageGroupName + "-" + virtualStorageGroupId);
+              logicalStorageGroupName);
       logger.info(
           "{} - {} a RecoverMergeTask {} starts...",
           logicalStorageGroupName,

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBGroupByMonthIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBGroupByMonthIT.java
@@ -34,6 +34,8 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.TimeZone;
 
 import static org.apache.iotdb.db.constant.TestConstant.sum;
@@ -237,12 +239,18 @@ public class IoTDBGroupByMonthIT {
 
       Assert.assertTrue(hasResultSet);
       int cnt = 0;
+      List<String> times = new ArrayList<>();
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
           String ans = resultSet.getString(sum("root.sg1.d1.temperature"));
+          times.add(resultSet.getString("Time"));
           if (ans.equals("0.0")) {
             cnt++;
           }
+        }
+        if (cnt < 28 || cnt > 31) {
+          System.out.println("cnt: " + cnt);
+          System.out.println(times);
         }
         Assert.assertTrue(cnt >= 28);
         Assert.assertTrue(cnt <= 31);


### PR DESCRIPTION
# Problem
Currently, when we recover cross space compaction, We pass ${logicalStorageName}-${virtualStorageGroupId} to find its timeseries in MManager which must be empty.
# Solution
Only pass storageGroupName to MManager.