### PR TITLE
Fix CI runs slow caused by connection not closing

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -2146,11 +2146,11 @@ public class TSServiceImpl implements TSIService.Iface {
     String message =
         String.format("[%s] Exception occurred while %s. ", statusCode.name(), operation);
     if (e instanceof NullPointerException) {
-      LOGGER.error(message, e);
+      LOGGER.error("Status code: {}, MSG: {}", statusCode, message, e);
     } else if (e instanceof UnSupportedDataTypeException) {
-      LOGGER.warn(e.getMessage());
+      LOGGER.warn("Status code: {}, MSG: {}", statusCode, e.getMessage());
     } else {
-      LOGGER.warn(message, e);
+      LOGGER.warn("Status code: {}, MSG: {}", statusCode, message, e);
     }
     return RpcUtils.getStatus(statusCode, message + e.getMessage());
   }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBArithmeticIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBArithmeticIT.java
@@ -188,9 +188,10 @@ public class IoTDBArithmeticIT {
 
   @Test
   public void testArithmeticUnary() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       String[] expressions = new String[] {"- s1", "- s2", "- s3", "- s4"};
       String sql = String.format("select %s from root.sg.d1", String.join(",", expressions));
       ResultSet resultSet = statement.executeQuery(sql);
@@ -205,6 +206,7 @@ public class IoTDBArithmeticIT {
           assertEquals(expected, actual, E);
         }
       }
