### PR TITLE
[IOTDB-1650] Rename the sql command `move`

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
@@ -95,7 +95,7 @@ statement
     | LOAD CONFIGURATION (MINUS GLOBAL)? #loadConfigurationStatement
     | LOAD stringLiteral loadFilesClause?#loadFiles
     | REMOVE stringLiteral #removeFile
-    | MOVE stringLiteral stringLiteral #moveFile
+    | UNLOAD stringLiteral stringLiteral #unloadFile
     | DELETE PARTITION prefixPath INT(COMMA INT)* #deletePartition
     | CREATE SNAPSHOT FOR SCHEMA #createSnapshot
     | CREATE TEMPORARY? FUNCTION udfName=ID AS className=stringLiteral #createFunction
@@ -514,7 +514,7 @@ nodeName
     | INFO
     | VERSION
     | REMOVE
-    | MOVE
+    | UNLOAD
     | CHILD
     | PATHS
     | DEVICES
@@ -619,7 +619,7 @@ nodeNameWithoutStar
     | INFO
     | VERSION
     | REMOVE
-    | MOVE
+    | UNLOAD
     | CHILD
     | PATHS
     | DEVICES
@@ -1078,8 +1078,8 @@ VERSION
 REMOVE
     : R E M O V E
     ;
-MOVE
-    : M O V E
+UNLOAD
+    : U N L O A D
     ;
 
 CHILD

--- a/docs/UserGuide/System-Tools/Load-External-Tsfile.md
+++ b/docs/UserGuide/System-Tools/Load-External-Tsfile.md
@@ -82,13 +82,13 @@ Examples:
 * `remove "root.vehicle/1575028885956-101-0.tsfile"` 
 * `remove "1575028885956-101-0.tsfile"`
 
-#### move a tsfile to a target directory
+#### unload a tsfile and move it to a target directory
 
-The command to move a tsfile to target directory is: `move "<path>" "<dir>"`.
+The command to unload a tsfile and move it to target directory is: `unload "<path>" "<dir>"`.
 
-This command moves a tsfile to a target directory by specifying tsfile path and the target directory(absolute path). The specific implementation is to remove the tsfile from the engine and move the tsfile file and its corresponding `.resource` file to the target directory.
+This command unload a tsfile and move it to a target directory by specifying tsfile path and the target directory(absolute path). The specific implementation is to remove the tsfile from the engine and move the tsfile file and its corresponding `.resource` file to the target directory.
 
 Examples:
 
-* `move "root.vehicle/1575029224130-101-0.tsfile" "/data/data/tmp"`
-* `move "1575029224130-101-0.tsfile" "/data/data/tmp"`
+* `unload "root.vehicle/1575029224130-101-0.tsfile" "/data/data/tmp"`
+* `unload "1575029224130-101-0.tsfile" "/data/data/tmp"`

--- a/docs/zh/UserGuide/System-Tools/Load-External-Tsfile.md
+++ b/docs/zh/UserGuide/System-Tools/Load-External-Tsfile.md
@@ -83,13 +83,13 @@ VERIFY 选项表示是否对载入的 tsfile 中的所有时间序列进行元�
 * `remove "root.vehicle/1575028885956-101-0.tsfile"`
 * `remove "1575028885956-101-0.tsfile"`
 
-#### 移出 tsfile 文件至指定目录
+#### 卸载 tsfile 文件至指定目录
 
-移出 tsfile 文件的指令为：`move "<path>" "<dir>"`
+卸载 tsfile 文件的指令为：`unload "<path>" "<dir>"`
 
-该指令将指定路径的 tsfile 文件移动至目标文件夹（绝对路径）中，具体做法是在引擎中移出该 tsfile，并将该 tsfile 文件和其对应的`.resource`文件移动到目标文件夹下
+该指令将指定路径的 tsfile 文件卸载并移动至目标文件夹（绝对路径）中，具体做法是在引擎中卸载该 tsfile，并将该 tsfile 文件和其对应的`.resource`文件移动到目标文件夹下
 
 示例：
 
-* `move "root.vehicle/1575029224130-101-0.tsfile" "/data/data/tmp"`
-* `move "1575029224130-101-0.tsfile" "/data/data/tmp"`
+* `unload "root.vehicle/1575029224130-101-0.tsfile" "/data/data/tmp"`
+* `unload "1575029224130-101-0.tsfile" "/data/data/tmp"`

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -893,10 +893,10 @@ public class StorageEngine implements IService {
         .deleteTsfile(deletedTsfile);
   }
 
