### PR TITLE
Fix Bug In Cases.testAutoCreateSchemaInClusterMode

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanRouter.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanRouter.java
@@ -353,14 +353,17 @@ public class ClusterPlanRouter {
       long[] subTimes = new long[count];
       int destLoc = 0;
       Object[] values = initTabletValues(plan.getDataTypes().length, count, plan.getDataTypes());
-      BitMap[] bitMaps = initBitmaps(plan.getDataTypes().length, count);
+      BitMap[] bitMaps =
+          plan.getBitMaps() == null ? null : initBitmaps(plan.getDataTypes().length, count);
       for (int i = 0; i < locs.size(); i += 2) {
         int start = locs.get(i);
         int end = locs.get(i + 1);
         System.arraycopy(plan.getTimes(), start, subTimes, destLoc, end - start);
         for (int k = 0; k < values.length; k++) {
           System.arraycopy(plan.getColumns()[k], start, values[k], destLoc, end - start);
-          BitMap.copyOfRange(plan.getBitMaps()[k], start, bitMaps[k], destLoc, end - start);
+          if (bitMaps != null && plan.getBitMaps()[k] != null) {
+            BitMap.copyOfRange(plan.getBitMaps()[k], start, bitMaps[k], destLoc, end - start);
+          }
         }
         destLoc += end - start;
       }


### PR DESCRIPTION
![bug](https://user-images.githubusercontent.com/43991780/136758605-7300bb86-dc4a-4c8b-865b-27cc4bfa5f10.jpg)

This bug is caused by the bitmap in Tablet is null, so i check whether bitmap is null before splitting Tablet.