+      resultSet.close();
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
@@ -212,9 +214,10 @@ public class IoTDBArithmeticIT {
 
   @Test
   public void testHybridQuery() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       String[] expressions = new String[] {"s1", "s1 + s2", "sin(s1)"};
       String sql = String.format("select %s from root.sg.d1", String.join(",", expressions));
       ResultSet resultSet = statement.executeQuery(sql);
@@ -227,6 +230,7 @@ public class IoTDBArithmeticIT {
         assertEquals(i + i, Double.parseDouble(resultSet.getString(3)), E);
         assertEquals(Math.sin(i), Double.parseDouble(resultSet.getString(4)), E);
       }
+      resultSet.close();
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
@@ -234,9 +238,10 @@ public class IoTDBArithmeticIT {
 
   @Test
   public void testNonAlign() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery("select s7 + s8 from root.sg.d1");
       assertEquals(1 + 1, resultSet.getMetaData().getColumnCount());
       assertTrue(resultSet.next());
@@ -246,6 +251,7 @@ public class IoTDBArithmeticIT {
       resultSet = statement.executeQuery("select s7 + s8 from root.sg.d1 where time < 5");
       assertEquals(1 + 1, resultSet.getMetaData().getColumnCount());
       assertFalse(resultSet.next());
+      resultSet.close();
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
@@ -253,9 +259,10 @@ public class IoTDBArithmeticIT {
 
   @Test
   public void testWrongTypeBoolean() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.executeQuery("select s1 + s5 from root.sg.d1");
     } catch (SQLException throwable) {
       assertTrue(throwable.getMessage().contains("Unsupported data type: BOOLEAN"));
@@ -264,9 +271,10 @@ public class IoTDBArithmeticIT {
 
   @Test
   public void testWrongTypeText() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.executeQuery("select s1 + s6 from root.sg.d1");
     } catch (SQLException throwable) {
       assertTrue(throwable.getMessage().contains("Unsupported data type: TEXT"));

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAutoCreateSchemaIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAutoCreateSchemaIT.java
@@ -24,7 +24,11 @@ import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
 import org.apache.iotdb.jdbc.IoTDBSQLException;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -169,6 +173,8 @@ public class IoTDBAutoCreateSchemaIT {
     // ensure that insert data in cache is right.
     insertAutoCreate1Tool();
 
+    statement.close();
+    connection.close();
     EnvironmentUtils.stopDaemon();
     setUp();
 
@@ -217,6 +223,8 @@ public class IoTDBAutoCreateSchemaIT {
     // ensure that current storage group in cache is right.
     InsertAutoCreate2Tool(storageGroup, timeSeriesPrefix);
 
+    statement.close();
+    connection.close();
     EnvironmentUtils.stopDaemon();
     setUp();
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBContinuousQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBContinuousQueryIT.java
@@ -53,16 +53,12 @@ public class IoTDBContinuousQueryIT {
 
   private final Thread dataGenerator =
       new Thread() {
-
         @Override
         public void run() {
-
-          try {
-            Connection connection =
-                DriverManager.getConnection(
-                    Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
-            Statement statement = connection.createStatement();
-
+          try (Connection connection =
+                  DriverManager.getConnection(
+                      Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+              Statement statement = connection.createStatement()) {
             do {
               for (String timeSeries : timeSeriesArray) {
                 boolean isSuccessful = false;
@@ -74,16 +70,8 @@ public class IoTDBContinuousQueryIT {
                             timeSeries, 200 * Math.random()));
                     isSuccessful = true;
                   } catch (SQLException throwable) {
-                    LOGGER.error(throwable.getMessage());
                     throwable.printStackTrace();
-
-                    statement.close();
-                    connection.close();
-
-                    connection =
-                        DriverManager.getConnection(
-                            Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
-                    statement = connection.createStatement();
+                    fail(throwable.getMessage());
                   }
                 }
               }
@@ -163,6 +151,8 @@ public class IoTDBContinuousQueryIT {
 
     checkShowContinuousQueriesResult(new String[] {"cq3"});
 
+    statement.close();
+    connection.close();
     EnvironmentUtils.shutdownDaemon();
     EnvironmentUtils.stopDaemon();
     setUp();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCreateStorageGroupIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCreateStorageGroupIT.java
@@ -72,6 +72,8 @@ public class IoTDBCreateStorageGroupIT {
     // ensure that current StorageGroup in cache is right.
     createStorageGroupTool(storageGroups);
 
+    statement.close();
+    connection.close();
     EnvironmentUtils.stopDaemon();
     setUp();
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCreateTimeseriesIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCreateTimeseriesIT.java
@@ -23,7 +23,11 @@ import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
 import org.apache.iotdb.jdbc.IoTDBSQLException;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -78,6 +82,8 @@ public class IoTDBCreateTimeseriesIT {
       // ensure that current timeseries in cache is right.
       createTimeSeries1Tool(timeSeriesArray);
 
+      statement.close();
+      connection.close();
       EnvironmentUtils.stopDaemon();
       setUp();
 
@@ -128,6 +134,8 @@ public class IoTDBCreateTimeseriesIT {
     // ensure that current storage group in cache is right.
     createTimeSeries2Tool(storageGroup);
 
+    statement.close();
+    connection.close();
     EnvironmentUtils.stopDaemon();
     setUp();
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryMemoryControlIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryMemoryControlIT.java
@@ -68,9 +68,10 @@ public class IoTDBQueryMemoryControlIT {
   }
 
   private static void createTimeSeries() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       for (String sql : sqls) {
         statement.execute(sql);
       }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSelectIntoIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSelectIntoIT.java
@@ -148,9 +148,10 @@ public class IoTDBSelectIntoIT {
 
   @Test // TODO: check values
   public void selectIntoSameDevice() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute(
           "select s1, s2, s3, s4, s5, s6 into s7, s8, s9, s10, s11, s12 from root.sg.d1");
 
@@ -176,9 +177,10 @@ public class IoTDBSelectIntoIT {
 
   @Test // TODO: check values
   public void selectIntoDifferentDevices() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute(
           "select s1, s2, s3, s4, s5, s6 into pre_${2}_suf.s1, pre_${2}_suf.s2, pre_${2}_suf.s3, pre_${2}_suf.s4, pre_${2}_suf.s5, pre_${2}_suf.s6 from root.sg.d1");
 
@@ -205,9 +207,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void selectFromEmptySourcePath() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select empty into target from root.sg.d1");
 
       try (ResultSet resultSet = statement.executeQuery("select target from root.sg.d1")) {
@@ -221,9 +224,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void selectIntoFullTargetPath() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1 into root.${2}.${1}.s1 from root.sg.d1 where time>0");
 
       try (ResultSet resultSet = statement.executeQuery("select sg.d1.s1, d1.sg.s1 from root")) {
@@ -244,9 +248,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void selectSameTimeSeries() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1, s1 into s1s2, s1s3 from root.sg.d1");
 
       try (ResultSet resultSet = statement.executeQuery("select s1s2, s1s3 from root.sg.d1")) {
@@ -268,9 +273,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testLargeData() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1 into large_s1 from root.sg.d3");
 
       try (ResultSet resultSet = statement.executeQuery("select large_s1 from root.sg.d3")) {
@@ -293,9 +299,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testUDFQuery() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute(
           "select s1, sin(s1), s1 + s1 into ${2}.s2, ${2}.s3, ${2}.s4 from root.sg.d1");
 
@@ -323,9 +330,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testGroupByQuery() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select count(s1) into count_s1 from root.sg.d1 group by ([1, 5),1ms);");
 
       try (ResultSet resultSet = statement.executeQuery("select count_s1 from root.sg.d1")) {
@@ -348,9 +356,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testGroupByFillQuery() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute(
           "select last_value(s1) into gbf_s1 from root.sg.d1 group by ([1, 10),1ms) fill (float[PREVIOUS]);");
 
@@ -374,9 +383,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testFillQuery() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute(
           "select s1 into fill_s1 from root.sg.d1 where time = 10 fill(float [linear, 1ms, 1ms])");
 
@@ -396,9 +406,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testDifferentNumbersOfSourcePathsAndTargetPaths() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1, s2 into target from root.sg.d1");
       fail();
     } catch (SQLException throwable) {
@@ -409,9 +420,10 @@ public class IoTDBSelectIntoIT {
                   "the number of source paths and the number of target paths should be the same"));
     }
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1 into target from root.sg.*");
       fail();
     } catch (SQLException throwable) {
@@ -422,9 +434,10 @@ public class IoTDBSelectIntoIT {
                   "the number of source paths and the number of target paths should be the same"));
     }
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select * into target from root.sg.d1");
       fail();
     } catch (SQLException throwable) {
@@ -438,9 +451,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testMultiPrefixPathsInFromClause() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1 into target from root.sg.d1, root.sg.d2");
       fail();
     } catch (SQLException throwable) {
@@ -453,9 +467,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testLeveledPathNodePatternLimit() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1 into root.${100}.s1 from root.sg.d1");
       fail();
     } catch (SQLException throwable) {
@@ -466,9 +481,10 @@ public class IoTDBSelectIntoIT {
                   "the x of ${x} should be greater than 0 and equal to or less than <level> or the length of queried path prefix."));
     }
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1 into root.${0}.s1 from root.sg.d1");
       fail();
     } catch (SQLException throwable) {
@@ -479,9 +495,10 @@ public class IoTDBSelectIntoIT {
                   "the x of ${x} should be greater than 0 and equal to or less than <level> or the length of queried path prefix."));
     }
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1 into root.${wrong}.s1 from root.sg.d1");
       fail();
     } catch (SQLException throwable) {
@@ -491,9 +508,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testAlignByDevice() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1 into root.${1}.s1 from root.sg.d1 align by device");
       fail();
     } catch (SQLException throwable) {
@@ -503,9 +521,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testDisableDevice() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1 into root.${1}.s1 from root.sg.d1 disable align");
       fail();
     } catch (SQLException throwable) {
@@ -515,9 +534,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testLastQuery() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select last s1 into root.${1}.s1 from root.sg.d1");
       fail();
     } catch (SQLException throwable) {
@@ -527,9 +547,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testSlimit() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1, s2 into ${1}.s1, ${2}.s1 from root.sg.d1 slimit 1");
       fail();
     } catch (SQLException throwable) {
@@ -539,9 +560,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testDescending() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1, s2 into ${1}.s1, ${2}.s1 from root.sg.d1 order by time desc");
       fail();
     } catch (SQLException throwable) {
@@ -551,9 +573,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testSameTargetPaths() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.execute("select s1, s2 into ${1}.s1, ${1}.s1 from root.sg.d1");
       fail();
     } catch (SQLException throwable) {
@@ -564,9 +587,10 @@ public class IoTDBSelectIntoIT {
 
   @Test
   public void testContainerCase() throws SQLException {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
 
       for (int i = 0; i < 10; i++) {
         statement.execute(

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBTriggerExecutionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBTriggerExecutionIT.java
@@ -60,12 +60,10 @@ public class IoTDBTriggerExecutionIT {
 
         @Override
         public void run() {
-
-          try {
-            Connection connection =
-                DriverManager.getConnection(
-                    Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
-            Statement statement = connection.createStatement();
+          try (Connection connection =
+                  DriverManager.getConnection(
+                      Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+              Statement statement = connection.createStatement()) {
 
             long count = 0;
             do {
@@ -85,16 +83,8 @@ public class IoTDBTriggerExecutionIT {
                           count));
                   isSuccessful = true;
                 } catch (SQLException throwable) {
+                  fail(throwable.getMessage());
                   LOGGER.error(throwable.getMessage());
-                  throwable.printStackTrace();
-
-                  statement.close();
-                  connection.close();
-
-                  connection =
-                      DriverManager.getConnection(
-                          Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
-                  statement = connection.createStatement();
                 }
               }
             } while (!isInterrupted());

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDFWindowQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDFWindowQueryIT.java
@@ -136,9 +136,10 @@ public class IoTDBUDFWindowQueryIT {
             "select counter(s1, \"%s\"=\"%s\") from root.vehicle.d1",
             ACCESS_STRATEGY_KEY, ACCESS_STRATEGY_ROW_BY_ROW);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sql);
       int count = 0;
       assertEquals(2, resultSet.getMetaData().getColumnCount());
@@ -197,9 +198,10 @@ public class IoTDBUDFWindowQueryIT {
             "select accumulator(s1, \"%s\"=\"%s\", \"%s\"=\"%s\") from root.vehicle.d1",
             ACCESS_STRATEGY_KEY, ACCESS_STRATEGY_SLIDING_SIZE, WINDOW_SIZE_KEY, windowSize);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sql);
       assertEquals(2, resultSet.getMetaData().getColumnCount());
 
@@ -328,9 +330,10 @@ public class IoTDBUDFWindowQueryIT {
             DISPLAY_WINDOW_END_KEY,
             displayWindowEnd);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sql);
       assertEquals(2, resultSet.getMetaData().getColumnCount());
 
@@ -395,9 +398,10 @@ public class IoTDBUDFWindowQueryIT {
 
     int displayWindowBegin = 0;
     int displayWindowEnd = ITERATION_TIMES;
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sql);
       assertEquals(2, resultSet.getMetaData().getColumnCount());
 
@@ -518,9 +522,10 @@ public class IoTDBUDFWindowQueryIT {
             "consumptionPoint",
             consumptionPoint);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sql);
       assertEquals(3, resultSet.getMetaData().getColumnCount());
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFAlignByTimeQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFAlignByTimeQueryIT.java
@@ -188,9 +188,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
     Set<Integer> s1 = new HashSet<>(Arrays.asList(2, 6));
     Set<Integer> s2 = new HashSet<>(Arrays.asList(3, 7));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
 
       int count = 0;
@@ -229,9 +230,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
   public void queryWithoutValueFilter2() {
     String sqlStr = "select udf(*, *) from root.vehicle.d1";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int count = 0;
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -256,9 +258,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
     Set<Integer> s1AndS2 = new HashSet<>(Arrays.asList(2, 3, 4, 5, 8, 9, 10, 11));
     Set<Integer> s1OrS2 = new HashSet<>(Arrays.asList(0, 1, 6, 7, 12, 13));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int count = 0;
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -290,9 +293,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
     Set<Integer> s1AndS2 = new HashSet<>(Arrays.asList(6, 7, 8, 9));
     Set<Integer> s1OrS2 = new HashSet<>(Arrays.asList(4, 5));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int count = 0;
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -323,9 +327,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
   public void queryWithoutValueFilter5() {
     String sqlStr = "select multiplier(s2, \"a\"=\"2\", \"b\"=\"5\") from root.vehicle.d1";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
 
       assertEquals(1 + 1, resultSet.getMetaData().getColumnCount());
@@ -349,9 +354,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
   public void queryWithoutValueFilter6() {
     String sqlStr = "select max(s1), max(s2) from root.vehicle.d4";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
 
       assertEquals(1 + 2, resultSet.getMetaData().getColumnCount());
@@ -380,9 +386,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
   public void queryWithoutValueFilter7() {
     String sqlStr = "select terminate(s1), terminate(s2) from root.vehicle.d4";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
 
       assertEquals(1 + 2, resultSet.getMetaData().getColumnCount());
@@ -418,9 +425,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
   public void queryWithoutValueFilter8() {
     String sqlStr = "select validate(s1, s2, 'k'='') from root.vehicle.d3";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.executeQuery(sqlStr);
       fail();
     } catch (SQLException throwable) {
@@ -436,9 +444,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
   public void queryWithoutValueFilter9() {
     String sqlStr = "select validate(s1, s2, s1, 'k'=''), * from root.vehicle.d1";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.executeQuery(sqlStr);
       fail();
     } catch (SQLException throwable) {
@@ -453,9 +462,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
   public void queryWithoutValueFilter10() {
     String sqlStr = "select validate(s1, s2), * from root.vehicle.d1";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.executeQuery(sqlStr);
       fail();
     } catch (SQLException throwable) {
@@ -476,9 +486,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
     Set<Integer> s1 = new HashSet<>(Arrays.asList(2, 6));
     Set<Integer> s2 = new HashSet<>(Arrays.asList(3, 7));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.25 * ITERATION_TIMES);
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -516,9 +527,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
     Set<Integer> s1AndS2 = new HashSet<>(Arrays.asList(6, 7, 8, 9));
     Set<Integer> s1OrS2 = new HashSet<>(Arrays.asList(4, 5));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.25 * ITERATION_TIMES);
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -554,9 +566,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
     Set<Integer> s1 = new HashSet<>(Arrays.asList(2, 6));
     Set<Integer> s2 = new HashSet<>(Arrays.asList(3, 7));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.3 * ITERATION_TIMES);
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -605,9 +618,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
     Set<Integer> s1 = new HashSet<>(Arrays.asList(8, 9, 20, 21));
     Set<Integer> s2 = new HashSet<>(Arrays.asList(10, 11, 22, 23));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.3 * ITERATION_TIMES);
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -637,9 +651,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
                 " where root.vehicle.d2.s1 >= %d and root.vehicle.d3.s2 < %d",
                 (int) (0.3 * ITERATION_TIMES), (int) (0.7 * ITERATION_TIMES));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.3 * ITERATION_TIMES);
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -666,9 +681,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
                 (int) (0.3 * ITERATION_TIMES), (int) (0.7 * ITERATION_TIMES))
             + String.format(" limit %d offset %d", LIMIT, OFFSET);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.3 * ITERATION_TIMES) + OFFSET;
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -695,9 +711,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
                 (int) (0.3 * ITERATION_TIMES), (int) (0.7 * ITERATION_TIMES))
             + String.format(" slimit %d soffset %d", SLIMIT, SOFFSET);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.3 * ITERATION_TIMES);
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -724,9 +741,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
                 " where root.vehicle.d4.s1 >= %d and root.vehicle.d4.s2 < %d ",
                 (int) (0.3 * ITERATION_TIMES), (int) (0.7 * ITERATION_TIMES));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
 
       assertEquals(1 + 2, resultSet.getMetaData().getColumnCount());
@@ -756,9 +774,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
                 " where root.vehicle.d4.s1 >= %d and root.vehicle.d4.s1 < %d ",
                 (int) (0.3 * ITERATION_TIMES), (int) (0.7 * ITERATION_TIMES));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
 
       assertEquals(1 + 2, resultSet.getMetaData().getColumnCount());
@@ -792,9 +811,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
                 " where root.vehicle.d4.s1 >= %d and root.vehicle.d4.s1 < %d ",
                 (int) (0.3 * ITERATION_TIMES), (int) (0.7 * ITERATION_TIMES));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
 
       assertEquals(1 + 2, resultSet.getMetaData().getColumnCount());
@@ -833,9 +853,10 @@ public class IoTDBUDTFAlignByTimeQueryIT {
     String sqlStr =
         "select max(s100), udf(*, s100), udf(*, s100), udf(s100, s100) from root.vehicle.d4";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       assertEquals(1, resultSet.getMetaData().getColumnCount());
       assertEquals("Time", resultSet.getMetaData().getColumnName(1));

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFBuiltinFunctionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFBuiltinFunctionIT.java
@@ -151,9 +151,10 @@ public class IoTDBUDTFBuiltinFunctionIT {
   }
 
   private void testMathFunction(String functionName, MathFunctionProxy functionProxy) {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet =
           statement.executeQuery(
               String.format(
@@ -171,6 +172,7 @@ public class IoTDBUDTFBuiltinFunctionIT {
           assertEquals(expected, actual, E);
         }
       }
+      resultSet.close();
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
@@ -182,9 +184,10 @@ public class IoTDBUDTFBuiltinFunctionIT {
     final String BOTTOM_K = "BOTTOM_K";
     final String K = "'k'='2'";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet =
           statement.executeQuery(
               String.format(
@@ -200,13 +203,15 @@ public class IoTDBUDTFBuiltinFunctionIT {
           assertEquals(i, Double.parseDouble(resultSet.getString(2 + j)), E);
         }
       }
+      resultSet.close();
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet =
           statement.executeQuery(
               String.format(
@@ -222,6 +227,7 @@ public class IoTDBUDTFBuiltinFunctionIT {
           assertEquals(i, Double.parseDouble(resultSet.getString(2 + j)), E);
         }
       }
+      resultSet.close();
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
@@ -229,9 +235,10 @@ public class IoTDBUDTFBuiltinFunctionIT {
 
   @Test
   public void testStringProcessingFunctions() {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet =
           statement.executeQuery(
               "select STRING_CONTAINS(s6, 's'='0'), STRING_MATCHES(s6, 'regex'='\\d') from root.sg.d1");
@@ -248,6 +255,7 @@ public class IoTDBUDTFBuiltinFunctionIT {
         }
         assertTrue(Boolean.parseBoolean(resultSet.getString(2 + 1)));
       }
+      resultSet.close();
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
@@ -263,9 +271,10 @@ public class IoTDBUDTFBuiltinFunctionIT {
   }
 
   public void testVariationTrendCalculationFunction(String functionName, double expected) {
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet =
           statement.executeQuery(
               String.format(
@@ -281,6 +290,7 @@ public class IoTDBUDTFBuiltinFunctionIT {
           assertEquals(expected, Double.parseDouble(resultSet.getString(2 + j)), E);
         }
       }
+      resultSet.close();
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFHybridQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFHybridQueryIT.java
@@ -111,9 +111,10 @@ public class IoTDBUDTFHybridQueryIT {
             "select count(*), counter(s1, \"%s\"=\"%s\") from root.vehicle.d1",
             ACCESS_STRATEGY_KEY, ACCESS_STRATEGY_ROW_BY_ROW);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.executeQuery(sql);
       fail();
     } catch (SQLException throwable) {
@@ -131,9 +132,10 @@ public class IoTDBUDTFHybridQueryIT {
             "select temperature, counter(temperature, \"%s\"=\"%s\") from root.sgcc.wf03.wt01 where time = 2017-11-01T16:37:50.000 fill(float [linear, 1m, 1m])",
             ACCESS_STRATEGY_KEY, ACCESS_STRATEGY_ROW_BY_ROW);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.executeQuery(sql);
       fail();
     } catch (SQLException throwable) {
@@ -149,9 +151,10 @@ public class IoTDBUDTFHybridQueryIT {
             "select last counter(temperature, \"%s\"=\"%s\") from root.sgcc.wf03.wt01",
             ACCESS_STRATEGY_KEY, ACCESS_STRATEGY_ROW_BY_ROW);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.executeQuery(sql);
       fail();
     } catch (SQLException throwable) {
@@ -167,9 +170,10 @@ public class IoTDBUDTFHybridQueryIT {
             "select adder(temperature), counter(temperature, \"%s\"=\"%s\") from root.sgcc.wf03.wt01 align by device",
             ACCESS_STRATEGY_KEY, ACCESS_STRATEGY_ROW_BY_ROW);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       statement.executeQuery(sql);
       fail();
     } catch (SQLException throwable) {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFNonAlignQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDTFNonAlignQueryIT.java
@@ -148,9 +148,10 @@ public class IoTDBUDTFNonAlignQueryIT {
     Set<Integer> s1AndS2 = new HashSet<>(Arrays.asList(6, 7, 8, 9));
     Set<Integer> s1OrS2 = new HashSet<>(Arrays.asList(4, 5));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int count = 0;
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -183,9 +184,10 @@ public class IoTDBUDTFNonAlignQueryIT {
   public void queryWithoutValueFilter2() {
     String sqlStr = "select udf(d1.s1, d1.s2), udf(d2.s1, d2.s2) from root.vehicle disable align";
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int count = 0;
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -228,9 +230,10 @@ public class IoTDBUDTFNonAlignQueryIT {
     Set<Integer> s1 = new HashSet<>(Arrays.asList(2, 6));
     Set<Integer> s2 = new HashSet<>(Arrays.asList(3, 7));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.25 * ITERATION_TIMES);
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -267,9 +270,10 @@ public class IoTDBUDTFNonAlignQueryIT {
                 " where root.vehicle.d1.s1 >= %d and root.vehicle.d1.s2 < %d disable align",
                 (int) (0.3 * ITERATION_TIMES), (int) (0.7 * ITERATION_TIMES));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.3 * ITERATION_TIMES);
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -303,9 +307,10 @@ public class IoTDBUDTFNonAlignQueryIT {
     Set<Integer> s1 = new HashSet<>(Arrays.asList(2, 6));
     Set<Integer> s2 = new HashSet<>(Arrays.asList(3, 7));
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.25 * ITERATION_TIMES);
       int columnCount = resultSet.getMetaData().getColumnCount();
@@ -342,9 +347,10 @@ public class IoTDBUDTFNonAlignQueryIT {
                 " where root.vehicle.d1.s1 >= %d and root.vehicle.d1.s2 < %d limit %d offset %d disable align",
                 (int) (0.3 * ITERATION_TIMES), (int) (0.7 * ITERATION_TIMES), LIMIT, OFFSET);
 
-    try (Statement statement =
-        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
-            .createStatement()) {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       ResultSet resultSet = statement.executeQuery(sqlStr);
       int index = (int) (0.3 * ITERATION_TIMES) + OFFSET;
       int columnCount = resultSet.getMetaData().getColumnCount();


### PR DESCRIPTION
## Description

The reason see #3724 .

Also be careful, **DO NOT** use this kind of pattern to create connection and statement. It will cause connection not closed.

```java
    try (Statement statement =
        DriverManager.getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root")
            .createStatement()) {
     ...
    }

```

also see https://github.com/apache/iotdb/pull/3728