### PR TITLE
[To autoai] Fix lock bug in cross space compaction selection

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -193,7 +193,7 @@ public abstract class TsFileManagement {
     }
   }
 
-  public synchronized boolean merge(
+  public boolean merge(
       boolean fullMerge,
       List<TsFileResource> seqMergeList,
       List<TsFileResource> unSeqMergeList,
@@ -209,89 +209,93 @@ public abstract class TsFileManagement {
       }
     }
     isUnseqMerging = true;
-
-    if (seqMergeList.isEmpty()) {
-      logger.info("{} no seq files to be merged", storageGroupName);
-      isUnseqMerging = false;
-      return false;
-    }
-
-    if (unSeqMergeList.isEmpty()) {
-      logger.info("{} no unseq files to be merged", storageGroupName);
-      isUnseqMerging = false;
-      return false;
-    }
-
-    if (unSeqMergeList.size() > maxOpenFileNumInEachUnseqCompaction) {
-      logger.info(
-          "{} too much unseq files to be merged, reduce it to {}",
-          storageGroupName,
-          maxOpenFileNumInEachUnseqCompaction);
-      unSeqMergeList = unSeqMergeList.subList(0, maxOpenFileNumInEachUnseqCompaction);
-    }
-
-    long budget = IoTDBDescriptor.getInstance().getConfig().getMergeMemoryBudget();
-    long timeLowerBound = System.currentTimeMillis() - dataTTL;
-    MergeResource mergeResource = new MergeResource(seqMergeList, unSeqMergeList, timeLowerBound);
-
-    IMergeFileSelector fileSelector = getMergeFileSelector(budget, mergeResource);
+    writeLock();
     try {
-      List[] mergeFiles = fileSelector.select();
-      if (mergeFiles.length == 0) {
-        logger.info(
-            "{} cannot select merge candidates under the budget {}", storageGroupName, budget);
+      if (seqMergeList.isEmpty()) {
+        logger.info("{} no seq files to be merged", storageGroupName);
         isUnseqMerging = false;
         return false;
       }
-      // avoid pending tasks holds the metadata and streams
-      mergeResource.clear();
-      String taskName = storageGroupName + "-" + System.currentTimeMillis();
-      // do not cache metadata until true candidates are chosen, or too much metadata will be
-      // cached during selection
-      mergeResource.setCacheDeviceMeta(true);
 
-      for (TsFileResource tsFileResource : mergeResource.getSeqFiles()) {
-        tsFileResource.setMerging(true);
-      }
-      for (TsFileResource tsFileResource : mergeResource.getUnseqFiles()) {
-        tsFileResource.setMerging(true);
+      if (unSeqMergeList.isEmpty()) {
+        logger.info("{} no unseq files to be merged", storageGroupName);
+        isUnseqMerging = false;
+        return false;
       }
 
-      mergeStartTime = System.currentTimeMillis();
-      MergeTask mergeTask =
-          new MergeTask(
-              mergeResource,
-              storageGroupDir,
-              this::mergeEndAction,
-              taskName,
-              fullMerge,
-              fileSelector.getConcurrentMergeNum(),
-              storageGroupName);
-      mergingModification =
-          new ModificationFile(storageGroupDir + File.separator + MERGING_MODIFICATION_FILE_NAME);
-      MergeManager.getINSTANCE().submitMainTask(mergeTask);
-      if (logger.isInfoEnabled()) {
+      if (unSeqMergeList.size() > maxOpenFileNumInEachUnseqCompaction) {
         logger.info(
-            "{} submits a merge task {}, merging {} seqFiles, {} unseqFiles",
+            "{} too much unseq files to be merged, reduce it to {}",
             storageGroupName,
-            taskName,
-            mergeFiles[0].size(),
-            mergeFiles[1].size());
+            maxOpenFileNumInEachUnseqCompaction);
+        unSeqMergeList = unSeqMergeList.subList(0, maxOpenFileNumInEachUnseqCompaction);
       }
-      // wait until unseq merge has finished
-      while (isUnseqMerging) {
-        try {
-          Thread.sleep(200);
-        } catch (InterruptedException e) {
-          logger.error("{} [Compaction] shutdown", storageGroupName, e);
-          Thread.currentThread().interrupt();
+
+      long budget = IoTDBDescriptor.getInstance().getConfig().getMergeMemoryBudget();
+      long timeLowerBound = System.currentTimeMillis() - dataTTL;
+      MergeResource mergeResource = new MergeResource(seqMergeList, unSeqMergeList, timeLowerBound);
+
+      IMergeFileSelector fileSelector = getMergeFileSelector(budget, mergeResource);
+      try {
+        List[] mergeFiles = fileSelector.select();
+        if (mergeFiles.length == 0) {
+          logger.info(
+              "{} cannot select merge candidates under the budget {}", storageGroupName, budget);
+          isUnseqMerging = false;
           return false;
         }
+        // avoid pending tasks holds the metadata and streams
+        mergeResource.clear();
+        String taskName = storageGroupName + "-" + System.currentTimeMillis();
+        // do not cache metadata until true candidates are chosen, or too much metadata will be
+        // cached during selection
+        mergeResource.setCacheDeviceMeta(true);
+
+        for (TsFileResource tsFileResource : mergeResource.getSeqFiles()) {
+          tsFileResource.setMerging(true);
+        }
+        for (TsFileResource tsFileResource : mergeResource.getUnseqFiles()) {
+          tsFileResource.setMerging(true);
+        }
+
+        mergeStartTime = System.currentTimeMillis();
+        MergeTask mergeTask =
+            new MergeTask(
+                mergeResource,
+                storageGroupDir,
+                this::mergeEndAction,
+                taskName,
+                fullMerge,
+                fileSelector.getConcurrentMergeNum(),
+                storageGroupName);
+        mergingModification =
+            new ModificationFile(storageGroupDir + File.separator + MERGING_MODIFICATION_FILE_NAME);
+        MergeManager.getINSTANCE().submitMainTask(mergeTask);
+        if (logger.isInfoEnabled()) {
+          logger.info(
+              "{} submits a merge task {}, merging {} seqFiles, {} unseqFiles",
+              storageGroupName,
+              taskName,
+              mergeFiles[0].size(),
+              mergeFiles[1].size());
+        }
+        // wait until unseq merge has finished
+        while (isUnseqMerging) {
+          try {
+            Thread.sleep(200);
+          } catch (InterruptedException e) {
+            logger.error("{} [Compaction] shutdown", storageGroupName, e);
+            Thread.currentThread().interrupt();
+            return false;
+          }
+        }
+        return true;
+      } catch (MergeException | IOException e) {
+        logger.error("{} cannot select file for merge", storageGroupName, e);
+        return false;
       }
-      return true;
-    } catch (MergeException | IOException e) {
-      logger.error("{} cannot select file for merge", storageGroupName, e);
-      return false;
+    } finally {
+      writeUnlock();
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
@@ -81,7 +81,8 @@ public class MergeResource {
   private boolean filterResource(TsFileResource res) {
     return res.getTsFile().exists()
         && !res.isDeleted()
-        && (!res.isClosed() || res.stillLives(timeLowerBound));
+        && (!res.isClosed() || res.stillLives(timeLowerBound))
+        && !res.isMerging();
   }
 
   public MergeResource(

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
@@ -155,7 +155,7 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
       if (seqSelectedNum != resource.getSeqFiles().size()) {
         selectOverlappedSeqFiles(unseqFile);
       }
-      boolean isClosed = checkClosed(unseqFile);
+      boolean isClosed = checkChoosable(unseqFile);
       if (!isClosed) {
         tmpSelectedSeqFiles.clear();
         unseqIndex++;
@@ -206,18 +206,19 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
     return false;
   }
 
-  private boolean checkClosed(TsFileResource unseqFile) {
-    boolean isClosed = unseqFile.isClosed();
-    if (!isClosed) {
+  private boolean checkChoosable(TsFileResource unseqFile) {
+    boolean choosable = unseqFile.isClosed() && !unseqFile.isMerging();
+    if (!choosable) {
       return false;
     }
     for (Integer seqIdx : tmpSelectedSeqFiles) {
-      if (!resource.getSeqFiles().get(seqIdx).isClosed()) {
-        isClosed = false;
+      if (!resource.getSeqFiles().get(seqIdx).isClosed()
+          || resource.getSeqFiles().get(seqIdx).isMerging()) {
+        choosable = false;
         break;
       }
     }
-    return isClosed;
+    return choosable;
   }
 
   private void selectOverlappedSeqFiles(TsFileResource unseqFile) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -522,7 +522,7 @@ public class TsFileResource {
     this.deleted = deleted;
   }
 
-  boolean isMerging() {
+  public boolean isMerging() {
     return isMerging;
   }
 


### PR DESCRIPTION
# Description
In the selection of cross space compaction, current code uses a syncrhoized to ensure atomicity. However, every time a selection is carried out, the program will new a MergeTask, which may fail to ensure atomicity, and two selection process will execute simultaneously.
![image](https://user-images.githubusercontent.com/37140360/127130383-34ac77cb-12c8-473c-ab75-7f81aed4f8b8.png)
![f13a9cf9ec13c35069b8313948d077b](https://user-images.githubusercontent.com/37140360/127130423-417cd24e-7024-4d08-b0a9-4f92d62e12ab.jpg)

Moreover, in the selection of cross space compaction, the program doesn't check the file's merging status, which may cause a file to be selected by two compaction task.
# Solution
We replace the synchronized with a write lock to ensure that only one selection can be carried out at the same time. And we check the merging status of file to avoid a file is selected by two compaction task