### PR TITLE
[IOTDB-1500] Remove current dynamic query memory control

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPhysicalGenerator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPhysicalGenerator.java
@@ -74,8 +74,7 @@ public class ClusterPhysicalGenerator extends PhysicalGenerator {
   }
 
   @Override
-  public PhysicalPlan transformToPhysicalPlan(Operator operator, int fetchSize)
-      throws QueryProcessException {
+  public PhysicalPlan transformToPhysicalPlan(Operator operator) throws QueryProcessException {
     // update storage groups before parsing query plans
     if (operator instanceof QueryOperator) {
       try {
@@ -84,7 +83,7 @@ public class ClusterPhysicalGenerator extends PhysicalGenerator {
         throw new QueryProcessException(e);
       }
     }
-    return super.transformToPhysicalPlan(operator, fetchSize);
+    return super.transformToPhysicalPlan(operator);
   }
 
   @Override

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanner.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanner.java
@@ -33,18 +33,17 @@ import java.time.ZoneId;
 
 public class ClusterPlanner extends Planner {
 
-  /** @param fetchSize this parameter only take effect when it is a query plan */
   @Override
-  public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr, ZoneId zoneId, int fetchSize)
+  public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr, ZoneId zoneId)
       throws QueryProcessException {
     // from SQL to logical operator
     Operator operator = LogicalGenerator.generate(sqlStr, zoneId);
     // check if there are logical errors
     LogicalChecker.check(operator);
     // optimize the logical operator
-    operator = logicalOptimize(operator, fetchSize);
+    operator = logicalOptimize(operator);
     // from logical operator to physical plan
-    return new ClusterPhysicalGenerator().transformToPhysicalPlan(operator, fetchSize);
+    return new ClusterPhysicalGenerator().transformToPhysicalPlan(operator);
   }
 
   @Override
@@ -56,10 +55,9 @@ public class ClusterPlanner extends Planner {
     // check if there are logical errors
     LogicalChecker.check(operator);
     // optimize the logical operator
-    operator = logicalOptimize(operator, rawDataQueryReq.fetchSize);
+    operator = logicalOptimize(operator);
     // from logical operator to physical plan
-    return new ClusterPhysicalGenerator()
-        .transformToPhysicalPlan(operator, rawDataQueryReq.fetchSize);
+    return new ClusterPhysicalGenerator().transformToPhysicalPlan(operator);
   }
 
   @Override
@@ -71,9 +69,8 @@ public class ClusterPlanner extends Planner {
     // check if there are logical errors
     LogicalChecker.check(operator);
     // optimize the logical operator
-    operator = logicalOptimize(operator, lastDataQueryReq.fetchSize);
+    operator = logicalOptimize(operator);
     // from logical operator to physical plan
-    return new ClusterPhysicalGenerator()
-        .transformToPhysicalPlan(operator, lastDataQueryReq.fetchSize);
+    return new ClusterPhysicalGenerator().transformToPhysicalPlan(operator);
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
@@ -92,8 +92,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.iotdb.session.Config.DEFAULT_FETCH_SIZE;
-
 public class LocalQueryExecutor {
 
   private static final Logger logger = LoggerFactory.getLogger(LocalQueryExecutor.class);
@@ -237,11 +235,7 @@ public class LocalQueryExecutor {
 
     // the same query from a requester correspond to a context here
     RemoteQueryContext queryContext =
-        queryManager.getQueryContext(
-            request.getRequester(),
-            request.getQueryId(),
-            request.getFetchSize(),
-            request.getDeduplicatedPathNum());
+        queryManager.getQueryContext(request.getRequester(), request.getQueryId());
     logger.debug(
         DEBUG_SHOW_QUERY_ID,
         name,
@@ -341,11 +335,7 @@ public class LocalQueryExecutor {
 
     // the same query from a requester correspond to a context here
     RemoteQueryContext queryContext =
-        queryManager.getQueryContext(
-            request.getRequester(),
-            request.getQueryId(),
-            request.getFetchSize(),
-            request.getDeduplicatedPathNum());
+        queryManager.getQueryContext(request.getRequester(), request.getQueryId());
     logger.debug(
         DEBUG_SHOW_QUERY_ID,
         name,
@@ -581,11 +571,7 @@ public class LocalQueryExecutor {
     Set<String> deviceMeasurements = request.getDeviceMeasurements();
 
     RemoteQueryContext queryContext =
-        queryManager.getQueryContext(
-            request.getRequester(),
-            request.getQueryId(),
-            request.getFetchSize(),
-            request.getDeduplicatedPathNum());
+        queryManager.getQueryContext(request.getRequester(), request.getQueryId());
     logger.debug(
         DEBUG_SHOW_QUERY_ID,
         name,
@@ -689,8 +675,7 @@ public class LocalQueryExecutor {
       timeFilter = FilterFactory.deserialize(request.timeFilterBytes);
     }
     RemoteQueryContext queryContext =
-        queryManager.getQueryContext(
-            request.getRequestor(), request.queryId, DEFAULT_FETCH_SIZE, -1);
+        queryManager.getQueryContext(request.getRequestor(), request.queryId);
     Set<String> deviceMeasurements = request.getDeviceMeasurements();
     boolean ascending = request.ascending;
 
@@ -881,8 +866,7 @@ public class LocalQueryExecutor {
     Set<String> deviceMeasurements = request.getDeviceMeasurements();
     boolean ascending = request.ascending;
 
-    RemoteQueryContext queryContext =
-        queryManager.getQueryContext(request.getRequestor(), queryId, DEFAULT_FETCH_SIZE, -1);
+    RemoteQueryContext queryContext = queryManager.getQueryContext(request.getRequestor(), queryId);
     LocalGroupByExecutor executor =
         getGroupByExecutor(
             path,
@@ -968,8 +952,7 @@ public class LocalQueryExecutor {
     long beforeRange = request.getBeforeRange();
     Node requester = request.getRequester();
     Set<String> deviceMeasurements = request.getDeviceMeasurements();
-    RemoteQueryContext queryContext =
-        queryManager.getQueryContext(requester, queryId, DEFAULT_FETCH_SIZE, -1);
+    RemoteQueryContext queryContext = queryManager.getQueryContext(requester, queryId);
 
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
@@ -1034,8 +1017,7 @@ public class LocalQueryExecutor {
     dataGroupMember.syncLeaderWithConsistencyCheck(false);
 
     RemoteQueryContext queryContext =
-        queryManager.getQueryContext(
-            request.getRequestor(), request.getQueryId(), DEFAULT_FETCH_SIZE, -1);
+        queryManager.getQueryContext(request.getRequestor(), request.getQueryId());
     List<PartialPath> partialPaths = new ArrayList<>();
     for (String path : request.getPaths()) {
       partialPaths.add(new PartialPath(path));

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/manage/ClusterQueryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/manage/ClusterQueryManager.java
@@ -43,16 +43,12 @@ public class ClusterQueryManager {
   private Map<Long, IAggregateReader> aggrReaderMap = new ConcurrentHashMap<>();
   private Map<Long, GroupByExecutor> groupByExecutorMap = new ConcurrentHashMap<>();
 
-  public synchronized RemoteQueryContext getQueryContext(
-      Node node, long queryId, int fetchSize, int deduplicatedPathNum) {
+  public synchronized RemoteQueryContext getQueryContext(Node node, long queryId) {
     Map<Long, RemoteQueryContext> nodeContextMap =
         queryContextMap.computeIfAbsent(node, n -> new HashMap<>());
     return nodeContextMap.computeIfAbsent(
         queryId,
-        qId ->
-            new RemoteQueryContext(
-                QueryResourceManager.getInstance()
-                    .assignQueryId(true, fetchSize, deduplicatedPathNum)));
+        qId -> new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true)));
   }
 
   public long registerReader(IBatchReader reader) {

--- a/cluster/src/test/java/org/apache/iotdb/cluster/common/IoTDBTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/common/IoTDBTest.java
@@ -158,8 +158,7 @@ public abstract class IoTDBTest {
   protected QueryDataSet query(List<String> pathStrs, IExpression expression)
       throws QueryProcessException, QueryFilterOptimizationException, StorageEngineException,
           IOException, MetadataException, InterruptedException {
-    QueryContext context =
-        new QueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+    QueryContext context = new QueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setExpression(expression);
     List<PartialPath> paths = new ArrayList<>();

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterAggregateExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterAggregateExecutorTest.java
@@ -85,7 +85,7 @@ public class ClusterAggregateExecutorTest extends BaseQueryTest {
     plan.setDeduplicatedAggregations(aggregations);
 
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       executor = new ClusterAggregateExecutor(plan, testMetaMember);
       QueryDataSet queryDataSet = executor.executeWithoutValueFilter(context, plan);
@@ -142,7 +142,7 @@ public class ClusterAggregateExecutorTest extends BaseQueryTest {
                 new PartialPath(TestUtils.getTestSeries(0, 0)), TimeFilter.gtEq(3))));
 
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       executor = new ClusterAggregateExecutor(plan, testMetaMember);
       QueryDataSet queryDataSet = executor.executeWithValueFilter(context, plan);

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterDataQueryExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterDataQueryExecutorTest.java
@@ -66,7 +66,7 @@ public class ClusterDataQueryExecutorTest extends BaseQueryTest {
     plan.setDeduplicatedDataTypes(dataTypes);
     queryExecutor = new ClusterDataQueryExecutor(plan, testMetaMember);
     RemoteQueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       QueryDataSet dataSet = queryExecutor.executeWithoutValueFilter(context);
       checkSequentialDataset(dataSet, 0, 20);
@@ -87,7 +87,7 @@ public class ClusterDataQueryExecutorTest extends BaseQueryTest {
     plan.setExpression(expression);
     queryExecutor = new ClusterDataQueryExecutor(plan, testMetaMember);
     RemoteQueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       QueryDataSet dataSet = queryExecutor.executeWithValueFilter(context);
       checkSequentialDataset(dataSet, 5, 15);
@@ -104,7 +104,7 @@ public class ClusterDataQueryExecutorTest extends BaseQueryTest {
     plan.setEnableRedirect(true);
     queryExecutor = new ClusterDataQueryExecutor(plan, testMetaMember);
     RemoteQueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       QueryDataSet dataSet = queryExecutor.executeWithoutValueFilter(context);
       assertNull(dataSet.getEndPoint());
@@ -126,7 +126,7 @@ public class ClusterDataQueryExecutorTest extends BaseQueryTest {
     plan.setEnableRedirect(true);
     queryExecutor = new ClusterDataQueryExecutor(plan, testMetaMember);
     RemoteQueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       QueryDataSet dataSet = queryExecutor.executeWithValueFilter(context);
       assertNull(dataSet.getEndPoint());
@@ -147,7 +147,7 @@ public class ClusterDataQueryExecutorTest extends BaseQueryTest {
     plan.setEnableRedirect(true);
     queryExecutor = new ClusterDataQueryExecutor(plan, testMetaMember);
     RemoteQueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       QueryDataSet dataSet = queryExecutor.executeWithoutValueFilter(context);
       assertEquals("ip:port=0.0.0.0:6667", dataSet.getEndPoint().toString());

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterFillExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterFillExecutorTest.java
@@ -60,7 +60,7 @@ public class ClusterFillExecutorTest extends BaseQueryTest {
             TSDataType.DOUBLE, new PreviousFill(TSDataType.DOUBLE, 0, defaultFillInterval));
     plan.setFillType(tsDataTypeIFillMap);
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
 
     try {
       ClusterFillExecutor fillExecutor;
@@ -107,7 +107,7 @@ public class ClusterFillExecutorTest extends BaseQueryTest {
             new LinearFill(TSDataType.DOUBLE, 0, defaultFillInterval, defaultFillInterval));
     plan.setFillType(tsDataTypeIFillMap);
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
 
     try {
       ClusterFillExecutor fillExecutor;

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterPhysicalGeneratorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterPhysicalGeneratorTest.java
@@ -65,8 +65,7 @@ public class ClusterPhysicalGeneratorTest extends BaseQueryTest {
 
     operator.setSelectComponent(selectComponent);
     operator.setFromComponent(fromComponent);
-    RawDataQueryPlan plan =
-        (RawDataQueryPlan) physicalGenerator.transformToPhysicalPlan(operator, 1024);
+    RawDataQueryPlan plan = (RawDataQueryPlan) physicalGenerator.transformToPhysicalPlan(operator);
 
     assertEquals(pathList, plan.getDeduplicatedPaths());
     assertEquals(dataTypes, plan.getDeduplicatedDataTypes());

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterPlanExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterPlanExecutorTest.java
@@ -61,7 +61,7 @@ public class ClusterPlanExecutorTest extends BaseQueryTest {
     queryPlan.setPaths(pathList);
     queryPlan.setDataTypes(dataTypes);
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
 
     try {
       QueryDataSet dataSet = queryExecutor.processQuery(queryPlan, context);
@@ -96,7 +96,7 @@ public class ClusterPlanExecutorTest extends BaseQueryTest {
           IOException, InterruptedException, QueryProcessException {
     ShowTimeSeriesPlan showTimeSeriesPlan = new ShowTimeSeriesPlan(pathList.get(0));
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       QueryDataSet dataSet = queryExecutor.processQuery(showTimeSeriesPlan, context);
       int count = 0;

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterQueryRouterTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterQueryRouterTest.java
@@ -73,7 +73,7 @@ public class ClusterQueryRouterTest extends BaseQueryTest {
     queryPlan.setDeduplicatedPathsAndUpdate(pathList);
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
 
     try {
       QueryDataSet dataSet = clusterQueryRouter.rawDataQuery(queryPlan, context);
@@ -117,7 +117,7 @@ public class ClusterQueryRouterTest extends BaseQueryTest {
     plan.setDeduplicatedAggregations(aggregations);
 
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       QueryDataSet queryDataSet = clusterQueryRouter.aggregate(plan, context);
       checkDoubleDataset(queryDataSet, new Object[] {0.0, 19.0, 9.5, 20.0, 190.0});
@@ -142,7 +142,7 @@ public class ClusterQueryRouterTest extends BaseQueryTest {
             TSDataType.DOUBLE, new PreviousFill(TSDataType.DOUBLE, 0, defaultFillInterval));
     plan.setFillType(tsDataTypeIFillMap);
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
 
     try {
       QueryDataSet queryDataSet;
@@ -183,7 +183,7 @@ public class ClusterQueryRouterTest extends BaseQueryTest {
     plan.setFillType(tsDataTypeIFillMap);
 
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
 
     try {
       QueryDataSet queryDataSet;
@@ -212,7 +212,7 @@ public class ClusterQueryRouterTest extends BaseQueryTest {
       throws IOException, StorageEngineException, QueryFilterOptimizationException,
           QueryProcessException, IllegalPathException {
     QueryContext queryContext =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       GroupByTimePlan groupByPlan = new GroupByTimePlan();
       List<PartialPath> pathList = new ArrayList<>();
@@ -265,7 +265,7 @@ public class ClusterQueryRouterTest extends BaseQueryTest {
       throws StorageEngineException, IOException, QueryFilterOptimizationException,
           QueryProcessException, IllegalPathException {
     QueryContext queryContext =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       GroupByTimePlan groupByPlan = new GroupByTimePlan();
       List<PartialPath> pathList = new ArrayList<>();

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/LoadConfigurationTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/LoadConfigurationTest.java
@@ -114,7 +114,7 @@ public class LoadConfigurationTest {
 
     LoadConfigurationPlan loadConfigurationPlan =
         (LoadConfigurationPlan)
-            physicalGenerator.transformToPhysicalPlan(loadConfigurationOperator, 0);
+            physicalGenerator.transformToPhysicalPlan(loadConfigurationOperator);
     String metricProperties =
         (String) loadConfigurationPlan.getIoTDBProperties().get("enable_metric_service");
     assertEquals("false", metricProperties);

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/ClusterGroupByNoVFilterDataSetTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/ClusterGroupByNoVFilterDataSetTest.java
@@ -48,7 +48,7 @@ public class ClusterGroupByNoVFilterDataSetTest extends BaseQueryTest {
   public void test()
       throws StorageEngineException, IOException, QueryProcessException, IllegalPathException {
     QueryContext queryContext =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       GroupByTimePlan groupByPlan = new GroupByTimePlan();
       List<PartialPath> pathList = new ArrayList<>();

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/ClusterGroupByVFilterDataSetTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/ClusterGroupByVFilterDataSetTest.java
@@ -51,7 +51,7 @@ public class ClusterGroupByVFilterDataSetTest extends BaseQueryTest {
   public void test()
       throws IOException, StorageEngineException, QueryProcessException, IllegalPathException {
     QueryContext queryContext =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       GroupByTimePlan groupByPlan = new GroupByTimePlan();
       List<PartialPath> pathList = new ArrayList<>();

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/MergeGroupByExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/MergeGroupByExecutorTest.java
@@ -50,7 +50,7 @@ public class MergeGroupByExecutorTest extends BaseQueryTest {
     PartialPath path = new PartialPath(TestUtils.getTestSeries(0, 0));
     TSDataType dataType = TSDataType.DOUBLE;
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       Filter timeFilter = null;
       Set<String> deviceMeasurements = new HashSet<>();
@@ -85,7 +85,7 @@ public class MergeGroupByExecutorTest extends BaseQueryTest {
     PartialPath path = new PartialPath(TestUtils.getTestSeries(0, 0));
     TSDataType dataType = TSDataType.DOUBLE;
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       Filter timeFilter = TimeFilter.gtEq(3);
       Set<String> deviceMeasurements = new HashSet<>();

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/groupby/RemoteGroupByExecutorTest.java
@@ -55,7 +55,7 @@ public class RemoteGroupByExecutorTest extends BaseQueryTest {
     PartialPath path = new PartialPath(TestUtils.getTestSeries(0, 0));
     TSDataType dataType = TSDataType.DOUBLE;
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       Filter timeFilter = null;
       List<Integer> aggregationTypes = new ArrayList<>();
@@ -113,7 +113,7 @@ public class RemoteGroupByExecutorTest extends BaseQueryTest {
     PartialPath path = new PartialPath(TestUtils.getTestSeries(0, 0));
     TSDataType dataType = TSDataType.DOUBLE;
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       Filter timeFilter = TimeFilter.gtEq(3);
       List<Integer> aggregationTypes = new ArrayList<>();

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/manage/ClusterQueryManagerTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/manage/ClusterQueryManagerTest.java
@@ -46,12 +46,9 @@ public class ClusterQueryManagerTest {
 
   @Test
   public void testContext() {
-    RemoteQueryContext queryContext1 =
-        queryManager.getQueryContext(TestUtils.getNode(0), 1, 1024, -1);
-    RemoteQueryContext queryContext2 =
-        queryManager.getQueryContext(TestUtils.getNode(0), 1, 1024, -1);
-    RemoteQueryContext queryContext3 =
-        queryManager.getQueryContext(TestUtils.getNode(1), 1, 1024, -1);
+    RemoteQueryContext queryContext1 = queryManager.getQueryContext(TestUtils.getNode(0), 1);
+    RemoteQueryContext queryContext2 = queryManager.getQueryContext(TestUtils.getNode(0), 1);
+    RemoteQueryContext queryContext3 = queryManager.getQueryContext(TestUtils.getNode(1), 1);
     assertSame(queryContext1, queryContext2);
     assertNotEquals(queryContext2, queryContext3);
   }
@@ -158,8 +155,7 @@ public class ClusterQueryManagerTest {
 
   @Test
   public void testEndQuery() throws StorageEngineException {
-    RemoteQueryContext queryContext =
-        queryManager.getQueryContext(TestUtils.getNode(0), 1, 1024, -1);
+    RemoteQueryContext queryContext = queryManager.getQueryContext(TestUtils.getNode(0), 1);
     for (int i = 0; i < 10; i++) {
       IBatchReader reader =
           new IBatchReader() {

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactoryTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactoryTest.java
@@ -46,7 +46,7 @@ public class ClusterReaderFactoryTest extends BaseQueryTest {
 
     ClusterReaderFactory readerFactory = new ClusterReaderFactory(testMetaMember);
     RemoteQueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
 
     try {
       SeriesRawDataBatchReader seriesReader =

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/reader/ClusterTimeGeneratorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/reader/ClusterTimeGeneratorTest.java
@@ -57,7 +57,7 @@ public class ClusterTimeGeneratorTest extends BaseQueryTest {
       throws StorageEngineException, IOException, IllegalPathException, QueryProcessException {
     RawDataQueryPlan dataQueryPlan = new RawDataQueryPlan();
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       IExpression expression =
           BinaryExpression.and(
@@ -86,7 +86,7 @@ public class ClusterTimeGeneratorTest extends BaseQueryTest {
       throws StorageEngineException, IOException, IllegalPathException, QueryProcessException {
     RawDataQueryPlan dataQueryPlan = new RawDataQueryPlan();
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     Filter valueFilter = ValueFilter.gtEq(3.0);
     Filter timeFilter = TimeFilter.ltEq(8);
     try {

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/DataGroupMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/DataGroupMemberTest.java
@@ -1160,7 +1160,7 @@ public class DataGroupMemberTest extends BaseMember {
     Filter timeFilter = TimeFilter.gtEq(5);
     request.setTimeFilterBytes(SerializeUtils.serializeFilter(timeFilter));
     QueryContext queryContext =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
     try {
       request.setQueryId(queryContext.getQueryId());
       request.setRequestor(TestUtils.getNode(0));

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/MetaGroupMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/MetaGroupMemberTest.java
@@ -919,7 +919,7 @@ public class MetaGroupMemberTest extends BaseMember {
     }
 
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
 
     try {
       ClusterReaderFactory readerFactory = new ClusterReaderFactory(testMetaMember);
@@ -985,7 +985,7 @@ public class MetaGroupMemberTest extends BaseMember {
     }
 
     QueryContext context =
-        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, -1));
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
 
     try {
       ClusterReaderFactory readerFactory = new ClusterReaderFactory(testMetaMember);

--- a/server/src/main/java/org/apache/iotdb/db/cq/ContinuousQueryTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/cq/ContinuousQueryTask.java
@@ -121,7 +121,7 @@ public class ContinuousQueryTask extends WrappedRunnable {
     // we need to save one copy of the original SelectComponent.
     SelectComponent selectComponentCopy = new SelectComponent(queryOperator.getSelectComponent());
 
-    GroupByTimePlan queryPlan = planner.cqQueryOperatorToGroupByTimePlan(queryOperator, FETCH_SIZE);
+    GroupByTimePlan queryPlan = planner.cqQueryOperatorToGroupByTimePlan(queryOperator);
 
     queryOperator.setSelectComponent(selectComponentCopy);
 
@@ -134,9 +134,7 @@ public class ContinuousQueryTask extends WrappedRunnable {
   private QueryDataSet doQuery(GroupByTimePlan queryPlan)
       throws StorageEngineException, QueryFilterOptimizationException, MetadataException,
           IOException, InterruptedException, QueryProcessException {
-    long queryId =
-        QueryResourceManager.getInstance()
-            .assignQueryId(true, FETCH_SIZE, queryPlan.getDeduplicatedPaths().size());
+    long queryId = QueryResourceManager.getInstance().assignQueryId(true);
 
     try {
       return planExecutor.processQuery(queryPlan, new QueryContext(queryId));

--- a/server/src/main/java/org/apache/iotdb/db/exception/query/PathNumOverLimitException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/query/PathNumOverLimitException.java
@@ -21,17 +21,10 @@ package org.apache.iotdb.db.exception.query;
 
 public class PathNumOverLimitException extends QueryProcessException {
 
-  public PathNumOverLimitException(long maxDeduplicatedPathNum, long deduplicatedPathNum) {
+  public PathNumOverLimitException(int maxQueryDeduplicatedPathNum) {
     super(
         String.format(
-            "Too many paths in one query! Currently allowed max deduplicated path number is %d, this query contains %d deduplicated path. Please use slimit to choose what you real want or adjust max_deduplicated_path_num in iotdb-engine.properties.",
-            maxDeduplicatedPathNum, deduplicatedPathNum));
-  }
-
-  public PathNumOverLimitException(long maxDeduplicatedPathNum) {
-    super(
-        String.format(
-            "Too many paths in one query! Currently allowed max deduplicated path number is %d, this query contains unknown deduplicated path. Please use slimit to choose what you real want or adjust max_deduplicated_path_num in iotdb-engine.properties.",
-            maxDeduplicatedPathNum));
+            "Too many paths in one query! Currently allowed max deduplicated path number is %d. Please use slimit or adjust max_deduplicated_path_num in iotdb-engine.properties.",
+            maxQueryDeduplicatedPathNum));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
@@ -167,7 +167,7 @@ public class StatMonitor implements StatMonitorMBean, IService {
           LastQueryExecutor.calculateLastPairForSeriesLocally(
                   Collections.singletonList(monitorSeries),
                   Collections.singletonList(TSDataType.INT64),
-                  new QueryContext(QueryResourceManager.getInstance().assignQueryId(true, 1024, 1)),
+                  new QueryContext(QueryResourceManager.getInstance().assignQueryId(true)),
                   null,
                   Collections.singletonMap(monitorSeries.getDevice(), measurementSet))
               .get(0)

--- a/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
@@ -52,25 +52,24 @@ public class Planner {
     // do nothing
   }
 
-  /** @param fetchSize this parameter only take effect when it is a query plan */
-  public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr, ZoneId zoneId, int fetchSize)
+  public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr, ZoneId zoneId)
       throws QueryProcessException {
     // from SQL to logical operator
     Operator operator = LogicalGenerator.generate(sqlStr, zoneId);
     // check if there are logical errors
     LogicalChecker.check(operator);
     // optimize the logical operator
-    operator = logicalOptimize(operator, fetchSize);
+    operator = logicalOptimize(operator);
     // from logical operator to physical plan
-    return new PhysicalGenerator().transformToPhysicalPlan(operator, fetchSize);
+    return new PhysicalGenerator().transformToPhysicalPlan(operator);
   }
 
-  public GroupByTimePlan cqQueryOperatorToGroupByTimePlan(QueryOperator operator, int fetchSize)
+  public GroupByTimePlan cqQueryOperatorToGroupByTimePlan(QueryOperator operator)
       throws QueryProcessException {
     // optimize the logical operator (no need to check since the operator has been checked
     // beforehand)
-    operator = (QueryOperator) logicalOptimize(operator, fetchSize);
-    return (GroupByTimePlan) new PhysicalGenerator().transformToPhysicalPlan(operator, fetchSize);
+    operator = (QueryOperator) logicalOptimize(operator);
+    return (GroupByTimePlan) new PhysicalGenerator().transformToPhysicalPlan(operator);
   }
 
   /** convert raw data query to physical plan directly */
@@ -82,9 +81,9 @@ public class Planner {
     // check if there are logical errors
     LogicalChecker.check(operator);
     // optimize the logical operator
-    operator = logicalOptimize(operator, rawDataQueryReq.fetchSize);
+    operator = logicalOptimize(operator);
     // from logical operator to physical plan
-    return new PhysicalGenerator().transformToPhysicalPlan(operator, rawDataQueryReq.fetchSize);
+    return new PhysicalGenerator().transformToPhysicalPlan(operator);
   }
 
   /** convert last data query to physical plan directly */
@@ -96,9 +95,9 @@ public class Planner {
     // check if there are logical errors
     LogicalChecker.check(operator);
     // optimize the logical operator
-    operator = logicalOptimize(operator, lastDataQueryReq.fetchSize);
+    operator = logicalOptimize(operator);
     // from logical operator to physical plan
-    return new PhysicalGenerator().transformToPhysicalPlan(operator, lastDataQueryReq.fetchSize);
+    return new PhysicalGenerator().transformToPhysicalPlan(operator);
   }
 
   /**
@@ -108,10 +107,10 @@ public class Planner {
    * @return optimized logical operator
    * @throws LogicalOptimizeException exception in logical optimizing
    */
-  protected Operator logicalOptimize(Operator operator, int fetchSize)
+  protected Operator logicalOptimize(Operator operator)
       throws LogicalOperatorException, PathNumOverLimitException {
     return operator.getType().equals(QUERY) || operator.getType().equals(QUERY_INDEX)
-        ? optimizeQueryOperator((QueryOperator) operator, fetchSize)
+        ? optimizeQueryOperator((QueryOperator) operator)
         : operator;
   }
 
@@ -122,9 +121,9 @@ public class Planner {
    * @return optimized query operator
    * @throws LogicalOptimizeException exception in query optimizing
    */
-  private QueryOperator optimizeQueryOperator(QueryOperator root, int fetchSize)
+  private QueryOperator optimizeQueryOperator(QueryOperator root)
       throws LogicalOperatorException, PathNumOverLimitException {
-    root = (QueryOperator) new ConcatPathOptimizer().transform(root, fetchSize);
+    root = (QueryOperator) new ConcatPathOptimizer().transform(root);
 
     WhereComponent whereComponent = root.getWhereComponent();
     if (whereComponent == null) {
@@ -141,6 +140,6 @@ public class Planner {
 
   @TestOnly
   public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr) throws QueryProcessException {
-    return parseSQLToPhysicalPlan(sqlStr, ZoneId.systemDefault(), 1024);
+    return parseSQLToPhysicalPlan(sqlStr, ZoneId.systemDefault());
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -37,8 +37,7 @@ import java.util.Map;
 /** Used to convert logical operator to physical plan */
 public class PhysicalGenerator {
 
-  public PhysicalPlan transformToPhysicalPlan(Operator operator, int fetchSize)
-      throws QueryProcessException {
+  public PhysicalPlan transformToPhysicalPlan(Operator operator) throws QueryProcessException {
     PhysicalPlan physicalPlan = operator.generatePhysicalPlan(this);
     physicalPlan.setDebug(operator.isDebug());
     return physicalPlan;

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
@@ -56,14 +56,14 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
       "failed to concat series paths because the given query operator didn't have prefix paths";
 
   @Override
-  public Operator transform(Operator operator, int fetchSize)
+  public Operator transform(Operator operator)
       throws LogicalOptimizeException, PathNumOverLimitException {
     QueryOperator queryOperator = (QueryOperator) operator;
     if (!optimizable(queryOperator)) {
       return queryOperator;
     }
     concatSelect(queryOperator);
-    removeWildcardsInSelectPaths(queryOperator, fetchSize);
+    removeWildcardsInSelectPaths(queryOperator);
     concatFilterAndRemoveWildcards(queryOperator);
     return queryOperator;
   }
@@ -97,13 +97,13 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
     queryOperator.getSelectComponent().setResultColumns(resultColumns);
   }
 
-  private void removeWildcardsInSelectPaths(QueryOperator queryOperator, int fetchSize)
+  private void removeWildcardsInSelectPaths(QueryOperator queryOperator)
       throws LogicalOptimizeException, PathNumOverLimitException {
     if (queryOperator.getIndexType() != null) {
       return;
     }
 
-    WildcardsRemover wildcardsRemover = new WildcardsRemover(queryOperator, fetchSize);
+    WildcardsRemover wildcardsRemover = new WildcardsRemover(queryOperator);
     List<ResultColumn> resultColumns = new ArrayList<>();
     for (ResultColumn resultColumn : queryOperator.getSelectComponent().getResultColumns()) {
       resultColumn.removeWildcards(wildcardsRemover, resultColumns);

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ILogicalOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ILogicalOptimizer.java
@@ -26,6 +26,5 @@ import org.apache.iotdb.db.qp.logical.Operator;
 @FunctionalInterface
 public interface ILogicalOptimizer {
 
-  Operator transform(Operator operator, int fetchSize)
-      throws LogicalOptimizeException, PathNumOverLimitException;
+  Operator transform(Operator operator) throws LogicalOptimizeException, PathNumOverLimitException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
@@ -112,18 +112,16 @@ public class SessionManager {
     }
   }
 
-  public long requestQueryId(
-      Long statementId, boolean isDataQuery, int fetchSize, int deduplicatedPathNum) {
-    long queryId = requestQueryId(isDataQuery, fetchSize, deduplicatedPathNum);
+  public long requestQueryId(Long statementId, boolean isDataQuery) {
+    long queryId = requestQueryId(isDataQuery);
     statementIdToQueryId
         .computeIfAbsent(statementId, k -> new CopyOnWriteArraySet<>())
         .add(queryId);
     return queryId;
   }
 
-  public long requestQueryId(boolean isDataQuery, int fetchSize, int deduplicatedPathNum) {
-    return QueryResourceManager.getInstance()
-        .assignQueryId(isDataQuery, fetchSize, deduplicatedPathNum);
+  public long requestQueryId(boolean isDataQuery) {
+    return QueryResourceManager.getInstance().assignQueryId(isDataQuery);
   }
 
   public void releaseQueryResource(long queryId) throws StorageEngineException {

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -58,7 +58,6 @@ import org.apache.iotdb.db.qp.physical.crud.InsertRowsPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertTabletPlan;
 import org.apache.iotdb.db.qp.physical.crud.LastQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
-import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.SetDeviceTemplatePlan;
 import org.apache.iotdb.db.qp.physical.crud.UDFPlan;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
@@ -131,7 +130,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
-import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.thrift.TException;
@@ -500,8 +498,7 @@ public class TSServiceImpl implements TSIService.Iface {
       String statement = req.getStatements().get(i);
       try {
         PhysicalPlan physicalPlan =
-            processor.parseSQLToPhysicalPlan(
-                statement, sessionManager.getZoneId(req.sessionId), DEFAULT_FETCH_SIZE);
+            processor.parseSQLToPhysicalPlan(statement, sessionManager.getZoneId(req.sessionId));
         if (physicalPlan.isQuery()) {
           throw new QueryInBatchStatementException(statement);
         }
@@ -598,8 +595,7 @@ public class TSServiceImpl implements TSIService.Iface {
 
       String statement = req.getStatement();
       PhysicalPlan physicalPlan =
-          processor.parseSQLToPhysicalPlan(
-              statement, sessionManager.getZoneId(req.getSessionId()), req.fetchSize);
+          processor.parseSQLToPhysicalPlan(statement, sessionManager.getZoneId(req.getSessionId()));
 
       return physicalPlan.isQuery()
           ? internalExecuteQueryStatement(
@@ -629,8 +625,7 @@ public class TSServiceImpl implements TSIService.Iface {
 
       String statement = req.getStatement();
       PhysicalPlan physicalPlan =
-          processor.parseSQLToPhysicalPlan(
-              statement, sessionManager.getZoneId(req.sessionId), req.fetchSize);
+          processor.parseSQLToPhysicalPlan(statement, sessionManager.getZoneId(req.sessionId));
 
       return physicalPlan.isQuery()
           ? internalExecuteQueryStatement(
@@ -738,12 +733,8 @@ public class TSServiceImpl implements TSIService.Iface {
     long queryId = -1;
     try {
 
-      // pair.left = fetchSize, pair.right = deduplicatedNum
-      Pair<Integer, Integer> p = getMemoryParametersFromPhysicalPlan(plan, fetchSize);
-      fetchSize = p.left;
-
       // generate the queryId for the operation
-      queryId = sessionManager.requestQueryId(statementId, true, fetchSize, p.right);
+      queryId = sessionManager.requestQueryId(statementId, true);
       // register query info to queryTimeManager
       if (!(plan instanceof ShowQueryProcesslistPlan)) {
         queryTimeManager.registerQuery(queryId, startTime, statement, timeout);
@@ -856,38 +847,6 @@ public class TSServiceImpl implements TSIService.Iface {
         SLOW_SQL_LOGGER.info("Cost: {} ms, sql is {}", costTime, statement);
       }
     }
-  }
-
-  /**
-   * get fetchSize and deduplicatedPathNum that are used for memory estimation
-   *
-   * @return Pair - fetchSize, deduplicatedPathNum
-   */
-  private Pair<Integer, Integer> getMemoryParametersFromPhysicalPlan(
-      PhysicalPlan plan, int fetchSizeBefore) {
-    // In case users forget to set this field in query, use the default value
-    int fetchSize = fetchSizeBefore == 0 ? DEFAULT_FETCH_SIZE : fetchSizeBefore;
-    int deduplicatedPathNum = -1;
-    if (plan instanceof GroupByTimePlan) {
-      fetchSize = Math.min(getFetchSizeForGroupByTimePlan((GroupByTimePlan) plan), fetchSize);
-    } else if (plan.getOperatorType() == OperatorType.AGGREGATION) {
-      // the actual row number of aggregation query is 1
-      fetchSize = 1;
-    }
-    if (plan instanceof AlignByDevicePlan) {
-      deduplicatedPathNum = ((AlignByDevicePlan) plan).getMeasurements().size();
-    } else if (plan instanceof LastQueryPlan) {
-      // dataset of last query consists of three column: time column + value column = 1
-      // deduplicatedPathNum
-      // and we assume that the memory which sensor name takes equals to 1 deduplicatedPathNum
-      deduplicatedPathNum = 2;
-      // last query's actual row number should be the minimum between the number of series and
-      // fetchSize
-      fetchSize = Math.min(((LastQueryPlan) plan).getDeduplicatedPaths().size(), fetchSize);
-    } else if (plan instanceof RawDataQueryPlan) {
-      deduplicatedPathNum = ((RawDataQueryPlan) plan).getDeduplicatedPaths().size();
-    }
-    return new Pair<>(fetchSize, deduplicatedPathNum);
   }
 
   /*
@@ -1186,7 +1145,7 @@ public class TSServiceImpl implements TSIService.Iface {
 
     status = executeNonQueryPlan(plan);
     TSExecuteStatementResp resp = RpcUtils.getTSExecuteStatementResp(status);
-    long queryId = sessionManager.requestQueryId(false, DEFAULT_FETCH_SIZE, -1);
+    long queryId = sessionManager.requestQueryId(false);
     return resp.setQueryId(queryId);
   }
 
@@ -1202,8 +1161,7 @@ public class TSServiceImpl implements TSIService.Iface {
   private TSExecuteStatementResp executeUpdateStatement(String statement, long sessionId)
       throws QueryProcessException {
     PhysicalPlan physicalPlan =
-        processor.parseSQLToPhysicalPlan(
-            statement, sessionManager.getZoneId(sessionId), DEFAULT_FETCH_SIZE);
+        processor.parseSQLToPhysicalPlan(statement, sessionManager.getZoneId(sessionId));
     return physicalPlan.isQuery()
         ? RpcUtils.getTSExecuteStatementResp(
             TSStatusCode.EXECUTE_STATEMENT_ERROR, "Statement is a query statement.")

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
@@ -206,8 +206,7 @@ public class IoTDBSequenceDataQueryIT {
         new PartialPath(TestConstant.d1 + TsFileConstant.PATH_SEPARATOR + TestConstant.s1));
     dataTypes.add(TSDataType.INT64);
 
-    TEST_QUERY_JOB_ID =
-        QueryResourceManager.getInstance().assignQueryId(true, 1024, pathList.size());
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
     RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
@@ -241,8 +240,7 @@ public class IoTDBSequenceDataQueryIT {
     dataTypes.add(TSDataType.INT64);
 
     GlobalTimeExpression globalTimeExpression = new GlobalTimeExpression(TimeFilter.gtEq(800L));
-    TEST_QUERY_JOB_ID =
-        QueryResourceManager.getInstance().assignQueryId(true, 1024, pathList.size());
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
     RawDataQueryPlan queryPlan = new RawDataQueryPlan();
@@ -298,8 +296,7 @@ public class IoTDBSequenceDataQueryIT {
     SingleSeriesExpression singleSeriesExpression =
         new SingleSeriesExpression(queryPath, ValueFilter.gtEq(14));
 
-    TEST_QUERY_JOB_ID =
-        QueryResourceManager.getInstance().assignQueryId(true, 1024, pathList.size());
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
     RawDataQueryPlan queryPlan = new RawDataQueryPlan();
@@ -337,8 +334,7 @@ public class IoTDBSequenceDataQueryIT {
     AndFilter andFilter = new AndFilter(ltLeft, gtRight);
 
     GlobalTimeExpression globalTimeExpression = new GlobalTimeExpression(andFilter);
-    TEST_QUERY_JOB_ID =
-        QueryResourceManager.getInstance().assignQueryId(true, 1024, pathList.size());
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
     RawDataQueryPlan queryPlan = new RawDataQueryPlan();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -313,8 +313,7 @@ public class IoTDBSeriesReaderIT {
         new PartialPath(TestConstant.d1 + TsFileConstant.PATH_SEPARATOR + TestConstant.s1));
     dataTypes.add(TSDataType.INT64);
 
-    TEST_QUERY_JOB_ID =
-        QueryResourceManager.getInstance().assignQueryId(true, 1024, pathList.size());
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
     RawDataQueryPlan queryPlan = new RawDataQueryPlan();
@@ -345,8 +344,7 @@ public class IoTDBSeriesReaderIT {
     SingleSeriesExpression singleSeriesExpression =
         new SingleSeriesExpression(p, ValueFilter.gtEq(20));
 
-    TEST_QUERY_JOB_ID =
-        QueryResourceManager.getInstance().assignQueryId(true, 1024, pathList.size());
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
     RawDataQueryPlan queryPlan = new RawDataQueryPlan();
@@ -374,7 +372,7 @@ public class IoTDBSeriesReaderIT {
     List<TSDataType> dataTypes = Collections.singletonList(TSDataType.INT32);
     SingleSeriesExpression expression = new SingleSeriesExpression(path, TimeFilter.gt(22987L));
 
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true, 1024, 1);
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
     RawDataQueryPlan queryPlan = new RawDataQueryPlan();
@@ -414,8 +412,7 @@ public class IoTDBSeriesReaderIT {
     dataTypes.add(TSDataType.INT64);
     queryPlan.setDeduplicatedDataTypes(dataTypes);
 
-    TEST_QUERY_JOB_ID =
-        QueryResourceManager.getInstance().assignQueryId(true, 1024, pathList.size());
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
     SingleSeriesExpression singleSeriesExpression =

--- a/server/src/test/java/org/apache/iotdb/db/qp/logical/LogicalPlanSmallTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/logical/LogicalPlanSmallTest.java
@@ -178,7 +178,7 @@ public class LogicalPlanSmallTest {
         (QueryOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     IoTDB.metaManager.init();
     ConcatPathOptimizer concatPathOptimizer = new ConcatPathOptimizer();
-    concatPathOptimizer.transform(operator, 1000);
+    concatPathOptimizer.transform(operator);
     IoTDB.metaManager.clear();
     // expected to throw LogicalOptimizeException: The value of SOFFSET (%d) is equal to or exceeds
     // the number of sequences (%d) that can actually be returned.

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -45,15 +45,16 @@ import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TSocketWrapper;
 
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
 import org.apache.commons.io.FileUtils;
 import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
 
 import java.io.File;
 import java.io.IOException;

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -30,7 +30,10 @@ import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.CompactionMergeTaskPoolManager;
 import org.apache.iotdb.db.engine.trigger.service.TriggerRegistrationService;
-import org.apache.iotdb.db.exception.*;
+import org.apache.iotdb.db.exception.ContinuousQueryException;
+import org.apache.iotdb.db.exception.StorageEngineException;
+import org.apache.iotdb.db.exception.TriggerManagementException;
+import org.apache.iotdb.db.exception.UDFRegistrationException;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
@@ -42,16 +45,15 @@ import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TSocketWrapper;
 
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
 import org.apache.commons.io.FileUtils;
 import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
 
 import java.io.File;
 import java.io.IOException;
@@ -255,7 +257,7 @@ public class EnvironmentUtils {
     }
 
     createAllDir();
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true, 1024, 0);
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
   }
 

--- a/spark-iotdb-connector/src/test/scala/org/apache/iotdb/spark/db/EnvironmentUtils.java
+++ b/spark-iotdb-connector/src/test/scala/org/apache/iotdb/spark/db/EnvironmentUtils.java
@@ -50,50 +50,47 @@ import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * <p>
- * This class is used for cleaning test environment in unit test and integration test
- * </p>
- */
+/** This class is used for cleaning test environment in unit test and integration test */
 public class EnvironmentUtils {
 
-  private static String[] creationSqls = new String[]{
-      "SET STORAGE GROUP TO root.vehicle.d0",
-      "SET STORAGE GROUP TO root.vehicle.d1",
-      "CREATE TIMESERIES root.vehicle.d0.s0 WITH DATATYPE=INT32, ENCODING=RLE",
-      "CREATE TIMESERIES root.vehicle.d0.s1 WITH DATATYPE=INT64, ENCODING=RLE",
-      "CREATE TIMESERIES root.vehicle.d0.s2 WITH DATATYPE=FLOAT, ENCODING=RLE",
-      "CREATE TIMESERIES root.vehicle.d0.s3 WITH DATATYPE=TEXT, ENCODING=PLAIN",
-      "CREATE TIMESERIES root.vehicle.d0.s4 WITH DATATYPE=BOOLEAN, ENCODING=PLAIN"
-  };
+  private static String[] creationSqls =
+      new String[] {
+        "SET STORAGE GROUP TO root.vehicle.d0",
+        "SET STORAGE GROUP TO root.vehicle.d1",
+        "CREATE TIMESERIES root.vehicle.d0.s0 WITH DATATYPE=INT32, ENCODING=RLE",
+        "CREATE TIMESERIES root.vehicle.d0.s1 WITH DATATYPE=INT64, ENCODING=RLE",
+        "CREATE TIMESERIES root.vehicle.d0.s2 WITH DATATYPE=FLOAT, ENCODING=RLE",
+        "CREATE TIMESERIES root.vehicle.d0.s3 WITH DATATYPE=TEXT, ENCODING=PLAIN",
+        "CREATE TIMESERIES root.vehicle.d0.s4 WITH DATATYPE=BOOLEAN, ENCODING=PLAIN"
+      };
 
-  private static String[] dataSet2 = new String[]{
-      "SET STORAGE GROUP TO root.ln.wf01.wt01",
-      "CREATE TIMESERIES root.ln.wf01.wt01.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
-      "CREATE TIMESERIES root.ln.wf01.wt01.temperature WITH DATATYPE=FLOAT, ENCODING=PLAIN",
-      "CREATE TIMESERIES root.ln.wf01.wt01.hardware WITH DATATYPE=INT32, ENCODING=PLAIN",
-      "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
-          + "values(1, 1.1, false, 11)",
-      "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
-          + "values(2, 2.2, true, 22)",
-      "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
-          + "values(3, 3.3, false, 33 )",
-      "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
-          + "values(4, 4.4, false, 44)",
-      "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
-          + "values(5, 5.5, false, 55)"
-  };
+  private static String[] dataSet2 =
+      new String[] {
+        "SET STORAGE GROUP TO root.ln.wf01.wt01",
+        "CREATE TIMESERIES root.ln.wf01.wt01.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
+        "CREATE TIMESERIES root.ln.wf01.wt01.temperature WITH DATATYPE=FLOAT, ENCODING=PLAIN",
+        "CREATE TIMESERIES root.ln.wf01.wt01.hardware WITH DATATYPE=INT32, ENCODING=PLAIN",
+        "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
+            + "values(1, 1.1, false, 11)",
+        "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
+            + "values(2, 2.2, true, 22)",
+        "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
+            + "values(3, 3.3, false, 33 )",
+        "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
+            + "values(4, 4.4, false, 44)",
+        "INSERT INTO root.ln.wf01.wt01(timestamp,temperature,status, hardware) "
+            + "values(5, 5.5, false, 55)"
+      };
 
-  private static String insertTemplate = "INSERT INTO root.vehicle.d0(timestamp,s0,s1,s2,s3,s4)"
-      + " VALUES(%d,%d,%d,%f,%s,%s)";
+  private static String insertTemplate =
+      "INSERT INTO root.vehicle.d0(timestamp,s0,s1,s2,s3,s4)" + " VALUES(%d,%d,%d,%f,%s,%s)";
 
   private static final Logger logger = LoggerFactory.getLogger(EnvironmentUtils.class);
 
   private static IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static DirectoryManager directoryManager = DirectoryManager.getInstance();
 
-  public static long TEST_QUERY_JOB_ID = QueryResourceManager.getInstance()
-      .assignQueryId(true, 1024, 0);
+  public static long TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
   public static QueryContext TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
   private static long oldTsFileThreshold = config.getTsFileSizeThreshold();
@@ -156,16 +153,12 @@ public class EnvironmentUtils {
     FileUtils.deleteDirectory(new File(dir));
   }
 
-  /**
-   * disable the system monitor</br> this function should be called before all code in the setup
-   */
+  /** disable the system monitor</br> this function should be called before all code in the setup */
   public static void closeStatMonitor() {
     config.setEnableStatMonitor(false);
   }
 
-  /**
-   * disable memory control</br> this function should be called before all code in the setup
-   */
+  /** disable memory control</br> this function should be called before all code in the setup */
   public static void envSetUp() throws StartupException {
     IoTDB.metaManager.init();
     createAllDir();
@@ -185,7 +178,7 @@ public class EnvironmentUtils {
     StorageEngine.getInstance().reset();
     MultiFileLogNodeManager.getInstance().start();
     FlushManager.getInstance().start();
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true, 1024, 0);
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
   }
 
@@ -214,9 +207,9 @@ public class EnvironmentUtils {
   }
 
   public static void prepareData() throws SQLException {
-    try (Connection connection = DriverManager
-        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root",
-            "root");
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
 
       for (String sql : creationSqls) {
@@ -229,36 +222,42 @@ public class EnvironmentUtils {
 
       // prepare BufferWrite file
       for (int i = 5000; i < 7000; i++) {
-        statement.execute(String
-            .format(Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "true"));
+        statement.execute(
+            String.format(
+                Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "true"));
       }
       statement.execute("flush");
       for (int i = 7500; i < 8500; i++) {
-        statement.execute(String
-            .format(Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "false"));
+        statement.execute(
+            String.format(
+                Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "false"));
       }
       statement.execute("flush");
       // prepare Unseq-File
       for (int i = 500; i < 1500; i++) {
-        statement.execute(String
-            .format(Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "true"));
+        statement.execute(
+            String.format(
+                Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "true"));
       }
       statement.execute("flush");
       for (int i = 3000; i < 6500; i++) {
-        statement.execute(String
-            .format(Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "false"));
+        statement.execute(
+            String.format(
+                Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "false"));
       }
       statement.execute("merge");
 
       // prepare BufferWrite cache
       for (int i = 9000; i < 10000; i++) {
-        statement.execute(String
-            .format(Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "true"));
+        statement.execute(
+            String.format(
+                Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "true"));
       }
       // prepare Overflow cache
       for (int i = 2000; i < 2500; i++) {
-        statement.execute(String
-            .format(Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "false"));
+        statement.execute(
+            String.format(
+                Locale.ENGLISH, insertTemplate, i, i, i, (double) i, "'" + i + "'", "false"));
       }
 
     } catch (Exception e) {


### PR DESCRIPTION
Current dynamic query memory control causes some problems, maybe bugs, we'd better remove it temporary.
