### PR TITLE
[To rel/0.12] MeasurementId check while create timeseries or template

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -96,6 +96,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -2038,7 +2039,10 @@ public class MManager {
 
   public void createDeviceTemplate(CreateTemplatePlan plan) throws MetadataException {
     try {
+      checkTemplateSchemaNames(plan.getSchemaNames());
+
       Template template = new Template(plan);
+
       if (templateMap.putIfAbsent(plan.getName(), template) != null) {
         // already have template
         throw new DuplicatedTemplateException(plan.getName());
@@ -2050,6 +2054,20 @@ public class MManager {
       }
     } catch (IOException e) {
       throw new MetadataException(e);
+    }
+  }
+
+  private void checkTemplateSchemaNames(List<String> schemaNames) throws MetadataException {
+    // check schema name.
+    String processedName;
+    for (String schemaName : schemaNames) {
+      processedName = schemaName.trim().toLowerCase(Locale.ENGLISH);
+      if ("time".equals(processedName)
+          || "timeseries".equals(processedName)
+          || (schemaName.contains(".")
+              && !(schemaName.startsWith("\"") && schemaName.endsWith("\"")))) {
+        throw new MetadataException(String.format("%s is an illegal schema name", schemaName));
+      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1901,12 +1901,6 @@ public class MManager {
           if (!config.isAutoCreateSchemaEnabled()) {
             throw new PathNotExistException(deviceId + PATH_SEPARATOR + measurementList[i]);
           } else {
-            // check measurementId syntax
-            if (measurementList[i].contains(".")
-                && !(measurementList[i].startsWith("\"") && measurementList[i].endsWith("\""))) {
-              throw new MetadataException(
-                  String.format("%s is an illegal measurementId", measurementList[i]));
-            }
             // child is null or child is type of MNode
             dataType = getTypeInLoc(plan, i);
             // create it, may concurrent created by multiple thread

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -2063,7 +2063,7 @@ public class MManager {
     for (String schemaName : schemaNames) {
       processedName = schemaName.trim().toLowerCase(Locale.ENGLISH);
       if ("time".equals(processedName)
-          || "timeseries".equals(processedName)
+          || "timestamp".equals(processedName)
           || (schemaName.contains(".")
               && !(schemaName.startsWith("\"") && schemaName.endsWith("\"")))) {
         throw new MetadataException(String.format("%s is an illegal schema name", schemaName));

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1889,6 +1889,13 @@ public class MManager {
     MeasurementMNode measurementMNode;
     TSDataType dataType;
     for (int i = 0; i < measurementList.length; i++) {
+      // check measurementId syntax
+      if (measurementList[i].contains(".")
+          && !(measurementList[i].startsWith("\"") && measurementList[i].endsWith("\""))) {
+        throw new MetadataException(
+            String.format("%s is an illegal measurementId", measurementList[i]));
+      }
+
       try {
         MNode child = getMNode(deviceMNode.left, measurementList[i]);
         if (child instanceof MeasurementMNode) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1889,13 +1889,6 @@ public class MManager {
     MeasurementMNode measurementMNode;
     TSDataType dataType;
     for (int i = 0; i < measurementList.length; i++) {
-      // check measurementId syntax
-      if (measurementList[i].contains(".")
-          && !(measurementList[i].startsWith("\"") && measurementList[i].endsWith("\""))) {
-        throw new MetadataException(
-            String.format("%s is an illegal measurementId", measurementList[i]));
-      }
-
       try {
         MNode child = getMNode(deviceMNode.left, measurementList[i]);
         if (child instanceof MeasurementMNode) {
@@ -1908,6 +1901,12 @@ public class MManager {
           if (!config.isAutoCreateSchemaEnabled()) {
             throw new PathNotExistException(deviceId + PATH_SEPARATOR + measurementList[i]);
           } else {
+            // check measurementId syntax
+            if (measurementList[i].contains(".")
+                && !(measurementList[i].startsWith("\"") && measurementList[i].endsWith("\""))) {
+              throw new MetadataException(
+                  String.format("%s is an illegal measurementId", measurementList[i]));
+            }
             // child is null or child is type of MNode
             dataType = getTypeInLoc(plan, i);
             // create it, may concurrent created by multiple thread

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -293,7 +293,7 @@ public class MTree implements Serializable {
     // filter special id, including "time" and "timeseries"
     for (String nodeName : timeseries.getNodes()) {
       nodeName = nodeName.trim().toLowerCase(Locale.ENGLISH);
-      if ("time".equals(nodeName) || "timeseries".equals(nodeName)) {
+      if ("time".equals(nodeName) || "timestamp".equals(nodeName)) {
         throw new IllegalPathException(timeseries.getFullPath());
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -73,6 +73,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
@@ -288,6 +289,15 @@ public class MTree implements Serializable {
       throw new IllegalPathException(
           String.format("The timeseries name contains unsupported character. %s", timeseries));
     }
+
+    // filter special id, including "time" and "timeseries"
+    for (String nodeName : timeseries.getNodes()) {
+      nodeName = nodeName.trim().toLowerCase(Locale.ENGLISH);
+      if ("time".equals(nodeName) || "timeseries".equals(nodeName)) {
+        throw new IllegalPathException(timeseries.getFullPath());
+      }
+    }
+
     String measurementId = timeseries.getMeasurement();
     // check measurementId syntax
     // only measurementId may be named separately from fullPath by user via API

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -288,12 +288,12 @@ public class MTree implements Serializable {
       throw new IllegalPathException(
           String.format("The timeseries name contains unsupported character. %s", timeseries));
     }
-    String[] nodeNames = timeseries.getNodes();
-    for (String name : nodeNames) {
-      // check measurementId syntax
-      if (name.contains(".") && !(name.startsWith("\"") && name.endsWith("\""))) {
-        throw new MetadataException(String.format("%s is an illegal measurementId", name));
-      }
+    String measurementId = timeseries.getMeasurement();
+    // check measurementId syntax
+    // only measurementId may be named separately from fullPath by user via API
+    if (measurementId.contains(".")
+        && !(measurementId.startsWith("\"") && measurementId.endsWith("\""))) {
+      throw new MetadataException(String.format("%s is an illegal measurementId", measurementId));
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -216,7 +216,7 @@ public class MTree implements Serializable {
     if (nodeNames.length <= 2 || !nodeNames[0].equals(root.getName())) {
       throw new IllegalPathException(path.getFullPath());
     }
-    checkTimeseries(path.getFullPath());
+    checkTimeseries(path);
     MNode cur = root;
     boolean hasSetStorageGroup = false;
     Template upperTemplate = cur.getDeviceTemplate();
@@ -283,10 +283,17 @@ public class MTree implements Serializable {
     }
   }
 
-  private void checkTimeseries(String timeseries) throws IllegalPathException {
-    if (!IoTDBConfig.NODE_PATTERN.matcher(timeseries).matches()) {
+  private void checkTimeseries(PartialPath timeseries) throws MetadataException {
+    if (!IoTDBConfig.NODE_PATTERN.matcher(timeseries.getFullPath()).matches()) {
       throw new IllegalPathException(
           String.format("The timeseries name contains unsupported character. %s", timeseries));
+    }
+    String[] nodeNames = timeseries.getNodes();
+    for (String name : nodeNames) {
+      // check measurementId syntax
+      if (name.contains(".") && !(name.startsWith("\"") && name.endsWith("\""))) {
+        throw new MetadataException(String.format("%s is an illegal measurementId", name));
+      }
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.metadata.mnode.MNode;
 import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
-import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.qp.physical.crud.CreateTemplatePlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -1282,8 +1282,7 @@ public class MManagerBasicTest {
         manager.getSeriesSchemasAndReadLockDevice(insertPlan);
         assertFalse(manager.isPathExist(deviceId.concatNode(measurementId)));
       } catch (MetadataException e) {
-        Assert.assertEquals(
-            String.format("%s is an illegal measurementId", measurementId), e.getMessage());
+        e.printStackTrace();
       }
     }
   }
@@ -1296,5 +1295,40 @@ public class MManagerBasicTest {
     InsertPlan insertPlan = new InsertRowPlan(deviceId, 1L, measurementList, values);
     insertPlan.setMeasurementMNodes(measurementMNodes);
     return insertPlan;
+  }
+
+  @Test
+  public void testTemplateNameCheckWhileCreate() {
+    MManager manager = IoTDB.metaManager;
+    String[] illegalSchemaNames = {"a.b", "time", "timeseries", "TIME", "TIMESERIES"};
+    for (String schemaName : illegalSchemaNames) {
+      CreateTemplatePlan plan = getCreateTemplatePlan(schemaName);
+      try {
+        manager.createDeviceTemplate(plan);
+      } catch (MetadataException e) {
+        Assert.assertEquals(
+            String.format("%s is an illegal schema name", schemaName), e.getMessage());
+      }
+    }
+  }
+
+  private CreateTemplatePlan getCreateTemplatePlan(String schemaName) {
+    List<List<String>> measurementList = new ArrayList<>();
+    measurementList.add(Collections.singletonList("s0"));
+
+    List<List<TSDataType>> dataTypeList = new ArrayList<>();
+    dataTypeList.add(Collections.singletonList(TSDataType.INT32));
+
+    List<List<TSEncoding>> encodingList = new ArrayList<>();
+    encodingList.add(Collections.singletonList(TSEncoding.RLE));
+
+    List<CompressionType> compressionTypes = new ArrayList<>();
+    compressionTypes.add(compressionType);
+
+    List<String> schemaNames = new ArrayList<>();
+    schemaNames.add(schemaName);
+
+    return new CreateTemplatePlan(
+        "template1", schemaNames, measurementList, dataTypeList, encodingList, compressionTypes);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -1277,12 +1277,14 @@ public class MManagerBasicTest {
 
     try {
       manager.getSeriesSchemasAndReadLockDevice(insertPlan);
-      fail();
+      assertFalse(manager.isPathExist(deviceId.concatNode("a.b")));
     } catch (MetadataException e) {
       Assert.assertEquals("a.b is an illegal measurementId", e.getMessage());
     }
 
     measurementList[1] = "a";
+    insertPlan = new InsertRowPlan(deviceId, 1L, measurementList, values);
+    insertPlan.setMeasurementMNodes(measurementMNodes);
     manager.getSeriesSchemasAndReadLockDevice(insertPlan);
     for (String measurementId : measurementList) {
       assertTrue(manager.isPathExist(deviceId.concatNode(measurementId)));

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -1275,7 +1275,7 @@ public class MManagerBasicTest {
     manager.getSeriesSchemasAndReadLockDevice(insertPlan);
     assertTrue(manager.isPathExist(deviceId.concatNode("\"a.b\"")));
 
-    String[] illegalMeasurementIds = {"a.b", "time", "timeseries", "TIME", "TIMESERIES"};
+    String[] illegalMeasurementIds = {"a.b", "time", "timestamp", "TIME", "TIMESTAMP"};
     for (String measurementId : illegalMeasurementIds) {
       insertPlan = getInsertPlan(measurementId);
       try {
@@ -1300,7 +1300,7 @@ public class MManagerBasicTest {
   @Test
   public void testTemplateNameCheckWhileCreate() {
     MManager manager = IoTDB.metaManager;
-    String[] illegalSchemaNames = {"a.b", "time", "timeseries", "TIME", "TIMESERIES"};
+    String[] illegalSchemaNames = {"a.b", "time", "timestamp", "TIME", "TIMESTAMP"};
     for (String schemaName : illegalSchemaNames) {
       CreateTemplatePlan plan = getCreateTemplatePlan(schemaName);
       try {


### PR DESCRIPTION
## Description

### Problem
When users use session API to insert data and auto create time series, there's no syntax check on deviceIds or measurementIds before insert plan generating like SQL  parse. If there's a id contains symbol ".", like device id as root.sg.d and measurement id as a.b, the measurement id is obviously illegal and the meaning of path root.sg.d.a.b is ambiguous.  

Also solved https://issues.apache.org/jira/browse/IOTDB-1475 .

The schema names in template is also a loophole.

### Solution
Currently, a syntax check is added to mtree.checkTimeseries while it's going to auto create time series.
Method checkTemplateSchemaNames is  added to mmanager  while create template

### Suggestion
The illegal ids should be filtered when the API is invoked or a query is parsed as soon as possible before further operation.  

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
