### PR TITLE
[IOTDB-1741] Fix double close in CompactionUtils

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/CompactionUtils.java
@@ -260,8 +260,9 @@ public class CompactionUtils {
       List<Modification> modifications)
       throws IOException, IllegalPathException {
     Map<String, TsFileSequenceReader> tsFileSequenceReaderMap = new HashMap<>();
+    RestorableTsFileIOWriter writer = null;
     try {
-      RestorableTsFileIOWriter writer = new RestorableTsFileIOWriter(targetResource.getTsFile());
+      writer = new RestorableTsFileIOWriter(targetResource.getTsFile());
       Map<String, List<Modification>> modificationCache = new HashMap<>();
       RateLimiter compactionWriteRateLimiter =
           MergeManager.getINSTANCE().getMergeWriteRateLimiter();
@@ -431,6 +432,9 @@ public class CompactionUtils {
     } finally {
       for (TsFileSequenceReader reader : tsFileSequenceReaderMap.values()) {
         reader.close();
+      }
+      if (writer != null && writer.canWrite()) {
+        writer.close();
       }
     }
   }


### PR DESCRIPTION
# Description
During level compaction, the write stream of target file sometimes is closed unexpectedly.The error log is shown below.
![image](https://user-images.githubusercontent.com/37140360/137891370-94d5154e-2173-41de-8f6f-98f74781f775.png)

# Analysis
By consulting related information, we know that when an OuputStream is closed and then written, there will be a Stream Closed exception. We troubleshoot the problem based on this idea. But in the process of level compaction execution, tasks are executed in a single thread in a static function (as shown in the figure).
![1](https://user-images.githubusercontent.com/37140360/137891407-0ee4a8dc-c826-451b-ae23-afff07c00a8e.png)

 Moreover, the Writer of each target file is declared in a function, so this Writer and its corresponding Stream are local variables which cannot be accessed outside this function. 
![image](https://user-images.githubusercontent.com/37140360/137891571-87039520-3430-456e-85d3-f05b6c9d7743.png)

In the end of compaction, the Writer's endFile function wll be called, in which Writer.close will be called once, and all the contents in the Writer buffer will be written to the file at this time. After calling endFile, the close function of Writer was manually called again. Theoretically, the second close does not produce any exceptions, because the buffer has been emptied and the Writer will not write anything to the file. But because we can't find other reasons, we can only attribute the cause of this exception to the two calls of the close function for the time being.