### PR TITLE
[IOTDB-1578] Set unsequnce when loading TsFile with the same establish time

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
@@ -459,18 +459,25 @@ public class IoTDBLoadExternalTsfileIT {
               .getUnSequenceFileList()
               .size());
       if (config.getTimeIndexLevel().equals(TimeIndexLevel.DEVICE_TIME_INDEX)) {
-        assertEquals(
-            1,
-            StorageEngine.getInstance()
+        if (StorageEngine.getInstance()
                 .getProcessor(new PartialPath("root.test"))
                 .getUnSequenceFileList()
-                .size());
-        assertEquals(
-            3,
-            StorageEngine.getInstance()
-                .getProcessor(new PartialPath("root.test"))
-                .getSequenceFileTreeSet()
-                .size());
+                .size()
+            == 1) {
+          assertEquals(
+              3,
+              StorageEngine.getInstance()
+                  .getProcessor(new PartialPath("root.test"))
+                  .getSequenceFileTreeSet()
+                  .size());
+        } else {
+          assertEquals(
+              2,
+              StorageEngine.getInstance()
+                  .getProcessor(new PartialPath("root.test"))
+                  .getSequenceFileTreeSet()
+                  .size());
+        }
       } else if (config.getTimeIndexLevel().equals(TimeIndexLevel.FILE_TIME_INDEX)) {
         assertEquals(
             2,


### PR DESCRIPTION
change rule for loading tsfile with the same establish time

e.g.
we want to load a tsfile in sequence list,
the previous tsfile has file name "a-b-c-d", the subsequence tsfile has file name "e-f-g-h".
and a(establish time of this file) is equal to e.

before:
we throw a exception with message "can not load TsFile because of can not find suitable location",
and stop loading process

now:
we load this file in unsequence folder.

and this update also solve the problem of "IoTDBLoadExternalTsfileIT.loadUnsequenceTsfileTest", it will be located in unsequence folder

cherry pick from #3983 