### PR TITLE
[IOTDB-1469][To rel/0.11] fix cross space compaction loss data bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
@@ -206,12 +206,9 @@ public class MergeMultiChunkTask {
 
   private void pathsMergeOneFile(int seqFileIdx, IPointReader[] unseqReaders) throws IOException {
     TsFileResource currTsFile = resource.getSeqFiles().get(seqFileIdx);
+    // all paths in one call are from the same device
     String deviceId = currMergingPaths.get(0).getDevice();
     long currDeviceMinTime = currTsFile.getStartTime(deviceId);
-    // all paths in one call are from the same device
-    if (currDeviceMinTime == Long.MAX_VALUE) {
-      return;
-    }
 
     for (PartialPath path : currMergingPaths) {
       mergeContext.getUnmergedChunkStartTimes().get(currTsFile).put(path, new ArrayList<>());
@@ -335,10 +332,8 @@ public class MergeMultiChunkTask {
     // series should also be written into a new chunk
     List<Integer> ret = new ArrayList<>();
     for (int i = 0; i < currMergingPaths.size(); i++) {
-      if (seqChunkMeta[i] == null
-          || seqChunkMeta[i].isEmpty()
-              && !(seqFileIdx + 1 == resource.getSeqFiles().size()
-                  && currTimeValuePairs[i] != null)) {
+      if ((seqChunkMeta[i] == null || seqChunkMeta[i].isEmpty())
+          && !(seqFileIdx + 1 == resource.getSeqFiles().size() && currTimeValuePairs[i] != null)) {
         continue;
       }
       ret.add(i);


### PR DESCRIPTION
# Behavior
Some data lost after cross space compaction.
Before compaction:
![image](https://user-images.githubusercontent.com/24886743/124583393-92cf2e00-de85-11eb-8c63-bc8c94507d18.png)
After compaction:
![image](https://user-images.githubusercontent.com/24886743/124583426-9a8ed280-de85-11eb-8023-60ff33336951.png)
Use the data below and execute cross space compaction can reproduce this problem.
https://cloud.tsinghua.edu.cn/f/4c320559a2574ca9b0d5/?dl=1

# Problem
In cross compaction, there is a logic: If none of the seq files has a timeseries, then data of this timeseries will be compacted into the last seq file. However, if the seq file miss the device of the timeseries, all these logic will be passed.
e.g.
compact 3 seqFile and 1 unseqFile
seqFile1: d1.s1:0-100 d1.s2:0-100
seqFile2: d1.s1:100-200
seqFile3: d2.s1:0-100
unseqFile1: d1.s3:0-100
the d1.s3 in unseqFile1 will loss.

# Solution
1. Even the seq file miss the device of the timeseries, do not return.
2. Solve a bug of filterNoDataPaths.