### PR TITLE
[IOTDB-1585][To rel/0.12] ModificationFile‘s write interface blocking

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,6 +37,7 @@
 
 ## Improvements
 * [IOTDB-1566] Do not restrict concurrent write partitions
+* [IOTDB-1585] ModificationFile‘s write interface blocking
 * Use StringCachedPool in TsFileResource to reduce the memory size 
 * write performance optimization when replicaNum == 1
 * Optimize Primitive Array Manager

--- a/server/src/main/java/org/apache/iotdb/db/engine/modification/ModificationFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/modification/ModificationFile.java
@@ -47,6 +47,7 @@ public class ModificationFile implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(ModificationFile.class);
   public static final String FILE_SUFFIX = ".mods";
 
+  // lazy loaded, set null when closed
   private List<Modification> modifications;
   private ModificationWriter writer;
   private ModificationReader reader;
@@ -88,8 +89,8 @@ public class ModificationFile implements AutoCloseable {
 
   public void abort() throws IOException {
     synchronized (this) {
-      if (!modifications.isEmpty()) {
-        writer.abort();
+      writer.abort();
+      if (modifications != null && !modifications.isEmpty()) {
         modifications.remove(modifications.size() - 1);
       }
     }
@@ -104,9 +105,10 @@ public class ModificationFile implements AutoCloseable {
    */
   public void write(Modification mod) throws IOException {
     synchronized (this) {
-      checkInit();
       writer.write(mod);
-      modifications.add(mod);
+      if (modifications != null) {
+        modifications.add(mod);
+      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/modification/io/ModificationWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/modification/io/ModificationWriter.java
@@ -31,7 +31,7 @@ public interface ModificationWriter {
 
   /**
    * Write a new modification to the persistent medium. Notice that after calling write(), a
-   * fileWriter is opened,
+   * fileWriter is opened.
    *
    * @param mod the modification to be written.
    */
@@ -40,6 +40,6 @@ public interface ModificationWriter {
   /** Release resources like streams. */
   void close() throws IOException;
 
-  /** Abort last modification. */
+  /** Abort last modification. Notice that after calling abort(), a fileWriter is opened. */
   void abort() throws IOException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1741,14 +1741,6 @@ public class StorageGroupProcessor {
     try {
       Set<PartialPath> devicePaths = IoTDB.metaManager.getDevices(path.getDevicePath());
       for (PartialPath device : devicePaths) {
-        Long lastUpdateTime = null;
-        for (Map<String, Long> latestTimeMap : latestTimeForEachDevice.values()) {
-          Long curTime = latestTimeMap.get(device.getFullPath());
-          if (curTime != null && (lastUpdateTime == null || lastUpdateTime < curTime)) {
-            lastUpdateTime = curTime;
-          }
-        }
-
         // delete Last cache record if necessary
         tryToDeleteLastCache(device, path, startTime, endTime);
       }
@@ -1771,6 +1763,8 @@ public class StorageGroupProcessor {
       // roll back
       for (ModificationFile modFile : updatedModFiles) {
         modFile.abort();
+        // remember to close mod file
+        modFile.close();
       }
       throw new IOException(e);
     } finally {


### PR DESCRIPTION
ModificationFile‘s write interface reads modifications from .mods file before writing modification, this causes deleting data costing too much time. After fixing, ModificationFile‘s write interface will write modifications directly into .mods file.

Before fixing:

![before](https://user-images.githubusercontent.com/43991780/130416068-d3f9530a-c686-481e-b147-1dba01a5a7c9.jpeg)

After fixing:

<img width="1188" alt="after" src="https://user-images.githubusercontent.com/43991780/130416061-0077bc71-0634-4e2b-ae5a-a4866b69b45e.png">
