### PR TITLE
[IOTDB-1478]The whole IoTDB can not read/write if any one sg is not ready

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -81,6 +81,7 @@ import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -121,7 +122,6 @@ public class StorageEngine implements IService {
 
   private AtomicBoolean isAllSgReady = new AtomicBoolean(false);
 
-  private ExecutorService recoverAllSgThreadPool;
   private ScheduledExecutorService ttlCheckThread;
   private TsFileFlushPolicy fileFlushPolicy = new DirectFlushPolicy();
   private ExecutorService recoveryThreadPool;
@@ -235,62 +235,37 @@ public class StorageEngine implements IService {
     recoveryThreadPool =
         IoTDBThreadPoolFactory.newFixedThreadPool(
             Runtime.getRuntime().availableProcessors(), "Recovery-Thread-Pool");
-    recoverAllSgThreadPool = IoTDBThreadPoolFactory.newSingleThreadExecutor("Begin-Recovery-Pool");
-    recoverAllSgThreadPool.submit(this::recoverAllSgs);
-  }
 
-  private void recoverAllSgs() {
-    /*
-     * recover all storage group processors.
-     */
-    List<Future<Void>> futures = new ArrayList<>();
-    recoverStorageGroupProcessor(futures);
-
-    for (Future<Void> future : futures) {
-      try {
-        future.get();
-      } catch (ExecutionException e) {
-        throw new StorageEngineFailureException("StorageEngine failed to recover.", e);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new StorageEngineFailureException("StorageEngine failed to recover.", e);
-      }
-    }
-    recoveryThreadPool.shutdown();
-    setAllSgReady(true);
-  }
-
-  /**
-   * recover logic storage group processor
-   *
-   * @param futures recover future task
-   */
-  private void recoverStorageGroupProcessor(List<Future<Void>> futures) {
+    // recover all logic storage group processors
     List<StorageGroupMNode> sgNodes = IoTDB.metaManager.getAllStorageGroupNodes();
+    List<Future<Void>> futures = new LinkedList<>();
     for (StorageGroupMNode storageGroup : sgNodes) {
-      futures.add(
-          recoveryThreadPool.submit(
-              () -> {
-                try {
-                  // for recovery in test
-                  VirtualStorageGroupManager virtualStorageGroupManager =
-                      processorMap.computeIfAbsent(
-                          storageGroup.getPartialPath(), id -> new VirtualStorageGroupManager());
+      VirtualStorageGroupManager virtualStorageGroupManager =
+          processorMap.computeIfAbsent(
+              storageGroup.getPartialPath(), id -> new VirtualStorageGroupManager(true));
 
-                  virtualStorageGroupManager.recover(storageGroup);
-
-                  logger.info(
-                      "Storage Group Processor {} is recovered successfully",
-                      storageGroup.getFullPath());
-                } catch (Exception e) {
-                  logger.error(
-                      "meet error when recovering storage group: {}",
-                      storageGroup.getFullPath(),
-                      e);
-                }
-                return null;
-              }));
+      // recover all virtual storage groups in one logic storage group
+      virtualStorageGroupManager.asyncRecover(storageGroup, recoveryThreadPool, futures);
     }
+
+    // operations after all virtual storage groups are recovered
+    Thread recoverEndTrigger =
+        new Thread(
+            () -> {
+              for (Future<Void> future : futures) {
+                try {
+                  future.get();
+                } catch (ExecutionException e) {
+                  throw new StorageEngineFailureException("StorageEngine failed to recover.", e);
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  throw new StorageEngineFailureException("StorageEngine failed to recover.", e);
+                }
+              }
+              recoveryThreadPool.shutdown();
+              setAllSgReady(true);
+            });
+    recoverEndTrigger.start();
   }
 
   @Override
@@ -310,10 +285,6 @@ public class StorageEngine implements IService {
     } catch (Exception e) {
       logger.error("An error occurred when checking TTL", e);
     }
-
-    if (isAllSgReady.get() && !recoverAllSgThreadPool.isShutdown()) {
-      recoverAllSgThreadPool.shutdownNow();
-    }
   }
 
   @Override
@@ -331,17 +302,6 @@ public class StorageEngine implements IService {
       }
     }
     recoveryThreadPool.shutdownNow();
