### PR TITLE
[To rel/0.12] Stop NO_COMPACTION strategy from submitting compaction task

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -2119,8 +2119,10 @@ public class StorageGroupProcessor {
   }
 
   public void merge() {
-    CompactionMergeTaskPoolManager.getInstance()
-        .submitTask(new CompactionAllPartitionTask(logicalStorageGroupName));
+    if (config.getCompactionStrategy() == CompactionStrategy.LEVEL_COMPACTION) {
+      CompactionMergeTaskPoolManager.getInstance()
+          .submitTask(new CompactionAllPartitionTask(logicalStorageGroupName));
+    }
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.compaction.CompactionMergeTaskPoolManager;
+import org.apache.iotdb.db.engine.compaction.CompactionStrategy;
 import org.apache.iotdb.db.engine.compaction.StorageGroupCompactionTask;
 import org.apache.iotdb.db.engine.compaction.TsFileManagement;
 import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
@@ -529,6 +530,10 @@ public class StorageGroupProcessor {
   }
 
   private void recoverCompaction() {
+    if (IoTDBDescriptor.getInstance().getConfig().getCompactionStrategy()
+        == CompactionStrategy.NO_COMPACTION) {
+      return;
+    }
     if (!CompactionMergeTaskPoolManager.getInstance().isTerminated()) {
       logger.info(
           "{} - {} submit a compaction recover merge task",
@@ -1952,10 +1957,13 @@ public class StorageGroupProcessor {
         "signal closing storage group condition in {}",
         logicalStorageGroupName + "-" + virtualStorageGroupId);
 
-    CompactionMergeTaskPoolManager.getInstance()
-        .submitTask(
-            new CompactionOnePartitionTask(
-                logicalStorageGroupName, tsFileProcessor.getTimeRangeId()));
+    if (IoTDBDescriptor.getInstance().getConfig().getCompactionStrategy()
+        == CompactionStrategy.LEVEL_COMPACTION) {
+      CompactionMergeTaskPoolManager.getInstance()
+          .submitTask(
+              new CompactionOnePartitionTask(
+                  logicalStorageGroupName, tsFileProcessor.getTimeRangeId()));
+    }
   }
 
   public class CompactionOnePartitionTask extends StorageGroupCompactionTask {
@@ -1992,6 +2000,10 @@ public class StorageGroupProcessor {
 
   /** close recover compaction merge callback, to start continuous compaction */
   private void closeCompactionRecoverCallBack(boolean isMerge, long timePartitionId) {
+    if (IoTDBDescriptor.getInstance().getConfig().getCompactionStrategy()
+        == CompactionStrategy.NO_COMPACTION) {
+      return;
+    }
     CompactionMergeTaskPoolManager.getInstance().clearCompactionStatus(logicalStorageGroupName);
     if (IoTDBDescriptor.getInstance().getConfig().isEnableContinuousCompaction()) {
       logger.info(


### PR DESCRIPTION
## Description
In current no compaction strategy, the system will submit a compaction task to thread pool when system recovers, a tsfile is sealed or a timed schedule thread wakes up. The compaction task in NO_COMPACTION strategy just does nothing. But it may block the system because the submission of the task synchronized the CompactionMergeTaskManager. In this PR we stop the system from submitting compaction task when the compaction strategy is NO_COMPACTION