### PR TITLE
[ISSUE-3653] [To rel/0.11] Max_time and last return inconsistent result

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
@@ -628,6 +628,7 @@ public class SeriesReader {
             if ((orderUtils.getAscending() && timeValuePair.getTimestamp() > firstPageReader
                 .getStatistics().getEndTime()) || (!orderUtils.getAscending()
                 && timeValuePair.getTimestamp() < firstPageReader.getStatistics().getStartTime())) {
+              cachedBatchData.flip();
               hasCachedNextOverlappedPage = cachedBatchData.hasCurrent();
               return hasCachedNextOverlappedPage;
             } else {
@@ -646,6 +647,7 @@ public class SeriesReader {
                 .getStatistics().getEndTime()) || (!orderUtils.getAscending()
                 && timeValuePair.getTimestamp() < seqPageReaders.get(0).getStatistics()
                 .getStartTime())) {
+              cachedBatchData.flip();
               hasCachedNextOverlappedPage = cachedBatchData.hasCurrent();
               return hasCachedNextOverlappedPage;
             } else {


### PR DESCRIPTION
It's a `order by time desc` bug. DescReadWriteBatchData should be flipped before returned.