### PR TITLE
[IOTDB-1718] correct the position of "chmod + cmake"

### DIFF
--- a/compile-tools/thrift/pom.xml
+++ b/compile-tools/thrift/pom.xml
@@ -54,25 +54,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.6.0</version>
-                        <executions>
-                            <execution>
-                                <id>make-cmake-executable</id>
-                                <phase>process-sources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <basedir>${cmake.root.dir}/bin</basedir>
-                                    <executable>${chmod.command}</executable>
-                                    <commandlineArgs>${chmod.command.para}</commandlineArgs>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>com.googlecode.maven-download-plugin</groupId>
                         <artifactId>download-maven-plugin</artifactId>
                         <version>1.3.0</version>
@@ -101,6 +82,25 @@
                                     <url>https://archive.apache.org/dist/thrift/${thrift.version}/thrift-${thrift.version}.tar.gz</url>
                                     <unpack>true</unpack>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
+                        <executions>
+                            <execution>
+                                <id>make-cmake-executable</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <basedir>${cmake.root.dir}/bin</basedir>
+                                    <executable>${chmod.command}</executable>
+                                    <commandlineArgs>${chmod.command.para}</commandlineArgs>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
[IOTDB-1718]  compile-tools/thrift/pom.xml, make-cmake-executable use wrong phase

compile-tools/thrift/pom.xml:62

```xml
<plugin>
<groupId>org.codehaus.mojo</groupId>
<artifactId>exec-maven-plugin</artifactId>
<version>1.6.0</version>
<executions>
<execution>
<id>make-cmake-executable</id>
<phase>process-sources</phase> //here, this phase is too late, becasue "cmake-generate" begin to run cmake file in <phase>generate-sources</phase>
<goals>
<goal>exec</goal>
</goals>
<configuration>
<basedir>${cmake.root.dir}/bin</basedir>
<executable>${chmod.command}</executable>
<commandlineArgs>${chmod.command.para}</commandlineArgs>
</configuration>
</execution>
</executions>
</plugin>
```

 "chmod +x cmake" should be run before running cmake.