### PR TITLE
[IoTDB-1449] path already exist error in IoTDBSink

### DIFF
--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
@@ -102,7 +102,7 @@ public class IoTDBSink<IN> extends RichSinkFunction<IN> {
               option.getPath(), option.getDataType(), option.getEncoding(), option.getCompressor());
         } catch (StatementExecutionException e) {
           // path could have been created by the other process here
-          if (e.getStatusCode() != (TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode())) {
+          if (e.getStatusCode() != TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode()) {
             throw e;
           }
         }

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
@@ -90,7 +90,7 @@ public class IoTDBSink<IN> extends RichSinkFunction<IN> {
     try {
       pool.setStorageGroup(options.getStorageGroup());
     } catch (StatementExecutionException e) {
-      if (e.getStatusCode() != (TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode())) {
+      if (e.getStatusCode() != TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode()) {
         throw e;
       }
     }


### PR DESCRIPTION
## Description
After starting IoTDB, executing `FlinkIoTDBSink.java` would result in an exception "... path already exists". It turns out `IoTDBSink.initSession()` would be executed in parallel. At the very beginning, `pool.checkTimeseriesExists(option.getPath())` retruns `true` among them. After one of them creating the path successfully, the others would fail. 

What is mentioned in JIRA is not an issue, which is reported in server and it is allowed. The client should receive the feedback (storage already exists), catch the exception and ignore it. 