### PR TITLE
Revert "Bump testcontainers from 1.15.2 to 1.16.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.16.0</version>
+            <version>1.15.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Reverts apache/iotdb#4136.

It has led to the failure of all e2E tests.