### PR TITLE
[IOTDB-1736] Error code is not printed in TSServiceImpl's log

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -2208,14 +2208,11 @@ public class TSServiceImpl implements TSIService.Iface {
 
   private TSStatus onNPEOrUnexpectedException(
       Exception e, String operation, TSStatusCode statusCode) {
-    String message =
-        String.format("[%s] Exception occurred: %s failed. ", statusCode.name(), operation);
+    String message = String.format("[%s] Exception occurred: %s failed. ", statusCode, operation);
     if (e instanceof NullPointerException) {
-      LOGGER.error("Status code: {}, MSG: {}", statusCode, message, e);
-    } else if (e instanceof UnSupportedDataTypeException) {
-      LOGGER.warn("Status code: {}, MSG: {}", statusCode, e.getMessage());
+      LOGGER.error("Status code: {}, operation: {} failed", statusCode, operation, e);
     } else {
-      LOGGER.warn("Status code: {}, MSG: {}", statusCode, message, e);
+      LOGGER.warn("Status code: {}, operation: {} failed", statusCode, operation, e);
     }
     return RpcUtils.getStatus(statusCode, message + e.getMessage());
   }
@@ -2226,16 +2223,12 @@ public class TSServiceImpl implements TSIService.Iface {
   }
 
   private TSStatus onIoTDBException(Exception e, String operation, int errorCode) {
-    String errorName = "IOTDBException";
-    for (TSStatusCode value : TSStatusCode.values()) {
-      if (value.getStatusCode() == errorCode) {
-        errorName = value.name();
-        break;
-      }
-    }
-    String message = String.format("[%s] Exception occurred: %s failed. ", errorName, operation);
-    LOGGER.warn("Status code: {}, MSG: {}", errorName, message, e);
-    return RpcUtils.getStatus(errorCode, message + e.getMessage());
+    TSStatusCode statusCode = TSStatusCode.representOf(errorCode);
+    String message =
+        String.format(
+            "[%s] Exception occurred: %s failed. %s", statusCode, operation, e.getMessage());
+    LOGGER.warn("Status code: {}, operation: {} failed", statusCode, operation, e);
+    return RpcUtils.getStatus(errorCode, message);
   }
 
   private TSStatus onIoTDBException(Exception e, OperationType operation, int errorCode) {

--- a/server/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationSmallDataIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationSmallDataIT.java
@@ -230,7 +230,7 @@ public class IoTDBAggregationSmallDataIT {
             e.toString()
                 .contains(
                     String.format(
-                        "500: [INTERNAL_SERVER_ERROR] Exception occurred: "
+                        "500: [INTERNAL_SERVER_ERROR(500)] Exception occurred: "
                             + "\"SELECT max_value(d0.s0),max_value(d1.s1),max_value(d0.s3) "
                             + "FROM root.vehicle\". %s failed. Binary statistics does not support: max",
                         OperationType.EXECUTE_STATEMENT.getName())));
@@ -276,7 +276,7 @@ public class IoTDBAggregationSmallDataIT {
             e.toString()
                 .contains(
                     String.format(
-                        "500: [INTERNAL_SERVER_ERROR] Exception occurred: "
+                        "500: [INTERNAL_SERVER_ERROR(500)] Exception occurred: "
                             + "\"SELECT extreme(d0.s0),extreme(d1.s1),extreme(d0.s3) "
                             + "FROM root.vehicle\". %s failed. Binary statistics does not support: max",
                         OperationType.EXECUTE_STATEMENT.getName())));

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TSStatusCode.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TSStatusCode.java
@@ -19,6 +19,9 @@
 
 package org.apache.iotdb.rpc;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum TSStatusCode {
   SUCCESS_STATUS(200),
   STILL_EXECUTING_STATUS(201),
@@ -97,11 +100,28 @@ public enum TSStatusCode {
 
   private int statusCode;
 
+  private static final Map<Integer, TSStatusCode> CODE_MAP = new HashMap<>();
+
+  static {
+    for (TSStatusCode value : TSStatusCode.values()) {
+      CODE_MAP.put(value.getStatusCode(), value);
+    }
+  }
+
   TSStatusCode(int statusCode) {
     this.statusCode = statusCode;
   }
 
   public int getStatusCode() {
     return statusCode;
+  }
+
+  public static TSStatusCode representOf(int statusCode) {
+    return CODE_MAP.get(statusCode);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s(%d)", name(), getStatusCode());
   }
 }

--- a/service-rpc/src/test/java/org/apache/iotdb/rpc/TSStatusCodeTest.java
+++ b/service-rpc/src/test/java/org/apache/iotdb/rpc/TSStatusCodeTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.rpc;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TSStatusCodeTest {
+
+  @Test
+  public void testToString() {
+    Assert.assertEquals("SUCCESS_STATUS(200)", TSStatusCode.SUCCESS_STATUS.toString());
+  }
+}


### PR DESCRIPTION
## Description
related Jira link: https://issues.apache.org/jira/browse/IOTDB-1736

After modified, the log looks like below:
```java
WARN  [2021-09-27 00:01:43,591] [pool-8-IoTDB-RPC-Client-2] org.apache.iotdb.db.service.TSServiceImpl:2216 - Status code: INTERNAL_SERVER_ERROR(500), operation: "SELECT max_value(d0.s0),max_value(d1.s1),max_value(d0.s3) FROM root.vehicle". executeStatement failed
org.apache.iotdb.tsfile.exception.filter.StatisticsClassException: Binary statistics does not support: max
	at org.apache.iotdb.tsfile.file.metadata.statistics.BinaryStatistics.getMaxValue(BinaryStatistics.java:88)
	at org.apache.iotdb.tsfile.file.metadata.statistics.BinaryStatistics.getMaxValue(BinaryStatistics.java:33)
	at org.apache.iotdb.db.query.aggregation.impl.MaxValueAggrResult.updateResultFromStatistics(MaxValueAggrResult.java:47)
	at org.apache.iotdb.db.query.executor.AggregationExecutor.aggregateStatistics(AggregationExecutor.java:284)
	at org.apache.iotdb.db.query.executor.AggregationExecutor.aggregateFromReader(AggregationExecutor.java:240)
	at org.apache.iotdb.db.query.executor.AggregationExecutor.aggregateOneSeries(AggregationExecutor.java:210)
	at org.apache.iotdb.db.query.executor.AggregationExecutor.aggregateOneSeries(AggregationExecutor.java:157)
	at org.apache.iotdb.db.query.executor.AggregationExecutor.executeWithoutValueFilter(AggregationExecutor.java:111)
	at org.apache.iotdb.db.query.executor.QueryRouter.aggregate(QueryRouter.java:150)
	at org.apache.iotdb.db.qp.executor.PlanExecutor.processDataQuery(PlanExecutor.java:569)
	at org.apache.iotdb.db.qp.executor.PlanExecutor.processQuery(PlanExecutor.java:237)
	at org.apache.iotdb.db.service.TSServiceImpl.createQueryDataSet(TSServiceImpl.java:1210)
	at org.apache.iotdb.db.service.TSServiceImpl.internalExecuteQueryStatement(TSServiceImpl.java:777)
	at org.apache.iotdb.db.service.TSServiceImpl.executeStatement(TSServiceImpl.java:603)
	at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$executeStatement.getResult(TSIService.java:2493)
	at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$executeStatement.getResult(TSIService.java:2473)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```


