### PR TITLE
[IOTDB-1461][To rel/0.12] Fix compaction conflicts with ttl 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1431,9 +1431,7 @@ public class StorageGroupProcessor {
   }
 
   private void checkFileTTL(TsFileResource resource, long timeLowerBound, boolean isSeq) {
-    if (resource.isMerging()
-        || !resource.isClosed()
-        || !resource.isDeleted() && resource.stillLives(timeLowerBound)) {
+    if (!resource.isClosed() || !resource.isDeleted() && resource.stillLives(timeLowerBound)) {
       return;
     }
 
@@ -1441,11 +1439,6 @@ public class StorageGroupProcessor {
     try {
       // prevent new merges and queries from choosing this file
       resource.setDeleted(true);
-      // the file may be chosen for merge after the last check and before writeLock()
-      // double check to ensure the file is not used by a merge
-      if (resource.isMerging()) {
-        return;
-      }
 
       // ensure that the file is not used by any queries
       if (resource.tryWriteLock()) {


### PR DESCRIPTION
# Problem
This problem occurs because when compaction processes, it will set TsFile's status to isMerging, which prevents TTL process from delete it.
However, when the Tsfile be deleted during compaction. The compaction will failed and it cannot set the isMerging status to false. So the TTL process cannot delete it.

# Solution
1. When the compaction failed, set the isMerging status to false.
2. Do not check isMerging status when checking TTL.