### PR TITLE
[To rel/0.12]Fix thrift out of sequence in cluster module

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
@@ -696,7 +696,6 @@ public class DataGroupMember extends RaftMember {
    */
   @Override
   public TSStatus executeNonQueryPlan(PhysicalPlan plan) {
-    long startTime = System.currentTimeMillis();
     if (ClusterDescriptor.getInstance().getConfig().getReplicationNum() == 1) {
       try {
         getLocalExecutor().processNonQuery(plan);
@@ -719,11 +718,6 @@ public class DataGroupMember extends RaftMember {
           }
         }
         return handleLogExecutionException(plan, cause);
-      } finally {
-        long elapsed = System.currentTimeMillis() - startTime;
-        if (elapsed > 5000) {
-          logger.error("PlanExecutor execute slowly : time cost : {}ms", elapsed);
-        }
       }
     } else {
       TSStatus status = executeNonQueryPlanWithKnownLeader(plan);
@@ -731,7 +725,7 @@ public class DataGroupMember extends RaftMember {
         return status;
       }
 
-      startTime = Timer.Statistic.DATA_GROUP_MEMBER_WAIT_LEADER.getOperationStartTime();
+      long startTime = Timer.Statistic.DATA_GROUP_MEMBER_WAIT_LEADER.getOperationStartTime();
       waitLeader();
       Timer.Statistic.DATA_GROUP_MEMBER_WAIT_LEADER.calOperationCostTimeFromStart(startTime);
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -507,7 +507,7 @@ public class MetaGroupMember extends RaftMember {
       client.refreshConnection(req);
     } catch (IOException ignored) {
     } catch (TException e) {
-      logger.info("encounter refreshing client timeout, throw broken connection", e);
+      logger.warn("encounter refreshing client timeout, throw broken connection", e);
       // the connection may be broken, close it to avoid it being reused
       client.getInputProtocol().getTransport().close();
     } finally {
@@ -529,7 +529,7 @@ public class MetaGroupMember extends RaftMember {
     try {
       client.refreshConnection(new RefreshReuqest(), new GenericHandler<>(receiver, null));
     } catch (TException e) {
-      logger.info("encounter refreshing client timeout, throw broken connection", e);
+      logger.warn("encounter refreshing client timeout, throw broken connection", e);
     }
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -169,7 +169,7 @@ public class MetaGroupMember extends RaftMember {
    * every "REFRESH_CLIENT_SEC" seconds, a dataClientRefresher thread will try to refresh one thrift
    * connection for each nodes other than itself.
    */
-  private static final int REFRESH_CLIENT_SEC = 1;
+  private static final int REFRESH_CLIENT_SEC = 5;
 
   /** how many times is a data record replicated, also the number of nodes in a data group */
   private static final int REPLICATION_NUM =
@@ -537,7 +537,7 @@ public class MetaGroupMember extends RaftMember {
     try {
       if (logger.isDebugEnabled()) {
         NodeReport report = genNodeReport();
-        logger.info(report.toString());
+        logger.debug(report.toString());
       }
     } catch (Exception e) {
       logger.error("{} exception occurred when generating node report", name, e);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -537,7 +537,7 @@ public class MetaGroupMember extends RaftMember {
     try {
       if (logger.isDebugEnabled()) {
         NodeReport report = genNodeReport();
-        logger.debug(report.toString());
+        logger.info(report.toString());
       }
     } catch (Exception e) {
       logger.error("{} exception occurred when generating node report", name, e);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -1317,7 +1317,6 @@ public abstract class RaftMember {
   }
 
   public TSStatus forwardPlanSync(PhysicalPlan plan, Node receiver, Node header, Client client) {
-    long startTime = System.currentTimeMillis();
     try {
       ExecutNonQueryReq req = new ExecutNonQueryReq();
       req.setPlanBytes(PlanSerializer.getInstance().serialize(plan));
@@ -1337,12 +1336,7 @@ public abstract class RaftMember {
       TSStatus status;
       if (e.getCause() instanceof SocketTimeoutException) {
         status = StatusUtils.TIME_OUT;
-        logger.warn(
-            MSG_FORWARD_TIMEOUT + ": {}ms",
-            name,
-            plan,
-            receiver,
-            System.currentTimeMillis() - startTime);
+        logger.warn(MSG_FORWARD_TIMEOUT, name, plan, receiver);
       } else {
         logger.error(MSG_FORWARD_ERROR, name, plan, receiver, e);
         status = StatusUtils.getStatus(StatusUtils.INTERNAL_ERROR, e.getMessage());

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -192,12 +192,7 @@ public class TsFileProcessor {
 
     if (IoTDBDescriptor.getInstance().getConfig().isEnableWal()) {
       try {
-        long startTime = System.currentTimeMillis();
         getLogNode().write(insertRowPlan);
-        long elapsed = System.currentTimeMillis() - startTime;
-        if (elapsed > 5000) {
-          logger.error("write wal slowly : cost {}ms", elapsed);
-        }
       } catch (Exception e) {
         throw new WriteProcessException(
             String.format(


### PR DESCRIPTION
The Thrift Client will assign a serial number to each RPC. SocketTimeoutException is a behavior of the client, after which we should discard it. If it is used to send RPC again, it will increase the serial number when sending, but it may receive the last packet when receiving data. This causes the out of sequence bug.