### PR TITLE
[IOTDB-1539] Fix delete operation with value filter is abnormal

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.qp.sql;
 
+import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.trigger.executor.TriggerEvent;
 import org.apache.iotdb.db.exception.index.UnsupportedIndexTypeException;
@@ -287,6 +288,10 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
   private static final String DELETE_RANGE_ERROR_MSG =
       "For delete statement, where clause can only contain atomic expressions like : "
           + "time > XXX, time <= XXX, or two atomic expressions connected by 'AND'";
+
+  private static final String DELETE_ONLY_SUPPORT_TIME_EXP_ERROR_MSG =
+      "For delete statement, where clause can only contain time expressions, "
+          + "value filter is not currently supported.";
 
   // used to match "{x}", where x is a integer.
   // for create-cq clause and select-into clause.
@@ -1954,6 +1959,12 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
   }
 
   private Pair<Long, Long> calcOperatorInterval(FilterOperator filterOperator) {
+
+    if (filterOperator.getSinglePath() != null
+        && !IoTDBConstant.TIME.equals(filterOperator.getSinglePath().getMeasurement())) {
+      throw new SQLParserException(DELETE_ONLY_SUPPORT_TIME_EXP_ERROR_MSG);
+    }
+
     long time = Long.parseLong(((BasicFunctionOperator) filterOperator).getValue());
     switch (filterOperator.getFilterType()) {
       case LESSTHAN:

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
@@ -94,6 +94,19 @@ public class IoTDBDeletionIT {
           "303: Check metadata error: For delete statement, where clause can only"
               + " contain time expressions, value filter is not currently supported.";
 
+      String errorMsg2 =
+          "303: Check metadata error: For delete statement, where clause can only contain"
+              + " atomic expressions like : time > XXX, time <= XXX,"
+              + " or two atomic expressions connected by 'AND'";
+
+      try {
+        statement.execute(
+            "DELETE FROM root.vehicle.d0.s0  WHERE s0 <= 300 AND time > 0 AND time < 100");
+        fail("should not reach here!");
+      } catch (SQLException e) {
+        assertEquals(errorMsg2, e.getMessage());
+      }
+
       try {
         statement.execute("DELETE FROM root.vehicle.d0.s0  WHERE s0 <= 300 AND s0 > 0");
         fail("should not reach here!");

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBDeletionIT.java
@@ -37,6 +37,7 @@ import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 public class IoTDBDeletionIT {
 
@@ -71,6 +72,73 @@ public class IoTDBDeletionIT {
   public void tearDown() throws Exception {
     EnvironmentUtils.cleanEnv();
     IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(prevPartitionInterval);
+  }
+
+  /**
+   * Should delete this case after the deletion value filter feature be implemented
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testUnsupportedValueFilter() throws SQLException {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("insert into root.vehicle.d0(time,s0) values (10,310)");
+      statement.execute("insert into root.vehicle.d0(time,s3) values (10,'text')");
+      statement.execute("insert into root.vehicle.d0(time,s4) values (10,true)");
+
+      String errorMsg =
+          "303: Check metadata error: For delete statement, where clause can only"
+              + " contain time expressions, value filter is not currently supported.";
+
+      try {
+        statement.execute("DELETE FROM root.vehicle.d0.s0  WHERE s0 <= 300 AND s0 > 0");
+        fail("should not reach here!");
+      } catch (SQLException e) {
+        assertEquals(errorMsg, e.getMessage());
+      }
+
+      try {
+        statement.execute("DELETE FROM root.vehicle.d0.s3  WHERE s3 = 'text'");
+        fail("should not reach here!");
+      } catch (SQLException e) {
+        assertEquals(errorMsg, e.getMessage());
+      }
+
+      try {
+        statement.execute("DELETE FROM root.vehicle.d0.s4  WHERE s4 != true");
+        fail("should not reach here!");
+      } catch (SQLException e) {
+        assertEquals(errorMsg, e.getMessage());
+      }
+
+      try (ResultSet set = statement.executeQuery("SELECT s0 FROM root.vehicle.d0")) {
+        int cnt = 0;
+        while (set.next()) {
+          cnt++;
+        }
+        assertEquals(1, cnt);
+      }
+
+      try (ResultSet set = statement.executeQuery("SELECT s3 FROM root.vehicle.d0")) {
+        int cnt = 0;
+        while (set.next()) {
+          cnt++;
+        }
+        assertEquals(1, cnt);
+      }
+
+      try (ResultSet set = statement.executeQuery("SELECT s4 FROM root.vehicle.d0")) {
+        int cnt = 0;
+        while (set.next()) {
+          cnt++;
+        }
+        assertEquals(1, cnt);
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description
https://issues.apache.org/jira/browse/IOTDB-1539

For now, deletion do not support values filter, but, all conditions in where clause will be treated as time condition, thus will product two affects:

1. If the data type in condition could be parsed to Long, the statement will be executed successfully, it's dangerous!!
    For example, the original statement is "delete from root.vehicle.d1.s1 where s1 > 100", but the actually statement be 
    executed is "delete from root.vehicle.d1.s1 where time > 100".  Then, data may be deleted abnormally.

2. If the data type in condition could not be parsed to Long, we will get a 500 error because of a NumberFormatException.

## Solution
Before the value filter feature is implemented, I temporally fixed this by return an error message like "For delete statement, where clause can only contain time expressions, value filter is not currently supported." if any non-time-expression appears in where clause.
