### PR TITLE
[IOTDB-1567]fix some WAL and SG processor threadpools having the same JMX name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -632,9 +632,7 @@
                             </importOrder>
                             <removeUnusedImports/>
                         </java>
-                        <lineEndings>
-                            UNIX
-                        </lineEndings>
+                        <lineEndings>UNIX</lineEndings>
                     </configuration>
                     <executions>
                         <execution>

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -382,7 +382,8 @@ public class StorageGroupProcessor {
             .getTsFileManagement(logicalStorageGroupName, storageGroupSysDir.getAbsolutePath());
 
     ScheduledExecutorService executorService =
-        IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("WAL-trimTask");
+        IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(
+            String.format("WAL-trimTask-%s/%s", logicalStorageGroupName, virtualStorageGroupId));
     executorService.scheduleWithFixedDelay(
         this::trimTask,
         config.getWalPoolTrimIntervalInMS(),

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -89,9 +89,9 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
     if (SystemFileFactory.INSTANCE.getFile(logDirectory).mkdirs()) {
       logger.info("create the WAL folder {}.", logDirectory);
     }
+    // this.identifier contains the storage group name + tsfile name.
     FLUSH_BUFFER_THREAD_POOL =
-        IoTDBThreadPoolFactory.newSingleThreadExecutor(
-            "Flush-WAL-Thread-" + SystemFileFactory.INSTANCE.getFile(logDirectory).getName());
+        IoTDBThreadPoolFactory.newSingleThreadExecutor("Flush-WAL-Thread-" + this.identifier);
   }
 
   @Override

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBJMXTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBJMXTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class IoTDBJMXTest {
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvironmentUtils.envSetUp();
+    Class.forName(Config.JDBC_DRIVER_NAME);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void testThreadPool() {
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement(); ) {
+      // make sure two storage groups having no conflict when registering their JMX info (for their
+      // thread pools)
+      statement.execute("set storage group to root.sg1");
+      statement.execute("set storage group to root.sg2");
+      statement.execute("insert into root.sg1.d1 (time, s1) values (1, 1)");
+      statement.execute("insert into root.sg2.d1 (time, s1) values (1, 1)");
+    } catch (SQLException throwables) {
+      throwables.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
## Description

JMX requires each monitored object having the identical address string.

However, in WAL and SG processor, some thread pool having the same name, when these objects are created multiply times.

Error log: 
https://issues.apache.org/jira/secure/attachment/13031996/log_all.log