### PR TITLE
[IOTDB-1651]add reconnect to solve out of sequence

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
@@ -95,7 +95,7 @@ public class SyncClient implements ISyncClient {
 
   private static final IoTDBConfig ioTDBConfig = IoTDBDescriptor.getInstance().getConfig();
 
-  private static final int TIMEOUT_MS = 1000;
+  private static final int TIMEOUT_MS = 2000;
 
   /**
    * When transferring schema information, it is a better choice to transfer only new schema
@@ -126,6 +126,8 @@ public class SyncClient implements ISyncClient {
 
   /** Record sync progress in log. */
   private ISyncSenderLogger syncLog;
+
+  private boolean isSyncConnect = false;
 
   private ISyncFileManager syncFileManager = SyncFileManager.getInstance();
 
@@ -233,6 +235,11 @@ public class SyncClient implements ISyncClient {
             syncAll();
           } catch (Exception e) {
             logger.error("Sync failed", e);
+          } finally {
+            if (transport != null && transport.isOpen()) {
+              transport.close();
+            }
+            isSyncConnect = false;
           }
         },
         SyncConstant.SYNC_PROCESS_DELAY,
@@ -322,10 +329,26 @@ public class SyncClient implements ISyncClient {
       if (!transport.isOpen()) {
         transport.open();
       }
+
+      isSyncConnect = true;
     } catch (TTransportException e) {
       logger.error("Cannot connect to the receiver.");
       throw new SyncConnectionException(e);
     }
+  }
+
+  private boolean reconnect() {
+    if (transport != null && transport.isOpen()) {
+      transport.close();
+    }
+
+    try {
+      establishConnection(config.getServerIp(), config.getServerPort());
+    } catch (SyncConnectionException e) {
+      logger.warn("Can not reconnect to receiver {}. Caused by ", config.getSyncReceiverName(), e);
+      return false;
+    }
+    return true;
   }
 
   @Override
@@ -401,6 +424,10 @@ public class SyncClient implements ISyncClient {
             String.format(
                 "Can not sync schema after %s retries.", config.getMaxNumOfSyncFileRetry()));
       }
+      if (!isSyncConnect && !reconnect()) {
+        retryCount++;
+        continue;
+      }
       if (tryToSyncSchema()) {
         writeSyncSchemaPos(getSchemaPosFile());
         break;
@@ -438,7 +465,13 @@ public class SyncClient implements ISyncClient {
 
       // check digest
       return checkDigestForSchema(new BigInteger(1, md.digest()).toString(16));
-    } catch (NoSuchAlgorithmException | IOException | TException e) {
+    } catch (TException e) {
+      logger.error(
+          "Can not finish transfer schema to receiver, thrift error happen {}, try to reconnect",
+          e);
+      isSyncConnect = false;
+      return false;
+    } catch (NoSuchAlgorithmException | IOException e) {
       logger.error("Can not finish transfer schema to receiver", e);
       return false;
     }
@@ -571,6 +604,9 @@ public class SyncClient implements ISyncClient {
     logger.info("Start to sync names of deleted files in storage group {}", sgName);
     for (File file : deletedFilesName) {
       try {
+        if (!isSyncConnect && !reconnect()) {
+          continue;
+        }
         if (serviceClient.syncDeletedFileName(getFileNameWithSG(file)).code == SUCCESS_CODE) {
           logger.info(
               "Receiver has received deleted file name {} successfully.", getFileNameWithSG(file));
@@ -579,6 +615,7 @@ public class SyncClient implements ISyncClient {
         }
       } catch (TException e) {
         logger.error("Can not sync deleted file name {}, skip it.", file);
+        isSyncConnect = false;
       }
     }
     logger.info("Finish to sync names of deleted files in storage group {}", sgName);


### PR DESCRIPTION
Sometimes sync process throws "Read time out" or some other exceptions because of unstable connection, and then thrift will throw a "out of sequence".

solution:
when a TException is thrown, make a new client connect to the receiver.

cherry pick from #4087 