### PR TITLE
[To rel/0.12][IOTDB-1837] Fix tagIndex rebuild failure after upgrade mlog from mlog.txt to mlog.bin

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogWriter.java
@@ -220,10 +220,7 @@ public class MLogWriter implements AutoCloseable {
 
       try (MLogWriter mLogWriter = new MLogWriter(schemaDir, newFileName + ".tmp");
           MLogTxtReader mLogTxtReader = new MLogTxtReader(schemaDir, oldFileName);
-          TagLogFile tagLogFile =
-              new TagLogFile(
-                  IoTDBDescriptor.getInstance().getConfig().getSchemaDir(),
-                  MetadataConstant.TAG_LOG)) {
+          TagLogFile tagLogFile = new TagLogFile(schemaDir, MetadataConstant.TAG_LOG)) {
         // upgrade from old character log file to new binary mlog
         while (mLogTxtReader.hasNext()) {
           String cmd = mLogTxtReader.next();


### PR DESCRIPTION
## Description
When upgrade mlog from mlog.txt to mlog.bin, the data of tags and attributes are not read to the mlog.bin which results tagIndex rebuild failure. Thus add tagFile read operation while upgrade mlog.
