### PR TITLE
[IOTDB-1521] Modify TsFile Format document, add more example and fix bug about dictionary order.

### DIFF
--- a/docs/SystemDesign/TsFile/Format.md
+++ b/docs/SystemDesign/TsFile/Format.md
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
+    
         http://www.apache.org/licenses/LICENSE-2.0
-
+    
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -27,15 +27,6 @@
 
 ### 1.1 Variable Storage
 
-- **Big Endian**
-       
-  - For Example, the `int` `0x8` will be stored as `00 00 00 08`, replace by `08 00 00 00`
-- **String with Variable Length**
-  - The format is `int size` plus `String literal`. Size can be zero.
-  - Size equals the number of bytes this string will take, and it may not equal to the length of the string. 
-  - For example "sensor_1" will be stored as `00 00 00 08` plus the encoding(ASCII) of "sensor_1".
-  - Note that for the file signature "TsFile000001" (`MAGIC STRING` + `Version Number`), the size(12) and encoding(ASCII)
-    is fixed so there is no need to put the size before this string literal.
 - **Data Type Hardcode**
   - 0: BOOLEAN
   - 1: INT32 (`int`)
@@ -43,25 +34,55 @@
   - 3: FLOAT
   - 4: DOUBLE
   - 5: TEXT (`String`)
+  
 - **Encoding Type Hardcode**
-  - 0: PLAIN
-  - 1: DICTIONARY
-  - 2: RLE
-  - 3: DIFF
-  - 4: TS_2DIFF
-  - 5: BITMAP
-  - 6: GORILLA_V1
-  - 7: REGULAR 
-  - 8: GORILLA
-- **Compressing Type Hardcode**
-  - 0: UNCOMPRESSED
-  - 1: SNAPPY
-  - 2: GZIP
-  - 3: LZO
-  - 4: SDT
-  - 5: PAA
-  - 6: PLA
-  - 7: LZ4
+
+  To improve the efficiency of data storage, it is necessary to encode data during data writing, thereby reducing the amount of disk space used. In the process of writing and reading data, the amount of data involved in the I/O operations can be reduced to improve performance. IoTDB supports the following encoding methods for different data types:
+
+  - **0: PLAIN**
+
+  	- PLAIN encoding, the default encoding mode, i.e, no encoding, supports multiple data types. It has high compression and decompression efficiency while suffering from low space storage efficiency.
+
+  - **1: DICTIONARY**
+
+  	- DICTIONARY encoding is lossless. It is suitable for TEXT data with low cardinality (i.e. low number of distinct values). It is not recommended to use it for high-cardinality data.
+
+  - **2: RLE**
+
+  	- Run-length encoding is suitable for storing sequence with continuous integer values, and is not recommended for sequence data with most of the time different values.
+
+  	- Run-length encoding can also be used to encode floating-point numbers, while it is necessary to specify reserved decimal digits (MAX_POINT_NUMBER) when creating time series. It is more suitable to store sequence data where floating-point values appear continuously, monotonously increasing or decreasing, and it is not suitable for storing sequence data with high precision requirements after the decimal point or with large fluctuations.
+
+  		> TS_2DIFF and RLE have precision limit for data type of float and double. By default, two decimal places are reserved. GORILLA is recommended.
+
+  - **3: DIFF**
+
+  - **4: TS_2DIFF**
+
+  	- Second-order differential encoding is more suitable for encoding monotonically increasing or decreasing sequence data, and is not recommended for sequence data with large fluctuations.
+
+  - **5: BITMAP**
+
+  - **6: GORILLA_V1**
+
+  	- GORILLA encoding is lossless. It is more suitable for numerical sequence with similar values and is not recommended for sequence data with large fluctuations.
+  	- Currently, there are two versions of GORILLA encoding implementation, it is recommended to use `GORILLA` instead of `GORILLA_V1` (deprecated).
+  	- Usage restrictions: When using GORILLA to encode INT32 data, you need to ensure that there is no data point with the value `Integer.MIN_VALUE` in the sequence. When using GORILLA to encode INT64 data, you need to ensure that there is no data point with the value `Long.MIN_VALUE` in the sequence.
+
+  - **7: REGULAR** 
+
+  - **8: GORILLA**
+
+- **The correspondence between the data type and its supported encodings**
+
+	| Data Type |      Supported Encoding       |
+	| :-------: | :---------------------------: |
+	|  BOOLEAN  |          PLAIN, RLE           |
+	|   INT32   | PLAIN, RLE, TS_2DIFF, GORILLA |
+	|   INT64   | PLAIN, RLE, TS_2DIFF, GORILLA |
+	|   FLOAT   | PLAIN, RLE, TS_2DIFF, GORILLA |
+	|  DOUBLE   | PLAIN, RLE, TS_2DIFF, GORILLA |
+	|   TEXT    |       PLAIN, DICTIONARY       |
 
 ### 1.2 TsFile Overview
 
