### PR TITLE
[IOTDB-1243]update DML delete grammar doc

### DIFF
--- a/docs/UserGuide/IoTDB-SQL-Language/DML-Data-Manipulation-Language.md
+++ b/docs/UserGuide/IoTDB-SQL-Language/DML-Data-Manipulation-Language.md
@@ -1562,11 +1562,10 @@ or
 ```
 delete from root.ln.wf02.wt02.* where time <= 2017-11-01T16:26:00;
 ```
-It should be noted that when the deleted path does not exist, IoTDB will give the corresponding error prompt as shown below:
-
+It should be noted that when the deleted path does not exist, IoTDB will not prompt that the path does not exist, but that the execution is successful, because SQL is a declarative programming method. Unless it is a syntax error, insufficient permissions and so on, it is not considered an error, as shown below:
 ```
 IoTDB> delete from root.ln.wf03.wt02.status where time < now()
-Msg: TimeSeries does not exist and its data cannot be deleted
+Msg: The statement is executed successfully.
 ```
 
 ### Delete Time Partition (experimental)

--- a/docs/zh/UserGuide/IoTDB-SQL-Language/DML-Data-Manipulation-Language.md
+++ b/docs/zh/UserGuide/IoTDB-SQL-Language/DML-Data-Manipulation-Language.md
@@ -1551,11 +1551,11 @@ delete from root.ln.wf02.wt02 where time <= 2017-11-01T16:26:00;
 delete from root.ln.wf02.wt02.* where time <= 2017-11-01T16:26:00;
 ```
 
-需要注意的是，当删除的路径不存在时，IoTDB会提示路径不存在，无法删除数据，如下所示。
+需要注意的是，当删除的路径不存在时，IoTDB不会提示路径不存在，而是显示执行成功，因为SQL是一种声明式的编程方式，除非是语法错误、权限不足等，否则都不认为是错误，如下所示。
 
 ```
 IoTDB> delete from root.ln.wf03.wt02.status where time < now()
-Msg: TimeSeries does not exist and its data cannot be deleted
+Msg: The statement is executed successfully.
 ```
 
 ### 删除时间分区 (实验性功能)


### PR DESCRIPTION
JR:https://issues.apache.org/jira/browse/IOTDB-1243

In Mysql: delete from table where id = 999;   if id not exist，It will not report an error, but it will display the execution result or influence result as 0
So,I think IOTDB code is true, we need update doc and  like mysql result in the future

![image](https://user-images.githubusercontent.com/55303647/124424080-fc254300-dd98-11eb-8ba8-e9c099999ddf.png)
