### PR TITLE
Throwing exception when StackOverFlow error is encountered

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -641,12 +641,12 @@ public class TSServiceImpl implements TSIService.Iface {
 
   @Override
   public TSExecuteStatementResp executeStatement(TSExecuteStatementReq req) {
+    String statement = req.getStatement();
     try {
       if (!checkLogin(req.getSessionId())) {
         return RpcUtils.getTSExecuteStatementResp(TSStatusCode.NOT_LOGIN_ERROR);
       }
 
-      String statement = req.getStatement();
       PhysicalPlan physicalPlan =
           processor.parseSQLToPhysicalPlan(
               statement, sessionIdZoneIdMap.get(req.getSessionId()), req.fetchSize);
@@ -664,9 +664,11 @@ public class TSServiceImpl implements TSIService.Iface {
     } catch (InterruptedException e) {
       LOGGER.error(INFO_INTERRUPT_ERROR, req, e);
       Thread.currentThread().interrupt();
-      return RpcUtils.getTSExecuteStatementResp(onQueryException(e, "executing executeStatement"));
+      return RpcUtils.getTSExecuteStatementResp(
+          onQueryException(e, "executing \"" + statement + "\""));
     } catch (Exception e) {
-      return RpcUtils.getTSExecuteStatementResp(onQueryException(e, "executing executeStatement"));
+      return RpcUtils.getTSExecuteStatementResp(
+          onQueryException(e, "executing \"" + statement + "\""));
     }
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/expression/util/ExpressionOptimizer.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/expression/util/ExpressionOptimizer.java
@@ -70,21 +70,25 @@ public class ExpressionOptimizer {
             (GlobalTimeExpression) right, left, selectedSeries, relation);
       } else if (left.getType() != ExpressionType.GLOBAL_TIME
           && right.getType() != ExpressionType.GLOBAL_TIME) {
-        IExpression regularLeft = optimize(left, selectedSeries);
-        IExpression regularRight = optimize(right, selectedSeries);
-        IBinaryExpression midRet = null;
-        if (relation == ExpressionType.AND) {
-          midRet = BinaryExpression.and(regularLeft, regularRight);
-        } else if (relation == ExpressionType.OR) {
-          midRet = BinaryExpression.or(regularLeft, regularRight);
-        } else {
-          throw new UnsupportedOperationException("unsupported IExpression type: " + relation);
-        }
-        if (midRet.getLeft().getType() == ExpressionType.GLOBAL_TIME
-            || midRet.getRight().getType() == ExpressionType.GLOBAL_TIME) {
-          return optimize(midRet, selectedSeries);
-        } else {
-          return midRet;
+        try {
+          IExpression regularLeft = optimize(left, selectedSeries);
+          IExpression regularRight = optimize(right, selectedSeries);
+          IBinaryExpression midRet = null;
+          if (relation == ExpressionType.AND) {
+            midRet = BinaryExpression.and(regularLeft, regularRight);
+          } else if (relation == ExpressionType.OR) {
+            midRet = BinaryExpression.or(regularLeft, regularRight);
+          } else {
+            throw new UnsupportedOperationException("unsupported IExpression type: " + relation);
+          }
+          if (midRet.getLeft().getType() == ExpressionType.GLOBAL_TIME
+              || midRet.getRight().getType() == ExpressionType.GLOBAL_TIME) {
+            return optimize(midRet, selectedSeries);
+          } else {
+            return midRet;
+          }
+        } catch (StackOverflowError stackOverflowError) {
+          throw new QueryFilterOptimizationException("StackOverflowError is encountered.");
         }
       }
     }


### PR DESCRIPTION
StackOverflowError is encountered during query optimization in TsFile. To avoid system failure, we catch the StackOverflow error and throw QueryFilterOptimizationException。 

![image](https://user-images.githubusercontent.com/7240743/126413236-24895e6b-cd34-4c81-8675-d5466300636d.png)