### PR TITLE
Remove timestamp datatype config

### DIFF
--- a/docs/UserGuide/Appendix/Config-Manual.md
+++ b/docs/UserGuide/Appendix/Config-Manual.md
@@ -159,15 +159,6 @@ The permission definitions are in ${IOTDB\_CONF}/conf/jmx.access.
 |Default| 128 |
 |Effective|Trigger|
 
-* time\_series\_data\_type
-
-|Name| time\_series\_data\_type |
-|:---:|:---|
-|Description|Timestamp data type|
-|Type|Enum String: "INT32", "INT64"|
-|Default| Int64 |
-|Effective|Trigger|
-
 * time\_encoder
 
 |Name| time\_encoder |

--- a/docs/zh/UserGuide/Appendix/Config-Manual.md
+++ b/docs/zh/UserGuide/Appendix/Config-Manual.md
@@ -138,15 +138,6 @@
 |默认值| 65536 |
 |改后生效方式|触发生效|
 
-* time\_series\_data\_type
-
-|名字| time\_series\_data\_type |
-|:---:|:---|
-|描述|时间戳数据类型|
-|类型|枚举 String: "INT32", "INT64"|
-|默认值| Int64 |
-|改后生效方式|触发生效|
-
 * time\_encoder
 
 |名字| time\_encoder |

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -716,10 +716,6 @@ timestamp_precision=ms
 # Datatype: int [xsy]
 # max_number_of_points_in_page=1048576
 
-# Data type configuration
-# Data type for input timestamp, supports INT32 or INT64
-# time_series_data_type=INT64
-
 # Max size limitation of input string
 # Datatype: int [xsy]
 # max_string_length=128

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -957,12 +957,6 @@ public class IoTDBDescriptor {
                         TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage()))));
     TSFileDescriptor.getInstance()
         .getConfig()
-        .setTimeSeriesDataType(
-            properties.getProperty(
-                "time_series_data_type",
-                TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType()));
-    TSFileDescriptor.getInstance()
-        .getConfig()
         .setMaxStringLength(
             Integer.parseInt(
                 properties.getProperty(

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.tsfile.common.conf;
 
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
 
 import java.io.Serializable;
@@ -76,8 +77,8 @@ public class TSFileConfig implements Serializable {
   private int maxNumberOfPointsInPage = 1024 * 1024;
   /** The maximum degree of a metadataIndex node, default value is 256 */
   private int maxDegreeOfIndexNode = 256;
-  /** Data type for input timestamp, TsFile supports INT32 or INT64. */
-  private String timeSeriesDataType = "INT64";
+  /** Data type for input timestamp, TsFile supports INT64. */
+  private TSDataType timestampDataType = TSDataType.INT64;
   /** Max length limitation of input string. */
   private int maxStringLength = 128;
   /** Floating-point precision. */
@@ -179,14 +180,14 @@ public class TSFileConfig implements Serializable {
     this.maxDegreeOfIndexNode = maxDegreeOfIndexNode;
   }
 
-  public String getTimeSeriesDataType() {
-    return timeSeriesDataType;
+  public TSDataType getTimestampDataType() {
+    return timestampDataType;
   }
 
   // TS_2DIFF configuration
 
-  public void setTimeSeriesDataType(String timeSeriesDataType) {
-    this.timeSeriesDataType = timeSeriesDataType;
+  public void setTimeSeriesDataType(TSDataType timestampDataType) {
+    this.timestampDataType = timestampDataType;
   }
 
   public int getMaxStringLength() {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -78,7 +78,7 @@ public class TSFileConfig implements Serializable {
   /** The maximum degree of a metadataIndex node, default value is 256 */
   private int maxDegreeOfIndexNode = 256;
   /** Data type for input timestamp, TsFile supports INT64. */
-  private TSDataType timestampDataType = TSDataType.INT64;
+  private TSDataType timeSeriesDataType = TSDataType.INT64;
   /** Max length limitation of input string. */
   private int maxStringLength = 128;
   /** Floating-point precision. */
@@ -180,14 +180,14 @@ public class TSFileConfig implements Serializable {
     this.maxDegreeOfIndexNode = maxDegreeOfIndexNode;
   }
 
-  public TSDataType getTimestampDataType() {
-    return timestampDataType;
+  public TSDataType getTimeSeriesDataType() {
+    return timeSeriesDataType;
   }
 
   // TS_2DIFF configuration
 
-  public void setTimeSeriesDataType(TSDataType timestampDataType) {
-    this.timestampDataType = timestampDataType;
+  public void setTimeSeriesDataType(TSDataType timeSeriesDataType) {
+    this.timeSeriesDataType = timeSeriesDataType;
   }
 
   public int getMaxStringLength() {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
@@ -127,8 +127,6 @@ public class TSFileDescriptor {
           Integer.parseInt(
               properties.getProperty(
                   "max_degree_of_index_node", Integer.toString(conf.getMaxDegreeOfIndexNode()))));
-      conf.setTimeSeriesDataType(
-          properties.getProperty("time_series_data_type", conf.getTimeSeriesDataType()));
       conf.setMaxStringLength(
           Integer.parseInt(
               properties.getProperty(

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/MeasurementSchema.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/MeasurementSchema.java
@@ -217,7 +217,7 @@ public class MeasurementSchema
   public Encoder getTimeEncoder() {
     TSEncoding timeEncoding =
         TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
-    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimestampDataType();
+    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType();
     return TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType);
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/MeasurementSchema.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/MeasurementSchema.java
@@ -217,8 +217,7 @@ public class MeasurementSchema
   public Encoder getTimeEncoder() {
     TSEncoding timeEncoding =
         TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
-    TSDataType timeType =
-        TSDataType.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType());
+    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimestampDataType();
     return TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType);
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/TimeseriesSchema.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/TimeseriesSchema.java
@@ -149,8 +149,7 @@ public class TimeseriesSchema implements Comparable<TimeseriesSchema>, Serializa
   public Encoder getTimeEncoder() {
     TSEncoding timeEncoding =
         TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
-    TSDataType timeType =
-        TSDataType.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType());
+    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimestampDataType();
     return TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType);
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/TimeseriesSchema.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/TimeseriesSchema.java
@@ -149,7 +149,7 @@ public class TimeseriesSchema implements Comparable<TimeseriesSchema>, Serializa
   public Encoder getTimeEncoder() {
     TSEncoding timeEncoding =
         TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
-    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimestampDataType();
+    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType();
     return TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType);
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/VectorMeasurementSchema.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/VectorMeasurementSchema.java
@@ -143,8 +143,7 @@ public class VectorMeasurementSchema
   public Encoder getTimeEncoder() {
     TSEncoding timeEncoding =
         TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
-    TSDataType timeType =
-        TSDataType.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType());
+    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimestampDataType();
     return TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType);
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/VectorMeasurementSchema.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/VectorMeasurementSchema.java
@@ -143,7 +143,7 @@ public class VectorMeasurementSchema
   public Encoder getTimeEncoder() {
     TSEncoding timeEncoding =
         TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
-    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimestampDataType();
+    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType();
     return TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType);
   }
 


### PR DESCRIPTION
## Description

Currently we have a meaningless config that changes the datatype of timestamp from INT64 to INT32. 
It also may cause bug if users change the default value to INT32.

It's better to remove it. 