### PR TITLE
Fix TestContainer  IT

### DIFF
--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -213,79 +213,6 @@ public abstract class Cases {
     }
   }
 
-  //  @Test
-  //  public void vectorCountTest() throws IoTDBConnectionException, StatementExecutionException {
-  //    List<List<String>> measurementList = new ArrayList<>();
-  //    List<String> schemaNames = new ArrayList<>();
-  //    List<List<TSEncoding>> encodingList = new ArrayList<>();
-  //    List<List<TSDataType>> dataTypeList = new ArrayList<>();
-  //    List<CompressionType> compressionTypes = new ArrayList<>();
-  //    List<TSDataType> dataTypes = new ArrayList<>();
-  //    List<TSEncoding> encodings = new ArrayList<>();
-  //    String[] vectorMeasurements = new String[10];
-  //
-  //    Stream.iterate(0, i -> i + 1)
-  //        .limit(10)
-  //        .forEach(
-  //            i -> {
-  //              dataTypes.add(TSDataType.DOUBLE);
-  //              vectorMeasurements[i] = "vm" + i;
-  //              encodings.add(TSEncoding.RLE);
-  //              compressionTypes.add(CompressionType.SNAPPY);
-  //            });
-  //    schemaNames.add("schema");
-  //    encodingList.add(encodings);
-  //    dataTypeList.add(dataTypes);
-  //    measurementList.add(Arrays.asList(vectorMeasurements));
-  //
-  //    session.createSchemaTemplate(
-  //        "testcontainer",
-  //        schemaNames,
-  //        measurementList,
-  //        dataTypeList,
-  //        encodingList,
-  //        compressionTypes);
-  //    session.setStorageGroup("root.template");
-  //    session.setSchemaTemplate("testcontainer", "root.template");
-  //
-  //    VectorMeasurementSchema vectorMeasurementSchema =
-  //        new VectorMeasurementSchema(
-  //            "vector", vectorMeasurements, dataTypes.toArray(new TSDataType[0]));
-  //
-  //    Tablet tablet = new Tablet("root.template.device1.vector",
-  //    Arrays.asList(vectorMeasurementSchema));
-  //    tablet.setAligned(true);
-  //    for (int i = 0; i < 10; i++) {
-  //      tablet.addTimestamp(i, i);
-  //      for (int j = 0; j < 10; j++) {
-  //        tablet.addValue("vm" + j, i, (double) i);
-  //        tablet.rowSize++;
-  //      }
-  //    }
-  //    session.insertTablet(tablet);
-  //
-  //    SessionDataSet sessionDataSet =
-  //        session.executeQueryStatement("select count(*) from root.template.device1");
-  //    Assert.assertTrue(sessionDataSet.hasNext());
-  //    RowRecord next = sessionDataSet.next();
-  //    Assert.assertEquals(10, next.getFields().get(0).getLongV());
-  //
-  //    sessionDataSet = session.executeQueryStatement("select count(vm1) from
-  // root.template.device1");
-  //    Assert.assertTrue(sessionDataSet.hasNext());
-  //    next = sessionDataSet.next();
-  //    Assert.assertEquals(10, next.getFields().get(0).getLongV());
-  //
-  //    sessionDataSet =
-  //        session.executeQueryStatement("select count(vm1),count(vm2) from
-  // root.template.device1");
-  //    Assert.assertTrue(sessionDataSet.hasNext());
-  //    next = sessionDataSet.next();
-  //    Assert.assertEquals(2, next.getFields().size());
-  //    Assert.assertEquals(10, next.getFields().get(0).getLongV());
-  //    Assert.assertEquals(10, next.getFields().get(1).getLongV());
-  //  }
-
   @Test
   public void clusterLastQueryTest() throws IoTDBConnectionException, StatementExecutionException {
 
@@ -490,42 +417,6 @@ public abstract class Cases {
           resultSet.close();
         }
       }
-    }
-  }
-
-  @Test
-  public void testApplyClearCache() throws InterruptedException {
-    String sql = "CLEAR CACHE";
-    try {
-      // Wait for 3S so that the leader can be elected
-      Thread.sleep(3000);
-      writeStatement.execute(sql);
-    } catch (SQLException e) {
-      Assert.assertNull(e);
-    }
-  }
-
-  @Test
-  public void testApplyMerge() throws InterruptedException {
-    String sql = "MERGE";
-    try {
-      // Wait for 3S so that the leader can be elected
-      Thread.sleep(3000);
-      writeStatement.execute(sql);
-    } catch (SQLException e) {
-      Assert.assertNull(e);
-    }
-  }
-
-  @Test
-  public void testCreateSnapshot() throws InterruptedException {
-    String sql = "CREATE SNAPSHOT FOR SCHEMA";
-    try {
-      // Wait for 3S so that the leader can be elected
-      Thread.sleep(3000);
-      writeStatement.execute(sql);
-    } catch (SQLException e) {
-      Assert.assertNull(e);
     }
   }
 


### PR DESCRIPTION
Remove unnecessary tests due to there reasons:
- Since each test case is currently tested in seven clusters started by TestContainer, the time to add a test CI increases by approximately 2 mins, so we need to minimize the number of test functions if possible.
- I don't think it makes any sense to put three operations functions in testContainer without checking them, and these functions should be added to applier's IT which is already done.
- Currently, master ci often fails because of the presence of leader Not found for these three functions. Although this may require us to add the corresponding retry logic, it is better to kill these unrelated functions first.