### PR TITLE
[IOTDB-1846]Optimize when count the total number of devices in cluster mode

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncClientAdaptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncClientAdaptor.java
@@ -370,6 +370,16 @@ public class SyncClientAdaptor {
     return handler.getResult(RaftServer.getReadOperationTimeoutMS());
   }
 
+  public static Integer getDeviceCount(
+      AsyncDataClient client, RaftNode header, List<String> pathsToQuery)
+      throws InterruptedException, TException {
+    AtomicReference<Integer> remoteResult = new AtomicReference<>(null);
+    GenericHandler<Integer> handler = new GenericHandler<>(client.getNode(), remoteResult);
+
+    client.getDeviceCount(header, pathsToQuery, handler);
+    return handler.getResult(RaftServer.getReadOperationTimeoutMS());
+  }
+
   public static Set<String> getAllDevices(
       AsyncDataClient client, RaftNode header, List<String> pathsToQuery)
       throws InterruptedException, TException {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
@@ -223,8 +223,7 @@ public class ClusterPlanExecutor extends PlanExecutor {
                   .getAsyncDataClient(node, RaftServer.getReadOperationTimeoutMS());
           client.setTimeout(RaftServer.getReadOperationTimeoutMS());
           count =
-              SyncClientAdaptor.getAllDevices(client, partitionGroup.getHeader(), pathsToCount)
-                  .size();
+              SyncClientAdaptor.getDeviceCount(client, partitionGroup.getHeader(), pathsToCount);
         } else {
           try (SyncDataClient syncDataClient =
               metaGroupMember
@@ -232,7 +231,7 @@ public class ClusterPlanExecutor extends PlanExecutor {
                   .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
             try {
               syncDataClient.setTimeout(RaftServer.getReadOperationTimeoutMS());
-              count = syncDataClient.getAllDevices(partitionGroup.getHeader(), pathsToCount).size();
+              count = syncDataClient.getDeviceCount(partitionGroup.getHeader(), pathsToCount);
             } catch (TException e) {
               // the connection may be broken, close it to avoid it being reused
               syncDataClient.getInputProtocol().getTransport().close();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
@@ -1014,6 +1014,17 @@ public class LocalQueryExecutor {
     return count;
   }
 
+  public int getDeviceCount(List<String> pathsToQuery)
+      throws CheckConsistencyException, MetadataException {
+    dataGroupMember.syncLeaderWithConsistencyCheck(false);
+
+    int count = 0;
+    for (String s : pathsToQuery) {
+      count += getCMManager().getDevicesNum(new PartialPath(s));
+    }
+    return count;
+  }
+
   @SuppressWarnings("java:S1135") // ignore todos
   public ByteBuffer last(LastQueryRequest request)
       throws CheckConsistencyException, QueryProcessException, IOException, StorageEngineException,

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/DataClusterServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/DataClusterServer.java
@@ -867,6 +867,16 @@ public class DataClusterServer extends RaftServer
   }
 
   @Override
+  public void getDeviceCount(
+      RaftNode header, List<String> pathsToQuery, AsyncMethodCallback<Integer> resultHandler)
+      throws TException {
+    DataAsyncService service = getDataAsyncService(header, resultHandler, "count device");
+    if (service != null) {
+      service.getDeviceCount(header, pathsToQuery, resultHandler);
+    }
+  }
+
+  @Override
   public void onSnapshotApplied(
       RaftNode header, List<Integer> slots, AsyncMethodCallback<Boolean> resultHandler) {
     DataAsyncService service = getDataAsyncService(header, resultHandler, "Snapshot applied");
@@ -999,6 +1009,11 @@ public class DataClusterServer extends RaftServer
   @Override
   public int getPathCount(RaftNode header, List<String> pathsToQuery, int level) throws TException {
     return getDataSyncService(header).getPathCount(header, pathsToQuery, level);
+  }
+
+  @Override
+  public int getDeviceCount(RaftNode header, List<String> pathsToQuery) throws TException {
+    return getDataSyncService(header).getDeviceCount(header, pathsToQuery);
   }
 
   @Override

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/service/DataAsyncService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/service/DataAsyncService.java
@@ -458,6 +458,18 @@ public class DataAsyncService extends BaseAsyncService implements TSDataService.
   }
 
   @Override
+  public void getDeviceCount(
+      RaftNode header, List<String> pathsToQuery, AsyncMethodCallback<Integer> resultHandler)
+      throws TException {
+    try {
+      resultHandler.onComplete(
+          dataGroupMember.getLocalQueryExecutor().getDeviceCount(pathsToQuery));
+    } catch (CheckConsistencyException | MetadataException e) {
+      resultHandler.onError(e);
+    }
+  }
+
+  @Override
   public void onSnapshotApplied(
       RaftNode header, List<Integer> slots, AsyncMethodCallback<Boolean> resultHandler) {
     resultHandler.onComplete(dataGroupMember.onSnapshotInstalled(slots));

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/service/DataSyncService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/service/DataSyncService.java
@@ -423,6 +423,15 @@ public class DataSyncService extends BaseSyncService implements TSDataService.If
   }
 
   @Override
+  public int getDeviceCount(RaftNode header, List<String> pathsToQuery) throws TException {
+    try {
+      return dataGroupMember.getLocalQueryExecutor().getDeviceCount(pathsToQuery);
+    } catch (CheckConsistencyException | MetadataException e) {
+      throw new TException(e);
+    }
+  }
+
+  @Override
   public boolean onSnapshotApplied(RaftNode header, List<Integer> slots) {
     return dataGroupMember.onSnapshotInstalled(slots);
   }

--- a/thrift-cluster/src/main/thrift/cluster.thrift
+++ b/thrift-cluster/src/main/thrift/cluster.thrift
@@ -463,6 +463,8 @@ service TSDataService extends RaftService {
 
   int getPathCount(1: RaftNode header, 2: list<string> pathsToQuery, 3: int level)
 
+  int getDeviceCount(1: RaftNode header, 2: list<string> pathsToQuery)
+
   /**
   * During slot transfer, when a member has pulled snapshot from a group, the member will use this
   * method to inform the group that one replica of such slots has been pulled.


### PR DESCRIPTION
The details of this problem: https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-1846?filter=allissues.

I optimize the count of devices.

The devices:

![1](https://user-images.githubusercontent.com/46039728/137913028-12b55336-6d74-45c4-8a32-a5869952bdb8.png)

The query:

![2](https://user-images.githubusercontent.com/46039728/137913141-b009b9ce-0b2c-4495-a648-cbd6d2625f84.png)

![3](https://user-images.githubusercontent.com/46039728/137913151-ae2d9b46-13cb-42c4-9c6a-9f3bed107148.png)

![4](https://user-images.githubusercontent.com/46039728/137913166-470d0ed9-0418-48e5-99c8-38052ba892c5.png)

