### PR TITLE
[IOTDB-1506] CI fails because of JDBC connection exceptions

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBTriggerExecutionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBTriggerExecutionIT.java
@@ -61,19 +61,44 @@ public class IoTDBTriggerExecutionIT {
         @Override
         public void run() {
 
-          try (Connection connection =
-                  DriverManager.getConnection(
-                      Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
-              Statement statement = connection.createStatement()) {
+          try {
+            Connection connection =
+                DriverManager.getConnection(
+                    Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+            Statement statement = connection.createStatement();
+
             long count = 0;
             do {
               ++count;
-              statement.execute(
-                  String.format(
-                      "insert into root.vehicle.d1(timestamp,s1,s2,s3,s4,s5,s6) values(%d,%d,%d,%d,%d,%s,\"%d\")",
-                      count, count, count, count, count, count % 2 == 0 ? "true" : "false", count));
+              boolean isSuccessful = false;
+              while (!isSuccessful) {
+                try {
+                  statement.execute(
+                      String.format(
+                          "insert into root.vehicle.d1(timestamp,s1,s2,s3,s4,s5,s6) values(%d,%d,%d,%d,%d,%s,\"%d\")",
+                          count,
+                          count,
+                          count,
+                          count,
+                          count,
+                          count % 2 == 0 ? "true" : "false",
+                          count));
+                  isSuccessful = true;
+                } catch (SQLException throwable) {
+                  LOGGER.error(throwable.getMessage());
+                  throwable.printStackTrace();
+
+                  statement.close();
+                  connection.close();
+
+                  connection =
+                      DriverManager.getConnection(
+                          Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+                  statement = connection.createStatement();
+                }
+              }
             } while (!isInterrupted());
-          } catch (SQLException e) {
+          } catch (Exception e) {
             exception = e;
           }
         }


### PR DESCRIPTION
The issue sometimes can be reproduced in IoTDBContinuousQueryIT & IoTDBTriggerExecutionIT.

A background data generator will be started when a ContinuousQueryIT or a TriggerExecutionIT runs. The data generator uses JDBC client to execute insertion statements. As we already know, the JDBC connection may break because of TException occurs and it does not have the retry logic.

To resolve the issue, we can catch the exception, create a new connection and execute the statement again.

A failed run example:
https://github.com/apache/iotdb/pull/3572/checks?check_run_id=3072369955