### PR TITLE
Fix template doc display

### DIFF
--- a/site/src/main/.vuepress/config.js
+++ b/site/src/main/.vuepress/config.js
@@ -666,6 +666,7 @@ var config = {
 						title: 'Data Concept',
 						children: [
 							['Data-Concept/Data-Model-and-Terminology','Data Model and Terminology'],
+							['Data-Concept/Measurement-Template','Measurement Template'],
 							['Data-Concept/Data-Type','Data Type'],
 							['Data-Concept/Encoding','Encoding'],
 							['Data-Concept/Compression','Compression'],
@@ -1461,6 +1462,7 @@ var config = {
 						title: '数据模式与概念',
 						children: [
 							['Data-Concept/Data-Model-and-Terminology','数据模型'],
+							['Data-Concept/Measurement-Template','物理量模板'],
 							['Data-Concept/Data-Type','数据类型'],
 							['Data-Concept/Encoding','编码方式'],
 							['Data-Concept/Compression','压缩方式'],


### PR DESCRIPTION
## Description
Measurement-Template Doc has not been added to config.js which results in that it won't be presented in our official website.
Fix this by update config.js.