### PR TITLE
[IOTDB-1719] client-cpp should firstly use thrift head files in thrif…

### DIFF
--- a/client-cpp/src/main/CMakeLists.txt
+++ b/client-cpp/src/main/CMakeLists.txt
@@ -24,6 +24,9 @@ SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y")
 SET(TOOLS_DIR "${CMAKE_SOURCE_DIR}/../../../../compile-tools")
 
+# Add Thrift include directory
+INCLUDE_DIRECTORIES(${TOOLS_DIR}/thrift/target/thrift-0.14.1/lib/cpp/src)
+
 FIND_PACKAGE(Boost REQUIRED)
 IF (DEFINED BOOST_INCLUDEDIR)
     include_directories(SYSTEM "${BOOST_INCLUDEDIR}")
@@ -37,8 +40,6 @@ ENDIF()
 
 # Add Boost include path for MacOS
 INCLUDE_DIRECTORIES(/usr/local/include)
-# Add Thrift include directory
-INCLUDE_DIRECTORIES(${TOOLS_DIR}/thrift/target/thrift-0.14.1/lib/cpp/src)
 
 # Add ./generated-sources-cpp as a Cmake subdirectory
 AUX_SOURCE_DIRECTORY(./generated-sources-cpp SESSION_SRCS)


### PR DESCRIPTION
https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-1719

client-cpp/src/main/CMakeLists.txt:39
```cmake
Add Boost include path for MacOS
INCLUDE_DIRECTORIES(/usr/local/include)
Add Thrift include directory
INCLUDE_DIRECTORIES(${TOOLS_DIR}/thrift/target/thrift-0.14.1/lib/cpp/src)
```

If local machine has installed other version's thrift,
this CMakeLists.txt will cause that compiling client-cpp use thrift head files in not compile-tools/thrift/target/thrift-0.14.1/lib/cpp/src/ but /usr/local/include.