### PR TITLE
PrimitiveArrayManager: make POOLED_ARRAYS_MEMORY_THRESHOLD smaller than its actual allowed value

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
@@ -40,9 +40,17 @@ public class PrimitiveArrayManager {
 
   public static final int ARRAY_SIZE = CONFIG.getPrimitiveArraySize();
 
+  /**
+   * The actual used memory will be 50% larger than the statistic, so we need to limit the size of
+   * POOLED_ARRAYS_MEMORY_THRESHOLD, make it smaller than its actual allowed value.
+   */
+  private static final double AMPLIFICATION_FACTOR = 1.5;
+
   /** threshold total size of arrays for all data types */
   private static final double POOLED_ARRAYS_MEMORY_THRESHOLD =
-      CONFIG.getAllocateMemoryForWrite() * CONFIG.getBufferedArraysMemoryProportion();
+      CONFIG.getAllocateMemoryForWrite()
+          * CONFIG.getBufferedArraysMemoryProportion()
+          / AMPLIFICATION_FACTOR;
 
   /** TSDataType#serialize() -> ArrayDeque<Array>, VECTOR is ignored */
   private static final ArrayDeque[] POOLED_ARRAYS = new ArrayDeque[TSDataType.values().length - 1];


### PR DESCRIPTION
Cherry-picked from 33758d68e0294576d6d27f1bec4c01bb4113a7b8.

The actual used memory will be 50% larger than the statistic, so we need to limit the size of POOLED_ARRAYS_MEMORY_THRESHOLD, make it smaller than its actual allowed value.