### PR TITLE
[IOTDB-1041]modify startUpCheck

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/utils/ClusterUtils.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/utils/ClusterUtils.java
@@ -252,18 +252,13 @@ public class ClusterUtils {
 
   public static boolean analyseStartUpCheckResult(
       int consistentNum, int inconsistentNum, int totalSeedNum) throws ConfigInconsistentException {
-    if (consistentNum == totalSeedNum) {
-      // break the loop and establish the cluster
-      return true;
-    } else if (inconsistentNum > 0) {
+    if (inconsistentNum > 0) {
       // find config InConsistence, stop building cluster
       throw new ConfigInconsistentException();
-    } else {
-      // The status of some nodes was not obtained, possibly because those node did not start
-      // successfully,
-      // this node can't connect to those nodes, try in next turn
-      return false;
     }
+    // If more than half of the nodes return consistency, it is considered that the current node can
+    // be started
+    return consistentNum > totalSeedNum / 2;
   }
 
   public static TServer createTThreadPoolServer(


### PR DESCRIPTION
Solve the fourth problem of JIRA：https://issues.apache.org/jira/browse/IOTDB-1041
When more than half of seednodes are satisfied, the check is considered correct