### PR TITLE
[To rel/0.12] [IOTDB-1580] Error result of order by time desc when enable time partition

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -71,6 +71,7 @@
 * [IOTDB-1552] Only allow equivalent filter for TEXT data type
 * [IOTDB-1556] Abort auto create device when meet exception in setStorageGroup
 * [IOTDB-1574] Deleted file handler leak
+* [IOTDB-1580] Error result of order by time desc when enable time partition
 * [ISSUE-3116] Bug when using natural month unit in time interval in group by query
 * [ISSUE-3316] Query result with the same time range is inconsistent in group by query
 * [ISSUE-3436] Fix query result not right after deleting multiple time interval of one timeseries

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -43,13 +43,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 import static org.apache.iotdb.db.engine.compaction.utils.CompactionLogger.COMPACTION_LOG_NAME;
@@ -74,10 +74,14 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
   private final boolean enableUnseqCompaction =
       IoTDBDescriptor.getInstance().getConfig().isEnableUnseqCompaction();
 
-  // First map is partition list; Second list is level list; Third list is file list in level;
+  /**
+   * Long -> partition list. Use treemap to keep the small partition in front.
+   * List<SortedSet<TsFileResource>> -> File level list<file list in each level>
+   */
   private final Map<Long, List<SortedSet<TsFileResource>>> sequenceTsFileResources =
-      new HashMap<>();
-  private final Map<Long, List<List<TsFileResource>>> unSequenceTsFileResources = new HashMap<>();
+      new TreeMap<>();
+
+  private final Map<Long, List<List<TsFileResource>>> unSequenceTsFileResources = new TreeMap<>();
   private final List<List<TsFileResource>> forkedSequenceTsFileResources = new ArrayList<>();
   private final List<List<TsFileResource>> forkedUnSequenceTsFileResources = new ArrayList<>();
   private final List<TsFileResource> sequenceRecoverTsFileResources = new ArrayList<>();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBTimePartitionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBTimePartitionIT.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.Assert.fail;
+
+public class IoTDBTimePartitionIT {
+
+  private long prevPartitionInterval;
+
+  @Before
+  public void setUp() throws ClassNotFoundException {
+    EnvironmentUtils.closeStatMonitor();
+    IoTDBDescriptor.getInstance().getConfig().setEnablePartition(true);
+    prevPartitionInterval = IoTDBDescriptor.getInstance().getConfig().getPartitionInterval();
+    IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(2592000);
+    EnvironmentUtils.envSetUp();
+    Class.forName(Config.JDBC_DRIVER_NAME);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    EnvironmentUtils.cleanEnv();
+    IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(prevPartitionInterval);
+    IoTDBDescriptor.getInstance().getConfig().setEnablePartition(false);
+  }
+
+  @Test
+  public void testOrderByTimeDesc() {
+    try (Connection connection =
+            DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      String[] sqls =
+          new String[] {
+            "insert into root.group_1.d_1(timestamp, s_1) values(2018-07-18T00:00:00.000+08:00, 18.0)",
+            "insert into root.group_1.d_1(timestamp, s_1) values(2018-07-19T00:00:00.000+08:00, 19.0)",
+            "insert into root.group_1.d_1(timestamp, s_1) values(2019-08-19T00:00:00.000+08:00, 20.0)"
+          };
+      for (String sql : sqls) {
+        statement.execute(sql);
+      }
+
+      String[] retArray = new String[] {"20.0", "19.0", "18.0"};
+      boolean hasResultSet = statement.execute("select * from root.group_1.d_1 order by time desc");
+
+      Assert.assertTrue(hasResultSet);
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString("root.group_1.d_1.s_1");
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+        Assert.assertEquals(3, cnt);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
The bug is caused by we didn't traverse the tsfile seqeunce in time partition order.
