### PR TITLE
[IOTDB-1716] Remove `TEMPORARY` keyword from `CREATE FUNCTION` statement

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/SqlBase.g4
@@ -98,9 +98,9 @@ statement
     | MOVE stringLiteral stringLiteral #moveFile
     | DELETE PARTITION prefixPath INT(COMMA INT)* #deletePartition
     | CREATE SNAPSHOT FOR SCHEMA #createSnapshot
-    | CREATE TEMPORARY? FUNCTION udfName=ID AS className=stringLiteral #createFunction
+    | CREATE FUNCTION udfName=ID AS className=stringLiteral #createFunction
     | DROP FUNCTION udfName=ID #dropFunction
-    | SHOW TEMPORARY? FUNCTIONS #showFunctions
+    | SHOW FUNCTIONS #showFunctions
     | CREATE TRIGGER triggerName=ID triggerEventClause ON fullPath
       AS className=stringLiteral triggerAttributeClause? #createTrigger
     | DROP TRIGGER triggerName=ID #dropTrigger
@@ -1221,10 +1221,6 @@ VERIFY
 
 SGLEVEL
     : S G L E V E L
-    ;
-
-TEMPORARY
-    : T E M P O R A R Y
     ;
 
 FUNCTION

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -398,8 +398,7 @@ public class PlanExecutor implements IPlanExecutor {
   }
 
   private boolean operateCreateFunction(CreateFunctionPlan plan) throws UDFRegistrationException {
-    UDFRegistrationService.getInstance()
-        .register(plan.getUdfName(), plan.getClassName(), plan.isTemporary(), true);
+    UDFRegistrationService.getInstance().register(plan.getUdfName(), plan.getClassName(), true);
     return true;
   }
 
