### PR TITLE
[To rel/0.12] Fix compaction recover loses data

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -456,7 +456,7 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
           // if not complete compaction, resume merge
           if (writer.hasCrashed()) {
             if (offset > 0) {
-              writer.getIOWriterOut().truncate(offset - 1);
+              writer.getIOWriterOut().truncate(offset);
             }
             CompactionLogger compactionLogger =
                 new CompactionLogger(storageGroupDir, storageGroupName);
@@ -502,7 +502,7 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
           // if not complete compaction, resume merge
           if (writer.hasCrashed()) {
             if (offset > 0) {
-              writer.getIOWriterOut().truncate(offset - 1);
+              writer.getIOWriterOut().truncate(offset);
             }
             CompactionLogger compactionLogger =
                 new CompactionLogger(storageGroupDir, storageGroupName);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
@@ -258,10 +258,13 @@ public class CompactionUtils {
       CompactionLogger compactionLogger,
       Set<String> devices,
       boolean sequence,
-      List<Modification> modifications)
+      List<Modification> modifications,
+      RestorableTsFileIOWriter writer)
       throws IOException, IllegalPathException {
     Map<String, TsFileSequenceReader> tsFileSequenceReaderMap = new HashMap<>();
-    RestorableTsFileIOWriter writer = new RestorableTsFileIOWriter(targetResource.getTsFile());
+    if (writer == null) {
+      writer = new RestorableTsFileIOWriter(targetResource.getTsFile());
+    }
     try {
       Map<String, List<Modification>> modificationCache = new HashMap<>();
       RateLimiter compactionWriteRateLimiter =

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -2074,8 +2074,11 @@ public class StorageGroupProcessor {
   }
 
   public void merge() {
-    if (!tsFileManagement.recovered) {
-      // doing recovered task
+    if (!tsFileManagement.recovered
+        || tsFileManagement.isSeqMerging
+        || tsFileManagement.isUnseqMerging) {
+      // recovering or doing compaction
+      // stop running new compaction
       return;
     }
     if (config.getCompactionStrategy() == CompactionStrategy.LEVEL_COMPACTION) {

--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
@@ -99,7 +99,7 @@ public class TsFileRecoverPerformer {
     // remove corrupted part of the TsFile
     RestorableTsFileIOWriter restorableTsFileIOWriter;
     try {
-      restorableTsFileIOWriter = new RestorableTsFileIOWriter(file);
+      restorableTsFileIOWriter = new RestorableTsFileIOWriter(file, false);
     } catch (NotCompatibleTsFileException e) {
       boolean result = file.delete();
       logger.warn("TsFile {} is incompatible. Delete it successfully {}", filePath, result);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/LevelCompactionRecoverTest.java
@@ -138,7 +138,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
         compactionLogger,
         new HashSet<>(),
         true,
-        new ArrayList<>());
+        new ArrayList<>(),
+        null);
     compactionLogger.close();
     levelCompactionTsFileManagement.add(targetTsFileResource, true);
     levelCompactionTsFileManagement.recover();
@@ -229,7 +230,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
         compactionLogger,
         new HashSet<>(),
         true,
-        new ArrayList<>());
+        new ArrayList<>(),
+        null);
     compactionLogger.close();
 
     BufferedReader logReader =
@@ -344,7 +346,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
         compactionLogger,
         new HashSet<>(),
         true,
-        new ArrayList<>());
+        new ArrayList<>(),
+        null);
     compactionLogger.close();
 
     BufferedReader logReader =
@@ -468,7 +471,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
         compactionLogger,
         new HashSet<>(),
         false,
-        new ArrayList<>());
+        new ArrayList<>(),
+        null);
     compactionLogger.close();
     levelCompactionTsFileManagement.add(targetTsFileResource, false);
     levelCompactionTsFileManagement.recover();
@@ -675,7 +679,8 @@ public class LevelCompactionRecoverTest extends LevelCompactionTest {
         compactionLogger,
         new HashSet<>(),
         true,
-        new ArrayList<>());
+        new ArrayList<>(),
+        null);
     levelCompactionTsFileManagement.add(targetTsFileResource, true);
     compactionLogger.close();
     levelCompactionTsFileManagement.recover();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriter.java
@@ -112,6 +112,47 @@ public class RestorableTsFileIOWriter extends TsFileIOWriter {
     }
   }
 
+  public RestorableTsFileIOWriter(File file, boolean truncate) throws IOException {
+    if (logger.isDebugEnabled()) {
+      logger.debug("{} is opened.", file.getName());
+    }
+    this.file = file;
+    this.out = FSFactoryProducer.getFileOutputFactory().getTsFileOutput(file.getPath(), true);
+
+    // file doesn't exist
+    if (file.length() == 0) {
+      startFile();
+      crashed = true;
+      canWrite = true;
+      return;
+    }
+
+    if (file.exists()) {
+      try (TsFileSequenceReader reader = new TsFileSequenceReader(file.getAbsolutePath(), false)) {
+
+        truncatedSize = reader.selfCheck(knownSchemas, chunkGroupMetadataList, true);
+        minPlanIndex = reader.getMinPlanIndex();
+        maxPlanIndex = reader.getMaxPlanIndex();
+        if (truncatedSize == TsFileCheckStatus.COMPLETE_FILE) {
+          crashed = false;
+          canWrite = false;
+          out.close();
+        } else if (truncatedSize == TsFileCheckStatus.INCOMPATIBLE_FILE) {
+          out.close();
+          throw new NotCompatibleTsFileException(
+              String.format("%s is not in TsFile format.", file.getAbsolutePath()));
+        } else {
+          crashed = true;
+          canWrite = true;
+          // remove broken data
+          if (truncate) {
+            out.truncate(truncatedSize);
+          }
+        }
+      }
+    }
+  }
+
   /**
    * Given a TsFile, generate a writable RestorableTsFileIOWriter. That is, for a complete TsFile,
    * the function erases all FileMetadata and supports writing new data; For a incomplete TsFile,

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileOutput.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileOutput.java
@@ -83,7 +83,9 @@ public interface TsFileOutput {
   void flush() throws IOException;
 
   /**
-   * The same with {@link java.nio.channels.FileChannel#truncate(long)}.
+   * The same with {@link java.nio.channels.FileChannel#truncate(long)}. truncate will truncate from
+   * the position to the end of file (including the position) for example, a file has 80 bytes, if
+   * use truncate(60), it will truncate from 60 to 80. The file remain has data of range [0, 59].
    *
    * @param size size The new size, a non-negative byte count
    */


### PR DESCRIPTION
## Description
During compaction recover, a RestorableIOWriter of target file will be new three times:
1. First new in StorageGroupProcessor, to determine whether a file is complete
2. Second new in CompactionRecoverTask, to truncate the file to the offset logged in compaction log
3. Third new in CompactionUtils, continues to compact files.

However, the last ChunkGroup in the file will be remove when a RestorableIOWriter is new. So the data will be lost when recovering inner space compaction.

In this PR, we add a new constructor for RestorableIOWriter. Beyond this, we fix a bug when truncating target file, which may cause a marker in target tsfile to be lost.
