### PR TITLE
[To rel/0.12] [IOTDB-1594] Fix show timeseries returns incorrect tag value

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/logfile/TagLogFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/logfile/TagLogFile.java
@@ -94,7 +94,7 @@ public class TagLogFile implements AutoCloseable {
   public long write(Map<String, String> tagMap, Map<String, String> attributeMap)
       throws IOException, MetadataException {
     ByteBuffer byteBuffer = convertMapToByteBuffer(tagMap, attributeMap);
-    synchronized (this){
+    synchronized (this) {
       // get offset and write data should be atomic operation
       long offset = fileChannel.position();
       fileChannel.write(byteBuffer);


### PR DESCRIPTION
## Description
When add tag or attribute to timeseries, the values will be written to tagLogFile and the offset  will return to be stored in MeasurementMNode. 
The offset get and value write operation are not encapsulated as atomic operation, which results in that two threads get the same offset and only one thread's data will be written to the expected position. 
The other filechannel operations in tagLogFile are atomic.
