### PR TITLE
init dummyIndex after restart cluster

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/StableEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/StableEntryManager.java
@@ -21,10 +21,13 @@ package org.apache.iotdb.cluster.log;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.iotdb.cluster.log.manage.serializable.LogManagerMeta;
 
 public interface StableEntryManager {
 
   List<Log> getAllEntriesAfterAppliedIndex();
+
+  List<Log> getAllEntriesAfterCommittedIndex();
 
   void append(List<Log> entries, long maxHaveAppliedCommitIndex) throws IOException;
 
@@ -37,6 +40,8 @@ public interface StableEntryManager {
   void setHardStateAndFlush(HardState state);
 
   HardState getHardState();
+
+  LogManagerMeta getMeta();
 
   /**
    * @param startIndex (inclusive) the log start index

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/StableEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/StableEntryManager.java
@@ -19,9 +19,10 @@
 
 package org.apache.iotdb.cluster.log;
 
+import org.apache.iotdb.cluster.log.manage.serializable.LogManagerMeta;
+
 import java.io.IOException;
 import java.util.List;
-import org.apache.iotdb.cluster.log.manage.serializable.LogManagerMeta;
 
 public interface StableEntryManager {
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
@@ -56,11 +56,10 @@ public class CommittedEntryManager {
 
   CommittedEntryManager(int maxNumOfLogInMem, LogManagerMeta meta) {
     entries = Collections.synchronizedList(new ArrayList<>(maxNumOfLogInMem));
-    entries
-        .add(new EmptyContentLog(meta.getMaxHaveAppliedCommitIndex() - 1, meta.getLastLogTerm()));
+    entries.add(
+        new EmptyContentLog(meta.getMaxHaveAppliedCommitIndex() - 1, meta.getLastLogTerm()));
     entryTotalMemSize = 0;
   }
-
 
   /**
    * Overwrite the contents of this object with those of the given snapshot. Note that this function
@@ -123,7 +122,7 @@ public class CommittedEntryManager {
    *
    * @param index request entry index
    * @return -1 if index > entries[entries.size()-1].index, throw EntryCompactedException if index <
-   * dummyIndex, or return the entry's term for given index
+   *     dummyIndex, or return the entry's term for given index
    * @throws EntryCompactedException
    */
   public long maybeTerm(long index) throws EntryCompactedException {
@@ -138,7 +137,7 @@ public class CommittedEntryManager {
    * Pack entries from low through high - 1, just like slice (entries[low:high]). dummyIndex < low
    * <= high. Note that caller must ensure low <= high.
    *
-   * @param low  request index low bound
+   * @param low request index low bound
    * @param high request index upper bound
    */
   public List<Log> getEntries(long low, long high) {
@@ -173,7 +172,7 @@ public class CommittedEntryManager {
    *
    * @param index request entry index
    * @return null if index > entries[entries.size()-1].index, throw EntryCompactedException if index
-   * < dummyIndex, or return the entry's log for given index
+   *     < dummyIndex, or return the entry's log for given index
    * @throws EntryCompactedException
    */
   Log getEntry(long index) throws EntryCompactedException {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.cluster.exception.TruncateCommittedEntryException;
 import org.apache.iotdb.cluster.log.Log;
 import org.apache.iotdb.cluster.log.Snapshot;
 import org.apache.iotdb.cluster.log.logtypes.EmptyContentLog;
+import org.apache.iotdb.cluster.log.manage.serializable.LogManagerMeta;
 import org.apache.iotdb.db.utils.TestOnly;
 
 import org.slf4j.Logger;
@@ -52,6 +53,14 @@ public class CommittedEntryManager {
     entries.add(new EmptyContentLog(-1, -1));
     entryTotalMemSize = 0;
   }
+
+  CommittedEntryManager(int maxNumOfLogInMem, LogManagerMeta meta) {
+    entries = Collections.synchronizedList(new ArrayList<>(maxNumOfLogInMem));
+    entries
+        .add(new EmptyContentLog(meta.getMaxHaveAppliedCommitIndex() - 1, meta.getLastLogTerm()));
+    entryTotalMemSize = 0;
+  }
+
 
   /**
    * Overwrite the contents of this object with those of the given snapshot. Note that this function
@@ -114,7 +123,7 @@ public class CommittedEntryManager {
    *
    * @param index request entry index
    * @return -1 if index > entries[entries.size()-1].index, throw EntryCompactedException if index <
-   *     dummyIndex, or return the entry's term for given index
+   * dummyIndex, or return the entry's term for given index
    * @throws EntryCompactedException
    */
   public long maybeTerm(long index) throws EntryCompactedException {
@@ -129,7 +138,7 @@ public class CommittedEntryManager {
    * Pack entries from low through high - 1, just like slice (entries[low:high]). dummyIndex < low
    * <= high. Note that caller must ensure low <= high.
    *
-   * @param low request index low bound
+   * @param low  request index low bound
    * @param high request index upper bound
    */
   public List<Log> getEntries(long low, long high) {
@@ -164,7 +173,7 @@ public class CommittedEntryManager {
    *
    * @param index request entry index
    * @return null if index > entries[entries.size()-1].index, throw EntryCompactedException if index
-   *     < dummyIndex, or return the entry's log for given index
+   * < dummyIndex, or return the entry's log for given index
    * @throws EntryCompactedException
    */
   Log getEntry(long index) throws EntryCompactedException {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
@@ -57,7 +57,11 @@ public class CommittedEntryManager {
   CommittedEntryManager(int maxNumOfLogInMem, LogManagerMeta meta) {
     entries = Collections.synchronizedList(new ArrayList<>(maxNumOfLogInMem));
     entries.add(
-        new EmptyContentLog(meta.getMaxHaveAppliedCommitIndex() - 1, meta.getLastLogTerm()));
+        new EmptyContentLog(
+            meta.getMaxHaveAppliedCommitIndex() == -1
+                ? -1
+                : meta.getMaxHaveAppliedCommitIndex() - 1,
+            meta.getLastLogTerm()));
     entryTotalMemSize = 0;
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/RaftLogManager.java
@@ -56,19 +56,13 @@ public abstract class RaftLogManager {
 
   private static final Logger logger = LoggerFactory.getLogger(RaftLogManager.class);
 
-  /**
-   * manage uncommitted entries
-   */
+  /** manage uncommitted entries */
   private UnCommittedEntryManager unCommittedEntryManager;
 
-  /**
-   * manage committed entries in memory as a cache
-   */
+  /** manage committed entries in memory as a cache */
   private CommittedEntryManager committedEntryManager;
 
-  /**
-   * manage committed entries in disk for safety
-   */
+  /** manage committed entries in disk for safety */
   private StableEntryManager stableEntryManager;
 
   private long commitIndex;
@@ -91,9 +85,7 @@ public abstract class RaftLogManager {
 
   protected LogApplier logApplier;
 
-  /**
-   * to distinguish managers of different members
-   */
+  /** to distinguish managers of different members */
   private String name;
 
   private ScheduledExecutorService deleteLogExecutorService;
@@ -102,15 +94,11 @@ public abstract class RaftLogManager {
   private ExecutorService checkLogApplierExecutorService;
   private Future<?> checkLogApplierFuture;
 
-  /**
-   * minimum number of committed logs in memory
-   */
+  /** minimum number of committed logs in memory */
   private int minNumOfLogsInMem =
       ClusterDescriptor.getInstance().getConfig().getMinNumOfLogsInMem();
 
-  /**
-   * maximum number of committed logs in memory
-   */
+  /** maximum number of committed logs in memory */
   private int maxNumOfLogsInMem =
       ClusterDescriptor.getInstance().getConfig().getMaxNumOfLogsInMem();
 
@@ -294,7 +282,7 @@ public abstract class RaftLogManager {
    *
    * @param index request entry index
    * @return throw EntryCompactedException if index < dummyIndex, -1 if index > lastIndex or the
-   * entry is compacted, otherwise return the entry's term for given index
+   *     entry is compacted, otherwise return the entry's term for given index
    * @throws EntryCompactedException
    */
   public long getTerm(long index) throws EntryCompactedException {
@@ -362,11 +350,11 @@ public abstract class RaftLogManager {
    * Used by follower node to support leader's complicated log replication rpc parameters and try to
    * commit entries.
    *
-   * @param lastIndex    leader's matchIndex for this follower node
-   * @param lastTerm     the entry's term which index is leader's matchIndex for this follower node
+   * @param lastIndex leader's matchIndex for this follower node
+   * @param lastTerm the entry's term which index is leader's matchIndex for this follower node
    * @param leaderCommit leader's commitIndex
-   * @param entries      entries sent from the leader node Note that the leader must ensure
-   *                     entries[0].index = lastIndex + 1
+   * @param entries entries sent from the leader node Note that the leader must ensure
+   *     entries[0].index = lastIndex + 1
    * @return -1 if the entries cannot be appended, otherwise the last index of new entries
    */
   public long maybeAppend(long lastIndex, long lastTerm, long leaderCommit, List<Log> entries) {
@@ -408,10 +396,10 @@ public abstract class RaftLogManager {
    * Used by follower node to support leader's complicated log replication rpc parameters and try to
    * commit entry.
    *
-   * @param lastIndex    leader's matchIndex for this follower node
-   * @param lastTerm     the entry's term which index is leader's matchIndex for this follower node
+   * @param lastIndex leader's matchIndex for this follower node
+   * @param lastTerm the entry's term which index is leader's matchIndex for this follower node
    * @param leaderCommit leader's commitIndex
-   * @param entry        entry sent from the leader node
+   * @param entry entry sent from the leader node
    * @return -1 if the entries cannot be appended, otherwise the last index of new entries
    */
   public long maybeAppend(long lastIndex, long lastTerm, long leaderCommit, Log entry) {
@@ -486,7 +474,7 @@ public abstract class RaftLogManager {
    * Used by leader node to try to commit entries.
    *
    * @param leaderCommit leader's commitIndex
-   * @param term         the entry's term which index is leaderCommit in leader's log module
+   * @param term the entry's term which index is leaderCommit in leader's log module
    * @return true or false
    */
   public synchronized boolean maybeCommit(long leaderCommit, long term) {
@@ -540,7 +528,7 @@ public abstract class RaftLogManager {
    * then whichever log has the larger lastIndex is more up-to-date. If the logs are the same, the
    * given log is up-to-date.
    *
-   * @param lastTerm  candidate's lastTerm
+   * @param lastTerm candidate's lastTerm
    * @param lastIndex candidate's lastIndex
    * @return true or false
    */
@@ -553,7 +541,7 @@ public abstract class RaftLogManager {
    * Pack entries from low through high - 1, just like slice (entries[low:high]). firstIndex <= low
    * <= high <= lastIndex.
    *
-   * @param low  request index low bound
+   * @param low request index low bound
    * @param high request index upper bound
    */
   public List<Log> getEntries(long low, long high) {
@@ -687,7 +675,7 @@ public abstract class RaftLogManager {
   /**
    * Returns whether the index and term passed in match.
    *
-   * @param term  request entry term
+   * @param term request entry term
    * @param index request entry index
    * @return true or false
    */
@@ -735,7 +723,7 @@ public abstract class RaftLogManager {
    * Check whether the parameters passed in satisfy the following properties. firstIndex <= low <=
    * high.
    *
-   * @param low  request index low bound
+   * @param low request index low bound
    * @param high request index upper bound
    * @throws EntryCompactedException
    * @throws GetEntriesWrongParametersException
@@ -883,9 +871,7 @@ public abstract class RaftLogManager {
     return maxHaveAppliedCommitIndex;
   }
 
-  /**
-   * check whether delete the committed log
-   */
+  /** check whether delete the committed log */
   void checkDeleteLog() {
     try {
       synchronized (this) {
@@ -1041,9 +1027,7 @@ public abstract class RaftLogManager {
     this.blockAppliedCommitIndex = blockAppliedCommitIndex;
   }
 
-  /**
-   * Apply the committed logs that were previously blocked by `blockAppliedCommitIndex` if any.
-   */
+  /** Apply the committed logs that were previously blocked by `blockAppliedCommitIndex` if any. */
   private void reapplyBlockedLogs() {
     if (!blockedUnappliedLogList.isEmpty()) {
       applyEntries(blockedUnappliedLogList);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
@@ -70,14 +70,10 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   private static final String LOG_DATA_FILE_SUFFIX = "data";
   private static final String LOG_INDEX_FILE_SUFFIX = "idx";
 
-  /**
-   * the log data files
-   */
+  /** the log data files */
   private List<File> logDataFileList;
 
-  /**
-   * the log index files
-   */
+  /** the log index files */
   private List<File> logIndexFileList;
 
   private LogParser parser = LogParser.getINSTANCE();
@@ -87,14 +83,10 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   private LogManagerMeta meta;
   private HardState state;
 
-  /**
-   * min version of available log
-   */
+  /** min version of available log */
   private long minAvailableVersion = 0;
 
-  /**
-   * max version of available log
-   */
+  /** max version of available log */
   private long maxAvailableVersion = Long.MAX_VALUE;
 
   private String logDir;
@@ -154,9 +146,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
 
   private static final int LOG_DELETE_CHECK_INTERVAL_SECOND = 5;
 
-  /**
-   * the lock uses when change the log data files or log index files
-   */
+  /** the lock uses when change the log data files or log index files */
   private final Lock lock = new ReentrantLock();
 
   private volatile boolean isClosed = false;
@@ -228,17 +218,13 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     return metaFile;
   }
 
-  /**
-   * for log tools
-   */
+  /** for log tools */
   @Override
   public LogManagerMeta getMeta() {
     return meta;
   }
 
-  /**
-   * Recover all the logs in disk. This function will be called once this instance is created.
-   */
+  /** Recover all the logs in disk. This function will be called once this instance is created. */
   @Override
   public List<Log> getAllEntriesAfterAppliedIndex() {
     logger.debug(
@@ -252,8 +238,8 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   }
 
   /**
-   * Recover un-committed logs but already persistent.
-   * Maybe,we can extract getAllEntriesAfterAppliedIndex and getAllEntriesAfterCommittedIndex into
+   * Recover un-committed logs but already persistent. Maybe,we can extract
+   * getAllEntriesAfterAppliedIndex and getAllEntriesAfterCommittedIndex into
    * getAllEntriesByIndex,but now there are too many test cases using it.
    */
   @Override
@@ -449,9 +435,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     }
   }
 
-  /**
-   * flush the log buffer and check if the file needs to be closed
-   */
+  /** flush the log buffer and check if the file needs to be closed */
   @Override
   public void forceFlushLogBuffer() {
     lock.lock();
@@ -495,9 +479,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     }
   }
 
-  /**
-   * The file name rules are as follows: ${startLogIndex}-${endLogIndex}-${version}.data
-   */
+  /** The file name rules are as follows: ${startLogIndex}-${endLogIndex}-${version}.data */
   private void recoverLogFiles() {
     // 1. first we should recover the log index file
     recoverLogFiles(LOG_INDEX_FILE_SUFFIX);
@@ -542,9 +524,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   /**
    * Check that the file is legal or not
    *
-   * @param file     file needs to be check
+   * @param file file needs to be check
    * @param fileType {@link SyncLogDequeSerializer#LOG_DATA_FILE_SUFFIX} or {@link
-   *                 SyncLogDequeSerializer#LOG_INDEX_FILE_SUFFIX}
+   *     SyncLogDequeSerializer#LOG_INDEX_FILE_SUFFIX}
    * @return true if the file legal otherwise false
    */
   private boolean checkLogFile(File file, String fileType) {
@@ -762,9 +744,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     }
   }
 
-  /**
-   * for unclosed file, the file name is ${startIndex}-${Long.MAX_VALUE}-{version}
-   */
+  /** for unclosed file, the file name is ${startIndex}-${Long.MAX_VALUE}-{version} */
   private void createNewLogFile(String dirName, long startLogIndex) throws IOException {
     lock.lock();
     try {
@@ -1107,7 +1087,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
 
   /**
    * @param startIndex the log start index
-   * @param endIndex   the log end index
+   * @param endIndex the log end index
    * @return the raft log which index between [startIndex, endIndex] or empty if not found
    */
   @Override
@@ -1229,9 +1209,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
 
   /**
    * @param startIndex the log start index
-   * @param endIndex   the log end index
+   * @param endIndex the log end index
    * @return first value-> the log data file, second value-> the left value is the start offset of
-   * the file, the right is the end offset of the file
+   *     the file, the right is the end offset of the file
    */
   private List<Pair<File, Pair<Long, Long>>> getLogDataFileAndOffset(
       long startIndex, long endIndex) {
@@ -1295,8 +1275,8 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   /**
    * @param startIndex the start log index
    * @return the first value of the pair is the log index file which contains the start index; the
-   * second pair's first value is the file's start log index. the second pair's second value is the
-   * file's end log index. null if not found
+   *     second pair's first value is the file's start log index. the second pair's second value is
+   *     the file's end log index. null if not found
    */
   public Pair<File, Pair<Long, Long>> getLogIndexFile(long startIndex) {
     for (File file : logIndexFileList) {
@@ -1317,8 +1297,8 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   /**
    * @param startIndex the start log index
    * @return the first value of the pair is the log data file which contains the start index; the
-   * second pair's first value is the file's start log index. the second pair's second value is the
-   * file's end log index. null if not found
+   *     second pair's first value is the file's start log index. the second pair's second value is
+   *     the file's end log index. null if not found
    */
   public Pair<File, Pair<Long, Long>> getLogDataFile(long startIndex) {
     for (File file : logDataFileList) {
@@ -1337,9 +1317,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   }
 
   /**
-   * @param file              the log data file
+   * @param file the log data file
    * @param startAndEndOffset the left value is the start offset of the file, the right is the end
-   *                          offset of the file
+   *     offset of the file
    * @return the logs between start offset and end offset
    */
   private List<Log> getLogsFromOneLogDataFile(File file, Pair<Long, Long> startAndEndOffset) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
@@ -70,10 +70,14 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   private static final String LOG_DATA_FILE_SUFFIX = "data";
   private static final String LOG_INDEX_FILE_SUFFIX = "idx";
 
-  /** the log data files */
+  /**
+   * the log data files
+   */
   private List<File> logDataFileList;
 
-  /** the log index files */
+  /**
+   * the log index files
+   */
   private List<File> logIndexFileList;
 
   private LogParser parser = LogParser.getINSTANCE();
@@ -83,10 +87,14 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   private LogManagerMeta meta;
   private HardState state;
 
-  /** min version of available log */
+  /**
+   * min version of available log
+   */
   private long minAvailableVersion = 0;
 
-  /** max version of available log */
+  /**
+   * max version of available log
+   */
   private long maxAvailableVersion = Long.MAX_VALUE;
 
   private String logDir;
@@ -146,7 +154,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
 
   private static final int LOG_DELETE_CHECK_INTERVAL_SECOND = 5;
 
-  /** the lock uses when change the log data files or log index files */
+  /**
+   * the lock uses when change the log data files or log index files
+   */
   private final Lock lock = new ReentrantLock();
 
   private volatile boolean isClosed = false;
@@ -218,12 +228,17 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     return metaFile;
   }
 
-  /** for log tools */
+  /**
+   * for log tools
+   */
+  @Override
   public LogManagerMeta getMeta() {
     return meta;
   }
 
-  /** Recover all the logs in disk. This function will be called once this instance is created. */
+  /**
+   * Recover all the logs in disk. This function will be called once this instance is created.
+   */
   @Override
   public List<Log> getAllEntriesAfterAppliedIndex() {
     logger.debug(
@@ -234,6 +249,24 @@ public class SyncLogDequeSerializer implements StableEntryManager {
       return Collections.emptyList();
     }
     return getLogs(meta.getMaxHaveAppliedCommitIndex(), meta.getCommitLogIndex());
+  }
+
+  /**
+   * Recover un-committed logs but already persistent.
+   * Maybe,we can extract getAllEntriesAfterAppliedIndex and getAllEntriesAfterCommittedIndex into
+   * getAllEntriesByIndex,but now there are too many test cases using it.
+   */
+  @Override
+  public List<Log> getAllEntriesAfterCommittedIndex() {
+    long lastIndex = firstLogIndex + logIndexOffsetList.size() - 1;
+    logger.debug(
+        "getAllEntriesBeforeAppliedIndex, firstUnCommitIndex={}, lastIndexBeforeStart={}",
+        meta.getCommitLogIndex() + 1,
+        lastIndex);
+    if (meta.getCommitLogIndex() >= lastIndex) {
+      return Collections.emptyList();
+    }
+    return getLogs(meta.getCommitLogIndex() + 1, lastIndex);
   }
 
   @Override
@@ -416,7 +449,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     }
   }
 
-  /** flush the log buffer and check if the file needs to be closed */
+  /**
+   * flush the log buffer and check if the file needs to be closed
+   */
   @Override
   public void forceFlushLogBuffer() {
     lock.lock();
@@ -460,7 +495,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     }
   }
 
-  /** The file name rules are as follows: ${startLogIndex}-${endLogIndex}-${version}.data */
+  /**
+   * The file name rules are as follows: ${startLogIndex}-${endLogIndex}-${version}.data
+   */
   private void recoverLogFiles() {
     // 1. first we should recover the log index file
     recoverLogFiles(LOG_INDEX_FILE_SUFFIX);
@@ -505,9 +542,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   /**
    * Check that the file is legal or not
    *
-   * @param file file needs to be check
+   * @param file     file needs to be check
    * @param fileType {@link SyncLogDequeSerializer#LOG_DATA_FILE_SUFFIX} or {@link
-   *     SyncLogDequeSerializer#LOG_INDEX_FILE_SUFFIX}
+   *                 SyncLogDequeSerializer#LOG_INDEX_FILE_SUFFIX}
    * @return true if the file legal otherwise false
    */
   private boolean checkLogFile(File file, String fileType) {
@@ -725,7 +762,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     }
   }
 
-  /** for unclosed file, the file name is ${startIndex}-${Long.MAX_VALUE}-{version} */
+  /**
+   * for unclosed file, the file name is ${startIndex}-${Long.MAX_VALUE}-{version}
+   */
   private void createNewLogFile(String dirName, long startLogIndex) throws IOException {
     lock.lock();
     try {
@@ -1068,7 +1107,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
 
   /**
    * @param startIndex the log start index
-   * @param endIndex the log end index
+   * @param endIndex   the log end index
    * @return the raft log which index between [startIndex, endIndex] or empty if not found
    */
   @Override
@@ -1190,9 +1229,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
 
   /**
    * @param startIndex the log start index
-   * @param endIndex the log end index
+   * @param endIndex   the log end index
    * @return first value-> the log data file, second value-> the left value is the start offset of
-   *     the file, the right is the end offset of the file
+   * the file, the right is the end offset of the file
    */
   private List<Pair<File, Pair<Long, Long>>> getLogDataFileAndOffset(
       long startIndex, long endIndex) {
@@ -1256,8 +1295,8 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   /**
    * @param startIndex the start log index
    * @return the first value of the pair is the log index file which contains the start index; the
-   *     second pair's first value is the file's start log index. the second pair's second value is
-   *     the file's end log index. null if not found
+   * second pair's first value is the file's start log index. the second pair's second value is the
+   * file's end log index. null if not found
    */
   public Pair<File, Pair<Long, Long>> getLogIndexFile(long startIndex) {
     for (File file : logIndexFileList) {
@@ -1278,8 +1317,8 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   /**
    * @param startIndex the start log index
    * @return the first value of the pair is the log data file which contains the start index; the
-   *     second pair's first value is the file's start log index. the second pair's second value is
-   *     the file's end log index. null if not found
+   * second pair's first value is the file's start log index. the second pair's second value is the
+   * file's end log index. null if not found
    */
   public Pair<File, Pair<Long, Long>> getLogDataFile(long startIndex) {
     for (File file : logDataFileList) {
@@ -1298,9 +1337,9 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   }
 
   /**
-   * @param file the log data file
+   * @param file              the log data file
    * @param startAndEndOffset the left value is the start offset of the file, the right is the end
-   *     offset of the file
+   *                          offset of the file
    * @return the logs between start offset and end offset
    */
   private List<Log> getLogsFromOneLogDataFile(File file, Pair<Long, Long> startAndEndOffset) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
@@ -238,9 +238,15 @@ public class SyncLogDequeSerializer implements StableEntryManager {
   }
 
   /**
-   * Recover un-committed logs but already persistent. Maybe,we can extract
-   * getAllEntriesAfterAppliedIndex and getAllEntriesAfterCommittedIndex into
-   * getAllEntriesByIndex,but now there are too many test cases using it.
+   * When raft log files flushed,meta would not be flushed synchronously.So data has flushed to disk
+   * is uncommitted for persistent LogManagerMeta(meta's info is stale).We need to recover these
+   * already persistent logs.
+   *
+   * <p>For example,commitIndex is 5 in persistent LogManagerMeta,But the log file has actually been
+   * flushed to 7,when we restart cluster,we need to recover 6 and 7.
+   *
+   * <p>Maybe,we can extract getAllEntriesAfterAppliedIndex and getAllEntriesAfterCommittedIndex
+   * into getAllEntriesByIndex,but now there are too many test cases using it.
    */
   @Override
   public List<Log> getAllEntriesAfterCommittedIndex() {


### PR DESCRIPTION
In current logic, if we restart cluster, and `applyIndex` is smaller than `commitIndex`,here are three problems occur.

- First, we cannot append un-apply logs to `commitManager`.Like 103 and 104 in the picture,they can not be appended to `commitEntries` in `commitManager`.
- Second, un-commitManager can not append a new log. Like 0 can not be appended to `unCommitEntries`  in `unCommitManager`.
-  Third, un-applied logs can not be re-applied.That means 103 and 104 could be lost. 

This is all because `dummyIndex` is initialized to the default value,it cannot return to its pre-reboot state.

_ps.The information in the picture assumes none of these questions exist_
<img width="612" alt="6211a9f5a25a465958c041d145f6dd5" src="https://user-images.githubusercontent.com/44458757/132673815-5a17451e-0434-459e-90d5-0587e724bb36.png">

This PR try to resolve this problem,but we may also need a processor to avoid logIndex is too big, dunmmyIndex need to re-initialize if logIndex will be bigger than our expect.
