### PR TITLE
[IOTDB-1287] C++ class Session has 2 useless sort()

### DIFF
--- a/client-cpp/src/main/Session.cpp
+++ b/client-cpp/src/main/Session.cpp
@@ -381,7 +381,6 @@ void Session::sortTablet(Tablet &tablet) {
     }
 
     this->sortIndexByTimestamp(index, tablet.timestamps, tablet.rowSize);
-    sort(tablet.timestamps.begin(), tablet.timestamps.begin() + tablet.rowSize);
     for (int i = 0; i < tablet.schemas.size(); i++) {
         tablet.values[i] = sortList(tablet.values[i], index, tablet.rowSize);
     }
@@ -678,7 +677,6 @@ void Session::insertRecordsOfOneDevice(string deviceId, vector <int64_t> &times,
         }
 
         this->sortIndexByTimestamp(index, times, times.size());
-        sort(times.begin(), times.end());
         measurementsList = sortList(measurementsList, index, times.size());
         typesList = sortList(typesList, index, times.size());
         valuesList = sortList(valuesList, index, times.size());


### PR DESCRIPTION
## Description
[IOTDB-1287] C++ class Session has 2 useless sort()
In below codes, those 2 sort() should be useless, because "tablet.timestamps" or "times" has been sorted in sortIndexByTimestamp()

============================================

File: ./client-cpp/src/main/Session.cpp

void Session::sortTablet(Tablet& tablet) {
   ... 
   this->sortIndexByTimestamp(index, tablet.timestamps, tablet.rowSize);    //here, has sorted timestamps
   sort(tablet.timestamps, tablet.timestamps + tablet.rowSize);  //useless sort
    ... 
}

void Session::insertRecordsOfOneDevice(string deviceId, ...){
    ... 
    this->sortIndexByTimestamp(index, times.data(), times.size());    //here, has sorted times
    sort(times.begin(), times.end());    //useless sort
     ... 
}
