### PR TITLE
[IOTDB-1670] Fix cli -e mode didn't fetch timestamp_precision from server

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/cli/Cli.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/Cli.java
@@ -121,6 +121,7 @@ public class Cli extends AbstractCli {
                 DriverManager.getConnection(
                     Config.IOTDB_URL_PREFIX + host + ":" + port + "/", username, password)) {
           properties = connection.getServerProperties();
+          timestampPrecision = properties.getTimestampPrecision();
           AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
           processCommand(execute, connection);
           return;

--- a/cli/src/main/java/org/apache/iotdb/cli/WinCli.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/WinCli.java
@@ -133,6 +133,7 @@ public class WinCli extends AbstractCli {
                 DriverManager.getConnection(
                     Config.IOTDB_URL_PREFIX + host + ":" + port + "/", username, password)) {
           properties = connection.getServerProperties();
+          timestampPrecision = properties.getTimestampPrecision();
           AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
           processCommand(execute, connection);
           return;


### PR DESCRIPTION
## Description
![41931631254773_ pic_hd](https://user-images.githubusercontent.com/25913899/132811853-0bc269af-5d6e-4e28-a89a-928d4b183833.jpg)


See IOTDB-1670 .