### PR TITLE
[IOTDB-1793] Support insert Tablet with null value in python client

### DIFF
--- a/client-py/SessionExample.py
+++ b/client-py/SessionExample.py
@@ -141,6 +141,19 @@ tablet_02 = Tablet(
 )
 session.insert_tablets([tablet_01, tablet_02])
 
+# insert one tablet with empty cell into the database.
+values_ = [
+    [None, 10, 11, 1.1, 10011.1, "test01"],
+    [True, None, 11111, 1.25, 101.0, "test02"],
+    [False, 100, 1, None, 688.25, "test03"],
+    [True, 0, 0, 0, 6.25, None],
+]  # Non-ASCII text will cause error since bytes can only hold 0-128 nums.
+timestamps_ = [16, 17, 18, 19]
+tablet_ = Tablet(
+    "root.sg_test_01.d_01", measurements_, data_types_, values_, timestamps_
+)
+session.insert_tablet(tablet_)
+
 # insert records of one device
 time_list = [1, 2, 3]
 measurements_list = [

--- a/client-py/SessionExample.py
+++ b/client-py/SessionExample.py
@@ -141,7 +141,7 @@ tablet_02 = Tablet(
 )
 session.insert_tablets([tablet_01, tablet_02])
 
-# insert one tablet with empty cell into the database.
+# insert one tablet with empty cells into the database.
 values_ = [
     [None, 10, 11, 1.1, 10011.1, "test01"],
     [True, None, 11111, 1.25, 101.0, "test02"],

--- a/client-py/SessionTest.py
+++ b/client-py/SessionTest.py
@@ -178,6 +178,20 @@ tablet_02 = Tablet(
 if session.insert_tablets([tablet_01, tablet_02]) < 0:
     test_fail("insert tablets failed")
 
+# insert one tablet with empty cells into the database.
+values_ = [
+    [None, 10, 11, 1.1, 10011.1, "test01"],
+    [True, None, 11111, 1.25, 101.0, "test02"],
+    [False, 100, 1, None, 688.25, "test03"],
+    [True, 0, 0, 0, None, None],
+]  # Non-ASCII text will cause error since bytes can only hold 0-128 nums.
+timestamps_ = [16, 17, 18, 19]
+tablet_ = Tablet(
+    "root.sg_test_01.d_01", measurements_, data_types_, values_, timestamps_
+)
+if session.insert_tablet(tablet_) < 0:
+    test_fail("insert tablet failed")
+
 # insert records of one device
 time_list = [1, 2, 3]
 measurements_list = [

--- a/client-py/iotdb/Session.py
+++ b/client-py/iotdb/Session.py
@@ -599,7 +599,7 @@ class Session(object):
             self.__session_id,
             tablet.get_device_id(),
             tablet.get_measurements(),
-            tablet.get_binary_values(),
+            tablet.get_binary_values,
             tablet.get_binary_timestamps(),
             data_type_values,
             tablet.get_row_number(),
@@ -618,7 +618,7 @@ class Session(object):
             ]
             device_id_lst.append(tablet.get_device_id())
             measurements_lst.append(tablet.get_measurements())
-            values_lst.append(tablet.get_binary_values())
+            values_lst.append(tablet.get_binary_values)
             timestamps_lst.append(tablet.get_binary_timestamps())
             type_lst.append(data_type_values)
             size_lst.append(tablet.get_row_number())

--- a/client-py/iotdb/Session.py
+++ b/client-py/iotdb/Session.py
@@ -459,7 +459,7 @@ class Session(object):
                          1,  125.3,  True,  text1
                          2,  111.6, False,  text2
                          3,  688.6,  True,  text3
-        Notice: The tablet should not have empty cell
+        Notice: From 0.13.0, the tablet can contain empty cell
                 The tablet itself is sorted (see docs of Tablet.py)
         :param tablet: a tablet specified above
         """
@@ -599,7 +599,7 @@ class Session(object):
             self.__session_id,
             tablet.get_device_id(),
             tablet.get_measurements(),
-            tablet.get_binary_values,
+            tablet.get_binary_values(),
             tablet.get_binary_timestamps(),
             data_type_values,
             tablet.get_row_number(),
@@ -618,7 +618,7 @@ class Session(object):
             ]
             device_id_lst.append(tablet.get_device_id())
             measurements_lst.append(tablet.get_measurements())
-            values_lst.append(tablet.get_binary_values)
+            values_lst.append(tablet.get_binary_values())
             timestamps_lst.append(tablet.get_binary_timestamps())
             type_lst.append(data_type_values)
             size_lst.append(tablet.get_row_number())

--- a/client-py/iotdb/utils/BitMap.py
+++ b/client-py/iotdb/utils/BitMap.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+class BitMap(object):
+    BIT_UTIL = [1, 1 << 1, 1 << 2, 1 << 3, 1 << 4, 1 << 5, 1 << 6, 1 << 7]
+
+    def __init__(self, size):
+        self.__size = size
+        self.__bits = []
+        for i in range (size // 8 + 1):
+            self.__bits.append(0)
+
+    def mark(self, position):
+        self.__bits[position // 8] |= BitMap.BIT_UTIL[position % 8]
+
+    def bits(self):
+        return self.__bits
+

--- a/client-py/iotdb/utils/Tablet.py
+++ b/client-py/iotdb/utils/Tablet.py
@@ -92,16 +92,13 @@ class Tablet(object):
         else:
             return self.__timestamps.tobytes()
 
-    @property
     def get_binary_values(self):
         if not self.__use_new:
             format_str_list = [">"]
             values_tobe_packed = []
-            column_has_none = []
             bitmaps = []
             for i in range(self.__column_number):
                 bitmap = None
-                column_has_none.insert(i, False)
                 bitmaps.insert(i, bitmap)
                 if self.__data_types[i] == TSDataType.BOOLEAN:
                     format_str_list.append(str(self.__row_number))
@@ -111,7 +108,6 @@ class Tablet(object):
                             values_tobe_packed.append(self.__values[j][i])
                         else:
                             values_tobe_packed.append(False)
-                            column_has_none.insert(i, True)
                             if bitmap is None:
                                 bitmap = BitMap(self.__row_number)
                                 bitmaps.insert(i, bitmap)
@@ -125,7 +121,6 @@ class Tablet(object):
                             values_tobe_packed.append(self.__values[j][i])
                         else:
                             values_tobe_packed.append(0)
-                            column_has_none.insert(i, True)
                             if bitmap is None:
                                 bitmap = BitMap(self.__row_number)
                                 bitmaps.insert(i, bitmap)
@@ -139,7 +134,6 @@ class Tablet(object):
                             values_tobe_packed.append(self.__values[j][i])
                         else:
                             values_tobe_packed.append(0)
-                            column_has_none.insert(i, True)
                             if bitmap is None:
                                 bitmap = BitMap(self.__row_number)
                                 bitmaps.insert(i, bitmap)
@@ -153,7 +147,6 @@ class Tablet(object):
                             values_tobe_packed.append(self.__values[j][i])
                         else:
                             values_tobe_packed.append(0)
-                            column_has_none.insert(i, True)
                             if bitmap is None:
                                 bitmap = BitMap(self.__row_number)
                                 bitmaps.insert(i, bitmap)
@@ -167,7 +160,6 @@ class Tablet(object):
                             values_tobe_packed.append(self.__values[j][i])
                         else:
                             values_tobe_packed.append(0)
-                            column_has_none.insert(i, True)
                             if bitmap is None:
                                 bitmap = BitMap(self.__row_number)
                                 bitmaps.insert(i, bitmap)
@@ -189,7 +181,6 @@ class Tablet(object):
                             format_str_list.append("s")
                             values_tobe_packed.append(len(value_bytes))
                             values_tobe_packed.append(value_bytes)
-                            column_has_none.insert(i, True)
                             if bitmap is None:
                                 bitmap = BitMap(self.__row_number)
                                 bitmaps.insert(i, bitmap)
@@ -198,11 +189,10 @@ class Tablet(object):
                 else:
                     raise RuntimeError("Unsupported data type:" + str(self.__data_types[i]))
 
-            if len(column_has_none) != 0:
+            if len(bitmaps) != 0:
                 for i in range(self.__column_number):
-                    format_str_list.append(str(1))
                     format_str_list.append("?")
-                    if not column_has_none[i]:
+                    if bitmaps[i] is None:
                         values_tobe_packed.append(False)
                     else:
                         values_tobe_packed.append(True)

--- a/client-py/iotdb/utils/Tablet.py
+++ b/client-py/iotdb/utils/Tablet.py
@@ -201,8 +201,6 @@ class Tablet(object):
                         for j in range(self.__row_number // 8 + 1):
                             values_tobe_packed.append(bytes([bitmaps[i].bits()[j]]))
             format_str = "".join(format_str_list)
-            print(format_str)
-            print(values_tobe_packed)
             return struct.pack(format_str, *values_tobe_packed)
         else:
             bs_len = 0


### PR DESCRIPTION
## Description
IOTDB-1793
Currently, java session API can support insert nullable Tablet to IoTDB server. It's time to implement this feature in python client. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
