### PR TITLE
[IOTDB-1541] Change sequence of wal and memtable in insert

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -393,13 +393,23 @@ public abstract class AbstractMemTable implements IMemTable {
   }
 
   @Override
+  public void releaseTVListRamCost(long cost) {
+    this.tvListRamCost -= cost;
+  }
+
+  @Override
   public long getTVListsRamCost() {
     return tvListRamCost;
   }
 
   @Override
-  public void addTextDataSize(long testDataSize) {
-    this.memSize += testDataSize;
+  public void addTextDataSize(long textDataSize) {
+    this.memSize += textDataSize;
+  }
+
+  @Override
+  public void releaseTextDataSize(long textDataSize) {
+    this.memSize -= textDataSize;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
@@ -58,6 +58,9 @@ public interface IMemTable {
   void addTVListRamCost(long cost);
 
   /** only used when mem control enabled */
+  void releaseTVListRamCost(long cost);
+
+  /** only used when mem control enabled */
   long getTVListsRamCost();
 
   /**
@@ -136,6 +139,9 @@ public interface IMemTable {
 
   /** only used when mem control enabled */
   void addTextDataSize(long textDataIncrement);
+
+  /** only used when mem control enabled */
+  void releaseTextDataSize(long textDataDecrement);
 
   long getMaxPlanIndex();
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -520,6 +520,7 @@ public class TsFileProcessor {
     memTableIncrement += textDataIncrement;
     storageGroupInfo.releaseStorageGroupMemCost(memTableIncrement);
     tsFileProcessorInfo.releaseTSPMemCost(chunkMetadataIncrement);
+    SystemInfo.getInstance().resetStorageGroupStatus(storageGroupInfo);
     workMemTable.releaseTVListRamCost(memTableIncrement);
     workMemTable.releaseTextDataSize(textDataIncrement);
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -209,20 +209,24 @@ public class TsFileProcessor {
       }
     }
 
+    long[] memIncrements = null;
+    if (enableMemControl) {
+      memIncrements = checkMemCostAndAddToTspInfo(insertRowPlan);
+    }
+
     if (IoTDBDescriptor.getInstance().getConfig().isEnableWal()) {
       try {
         getLogNode().write(insertRowPlan);
       } catch (Exception e) {
+        if (memIncrements != null) {
+          rollbackMemoryInfo(memIncrements);
+        }
         throw new WriteProcessException(
             String.format(
                 "%s: %s write WAL failed",
                 storageGroupName, tsFileResource.getTsFile().getAbsolutePath()),
             e);
       }
-    }
-
-    if (enableMemControl) {
-      checkMemCostAndAddToTspInfo(insertRowPlan);
     }
 
     workMemTable.insert(insertRowPlan);
@@ -261,6 +265,18 @@ public class TsFileProcessor {
       }
     }
 
+    long[] memIncrements = null;
+    try {
+      if (enableMemControl) {
+        memIncrements = checkMemCostAndAddToTspInfo(insertTabletPlan, start, end);
+      }
+    } catch (WriteProcessException e) {
+      for (int i = start; i < end; i++) {
+        results[i] = RpcUtils.getStatus(TSStatusCode.WRITE_PROCESS_REJECT, e.getMessage());
+      }
+      throw new WriteProcessException(e);
+    }
+
     try {
       if (IoTDBDescriptor.getInstance().getConfig().isEnableWal()) {
         insertTabletPlan.setStart(start);
@@ -271,16 +287,8 @@ public class TsFileProcessor {
       for (int i = start; i < end; i++) {
         results[i] = RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());
       }
-      throw new WriteProcessException(e);
-    }
-
-    try {
-      if (enableMemControl) {
-        checkMemCostAndAddToTspInfo(insertTabletPlan, start, end);
-      }
-    } catch (WriteProcessException e) {
-      for (int i = start; i < end; i++) {
-        results[i] = RpcUtils.getStatus(TSStatusCode.WRITE_PROCESS_REJECT, e.getMessage());
+      if (memIncrements != null) {
+        rollbackMemoryInfo(memIncrements);
       }
       throw new WriteProcessException(e);
     }
@@ -310,7 +318,7 @@ public class TsFileProcessor {
   }
 
   @SuppressWarnings("squid:S3776") // high Cognitive Complexity
-  private void checkMemCostAndAddToTspInfo(InsertRowPlan insertRowPlan)
+  private long[] checkMemCostAndAddToTspInfo(InsertRowPlan insertRowPlan)
       throws WriteProcessException {
     // memory of increased PrimitiveArray and TEXT values, e.g., add a long[128], add 128*8
     long memTableIncrement = 0L;
@@ -357,12 +365,13 @@ public class TsFileProcessor {
       }
     }
     updateMemoryInfo(memTableIncrement, chunkMetadataIncrement, textDataIncrement);
+    return new long[] {memTableIncrement, textDataIncrement, chunkMetadataIncrement};
   }
 
-  private void checkMemCostAndAddToTspInfo(InsertTabletPlan insertTabletPlan, int start, int end)
+  private long[] checkMemCostAndAddToTspInfo(InsertTabletPlan insertTabletPlan, int start, int end)
       throws WriteProcessException {
     if (start >= end) {
-      return;
+      return new long[] {0, 0, 0};
     }
     long[] memIncrements = new long[3]; // memTable, text, chunk metadata
 
@@ -398,6 +407,7 @@ public class TsFileProcessor {
     long textDataIncrement = memIncrements[1];
     long chunkMetadataIncrement = memIncrements[2];
     updateMemoryInfo(memTableIncrement, chunkMetadataIncrement, textDataIncrement);
+    return memIncrements;
   }
 
   private void updateMemCost(
@@ -500,6 +510,18 @@ public class TsFileProcessor {
     }
     workMemTable.addTVListRamCost(memTableIncrement);
     workMemTable.addTextDataSize(textDataIncrement);
+  }
+
+  private void rollbackMemoryInfo(long[] memIncrements) {
+    long memTableIncrement = memIncrements[0];
+    long textDataIncrement = memIncrements[1];
+    long chunkMetadataIncrement = memIncrements[2];
+
+    memTableIncrement += textDataIncrement;
+    storageGroupInfo.releaseStorageGroupMemCost(memTableIncrement);
+    tsFileProcessorInfo.releaseTSPMemCost(chunkMetadataIncrement);
+    workMemTable.releaseTVListRamCost(memTableIncrement);
+    workMemTable.releaseTextDataSize(textDataIncrement);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -213,8 +213,6 @@ public class TsFileProcessor {
       checkMemCostAndAddToTspInfo(insertRowPlan);
     }
 
-    workMemTable.insert(insertRowPlan);
-
     if (IoTDBDescriptor.getInstance().getConfig().isEnableWal()) {
       try {
         getLogNode().write(insertRowPlan);
@@ -226,6 +224,8 @@ public class TsFileProcessor {
             e);
       }
     }
+
+    workMemTable.insert(insertRowPlan);
 
     // update start time of this memtable
     tsFileResource.updateStartTime(
@@ -272,12 +272,12 @@ public class TsFileProcessor {
       throw new WriteProcessException(e);
     }
     try {
-      workMemTable.insertTablet(insertTabletPlan, start, end);
       if (IoTDBDescriptor.getInstance().getConfig().isEnableWal()) {
         insertTabletPlan.setStart(start);
         insertTabletPlan.setEnd(end);
         getLogNode().write(insertTabletPlan);
       }
+      workMemTable.insertTablet(insertTabletPlan, start, end);
     } catch (Exception e) {
       for (int i = start; i < end; i++) {
         results[i] = RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -218,7 +218,7 @@ public class TsFileProcessor {
       try {
         getLogNode().write(insertRowPlan);
       } catch (Exception e) {
-        if (memIncrements != null) {
+        if (enableMemControl && memIncrements != null) {
           rollbackMemoryInfo(memIncrements);
         }
         throw new WriteProcessException(
@@ -287,7 +287,7 @@ public class TsFileProcessor {
       for (int i = start; i < end; i++) {
         results[i] = RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());
       }
-      if (memIncrements != null) {
+      if (enableMemControl && memIncrements != null) {
         rollbackMemoryInfo(memIncrements);
       }
       throw new WriteProcessException(e);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -267,9 +267,9 @@ public class TsFileProcessor {
         insertTabletPlan.setEnd(end);
         getLogNode().write(insertTabletPlan);
       }
-    } catch (IOException e) {
+    } catch (Exception e) {
       for (int i = start; i < end; i++) {
-        results[i] = RpcUtils.getStatus(TSStatusCode.WRITE_PROCESS_REJECT, e.getMessage());
+        results[i] = RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());
       }
       throw new WriteProcessException(e);
     }

--- a/server/src/test/java/org/apache/iotdb/db/sink/LocalIoTDBSinkTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sink/LocalIoTDBSinkTest.java
@@ -204,7 +204,7 @@ public class LocalIoTDBSinkTest {
     localIoTDBHandler.close();
   }
 
-  @Test(expected = ClassCastException.class)
+  @Test(expected = QueryProcessException.class)
   public void onEventWithWrongType2() throws Exception {
     LocalIoTDBHandler localIoTDBHandler = new LocalIoTDBHandler();
     localIoTDBHandler.open(

--- a/server/src/test/java/org/apache/iotdb/db/sink/LocalIoTDBSinkTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sink/LocalIoTDBSinkTest.java
@@ -204,7 +204,7 @@ public class LocalIoTDBSinkTest {
     localIoTDBHandler.close();
   }
 
-  @Test(expected = QueryProcessException.class)
+  @Test(expected = ClassCastException.class)
   public void onEventWithWrongType2() throws Exception {
     LocalIoTDBHandler localIoTDBHandler = new LocalIoTDBHandler();
     localIoTDBHandler.open(


### PR DESCRIPTION
When inserting data, IoTDB first inserts data into memtable and then writes wal. If writing wal occurs error, the data in memtable should rollback, but IoTDB doesn't implement this. This problem can be fixed by changing the sequence of wal and memtable in insert.