### PR TITLE
improve mlog compatibility from 0.12.2 to 0.13.0

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -388,13 +388,13 @@ public abstract class PhysicalPlan {
     }
   }
 
+  /** If you want to add new PhysicalPlanType, you must add it in the last. */
   public enum PhysicalPlanType {
     INSERT,
     DELETE,
     BATCHINSERT,
     SET_STORAGE_GROUP,
     CREATE_TIMESERIES,
-    CREATE_ALIGNED_TIMESERIES,
     TTL,
     GRANT_WATERMARK_EMBEDDING,
     REVOKE_WATERMARK_EMBEDDING,
@@ -423,7 +423,6 @@ public abstract class PhysicalPlan {
     MNODE,
     MEASUREMENT_MNODE,
     STORAGE_GROUP_MNODE,
-    CLUSTER_LOG,
     BATCH_INSERT_ONE_DEVICE,
     MULTI_BATCH_INSERT,
     BATCH_INSERT_ROWS,
@@ -432,6 +431,8 @@ public abstract class PhysicalPlan {
     SET_DEVICE_TEMPLATE,
     SET_USING_DEVICE_TEMPLATE,
     AUTO_CREATE_DEVICE_MNODE,
+    CREATE_ALIGNED_TIMESERIES,
+    CLUSTER_LOG,
     CREATE_TRIGGER,
     DROP_TRIGGER,
     START_TRIGGER,


### PR DESCRIPTION
## Description
Since 0.12.2 introduce some new PhysicalPlans about template, the mlog will record some template information. 
Therefore, we need to reorder the PhysicalPlanType in master branch to keep the compatibility of mlog with 0.12.2.