### PR TITLE
[IOTDB-1541][To rel/0.12] Change sequence of wal and memtable in insert

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -304,13 +304,23 @@ public abstract class AbstractMemTable implements IMemTable {
   }
 
   @Override
+  public void releaseTVListRamCost(long cost) {
+    this.tvListRamCost -= cost;
+  }
+
+  @Override
   public long getTVListsRamCost() {
     return tvListRamCost;
   }
 
   @Override
-  public void addTextDataSize(long testDataSize) {
-    this.memSize += testDataSize;
+  public void addTextDataSize(long textDataSize) {
+    this.memSize += textDataSize;
+  }
+
+  @Override
+  public void releaseTextDataSize(long textDataSize) {
+    this.memSize -= textDataSize;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
@@ -65,6 +65,9 @@ public interface IMemTable {
   void addTVListRamCost(long cost);
 
   /** only used when mem control enabled */
+  void releaseTVListRamCost(long cost);
+
+  /** only used when mem control enabled */
   long getTVListsRamCost();
 
   /**
@@ -133,6 +136,9 @@ public interface IMemTable {
 
   /** only used when mem control enabled */
   void addTextDataSize(long textDataIncrement);
+
+  /** only used when mem control enabled */
+  void releaseTextDataSize(long textDataDecrement);
 
   long getMaxPlanIndex();
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -188,8 +188,6 @@ public class TsFileProcessor {
       checkMemCostAndAddToTspInfo(insertRowPlan);
     }
 
-    workMemTable.insert(insertRowPlan);
-
     if (IoTDBDescriptor.getInstance().getConfig().isEnableWal()) {
       try {
         getLogNode().write(insertRowPlan);
@@ -201,6 +199,8 @@ public class TsFileProcessor {
             e);
       }
     }
+
+    workMemTable.insert(insertRowPlan);
 
     // update start time of this memtable
     tsFileResource.updateStartTime(
@@ -247,7 +247,6 @@ public class TsFileProcessor {
       throw new WriteProcessException(e);
     }
     try {
-      workMemTable.insertTablet(insertTabletPlan, start, end);
       long startTime = System.currentTimeMillis();
       if (IoTDBDescriptor.getInstance().getConfig().isEnableWal()) {
         insertTabletPlan.setStart(start);
@@ -258,6 +257,8 @@ public class TsFileProcessor {
       if (elapsed > 5000) {
         logger.error("write wal slowly : cost {}ms", elapsed);
       }
+
+      workMemTable.insertTablet(insertTabletPlan, start, end);
     } catch (Exception e) {
       for (int i = start; i < end; i++) {
         results[i] = RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -193,7 +193,7 @@ public class TsFileProcessor {
       try {
         getLogNode().write(insertRowPlan);
       } catch (Exception e) {
-        if (memIncrements != null) {
+        if (enableMemControl && memIncrements != null) {
           rollbackMemoryInfo(memIncrements);
         }
         throw new WriteProcessException(
@@ -267,7 +267,7 @@ public class TsFileProcessor {
       for (int i = start; i < end; i++) {
         results[i] = RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());
       }
-      if (memIncrements != null) {
+      if (enableMemControl && memIncrements != null) {
         rollbackMemoryInfo(memIncrements);
       }
       throw new WriteProcessException(e);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -426,6 +426,7 @@ public class TsFileProcessor {
     memTableIncrement += textDataIncrement;
     storageGroupInfo.releaseStorageGroupMemCost(memTableIncrement);
     tsFileProcessorInfo.releaseTSPMemCost(chunkMetadataIncrement);
+    SystemInfo.getInstance().resetStorageGroupStatus(storageGroupInfo);
     workMemTable.releaseTVListRamCost(memTableIncrement);
     workMemTable.releaseTextDataSize(textDataIncrement);
   }


### PR DESCRIPTION
When inserting data, IoTDB first inserts data into memtable and then writes wal. If writing wal occurs error, the data in memtable should rollback, but IoTDB doesn't implement this. This problem can be fixed by changing the sequence of wal and memtable in insert.