### PR TITLE
[To rel/0.12][IoTDB-1499] Remove series registeration using IoTDBSink ->  0.12

### DIFF
--- a/docs/UserGuide/Ecosystem Integration/Flink IoTDB.md
+++ b/docs/UserGuide/Ecosystem Integration/Flink IoTDB.md
@@ -35,6 +35,8 @@ This example shows a case that sends data to a IoTDB server from a Flink job:
 - A simulated Source `SensorSource` generates data points per 1 second.
 - Flink uses `IoTDBSink` to consume the generated data points and write the data into IoTDB.
 
+It is noteworthy that to use IoTDBSink, schema auto-creation in IoTDB should be enabled. 
+
 ```java
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -59,7 +61,6 @@ public class FlinkIoTDBSink {
     options.setPort(6667);
     options.setUser("root");
     options.setPassword("root");
-    options.setStorageGroup("root.sg");
 
     // If the server enables auto_create_schema, then we do not need to register all timeseries
     // here.

--- a/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSink.java
+++ b/example/flink/src/main/java/org/apache/iotdb/flink/FlinkIoTDBSink.java
@@ -41,7 +41,6 @@ public class FlinkIoTDBSink {
     options.setPort(6667);
     options.setUser("root");
     options.setPassword("root");
-    options.setStorageGroup("root.sg");
 
     // If the server enables auto_create_schema, then we do not need to register all timeseries
     // here.

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
@@ -19,8 +19,6 @@
 package org.apache.iotdb.flink;
 
 import org.apache.iotdb.flink.options.IoTDBSinkOptions;
-import org.apache.iotdb.rpc.StatementExecutionException;
-import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.pool.SessionPool;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -86,21 +84,6 @@ public class IoTDBSink<IN> extends RichSinkFunction<IN> {
             options.getUser(),
             options.getPassword(),
             sessionPoolSize);
-
-    try {
-      pool.setStorageGroup(options.getStorageGroup());
-    } catch (StatementExecutionException e) {
-      if (e.getStatusCode() != TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode()) {
-        throw e;
-      }
-    }
-
-    for (IoTDBSinkOptions.TimeseriesOption option : options.getTimeseriesOptionList()) {
-      if (!pool.checkTimeseriesExists(option.getPath())) {
-        pool.createTimeseries(
-            option.getPath(), option.getDataType(), option.getEncoding(), option.getCompressor());
-      }
-    }
   }
 
   void initScheduler() {

--- a/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSinkOptions.java
+++ b/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/options/IoTDBSinkOptions.java
@@ -28,7 +28,6 @@ import java.util.List;
 /** IoTDBOptions describes the configuration related information for IoTDB and timeseries. */
 public class IoTDBSinkOptions extends IoTDBOptions {
 
-  private String storageGroup;
   private List<TimeseriesOption> timeseriesOptionList;
 
   public IoTDBSinkOptions() {}
@@ -38,19 +37,9 @@ public class IoTDBSinkOptions extends IoTDBOptions {
       int port,
       String user,
       String password,
-      String storageGroup,
       List<TimeseriesOption> timeseriesOptionList) {
     super(host, port, user, password);
-    this.storageGroup = storageGroup;
     this.timeseriesOptionList = timeseriesOptionList;
-  }
-
-  public String getStorageGroup() {
-    return storageGroup;
-  }
-
-  public void setStorageGroup(String storageGroup) {
-    this.storageGroup = storageGroup;
   }
 
   public List<TimeseriesOption> getTimeseriesOptionList() {


### PR DESCRIPTION
The storage group and time series registerations are not necessary in IoTDBSink, which would introduce inconvenience for users.