### PR TITLE
[IoTDB-1513] fix recover TsFileResource time interval bug

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBRestartIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBRestartIT.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iotdb.db.integration;
 
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.compaction.CompactionMergeTaskPoolManager;
 import org.apache.iotdb.db.exception.StorageEngineException;
@@ -349,6 +351,52 @@ public class IoTDBRestartIT {
       assertEquals(1, cnt);
     }
 
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void testRecoverWALDeleteSchemaCheckResourceTime() throws Exception {
+    EnvironmentUtils.envSetUp();
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
+    int avgSeriesPointNumberThreshold = config.getAvgSeriesPointNumberThreshold();
+    config.setAvgSeriesPointNumberThreshold(2);
+    long tsfileSize = config.getTsFileSizeThreshold();
+    config.setTsFileSizeThreshold(10000000);
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("create timeseries root.turbine1.d1.s1 with datatype=INT64");
+      statement.execute("insert into root.turbine1.d1(timestamp,s1) values(1,1)");
+      statement.execute("insert into root.turbine1.d1(timestamp,s1) values(2,1)");
+      statement.execute("create timeseries root.turbine1.d1.s2 with datatype=BOOLEAN");
+      statement.execute("insert into root.turbine1.d1(timestamp,s2) values(3,true)");
+      statement.execute("insert into root.turbine1.d1(timestamp,s2) values(4,true)");
+    }
+
+    Thread.sleep(1000);
+    EnvironmentUtils.restartDaemon();
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      long[] result = new long[] {1L, 2L};
+      statement.execute("select s1 from root.turbine1.d1 where time < 3");
+      ResultSet resultSet = statement.getResultSet();
+      int cnt = 0;
+      while (resultSet.next()) {
+        assertEquals(resultSet.getLong(1), result[cnt]);
+        cnt++;
+      }
+      assertEquals(2, cnt);
+    }
+
+    config.setAvgSeriesPointNumberThreshold(avgSeriesPointNumberThreshold);
+    config.setTsFileSizeThreshold(tsfileSize);
     EnvironmentUtils.cleanEnv();
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IOTDB-1513

Suppose we have the following ChunkMetadata in a unclosed tsfile:

d1.s1: ChunkMetadata(INT32, starttime=1, endtime=2)，ChunkMetadata(INT32, starttime=1, endtime=2)
d1.s2: ChunkMetadata(BOOLEAN, starttime=1, endtime=2)，ChunkMetadata(INT32, starttime=1, endtime=2)

To solve this problem, we need to group the Chunkmetadata by measurement, and only remove the first ChunkMetadata of d1.s2, because the d1.s2 may be deleted and recreated.