### PR TITLE
[IOTDB-1694] change name for loading dir and add an IT for loading dir

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -193,7 +193,7 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
       List<TsFileResource> result = new ArrayList<>();
       if (sequence) {
         List<SortedSet<TsFileResource>> sequenceTsFileList =
-            sequenceTsFileResources.get(timePartition);
+            sequenceTsFileResources.getOrDefault(timePartition, new ArrayList<>());
         for (int i = sequenceTsFileList.size() - 1; i >= 0; i--) {
           result.addAll(sequenceTsFileList.get(i));
         }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -2407,7 +2407,8 @@ public class StorageGroupProcessor {
     long newFilePartitionId = newTsFileResource.getTimePartitionWithCheck();
     writeLock("loadNewTsFile");
     try {
-      List<TsFileResource> sequenceList = tsFileManagement.getTsFileListByTimePartition(true, newFilePartitionId);
+      List<TsFileResource> sequenceList =
+          tsFileManagement.getTsFileListByTimePartition(true, newFilePartitionId);
 
       int insertPos = findInsertionPosition(newTsFileResource, sequenceList);
       String newFileName, renameInfo;
@@ -2487,8 +2488,7 @@ public class StorageGroupProcessor {
    *     file can be inserted between [i, i+1]
    */
   private int findInsertionPosition(
-      TsFileResource newTsFileResource,
-      List<TsFileResource> sequenceList) {
+      TsFileResource newTsFileResource, List<TsFileResource> sequenceList) {
 
     int insertPos = -1;
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -2407,9 +2407,9 @@ public class StorageGroupProcessor {
     long newFilePartitionId = newTsFileResource.getTimePartitionWithCheck();
     writeLock("loadNewTsFile");
     try {
-      List<TsFileResource> sequenceList = tsFileManagement.getTsFileList(true);
+      List<TsFileResource> sequenceList = tsFileManagement.getTsFileListByTimePartition(true, newFilePartitionId);
 
-      int insertPos = findInsertionPosition(newTsFileResource, newFilePartitionId, sequenceList);
+      int insertPos = findInsertionPosition(newTsFileResource, sequenceList);
       String newFileName, renameInfo;
       LoadTsFileType tsFileType;
 
@@ -2488,7 +2488,6 @@ public class StorageGroupProcessor {
    */
   private int findInsertionPosition(
       TsFileResource newTsFileResource,
-      long newFilePartitionId,
       List<TsFileResource> sequenceList) {
 
     int insertPos = -1;
@@ -2496,12 +2495,6 @@ public class StorageGroupProcessor {
     // find the position where the new file should be inserted
     for (int i = 0; i < sequenceList.size(); i++) {
       TsFileResource localFile = sequenceList.get(i);
-      long localPartitionId = Long.parseLong(localFile.getTsFile().getParentFile().getName());
-
-      if (newFilePartitionId > localPartitionId) {
-        insertPos = i;
-        continue;
-      }
 
       if (!localFile.isClosed() && localFile.getProcessor() != null) {
         // we cannot compare two files by TsFileResource unless they are both closed
@@ -2532,8 +2525,10 @@ public class StorageGroupProcessor {
    */
   private int compareTsFileDevices(TsFileResource fileA, TsFileResource fileB) {
     boolean hasPre = false, hasSubsequence = false;
-    for (String device : fileA.getDevices()) {
-      if (!fileB.getDevices().contains(device)) {
+    Set<String> fileADevices = fileA.getDevices();
+    Set<String> fileBDevices = fileB.getDevices();
+    for (String device : fileADevices) {
+      if (!fileBDevices.contains(device)) {
         continue;
       }
       long startTimeA = fileA.getStartTime(device);
@@ -2666,6 +2661,7 @@ public class StorageGroupProcessor {
   private String getFileNameForSequenceLoadingFile(
       int insertIndex, TsFileResource newTsFileResource, List<TsFileResource> sequenceList)
       throws LoadFileException {
+    int sequenceListLength = sequenceList.size();
     long timePartitionId = newTsFileResource.getTimePartition();
     long preTime, subsequenceTime;
 
@@ -2675,7 +2671,7 @@ public class StorageGroupProcessor {
       String preName = sequenceList.get(insertIndex).getTsFile().getName();
       preTime = Long.parseLong(preName.split(FILE_NAME_SEPARATOR)[0]);
     }
-    if (insertIndex == tsFileManagement.size(true) - 1) {
+    if (insertIndex == sequenceListLength - 1) {
       subsequenceTime = preTime + ((System.currentTimeMillis() - preTime) << 1);
     } else {
       String subsequenceName = sequenceList.get(insertIndex + 1).getTsFile().getName();

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -2447,6 +2447,7 @@ public class StorageGroupProcessor {
       updateLatestTimeMap(newTsFileResource);
       long partitionNum = newTsFileResource.getTimePartition();
       updatePartitionFileVersion(partitionNum, newTsFileResource.getVersion());
+      logger.info("TsFile {} is successfully loaded in {} list.", newFileName, renameInfo);
     } catch (DiskSpaceInsufficientException e) {
       logger.error(
           "Failed to append the tsfile {} to storage group processor {} because the disk space is insufficient.",

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1072,13 +1072,13 @@ public class PlanExecutor implements IPlanExecutor {
           String.format("File path %s doesn't exists.", file.getPath()));
     }
     if (file.isDirectory()) {
-      recursionFileDir(file, plan);
+      loadDir(file, plan);
     } else {
       loadFile(file, plan);
     }
   }
 
-  private void recursionFileDir(File curFile, OperateFilePlan plan) throws QueryProcessException {
+  private void loadDir(File curFile, OperateFilePlan plan) throws QueryProcessException {
     File[] files = curFile.listFiles();
     long[] establishTime = new long[files.length];
     List<Integer> tsfiles = new ArrayList<>();
@@ -1104,7 +1104,7 @@ public class PlanExecutor implements IPlanExecutor {
 
     for (File file : files) {
       if (file.isDirectory()) {
-        recursionFileDir(file, plan);
+        loadDir(file, plan);
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1093,11 +1093,12 @@ public class PlanExecutor implements IPlanExecutor {
         }
       }
     }
-    Collections.sort(tsfiles, (o1, o2) -> {
-      if (establishTime[o1] == establishTime[o2])
-        return 0;
-      return establishTime[o1] < establishTime[o2] ? -1 : 1;
-    });
+    Collections.sort(
+        tsfiles,
+        (o1, o2) -> {
+          if (establishTime[o1] == establishTime[o2]) return 0;
+          return establishTime[o1] < establishTime[o2] ? -1 : 1;
+        });
     for (Integer i : tsfiles) {
       loadFile(files[i], plan);
     }

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -198,6 +198,7 @@ import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TASK_NAME;
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TTL;
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_USER;
 import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_VALUE;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
 import static org.apache.iotdb.db.conf.IoTDBConstant.FUNCTION_TYPE_BUILTIN_UDAF;
 import static org.apache.iotdb.db.conf.IoTDBConstant.FUNCTION_TYPE_BUILTIN_UDTF;
 import static org.apache.iotdb.db.conf.IoTDBConstant.FUNCTION_TYPE_EXTERNAL_UDAF;
@@ -1079,11 +1080,31 @@ public class PlanExecutor implements IPlanExecutor {
 
   private void recursionFileDir(File curFile, OperateFilePlan plan) throws QueryProcessException {
     File[] files = curFile.listFiles();
+    long[] establishTime = new long[files.length];
+    List<Integer> tsfiles = new ArrayList<>();
+
+    for (int i = 0; i < files.length; i++) {
+      File file = files[i];
+      if (!file.isDirectory()) {
+        String fileName = file.getName();
+        if (fileName.endsWith(TSFILE_SUFFIX)) {
+          establishTime[i] = Long.parseLong(fileName.split(FILE_NAME_SEPARATOR)[0]);
+          tsfiles.add(i);
+        }
+      }
+    }
+    Collections.sort(tsfiles, (o1, o2) -> {
+      if (establishTime[o1] == establishTime[o2])
+        return 0;
+      return establishTime[o1] < establishTime[o2] ? -1 : 1;
+    });
+    for (Integer i : tsfiles) {
+      loadFile(files[i], plan);
+    }
+
     for (File file : files) {
       if (file.isDirectory()) {
         recursionFileDir(file, plan);
-      } else {
-        loadFile(file, plan);
       }
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsFileWithTimePartitionIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsFileWithTimePartitionIT.java
@@ -44,7 +44,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.xml.crypto.Data;
 import java.io.File;
 import java.io.IOException;
 import java.sql.*;
@@ -209,7 +208,7 @@ public class IoTDBLoadExternalTsFileWithTimePartitionIT {
   }
 
   void writeDataWithDifferentDevice(TsFileWriter tsFileWriter, long timestamp, int counter)
-          throws IOException, WriteProcessException {
+      throws IOException, WriteProcessException {
     int mod = (counter % 6);
     if (mod < 3) {
       TSRecord tsRecord = new TSRecord(timestamp, STORAGE_GROUP + DOT + devices[mod]);
@@ -282,8 +281,8 @@ public class IoTDBLoadExternalTsFileWithTimePartitionIT {
   @Test
   public void loadTsFileWithDifferentDevice() {
     try (Connection connection =
-                 DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
-         Statement statement = connection.createStatement()) {
+            DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
       prepareDataWithDifferentDevice();
 
       statement.execute(String.format("load \"%s\"", new File(tempDir).getAbsolutePath()));
@@ -291,11 +290,10 @@ public class IoTDBLoadExternalTsFileWithTimePartitionIT {
       String dataDir = config.getDataDirs()[0];
       // sequence/logical_sg/virtual_sg/time_partitions
       File f =
-              new File(
-                      dataDir,
-                      new PartialPath("sequence") + File.separator + "root.ln" + File.separator + "0");
-      Assert.assertEquals(
-              (endTime - startTime) / (timePartition), f.list().length);
+          new File(
+              dataDir,
+              new PartialPath("sequence") + File.separator + "root.ln" + File.separator + "0");
+      Assert.assertEquals((endTime - startTime) / (timePartition), f.list().length);
 
       int totalPartitionsNum = (int) ((endTime - startTime) / (timePartition));
       int[] splitTsFilePartitions = new int[totalPartitionsNum];
@@ -310,8 +308,7 @@ public class IoTDBLoadExternalTsFileWithTimePartitionIT {
 
       // each time partition folder should contain 2 files, the tsfile and the resource file
       for (int i = 0; i < (endTime - startTime) / (timePartition); i++) {
-        Assert.assertEquals(
-                2, new File(f.getAbsolutePath(), "" + i).list().length);
+        Assert.assertEquals(2, new File(f.getAbsolutePath(), "" + i).list().length);
       }
 
       for (int i = 0; i < devices.length; i++) {
@@ -321,7 +318,7 @@ public class IoTDBLoadExternalTsFileWithTimePartitionIT {
         set.next();
         long number = set.getLong(1);
         Assert.assertEquals(deviceDataPointNumber[i], number);
-        }
+      }
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail();


### PR DESCRIPTION
change name for loading dir from recursionFileDir to loadDir

add an IT for testing following case:

enable time partition
load a dir which has some tsfiles with different timeseries
because of the unorder list in loading dir, maybe an "cannot find a suitable position" message will be found, and the loading process will stop.
this case may happened before #3795
To avoid this case, i add this IT

cherry pick from #3873 