### PR TITLE
add .asf.yaml file for deploying website

### DIFF
--- a/site/README-zh.md
+++ b/site/README-zh.md
@@ -29,7 +29,7 @@
 
 ## 如何建立
 
-跑`mvn compile -DskipTests  -P compile-site -P download-site` 
+跑`mvn compile -DskipTests  -P compile-site -P download-site`
 
 ## 如何调试
 
@@ -55,6 +55,13 @@ npm run build
 Apache ID和密码是必须的
 
 或直接运行`mvn compile scm-publish:publish-scm -Dusername={你的Apache ID} -Dpassword={你的Apache账号密码}  -P compile-site`
+
+## 上传并预览
+
+## Preview your website
+
+在上传命令中增加 `-Dscm-branch=asf-staging`, 则网站会被发布到 https://iotdb.staged.apache.org， 用于预览。
+
 
 ## 常见问题
 

--- a/site/README.md
+++ b/site/README.md
@@ -69,6 +69,11 @@ Apache ID and passwored is needed.
 
 Or run `mvn compile scm-publish:publish-scm -Dusername={YOUR_APACHE_ID} -Dpassword={YOUR_APACHE_PASSWORD}  -P compile-site`
 
+## Preview your website
+
+If you add `-Dscm-branch=asf-staging` in your command, then the website will be published to https://iotdb.staged.apache.org
+
+
 ## FAQ
 
 If you get an error on your MacOS:

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -30,6 +30,7 @@
     <artifactId>iotdb-website</artifactId>
     <properties>
         <frontend-maven-plugin.version>1.9.1</frontend-maven-plugin.version>
+        <scm-branch>asf-site</scm-branch>
     </properties>
     <distributionManagement>
         <site>
@@ -295,56 +296,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <!-- copy single files, and move UserGuide of master into tmp folder -->
-                    <plugin>
-                        <groupId>com.coderplus.maven.plugins</groupId>
-                        <artifactId>copy-rename-maven-plugin</artifactId>
-                        <version>1.0</version>
-                        <executions>
-                            <execution>
-                                <id>copy-package-json</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <configuration>
-                                    <fileSets>
-                                        <fileSet>
-                                            <sourceFile>${basedir}/src/main/package.json</sourceFile>
-                                            <destinationFile>${project.build.directory}/vue-source/package.json</destinationFile>
-                                        </fileSet>
-                                        <fileSet>
-                                            <sourceFile>${basedir}/src/main/deploy.js</sourceFile>
-                                            <destinationFile>${project.build.directory}/vue-source/deploy.js</destinationFile>
-                                        </fileSet>
-                                    </fileSets>
-                                </configuration>
-                            </execution>
-                            <!-- remove files if `existing` folder exist-->
-                            <execution>
-                                <id>clean-stale-master-doc</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>rename</goal>
-                                </goals>
-                                <configuration>
-                                    <sourceFile>${project.build.directory}/existing/UserGuide/Master</sourceFile>
-                                    <destinationFile>${project.build.directory}/existing/Master</destinationFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>clean-stale-master-zh-doc</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>rename</goal>
-                                </goals>
-                                <configuration>
-                                    <sourceFile>${project.build.directory}/existing/zh/UserGuide/Master</sourceFile>
-                                    <destinationFile>${project.build.directory}/existing/zh/Master</destinationFile>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <!--install node and npm， then run `npm install` and `npm run build`-->
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
@@ -391,6 +342,75 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- copy single files, and move UserGuide of master into tmp folder -->
+                    <plugin>
+                        <groupId>com.coderplus.maven.plugins</groupId>
+                        <artifactId>copy-rename-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <id>copy-package-json</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <fileSets>
+                                        <fileSet>
+                                            <sourceFile>${basedir}/src/main/package.json</sourceFile>
+                                            <destinationFile>${project.build.directory}/vue-source/package.json</destinationFile>
+                                        </fileSet>
+                                        <fileSet>
+                                            <sourceFile>${basedir}/src/main/deploy.js</sourceFile>
+                                            <destinationFile>${project.build.directory}/vue-source/deploy.js</destinationFile>
+                                        </fileSet>
+                                        <fileSet>
+                                            <sourceFile>${basedir}/src/main/.asf.yaml</sourceFile>
+                                            <destinationFile>${project.build.directory}/vue-source/src/.vuepress/dist/.asf.yaml</destinationFile>
+                                        </fileSet>
+                                    </fileSets>
+                                </configuration>
+                            </execution>
+                            <!-- remove files if `existing` folder exist-->
+                            <execution>
+                                <id>clean-stale-master-doc</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>rename</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceFile>${project.build.directory}/existing/UserGuide/Master</sourceFile>
+                                    <destinationFile>${project.build.directory}/existing/Master</destinationFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>clean-stale-master-zh-doc</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>rename</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceFile>${project.build.directory}/existing/zh/UserGuide/Master</sourceFile>
+                                    <destinationFile>${project.build.directory}/existing/zh/Master</destinationFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>copy-asf-yaml</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <fileSets>
+                                        <fileSet>
+                                            <sourceFile>${basedir}/src/main/.asf.yaml</sourceFile>
+                                            <destinationFile>${project.build.directory}/vue-source/src/.vuepress/dist/.asf.yaml</destinationFile>
+                                        </fileSet>
+                                    </fileSets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-scm-publish-plugin</artifactId>
@@ -398,7 +418,7 @@
                             <!-- mono-module doesn't require site:stage -->
                             <content>${project.build.directory}/vue-source/src/.vuepress/dist</content>
                             <!-- branch where to deploy -->
-                            <scmBranch>asf-site</scmBranch>
+                            <scmBranch>${scm-branch}</scmBranch>
                         </configuration>
                     </plugin>
                     <!--<plugin>

--- a/site/src/main/.asf.yaml
+++ b/site/src/main/.asf.yaml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+staging:
+  profile: ~
+  whoami:  asf-staging
+
+publish:
+  whoami:  asf-site


### PR DESCRIPTION
The website is no longer updated anymore after July 1st because of we are using Git rather than SVN.

see (Apache id login needed):

https://lists.apache.org/thread.html/raf30ca1c77b81bc8c535c53b7aff38e1ff3c755ce84f4a40a6d8ad53%40%3Cusers.infra.apache.org%3E

According to the doc: 

https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-WebSiteDeploymentServiceforGitRepositories

I add the .asf.yaml file for deploying the website.


See the page for checking whether the website is healthy:

https://infra-reports.apache.org/site-source/