### PR TITLE
[IOTDB-1619] There is an error msg when I restart iotdb-cluster

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
@@ -450,11 +450,6 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     this.firstLogIndex = meta.getCommitLogIndex() + 1;
     try {
       recoverLogFiles();
-
-      logDataFileList.sort(this::comparePersistLogFileName);
-
-      logIndexFileList.sort(this::comparePersistLogFileName);
-
       // add init log file
       if (logDataFileList.isEmpty()) {
         createNewLogFile(metaFile.getParentFile().getPath(), meta.getCommitLogIndex() + 1);
@@ -472,6 +467,10 @@ public class SyncLogDequeSerializer implements StableEntryManager {
 
     // 2. recover the log data file
     recoverLogFiles(LOG_DATA_FILE_SUFFIX);
+
+    // sort by name before recover
+    logDataFileList.sort(this::comparePersistLogFileName);
+    logIndexFileList.sort(this::comparePersistLogFileName);
 
     // 3. recover the last log file in case of abnormal exit
     recoverTheLastLogFile();


### PR DESCRIPTION
When i try to figure out why this issue occurs, i find that the result of last raft log file is different with my guess.Here are the result of my test environment _(ps.I ran into the same problem.)_

We find these files of raft log:
```
/.../system/raftLog/-1869016501/49923372-9223372036854775807-244-idx, 
/.../system/raftLog/-1869016501/48875442-49224751-241-idx, 
/.../system/raftLog/-1869016501/49224752-49574061-242-idx, 
/.../system/raftLog/-1869016501/49574062-49923371-243-idx

/.../system/raftLog/-1869016501/49574062-49923371-243-data, 
/.../system/raftLog/-1869016501/49923372-9223372036854775807-244-data, 
/.../system/raftLog/-1869016501/48875442-49224751-241-data, 
/.../system/raftLog/-1869016501/49224752-49574061-242-data
```
and process these files _(242-index and 243-data?)_ :
![image](https://user-images.githubusercontent.com/44458757/132473083-c78e35f7-7b47-4aef-a7a6-83a8139643ff.png)

Obviously, we have a problem with where the files are sorted.That may be a bomb in `recover` module.

_footnote_  Here's meta info
```
commitLogTerm=1, 
commitLogIndex=49923370, 
lastLogIndex=49923370, 
lastLogTerm=1, 
maxHaveAppliedCommitIndex=49923357
```