### PR TITLE
Improve group by month performance

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/GroupByMonthFilter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/GroupByMonthFilter.java
@@ -74,21 +74,18 @@ public class GroupByMonthFilter extends GroupByFilter {
   // TODO: time descending order
   @Override
   public boolean satisfy(long time, Object value) {
-    boolean isSatisfy;
-    long count = getTimePointPosition(time);
-    getNthTimeInterval(count);
-    if (time < startTime || time >= endTime) {
-      isSatisfy = false;
+    if (satisfyCurrentInterval(time)) {
+      return true;
     } else {
-      isSatisfy = time - startTime < interval;
+      long count = getTimePointPosition(time);
+      getNthTimeInterval(count);
+      return satisfyCurrentInterval(time);
     }
-    return isSatisfy;
   }
 
   @Override
   public boolean satisfyStartEndTime(long startTime, long endTime) {
-    boolean isSatisfy = satisfyCurrentInterval(startTime, endTime);
-    if (isSatisfy) {
+    if (satisfyCurrentInterval(startTime, endTime)) {
       return true;
     } else {
       // get the interval which contains the start time
@@ -96,20 +93,25 @@ public class GroupByMonthFilter extends GroupByFilter {
       getNthTimeInterval((int) count);
       // judge two adjacent intervals
       if (satisfyCurrentInterval(startTime, endTime)) {
-        isSatisfy = true;
+        return true;
       } else {
         getNthTimeInterval((int) count + 1);
-        if (satisfyCurrentInterval(startTime, endTime)) {
-          isSatisfy = true;
-        }
+        return satisfyCurrentInterval(startTime, endTime);
       }
-      return isSatisfy;
     }
   }
 
   @Override
   public Filter copy() {
     return new GroupByMonthFilter(this);
+  }
+
+  private boolean satisfyCurrentInterval(long time) {
+    if (time < startTime || time >= endTime) {
+      return false;
+    } else {
+      return time - startTime < interval;
+    }
   }
 
   private boolean satisfyCurrentInterval(long startTime, long endTime) {
@@ -122,18 +124,14 @@ public class GroupByMonthFilter extends GroupByFilter {
 
   @Override
   public boolean containStartEndTime(long startTime, long endTime) {
-    boolean isContained = isContainedByCurrentInterval(startTime, endTime);
-    if (isContained) {
+    if (isContainedByCurrentInterval(startTime, endTime)) {
       return true;
     } else {
       // get the interval which contains the start time
       long count = getTimePointPosition(startTime);
       getNthTimeInterval((int) count);
       // judge single interval that contains start time
-      if (isContainedByCurrentInterval(startTime, endTime)) {
-        isContained = true;
-      }
-      return isContained;
+      return isContainedByCurrentInterval(startTime, endTime);
     }
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/GroupByMonthFilter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/GroupByMonthFilter.java
@@ -74,16 +74,14 @@ public class GroupByMonthFilter extends GroupByFilter {
   // TODO: time descending order
   @Override
   public boolean satisfy(long time, Object value) {
-    if (time < startTime || time >= endTime) {
+    if (time < initialStartTime || time >= endTime) {
       return false;
-    } else if (time - startTime < interval) {
-      return true;
-    } else if (time - startTime < slidingStep) {
-      return false;
+    } else if (time >= startTime && time < startTime + slidingStep) {
+      return time - startTime < interval;
     } else {
       long count = getTimePointPosition(time);
       getNthTimeInterval(count);
-      return satisfy(time, value);
+      return time - startTime < interval;
     }
   }
 
@@ -183,6 +181,7 @@ public class GroupByMonthFilter extends GroupByFilter {
 
   /** get the Nth time interval */
   private void getNthTimeInterval(long n) {
+    // get start time of time interval
     if (isSlidingStepByMonth) {
       calendar.setTimeInMillis(initialStartTime);
       calendar.add(Calendar.MONTH, (int) (slidingStepsInMo * n));
@@ -191,9 +190,14 @@ public class GroupByMonthFilter extends GroupByFilter {
     }
     this.startTime = calendar.getTimeInMillis();
 
+    // get interval and sliding step
     if (isIntervalByMonth) {
-      calendar.setTimeInMillis(initialStartTime);
-      calendar.add(Calendar.MONTH, (int) (slidingStepsInMo * n) + intervalInMo);
+      if (isSlidingStepByMonth) {
+        calendar.setTimeInMillis(initialStartTime);
+        calendar.add(Calendar.MONTH, (int) (slidingStepsInMo * n) + intervalInMo);
+      } else {
+        calendar.add(Calendar.MONTH, intervalInMo);
+      }
       this.interval = calendar.getTimeInMillis() - startTime;
     }
     if (isSlidingStepByMonth) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/GroupByMonthFilter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/GroupByMonthFilter.java
@@ -92,12 +92,12 @@ public class GroupByMonthFilter extends GroupByFilter {
     } else {
       // get the interval which contains the start time
       long count = getTimePointPosition(startTime);
-      getNthTimeInterval((int) count);
+      getNthTimeInterval(count);
       // judge two adjacent intervals
       if (satisfyCurrentInterval(startTime, endTime)) {
         return true;
       } else {
-        getNthTimeInterval((int) count + 1);
+        getNthTimeInterval(count + 1);
         return satisfyCurrentInterval(startTime, endTime);
       }
     }
@@ -123,7 +123,7 @@ public class GroupByMonthFilter extends GroupByFilter {
     } else {
       // get the interval which contains the start time
       long count = getTimePointPosition(startTime);
-      getNthTimeInterval((int) count);
+      getNthTimeInterval(count);
       // judge single interval that contains start time
       return isContainedByCurrentInterval(startTime, endTime);
     }
@@ -157,7 +157,7 @@ public class GroupByMonthFilter extends GroupByFilter {
         interval, slidingStep, startTime, endTime, isSlidingStepByMonth, isIntervalByMonth);
   }
 
-  /** Get the interval that @param time belongs to */
+  /** Get the interval that @param time belongs to. */
   private long getTimePointPosition(long time) {
     long count;
     if (isSlidingStepByMonth) {
@@ -179,7 +179,7 @@ public class GroupByMonthFilter extends GroupByFilter {
     return count;
   }
 
-  /** get the Nth time interval */
+  /** get the Nth time interval. */
   private void getNthTimeInterval(long n) {
     // get start time of time interval
     if (isSlidingStepByMonth) {

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/filter/GroupByMonthFilterTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/filter/GroupByMonthFilterTest.java
@@ -92,6 +92,9 @@ public class GroupByMonthFilterTest {
     // 1970-03-01 08:00:00
     assertTrue(filter.satisfy(5097600000L, null));
 
+    // 1970-12-30 08:00:00
+    assertTrue(filter.satisfy(31363200000L, null));
+
     // 1970-12-31 23:59:58
     assertTrue(filter.satisfy(31507198000L, null));
 
@@ -128,6 +131,25 @@ public class GroupByMonthFilterTest {
 
     // 1970-12-31 23:59:59
     assertFalse(filter.satisfy(31507199000L, null));
+  }
+
+  /** Test filter with slidingStep = 100 days, and timeInterval = 1 mo */
+  @Test
+  public void TestSatisfy4() {
+    GroupByMonthFilter filter =
+        new GroupByMonthFilter(MS_TO_MONTH, MS_TO_DAY * 100, 0, END_TIME, false, true);
+
+    // 1970-01-01 08:00:00, timezone = GMT+08:00
+    assertTrue(filter.satisfy(0, null));
+
+    // 1970-02-01 07:59:59
+    assertTrue(filter.satisfy(2678399000L, null));
+
+    // 1970-03-01 08:00:00
+    assertFalse(filter.satisfy(5097600000L, null));
+
+    // 1970-05-01 08:00:00
+    assertTrue(filter.satisfy(10368000000L, null));
   }
 
   /** Test filter with slidingStep = 1 month, and timeInterval = 1 day */


### PR DESCRIPTION
Currently, when judging whether a page/chunk/point statisfies group by month filter, we get the interval that need to juege directly instead of one by one.