-  public boolean moveTsfile(File tsfileToBeMoved, File targetDir)
+  public boolean unloadTsfile(File tsfileToBeUnloaded, File targetDir)
       throws StorageEngineException, IllegalPathException {
-    return getProcessorDirectly(new PartialPath(getSgByEngineFile(tsfileToBeMoved)))
-        .moveTsfile(tsfileToBeMoved, targetDir);
+    return getProcessorDirectly(new PartialPath(getSgByEngineFile(tsfileToBeUnloaded)))
+        .unloadTsfile(tsfileToBeUnloaded, targetDir);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -2922,23 +2922,23 @@ public class StorageGroupProcessor {
   }
 
   /**
-   * Move tsfile to the target directory if it exists.
+   * Unload tsfile and move it to the target directory if it exists.
    *
-   * <p>Firstly, remove the TsFileResource from sequenceFileList/unSequenceFileList.
+   * <p>Firstly, unload the TsFileResource from sequenceFileList/unSequenceFileList.
    *
    * <p>Secondly, move the tsfile and .resource file to the target directory.
    *
-   * @param fileToBeMoved tsfile to be moved
-   * @return whether the file to be moved exists. @UsedBy load external tsfile module.
+   * @param fileToBeUnloaded tsfile to be unloaded
+   * @return whether the file to be unloaded exists. @UsedBy load external tsfile module.
    */
-  public boolean moveTsfile(File fileToBeMoved, File targetDir) {
-    writeLock("moveTsfile");
+  public boolean unloadTsfile(File fileToBeUnloaded, File targetDir) {
+    writeLock("unloadTsfile");
     TsFileResource tsFileResourceToBeMoved = null;
     try {
       Iterator<TsFileResource> sequenceIterator = tsFileManagement.getIterator(true);
       while (sequenceIterator.hasNext()) {
         TsFileResource sequenceResource = sequenceIterator.next();
-        if (sequenceResource.getTsFile().getName().equals(fileToBeMoved.getName())) {
+        if (sequenceResource.getTsFile().getName().equals(fileToBeUnloaded.getName())) {
           tsFileResourceToBeMoved = sequenceResource;
           tsFileManagement.remove(tsFileResourceToBeMoved, true);
           break;
@@ -2948,7 +2948,7 @@ public class StorageGroupProcessor {
         Iterator<TsFileResource> unsequenceIterator = tsFileManagement.getIterator(false);
         while (unsequenceIterator.hasNext()) {
           TsFileResource unsequenceResource = unsequenceIterator.next();
-          if (unsequenceResource.getTsFile().getName().equals(fileToBeMoved.getName())) {
+          if (unsequenceResource.getTsFile().getName().equals(fileToBeUnloaded.getName())) {
             tsFileResourceToBeMoved = unsequenceResource;
             tsFileManagement.remove(tsFileResourceToBeMoved, false);
             break;

--- a/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
@@ -130,7 +130,7 @@ public class SQLConstant {
   public static final int TOK_FLUSH_TASK_INFO = 67;
   public static final int TOK_LOAD_FILES = 69;
   public static final int TOK_REMOVE_FILE = 70;
-  public static final int TOK_MOVE_FILE = 71;
+  public static final int TOK_UNLOAD_FILE = 71;
   public static final int TOK_VERSION = 72;
   public static final int TOK_TIMESERIES = 73;
   public static final int TOK_STORAGE_GROUP = 74;
@@ -227,7 +227,7 @@ public class SQLConstant {
 
     tokenNames.put(TOK_LOAD_FILES, "TOK_LOAD_FILES");
     tokenNames.put(TOK_REMOVE_FILE, "TOK_REMOVE_FILE");
-    tokenNames.put(TOK_MOVE_FILE, "TOK_MOVE_FILE");
+    tokenNames.put(TOK_UNLOAD_FILE, "TOK_UNLOAD_FILE");
 
     tokenNames.put(TOK_SHOW_MERGE_STATUS, "TOK_SHOW_MERGE_STATUS");
     tokenNames.put(TOK_DELETE_PARTITION, "TOK_DELETE_PARTITION");

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -308,8 +308,8 @@ public class PlanExecutor implements IPlanExecutor {
       case REMOVE_FILE:
         operateRemoveFile((OperateFilePlan) plan);
         return true;
-      case MOVE_FILE:
-        operateMoveFile((OperateFilePlan) plan);
+      case UNLOAD_FILE:
+        operateUnloadFile((OperateFilePlan) plan);
         return true;
       case FLUSH:
         operateFlush((FlushPlan) plan);
@@ -1242,20 +1242,20 @@ public class PlanExecutor implements IPlanExecutor {
     }
   }
 
-  private void operateMoveFile(OperateFilePlan plan) throws QueryProcessException {
+  private void operateUnloadFile(OperateFilePlan plan) throws QueryProcessException {
     if (!plan.getTargetDir().exists() || !plan.getTargetDir().isDirectory()) {
       throw new QueryProcessException(
           String.format("Target dir %s is invalid.", plan.getTargetDir().getPath()));
     }
     try {
-      if (!StorageEngine.getInstance().moveTsfile(plan.getFile(), plan.getTargetDir())) {
+      if (!StorageEngine.getInstance().unloadTsfile(plan.getFile(), plan.getTargetDir())) {
         throw new QueryProcessException(
             String.format("File %s doesn't exist.", plan.getFile().getName()));
       }
     } catch (StorageEngineException | IllegalPathException e) {
       throw new QueryProcessException(
           String.format(
-              "Cannot move file %s to target directory %s because %s",
+              "Cannot unload file %s to target directory %s because %s",
               plan.getFile().getPath(), plan.getTargetDir().getPath(), e.getMessage()));
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/Operator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/Operator.java
@@ -140,7 +140,7 @@ public abstract class Operator {
 
     LOAD_FILES,
     REMOVE_FILE,
-    MOVE_FILE,
+    UNLOAD_FILE,
 
     CREATE_TRIGGER,
     DROP_TRIGGER,

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/UnloadFileOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/UnloadFileOperator.java
@@ -27,16 +27,16 @@ import org.apache.iotdb.db.qp.strategy.PhysicalGenerator;
 
 import java.io.File;
 
-public class MoveFileOperator extends Operator {
+public class UnloadFileOperator extends Operator {
 
   private File file;
   private File targetDir;
 
-  public MoveFileOperator(File file, File targetDir) {
-    super(SQLConstant.TOK_MOVE_FILE);
+  public UnloadFileOperator(File file, File targetDir) {
+    super(SQLConstant.TOK_UNLOAD_FILE);
     this.file = file;
     this.targetDir = targetDir;
-    this.operatorType = OperatorType.MOVE_FILE;
+    this.operatorType = OperatorType.UNLOAD_FILE;
   }
 
   public File getFile() {
@@ -50,6 +50,6 @@ public class MoveFileOperator extends Operator {
   @Override
   public PhysicalPlan generatePhysicalPlan(PhysicalGenerator generator)
       throws QueryProcessException {
-    return new OperateFilePlan(file, targetDir, OperatorType.MOVE_FILE);
+    return new OperateFilePlan(file, targetDir, OperatorType.UNLOAD_FILE);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -79,7 +79,6 @@ import org.apache.iotdb.db.qp.logical.sys.LoadConfigurationOperator.LoadConfigur
 import org.apache.iotdb.db.qp.logical.sys.LoadDataOperator;
 import org.apache.iotdb.db.qp.logical.sys.LoadFilesOperator;
 import org.apache.iotdb.db.qp.logical.sys.MergeOperator;
-import org.apache.iotdb.db.qp.logical.sys.MoveFileOperator;
 import org.apache.iotdb.db.qp.logical.sys.RemoveFileOperator;
 import org.apache.iotdb.db.qp.logical.sys.SetStorageGroupOperator;
 import org.apache.iotdb.db.qp.logical.sys.SetSystemModeOperator;
@@ -100,6 +99,7 @@ import org.apache.iotdb.db.qp.logical.sys.StartTriggerOperator;
 import org.apache.iotdb.db.qp.logical.sys.StopTriggerOperator;
 import org.apache.iotdb.db.qp.logical.sys.TracingOperator;
 import org.apache.iotdb.db.qp.logical.sys.UnSetTTLOperator;
+import org.apache.iotdb.db.qp.logical.sys.UnloadFileOperator;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.AliasClauseContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.AlignByDeviceClauseOrDisableAlignContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.AlignByDeviceClauseOrDisableAlignStatementContext;
@@ -181,7 +181,6 @@ import org.apache.iotdb.db.qp.sql.SqlBaseParser.LoadStatementContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.MeasurementNameContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.MeasurementValueContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.MergeContext;
-import org.apache.iotdb.db.qp.sql.SqlBaseParser.MoveFileContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.NodeNameContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.NodeNameWithoutStarContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.OffsetClauseContext;
@@ -240,6 +239,7 @@ import org.apache.iotdb.db.qp.sql.SqlBaseParser.TracingOffContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.TracingOnContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.TriggerAttributeContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.TypeClauseContext;
+import org.apache.iotdb.db.qp.sql.SqlBaseParser.UnloadFileContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.UnsetTTLStatementContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.WhereClauseContext;
 import org.apache.iotdb.db.qp.sql.SqlBaseParser.WithoutNullClauseContext;
@@ -1021,8 +1021,8 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
   }
 
   @Override
-  public Operator visitMoveFile(MoveFileContext ctx) {
-    return new MoveFileOperator(
+  public Operator visitUnloadFile(UnloadFileContext ctx) {
+    return new UnloadFileOperator(
         new File(removeStringQuote(ctx.stringLiteral(0).getText())),
         new File(removeStringQuote(ctx.stringLiteral(1).getText())));
   }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
@@ -250,7 +250,7 @@ public class IoTDBLoadExternalTsfileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
 
       // move root.test
@@ -279,7 +279,7 @@ public class IoTDBLoadExternalTsfileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
 
       // load all tsfile in tmp dir
@@ -407,7 +407,7 @@ public class IoTDBLoadExternalTsfileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
       resources =
           new ArrayList<>(
@@ -416,7 +416,7 @@ public class IoTDBLoadExternalTsfileIT {
                   .getUnSequenceFileList());
       assertEquals(1, resources.size());
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
 
       // move root.test
@@ -431,7 +431,7 @@ public class IoTDBLoadExternalTsfileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
       resources =
           new ArrayList<>(
@@ -440,7 +440,7 @@ public class IoTDBLoadExternalTsfileIT {
                   .getUnSequenceFileList());
       assertEquals(2, resources.size());
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
 
       // load all tsfile in tmp dir
@@ -558,7 +558,7 @@ public class IoTDBLoadExternalTsfileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
 
       // move root.test
@@ -581,7 +581,7 @@ public class IoTDBLoadExternalTsfileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
 
       Set<String> expectedSet =
@@ -676,7 +676,7 @@ public class IoTDBLoadExternalTsfileIT {
       }
 
       for (TsFileResource resource : resources) {
-        statement.execute("move \"" + resource.getTsFilePath() + "\" \"" + vehicleTmpDir + "\"");
+        statement.execute("unload \"" + resource.getTsFilePath() + "\" \"" + vehicleTmpDir + "\"");
       }
 
       resources =
@@ -692,7 +692,7 @@ public class IoTDBLoadExternalTsfileIT {
       }
 
       for (TsFileResource resource : resources) {
-        statement.execute("move \"" + resource.getTsFilePath() + "\" \"" + testTmpDir + "\"");
+        statement.execute("unload \"" + resource.getTsFilePath() + "\" \"" + testTmpDir + "\"");
       }
 
       for (String sql : deleteSqls) {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
@@ -157,7 +157,7 @@ public class IoTDBLoadExternalTsfileIT {
   }
 
   @Test
-  public void moveTsfileTest() throws SQLException {
+  public void unloadTsfileTest() throws SQLException {
     try (Connection connection =
             DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
@@ -177,7 +177,7 @@ public class IoTDBLoadExternalTsfileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
       assertEquals(
           0,
@@ -203,7 +203,7 @@ public class IoTDBLoadExternalTsfileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("move \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
+        statement.execute(String.format("unload \"%s\" \"%s\"", resource.getTsFilePath(), tmpDir));
       }
       assertEquals(
           0,

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
@@ -1079,15 +1079,15 @@ public class PhysicalPlanTest {
   }
 
   @Test
-  public void testMoveFile() throws QueryProcessException {
+  public void testUnloadFile() throws QueryProcessException {
     String filePath = "data" + File.separator + "213213441243-1-2.tsfile";
     String targetDir = "user" + File.separator + "backup";
-    String metadata = String.format("move \"%s\" \"%s\"", filePath, targetDir);
+    String metadata = String.format("unload \"%s\" \"%s\"", filePath, targetDir);
     Planner processor = new Planner();
     OperateFilePlan plan = (OperateFilePlan) processor.parseSQLToPhysicalPlan(metadata);
     assertEquals(
         String.format(
-            "OperateFilePlan{file=%s, targetDir=%s, autoCreateSchema=false, sgLevel=0, verify=false, operatorType=MOVE_FILE}",
+            "OperateFilePlan{file=%s, targetDir=%s, autoCreateSchema=false, sgLevel=0, verify=false, operatorType=UNLOAD_FILE}",
             filePath, targetDir),
         plan.toString());
   }


### PR DESCRIPTION
MOVE command is confusing, it should move some TsFile to the target directory, but it also unloads the TsFile from IoTDB and the data moved cannot be searched any more. So, i think UNLOAD is more suitable than MOVE.