### PR TITLE
[IOTDB-1588] Bug fix: MAX_TIME is incorrect in cluster mode with TTL

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
@@ -733,7 +733,7 @@ public class LocalQueryExecutor {
     ClusterQueryUtils.checkPathExistence(path);
     List<AggregateResult> results = new ArrayList<>();
     for (String aggregation : aggregations) {
-      results.add(AggregateResultFactory.getAggrResultByName(aggregation, dataType));
+      results.add(AggregateResultFactory.getAggrResultByName(aggregation, dataType, ascending));
     }
     List<Integer> nodeSlots =
         ((SlotPartitionTable) dataGroupMember.getMetaGroupMember().getPartitionTable())


### PR DESCRIPTION
MAX_TIME is incorrect in cluster mode with TTL.
![image2021-7-28_10-47-2](https://user-images.githubusercontent.com/36565497/130647218-6339c4e0-edee-402d-a9be-d20c9e2d441f.png)
