### PR TITLE
 [To rel/0.12][IOTDB-1651]add reconnect to solve out of sequence

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
@@ -224,7 +224,7 @@ public class SyncClient implements ISyncClient {
             syncAll();
           } catch (Exception e) {
             logger.error("Sync failed", e);
-          } finally{
+          } finally {
             if (transport != null && transport.isOpen()) {
               transport.close();
             }
@@ -404,7 +404,7 @@ public class SyncClient implements ISyncClient {
                 "Can not sync schema after %s retries.", config.getMaxNumOfSyncFileRetry()));
       }
       if (!isSyncConnect && !reconnect()) {
-        retryCount ++;
+        retryCount++;
         continue;
       }
       if (tryToSyncSchema()) {
@@ -445,7 +445,9 @@ public class SyncClient implements ISyncClient {
       // check digest
       return checkDigestForSchema(new BigInteger(1, md.digest()).toString(16));
     } catch (TException e) {
-      logger.error("Can not finish transfer schema to receiver, thrift error happen {}, try to reconnect", e);
+      logger.error(
+          "Can not finish transfer schema to receiver, thrift error happen {}, try to reconnect",
+          e);
       isSyncConnect = false;
       return false;
     } catch (NoSuchAlgorithmException | IOException e) {


### PR DESCRIPTION
Sometimes sync process throws "Read time out" or some other exceptions because of unstable connection, and then thrift will throw a  "out of sequence".

solution:
  when a TException is thrown, make a new client connect to the receiver.