### PR TITLE
fix usage of removeNode

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/ClusterMain.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/ClusterMain.java
@@ -220,7 +220,7 @@ public class ClusterMain {
 
   private static void doRemoveNode(String[] args) throws IOException {
     if (args.length != 3) {
-      logger.error("Usage: -r <ip> <metaPort>");
+      logger.error("Usage: <ip> <metaPort>");
       return;
     }
     String ip = args[1];


### PR DESCRIPTION
The parameter of '-r' is already in _removeNode.sh_ 

![image](https://user-images.githubusercontent.com/44458757/135408519-8e538cf3-dc3d-48e6-a331-86d2b7f8d985.png)

