### PR TITLE
[IOTDB-1690] Fix align by device type cast error

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1241,7 +1241,7 @@ public class MManager {
       Template template = node.getUpperTemplate();
 
       for (IMNode child : node.getChildren().values()) {
-        if (child instanceof IMeasurementMNode){
+        if (child instanceof IMeasurementMNode) {
           IMeasurementMNode measurementMNode = (IMeasurementMNode) child;
           res.add(measurementMNode.getSchema());
         }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1241,7 +1241,7 @@ public class MManager {
       Template template = node.getUpperTemplate();
 
       for (IMNode child : node.getChildren().values()) {
-        if (child instanceof IMeasurementMNode) {
+        if (child.isMeasurement()) {
           IMeasurementMNode measurementMNode = (IMeasurementMNode) child;
           res.add(measurementMNode.getSchema());
         }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1241,8 +1241,10 @@ public class MManager {
       Template template = node.getUpperTemplate();
 
       for (IMNode child : node.getChildren().values()) {
-        IMeasurementMNode measurementMNode = (IMeasurementMNode) child;
-        res.add(measurementMNode.getSchema());
+        if (child instanceof IMeasurementMNode){
+          IMeasurementMNode measurementMNode = (IMeasurementMNode) child;
+          res.add(measurementMNode.getSchema());
+        }
       }
 
       // template


### PR DESCRIPTION
Use align by device function:

select * from root.database.student(any similar sql) align by device

Will print error:

Msg: 500: [INTERNAL_SERVER_ERROR] Exception occurred: "select * from root.database.student align by device". executeStatement failed. org.apache.iotdb.db.metadata.mnode.EntityMNode cannot be cast to org.apache.iotdb.db.metadata.mnode.IMeasurementMNode

Reason:

Children may be path or root node. ("country" and "score" belong path, and "anhui" belongs path)if it belong to path node, they don't need to type cast and add their schema to the res. Otherwise, if we don't make type  judgment , will be throw type cast exception.



![image](https://user-images.githubusercontent.com/44310040/133455115-7f6a5b75-831d-483c-b69d-7533a4fd3a7d.png)

The actual stored time series is shown in the figure below.

![image](https://user-images.githubusercontent.com/44310040/133457872-1d57d7c3-d95f-4882-a25b-04e15aa819ef.png)
