### PR TITLE
[IOTDB-1289] to rel/0.12, fix CPP mem-leak in SessionExample.cpp insertRecords()

### DIFF
--- a/example/client-cpp-example/src/SessionExample.cpp
+++ b/example/client-cpp-example/src/SessionExample.cpp
@@ -187,17 +187,16 @@ void insertRecords() {
     vector<vector<string>> measurementsList;
     vector<vector<string>> valuesList;
     vector<int64_t> timestamps;
-    vector<string>* values;
 
     for (int64_t time = 0; time < 500; time++) {
-        values = new vector<string>();
-        values->push_back("1");
-        values->push_back("2");
-        values->push_back("3");
+        vector<string> values;
+        values.push_back("1");
+        values.push_back("2");
+        values.push_back("3");
 
         deviceIds.push_back(deviceId);
         measurementsList.push_back(measurements);
-        valuesList.push_back(*values);
+        valuesList.push_back(values);
         timestamps.push_back(time);
         if (time != 0 && time % 100 == 0) {
             session->insertRecords(deviceIds, timestamps, measurementsList, valuesList);


### PR DESCRIPTION
## Description
[IOTDB-1289] fix CPP mem-leak in SessionExample.cpp insertRecords()


