### PR TITLE
[To rel/0.12][IOTDB-1785] Fix Illegal String ending with . being parsed to PartialPath

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MetaUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MetaUtils.java
@@ -56,6 +56,9 @@ public class MetaUtils {
         }
         nodes.add(node);
         startIndex = i + 1;
+        if (startIndex == path.length()) {
+          throw new IllegalPathException(path);
+        }
       } else if (path.charAt(i) == '"') {
         int endIndex = path.indexOf('"', i + 1);
         // if a double quotes with escape character

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MetaUtilsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MetaUtilsTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
 
 public class MetaUtilsTest {
 
@@ -62,20 +63,31 @@ public class MetaUtilsTest {
 
     try {
       MetaUtils.splitPathToDetachedPath("root.sg.\"d.1\"\"s.1\"");
+      fail();
     } catch (IllegalPathException e) {
       Assert.assertEquals("root.sg.\"d.1\"\"s.1\" is not a legal path", e.getMessage());
     }
 
     try {
       MetaUtils.splitPathToDetachedPath("root..a");
+      fail();
     } catch (IllegalPathException e) {
       Assert.assertEquals("root..a is not a legal path", e.getMessage());
     }
 
     try {
       MetaUtils.splitPathToDetachedPath("root.sg.d1.'s1'");
+      fail();
     } catch (IllegalPathException e) {
       Assert.assertEquals("root.sg.d1.'s1' is not a legal path", e.getMessage());
+    }
+
+    try {
+      String[] nodes = MetaUtils.splitPathToDetachedPath("root.sg.d1.");
+      System.out.println(nodes[nodes.length - 1]);
+      fail();
+    } catch (IllegalPathException e) {
+      Assert.assertEquals("root.sg.d1. is not a legal path", e.getMessage());
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MetaUtilsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MetaUtilsTest.java
@@ -83,8 +83,7 @@ public class MetaUtilsTest {
     }
 
     try {
-      String[] nodes = MetaUtils.splitPathToDetachedPath("root.sg.d1.");
-      System.out.println(nodes[nodes.length - 1]);
+      MetaUtils.splitPathToDetachedPath("root.sg.d1.");
       fail();
     } catch (IllegalPathException e) {
       Assert.assertEquals("root.sg.d1. is not a legal path", e.getMessage());


### PR DESCRIPTION
## Description
When parsing strings, like root.sg.d. , to partialPath, an illegalPathException should be thrown rather than parse it to {"root", "sg", "d"}.