### PR TITLE
[To rel/0.12][IOTDB-1703] Fix MManager slow recover with tag

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,7 @@
 * [IOTDB-1678] Fix client-cpp session bug: can cause connection leak.
 * [IOTDB-1679] client-cpp: Session descontruction need release server resource
 * [IOTDB-1690] Fix align by device type cast error
+* [IOTDB-1703] Fix MManager slow recover with tag  
 * [ISSUE-3945] Fix Fuzzy query not support multiDevices and alignByDevice Dataset
 * fix IoTDB restart does not truncate broken ChunkGroup bug
 * fix merge ClassCastException: MeasurementMNode

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -440,7 +440,7 @@ public class MManager {
           }
           tagIndex
               .computeIfAbsent(entry.getKey(), k -> new ConcurrentHashMap<>())
-              .computeIfAbsent(entry.getValue(), v -> new CopyOnWriteArraySet<>())
+              .computeIfAbsent(entry.getValue(), v -> Collections.synchronizedSet(new HashSet<>()))
               .add(leafMNode);
         }
       }
@@ -1275,7 +1275,7 @@ public class MManager {
         for (Entry<String, String> entry : tagsMap.entrySet()) {
           tagIndex
               .computeIfAbsent(entry.getKey(), k -> new ConcurrentHashMap<>())
-              .computeIfAbsent(entry.getValue(), v -> new CopyOnWriteArraySet<>())
+              .computeIfAbsent(entry.getValue(), v -> Collections.synchronizedSet(new HashSet<>()))
               .add(leafMNode);
         }
       }
@@ -1328,7 +1328,7 @@ public class MManager {
         if (beforeValue == null || !beforeValue.equals(value)) {
           tagIndex
               .computeIfAbsent(key, k -> new ConcurrentHashMap<>())
-              .computeIfAbsent(value, v -> new CopyOnWriteArraySet<>())
+              .computeIfAbsent(value, v -> Collections.synchronizedSet(new HashSet<>()))
               .add(leafMNode);
         }
       }
@@ -1402,7 +1402,7 @@ public class MManager {
       for (Entry<String, String> entry : tagsMap.entrySet()) {
         tagIndex
             .computeIfAbsent(entry.getKey(), k -> new ConcurrentHashMap<>())
-            .computeIfAbsent(entry.getValue(), v -> new CopyOnWriteArraySet<>())
+            .computeIfAbsent(entry.getValue(), v -> Collections.synchronizedSet(new HashSet<>()))
             .add(leafMNode);
       }
       return;
@@ -1429,7 +1429,7 @@ public class MManager {
         (key, value) ->
             tagIndex
                 .computeIfAbsent(key, k -> new ConcurrentHashMap<>())
-                .computeIfAbsent(value, v -> new CopyOnWriteArraySet<>())
+                .computeIfAbsent(value, v -> Collections.synchronizedSet(new HashSet<>()))
                 .add(leafMNode));
   }
 
@@ -1589,7 +1589,7 @@ public class MManager {
       }
       tagIndex
           .computeIfAbsent(key, k -> new ConcurrentHashMap<>())
-          .computeIfAbsent(currentValue, k -> new CopyOnWriteArraySet<>())
+          .computeIfAbsent(currentValue, k -> Collections.synchronizedSet(new HashSet<>()))
           .add(leafMNode);
     }
   }
@@ -1660,7 +1660,7 @@ public class MManager {
       }
       tagIndex
           .computeIfAbsent(newKey, k -> new ConcurrentHashMap<>())
-          .computeIfAbsent(value, k -> new CopyOnWriteArraySet<>())
+          .computeIfAbsent(value, k -> Collections.synchronizedSet(new HashSet<>()))
           .add(leafMNode);
     } else if (pair.right.containsKey(oldKey)) {
       // check attribute map

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -102,7 +102,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
@@ -352,7 +352,7 @@ public class MNode implements Serializable {
     if (fullPath == null) {
       return Objects.equals(getFullPath(), mNode.getFullPath());
     } else {
-      return Objects.equals(fullPath, mNode.fullPath);
+      return Objects.equals(fullPath, mNode.getFullPath());
     }
   }
 


### PR DESCRIPTION
## Description


### Problem
IoTDB support tagIndex in memory for tag based timeseries query.

Current tagIndex is based on CopyOnWriteArraySet and the time complexity to construct each set is O(n2).

An existing case is that the time for recovering tagIndex for 50000 timeseries with tags costs 5min or even more, based on working environment.

### Solution

Replace CopyOnWriteArraySet usage with Collections.synchronizedSet(new HashSet()) and the time cost is only 2s on my laptop.

