### PR TITLE
[IOTDB-1721] client-cpp-example pom.xml copy useless client-cpp-xxx.zip

### DIFF
--- a/example/client-cpp-example/pom.xml
+++ b/example/client-cpp-example/pom.xml
@@ -111,10 +111,6 @@
                                             <sourceFile>${project.basedir}/src/CMakeLists.txt</sourceFile>
                                             <destinationFile>${project.build.directory}/CMakeLists.txt</destinationFile>
                                         </fileSet>
-                                        <fileSet>
-                                            <sourceFile>${project.parent.basedir}/../client-cpp/target/client-cpp-${project.version}-cpp-${os.classifier}.zip</sourceFile>
-                                            <destinationFile>${project.build.directory}/client-cpp-${project.version}-cpp-${os.classifier}.zip</destinationFile>
-                                        </fileSet>
                                     </fileSets>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
example/client-cpp-example/pom.xml:114
below codes are useless, so should remove them.

 `<fileSet>
<sourceFile>${project.parent.basedir}/../client-cpp/target/client-cpp-${project.version}cpp${os.classifier}.zip</sourceFile>
<destinationFile>${project.build.directory}/client-cpp-${project.version}cpp${os.classifier}.zip</destinationFile>
</fileSet>`

