### PR TITLE
[IOTDB-1473] Fix the bug that run SessionExample.java will be failed in

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
@@ -47,6 +47,7 @@ import org.apache.iotdb.cluster.log.snapshot.FileSnapshot;
 import org.apache.iotdb.cluster.log.snapshot.PartitionedSnapshot;
 import org.apache.iotdb.cluster.log.snapshot.PullSnapshotTask;
 import org.apache.iotdb.cluster.log.snapshot.PullSnapshotTaskDescriptor;
+import org.apache.iotdb.cluster.metadata.CMManager;
 import org.apache.iotdb.cluster.partition.NodeAdditionResult;
 import org.apache.iotdb.cluster.partition.NodeRemovalResult;
 import org.apache.iotdb.cluster.partition.PartitionGroup;
@@ -79,16 +80,21 @@ import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.storagegroup.StorageGroupProcessor.TimePartitionFilter;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
+import org.apache.iotdb.db.exception.metadata.MetadataException;
+import org.apache.iotdb.db.exception.metadata.PathNotExistException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.exception.metadata.UndefinedTemplateException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.executor.PlanExecutor;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertMultiTabletPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertTabletPlan;
 import org.apache.iotdb.db.qp.physical.sys.FlushPlan;
 import org.apache.iotdb.db.qp.physical.sys.LogPlan;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.TestOnly;
+import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.EndPoint;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 import org.apache.iotdb.tsfile.utils.Pair;
@@ -709,6 +715,21 @@ public class DataGroupMember extends RaftMember {
             return handleLogExecutionException(plan, IOUtils.getRootCause(ne));
           }
         }
+        if (cause instanceof PathNotExistException) {
+          boolean hasCreated = false;
+          try {
+            if (plan instanceof InsertPlan
+                && ClusterDescriptor.getInstance().getConfig().isEnableAutoCreateSchema()) {
+              hasCreated = createTimeseriesForFailedInsertion(((InsertPlan) plan));
+            }
+          } catch (MetadataException | CheckConsistencyException ex) {
+            logger.error("{}: Cannot auto-create timeseries for {}", name, plan, e);
+            return StatusUtils.getStatus(StatusUtils.EXECUTE_STATEMENT_ERROR, ex.getMessage());
+          }
+          if (hasCreated) {
+            return executeNonQueryPlan(plan);
+          }
+        }
         return handleLogExecutionException(plan, cause);
       }
     } else {
@@ -751,6 +772,20 @@ public class DataGroupMember extends RaftMember {
     if (character == NodeCharacter.LEADER) {
       long startTime = Statistic.DATA_GROUP_MEMBER_LOCAL_EXECUTION.getOperationStartTime();
       TSStatus status = processPlanLocally(plan);
+      boolean hasCreated = false;
+      try {
+        if (plan instanceof InsertPlan
+            && status.getCode() == TSStatusCode.TIMESERIES_NOT_EXIST.getStatusCode()
+            && ClusterDescriptor.getInstance().getConfig().isEnableAutoCreateSchema()) {
+          hasCreated = createTimeseriesForFailedInsertion(((InsertPlan) plan));
+        }
+      } catch (MetadataException | CheckConsistencyException e) {
+        logger.error("{}: Cannot auto-create timeseries for {}", name, plan, e);
+        return StatusUtils.getStatus(StatusUtils.EXECUTE_STATEMENT_ERROR, e.getMessage());
+      }
+      if (hasCreated) {
+        status = processPlanLocally(plan);
+      }
       Statistic.DATA_GROUP_MEMBER_LOCAL_EXECUTION.calOperationCostTimeFromStart(startTime);
       if (status != null) {
         return status;
@@ -766,6 +801,25 @@ public class DataGroupMember extends RaftMember {
       }
     }
     return StatusUtils.NO_LEADER;
+  }
+
+  private boolean createTimeseriesForFailedInsertion(InsertPlan plan)
+      throws CheckConsistencyException, IllegalPathException {
+    logger.info("create time series for failed insertion {}", plan);
+    // apply measurements according to failed measurements
+    if (plan instanceof InsertMultiTabletPlan) {
+      for (InsertTabletPlan insertPlan : ((InsertMultiTabletPlan) plan).getInsertTabletPlanList()) {
+        if (insertPlan.getFailedMeasurements() != null) {
+          insertPlan.getPlanFromFailed();
+        }
+      }
+    }
+
+    if (plan.getFailedMeasurements() != null) {
+      plan.getPlanFromFailed();
+    }
+
+    return ((CMManager) IoTDB.metaManager).createTimeseries(plan);
   }
 
   /**


### PR DESCRIPTION
**Note** this is the replacement of PR: https://github.com/apache/iotdb/pull/3755

JIRA issue: https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-1473

The issue happens because auto create schema not work in cluster mode. The `insertTables()` tries to insert timeseries to `root.sg1.d2.s1`, `root.sg1.d2.s2`, `root.sg1.d2.s3` but which aren't created until the insertion. The schema create logic fail in the execution path which cause the issue.

Actually, there are three errors auto create schema related in the cluster as far as I can know (comment out the create timeseries related code in `SessionExample.java` to reproduce).

```
    ...
    // createTimeseries();
    // createMultiTimeseries();
    // insertRecord();
    insertTablet();   // can't auto create schema
    insertTablets(); // can't auto create schema
    insertRecords(); // can't auto create schema
    selectInto();
   .....
```
This PR fixed the first two of situations. Has filed a JIRA issue to track the third situation which need some more discussion.

## Fix logic
### Rule
Put the create schema logic as low level as possible in cluster handle logic. Previous, schema auto creating logic is handle in `Coordinator.java` which often fails because `PathNotExistException` often be wrapped. And it can't handle batch insertion as well.

According to the rule, we move the schema creating logic to `executeNonQueryPlan` in `DataGroupMember.java`.

### Concrete fix

`insertTablet()` fails because this kind of insertion will call `forwardMultiSubPlan()` which will return a wrapper result instead of 304 error directly which cause the error handling logic doesn't work.

For `insertTablets()`, it also need to apply measurements according to failed measurements for all sub `insertTablet`.