### PR TITLE
[IOTDB-1428] Ask query threads to quit if query is timeout

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -59,7 +59,7 @@ public class IoTDBStatement implements Statement {
 
   /**
    * Timeout of query can be set by users. Unit: s If not set, default value 0 will be used, which
-   * will use server configuration.
+   * will disable the function of query timeout.
    */
   private int queryTimeout;
 

--- a/server/src/main/java/org/apache/iotdb/db/query/control/QueryTimeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/QueryTimeManager.java
@@ -19,8 +19,6 @@
 package org.apache.iotdb.db.query.control;
 
 import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
-import org.apache.iotdb.db.conf.IoTDBConfig;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.query.QueryTimeoutRuntimeException;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowQueryProcesslistPlan;
@@ -44,7 +42,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class QueryTimeManager implements IService {
 
   private static final Logger logger = LoggerFactory.getLogger(QueryTimeManager.class);
-  private final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
   /**
    * the key of queryInfoMap is the query id and the value of queryInfoMap is the start time, the

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
@@ -70,7 +70,9 @@ public class RawQueryDataSetWithoutValueFilter extends QueryDataSet
     public void runMayThrow() {
       try {
         // check the status of mainThread before next reading
-        QueryTimeManager.checkQueryAlive(queryId);
+        if (!QueryTimeManager.checkQueryAlive(queryId)) {
+          return;
+        }
 
         synchronized (reader) {
           // if the task is submitted, there must be free space in the queue

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -81,8 +81,8 @@ public class Session {
   protected int fetchSize;
   private static final byte TYPE_NULL = -2;
   /**
-   * Timeout of query can be set by users. If not set, default value 0 will be used, which will use
-   * server configuration.
+   * Timeout of query can be set by users. If not set, default value 0 will be used, which will
+   * disable the function of query timeout.
    */
   private long queryTimeoutInMs = 0;
 


### PR DESCRIPTION
I modified the `checkQueryAlive()` method to bring a return value.

In this way, sub thread will **still get just one batchData instead of filling the blocking queue**. However, there will still be some cost. If you have a better idea, welcome to discussion :D

