### PR TITLE
Fix template restart bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -809,6 +809,7 @@ public class MManager {
       try {
         mNodes[i] = (MeasurementMNode) getNodeByPath(deviceId.concatNode(measurements[i]));
       } catch (PathNotExistException ignored) {
+        logger.warn("{} does not exist in {}", measurements[i], deviceId);
       }
       if (mNodes[i] == null && !IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
         throw new MetadataException(measurements[i] + " does not exist in " + deviceId);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -804,10 +804,12 @@ public class MManager {
 
   public MeasurementMNode[] getMNodes(PartialPath deviceId, String[] measurements)
       throws MetadataException {
-    MNode deviceNode = getNodeByPath(deviceId);
     MeasurementMNode[] mNodes = new MeasurementMNode[measurements.length];
     for (int i = 0; i < mNodes.length; i++) {
-      mNodes[i] = ((MeasurementMNode) deviceNode.getChild(measurements[i]));
+      try {
+        mNodes[i] = (MeasurementMNode) getNodeByPath(deviceId.concatNode(measurements[i]));
+      } catch (PathNotExistException ignored) {
+      }
       if (mNodes[i] == null && !IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
         throw new MetadataException(measurements[i] + " does not exist in " + deviceId);
       }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -876,6 +876,14 @@ public class MManagerBasicTest {
     }
 
     assertTrue(allSchema.isEmpty());
+
+    MeasurementMNode[] mNodes =
+        manager.getMNodes(new PartialPath("root.sg1.d1"), new String[] {"s11"});
+    assertNotNull(mNodes[0]);
+    assertEquals(mNodes[0].getSchema(), s11);
+
+    mNodes = manager.getMNodes(new PartialPath("root.sg1.d1"), new String[] {"s100"});
+    assertNull(mNodes[0]);
   }
 
   private CreateTemplatePlan getCreateTemplatePlan() {


### PR DESCRIPTION
In the current implementation, the template-based time series is restored by calling the getMNodes function after a restart. However, the getMNodes function currently does not support template lookup and this needs to be fixed.