### PR TITLE
[To rel/0.12] add JMX monitor to all ThreadPools in the server module

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@
 * [IOTDB-1466] Support device template
 * [IOTDB-1491] UDTF query supported in cluster
 * TTL can be set to the prefix path of storage group
+* add JMX monitor to all ThreadPools in the server module 
 
 ## Improvements
 * Use StringCachedPool in TsFileResource to reduce the memory size 

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/IThreadPoolMBean.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/IThreadPoolMBean.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.concurrent.threadpool;
+
+import java.util.Queue;
+
+public interface IThreadPoolMBean {
+
+  int getCorePoolSize();
+
+  boolean prestartCoreThread();
+
+  int getMaximumPoolSize();
+
+  Queue<Runnable> getQueue();
+
+  int getQueueLength();
+
+  int getPoolSize();
+
+  int getActiveCount();
+
+  int getLargestPoolSize();
+
+  long getTaskCount();
+
+  long getCompletedTaskCount();
+}

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedScheduledExecutorService.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedScheduledExecutorService.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.concurrent.threadpool;
+
+import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.service.JMXService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class WrappedScheduledExecutorService
+    implements ScheduledExecutorService, WrappedScheduledExecutorServiceMBean {
+  private final String mbeanName;
+  ScheduledExecutorService service;
+
+  public WrappedScheduledExecutorService(ScheduledExecutorService service, String mbeanName) {
+    this.mbeanName =
+        String.format(
+            "%s:%s=%s", IoTDBConstant.IOTDB_THREADPOOL_PACKAGE, IoTDBConstant.JMX_TYPE, mbeanName);
+    this.service = service;
+    JMXService.registerMBean(this, this.mbeanName);
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+    return service.schedule(command, delay, unit);
+  }
+
+  @Override
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+    return service.schedule(callable, delay, unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(
+      Runnable command, long initialDelay, long period, TimeUnit unit) {
+    return service.scheduleAtFixedRate(command, initialDelay, period, unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(
+      Runnable command, long initialDelay, long delay, TimeUnit unit) {
+    return service.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+  }
+
+  @Override
+  public void shutdown() {
+    service.shutdown();
+    JMXService.deregisterMBean(mbeanName);
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    JMXService.deregisterMBean(mbeanName);
+    return service.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return service.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return service.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return service.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return service.submit(task);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return service.submit(task, result);
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return service.submit(task);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    return service.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(
+      Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    return service.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException, ExecutionException {
+    return service.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return service.invokeAny(tasks, timeout, unit);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    service.execute(command);
+  }
+
+  @Override
+  public int getCorePoolSize() {
+    return ((ThreadPoolExecutor) service).getCorePoolSize();
+  }
+
+  @Override
+  public boolean prestartCoreThread() {
+    return ((ThreadPoolExecutor) service).prestartCoreThread();
+  }
+
+  @Override
+  public int getMaximumPoolSize() {
+    return ((ThreadPoolExecutor) service).getMaximumPoolSize();
+  }
+
+  @Override
+  public Queue<Runnable> getQueue() {
+    return ((ThreadPoolExecutor) service).getQueue();
+  }
+
+  @Override
+  public int getPoolSize() {
+    return ((ThreadPoolExecutor) service).getPoolSize();
+  }
+
+  @Override
+  public int getActiveCount() {
+    return ((ThreadPoolExecutor) service).getActiveCount();
+  }
+
+  @Override
+  public int getLargestPoolSize() {
+    return ((ThreadPoolExecutor) service).getLargestPoolSize();
+  }
+
+  @Override
+  public long getTaskCount() {
+    return ((ThreadPoolExecutor) service).getTaskCount();
+  }
+
+  @Override
+  public long getCompletedTaskCount() {
+    return ((ThreadPoolExecutor) service).getCompletedTaskCount();
+  }
+
+  @Override
+  public int getQueueLength() {
+    return getQueue().size();
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedScheduledExecutorServiceMBean.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedScheduledExecutorServiceMBean.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.concurrent.threadpool;
+
+public interface WrappedScheduledExecutorServiceMBean extends IThreadPoolMBean {}

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedSingleThreadExecutorService.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedSingleThreadExecutorService.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.concurrent.threadpool;
+
+import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.service.JMXService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class WrappedSingleThreadExecutorService
+    implements ExecutorService, WrappedSingleThreadExecutorServiceMBean {
+  private final String mbeanName;
+
+  ExecutorService service;
+
+  public WrappedSingleThreadExecutorService(ExecutorService service, String mbeanName) {
+    this.service = service;
+    this.mbeanName =
+        String.format(
+            "%s:%s=%s", IoTDBConstant.IOTDB_THREADPOOL_PACKAGE, IoTDBConstant.JMX_TYPE, mbeanName);
+    JMXService.registerMBean(this, this.mbeanName);
+  }
+
+  @Override
+  public void shutdown() {
+    service.shutdown();
+    JMXService.deregisterMBean(mbeanName);
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    JMXService.deregisterMBean(mbeanName);
+    return service.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return service.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return service.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return service.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return service.submit(task);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return service.submit(task, result);
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return service.submit(task);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    return service.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(
+      Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    return service.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException, ExecutionException {
+    return service.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return service.invokeAny(tasks, timeout, unit);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    service.execute(command);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedSingleThreadExecutorServiceMBean.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedSingleThreadExecutorServiceMBean.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.concurrent.threadpool;
+
+public interface WrappedSingleThreadExecutorServiceMBean {}

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedSingleThreadScheduledExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedSingleThreadScheduledExecutor.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.concurrent.threadpool;
+
+import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.service.JMXService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class WrappedSingleThreadScheduledExecutor
+    implements ScheduledExecutorService, WrappedSingleThreadScheduledExecutorMBean {
+  private final String mbeanName;
+  ScheduledExecutorService service;
+
+  public WrappedSingleThreadScheduledExecutor(ScheduledExecutorService service, String mbeanName) {
+    this.service = service;
+    this.mbeanName =
+        String.format(
+            "%s:%s=%s", IoTDBConstant.IOTDB_THREADPOOL_PACKAGE, IoTDBConstant.JMX_TYPE, mbeanName);
+    JMXService.registerMBean(this, this.mbeanName);
+  }
+
+  public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+    return service.schedule(command, delay, unit);
+  }
+
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+    return service.schedule(callable, delay, unit);
+  }
+
+  public ScheduledFuture<?> scheduleAtFixedRate(
+      Runnable command, long initialDelay, long period, TimeUnit unit) {
+    return service.scheduleAtFixedRate(command, initialDelay, period, unit);
+  }
+
+  public ScheduledFuture<?> scheduleWithFixedDelay(
+      Runnable command, long initialDelay, long delay, TimeUnit unit) {
+    return service.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+  }
+
+  public void shutdown() {
+    service.shutdown();
+    JMXService.deregisterMBean(mbeanName);
+  }
+
+  public List<Runnable> shutdownNow() {
+    JMXService.deregisterMBean(mbeanName);
+    return service.shutdownNow();
+  }
+
+  public boolean isShutdown() {
+    return service.isShutdown();
+  }
+
+  public boolean isTerminated() {
+    return service.isTerminated();
+  }
+
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return service.awaitTermination(timeout, unit);
+  }
+
+  public <T> Future<T> submit(Callable<T> task) {
+    return service.submit(task);
+  }
+
+  public <T> Future<T> submit(Runnable task, T result) {
+    return service.submit(task, result);
+  }
+
+  public Future<?> submit(Runnable task) {
+    return service.submit(task);
+  }
+
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    return service.invokeAll(tasks);
+  }
+
+  public <T> List<Future<T>> invokeAll(
+      Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    return service.invokeAll(tasks, timeout, unit);
+  }
+
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException, ExecutionException {
+    return service.invokeAny(tasks);
+  }
+
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return service.invokeAny(tasks, timeout, unit);
+  }
+
+  public void execute(Runnable command) {
+    service.execute(command);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedSingleThreadScheduledExecutorMBean.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedSingleThreadScheduledExecutorMBean.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.concurrent.threadpool;
+
+public interface WrappedSingleThreadScheduledExecutorMBean {}

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedThreadPoolExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedThreadPoolExecutor.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.concurrent.threadpool;
+
+import org.apache.iotdb.db.concurrent.IoTThreadFactory;
+import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.service.JMXService;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class WrappedThreadPoolExecutor extends ThreadPoolExecutor
+    implements WrappedThreadPoolExecutorMBean {
+  private final String mbeanName;
+
+  public WrappedThreadPoolExecutor(
+      int corePoolSize,
+      int maximumPoolSize,
+      long keepAliveTime,
+      TimeUnit unit,
+      BlockingQueue<Runnable> workQueue,
+      ThreadFactory threadFactory,
+      String mbeanName) {
+    super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+    this.mbeanName =
+        String.format(
+            "%s:%s=%s", IoTDBConstant.IOTDB_THREADPOOL_PACKAGE, IoTDBConstant.JMX_TYPE, mbeanName);
+    JMXService.registerMBean(this, this.mbeanName);
+  }
+
+  public WrappedThreadPoolExecutor(
+      int minWorkerThreads,
+      int maxWorkerThreads,
+      int stopTimeoutVal,
+      TimeUnit stopTimeoutUnit,
+      SynchronousQueue<Runnable> executorQueue,
+      IoTThreadFactory ioTThreadFactory,
+      String mbeanName) {
+    super(
+        minWorkerThreads,
+        maxWorkerThreads,
+        stopTimeoutVal,
+        stopTimeoutUnit,
+        executorQueue,
+        ioTThreadFactory);
+    this.mbeanName =
+        String.format(
+            "%s:%s=%s", IoTDBConstant.IOTDB_THREADPOOL_PACKAGE, IoTDBConstant.JMX_TYPE, mbeanName);
+    JMXService.registerMBean(this, this.mbeanName);
+  }
+
+  @Override
+  public void shutdown() {
+    super.shutdown();
+    JMXService.deregisterMBean(mbeanName);
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    JMXService.deregisterMBean(mbeanName);
+    return super.shutdownNow();
+  }
+
+  @Override
+  public int getQueueLength() {
+    return getQueue().size();
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedThreadPoolExecutorMBean.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/threadpool/WrappedThreadPoolExecutorMBean.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.concurrent.threadpool;
+
+public interface WrappedThreadPoolExecutorMBean extends IThreadPoolMBean {}

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -37,6 +37,7 @@ public class IoTDBConstant {
   public static final String IOTDB_JMX_PORT = "iotdb.jmx.port";
 
   public static final String IOTDB_PACKAGE = "org.apache.iotdb.service";
+  public static final String IOTDB_THREADPOOL_PACKAGE = "org.apache.iotdb.threadpool";
   public static final String JMX_TYPE = "type";
 
   public static final long GB = 1024 * 1024 * 1024L;

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -88,7 +88,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -293,7 +292,7 @@ public class StorageEngine implements IService {
 
   @Override
   public void start() {
-    ttlCheckThread = Executors.newSingleThreadScheduledExecutor();
+    ttlCheckThread = IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("TTL");
     ttlCheckThread.scheduleAtFixedRate(
         this::checkTTL, TTL_CHECK_INTERVAL, TTL_CHECK_INTERVAL, TimeUnit.MILLISECONDS);
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionMergeTaskPoolManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionMergeTaskPoolManager.java
@@ -39,7 +39,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.engine.compaction.utils.CompactionLogger.COMPACTION_LOG_NAME;
@@ -51,7 +52,7 @@ public class CompactionMergeTaskPoolManager implements IService {
       LoggerFactory.getLogger(CompactionMergeTaskPoolManager.class);
   private static final CompactionMergeTaskPoolManager INSTANCE =
       new CompactionMergeTaskPoolManager();
-  private ScheduledThreadPoolExecutor pool;
+  private ScheduledExecutorService pool;
   private Map<String, List<Future<Void>>> storageGroupTasks = new ConcurrentHashMap<>();
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
@@ -64,11 +65,10 @@ public class CompactionMergeTaskPoolManager implements IService {
   @Override
   public void start() {
     if (pool == null) {
-      this.pool =
-          (ScheduledThreadPoolExecutor)
-              IoTDBThreadPoolFactory.newScheduledThreadPool(
-                  IoTDBDescriptor.getInstance().getConfig().getCompactionThreadNum(),
-                  ThreadName.COMPACTION_SERVICE.getName());
+      pool =
+          IoTDBThreadPoolFactory.newScheduledThreadPool(
+              IoTDBDescriptor.getInstance().getConfig().getCompactionThreadNum(),
+              ThreadName.COMPACTION_SERVICE.getName());
     }
     logger.info("Compaction task manager started.");
   }
@@ -192,7 +192,7 @@ public class CompactionMergeTaskPoolManager implements IService {
 
   @TestOnly
   public synchronized int getCompactionTaskNum() {
-    return pool.getActiveCount();
+    return ((ThreadPoolExecutor) pool).getActiveCount();
   }
 
   public boolean isTerminated() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/FlushManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/FlushManager.java
@@ -51,13 +51,13 @@ public class FlushManager implements FlushManagerMBean, IService {
 
   @Override
   public void start() throws StartupException {
-    FlushSubTaskPoolManager.getInstance().start();
-    FlushTaskPoolManager.getInstance().start();
     try {
       JMXService.registerMBean(this, ServiceType.FLUSH_SERVICE.getJmxName());
     } catch (Exception e) {
       throw new StartupException(this.getID().getName(), e.getMessage());
     }
+    FlushSubTaskPoolManager.getInstance().start();
+    FlushTaskPoolManager.getInstance().start();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.engine.merge.manage;
 
+import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.concurrent.ThreadName;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -45,7 +46,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -144,7 +144,7 @@ public class MergeManager implements IService, MergeManagerMBean {
               r -> new Thread(r, "MergeChunkSubThread-" + threadCnt.getAndIncrement()));
 
       taskCleanerThreadPool =
-          Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "MergeTaskCleaner"));
+          IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("MergeTaskCleaner");
       taskCleanerThreadPool.scheduleAtFixedRate(this::cleanFinishedTask, 30, 30, TimeUnit.MINUTES);
       logger.info("MergeManager started");
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.engine.storagegroup;
 
+import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -102,7 +103,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -379,7 +379,8 @@ public class StorageGroupProcessor {
             .getCompactionStrategy()
             .getTsFileManagement(logicalStorageGroupName, storageGroupSysDir.getAbsolutePath());
 
-    ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    ScheduledExecutorService executorService =
+        IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("WAL-trimTask");
     executorService.scheduleWithFixedDelay(
         this::trimTask,
         config.getWalPoolTrimIntervalInMS(),

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.metadata;
 
+import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
@@ -102,7 +103,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -209,8 +209,8 @@ public class MManager {
 
     if (config.isEnableMTreeSnapshot()) {
       timedCreateMTreeSnapshotThread =
-          Executors.newSingleThreadScheduledExecutor(
-              r -> new Thread(r, "timedCreateMTreeSnapshotThread"));
+          IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("timedCreateMTreeSnapshotThread");
+
       timedCreateMTreeSnapshotThread.scheduleAtFixedRate(
           this::checkMTreeModified,
           MTREE_SNAPSHOT_THREAD_CHECK_TIME,

--- a/server/src/main/java/org/apache/iotdb/db/service/MetricsService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/MetricsService.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.service;
 
+import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.concurrent.ThreadName;
 import org.apache.iotdb.db.concurrent.WrappedRunnable;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -37,7 +38,6 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class MetricsService implements MetricsServiceMBean, IService {
@@ -90,7 +90,7 @@ public class MetricsService implements MetricsServiceMBean, IService {
       return;
     }
     logger.info("{}: start {}...", IoTDBConstant.GLOBAL_DB_NAME, this.getID().getName());
-    executorService = Executors.newSingleThreadExecutor();
+    executorService = IoTDBThreadPoolFactory.newSingleThreadExecutor("DeprecatedMetricsWeb");
     int port = getMetricsPort();
     MetricsSystem metricsSystem = new MetricsSystem(new ServerArgument(port));
     MetricsWebUI metricsWebUI = new MetricsWebUI(metricsSystem.getMetricRegistry());

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iotdb.db.service;
 
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.iotdb.db.auth.AuthException;
 import org.apache.iotdb.db.auth.AuthorityChecker;
 import org.apache.iotdb.db.auth.authorizer.BasicAuthorizer;
 import org.apache.iotdb.db.auth.authorizer.IAuthorizer;
+import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -124,8 +126,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
-
-import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,7 +141,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -195,7 +194,7 @@ public class TSServiceImpl implements TSIService.Iface {
     executor = new PlanExecutor();
 
     ScheduledExecutorService timedQuerySqlCountThread =
-        Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "timedQuerySqlCountThread"));
+        IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("timedQuerySqlCountThread");
     timedQuerySqlCountThread.scheduleAtFixedRate(
         () -> {
           if (queryCount.get() != 0) {

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.service;
 
-import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.iotdb.db.auth.AuthException;
 import org.apache.iotdb.db.auth.AuthorityChecker;
 import org.apache.iotdb.db.auth.authorizer.BasicAuthorizer;
@@ -126,6 +125,8 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
+
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/src/main/java/org/apache/iotdb/db/service/UpgradeSevice.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/UpgradeSevice.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.service;
 
+import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.upgrade.UpgradeLog;
@@ -29,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class UpgradeSevice implements IService {
@@ -38,7 +38,6 @@ public class UpgradeSevice implements IService {
 
   private static final UpgradeSevice INSTANCE = new UpgradeSevice();
   private ExecutorService upgradeThreadPool;
-  private AtomicInteger threadCnt = new AtomicInteger();
   private static AtomicInteger cntUpgradeFileNum = new AtomicInteger();
 
   private UpgradeSevice() {}
@@ -53,9 +52,7 @@ public class UpgradeSevice implements IService {
     if (updateThreadNum <= 0) {
       updateThreadNum = 1;
     }
-    upgradeThreadPool =
-        Executors.newFixedThreadPool(
-            updateThreadNum, r -> new Thread(r, "UpgradeThread-" + threadCnt.getAndIncrement()));
+    upgradeThreadPool = IoTDBThreadPoolFactory.newFixedThreadPool(updateThreadNum, "UpgradeThread");
     UpgradeLog.createUpgradeLog();
     countUpgradeFiles();
     if (cntUpgradeFileNum.get() == 0) {

--- a/server/src/main/java/org/apache/iotdb/db/writelog/manager/MultiFileLogNodeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/manager/MultiFileLogNodeManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.writelog.manager;
 
+import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StartupException;
@@ -33,7 +34,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -122,7 +122,8 @@ public class MultiFileLogNodeManager implements WriteLogNodeManager, IService {
         return;
       }
       if (config.getForceWalPeriodInMs() > 0) {
-        executorService = Executors.newSingleThreadScheduledExecutor();
+        executorService = IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("WAL-ForceSync");
+
         executorService.scheduleWithFixedDelay(
             this::forceTask,
             config.getForceWalPeriodInMs(),

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.writelog.node;
 
+import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
@@ -41,7 +42,6 @@ import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -68,8 +68,7 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
 
   private final Object switchBufferCondition = new Object();
   private final ReentrantLock lock = new ReentrantLock();
-  private final ExecutorService FLUSH_BUFFER_THREAD_POOL =
-      Executors.newSingleThreadExecutor(r -> new Thread(r, "Flush-WAL-Thread-" + this.hashCode()));
+  private final ExecutorService FLUSH_BUFFER_THREAD_POOL;
 
   private long fileId = 0;
   private long lastFlushedId = 0;
@@ -90,6 +89,9 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
     if (SystemFileFactory.INSTANCE.getFile(logDirectory).mkdirs()) {
       logger.info("create the WAL folder {}.", logDirectory);
     }
+    FLUSH_BUFFER_THREAD_POOL =
+        IoTDBThreadPoolFactory.newSingleThreadExecutor(
+            "Flush-WAL-Thread-" + SystemFileFactory.INSTANCE.getFile(logDirectory).getName());
   }
 
   @Override


### PR DESCRIPTION
## Description

We use many thread pools in IoTDB and it is hard to know how many thread pool we have totally and whether a thread pool is busy.

Therefore, I unify the creation of ThreadPool, register it to JMX and allow using JMX to check its active size, pending size, etc..
When the threadpool is `shutdown()` or `shutdownNow()`, the Pool will be deregistered from JMX.

Only The server module has been upgrade to such kind of ThreadPool.

I will do the same thing in the Master branch and replace all thread pools in the cluster module using this kind of thread pool.

## NOTICE

Once this PR is merged, in the server module, DO NOT USE `Executors.newXXX()` FUNCTIONS ANY MORE IN THE FUTURE.

## Screenshot

See the effect:
![image](https://user-images.githubusercontent.com/1021782/128897599-ef679f94-937a-4c88-b74d-219da4b268d8.png)




( This PR is hard to add UT to cover the codes. I have tested manually.)
