### PR TITLE
[To rel/0.12] Fix CreateTimeseriesIT runs slow

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCreateTimeseriesIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCreateTimeseriesIT.java
@@ -51,22 +51,19 @@ public class IoTDBCreateTimeseriesIT {
   @Before
   public void setUp() throws Exception {
     EnvironmentUtils.envSetUp();
-
-    Class.forName(Config.JDBC_DRIVER_NAME);
-    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
-    statement = connection.createStatement();
   }
 
   @After
   public void tearDown() throws Exception {
-    statement.close();
-    connection.close();
     EnvironmentUtils.cleanEnv();
   }
 
   /** Test creating a time series that is a prefix path of an existing time series */
   @Test
   public void testCreateTimeseries1() throws Exception {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+    statement = connection.createStatement();
     String[] timeSeriesArray = {"root.sg1.aa.bb", "root.sg1.aa.bb.cc", "root.sg1.aa"};
 
     for (String timeSeries : timeSeriesArray) {
@@ -79,11 +76,17 @@ public class IoTDBCreateTimeseriesIT {
     // ensure that current timeseries in cache is right.
     createTimeSeries1Tool(timeSeriesArray);
 
-    EnvironmentUtils.stopDaemon();
-    setUp();
+    statement.close();
+    connection.close();
+    EnvironmentUtils.restartDaemon();
 
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+    statement = connection.createStatement();
     // ensure timeseries in cache is right after recovered.
     createTimeSeries1Tool(timeSeriesArray);
+    statement.close();
+    connection.close();
   }
 
   private void createTimeSeries1Tool(String[] timeSeriesArray) throws SQLException {
@@ -112,6 +115,9 @@ public class IoTDBCreateTimeseriesIT {
   /** Test if creating a time series will cause the storage group with same name to disappear */
   @Test
   public void testCreateTimeseries2() throws Exception {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+    statement = connection.createStatement();
     String storageGroup = "root.sg1.a.b.c";
 
     statement.execute(String.format("SET storage group TO %s", storageGroup));
@@ -126,11 +132,17 @@ public class IoTDBCreateTimeseriesIT {
     // ensure that current storage group in cache is right.
     createTimeSeries2Tool(storageGroup);
 
-    EnvironmentUtils.stopDaemon();
-    setUp();
+    statement.close();
+    connection.close();
+    EnvironmentUtils.restartDaemon();
 
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+    statement = connection.createStatement();
     // ensure storage group in cache is right after recovered.
     createTimeSeries2Tool(storageGroup);
+    statement.close();
+    connection.close();
   }
 
   private void createTimeSeries2Tool(String storageGroup) throws SQLException {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCreateTimeseriesIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCreateTimeseriesIT.java
@@ -51,19 +51,22 @@ public class IoTDBCreateTimeseriesIT {
   @Before
   public void setUp() throws Exception {
     EnvironmentUtils.envSetUp();
+
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+    statement = connection.createStatement();
   }
 
   @After
   public void tearDown() throws Exception {
+    statement.close();
+    connection.close();
     EnvironmentUtils.cleanEnv();
   }
 
   /** Test creating a time series that is a prefix path of an existing time series */
   @Test
   public void testCreateTimeseries1() throws Exception {
-    Class.forName(Config.JDBC_DRIVER_NAME);
-    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
-    statement = connection.createStatement();
     String[] timeSeriesArray = {"root.sg1.aa.bb", "root.sg1.aa.bb.cc", "root.sg1.aa"};
 
     for (String timeSeries : timeSeriesArray) {
@@ -78,15 +81,11 @@ public class IoTDBCreateTimeseriesIT {
 
     statement.close();
     connection.close();
-    EnvironmentUtils.restartDaemon();
+    EnvironmentUtils.stopDaemon();
+    setUp();
 
-    Class.forName(Config.JDBC_DRIVER_NAME);
-    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
-    statement = connection.createStatement();
     // ensure timeseries in cache is right after recovered.
     createTimeSeries1Tool(timeSeriesArray);
-    statement.close();
-    connection.close();
   }
 
   private void createTimeSeries1Tool(String[] timeSeriesArray) throws SQLException {
@@ -115,9 +114,6 @@ public class IoTDBCreateTimeseriesIT {
   /** Test if creating a time series will cause the storage group with same name to disappear */
   @Test
   public void testCreateTimeseries2() throws Exception {
-    Class.forName(Config.JDBC_DRIVER_NAME);
-    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
-    statement = connection.createStatement();
     String storageGroup = "root.sg1.a.b.c";
 
     statement.execute(String.format("SET storage group TO %s", storageGroup));
@@ -134,15 +130,11 @@ public class IoTDBCreateTimeseriesIT {
 
     statement.close();
     connection.close();
-    EnvironmentUtils.restartDaemon();
+    EnvironmentUtils.stopDaemon();
+    setUp();
 
-    Class.forName(Config.JDBC_DRIVER_NAME);
-    connection = DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
-    statement = connection.createStatement();
     // ensure storage group in cache is right after recovered.
     createTimeSeries2Tool(storageGroup);
-    statement.close();
-    connection.close();
   }
 
   private void createTimeSeries2Tool(String storageGroup) throws SQLException {

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -38,6 +38,8 @@ import org.apache.iotdb.db.query.udf.service.UDFRegistrationService;
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
 import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.db.service.IoTDB;
+import org.apache.iotdb.db.service.RPCService;
+import org.apache.iotdb.db.service.thrift.ThriftService;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TSocketWrapper;
 
@@ -93,6 +95,7 @@ public class EnvironmentUtils {
       fail(e.getMessage());
     }
 
+    RPCService.getInstance().stopService();
     logger.warn("EnvironmentUtil cleanEnv...");
     if (daemon != null) {
       daemon.stop();

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -38,8 +38,6 @@ import org.apache.iotdb.db.query.udf.service.UDFRegistrationService;
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
 import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.db.service.IoTDB;
-import org.apache.iotdb.db.service.RPCService;
-import org.apache.iotdb.db.service.thrift.ThriftService;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TSocketWrapper;
 
@@ -95,7 +93,6 @@ public class EnvironmentUtils {
       fail(e.getMessage());
     }
 
-    RPCService.getInstance().stopService();
     logger.warn("EnvironmentUtil cleanEnv...");
     if (daemon != null) {
       daemon.stop();


### PR DESCRIPTION
When I run this IT on my computer, it costs as long as 1 min to stop the rpc service. 
And I got an error message `org.apache.thrift.server.TThreadPoolServer:144 - Shutdown is not done after 60 SECONDS`.

The reason is this test doesn't close the statement and connection before execute `EnvironmentUtils.stopDaemon()`.