### PR TITLE
[IOTDB-1677] not generate file apache-iotdb-0.x.x-client-cpp-linux-x8…

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -86,7 +86,7 @@
                                         <include>apache-iotdb-${project.version}-cli-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-cluster-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-grafana-bin.zip</include>
-                                        <include>apache-iotdb-${project.version}-client-cpp-bin.zip</include>
+                                        <include>apache-iotdb-${project.version}-client-cpp-${os.classifier}-bin.zip</include>
                                     </includes>
                                 </fileSet>
                             </fileSets>


### PR DESCRIPTION
## Description
fix 1 bug: IotDB-distribution can not generate file apache-iotdb-0.x.x-client-cpp-linux-x86_64-bin.zip.sha512


