### PR TITLE
[IOTDB-1531] Check tsfile creation time when recovering

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -723,12 +723,18 @@ public class StorageGroupProcessor {
   /** check if the tsfile's time is smaller than system current time */
   private void checkTsFileTime(File tsFile) throws StorageGroupProcessorException {
     String[] items = tsFile.getName().replace(TSFILE_SUFFIX, "").split(FILE_NAME_SEPARATOR);
-    long time = Long.parseLong(items[0]);
-    if (time > System.currentTimeMillis()) {
+    long fileTime = Long.parseLong(items[0]);
+    long currentTime = System.currentTimeMillis();
+    if (fileTime > currentTime) {
       throw new StorageGroupProcessorException(
           String.format(
-              "the time of tsfile %s is larger than system current time, please check it.",
-              tsFile.getAbsolutePath()));
+              "virtual storage group %s[%s] is down, because the time of tsfile %s is larger than system current time, "
+                  + "file time is %d while system current time is %d, please check it.",
+              logicalStorageGroupName,
+              virtualStorageGroupId,
+              tsFile.getAbsolutePath(),
+              fileTime,
+              currentTime));
     }
   }
 


### PR DESCRIPTION
Check tsfile's time when recovering, make sure all tsfile time are less than System.currentTimeMillis(). If the tsfile's time is larger than System.currentTimeMillis(), the recover of corresponding virtual storage group will fail, users cannot read/write this virtual storage group until the time of the tsfile is correct.

Before fixing time：
<img width="846" alt="before fix" src="https://user-images.githubusercontent.com/43991780/127419672-74134e15-2200-484a-9938-5c6ac4d067c4.png">
After fixing time：
<img width="846" alt="after fix" src="https://user-images.githubusercontent.com/43991780/127419695-5eacefaa-5491-4fa3-a6a9-87cb1a4345d8.png">