### PR TITLE
[IOTDB-1805][to rel/0.12]iotdb-grafana-dockerfile

### DIFF
--- a/docker/ReadMe.md
+++ b/docker/ReadMe.md
@@ -66,4 +66,11 @@ docker exec -it c82321c70137 /bin/bash
 
 Then, for the latest version (or, >=0.10.x), run `start-cli.sh`, for version 0.9.x and 0.8.1, run `start-client.sh`.
 
+# How to run IoTDB-grafana-connector
+
+```
+docker run -it -v /D/your_application.properties_folder:/iotdb-grafana/config -p 8888:8888 apache/iotdb:<version>-grafana
+```
+
+
 Enjoy it!

--- a/docker/src/main/Dockerfile-0.12.2-grafana
+++ b/docker/src/main/Dockerfile-0.12.2-grafana
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.2/apache-iotdb-0.12.2-grafana-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.2/apache-iotdb-0.12.2-grafana-bin.zip \
+  && unzip apache-iotdb-0.12.2-grafana-bin.zip \
+  && rm apache-iotdb-0.12.2-grafana-bin.zip \
+  && mv apache-iotdb-0.12.2-grafana-bin /iotdb-grafana \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y
+# rpc port
+EXPOSE 8888
+VOLUME /iotdb-grafana/config
+RUN echo "#!/bin/bash" > /iotdb-grafana/runboot.sh
+RUN echo "java -Djava.security.egd=file:/dev/./urandom -jar /iotdb-grafana/iotdb-grafana.war" >> /iotdb-grafana/runboot.sh
+RUN chmod a+x /iotdb-grafana/runboot.sh
+WORKDIR /iotdb-grafana
+ENTRYPOINT ["./runboot.sh"]

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDriver.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDriver.java
@@ -64,7 +64,8 @@ public class IoTDBDriver implements Driver {
     } catch (TTransportException e) {
       throw new SQLException(
           "Connection Error, please check whether the network is available or the server"
-              + " has started.");
+              + " has started: "
+              + url);
     }
   }
 


### PR DESCRIPTION
how to use: 
`docker run -it --rm -v /your_application.properties_folder:/iotdb-grafana/config -p 8888:8888 apache/iotdb:<version>-grafana

can cherry-pick to master directly.