### PR TITLE
[IOTDB-1651]Fix sync error between different os

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,7 @@
 * [IOTDB-1275] Fix backgroup exec for cli -e function causes an infinite loop
 * [IOTDB-1287] Fix C++ class Session has 2 useless sort()
 * [IOTDB-1289] fix CPP mem-leak in SessionExample.cpp insertRecords()
+* [IOTDB-1484] fix auto create schema in cluster
 * [IOTDB-1578] Set unsequnce when loading TsFile with the same establish time
 * [IOTDB-1619] Fix an error msg when restart iotdb-cluster
 * [IOTDB-1629] fix the NPE when using value fill in cluster mode

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
@@ -550,9 +550,9 @@ public class SyncClient implements ISyncClient {
     logger.info("Start to sync names of deleted files in storage group {}", sgName);
     for (File file : deletedFilesName) {
       try {
-        if (serviceClient.syncDeletedFileName(getFileNameWithSG(file)).code == SUCCESS_CODE) {
+        if (serviceClient.syncDeletedFileName(getFileInfoWithVgAndTimePartition(file)).code == SUCCESS_CODE) {
           logger.info(
-              "Receiver has received deleted file name {} successfully.", getFileNameWithSG(file));
+              "Receiver has received deleted file name {} successfully.", file.getPath());
           lastLocalFilesMap.get(sgName).get(vgId).get(timeRangeId).remove(file);
           syncLog.finishSyncDeletedFileName(file);
         }
@@ -623,7 +623,7 @@ public class SyncClient implements ISyncClient {
     try {
       int retryCount = 0;
       MessageDigest md = MessageDigest.getInstance(SyncConstant.MESSAGE_DIGIT_NAME);
-      serviceClient.initSyncData(getFileNameWithSG(snapshotFile));
+      serviceClient.initSyncData(getFileInfoWithVgAndTimePartition(snapshotFile));
       outer:
       while (true) {
         retryCount++;
@@ -745,13 +745,11 @@ public class SyncClient implements ISyncClient {
     SyncClient.config = config;
   }
 
-  private String getFileNameWithSG(File file) {
-    return file.getParentFile().getParentFile().getParentFile().getName()
-        + File.separator
-        + file.getParentFile().getParentFile().getName()
-        + File.separator
+  private String getFileInfoWithVgAndTimePartition(File file) {
+    return file.getParentFile().getParentFile().getName()
+        + SyncConstant.SYNC_DIR_NAME_SEPARATOR
         + file.getParentFile().getName()
-        + File.separator
+        + SyncConstant.SYNC_DIR_NAME_SEPARATOR
         + file.getName();
   }
 }


### PR DESCRIPTION
origin from discussion#4001(https://github.com/apache/iotdb/discussions/4001)

if we want to sync one computer with windows os data to another computer with unix os,
the sync process will stop, and a error is thrown like this:

-receiver/10.20.12.142_0583441c495b416d95c9945631bc3eff/data/root.industry.w9/root.industry.w9\0\0\1631930688647-1-0-0.tsfile, type=ADD}
java.io.IOException: Can not load new tsfile /data/local/iotdb-server/./sbin/../data/data/sync-receiver/10.20.12.142_0583441c495b416d95c9945631bc3eff/data/root.industry.w9/root.industry.w9\0\0\1631930688647-1-0-0.tsfile
at org.apache.iotdb.db.sync.receiver.load.FileLoader.loadNewTsfile(FileLoader.java:148)
at org.apache.iotdb.db.sync.receiver.load.FileLoader.handleLoadTask(FileLoader.java:120)
at org.apache.iotdb.db.sync.receiver.load.FileLoader.lambda$new$0(FileLoader.java:87)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.iotdb.db.exception.StorageEngineException: org.apache.iotdb.db.exception.metadata.IllegalPathException: 10.20.12.142_0583441c495b416d95c9945631bc3eff is not a legal path
at org.apache.iotdb.db.engine.StorageEngine.getProcessorDirectly(StorageEngine.java:391)
at org.apache.iotdb.db.engine.StorageEngine.loadNewTsFileForSync(StorageEngine.java:820)
at org.apache.iotdb.db.sync.receiver.load.FileLoader.loadNewTsfile(FileLoader.java:143)
... 7 common frames omitted
Caused by: org.apache.iotdb.db.exception.metadata.IllegalPathException: 10.20.12.142_0583441c495b416d95c9945631bc3eff is not a legal path
at org.apache.iotdb.db.metadata.MTree.getStorageGroupNodeByPath(MTree.java:560)
at org.apache.iotdb.db.metadata.MManager.getStorageGroupNodeByPath(MManager.java:1055)
at org.apache.iotdb.db.engine.StorageEngine.getProcessorDirectly(StorageEngine.java:387)
... 9 common frames omitted
2021-09-18 10:09:03,790 [pool-9-IoTDB-Load-TsFile-1] INFO o.a.i.d.s.r.l.FileLoader:177 - Sync loading process for 10.20.12.142_0583441c495b416d95c9945631bc3eff has finished.

the reason is:
- file path was generated by sender
- file path was send to receiver
- because of File.seperator is different between windows and unix, the file path was recognized to a file name
- file path can not be set correct in receiver

solution is:
- reprogramming the transfer string
- receiver will rebuild the file path by transfer string