### PR TITLE
[IOTDB-1545] Query dataset momory leak on server caused by cpp client

### DIFF
--- a/client-cpp/src/main/Session.cpp
+++ b/client-cpp/src/main/Session.cpp
@@ -332,6 +332,7 @@ RowRecord *SessionDataSet::next() {
 void SessionDataSet::closeOperationHandle() {
     shared_ptr <TSCloseOperationReq> closeReq(new TSCloseOperationReq());
     closeReq->__set_sessionId(sessionId);
+    closeReq->__set_statementId(statementId);
     closeReq->__set_queryId(queryId);
     shared_ptr <TSStatus> closeResp(new TSStatus());
     try {
@@ -1073,7 +1074,7 @@ unique_ptr <SessionDataSet> Session::executeQueryStatement(string sql) {
     }
     shared_ptr <TSQueryDataSet> queryDataSet(new TSQueryDataSet(resp->queryDataSet));
     return unique_ptr<SessionDataSet>(new SessionDataSet(
-            sql, resp->columns, resp->dataTypeList, resp->queryId, client, sessionId, queryDataSet));
+            sql, resp->columns, resp->dataTypeList, resp->queryId, statementId, client, sessionId, queryDataSet));
 }
 
 void Session::executeNonQueryStatement(string sql) {

--- a/client-cpp/src/main/Session.h
+++ b/client-cpp/src/main/Session.h
@@ -491,6 +491,7 @@ private:
     bool hasCachedRecord = false;
     std::string sql;
     int64_t queryId;
+    int64_t statementId;
     int64_t sessionId;
     std::shared_ptr <TSIServiceIf> client;
     int batchSize = 1024;
@@ -516,12 +517,13 @@ public:
     SessionDataSet() {}
 
     SessionDataSet(std::string sql, std::vector <std::string> &columnNameList,
-                   std::vector <std::string> &columnTypeList, int64_t queryId,
+                   std::vector <std::string> &columnTypeList, int64_t queryId, int64_t statementId,
                    std::shared_ptr <TSIServiceIf> client, int64_t sessionId,
                    std::shared_ptr <TSQueryDataSet> queryDataSet) : tsQueryDataSetTimeBuffer(queryDataSet->time) {
         this->sessionId = sessionId;
         this->sql = sql;
         this->queryId = queryId;
+        this->statementId = statementId;
         this->client = client;
         this->columnNameList = columnNameList;
         this->currentBitmap = new char[columnNameList.size()];

--- a/client-cpp/src/test/main.cpp
+++ b/client-cpp/src/test/main.cpp
@@ -18,6 +18,7 @@
  */
 
 #define CATCH_CONFIG_MAIN
+
 #include <catch.hpp>
 #include "Session.h"
 
@@ -27,14 +28,15 @@ struct SessionListener : Catch::TestEventListenerBase {
 
     using TestEventListenerBase::TestEventListenerBase;
 
-    void testCaseStarting( Catch::TestCaseInfo const& testInfo ) override {
+    void testCaseStarting(Catch::TestCaseInfo const &testInfo) override {
         // Perform some setup before a test case is run
         session->open(false);
     }
 
-    void testCaseEnded( Catch::TestCaseStats const& testCaseStats ) override {
+    void testCaseEnded(Catch::TestCaseStats const &testCaseStats) override {
         // Tear-down after a test case is run
         session->close();
     }
 };
+
 CATCH_REGISTER_LISTENER( SessionListener )

--- a/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.ZoneId;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
@@ -78,6 +77,7 @@ public class SessionManager {
 
   public long requestSessionId(String username, String zoneId) {
     long sessionId = sessionIdGenerator.incrementAndGet();
+
     currSessionId.set(sessionId);
     sessionIdToUsername.put(sessionId, username);
     sessionIdToZoneId.put(sessionId, ZoneId.of(zoneId));
@@ -88,10 +88,15 @@ public class SessionManager {
   public boolean releaseSessionResource(long sessionId) {
     sessionIdToZoneId.remove(sessionId);
 
-    for (long statementId :
-        sessionIdToStatementId.getOrDefault(sessionId, Collections.emptySet())) {
-      for (long queryId : statementIdToQueryId.getOrDefault(statementId, Collections.emptySet())) {
-        releaseQueryResourceNoExceptions(queryId);
+    Set<Long> statementIdSet = sessionIdToStatementId.remove(sessionId);
+    if (statementIdSet != null) {
+      for (Long statementId : statementIdSet) {
+        Set<Long> queryIdSet = statementIdToQueryId.remove(statementId);
+        if (queryIdSet != null) {
+          for (Long queryId : queryIdSet) {
+            releaseQueryResourceNoExceptions(queryId);
+          }
+        }
       }
     }
 
@@ -123,7 +128,7 @@ public class SessionManager {
   public void closeStatement(long sessionId, long statementId) {
     Set<Long> queryIdSet = statementIdToQueryId.remove(statementId);
     if (queryIdSet != null) {
-      for (long queryId : queryIdSet) {
+      for (Long queryId : queryIdSet) {
         releaseQueryResourceNoExceptions(queryId);
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -308,12 +308,17 @@ public class TSServiceImpl implements TSIService.Iface {
     }
 
     try {
-      if (req.isSetStatementId() && req.isSetQueryId()) {
-        sessionManager.closeDataset(req.statementId, req.queryId);
+      if (req.isSetStatementId()) {
+        if (req.isSetQueryId()) {
+          sessionManager.closeDataset(req.statementId, req.queryId);
+        } else {
+          sessionManager.closeStatement(req.sessionId, req.statementId);
+        }
+        return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
       } else {
-        sessionManager.closeStatement(req.sessionId, req.statementId);
+        return RpcUtils.getStatus(
+            TSStatusCode.CLOSE_OPERATION_ERROR, "statement id not set by client.");
       }
-      return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
     } catch (Exception e) {
       return onNPEOrUnexpectedException(
           e, "executing closeOperation", TSStatusCode.CLOSE_OPERATION_ERROR);


### PR DESCRIPTION
I made the following changes in this PR:

1. fix leak in sessionIdToStatementId & statementIdToQueryId
2. fix leak caused by cpp client: statementId not set in TSCloseOperationReq
3. fix code format of cpp tests

JIRA: https://issues.apache.org/jira/browse/IOTDB-1545