### PR TITLE
[To rel/0.12][IOTDB-1674] Fix command interpreting error causing somaxconn warning failed

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-env.sh
+++ b/server/src/assembly/resources/conf/iotdb-env.sh
@@ -36,7 +36,7 @@ fi
 SOMAXCONN=65535
 case "$(uname)" in
     Linux)
-        somaxconn=$(sysctl net.core.somaxconn | awk '{print $2}')
+        somaxconn=$(sysctl -n net.core.somaxconn)
         if [ "$somaxconn" -lt $SOMAXCONN ]; then
             echo "WARN:"
             echo "WARN: the value of net.core.somaxconn (=$somaxconn) is too small, please set it to a larger value using the following command."
@@ -46,7 +46,7 @@ case "$(uname)" in
         fi
     ;;
     FreeBSD | Darwin)
-        somaxconn=$(sysctl kern.ipc.somaxconn | awk '{print $2}')
+        somaxconn=$(sysctl -n kern.ipc.somaxconn)
         if [ "$somaxconn" -lt $SOMAXCONN ]; then
             echo "WARN:"
             echo "WARN: the value of kern.ipc.somaxconn (=$somaxconn) is too small, please set it to a larger value using the following command."


### PR DESCRIPTION
A cherry-pick of https://github.com/apache/iotdb/pull/3951