### PR TITLE
[To rel/0.12] [ISSUE-3786] Data file is deleted while file handle is not released

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
+
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one
@@ -67,6 +68,7 @@
 * [IOTDB-1546] Optimize the Upgrade Tool rewrite logic to reduce the temp memory cost
 * [IOTDB-1552] Only allow equivalent filter for TEXT data type
 * [IOTDB-1556] Abort auto create device when meet exception in setStorageGroup
+* [IOTDB-1574] Deleted file handler leak
 * [ISSUE-3116] Bug when using natural month unit in time interval in group by query
 * [ISSUE-3316] Query result with the same time range is inconsistent in group by query
 * [ISSUE-3436] Fix query result not right after deleting multiple time interval of one timeseries

--- a/server/src/main/java/org/apache/iotdb/db/query/control/QueryFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/QueryFileManager.java
@@ -102,7 +102,7 @@ public class QueryFileManager {
         queryId,
         (k, v) -> {
           for (TsFileResource tsFile : v) {
-            FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, true);
+            FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, false);
           }
           return null;
         });


### PR DESCRIPTION
#3786

This problem is caused by the reference number of query reader is not decreased corrcetly, which leads to the reference number is not 0 and the object can not be closed.
