### PR TITLE
[IOTDB-1515]Fix binary convertion in LastQueryExecutor

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -45,17 +45,13 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TIMESERIES;
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_VALUE;
@@ -109,7 +105,12 @@ public class LastQueryExecutor {
         resultRecord.addField(pathField);
 
         Field valueField = new Field(TSDataType.TEXT);
-        valueField.setBinaryV(new Binary(lastTimeValuePair.getValue().getStringValue()));
+        TsPrimitiveType v = lastTimeValuePair.getValue();
+        if (v.getDataType() == TSDataType.TEXT) {
+          valueField.setBinaryV(v.getBinary());
+        } else {
+          valueField.setBinaryV(new Binary(v.getStringValue()));
+        }
         resultRecord.addField(valueField);
 
         dataSet.putRecord(resultRecord);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/TsPrimitiveType.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/TsPrimitiveType.java
@@ -118,6 +118,14 @@ public abstract class TsPrimitiveType implements Serializable {
 
   public abstract Object getValue();
 
+  /**
+   * get the string representation of the value.
+   *
+   * <p>If the type is TSDataType.TEXT and the data is not a valid UTF-8 byte array, some unknown
+   * characters (0xfffd) may add to the final result.
+   *
+   * @return the string representation of the value.
+   */
   public abstract String getStringValue();
 
   public abstract TSDataType getDataType();


### PR DESCRIPTION
Please see JIRA https://issues.apache.org/jira/browse/IOTDB-1515 .

Here are another two questions. Any guidance or discussion is welcomed :).

1. What is the `Binary` type designed for? Any bytes or only valid UTF-8 strings?
2. If any bytes is allowed,  the implementation of `AbstractIoTDBJDBCResultSet.getBytes` is needed. As we cannot restore orignal binary data from a malformed UTF-8 string.

If this PR is accepted. I think it should be cherry-picked to release branches.
