### PR TITLE
fix defaut max_sync_log_lag

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -300,7 +300,7 @@ public class ClusterDescriptor {
 
     config.setMaxSyncLogLag(
         Long.parseLong(
-            properties.getProperty("max_sync_log_lag", String.valueOf(config.getMaxReadLogLag()))));
+            properties.getProperty("max_sync_log_lag", String.valueOf(config.getMaxSyncLogLag()))));
 
     config.setMaxClientPerNodePerMember(
         Integer.parseInt(


### PR DESCRIPTION
The default max_sync_log_lag is mistakenly set to default max_read_log_lag.