### PR TITLE
[IOTDB-1509] show timeseries throw a bug

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/metadata/CMManager.java
@@ -1565,7 +1565,7 @@ public class CMManager extends MManager {
               () -> {
                 try {
                   showTimeseries(group, plan, resultSet, context);
-                } catch (CheckConsistencyException e) {
+                } catch (CheckConsistencyException | MetadataException e) {
                   logger.error("Cannot get show timeseries result of {} from {}", plan, group);
                 }
                 return null;

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -333,6 +333,9 @@ public abstract class Cases {
         "create timeseries root.ln.wf01.wt2 WITH DATATYPE=DOUBLE, ENCODING=RLE, compression=SNAPPY tags(tag1=v1, tag2=v2)";
     writeStatement.execute(createTimeSeries1);
     writeStatement.execute(createTimeSeries2);
+
+    Thread.sleep(200);
+
     // try to read data on each node. select .*
     for (Statement readStatement : readStatements) {
       ResultSet resultSet =

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -326,14 +326,13 @@ public abstract class Cases {
 
   // test https://issues.apache.org/jira/browse/IOTDB-1407
   @Test
-  public void showTimeseriesTagsTest() throws SQLException, InterruptedException {
+  public void showTimeseriesTagsTest() throws SQLException {
     String createTimeSeries1 =
         "create timeseries root.ln.wf01.wt1 WITH DATATYPE=DOUBLE, ENCODING=RLE, compression=SNAPPY tags(tag1=v1, tag2=v2)";
     String createTimeSeries2 =
         "create timeseries root.ln.wf01.wt2 WITH DATATYPE=DOUBLE, ENCODING=RLE, compression=SNAPPY tags(tag1=v1, tag2=v2)";
     writeStatement.execute(createTimeSeries1);
     writeStatement.execute(createTimeSeries2);
-
     // try to read data on each node. select .*
     for (Statement readStatement : readStatements) {
       ResultSet resultSet =

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -334,7 +334,7 @@ public abstract class Cases {
     writeStatement.execute(createTimeSeries1);
     writeStatement.execute(createTimeSeries2);
 
-    Thread.sleep(200);
+    Thread.sleep(3000);
 
     // try to read data on each node. select .*
     for (Statement readStatement : readStatements) {

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -334,8 +334,6 @@ public abstract class Cases {
     writeStatement.execute(createTimeSeries1);
     writeStatement.execute(createTimeSeries2);
 
-    Thread.sleep(3000);
-
     // try to read data on each node. select .*
     for (Statement readStatement : readStatements) {
       ResultSet resultSet =
@@ -385,17 +383,8 @@ public abstract class Cases {
 
     // try to read data on each node. SHOW TIMESERIES root.ln.wf01.* where tag1=v3"
     for (Statement readStatement : readStatements) {
-      ResultSet resultSet = null;
-      int retry = 3;
-      while (retry > 0) {
-        try {
-          resultSet = readStatement.executeQuery("SHOW TIMESERIES root.ln.wf01.* where tag1=v3");
-          break;
-        } catch (Exception e) {
-          retry--;
-          Thread.sleep(3000);
-        }
-      }
+      ResultSet resultSet =
+          readStatement.executeQuery("SHOW TIMESERIES root.ln.wf01.* where tag1=v3");
       int cnt = 0;
       while (resultSet.next()) {
         cnt++;

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -326,7 +326,7 @@ public abstract class Cases {
 
   // test https://issues.apache.org/jira/browse/IOTDB-1407
   @Test
-  public void showTimeseriesTagsTest() throws SQLException {
+  public void showTimeseriesTagsTest() throws SQLException, InterruptedException {
     String createTimeSeries1 =
         "create timeseries root.ln.wf01.wt1 WITH DATATYPE=DOUBLE, ENCODING=RLE, compression=SNAPPY tags(tag1=v1, tag2=v2)";
     String createTimeSeries2 =

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -385,8 +385,17 @@ public abstract class Cases {
 
     // try to read data on each node. SHOW TIMESERIES root.ln.wf01.* where tag1=v3"
     for (Statement readStatement : readStatements) {
-      ResultSet resultSet =
-          readStatement.executeQuery("SHOW TIMESERIES root.ln.wf01.* where tag1=v3");
+      ResultSet resultSet = null;
+      int retry = 3;
+      while (retry > 0) {
+        try {
+          resultSet = readStatement.executeQuery("SHOW TIMESERIES root.ln.wf01.* where tag1=v3");
+          break;
+        } catch (Exception e) {
+          retry--;
+          Thread.sleep(3000);
+        }
+      }
       int cnt = 0;
       while (resultSet.next()) {
         cnt++;


### PR DESCRIPTION
In a whole new environment, it has to be a whole new environment.

1. create timeseries root.ln.wf01.wt21 WITH DATATYPE=DOUBLE, ENCODING=RLE, compression=SNAPPY tags(tag1=v1, tag2=v2)

2. SHOW TIMESERIES root where tag1=v1

Msg: 303: The key tag1 is not a tag

Reason:
The show timeseries root... command is used to query all DataGroup groups. If a DataGroup group does not have a sequence, an error is reported. As a result, other DataGroups that have a sequence cannot obtain the result.
Solution:
we should catch a remote show-timeseries.