@@ -950,10 +949,6 @@ public class PlanExecutor implements IPlanExecutor {
       throws QueryProcessException {
     for (UDFRegistrationInformation info :
         UDFRegistrationService.getInstance().getRegistrationInformation()) {
-      if (showPlan.showTemporary() && !info.isTemporary()) {
-        continue;
-      }
-
       RowRecord rowRecord = new RowRecord(0); // ignore timestamp
       rowRecord.addField(Binary.valueOf(info.getFunctionName()), TSDataType.TEXT);
       String functionType = "";
@@ -1016,10 +1011,6 @@ public class PlanExecutor implements IPlanExecutor {
   }
 
   private void appendNativeFunctions(ListDataSet listDataSet, ShowFunctionsPlan showPlan) {
-    if (showPlan.showTemporary()) {
-      return;
-    }
-
     final Binary functionType = Binary.valueOf(FUNCTION_TYPE_NATIVE);
     final Binary className = Binary.valueOf("");
     for (String functionName : SQLConstant.getNativeFunctionNames()) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/CreateFunctionOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/CreateFunctionOperator.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.db.qp.strategy.PhysicalGenerator;
 
 public class CreateFunctionOperator extends Operator {
 
-  private boolean isTemporary;
   private String udfName;
   private String className;
 
@@ -36,20 +35,12 @@ public class CreateFunctionOperator extends Operator {
     operatorType = OperatorType.CREATE_FUNCTION;
   }
 
-  public void setTemporary(boolean temporary) {
-    isTemporary = temporary;
-  }
-
   public void setUdfName(String udfName) {
     this.udfName = udfName;
   }
 
   public void setClassName(String className) {
     this.className = className;
-  }
-
-  public boolean isTemporary() {
-    return isTemporary;
   }
 
   public String getUdfName() {
@@ -63,6 +54,6 @@ public class CreateFunctionOperator extends Operator {
   @Override
   public PhysicalPlan generatePhysicalPlan(PhysicalGenerator generator)
       throws QueryProcessException {
-    return new CreateFunctionPlan(isTemporary, udfName, className);
+    return new CreateFunctionPlan(udfName, className);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/ShowFunctionsOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/ShowFunctionsOperator.java
@@ -26,23 +26,13 @@ import org.apache.iotdb.db.qp.strategy.PhysicalGenerator;
 
 public class ShowFunctionsOperator extends ShowOperator {
 
-  private boolean showTemporary;
-
   public ShowFunctionsOperator(int tokenIntType) {
     super(tokenIntType);
-  }
-
-  public void setShowTemporary(boolean showTemporary) {
-    this.showTemporary = showTemporary;
-  }
-
-  public boolean showTemporary() {
-    return showTemporary;
   }
 
   @Override
   public PhysicalPlan generatePhysicalPlan(PhysicalGenerator generator)
       throws QueryProcessException {
-    return new ShowFunctionsPlan(showTemporary);
+    return new ShowFunctionsPlan();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateFunctionPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateFunctionPlan.java
@@ -32,7 +32,6 @@ import java.util.List;
 
 public class CreateFunctionPlan extends PhysicalPlan {
 
-  private boolean isTemporary;
   private String udfName;
   private String className;
 
@@ -40,15 +39,10 @@ public class CreateFunctionPlan extends PhysicalPlan {
     super(false, OperatorType.CREATE_FUNCTION);
   }
 
-  public CreateFunctionPlan(boolean isTemporary, String udfName, String className) {
+  public CreateFunctionPlan(String udfName, String className) {
     super(false, OperatorType.CREATE_FUNCTION);
-    this.isTemporary = isTemporary;
     this.udfName = udfName;
     this.className = className;
-  }
-
-  public boolean isTemporary() {
-    return isTemporary;
   }
 
   public String getUdfName() {
@@ -57,14 +51,6 @@ public class CreateFunctionPlan extends PhysicalPlan {
 
   public String getClassName() {
     return className;
-  }
-
-  public void setTemporary(boolean temporary) {
-    isTemporary = temporary;
-  }
-
-  public void setUdfName(String udfName) {
-    this.udfName = udfName;
   }
 
   public void setClassName(String className) {
@@ -80,7 +66,6 @@ public class CreateFunctionPlan extends PhysicalPlan {
   public void serialize(DataOutputStream outputStream) throws IOException {
     outputStream.writeByte((byte) PhysicalPlanType.CREATE_FUNCTION.ordinal());
 
-    outputStream.writeBoolean(isTemporary);
     putString(outputStream, udfName);
     putString(outputStream, className);
     outputStream.writeLong(index);
@@ -89,7 +74,6 @@ public class CreateFunctionPlan extends PhysicalPlan {
   @Override
   public void deserialize(ByteBuffer buffer) throws IllegalPathException {
 
-    isTemporary = buffer.get() == 1;
     udfName = readString(buffer);
     className = readString(buffer);
     this.index = buffer.getLong();

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowFunctionsPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowFunctionsPlan.java
@@ -21,14 +21,7 @@ package org.apache.iotdb.db.qp.physical.sys;
 
 public class ShowFunctionsPlan extends ShowPlan {
 
-  private final boolean showTemporary;
-
-  public ShowFunctionsPlan(boolean showTemporary) {
+  public ShowFunctionsPlan() {
     super(ShowContentType.FUNCTIONS);
-    this.showTemporary = showTemporary;
-  }
-
-  public boolean showTemporary() {
-    return showTemporary;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -476,7 +476,6 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
   public Operator visitCreateFunction(CreateFunctionContext ctx) {
     CreateFunctionOperator createFunctionOperator =
         new CreateFunctionOperator(SQLConstant.TOK_FUNCTION_CREATE);
-    createFunctionOperator.setTemporary(ctx.TEMPORARY() != null);
     createFunctionOperator.setUdfName(ctx.udfName.getText());
     createFunctionOperator.setClassName(removeStringQuote(ctx.className.getText()));
     return createFunctionOperator;
@@ -492,10 +491,7 @@ public class IoTDBSqlVisitor extends SqlBaseBaseVisitor<Operator> {
 
   @Override
   public Operator visitShowFunctions(ShowFunctionsContext ctx) {
-    ShowFunctionsOperator showFunctionsOperator =
-        new ShowFunctionsOperator(SQLConstant.TOK_SHOW_FUNCTIONS);
-    showFunctionsOperator.setShowTemporary(ctx.TEMPORARY() != null);
-    return showFunctionsOperator;
+    return new ShowFunctionsOperator(SQLConstant.TOK_SHOW_FUNCTIONS);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationInformation.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationInformation.java
@@ -27,20 +27,14 @@ public class UDFRegistrationInformation {
 
   private final String functionName;
   private final String className;
-  private final boolean isTemporary;
   private final boolean isBuiltin;
 
   private Class<?> functionClass;
 
   public UDFRegistrationInformation(
-      String functionName,
-      String className,
-      boolean isTemporary,
-      boolean isBuiltin,
-      Class<?> functionClass) {
+      String functionName, String className, boolean isBuiltin, Class<?> functionClass) {
     this.functionName = functionName;
     this.className = className;
-    this.isTemporary = isTemporary;
     this.isBuiltin = isBuiltin;
     this.functionClass = functionClass;
   }
@@ -51,11 +45,6 @@ public class UDFRegistrationInformation {
 
   public String getClassName() {
     return className;
-  }
-
-  /** For a builtin function, this method always returns false. */
-  public boolean isTemporary() {
-    return !isBuiltin && isTemporary;
   }
 
   public boolean isBuiltin() {

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/service/UDFRegistrationService.java
@@ -80,14 +80,13 @@ public class UDFRegistrationService implements IService {
     registrationLock.unlock();
   }
 
-  public void register(
-      String functionName, String className, boolean isTemporary, boolean writeToTemporaryLogFile)
+  public void register(String functionName, String className, boolean writeToTemporaryLogFile)
       throws UDFRegistrationException {
     functionName = functionName.toUpperCase();
     validateFunctionName(functionName, className);
-    checkIfRegistered(functionName, className, isTemporary);
-    doRegister(functionName, className, isTemporary);
-    tryAppendRegistrationLog(functionName, className, isTemporary, writeToTemporaryLogFile);
+    checkIfRegistered(functionName, className);
+    doRegister(functionName, className);
+    tryAppendRegistrationLog(functionName, className, writeToTemporaryLogFile);
   }
 
   private static void validateFunctionName(String functionName, String className)
@@ -105,7 +104,7 @@ public class UDFRegistrationService implements IService {
     throw new UDFRegistrationException(errorMessage);
   }
 
-  private void checkIfRegistered(String functionName, String className, boolean isTemporary)
+  private void checkIfRegistered(String functionName, String className)
       throws UDFRegistrationException {
     UDFRegistrationInformation information = registrationInformation.get(functionName);
     if (information == null) {
@@ -122,13 +121,8 @@ public class UDFRegistrationService implements IService {
       if (information.getClassName().equals(className)) {
         errorMessage =
             String.format(
-                "Failed to register %sTEMPORARY UDF %s(%s), because a %sTEMPORARY UDF %s(%s) with the same function name and the class name has already been registered.",
-                isTemporary ? "" : "non-",
-                functionName,
-                className,
-                information.isTemporary() ? "" : "non-",
-                information.getFunctionName(),
-                information.getClassName());
+                "Failed to register UDF %s(%s), because a UDF %s(%s) with the same function name and the class name has already been registered.",
+                functionName, className, information.getFunctionName(), information.getClassName());
       } else {
         errorMessage =
             String.format(
@@ -141,8 +135,7 @@ public class UDFRegistrationService implements IService {
     throw new UDFRegistrationException(errorMessage);
   }
 
-  private void doRegister(String functionName, String className, boolean isTemporary)
-      throws UDFRegistrationException {
+  private void doRegister(String functionName, String className) throws UDFRegistrationException {
     acquireRegistrationLock();
     try {
       UDFClassLoader currentActiveClassLoader =
@@ -153,8 +146,7 @@ public class UDFRegistrationService implements IService {
       functionClass.getDeclaredConstructor().newInstance();
       registrationInformation.put(
           functionName,
-          new UDFRegistrationInformation(
-              functionName, className, isTemporary, false, functionClass));
+          new UDFRegistrationInformation(functionName, className, false, functionClass));
     } catch (IOException
         | InstantiationException
         | InvocationTargetException
@@ -173,9 +165,9 @@ public class UDFRegistrationService implements IService {
   }
 
   private void tryAppendRegistrationLog(
-      String functionName, String className, boolean isTemporary, boolean writeToTemporaryLogFile)
+      String functionName, String className, boolean writeToTemporaryLogFile)
       throws UDFRegistrationException {
-    if (!writeToTemporaryLogFile || isTemporary) {
+    if (!writeToTemporaryLogFile) {
       return;
     }
 
@@ -217,17 +209,15 @@ public class UDFRegistrationService implements IService {
       throw new UDFRegistrationException(errorMessage);
     }
 
-    if (!information.isTemporary()) {
-      try {
-        appendDeregistrationLog(functionName);
-      } catch (IOException e) {
-        registrationInformation.put(functionName, information);
-        String errorMessage =
-            String.format(
-                "Failed to append UDF log when deregistering UDF %s, because %s", functionName, e);
-        logger.error(errorMessage);
-        throw new UDFRegistrationException(errorMessage, e);
-      }
+    try {
+      appendDeregistrationLog(functionName);
+    } catch (IOException e) {
+      registrationInformation.put(functionName, information);
+      String errorMessage =
+          String.format(
+              "Failed to append UDF log when deregistering UDF %s, because %s", functionName, e);
+      logger.error(errorMessage);
+      throw new UDFRegistrationException(errorMessage, e);
     }
   }
 
@@ -305,7 +295,6 @@ public class UDFRegistrationService implements IService {
           new UDFRegistrationInformation(
               functionName,
               builtinFunction.getClassName(),
-              false,
               true,
               builtinFunction.getFunctionClass()));
     }
@@ -354,7 +343,7 @@ public class UDFRegistrationService implements IService {
 
     for (Entry<String, String> udf : recoveredUDFs.entrySet()) {
       try {
-        register(udf.getKey(), udf.getValue(), false, false);
+        register(udf.getKey(), udf.getValue(), false);
       } catch (UDFRegistrationException ignored) {
         // ignored
       }
@@ -380,7 +369,7 @@ public class UDFRegistrationService implements IService {
   private void writeTemporaryLogFile() throws IOException {
     UDFLogWriter temporaryLogFile = new UDFLogWriter(TEMPORARY_LOG_FILE_NAME);
     for (UDFRegistrationInformation information : registrationInformation.values()) {
-      if (information.isBuiltin() || information.isTemporary()) {
+      if (information.isBuiltin()) {
         continue;
       }
       temporaryLogFile.register(information.getFunctionName(), information.getClassName());
@@ -404,8 +393,7 @@ public class UDFRegistrationService implements IService {
     Class<?> functionClass = Class.forName(className, true, classLoader);
     functionName = functionName.toUpperCase();
     registrationInformation.put(
-        functionName,
-        new UDFRegistrationInformation(functionName, className, false, true, functionClass));
+        functionName, new UDFRegistrationInformation(functionName, className, true, functionClass));
   }
 
   @TestOnly

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDFManagementIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBUDFManagementIT.java
@@ -101,15 +101,7 @@ public class IoTDBUDFManagementIT {
         ++count;
       }
       Assert.assertEquals(1 + BUILTIN_FUNCTIONS_COUNT, count);
-
-      resultSet = statement.executeQuery("show temporary functions");
-      count = 0;
-      while (resultSet.next()) {
-        ++count;
-      }
-      Assert.assertEquals(0, count);
-      assertEquals(3, resultSet.getMetaData().getColumnCount());
-
+      resultSet.close();
       statement.execute("drop function udf");
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
@@ -132,37 +124,9 @@ public class IoTDBUDFManagementIT {
       }
       Assert.assertEquals(1 + NATIVE_FUNCTIONS_COUNT + BUILTIN_FUNCTIONS_COUNT, count);
       assertEquals(3, resultSet.getMetaData().getColumnCount());
-
-      resultSet = statement.executeQuery("show temporary functions");
-      count = 0;
-      while (resultSet.next()) {
-        ++count;
-      }
-      Assert.assertEquals(0, count);
-      assertEquals(3, resultSet.getMetaData().getColumnCount());
-
+      resultSet.close();
       statement.execute("drop function udf");
-      statement.execute(
-          "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
-      statement.execute("select udf(*, *) from root.vehicle");
 
-      resultSet = statement.executeQuery("show functions");
-      count = 0;
-      while (resultSet.next()) {
-        ++count;
-      }
-      Assert.assertEquals(1 + NATIVE_FUNCTIONS_COUNT + BUILTIN_FUNCTIONS_COUNT, count);
-      assertEquals(3, resultSet.getMetaData().getColumnCount());
-
-      resultSet = statement.executeQuery("show temporary functions");
-      count = 0;
-      while (resultSet.next()) {
-        ++count;
-      }
-      Assert.assertEquals(1, count);
-      assertEquals(3, resultSet.getMetaData().getColumnCount());
-
-      statement.execute("drop function udf");
       statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
       statement.execute("select udf(*, *) from root.vehicle");
 
@@ -173,15 +137,7 @@ public class IoTDBUDFManagementIT {
       }
       Assert.assertEquals(1 + NATIVE_FUNCTIONS_COUNT + BUILTIN_FUNCTIONS_COUNT, count);
       assertEquals(3, resultSet.getMetaData().getColumnCount());
-
-      resultSet = statement.executeQuery("show temporary functions");
-      count = 0;
-      while (resultSet.next()) {
-        ++count;
-      }
-      Assert.assertEquals(0, count);
-      assertEquals(3, resultSet.getMetaData().getColumnCount());
-
+      resultSet.close();
       statement.execute("drop function udf");
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
@@ -265,48 +221,7 @@ public class IoTDBUDFManagementIT {
   }
 
   @Test
-  public void testCreateFunction2() throws SQLException { // create function twice
-    try (Connection connection =
-            DriverManager.getConnection(
-                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
-        Statement statement = connection.createStatement()) {
-      statement.execute(
-          "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
-
-      try {
-        statement.execute(
-            "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
-        fail();
-      } catch (SQLException throwable) {
-        assertTrue(throwable.getMessage().contains("Failed to register"));
-      }
-    }
-  }
-
-  @Test
   public void testCreateFunction3() throws SQLException { // create function twice
-    try (Connection connection =
-            DriverManager.getConnection(
-                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
-        Statement statement = connection.createStatement()) {
-      statement.execute(
-          "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
-
-      try {
-        statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
-        fail();
-      } catch (SQLException throwable) {
-        assertTrue(
-            throwable
-                .getMessage()
-                .contains(
-                    "with the same function name and the class name has already been registered"));
-      }
-    }
-  }
-
-  @Test
-  public void testCreateFunction4() throws SQLException { // create function twice
     try (Connection connection =
             DriverManager.getConnection(
                 Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
@@ -314,8 +229,7 @@ public class IoTDBUDFManagementIT {
       statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
 
       try {
-        statement.execute(
-            "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
+        statement.execute("create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
         fail();
       } catch (SQLException throwable) {
         assertTrue(
@@ -447,15 +361,7 @@ public class IoTDBUDFManagementIT {
         }
       }
       Assert.assertEquals(2 + BUILTIN_FUNCTIONS_COUNT, count);
-
-      resultSet = statement.executeQuery("show temporary functions");
-      count = 0;
-      while (resultSet.next()) {
-        ++count;
-      }
-      Assert.assertEquals(0, count);
-      assertEquals(3, resultSet.getMetaData().getColumnCount());
-
+      resultSet.close();
       statement.execute("drop function udf");
     } catch (SQLException throwable) {
       fail(throwable.getMessage());

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
@@ -513,7 +513,6 @@ public class PhysicalPlanTest {
       assertEquals("udf", createFunctionPlan.getUdfName());
       assertEquals(
           "org.apache.iotdb.db.query.udf.example.Adder", createFunctionPlan.getClassName());
-      assertFalse(createFunctionPlan.isTemporary());
     } catch (QueryProcessException e) {
       fail(e.toString());
     }
@@ -532,7 +531,6 @@ public class PhysicalPlanTest {
       assertEquals("udf", createFunctionPlan.getUdfName());
       assertEquals(
           "org.apache.iotdb.db.query.udf.example.Adder", createFunctionPlan.getClassName());
-      assertTrue(createFunctionPlan.isTemporary());
     } catch (QueryProcessException e) {
       fail(e.toString());
     }
@@ -546,11 +544,7 @@ public class PhysicalPlanTest {
               processor.parseSQLToPhysicalPlan(
                   "create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
       UDFRegistrationService.getInstance()
-          .register(
-              createFunctionPlan.getUdfName(),
-              createFunctionPlan.getClassName(),
-              createFunctionPlan.isTemporary(),
-              true);
+          .register(createFunctionPlan.getUdfName(), createFunctionPlan.getClassName(), true);
 
       String sqlStr =
           "select udf(d2.s1, d1.s1), udf(d1.s1, d2.s1), d1.s1, d2.s1, udf(d1.s1, d2.s1), udf(d2.s1, d1.s1), d1.s1, d2.s1 from root.vehicle";
@@ -592,11 +586,7 @@ public class PhysicalPlanTest {
               processor.parseSQLToPhysicalPlan(
                   "create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
       UDFRegistrationService.getInstance()
-          .register(
-              createFunctionPlan.getUdfName(),
-              createFunctionPlan.getClassName(),
-              createFunctionPlan.isTemporary(),
-              true);
+          .register(createFunctionPlan.getUdfName(), createFunctionPlan.getClassName(), true);
 
       String sqlStr =
           "select udf(d2.s1, d1.s1, \"addend\"=\"100\"), udf(d1.s1, d2.s1), d1.s1, d2.s1, udf(d2.s1, d1.s1) from root.vehicle";
@@ -641,11 +631,7 @@ public class PhysicalPlanTest {
               processor.parseSQLToPhysicalPlan(
                   "create function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
       UDFRegistrationService.getInstance()
-          .register(
-              createFunctionPlan.getUdfName(),
-              createFunctionPlan.getClassName(),
-              createFunctionPlan.isTemporary(),
-              true);
+          .register(createFunctionPlan.getUdfName(), createFunctionPlan.getClassName(), true);
 
       String sqlStr = "select *, udf(*, *), *, udf(*, *), * from root.vehicle";
       PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
@@ -519,24 +519,6 @@ public class PhysicalPlanTest {
   }
 
   @Test
-  public void testCreateFunctionPlan2() { // create temporary function
-    try {
-      PhysicalPlan plan =
-          processor.parseSQLToPhysicalPlan(
-              "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
-      if (plan.isQuery() || !(plan instanceof CreateFunctionPlan)) {
-        fail();
-      }
-      CreateFunctionPlan createFunctionPlan = (CreateFunctionPlan) plan;
-      assertEquals("udf", createFunctionPlan.getUdfName());
-      assertEquals(
-          "org.apache.iotdb.db.query.udf.example.Adder", createFunctionPlan.getClassName());
-    } catch (QueryProcessException e) {
-      fail(e.toString());
-    }
-  }
-
-  @Test
   public void testUDTFQuery1() {
     try {
       CreateFunctionPlan createFunctionPlan =

--- a/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
+++ b/testcontainer/src/test/java/org/apache/iotdb/db/sql/Cases.java
@@ -349,7 +349,7 @@ public abstract class Cases {
   }
 
   @Test
-  public void testCreateFunctionPlan1() {
+  public void testCreateFunctionPlan() {
     try {
       PhysicalPlan plan =
           processor.parseSQLToPhysicalPlan(
@@ -361,26 +361,6 @@ public abstract class Cases {
       Assert.assertEquals("udf", createFunctionPlan.getUdfName());
       Assert.assertEquals(
           "org.apache.iotdb.db.query.udf.example.Adder", createFunctionPlan.getClassName());
-      Assert.assertFalse(createFunctionPlan.isTemporary());
-    } catch (QueryProcessException e) {
-      Assert.fail(e.toString());
-    }
-  }
-
-  @Test
-  public void testCreateFunctionPlan2() { // create temporary function
-    try {
-      PhysicalPlan plan =
-          processor.parseSQLToPhysicalPlan(
-              "create temporary function udf as \"org.apache.iotdb.db.query.udf.example.Adder\"");
-      if (plan.isQuery() || !(plan instanceof CreateFunctionPlan)) {
-        Assert.fail();
-      }
-      CreateFunctionPlan createFunctionPlan = (CreateFunctionPlan) plan;
-      Assert.assertEquals("udf", createFunctionPlan.getUdfName());
-      Assert.assertEquals(
-          "org.apache.iotdb.db.query.udf.example.Adder", createFunctionPlan.getClassName());
-      Assert.assertTrue(createFunctionPlan.isTemporary());
     } catch (QueryProcessException e) {
       Assert.fail(e.toString());
     }


### PR DESCRIPTION
See JIRA https://issues.apache.org/jira/browse/IOTDB-1716. The **TEMPORARY** keyword will be removed.