### PR TITLE
[To rel/0.12][IOTDB-1482] Fix Count Timeseries and Count Devices with Template Bug 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -927,7 +927,7 @@ public class MTree implements Serializable {
         MNode child = node.getChild(nodes[idx]);
         if (child == null) {
           if (node.isUseTemplate()
-              && node.getDeviceTemplate().getSchemaMap().containsKey(nodes[idx])) {
+              && node.getUpperTemplate().getSchemaMap().containsKey(nodes[idx])) {
             return 1;
           }
           if (!wildcard) {
@@ -941,7 +941,7 @@ public class MTree implements Serializable {
     } else {
       int sum = node instanceof MeasurementMNode ? 1 : 0;
       if (node.isUseTemplate()) {
-        sum += node.getDeviceTemplate().getSchemaMap().size();
+        sum += node.getUpperTemplate().getSchemaMap().size();
       }
       for (MNode child : node.getChildren().values()) {
         sum += getCount(child, nodes, idx + 1, wildcard);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -926,7 +926,8 @@ public class MTree implements Serializable {
       } else {
         MNode child = node.getChild(nodes[idx]);
         if (child == null) {
-          if(node.isUseTemplate() && node.getDeviceTemplate().getSchemaMap().containsKey(nodes[idx])){
+          if (node.isUseTemplate()
+              && node.getDeviceTemplate().getSchemaMap().containsKey(nodes[idx])) {
             return 1;
           }
           if (!wildcard) {
@@ -939,7 +940,7 @@ public class MTree implements Serializable {
       }
     } else {
       int sum = node instanceof MeasurementMNode ? 1 : 0;
-      if(node.isUseTemplate()){
+      if (node.isUseTemplate()) {
         sum += node.getDeviceTemplate().getSchemaMap().size();
       }
       for (MNode child : node.getChildren().values()) {
@@ -999,22 +1000,22 @@ public class MTree implements Serializable {
   /** Traverse the MTree to get the count of devices. */
   private int getDevicesCount(MNode node, String[] nodes, int idx) {
     String nodeReg = MetaUtils.getNodeRegByIdx(idx, nodes);
-    int cnt = 0;
+    boolean curIsDevice = node.isUseTemplate();
+    int cnt = curIsDevice ? 1 : 0;
     if (!(PATH_WILDCARD).equals(nodeReg)) {
       MNode next = node.getChild(nodeReg);
       if (next != null) {
-        if (next instanceof MeasurementMNode && idx >= nodes.length) {
+        if (next instanceof MeasurementMNode && idx >= nodes.length && !curIsDevice) {
           cnt++;
         } else {
           cnt += getDevicesCount(node.getChild(nodeReg), nodes, idx + 1);
         }
       }
     } else {
-      boolean deviceAdded = false;
       for (MNode child : node.getChildren().values()) {
-        if (child instanceof MeasurementMNode && !deviceAdded && idx >= nodes.length) {
+        if (child instanceof MeasurementMNode && !curIsDevice && idx >= nodes.length) {
           cnt++;
-          deviceAdded = true;
+          curIsDevice = true;
         }
         cnt += getDevicesCount(child, nodes, idx + 1);
       }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -926,6 +926,9 @@ public class MTree implements Serializable {
       } else {
         MNode child = node.getChild(nodes[idx]);
         if (child == null) {
+          if(node.isUseTemplate() && node.getDeviceTemplate().getSchemaMap().containsKey(nodes[idx])){
+            return 1;
+          }
           if (!wildcard) {
             throw new PathNotExistException(node.getName() + NO_CHILDNODE_MSG + nodes[idx]);
           } else {
@@ -936,6 +939,9 @@ public class MTree implements Serializable {
       }
     } else {
       int sum = node instanceof MeasurementMNode ? 1 : 0;
+      if(node.isUseTemplate()){
+        sum += node.getDeviceTemplate().getSchemaMap().size();
+      }
       for (MNode child : node.getChildren().values()) {
         sum += getCount(child, nodes, idx + 1, wildcard);
       }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -1041,7 +1041,7 @@ public class MManagerBasicTest {
   }
 
   @Test
-  public void testCountTimeseriesWithTemplate(){
+  public void testCountTimeseriesWithTemplate() {
     List<List<String>> measurementList = new ArrayList<>();
     measurementList.add(Collections.singletonList("s0"));
     measurementList.add(Collections.singletonList("s1"));
@@ -1064,25 +1064,25 @@ public class MManagerBasicTest {
     schemaNames.add("s1");
 
     CreateTemplatePlan plan =
-            new CreateTemplatePlan(
-                    "template1",
-                    schemaNames,
-                    measurementList,
-                    dataTypeList,
-                    encodingList,
-                    compressionTypes);
+        new CreateTemplatePlan(
+            "template1",
+            schemaNames,
+            measurementList,
+            dataTypeList,
+            encodingList,
+            compressionTypes);
     MManager manager = IoTDB.metaManager;
     try {
       manager.createDeviceTemplate(plan);
 
       // set device template
       SetDeviceTemplatePlan setDeviceTemplatePlan =
-              new SetDeviceTemplatePlan("template1", "root.laptop.d1");
+          new SetDeviceTemplatePlan("template1", "root.laptop.d1");
       manager.setDeviceTemplate(setDeviceTemplatePlan);
       manager.getDeviceNode(new PartialPath("root.laptop.d1")).setUseTemplate(true);
 
-      Assert.assertEquals(2,manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1")));
-      Assert.assertEquals(1,manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1.s1")));
+      Assert.assertEquals(2, manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1")));
+      Assert.assertEquals(1, manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1.s1")));
 
     } catch (MetadataException e) {
       e.printStackTrace();
@@ -1091,8 +1091,61 @@ public class MManagerBasicTest {
   }
 
   @Test
-  public void testCountDeviceWithTemplate(){
+  public void testCountDeviceWithTemplate() {
+    List<List<String>> measurementList = new ArrayList<>();
+    measurementList.add(Collections.singletonList("s0"));
+    measurementList.add(Collections.singletonList("s1"));
 
+    List<List<TSDataType>> dataTypeList = new ArrayList<>();
+    dataTypeList.add(Collections.singletonList(TSDataType.INT32));
+    dataTypeList.add(Collections.singletonList(TSDataType.FLOAT));
+
+    List<List<TSEncoding>> encodingList = new ArrayList<>();
+    encodingList.add(Collections.singletonList(TSEncoding.RLE));
+    encodingList.add(Collections.singletonList(TSEncoding.RLE));
+
+    List<CompressionType> compressionTypes = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      compressionTypes.add(compressionType);
+    }
+
+    List<String> schemaNames = new ArrayList<>();
+    schemaNames.add("s0");
+    schemaNames.add("s1");
+
+    CreateTemplatePlan plan =
+        new CreateTemplatePlan(
+            "template1",
+            schemaNames,
+            measurementList,
+            dataTypeList,
+            encodingList,
+            compressionTypes);
+    MManager manager = IoTDB.metaManager;
+
+    try {
+      manager.createDeviceTemplate(plan);
+      // set device template
+      SetDeviceTemplatePlan setDeviceTemplatePlan =
+          new SetDeviceTemplatePlan("template1", "root.laptop.d1");
+      manager.setDeviceTemplate(setDeviceTemplatePlan);
+      manager.getDeviceNode(new PartialPath("root.laptop.d1")).setUseTemplate(true);
+
+      manager.createTimeseries(
+          new PartialPath("root.laptop.d2.s1"),
+          TSDataType.INT32,
+          TSEncoding.PLAIN,
+          CompressionType.GZIP,
+          null);
+
+      Assert.assertEquals(1, manager.getDevicesNum(new PartialPath("root.laptop.d1")));
+      Assert.assertEquals(1, manager.getDevicesNum(new PartialPath("root.laptop.d2")));
+      Assert.assertEquals(2, manager.getDevicesNum(new PartialPath("root.laptop")));
+
+    } catch (MetadataException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -1081,8 +1081,24 @@ public class MManagerBasicTest {
       manager.setDeviceTemplate(setDeviceTemplatePlan);
       manager.getDeviceNode(new PartialPath("root.laptop.d1")).setUseTemplate(true);
 
+      manager.createTimeseries(
+          new PartialPath("root.computer.d1.s2"),
+          TSDataType.INT32,
+          TSEncoding.PLAIN,
+          CompressionType.GZIP,
+          null);
+
+      setDeviceTemplatePlan = new SetDeviceTemplatePlan("template1", "root.computer");
+      manager.setDeviceTemplate(setDeviceTemplatePlan);
+      manager.getDeviceNode(new PartialPath("root.computer.d1")).setUseTemplate(true);
+
       Assert.assertEquals(2, manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1")));
       Assert.assertEquals(1, manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1.s1")));
+      Assert.assertEquals(1, manager.getAllTimeseriesCount(new PartialPath("root.computer.d1.s1")));
+      Assert.assertEquals(1, manager.getAllTimeseriesCount(new PartialPath("root.computer.d1.s2")));
+      Assert.assertEquals(3, manager.getAllTimeseriesCount(new PartialPath("root.computer.d1")));
+      Assert.assertEquals(3, manager.getAllTimeseriesCount(new PartialPath("root.computer")));
+      Assert.assertEquals(5, manager.getAllTimeseriesCount(new PartialPath("root")));
 
     } catch (MetadataException e) {
       e.printStackTrace();

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -1041,6 +1041,61 @@ public class MManagerBasicTest {
   }
 
   @Test
+  public void testCountTimeseriesWithTemplate(){
+    List<List<String>> measurementList = new ArrayList<>();
+    measurementList.add(Collections.singletonList("s0"));
+    measurementList.add(Collections.singletonList("s1"));
+
+    List<List<TSDataType>> dataTypeList = new ArrayList<>();
+    dataTypeList.add(Collections.singletonList(TSDataType.INT32));
+    dataTypeList.add(Collections.singletonList(TSDataType.FLOAT));
+
+    List<List<TSEncoding>> encodingList = new ArrayList<>();
+    encodingList.add(Collections.singletonList(TSEncoding.RLE));
+    encodingList.add(Collections.singletonList(TSEncoding.RLE));
+
+    List<CompressionType> compressionTypes = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      compressionTypes.add(compressionType);
+    }
+
+    List<String> schemaNames = new ArrayList<>();
+    schemaNames.add("s0");
+    schemaNames.add("s1");
+
+    CreateTemplatePlan plan =
+            new CreateTemplatePlan(
+                    "template1",
+                    schemaNames,
+                    measurementList,
+                    dataTypeList,
+                    encodingList,
+                    compressionTypes);
+    MManager manager = IoTDB.metaManager;
+    try {
+      manager.createDeviceTemplate(plan);
+
+      // set device template
+      SetDeviceTemplatePlan setDeviceTemplatePlan =
+              new SetDeviceTemplatePlan("template1", "root.laptop.d1");
+      manager.setDeviceTemplate(setDeviceTemplatePlan);
+      manager.getDeviceNode(new PartialPath("root.laptop.d1")).setUseTemplate(true);
+
+      Assert.assertEquals(2,manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1")));
+      Assert.assertEquals(1,manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1.s1")));
+
+    } catch (MetadataException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCountDeviceWithTemplate(){
+
+  }
+
+  @Test
   public void testTotalSeriesNumber() throws Exception {
     MManager manager = IoTDB.metaManager;
 


### PR DESCRIPTION
## Description


### Bug Description

Apache IoTDB v0.12 cannot count timeseries and device correctly after introducing template. 

### Bug Reproduction

When we create a template t1(s1, s2) and then set it to device root.sg1.d1, we expect value 2 produced by count timeseries and value 1 produced by count device. However, the actual result is 0 timeseries and 0 device.

### Bug Fix Solution
If a MNode is using template, it should be considered as device and the schema in its template will be considered as timeseries. However, the current code only consider a MeasurementMNode as timeseries and a MNode with MeasurementMNode child as device. Therefore, the method getAllTimeseriesCount  and  getAllTimeseriesCount in MTree.java should be modified and the judging criteria will be extended with template usage. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
