### PR TITLE
[To rel/0.12] PrimitiveArrayManager: improve accuracy when updating limits

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -137,8 +137,6 @@ public class MManager {
   // tag key -> tag value -> LeafMNode
   private Map<String, Map<String, Set<MeasurementMNode>>> tagIndex = new ConcurrentHashMap<>();
 
-  // data type -> number
-  private Map<TSDataType, Integer> schemaDataTypeNumMap = new ConcurrentHashMap<>();
   private AtomicLong totalSeriesNumber = new AtomicLong();
   private boolean initialized;
   protected static IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
@@ -308,7 +306,6 @@ public class MManager {
         tagLogFile.close();
         tagLogFile = null;
       }
-      this.schemaDataTypeNumMap.clear();
       initialized = false;
       if (config.isEnableMTreeSnapshot() && timedCreateMTreeSnapshotThread != null) {
         timedCreateMTreeSnapshotThread.shutdownNow();

--- a/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
@@ -146,7 +146,7 @@ public class PrimitiveArrayManager {
     //     limitBase * ∑(datatype[i].getDataTypeSize() * ratios[i]) * ARRAY_SIZE
     // => limitBase = POOLED_ARRAYS_MEMORY_THRESHOLD / ARRAY_SIZE
     //     / ∑(datatype[i].getDataTypeSize() * ratios[i])
-    long weightedSumOfRatios = 0;
+    double weightedSumOfRatios = 0;
     for (TSDataType dataType : TSDataType.values()) {
       weightedSumOfRatios += dataType.getDataTypeSize() * ratios[dataType.serialize()];
     }


### PR DESCRIPTION
Cast long to double may cause accuracy loss.