@@ -216,33 +237,71 @@ IndexEntry has members as below:
 
 All IndexNode forms an **index tree (secondary index)** like a B+ tree, which consists of two levels: entity index level and measurement index level. The IndexNodeType has four enums: `INTERNAL_ENTITY`, `LEAF_ENTITY`, `INTERNAL_MEASUREMENT`, `LEAF_MEASUREMENT`, which indicates the internal or leaf node of entity index level and measurement index level respectively. Only the `LEAF_MEASUREMENT` nodes point to `TimeseriesIndex`.
 
-Here are four detailed examples.
+Consider the introduction of multi-variable timeseries, each multi-variable timeseries is called a vector with a `TimeColumn`. For example, the multi-variable timeseries *vector1* belongs to the entity *d* , with two measurements *s1, s2*. i.e. `d1.vector1.(s1,s2)`, we call vector1 as `TimeValue`. In the storage, you need to store an extra Chunk of vector1.
+
+Except for `TimeValue`, measurements of a multi-variable timeseries are concatenated with `TimeValue` when constructing `IndexOfTimeseriesIndex`, e.g. we Indicates `vector1.s1` as a measurement.
+
+> From v0.13, IoTDB supports [Multi-variable Timeseries](https://iotdb.apache.org/UserGuide/Master/Data-Concept/Data-Model-and-Terminology.html). A multi-variable measurements of an entity corresponds to a multi-variable timeseries. These timeseries are called **multi-variable timeseries**, also called **aligned timeseries**.
+>
+> Multi-variable timeseries need to be created, inserted and deleted at the same time. However, when querying, you can query each sub-measurement separately.
+>
+> By using multi-variable timeseries, the timestamp columns of a group of multi-variable timeseries need to be stored only once in memory and disk when inserting data, instead of once per timeseries.
+>
+> ![img](https://cwiki.apache.org/confluence/download/attachments/184617773/image-20210720151044629.png?version=1&modificationDate=1626773824000&api=v2)
+
+Here are seven detailed examples.
 
 The degree of the index tree (that is, the max number of each node's children) could be configured by users, and is 256 by default. In the examples below, we assume `max_degree_of_index_node = 10`.
 
-* Example 1: 5 entities with 5 measurements each
+Note that the keys are arranged in dictionary order in each type of nodes (LEAF, MEASUREMENT) of the index tree. In the following example, we assumed that the dictionary order **di<dj** if i<j. (Otherwise, in fact, the dictionary order of [d1,d2,... .d10] should be [d1,d10,d2,.... .d9])
+
+Example 1\~4 is an example of a single-variable timeseries.
+
+Example 5\~6 is an example of a multi-variale timeseries.
+
+Example 7 is a comprehensive example.
+
+* **Example 1: 5 entities with 5 measurements each**
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/125254013-9d2d7400-e32c-11eb-9f95-1663e14cffbb.png">
 
 In the case of 5 entities with 5 measurements each: Since the numbers of entities and measurements are both no more than `max_degree_of_index_node`, the tree has only measurement index level by default. In this level, each IndexNode is composed of no more than 10 index entries. The root node is `INTERNAL_ENTITY` type, and the 5 index entries point to index nodes of related entities. These nodes point to  `TimeseriesIndex` directly, as they are `LEAF_MEASUREMENT` type.
 
-* Example 2: 1 entity with 150 measurements
+* **Example 2: 1 entity with 150 measurements**
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/125254022-a0c0fb00-e32c-11eb-8fd1-462936358288.png">
 
 In the case of 1 entity with 150 measurements: The number of measurements exceeds `max_degree_of_index_node`, so the tree has only measurement index level by default. In this level, each IndexNode is composed of no more than 10 index entries. The nodes that point to `TimeseriesIndex` directly are `LEAF_MEASUREMENT` type. Other nodes are not leaf nodes of measurement index level, so they are `INTERNAL_MEASUREMENT` type. The root node is `INTERNAL_ENTITY` type.
 
-* Example 3: 150 entities with 1 measurement each
+* **Example 3: 150 entities with 1 measurement each**
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/122771008-9a64d380-d2d8-11eb-9044-5ac794dd38f7.png">
 
 In the case of 150 entities with 1 measurement each: The number of entities exceeds `max_degree_of_index_node`, so the entity index level and measurement index level of the tree are both formed. In these two levels, each IndexNode is composed of no more than 10 index entries. The nodes that point to `TimeseriesIndex` directly are `LEAF_MEASUREMENT` type. The root nodes of measurement index level are also the leaf nodes of entity index level, which are `LEAF_ENTITY` type. Other nodes and root node of index tree are not leaf nodes of entity level, so they are `INTERNAL_ENTITY` type.
 
-* Example 4: 150 entities with 150 measurements each
+* **Example 4: 150 entities with 150 measurements each**
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/122677241-1a753580-d214-11eb-817f-17bcf797251f.png">
 
 In the case of 150 entities with 150 measurements each: The numbers of entities and measurements both exceed `max_degree_of_index_node`, so the entity index level and measurement index level are both formed. In these two levels, each IndexNode is composed of no more than 10 index entries. As is described before, from the root node to the leaf nodes of entity index level, their types are `INTERNAL_ENTITY` and `LEAF_ENTITY`; each leaf node of entity index level can be seen as the root node of measurement index level, and from here to the leaf nodes of measurement index level, their types are `INTERNAL_MEASUREMENT` and `LEAF_MEASUREMENT`.
+
+* **Example 5: 1 entities with 2 vectors, 9 measurements for each vector**
+
+	![img](https://cwiki.apache.org/confluence/download/attachments/184617773/tsFileVectorIndexCase5.png?version=2&modificationDate=1626952911868&api=v2)
+
+* **Example 6: 1 entities with 2 vectors, 15 measurements for each vector**
+
+	![img](https://cwiki.apache.org/confluence/download/attachments/184617773/tsFileVectorIndexCase6.png?version=2&modificationDate=1626952911054&api=v2)
+
+* **Example 7: 2 entities, measurements of entities are shown in the following table**
+
+	| entity: d0                                      | entity: d1                                      |
+	| :---------------------------------------------- | :---------------------------------------------- |
+	| 【Single-variable Tmeseries】s0,s1...,s4        | 【Single-variable Tmeseries】s0,s1,...s14       |
+	| 【Multi-variable Timeseries】v0.(s5,s6,...,s14) | 【Multi-variable Timeseries】v0.(s15,s16,..s18) |
+	| 【Single-variable Tmeseries】z15,z16,..,z18     |                                                 |
+
+	![img](https://cwiki.apache.org/confluence/download/attachments/184617773/tsFileVectorIndexCase7.png?version=2&modificationDate=1626952910746&api=v2)
 
 The IndexTree is designed as tree structure so that not all the `TimeseriesIndex` need to be read when the number of entities or measurements is too large. Only reading specific IndexTree nodes according to requirement and reducing I/O could speed up the query. More reading process of TsFile in details will be described in the last section of this chapter.
 
@@ -774,3 +833,28 @@ Plot results:
 ![3](https://user-images.githubusercontent.com/33376433/123760418-66e70200-d8f3-11eb-8701-437afd73ac4c.png)
 ![4](https://user-images.githubusercontent.com/33376433/123760424-69e1f280-d8f3-11eb-9f45-571496685a6e.png)
 ![5](https://user-images.githubusercontent.com/33376433/123760433-6cdce300-d8f3-11eb-8ecd-da04a475af41.png)
+
+
+
+## Appendix
+
+### 
+
+- **Big Endian**
+	- For Example, the `int` `0x8` will be stored as `00 00 00 08`, replace by `08 00 00 00`
+- **String with Variable Length**
+	- The format is `int size` plus `String literal`. Size can be zero.
+	- Size equals the number of bytes this string will take, and it may not equal to the length of the string. 
+	- For example "sensor_1" will be stored as `00 00 00 08` plus the encoding(ASCII) of "sensor_1".
+	- Note that for the file signature "TsFile000001" (`MAGIC STRING` + `Version Number`), the size(12) and encoding(ASCII)
+		is fixed so there is no need to put the size before this string literal.
+- **Compressing Type Hardcode**
+	- 0: UNCOMPRESSED
+	- 1: SNAPPY
+	- 2: GZIP
+	- 3: LZO
+	- 4: SDT
+	- 5: PAA
+	- 6: PLA
+	- 7: LZ4
+

--- a/docs/zh/SystemDesign/TsFile/Format.md
+++ b/docs/zh/SystemDesign/TsFile/Format.md
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
+    
         http://www.apache.org/licenses/LICENSE-2.0
-
+    
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,6 +21,10 @@
 
 # TsFile 文件格式
 
+[TOC]
+
+
+
 
 ## 1. TsFile 设计
 
@@ -28,39 +32,63 @@
 
 ### 1.1 变量的存储
 
-- **大端存储**
-  - 比如： `int` `0x8` 将会被存储为 `00 00 00 08`, 而不是 `08 00 00 00`
-- **可变长的字符串类型**
-  - 存储的方式是以一个 `int` 类型的 `Size` + 字符串组成。`Size` 的值可以为 0。
-  - `Size` 指的是字符串所占的字节数，它并不一定等于字符串的长度。 
-  - 举例来说，"sensor_1" 这个字符串将被存储为 `00 00 00 08` + "sensor_1" (ASCII编码)。
-  - 另外需要注意的一点是文件签名 "TsFile000001" (`Magic String` + `Version`), 因为他的 `Size(12)` 和 ASCII 编码值是固定的，所以没有必要在这个字符串前的写入 `Size` 值。
 - **数据类型**
+  
   - 0: BOOLEAN
   - 1: INT32 (`int`)
   - 2: INT64 (`long`)
   - 3: FLOAT
   - 4: DOUBLE
   - 5: TEXT (`String`)
+  
 - **编码类型**
-  - 0: PLAIN
-  - 1: DICTIONARY
-  - 2: RLE
-  - 3: DIFF
-  - 4: TS_2DIFF
-  - 5: BITMAP
-  - 6: GORILLA_V1
-  - 7: REGULAR 
-  - 8: GORILLA 
-- **压缩类型**
-  - 0: UNCOMPRESSED
-  - 1: SNAPPY
-  - 2: GZIP
-  - 3: LZO
-  - 4: SDT
-  - 5: PAA
-  - 6: PLA
-  - 7: LZ4
+
+	为了提高数据的存储效率，需要在数据写入的过程中对数据进行编码，从而减少磁盘空间的使用量。在写数据以及读数据的过程中都能够减少I/O操作的数据量从而提高性能。IoTDB支持多种针对不同类型的数据的编码方法：
+
+	- **0: PLAIN**
+
+		- PLAIN编码，默认的编码方式，即不编码，支持多种数据类型，压缩和解压缩的时间效率较高，但空间存储效率较低。
+
+	- **1: DICTIONARY**
+
+		- 字典编码是一种无损编码。它适合编码基数小的数据（即数据去重后唯一值数量小）。不推荐用于基数大的数据。
+
+	- **2: RLE**
+
+		- 游程编码，比较适合存储某些整数值连续出现的序列，不适合编码大部分情况下前后值不一样的序列数据。
+
+		- 游程编码也可用于对浮点数进行编码，但在创建时间序列的时候需指定保留小数位数（MAX_POINT_NUMBER，具体指定方式参见本文[SQL 参考文档](https://iotdb.apache.org/zh/UserGuide/Master/Operation Manual/SQL Reference.html)）。比较适合存储某些浮点数值连续出现的序列数据，不适合存储对小数点后精度要求较高以及前后波动较大的序列数据。
+
+			> 游程编码（RLE）和二阶差分编码（TS_2DIFF）对 float 和 double 的编码是有精度限制的，默认保留2位小数。推荐使用 GORILLA。
+
+	- **3: DIFF**
+
+	- **4: TS_2DIFF**
+
+		- 二阶差分编码，比较适合编码单调递增或者递减的序列数据，不适合编码波动较大的数据。
+
+	- **5: BITMAP**
+
+	- **6: GORILLA_V1**
+
+		- GORILLA编码是一种无损编码，它比较适合编码前后值比较接近的数值序列，不适合编码前后波动较大的数据。
+		- 当前系统中存在两个版本的GORILLA编码实现，推荐使用`GORILLA`，不推荐使用`GORILLA_V1`（已过时）。
+		- 使用限制：使用Gorilla编码INT32数据时，需要保证序列中不存在值为`Integer.MIN_VALUE`的数据点；使用Gorilla编码INT64数据时，需要保证序列中不存在值为`Long.MIN_VALUE`的数据点。
+
+	- **7: REGULAR**
+
+	- **8: GORILLA**
+
+- **数据类型与支持编码的对应关系**
+
+	| 数据类型 |          支持的编码           |
+	| :------: | :---------------------------: |
+	| BOOLEAN  |          PLAIN, RLE           |
+	|  INT32   | PLAIN, RLE, TS_2DIFF, GORILLA |
+	|  INT64   | PLAIN, RLE, TS_2DIFF, GORILLA |
+	|  FLOAT   | PLAIN, RLE, TS_2DIFF, GORILLA |
+	|  DOUBLE  | PLAIN, RLE, TS_2DIFF, GORILLA |
+	|   TEXT   |       PLAIN, DICTIONARY       |
 
 ### 1.2 TsFile 概述
 
@@ -218,33 +246,63 @@ PageHeader 结构：
 
 所有的索引节点构成一棵类B+树结构的**索引树（二级索引）**，这棵树由两部分组成：实体索引部分和物理量索引部分。索引节点类型有四种，分别是`INTERNAL_ENTITY`、`LEAF_ENTITY`、`INTERNAL_MEASUREMENT`、`LEAF_MEASUREMENT`，分别对应实体索引部分的中间节点和叶子节点，和物理量索引部分的中间节点和叶子节点。 只有物理量索引部分的叶子节点(`LEAF_MEASUREMENT`) 指向 `TimeseriesIndex`。
 
-下面，我们使用四个例子来加以详细说明。
+考虑多元时间序列的引入，每个多元时间序列称为一个vector，有一个`TimeColumn`，例如d1实体下的多元时间序列vector1，有s1、s2两个物理量，即`d1.vector1.(s1,s2)`，我们称vector1为`TimeValue`，在存储的时候需要多存储一个vector1的Chunk。
+
+构建`IndexOfTimeseriesIndex`时，对于多元时间序列的非`TimeValue`的物理量量，使用与`TimeValue`拼接的方式，例如`vector1.s1`视为“物理量”。
+
+> 注：从0.13起，系统支持[多元时间序列](https://iotdb.apache.org/zh/UserGuide/Master/Data-Concept/Data-Model-and-Terminology.html)（Multi-variable timeseries 或 Aligned timeseries），一个实体的一个多元物理量对应一个多元时间序列。这些时间序列称为**多元时间序列**，也叫**对齐时间序列**。多元时间序列需要被同时创建、同时插入值，删除时也必须同时删除，一组多元序列的时间戳列在内存和磁盘中仅需存储一次，而不是每个时间序列存储一次。
+>
+> ![img](https://cwiki.apache.org/confluence/download/attachments/184617773/image-20210720151044629.png?version=1&modificationDate=1626773824000&api=v2)
+
+下面，我们使用七个例子来加以详细说明。
 
 索引树节点的度（即每个节点的最大子节点个数）可以由用户进行配置，配置项为`max_degree_of_index_node`，其默认值为256。在以下例子中，我们假定 `max_degree_of_index_node = 10`。
 
-* 例1：5个实体，每个实体有5个物理量
+需要注意的是，在索引树的每类节点（LEAF、MEASUREMENT）中，键按照字典序排列。在下面的例子中，若i<j，假设字典序di<dj。（否则，实际上[d1,d2,...d10]的字典序排列应该为[d1,d10,d2,...d9]）
+
+其中，例1\~4为一元时间序列的例子，例5\~6为多元时间序列的例子，例7为综合例子。
+
+* **例1：5个实体，每个实体有5个物理量**
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/125254013-9d2d7400-e32c-11eb-9f95-1663e14cffbb.png">
 
 在5个实体，每个实体有5个物理量的情况下，由于实体数和物理量数均不超过 `max_degree_of_index_node`，因此索引树只有默认的物理量部分。在这部分中，每个 IndexNode 最多由10个 IndexEntry 组成。根节点是 `LEAF_ENTITY` 类型，其中的5个 IndexEntry 指向对应的实体的 IndexNode，这些节点直接指向 `TimeseriesIndex`，是 `LEAF_MEASUREMENT`。
 
-* 例2：1个实体，150个物理量
+* **例2：1个实体，150个物理量**
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/125254022-a0c0fb00-e32c-11eb-8fd1-462936358288.png">
 
 在1个实体，实体中有150个物理量的情况下，物理量个数超过了 `max_degree_of_index_node`，索引树有默认的物理量层级。在这个层级里，每个 IndexNode 最多由10个 IndexEntry 组成。直接指向 `TimeseriesIndex`的节点类型均为 `LEAF_MEASUREMENT`；而后续产生的中间节点不是物理量索引层级的叶子节点，这些节点是 `INTERNAL_MEASUREMENT`；根节点是 `LEAF_ENTITY` 类型。
 
-* 例3：150个实体，每个实体有1个物理量
+* **例3：150个实体，每个实体有1个物理量**
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/122771008-9a64d380-d2d8-11eb-9044-5ac794dd38f7.png">
 
 在150个实体，每个实体中有1个物理量的情况下，实体个数超过了 `max_degree_of_index_node`，形成索引树的物理量层级和实体索引层级。在这两个层级里，每个 IndexNode 最多由10个 IndexEntry 组成。直接指向 `TimeseriesIndex` 的节点类型为 `LEAF_MEASUREMENT`，物理量索引层级的根节点同时作为实体索引层级的叶子节点，其节点类型为 `LEAF_ENTITY`；而后续产生的中间节点和根节点不是实体索引层级的叶子节点，因此节点类型为 `INTERNAL_ENTITY`。
 
-* 例4：150个实体，每个实体有150个物理量
+* **例4：150个实体，每个实体有150个物理量**
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/19167280/122677241-1a753580-d214-11eb-817f-17bcf797251f.png">
 
 在150个实体，每个实体中有150个物理量的情况下，物理量和实体个数均超过了 `max_degree_of_index_node`，形成索引树的物理量层级和实体索引层级。在这两个层级里，每个 IndexNode 均最多由10个 IndexEntry 组成。如前所述，从根节点到实体索引层级的叶子节点，类型分别为`INTERNAL_ENTITY` 和 `LEAF_ENTITY`，而每个实体索引层级的叶子节点都是物理量索引层级的根节点，从这里到物理量索引层级的叶子节点，类型分别为`INTERNAL_MEASUREMENT` 和 `LEAF_MEASUREMENT`。
+
+- **例5：1个实体，20个物理量，2个多元时间序列组，每个多元时间序列组分别有9个物理量**
+
+![img](https://cwiki.apache.org/confluence/download/attachments/184617773/tsFileVectorIndexCase5.png?version=2&modificationDate=1626952911868&api=v2)
+
+- **例6：1个实体，30个物理量，2个多元时间序列组，每个多元时间序列组分别有15个物理量**
+
+![img](https://cwiki.apache.org/confluence/download/attachments/184617773/tsFileVectorIndexCase6.png?version=2&modificationDate=1626952911054&api=v2)
+
+- **例7：2个实体，每个实体的物理量如下表所示**
+
+| d0                                 | d1                                 |
+| :--------------------------------- | :--------------------------------- |
+| 【一元时间序列】s0,s1...,s4        | 【一元时间序列】s0,s1,...s14       |
+| 【多元时间序列】v0.(s5,s6,...,s14) | 【多元时间序列】v0.(s15,s16,..s18) |
+| 【一元时间序列】z15,z16,..,z18     |                                    |
+
+![img](https://cwiki.apache.org/confluence/download/attachments/184617773/tsFileVectorIndexCase7.png?version=2&modificationDate=1626952910746&api=v2)
 
 索引采用树形结构进行设计的目的是在实体数或者物理量数量过大时，可以不用一次读取所有的 `TimeseriesIndex`，只需要根据所读取的物理量定位对应的节点，从而减少 I/O，加快查询速度。有关 TsFile 的读流程将在本章最后一节加以详细说明。
 
@@ -771,3 +829,22 @@ title("draw(timeMap,countMap,{'root.vehicle.d0.s0','root.vehicle.d0.s1'},true)")
 ![3](https://user-images.githubusercontent.com/33376433/123760418-66e70200-d8f3-11eb-8701-437afd73ac4c.png)
 ![4](https://user-images.githubusercontent.com/33376433/123760424-69e1f280-d8f3-11eb-9f45-571496685a6e.png)
 ![5](https://user-images.githubusercontent.com/33376433/123760433-6cdce300-d8f3-11eb-8ecd-da04a475af41.png)
+
+## 附录
+
+- **大端存储**
+	- 比如： `int` `0x8` 将会被存储为 `00 00 00 08`, 而不是 `08 00 00 00`
+- **可变长的字符串类型**
+	- 存储的方式是以一个 `int` 类型的 `Size` + 字符串组成。`Size` 的值可以为 0。
+	- `Size` 指的是字符串所占的字节数，它并不一定等于字符串的长度。
+	- 举例来说，"sensor_1" 这个字符串将被存储为 `00 00 00 08` + "sensor_1" (ASCII编码)。
+	- 另外需要注意的一点是文件签名 "TsFile000001" (`Magic String` + `Version`), 因为他的 `Size(12)` 和 ASCII 编码值是固定的，所以没有必要在这个字符串前的写入 `Size` 值。
+- **压缩类型**
+	- 0: UNCOMPRESSED
+	- 1: SNAPPY
+	- 2: GZIP
+	- 3: LZO
+	- 4: SDT
+	- 5: PAA
+	- 6: PLA
+	- 7: LZ4


### PR DESCRIPTION
* update tsfile vector index example about **1.2.3.3 IndexOfTimeseriesIndex (Secondary Index)**
* refact structure about  **1.1 Variable Storage**
* fix bug about dictionary order, I add some explaination about example1-4. (In fact, the dictionary order of [d1,d2,... .d10] should be [d1,d10,d2,.... .d9])
