### PR TITLE
[IOTDB-1511] Implement EntityMNode

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -594,7 +594,7 @@ public class MManager {
       // for not support deleting part of aligned timeseies
       // should be removed after partial deletion is supported
       IMNode lastNode = getNodeByPath(allTimeseries.get(0));
-      if (lastNode instanceof MeasurementMNode) {
+      if (lastNode.isMeasurement()) {
         IMeasurementSchema schema = ((IMeasurementMNode) lastNode).getSchema();
         if (schema instanceof VectorMeasurementSchema) {
           if (schema.getValueMeasurementIdList().size() != allTimeseries.size()) {
@@ -1252,14 +1252,14 @@ public class MManager {
         }
       }
       node = mtree.getDeviceNodeWithAutoCreating(path, sgLevel);
-      if (!(node.left instanceof StorageGroupMNode)) {
+      if (!(node.left.isStorageGroup())) {
         logWriter.autoCreateDeviceMNode(new AutoCreateDeviceMNodePlan(node.left.getPartialPath()));
       }
       return node;
     } catch (StorageGroupAlreadySetException e) {
       // ignore set storage group concurrently
       node = mtree.getDeviceNodeWithAutoCreating(path, sgLevel);
-      if (!(node.left instanceof StorageGroupMNode)) {
+      if (!(node.left.isStorageGroup())) {
         logWriter.autoCreateDeviceMNode(new AutoCreateDeviceMNodePlan(node.left.getPartialPath()));
       }
       return node;
@@ -1395,7 +1395,7 @@ public class MManager {
       PartialPath fullPath)
       throws MetadataException, IOException {
     IMNode IMNode = mtree.getNodeByPath(fullPath);
-    if (!(IMNode instanceof MeasurementMNode)) {
+    if (!(IMNode.isMeasurement())) {
       throw new PathNotExistException(fullPath.getFullPath());
     }
     IMeasurementMNode leafMNode = (IMeasurementMNode) IMNode;
@@ -1445,7 +1445,7 @@ public class MManager {
   public void addAttributes(Map<String, String> attributesMap, PartialPath fullPath)
       throws MetadataException, IOException {
     IMNode IMNode = mtree.getNodeByPath(fullPath);
-    if (!(IMNode instanceof MeasurementMNode)) {
+    if (!(IMNode.isMeasurement())) {
       throw new PathNotExistException(fullPath.getFullPath());
     }
     IMeasurementMNode leafMNode = (IMeasurementMNode) IMNode;
@@ -1469,7 +1469,7 @@ public class MManager {
   public void addTags(Map<String, String> tagsMap, PartialPath fullPath)
       throws MetadataException, IOException {
     IMNode IMNode = mtree.getNodeByPath(fullPath);
-    if (!(IMNode instanceof MeasurementMNode)) {
+    if (!(IMNode.isMeasurement())) {
       throw new PathNotExistException(fullPath.getFullPath());
     }
     IMeasurementMNode leafMNode = (IMeasurementMNode) IMNode;
@@ -1496,7 +1496,7 @@ public class MManager {
   public void dropTagsOrAttributes(Set<String> keySet, PartialPath fullPath)
       throws MetadataException, IOException {
     IMNode IMNode = mtree.getNodeByPath(fullPath);
-    if (!(IMNode instanceof MeasurementMNode)) {
+    if (!(IMNode.isMeasurement())) {
       throw new PathNotExistException(fullPath.getFullPath());
     }
     IMeasurementMNode leafMNode = (IMeasurementMNode) IMNode;
@@ -1517,7 +1517,7 @@ public class MManager {
   public void setTagsOrAttributesValue(Map<String, String> alterMap, PartialPath fullPath)
       throws MetadataException, IOException {
     IMNode IMNode = mtree.getNodeByPath(fullPath);
-    if (!(IMNode instanceof MeasurementMNode)) {
+    if (!(IMNode.isMeasurement())) {
       throw new PathNotExistException(fullPath.getFullPath());
     }
     IMeasurementMNode leafMNode = (IMeasurementMNode) IMNode;
@@ -1541,7 +1541,7 @@ public class MManager {
   public void renameTagOrAttributeKey(String oldKey, String newKey, PartialPath fullPath)
       throws MetadataException, IOException {
     IMNode IMNode = mtree.getNodeByPath(fullPath);
-    if (!(IMNode instanceof MeasurementMNode)) {
+    if (!(IMNode.isMeasurement())) {
       throw new PathNotExistException(fullPath.getFullPath());
     }
     IMeasurementMNode leafMNode = (IMeasurementMNode) IMNode;
@@ -1579,7 +1579,7 @@ public class MManager {
     nodeDeque.addLast(startingNode);
     while (!nodeDeque.isEmpty()) {
       IMNode node = nodeDeque.removeFirst();
-      if (node instanceof MeasurementMNode) {
+      if (node.isMeasurement()) {
         IMeasurementSchema nodeSchema = ((IMeasurementMNode) node).getSchema();
         timeseriesSchemas.add(
             new TimeseriesSchema(
@@ -1604,7 +1604,7 @@ public class MManager {
     nodeDeque.addLast(startingNode);
     while (!nodeDeque.isEmpty()) {
       IMNode node = nodeDeque.removeFirst();
-      if (node instanceof MeasurementMNode) {
+      if (node.isMeasurement()) {
         IMeasurementSchema nodeSchema = ((IMeasurementMNode) node).getSchema();
         measurementSchemas.add(nodeSchema);
       } else if (!node.getChildren().isEmpty()) {
@@ -1709,13 +1709,13 @@ public class MManager {
 
     // 1. get device node
     Pair<IMNode, Template> deviceMNode = getDeviceNodeWithAutoCreate(deviceId);
-    if (!(deviceMNode.left instanceof MeasurementMNode)
+    if (!(deviceMNode.left.isMeasurement())
         && deviceMNode.left.getDeviceTemplate() != null) {
       deviceMNode.right = deviceMNode.left.getDeviceTemplate();
     }
 
     // check insert non-aligned InsertPlan for aligned timeseries
-    if (deviceMNode.left instanceof MeasurementMNode
+    if (deviceMNode.left.isMeasurement()
         && ((IMeasurementMNode) deviceMNode.left).getSchema() instanceof VectorMeasurementSchema
         && !plan.isAligned()) {
       throw new MetadataException(
@@ -1726,7 +1726,7 @@ public class MManager {
     // check insert aligned InsertPlan for non-aligned timeseries
     else if (plan.isAligned()
         && deviceMNode.left.getChild(vectorId) != null
-        && !(deviceMNode.left.getChild(vectorId) instanceof MeasurementMNode)) {
+        && !(deviceMNode.left.getChild(vectorId).isMeasurement())) {
       throw new MetadataException(
           String.format(
               "Path [%s] is not an aligned timeseries, please set InsertPlan.isAligned() = false",
@@ -1740,9 +1740,9 @@ public class MManager {
       try {
         String measurement = measurementList[i];
         IMNode child = getMNode(deviceMNode.left, plan.isAligned() ? vectorId : measurement);
-        if (child instanceof MeasurementMNode) {
+        if (child.isMeasurement()) {
           measurementMNode = (IMeasurementMNode) child;
-        } else if (child instanceof StorageGroupMNode) {
+        } else if (child.isStorageGroup()) {
           throw new PathAlreadyExistException(deviceId + PATH_SEPARATOR + measurement);
         } else if ((measurementMNode = findTemplate(deviceMNode, measurement, vectorId)) != null) {
           // empty

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1709,8 +1709,7 @@ public class MManager {
 
     // 1. get device node
     Pair<IMNode, Template> deviceMNode = getDeviceNodeWithAutoCreate(deviceId);
-    if (!(deviceMNode.left.isMeasurement())
-        && deviceMNode.left.getDeviceTemplate() != null) {
+    if (!(deviceMNode.left.isMeasurement()) && deviceMNode.left.getDeviceTemplate() != null) {
       deviceMNode.right = deviceMNode.left.getDeviceTemplate();
     }
 
@@ -1740,9 +1739,9 @@ public class MManager {
       try {
         String measurement = measurementList[i];
         IMNode child = getMNode(deviceMNode.left, plan.isAligned() ? vectorId : measurement);
-        if (child.isMeasurement()) {
+        if (child != null && child.isMeasurement()) {
           measurementMNode = (IMeasurementMNode) child;
-        } else if (child.isStorageGroup()) {
+        } else if (child != null && child.isStorageGroup()) {
           throw new PathAlreadyExistException(deviceId + PATH_SEPARATOR + measurement);
         } else if ((measurementMNode = findTemplate(deviceMNode, measurement, vectorId)) != null) {
           // empty

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.metadata.MManager.StorageGroupFilter;
 import org.apache.iotdb.db.metadata.logfile.MLogReader;
 import org.apache.iotdb.db.metadata.logfile.MLogWriter;
+import org.apache.iotdb.db.metadata.mnode.IEntityMNode;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
 import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -1813,9 +1813,7 @@ public class MTree implements Serializable {
     for (int i = 1; i < nodes.length; i++) {
       if (node.getChild(nodes[i]) != null) {
         node = node.getChild(nodes[i]);
-        if (node.isStorageGroup()
-            && filter != null
-            && !filter.satisfy(node.getFullPath())) {
+        if (node.isStorageGroup() && filter != null && !filter.satisfy(node.getFullPath())) {
           return res;
         }
       } else {
@@ -1838,9 +1836,7 @@ public class MTree implements Serializable {
       int targetLevel,
       StorageGroupFilter filter) {
     if (node == null
-        || node.isStorageGroup()
-            && filter != null
-            && !filter.satisfy(node.getFullPath())) {
+        || node.isStorageGroup() && filter != null && !filter.satisfy(node.getFullPath())) {
       return;
     }
     if (targetLevel == 0) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/EntityMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/EntityMNode.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.metadata.mnode;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class EntityMNode extends InternalMNode implements IEntityMNode {
+
+  /**
+   * suppress warnings reason: volatile for double synchronized check
+   *
+   * <p>This will be a ConcurrentHashMap instance
+   */
+  @SuppressWarnings("squid:S3077")
+  private transient volatile Map<String, IMeasurementMNode> aliasChildren = null;
+
+  private volatile boolean useTemplate = false;
+
+  /**
+   * Constructor of MNode.
+   *
+   * @param parent
+   * @param name
+   */
+  public EntityMNode(IMNode parent, String name) {
+    super(parent, name);
+  }
+
+  /** check whether the MNode has a child with the name */
+  @Override
+  public boolean hasChild(String name) {
+    return (children != null && children.containsKey(name))
+        || (aliasChildren != null && aliasChildren.containsKey(name));
+  }
+
+  /** get the child with the name */
+  @Override
+  public IMNode getChild(String name) {
+    IMNode child = null;
+    if (children != null) {
+      child = children.get(name);
+    }
+    if (child != null) {
+      return child;
+    }
+    return aliasChildren == null ? null : aliasChildren.get(name);
+  }
+
+  /** add an alias */
+  @Override
+  public boolean addAlias(String alias, IMeasurementMNode child) {
+    if (aliasChildren == null) {
+      // double check, alias children volatile
+      synchronized (this) {
+        if (aliasChildren == null) {
+          aliasChildren = new ConcurrentHashMap<>();
+        }
+      }
+    }
+
+    return aliasChildren.computeIfAbsent(alias, aliasName -> child) == child;
+  }
+
+  /** delete the alias of a child */
+  @Override
+  public void deleteAliasChild(String alias) {
+    if (aliasChildren != null) {
+      aliasChildren.remove(alias);
+    }
+  }
+
+  @Override
+  public Map<String, IMeasurementMNode> getAliasChildren() {
+    if (aliasChildren == null) {
+      return Collections.emptyMap();
+    }
+    return aliasChildren;
+  }
+
+  @Override
+  public void setAliasChildren(Map<String, IMeasurementMNode> aliasChildren) {
+    this.aliasChildren = aliasChildren;
+  }
+
+  @Override
+  public boolean isUseTemplate() {
+    return useTemplate;
+  }
+
+  @Override
+  public void setUseTemplate(boolean useTemplate) {
+    this.useTemplate = useTemplate;
+  }
+
+  @Override
+  public boolean isEntity() {
+    return true;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IEntityMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IEntityMNode.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.metadata.mnode;
+
+import java.util.Map;
+
+public interface IEntityMNode extends IMNode {
+
+  boolean addAlias(String alias, IMeasurementMNode child);
+
+  void deleteAliasChild(String alias);
+
+  Map<String, IMeasurementMNode> getAliasChildren();
+
+  void setAliasChildren(Map<String, IMeasurementMNode> aliasChildren);
+
+  boolean isUseTemplate();
+
+  void setUseTemplate(boolean useTemplate);
+
+  static IEntityMNode setToEntity(IMNode node) {
+    IEntityMNode entityMNode;
+    if (node.isEntity()) {
+      entityMNode = (IEntityMNode) node;
+    } else {
+      if (node.isStorageGroup()) {
+        entityMNode =
+            new StorageGroupEntityMNode(
+                node.getParent(), node.getName(), ((StorageGroupMNode) node).getDataTTL());
+      } else {
+        entityMNode = new EntityMNode(node.getParent(), node.getName());
+      }
+      if (node.getParent() != null) {
+        node.getParent().replaceChild(node.getName(), entityMNode);
+      }
+    }
+    return entityMNode;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMNode.java
@@ -52,11 +52,7 @@ public interface IMNode extends Serializable {
 
   IMNode addChild(IMNode child);
 
-  boolean addAlias(String alias, IMNode child);
-
   void deleteChild(String name);
-
-  void deleteAliasChild(String alias);
 
   void replaceChild(String measurement, IMNode newChildNode);
 
@@ -64,9 +60,13 @@ public interface IMNode extends Serializable {
 
   Map<String, IMNode> getChildren();
 
-  Map<String, IMNode> getAliasChildren();
-
   void setChildren(Map<String, IMNode> children);
+
+  boolean addAlias(String alias, IMNode child);
+
+  void deleteAliasChild(String alias);
+
+  Map<String, IMNode> getAliasChildren();
 
   void setAliasChildren(Map<String, IMNode> aliasChildren);
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMNode.java
@@ -54,7 +54,7 @@ public interface IMNode extends Serializable {
 
   void deleteChild(String name);
 
-  void replaceChild(String measurement, IMNode newChildNode);
+  void replaceChild(String oldChildName, IMNode newChildNode);
 
   IMNode getChildOfAlignedTimeseries(String name) throws MetadataException;
 
@@ -62,17 +62,7 @@ public interface IMNode extends Serializable {
 
   void setChildren(Map<String, IMNode> children);
 
-  boolean addAlias(String alias, IMNode child);
-
-  void deleteAliasChild(String alias);
-
-  Map<String, IMNode> getAliasChildren();
-
-  void setAliasChildren(Map<String, IMNode> aliasChildren);
-
   boolean isUseTemplate();
-
-  void setUseTemplate(boolean useTemplate);
 
   Template getUpperTemplate();
 
@@ -81,6 +71,12 @@ public interface IMNode extends Serializable {
   void setDeviceTemplate(Template deviceTemplate);
 
   int getMeasurementMNodeCount();
+
+  boolean isStorageGroup();
+
+  boolean isEntity();
+
+  boolean isMeasurement();
 
   void serializeTo(MLogWriter logWriter) throws IOException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMeasurementMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMeasurementMNode.java
@@ -26,6 +26,9 @@ import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 /** This interface defines a MeasurementMNode's operation interfaces. */
 public interface IMeasurementMNode extends IMNode {
 
+  @Override
+  IEntityMNode getParent();
+
   IMeasurementSchema getSchema();
 
   void setSchema(IMeasurementSchema schema);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMeasurementMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMeasurementMNode.java
@@ -25,9 +25,26 @@ import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 
 /** This interface defines a MeasurementMNode's operation interfaces. */
 public interface IMeasurementMNode extends IMNode {
-  int getMeasurementCount();
 
   IMeasurementSchema getSchema();
+
+  void setSchema(IMeasurementSchema schema);
+
+  TSDataType getDataType(String measurementId);
+
+  int getMeasurementCount();
+
+  String getAlias();
+
+  void setAlias(String alias);
+
+  long getOffset();
+
+  void setOffset(long offset);
+
+  TriggerExecutor getTriggerExecutor();
+
+  void setTriggerExecutor(TriggerExecutor triggerExecutor);
 
   TimeValuePair getCachedLast();
 
@@ -35,20 +52,4 @@ public interface IMeasurementMNode extends IMNode {
       TimeValuePair timeValuePair, boolean highPriorityUpdate, Long latestFlushedTime);
 
   void resetCache();
-
-  long getOffset();
-
-  void setOffset(long offset);
-
-  String getAlias();
-
-  TriggerExecutor getTriggerExecutor();
-
-  void setAlias(String alias);
-
-  void setSchema(IMeasurementSchema schema);
-
-  void setTriggerExecutor(TriggerExecutor triggerExecutor);
-
-  TSDataType getDataType(String measurementId);
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IStorageGroupMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IStorageGroupMNode.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.metadata.mnode;
 
 /** This interface defines a StorageGroupMNode's operation interfaces. */
 public interface IStorageGroupMNode extends IMNode {
+
   long getDataTTL();
 
   void setDataTTL(long dataTTL);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
@@ -114,6 +114,26 @@ public abstract class MNode implements IMNode {
   }
 
   @Override
+  public boolean isUseTemplate() {
+    return false;
+  }
+
+  @Override
+  public boolean isStorageGroup() {
+    return false;
+  }
+
+  @Override
+  public boolean isEntity() {
+    return false;
+  }
+
+  @Override
+  public boolean isMeasurement() {
+    return false;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MeasurementMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MeasurementMNode.java
@@ -82,6 +82,16 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
   }
 
   @Override
+  public IMeasurementSchema getSchema() {
+    return schema;
+  }
+
+  @Override
+  public void setSchema(IMeasurementSchema schema) {
+    this.schema = schema;
+  }
+
+  @Override
   public int getMeasurementMNodeCount() {
     return 1;
   }
@@ -91,9 +101,50 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
     return schema.getMeasurementCount();
   }
 
+  /**
+   * get data type
+   *
+   * @param measurementId if it's a vector schema, we need sensor name of it
+   * @return measurement data type
+   */
   @Override
-  public IMeasurementSchema getSchema() {
-    return schema;
+  public TSDataType getDataType(String measurementId) {
+    if (schema instanceof MeasurementSchema) {
+      return schema.getType();
+    } else {
+      int index = schema.getMeasurementIdColumnIndex(measurementId);
+      return schema.getValueTSDataTypeList().get(index);
+    }
+  }
+
+  @Override
+  public long getOffset() {
+    return offset;
+  }
+
+  @Override
+  public void setOffset(long offset) {
+    this.offset = offset;
+  }
+
+  @Override
+  public String getAlias() {
+    return alias;
+  }
+
+  @Override
+  public void setAlias(String alias) {
+    this.alias = alias;
+  }
+
+  @Override
+  public TriggerExecutor getTriggerExecutor() {
+    return triggerExecutor;
+  }
+
+  @Override
+  public void setTriggerExecutor(TriggerExecutor triggerExecutor) {
+    this.triggerExecutor = triggerExecutor;
   }
 
   @Override
@@ -131,48 +182,8 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
   }
 
   @Override
-  public String getFullPath() {
-    return concatFullPath();
-  }
-
-  @Override
   public void resetCache() {
     cachedLastValuePair = null;
-  }
-
-  @Override
-  public long getOffset() {
-    return offset;
-  }
-
-  @Override
-  public void setOffset(long offset) {
-    this.offset = offset;
-  }
-
-  @Override
-  public String getAlias() {
-    return alias;
-  }
-
-  @Override
-  public TriggerExecutor getTriggerExecutor() {
-    return triggerExecutor;
-  }
-
-  @Override
-  public void setAlias(String alias) {
-    this.alias = alias;
-  }
-
-  @Override
-  public void setSchema(IMeasurementSchema schema) {
-    this.schema = schema;
-  }
-
-  @Override
-  public void setTriggerExecutor(TriggerExecutor triggerExecutor) {
-    this.triggerExecutor = triggerExecutor;
   }
 
   @Override
@@ -218,25 +229,22 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
     return node;
   }
 
-  /**
-   * get data type
-   *
-   * @param measurementId if it's a vector schema, we need sensor name of it
-   * @return measurement data type
-   */
   @Override
-  public TSDataType getDataType(String measurementId) {
-    if (schema instanceof MeasurementSchema) {
-      return schema.getType();
-    } else {
-      int index = schema.getMeasurementIdColumnIndex(measurementId);
-      return schema.getValueTSDataTypeList().get(index);
-    }
+  public String getFullPath() {
+    return concatFullPath();
   }
 
   @Override
   public boolean hasChild(String name) {
     return false;
+  }
+
+  @Override
+  public IMNode getChild(String name) {
+    logger.warn("current node {} is a MeasurementMNode, can not get child {}", super.name, name);
+    throw new RuntimeException(
+        String.format(
+            "current node %s is a MeasurementMNode, can not get child %s", super.name, name));
   }
 
   @Override
@@ -255,26 +263,11 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
   }
 
   @Override
-  public void deleteAliasChild(String alias) {
-    // Do nothing
-  }
-
-  @Override
-  public IMNode getChild(String name) {
-    logger.warn("current node {} is a MeasurementMNode, can not get child {}", super.name, name);
-    throw new RuntimeException(
-        String.format(
-            "current node %s is a MeasurementMNode, can not get child %s", super.name, name));
-  }
+  public void replaceChild(String measurement, IMNode newChildNode) {}
 
   @Override
   public IMNode getChildOfAlignedTimeseries(String name) throws MetadataException {
     return null;
-  }
-
-  @Override
-  public boolean addAlias(String alias, IMNode child) {
-    return false;
   }
 
   @Override
@@ -283,28 +276,39 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
   }
 
   @Override
-  public Map<String, IMNode> getAliasChildren() {
-    return null;
-  }
-
   public void setChildren(Map<String, IMNode> children) {
     // Do nothing
+  }
+
+  @Override
+  public boolean addAlias(String alias, IMNode child) {
+    return false;
+  }
+
+  @Override
+  public void deleteAliasChild(String alias) {
+    // Do nothing
+  }
+
+  @Override
+  public Map<String, IMNode> getAliasChildren() {
+    return null;
   }
 
   @Override
   public void setAliasChildren(Map<String, IMNode> aliasChildren) {}
 
   @Override
-  public void replaceChild(String measurement, IMNode newChildNode) {}
+  public boolean isUseTemplate() {
+    return false;
+  }
+
+  @Override
+  public void setUseTemplate(boolean useTemplate) {}
 
   @Override
   public Template getUpperTemplate() {
     return parent.getUpperTemplate();
-  }
-
-  @Override
-  public boolean isUseTemplate() {
-    return false;
   }
 
   @Override
@@ -316,7 +320,4 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
 
   @Override
   public void setDeviceTemplate(Template deviceTemplate) {}
-
-  @Override
-  public void setUseTemplate(boolean useTemplate) {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MeasurementMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MeasurementMNode.java
@@ -82,6 +82,11 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
   }
 
   @Override
+  public IEntityMNode getParent() {
+    return (IEntityMNode) parent;
+  }
+
+  @Override
   public IMeasurementSchema getSchema() {
     return schema;
   }
@@ -263,7 +268,7 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
   }
 
   @Override
-  public void replaceChild(String measurement, IMNode newChildNode) {}
+  public void replaceChild(String oldChildName, IMNode newChildNode) {}
 
   @Override
   public IMNode getChildOfAlignedTimeseries(String name) throws MetadataException {
@@ -281,32 +286,6 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
   }
 
   @Override
-  public boolean addAlias(String alias, IMNode child) {
-    return false;
-  }
-
-  @Override
-  public void deleteAliasChild(String alias) {
-    // Do nothing
-  }
-
-  @Override
-  public Map<String, IMNode> getAliasChildren() {
-    return null;
-  }
-
-  @Override
-  public void setAliasChildren(Map<String, IMNode> aliasChildren) {}
-
-  @Override
-  public boolean isUseTemplate() {
-    return false;
-  }
-
-  @Override
-  public void setUseTemplate(boolean useTemplate) {}
-
-  @Override
   public Template getUpperTemplate() {
     return parent.getUpperTemplate();
   }
@@ -320,4 +299,9 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
 
   @Override
   public void setDeviceTemplate(Template deviceTemplate) {}
+
+  @Override
+  public boolean isMeasurement() {
+    return true;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/StorageGroupEntityMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/StorageGroupEntityMNode.java
@@ -19,21 +19,17 @@
 package org.apache.iotdb.db.metadata.mnode;
 
 import org.apache.iotdb.db.metadata.logfile.MLogWriter;
-import org.apache.iotdb.db.qp.physical.sys.StorageGroupMNodePlan;
 
 import java.io.IOException;
 
-public class StorageGroupMNode extends InternalMNode implements IStorageGroupMNode {
-
-  private static final long serialVersionUID = 7999036474525817732L;
-
+public class StorageGroupEntityMNode extends EntityMNode implements IStorageGroupMNode {
   /**
    * when the data file in a storage group is older than dataTTL, it is considered invalid and will
    * be eventually deleted.
    */
   private long dataTTL;
 
-  public StorageGroupMNode(IMNode parent, String name, long dataTTL) {
+  public StorageGroupEntityMNode(IMNode parent, String name, long dataTTL) {
     super(parent, name);
     this.dataTTL = dataTTL;
   }
@@ -58,13 +54,5 @@ public class StorageGroupMNode extends InternalMNode implements IStorageGroupMNo
     serializeChildren(logWriter);
 
     logWriter.serializeStorageGroupMNode(this);
-  }
-
-  public static StorageGroupMNode deserializeFrom(StorageGroupMNodePlan plan) {
-    return new StorageGroupMNode(null, plan.getName(), plan.getDataTTL());
-  }
-
-  public static StorageGroupMNode deserializeFrom(String[] nodeInfo) {
-    return new StorageGroupMNode(null, nodeInfo[1], Long.parseLong(nodeInfo[2]));
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -862,7 +862,7 @@ public class MManagerBasicTest {
     manager.setDeviceTemplate(setDeviceTemplatePlan);
 
     IMNode node = manager.getDeviceNode(new PartialPath("root.sg1.d1"));
-    node.setUseTemplate(true);
+    node = manager.setUsingDeviceTemplate(node);
 
     MeasurementSchema s11 =
         new MeasurementSchema("s11", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
@@ -1264,7 +1264,7 @@ public class MManagerBasicTest {
       SetDeviceTemplatePlan setDeviceTemplatePlan =
           new SetDeviceTemplatePlan("template1", "root.laptop.d1");
       manager.setDeviceTemplate(setDeviceTemplatePlan);
-      manager.getDeviceNode(new PartialPath("root.laptop.d1")).setUseTemplate(true);
+      manager.setUsingDeviceTemplate(manager.getDeviceNode(new PartialPath("root.laptop.d1")));
 
       // show timeseries root.laptop.d1.s0
       ShowTimeSeriesPlan showTimeSeriesPlan =
@@ -1357,7 +1357,7 @@ public class MManagerBasicTest {
       SetDeviceTemplatePlan setDeviceTemplatePlan =
           new SetDeviceTemplatePlan("template1", "root.laptop.d1");
       manager.setDeviceTemplate(setDeviceTemplatePlan);
-      manager.getDeviceNode(new PartialPath("root.laptop.d1")).setUseTemplate(true);
+      manager.setUsingDeviceTemplate(manager.getDeviceNode(new PartialPath("root.laptop.d1")));
 
       manager.createTimeseries(
           new PartialPath("root.computer.d1.s2"),
@@ -1368,7 +1368,7 @@ public class MManagerBasicTest {
 
       setDeviceTemplatePlan = new SetDeviceTemplatePlan("template1", "root.computer");
       manager.setDeviceTemplate(setDeviceTemplatePlan);
-      manager.getDeviceNode(new PartialPath("root.computer.d1")).setUseTemplate(true);
+      manager.setUsingDeviceTemplate(manager.getDeviceNode(new PartialPath("root.computer.d1")));
 
       Assert.assertEquals(2, manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1")));
       Assert.assertEquals(1, manager.getAllTimeseriesCount(new PartialPath("root.laptop.d1.s1")));
@@ -1423,7 +1423,7 @@ public class MManagerBasicTest {
       SetDeviceTemplatePlan setDeviceTemplatePlan =
           new SetDeviceTemplatePlan("template1", "root.laptop.d1");
       manager.setDeviceTemplate(setDeviceTemplatePlan);
-      manager.getDeviceNode(new PartialPath("root.laptop.d1")).setUseTemplate(true);
+      manager.setUsingDeviceTemplate(manager.getDeviceNode(new PartialPath("root.laptop.d1")));
 
       manager.createTimeseries(
           new PartialPath("root.laptop.d2.s1"),

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mnode/MNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mnode/MNodeTest.java
@@ -47,16 +47,17 @@ public class MNodeTest {
     // after replacing a with c, the timeseries root.a.b becomes root.c.b
     InternalMNode rootNode = new InternalMNode(null, "root");
 
-    InternalMNode aNode = new InternalMNode(rootNode, "a");
+    IEntityMNode aNode = new EntityMNode(rootNode, "a");
     rootNode.addChild(aNode.getName(), aNode);
 
-    InternalMNode bNode = new InternalMNode(aNode, "b");
+    MeasurementMNode bNode = new MeasurementMNode(aNode, "b", null, null);
+
     aNode.addChild(bNode.getName(), bNode);
     aNode.addAlias("aliasOfb", bNode);
 
     for (int i = 0; i < 500; i++) {
       service.submit(
-          new Thread(() -> rootNode.replaceChild(aNode.getName(), new InternalMNode(null, "c"))));
+          new Thread(() -> rootNode.replaceChild(aNode.getName(), new EntityMNode(null, "c"))));
     }
 
     if (!service.isShutdown()) {


### PR DESCRIPTION
## Description

### Set IEntityMNode Interface
IEntityMNode defines the operations on an EntityMNode, in terms of aliasChilren and template usage for the time being. More functions like template lastCache will be implemented based on EntityMNode soon.

### Implement EntityMNode
The EntityMNode will be used when timeseries is created or the template is used on an InternalMNode. The parent node of a MeasurementMNode and node using template will be transform to EntityMNode.

### Implement StorageGroupEntityMNode
To avoid the conflict between StorageGroupMNode and EntityMNode, StorageGroupEntityMNode is implemented combining functions of both side, which means an entity can be a storage group and measurements can be created directly under a storage group path. StorageGroupEntityMNode extends EntityMNode and implements IStorageGroupMNode interface with the same code in StorageGroupMNode. 

### Eliminate "instanceof" usage on MNode 
Since the number of MNode class is increasing, the performance of instanceof will decrease and be no match to function override. Besides, the usage of instance violates the OO code design.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
