### PR TITLE
[IOTDB-1574] [ISSUE-3786] Data file is deleted while file handle is not released

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/control/QueryFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/QueryFileManager.java
@@ -102,7 +102,7 @@ public class QueryFileManager {
         queryId,
         (k, v) -> {
           for (TsFileResource tsFile : v) {
-            FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, true);
+            FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, false);
           }
           return null;
         });


### PR DESCRIPTION
#3786 

This problem is caused by the reference number of query reader is not decreased corrcetly, which leads to the reference number is not 0 and the object can not be closed.
