### PR TITLE
[IOTDB-1588] [To rel/0.12] Bug fix: MAX_TIME is incorrect in cluster mode with TTL

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
@@ -628,7 +628,7 @@ public class LocalQueryExecutor {
     ClusterQueryUtils.checkPathExistence(path);
     List<AggregateResult> results = new ArrayList<>();
     for (String aggregation : aggregations) {
-      results.add(AggregateResultFactory.getAggrResultByName(aggregation, dataType));
+      results.add(AggregateResultFactory.getAggrResultByName(aggregation, dataType, ascending));
     }
     List<Integer> nodeSlots =
         ((SlotPartitionTable) dataGroupMember.getMetaGroupMember().getPartitionTable())


### PR DESCRIPTION
MAX_TIME is incorrect in cluster mode with TTL.
![image2021-7-28_10-47-2](https://user-images.githubusercontent.com/36565497/130640926-c6f0a79b-8a68-4bb6-99f8-500b93cb0ae3.png)