### PR TITLE
[ISSUE-3856] refine exception handling logic in commitTo in Raft…

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
@@ -585,71 +585,87 @@ public abstract class RaftLogManager {
           .subList(0, (int) (getCommitLogIndex() - entries.get(0).getCurrLogIndex() + 1))
           .clear();
     }
+
+    boolean needToCompactLog = false;
+    int numToReserveForNew = minNumOfLogsInMem;
+    if (committedEntryManager.getTotalSize() + entries.size() > maxNumOfLogsInMem) {
+      needToCompactLog = true;
+      numToReserveForNew = maxNumOfLogsInMem - entries.size();
+    }
+
+    long newEntryMemSize = 0;
+    for (Log entry : entries) {
+      if (entry.getByteSize() == 0) {
+        logger.debug(
+            "{} should not go here, must be send to the follower, "
+                + "so the log has been serialized exclude single node mode",
+            entry);
+        entry.setByteSize((int) RamUsageEstimator.sizeOf(entry));
+      }
+      newEntryMemSize += entry.getByteSize();
+    }
+    int sizeToReserveForNew = minNumOfLogsInMem;
+    if (newEntryMemSize + committedEntryManager.getEntryTotalMemSize() > maxLogMemSize) {
+      needToCompactLog = true;
+      sizeToReserveForNew =
+          committedEntryManager.maxLogNumShouldReserve(maxLogMemSize - newEntryMemSize);
+    }
+
+    if (needToCompactLog) {
+      int numForNew = Math.min(numToReserveForNew, sizeToReserveForNew);
+      int sizeToReserveForConfig = minNumOfLogsInMem;
+      startTime = Statistic.RAFT_SENDER_COMMIT_DELETE_EXCEEDING_LOGS.getOperationStartTime();
+      synchronized (this) {
+        innerDeleteLog(Math.min(sizeToReserveForConfig, numForNew));
+      }
+      Statistic.RAFT_SENDER_COMMIT_DELETE_EXCEEDING_LOGS.calOperationCostTimeFromStart(startTime);
+    }
+
+    startTime = Statistic.RAFT_SENDER_COMMIT_APPEND_AND_STABLE_LOGS.getOperationStartTime();
     try {
-      boolean needToCompactLog = false;
-      int numToReserveForNew = minNumOfLogsInMem;
-      if (committedEntryManager.getTotalSize() + entries.size() > maxNumOfLogsInMem) {
-        needToCompactLog = true;
-        numToReserveForNew = maxNumOfLogsInMem - entries.size();
-      }
-
-      long newEntryMemSize = 0;
-      for (Log entry : entries) {
-        if (entry.getByteSize() == 0) {
-          logger.debug(
-              "{} should not go here, must be send to the follower, "
-                  + "so the log has been serialized exclude single node mode",
-              entry);
-          entry.setByteSize((int) RamUsageEstimator.sizeOf(entry));
-        }
-        newEntryMemSize += entry.getByteSize();
-      }
-      int sizeToReserveForNew = minNumOfLogsInMem;
-      if (newEntryMemSize + committedEntryManager.getEntryTotalMemSize() > maxLogMemSize) {
-        needToCompactLog = true;
-        sizeToReserveForNew =
-            committedEntryManager.maxLogNumShouldReserve(maxLogMemSize - newEntryMemSize);
-      }
-
-      if (needToCompactLog) {
-        int numForNew = Math.min(numToReserveForNew, sizeToReserveForNew);
-        int sizeToReserveForConfig = minNumOfLogsInMem;
-        startTime = Statistic.RAFT_SENDER_COMMIT_DELETE_EXCEEDING_LOGS.getOperationStartTime();
-        synchronized (this) {
-          innerDeleteLog(Math.min(sizeToReserveForConfig, numForNew));
-        }
-        Statistic.RAFT_SENDER_COMMIT_DELETE_EXCEEDING_LOGS.calOperationCostTimeFromStart(startTime);
-      }
-
-      startTime = Statistic.RAFT_SENDER_COMMIT_APPEND_AND_STABLE_LOGS.getOperationStartTime();
+      // As the operations here are so simple that we can think the execution
+      // are success or fail at same time approximately.
       getCommittedEntryManager().append(entries);
-      if (ClusterDescriptor.getInstance().getConfig().isEnableRaftLogPersistence()) {
-        getStableEntryManager().append(entries, maxHaveAppliedCommitIndex);
-      }
       Log lastLog = entries.get(entries.size() - 1);
       getUnCommittedEntryManager().stableTo(lastLog.getCurrLogIndex());
-      Statistic.RAFT_SENDER_COMMIT_APPEND_AND_STABLE_LOGS.calOperationCostTimeFromStart(startTime);
-
       commitIndex = lastLog.getCurrLogIndex();
-      startTime = Statistic.RAFT_SENDER_COMMIT_APPLY_LOGS.getOperationStartTime();
-      applyEntries(entries);
-      Statistic.RAFT_SENDER_COMMIT_APPLY_LOGS.calOperationCostTimeFromStart(startTime);
 
-      long unappliedLogSize = commitLogIndex - maxHaveAppliedCommitIndex;
-      if (unappliedLogSize > ClusterDescriptor.getInstance().getConfig().getMaxNumOfLogsInMem()) {
-        logger.debug(
-            "There are too many unapplied logs [{}], wait for a while to avoid memory "
-                + "overflow",
-            unappliedLogSize);
-        Thread.sleep(
-            unappliedLogSize - ClusterDescriptor.getInstance().getConfig().getMaxNumOfLogsInMem());
+      if (ClusterDescriptor.getInstance().getConfig().isEnableRaftLogPersistence()) {
+        // Cluster could continue provide service when exception is thrown here
+        getStableEntryManager().append(entries, maxHaveAppliedCommitIndex);
       }
     } catch (TruncateCommittedEntryException e) {
+      // fatal error, node won't recover from the error anymore
+      // TODO: let node quit the raft group once encounter the error
       logger.error("{}: Unexpected error:", name, e);
     } catch (IOException e) {
+      // The exception happens because persistent entries fail which should block the service
+      // continue accept data. We need to know that since then, the persisted raft log for the
+      // group has corrupted.
+      // TODO: Notify user that the persisted logs before these entries(include) are corrupted.
+      // TODO: An idea is that we can degrade the service by disable raft log persistent for
+      // TODO: the group. It needs fine-grained control for the config of Raft log persistence.
+      logger.error("{}: persistent raft log error:", name, e);
       throw new LogExecutionException(e);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
+    } finally {
+      Statistic.RAFT_SENDER_COMMIT_APPEND_AND_STABLE_LOGS.calOperationCostTimeFromStart(startTime);
+    }
+
+    startTime = Statistic.RAFT_SENDER_COMMIT_APPLY_LOGS.getOperationStartTime();
+    applyEntries(entries);
+    Statistic.RAFT_SENDER_COMMIT_APPLY_LOGS.calOperationCostTimeFromStart(startTime);
+
+    long unappliedLogSize = commitLogIndex - maxHaveAppliedCommitIndex;
+    if (unappliedLogSize > ClusterDescriptor.getInstance().getConfig().getMaxNumOfLogsInMem()) {
+      logger.debug(
+          "There are too many unapplied logs [{}], wait for a while to avoid memory overflow",
+          unappliedLogSize);
+      try {
+        Thread.sleep(
+            unappliedLogSize - ClusterDescriptor.getInstance().getConfig().getMaxNumOfLogsInMem());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
@@ -623,8 +623,9 @@ public abstract class RaftLogManager {
 
     startTime = Statistic.RAFT_SENDER_COMMIT_APPEND_AND_STABLE_LOGS.getOperationStartTime();
     try {
-      // As the operations here are so simple that we can think the execution
-      // are success or fail at same time approximately.
+      // Operations here are so simple that the execution could be thought
+      // success or fail together approximately.
+      // TODO: make it real atomic
       getCommittedEntryManager().append(entries);
       Log lastLog = entries.get(entries.size() - 1);
       getUnCommittedEntryManager().stableTo(lastLog.getCurrLogIndex());
@@ -639,9 +640,7 @@ public abstract class RaftLogManager {
       // TODO: let node quit the raft group once encounter the error
       logger.error("{}: Unexpected error:", name, e);
     } catch (IOException e) {
-      // The exception happens because persistent entries fail which should block the service
-      // continue accept data. We need to know that since then, the persisted raft log for the
-      // group has corrupted.
+      // The exception will block the raft service continue accept log.
       // TODO: Notify user that the persisted logs before these entries(include) are corrupted.
       // TODO: An idea is that we can degrade the service by disable raft log persistent for
       // TODO: the group. It needs fine-grained control for the config of Raft log persistence.


### PR DESCRIPTION
The idea come from the discussion: https://github.com/apache/iotdb/discussions/3833

Here I want to refine the error handling logic in `commitTo` to make cluster more robust and make code a bit more clear.

The idea here is don't let Raft group run into a invalid state when some error happened from Raft log persistence.  And refine try catch block make the code clean.
