### PR TITLE
[To rel/0.12] [IOTDB-1464] fix take byte array null pointer

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/utils/PlanSerializer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/utils/PlanSerializer.java
@@ -35,7 +35,13 @@ public class PlanSerializer {
   }
 
   public byte[] serialize(PhysicalPlan plan) throws IOException {
-    ByteArrayOutputStream poll = baosBlockingDeque.poll();
+    ByteArrayOutputStream poll;
+    try {
+      poll = baosBlockingDeque.take();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("take byte array output stream interrupted", e);
+    }
     poll.reset();
 
     try (DataOutputStream dataOutputStream = new DataOutputStream(poll)) {


### PR DESCRIPTION
The BlockingDeque has some buffered ByteArrayOutputStream to reuse.
However, if the buffered ByteArrayOutputStreams are all in use, the poll() method will return a null object without waiting. which causes a null pointer.

So, we need to use the take() method to take a ByteArrayOutputStream until we could take one.