-    if (!recoverAllSgThreadPool.isShutdown()) {
-      recoverAllSgThreadPool.shutdownNow();
-      try {
-        recoverAllSgThreadPool.awaitTermination(60, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        logger.warn("recoverAllSgThreadPool thread still doesn't exit after 60s");
-        Thread.currentThread().interrupt();
-        throw new StorageEngineFailureException(
-            "StorageEngine failed to stop because of " + "recoverAllSgThreadPool.", e);
-      }
-    }
     for (PartialPath storageGroup : IoTDB.metaManager.getAllStorageGroupPaths()) {
       this.releaseWalDirectByteBufferPoolInOneStorageGroup(storageGroup);
     }
@@ -443,22 +403,12 @@ public class StorageEngine implements IService {
     VirtualStorageGroupManager virtualStorageGroupManager =
         processorMap.get(storageGroupMNode.getPartialPath());
     if (virtualStorageGroupManager == null) {
-      // if finish recover
-      if (isAllSgReady.get()) {
-        synchronized (this) {
-          virtualStorageGroupManager = processorMap.get(storageGroupMNode.getPartialPath());
-          if (virtualStorageGroupManager == null) {
-            virtualStorageGroupManager = new VirtualStorageGroupManager();
-            processorMap.put(storageGroupMNode.getPartialPath(), virtualStorageGroupManager);
-          }
+      synchronized (this) {
+        virtualStorageGroupManager = processorMap.get(storageGroupMNode.getPartialPath());
+        if (virtualStorageGroupManager == null) {
+          virtualStorageGroupManager = new VirtualStorageGroupManager();
+          processorMap.put(storageGroupMNode.getPartialPath(), virtualStorageGroupManager);
         }
-      } else {
-        // not finished recover, refuse the request
-        throw new StorageEngineException(
-            "the sg "
-                + storageGroupMNode.getPartialPath()
-                + " may not ready now, please wait and retry later",
-            TSStatusCode.STORAGE_GROUP_NOT_READY.getStatusCode());
       }
     }
     return virtualStorageGroupManager.getProcessor(devicePath, storageGroupMNode);
@@ -493,14 +443,14 @@ public class StorageEngine implements IService {
   }
 
   private void waitAllSgReady(PartialPath storageGroupPath) throws StorageEngineException {
-    if (isAllSgReady.get()) {
+    if (isAllSgReady()) {
       return;
     }
 
     long waitStart = System.currentTimeMillis();
     long waited = 0L;
     final long MAX_WAIT = 5000L;
-    while (!isAllSgReady.get() && waited < MAX_WAIT) {
+    while (!isAllSgReady() && waited < MAX_WAIT) {
       try {
         Thread.sleep(10);
       } catch (InterruptedException e) {
@@ -510,7 +460,7 @@ public class StorageEngine implements IService {
       waited = System.currentTimeMillis() - waitStart;
     }
 
-    if (!isAllSgReady.get()) {
+    if (!isAllSgReady()) {
       // not finished recover, refuse the request
       throw new StorageEngineException(
           "the sg " + storageGroupPath + " may not ready now, please wait and retry later",

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -442,32 +442,6 @@ public class StorageEngine implements IService {
     return processor;
   }
 
-  private void waitAllSgReady(PartialPath storageGroupPath) throws StorageEngineException {
-    if (isAllSgReady()) {
-      return;
-    }
-
-    long waitStart = System.currentTimeMillis();
-    long waited = 0L;
-    final long MAX_WAIT = 5000L;
-    while (!isAllSgReady() && waited < MAX_WAIT) {
-      try {
-        Thread.sleep(10);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new StorageEngineException(e);
-      }
-      waited = System.currentTimeMillis() - waitStart;
-    }
-
-    if (!isAllSgReady()) {
-      // not finished recover, refuse the request
-      throw new StorageEngineException(
-          "the sg " + storageGroupPath + " may not ready now, please wait and retry later",
-          TSStatusCode.STORAGE_GROUP_NOT_READY.getStatusCode());
-    }
-  }
-
   /** This function is just for unit test. */
   public synchronized void reset() {
     for (VirtualStorageGroupManager virtualStorageGroupManager : processorMap.values()) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -438,7 +438,10 @@ public class StorageGroupProcessor {
 
   /** recover from file */
   private void recover() throws StorageGroupProcessorException {
-    logger.info("recover Storage Group  {}", logicalStorageGroupName + "-" + virtualStorageGroupId);
+    logger.info(
+        String.format(
+            "start recovering virtual storage group %s[%s]",
+            logicalStorageGroupName, virtualStorageGroupId));
 
     try {
       // collect candidate TsFiles from sequential and unsequential data directory
@@ -542,6 +545,11 @@ public class StorageGroupProcessor {
             timePartitionId, IoTDBDescriptor.getInstance().getConfig().isForceFullMerge());
       }
     }
+
+    logger.info(
+        String.format(
+            "the virtual storage group %s[%s] is recovered successfully",
+            logicalStorageGroupName, virtualStorageGroupId));
   }
 
   private void recoverCompaction() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualStorageGroupManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualStorageGroupManager.java
@@ -40,6 +40,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class VirtualStorageGroupManager {
 
@@ -52,11 +56,23 @@ public class VirtualStorageGroupManager {
   /** all virtual storage group processor */
   StorageGroupProcessor[] virtualStorageGroupProcessor;
 
+  /** recover status of each virtual storage group processor */
+  private AtomicBoolean[] isVsgReady;
+
   /** value of root.stats."root.sg".TOTAL_POINTS */
   private long monitorSeriesValue;
 
   public VirtualStorageGroupManager() {
+    this(false);
+  }
+
+  public VirtualStorageGroupManager(boolean needRecovering) {
     virtualStorageGroupProcessor = new StorageGroupProcessor[partitioner.getPartitionCount()];
+    isVsgReady = new AtomicBoolean[partitioner.getPartitionCount()];
+    boolean recoverStatus = !needRecovering;
+    for (int i = 0; i < partitioner.getPartitionCount(); i++) {
+      isVsgReady[i] = new AtomicBoolean(recoverStatus);
+    }
   }
 
   /** push forceCloseAllWorkingTsFileProcessors down to all sg */
@@ -102,7 +118,7 @@ public class VirtualStorageGroupManager {
     StorageGroupProcessor processor = virtualStorageGroupProcessor[loc];
     if (processor == null) {
       // if finish recover
-      if (StorageEngine.getInstance().isAllSgReady()) {
+      if (isVsgReady[loc].get()) {
         synchronized (storageGroupMNode) {
           processor = virtualStorageGroupProcessor[loc];
           if (processor == null) {
@@ -116,7 +132,9 @@ public class VirtualStorageGroupManager {
       } else {
         // not finished recover, refuse the request
         throw new StorageEngineException(
-            "the sg "
+            "the virtual sg "
+                + loc
+                + " in sg"
                 + storageGroupMNode.getFullPath()
                 + " may not ready now, please wait and retry later",
             TSStatusCode.STORAGE_GROUP_NOT_READY.getStatusCode());
@@ -127,53 +145,44 @@ public class VirtualStorageGroupManager {
   }
 
   /**
-   * recover
+   * async recover all virtual storage groups in this logical storage group
    *
    * @param storageGroupMNode logical sg mnode
+   * @param pool thread pool to run virtual storage group recover task
+   * @param futures virtual storage group recover tasks
    */
-  public void recover(StorageGroupMNode storageGroupMNode) {
-    List<Thread> threadList = new ArrayList<>(partitioner.getPartitionCount());
+  public void asyncRecover(
+      StorageGroupMNode storageGroupMNode, ExecutorService pool, List<Future<Void>> futures) {
     for (int i = 0; i < partitioner.getPartitionCount(); i++) {
       int cur = i;
-      Thread recoverThread =
-          new Thread(
-              new Runnable() {
-                @Override
-                public void run() {
-                  StorageGroupProcessor processor = null;
-                  try {
-                    processor =
-                        StorageEngine.getInstance()
-                            .buildNewStorageGroupProcessor(
-                                storageGroupMNode.getPartialPath(),
-                                storageGroupMNode,
-                                String.valueOf(cur));
-                  } catch (StorageGroupProcessorException e) {
-                    logger.error(
-                        "failed to recover storage group processor in "
-                            + storageGroupMNode.getFullPath()
-                            + " virtual storage group id is "
-                            + cur);
-                  }
-                  virtualStorageGroupProcessor[cur] = processor;
-                }
-              });
+      Callable<Void> recoverVsgTask =
+          () -> {
+            isVsgReady[cur].set(false);
+            StorageGroupProcessor processor = null;
+            try {
+              processor =
+                  StorageEngine.getInstance()
+                      .buildNewStorageGroupProcessor(
+                          storageGroupMNode.getPartialPath(),
+                          storageGroupMNode,
+                          String.valueOf(cur));
 
-      threadList.add(recoverThread);
-      recoverThread.start();
-    }
-
-    for (int i = 0; i < partitioner.getPartitionCount(); i++) {
-      try {
-        threadList.get(i).join();
-      } catch (InterruptedException e) {
-        logger.error(
-            "failed to recover storage group processor in "
-                + storageGroupMNode.getFullPath()
-                + " virtual storage group id is "
-                + i);
-        Thread.currentThread().interrupt();
-      }
+              logger.info(
+                  "Virtual Storage Group Processor {} of {} is recovered successfully",
+                  cur,
+                  storageGroupMNode.getFullPath());
+            } catch (StorageGroupProcessorException e) {
+              logger.error(
+                  "Failed to recover storage group processor in {} virtual storage group id is {}",
+                  storageGroupMNode.getFullPath(),
+                  cur,
+                  e);
+            }
+            virtualStorageGroupProcessor[cur] = processor;
+            isVsgReady[cur].set(true);
+            return null;
+          };
+      futures.add(pool.submit(recoverVsgTask));
     }
   }
 
@@ -408,5 +417,6 @@ public class VirtualStorageGroupManager {
   /** only for test */
   public void reset() {
     Arrays.fill(virtualStorageGroupProcessor, null);
+    isVsgReady = null;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualStorageGroupManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualStorageGroupManager.java
@@ -71,13 +71,10 @@ public class VirtualStorageGroupManager {
 
   public VirtualStorageGroupManager(boolean needRecovering) {
     virtualStorageGroupProcessor = new StorageGroupProcessor[partitioner.getPartitionCount()];
-    if (needRecovering) {
-      isVsgReady = new AtomicBoolean[partitioner.getPartitionCount()];
-      for (int i = 0; i < partitioner.getPartitionCount(); i++) {
-        isVsgReady[i] = new AtomicBoolean(false);
-      }
-    } else {
-      isVsgReady = null;
+    isVsgReady = new AtomicBoolean[partitioner.getPartitionCount()];
+    boolean recoverReady = !needRecovering;
+    for (int i = 0; i < partitioner.getPartitionCount(); i++) {
+      isVsgReady[i] = new AtomicBoolean(recoverReady);
     }
   }
 
@@ -124,7 +121,7 @@ public class VirtualStorageGroupManager {
     StorageGroupProcessor processor = virtualStorageGroupProcessor[loc];
     if (processor == null) {
       // if finish recover
-      if (isVsgReady == null || isVsgReady[loc].get()) {
+      if (isVsgReady[loc].get()) {
         synchronized (storageGroupMNode) {
           processor = virtualStorageGroupProcessor[loc];
           if (processor == null) {
@@ -416,6 +413,5 @@ public class VirtualStorageGroupManager {
   /** only for test */
   public void reset() {
     Arrays.fill(virtualStorageGroupProcessor, null);
-    isVsgReady = null;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualStorageGroupManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/VirtualStorageGroupManager.java
@@ -138,11 +138,9 @@ public class VirtualStorageGroupManager {
       } else {
         // not finished recover, refuse the request
         throw new StorageEngineException(
-            "the virtual sg "
-                + loc
-                + " in sg"
-                + storageGroupMNode.getFullPath()
-                + " may not ready now, please wait and retry later",
+            String.format(
+                "the virtual storage group %s[%d] may not ready now, please wait and retry later",
+                storageGroupMNode.getFullPath(), loc),
             TSStatusCode.STORAGE_GROUP_NOT_READY.getStatusCode());
       }
     }
@@ -172,14 +170,9 @@ public class VirtualStorageGroupManager {
                           storageGroupMNode.getPartialPath(),
                           storageGroupMNode,
                           String.valueOf(cur));
-
-              logger.info(
-                  "Virtual Storage Group Processor {} of {} is recovered successfully",
-                  cur,
-                  storageGroupMNode.getFullPath());
             } catch (StorageGroupProcessorException e) {
               logger.error(
-                  "Failed to recover storage group processor in {} virtual storage group id is {}",
+                  "failed to recover virtual storage group {}[{}]",
                   storageGroupMNode.getFullPath(),
                   cur,
                   e);


### PR DESCRIPTION
When recovering IoTDB, if one storage group is not ready, all read/write requests will be rejected, which is not our respected.
To make each virtual storage group independent,  i change the ready unit of recovering IoTDB from the whole db to each independent virtual storage group, so each virtual storage group can resolve read/write requests if it has recovered.