### PR TITLE
[IOTDB-1609] Print the actual size of plan when it exceeds the wal_buffer_size

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -163,7 +163,7 @@ public abstract class PhysicalPlan {
       DataOutputStream dataOutputStream = new DataOutputStream(new EmptyOutputStream());
       serialize(dataOutputStream);
       return dataOutputStream.size();
-    }catch (UnsupportedOperationException e){
+    } catch (UnsupportedOperationException e) {
       throw e;
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -68,6 +68,7 @@ import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
 import org.apache.iotdb.db.qp.physical.sys.StartTriggerPlan;
 import org.apache.iotdb.db.qp.physical.sys.StopTriggerPlan;
 import org.apache.iotdb.db.qp.physical.sys.StorageGroupMNodePlan;
+import org.apache.iotdb.db.qp.utils.EmptyOutputStream;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataOutputStream;
@@ -149,6 +150,22 @@ public abstract class PhysicalPlan {
 
   public void setDebug(boolean debug) {
     this.debug = debug;
+  }
+
+  /**
+   * Calculate size after serialization.
+   *
+   * @return size
+   * @throws IOException
+   */
+  public int getSerializedSize() throws IOException {
+    try {
+      DataOutputStream dataOutputStream = new DataOutputStream(new EmptyOutputStream());
+      serialize(dataOutputStream);
+      return dataOutputStream.size();
+    }catch (UnsupportedOperationException e){
+      throw e;
+    }
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/qp/utils/EmptyOutputStream.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/utils/EmptyOutputStream.java
@@ -21,20 +21,14 @@ package org.apache.iotdb.db.qp.utils;
 import java.io.IOException;
 import java.io.OutputStream;
 
-/**
- * Empty OutputStream
- * To count serialize size without serialization
- */
+/** Empty OutputStream To count serialize size without serialization */
 public class EmptyOutputStream extends OutputStream {
 
-    @Override
-    public void write(int b) throws IOException {
-    }
+  @Override
+  public void write(int b) throws IOException {}
 
-    @Override
-    public void write(byte b[], int off, int len) throws IOException {
-    }
+  @Override
+  public void write(byte b[], int off, int len) throws IOException {}
 
-    public void write(byte b[]) throws IOException {
-    }
+  public void write(byte b[]) throws IOException {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/utils/EmptyOutputStream.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/utils/EmptyOutputStream.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.qp.utils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Empty OutputStream
+ * To count serialize size without serialization
+ */
+public class EmptyOutputStream extends OutputStream {
+
+    @Override
+    public void write(int b) throws IOException {
+    }
+
+    @Override
+    public void write(byte b[], int off, int len) throws IOException {
+    }
+
+    public void write(byte b[]) throws IOException {
+    }
+}

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -33,9 +33,7 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
+import java.io.*;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -115,8 +113,12 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
     } catch (BufferOverflowException e) {
       // if the size of a single plan bigger than logBufferWorking
       // we need to clear the buffer to drop something wrong that has written.
+      DataOutputStream dos = new DataOutputStream(new ByteArrayOutputStream());
+      plan.serialize(dos);
+      int neededSize = dos.size();
+      dos.close();
       logBufferWorking.clear();
-      throw new IOException("Log cannot fit into the buffer, please increase wal_buffer_size", e);
+      throw new IOException("Log cannot fit into the buffer, please increase wal_buffer_size to more than "+neededSize*2, e);
     } finally {
       lock.unlock();
     }

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -113,11 +113,8 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
     } catch (BufferOverflowException e) {
       // if the size of a single plan bigger than logBufferWorking
       // we need to clear the buffer to drop something wrong that has written.
-      DataOutputStream dos = new DataOutputStream(new ByteArrayOutputStream());
-      plan.serialize(dos);
-      int neededSize = dos.size();
-      dos.close();
       logBufferWorking.clear();
+      int neededSize = plan.getSerializedSize();
       throw new IOException(
           "Log cannot fit into the buffer, please increase wal_buffer_size to more than "
               + neededSize * 2,

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -118,7 +118,10 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
       int neededSize = dos.size();
       dos.close();
       logBufferWorking.clear();
-      throw new IOException("Log cannot fit into the buffer, please increase wal_buffer_size to more than "+neededSize*2, e);
+      throw new IOException(
+          "Log cannot fit into the buffer, please increase wal_buffer_size to more than "
+              + neededSize * 2,
+          e);
     } finally {
       lock.unlock();
     }

--- a/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
@@ -317,8 +317,8 @@ public class WriteLogNodeTest {
     } catch (IOException e) {
       caught = true;
       Pattern r = Pattern.compile("\\d+");
-      Matcher m =  r.matcher(e.getMessage());
-      if(m.find()){
+      Matcher m = r.matcher(e.getMessage());
+      if (m.find()) {
         neededSize = Integer.valueOf(m.group());
       }
     }
@@ -355,16 +355,15 @@ public class WriteLogNodeTest {
       MmapUtil.clean((MappedByteBuffer) byteBuffer);
     }
 
-
     // try to set wal_buffer_size according to error message
     IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(neededSize);
     WriteLogNode logNode2 = new ExclusiveWriteLogNode("root.logTestDevice.oversize");
     logNode2.initBuffer(byteBuffers);
     ByteBuffer[] byteBuffers2 = new ByteBuffer[2];
     byteBuffers2[0] =
-            ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
+        ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
     byteBuffers2[1] =
-            ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
+        ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
     logNode2.initBuffer(byteBuffers2);
     caught = false;
     try {
@@ -378,16 +377,15 @@ public class WriteLogNodeTest {
       MmapUtil.clean((MappedByteBuffer) byteBuffer);
     }
 
-
     // try to set wal_buffer_size less than error message
-    IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(neededSize-1);
+    IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(neededSize - 1);
     WriteLogNode logNode3 = new ExclusiveWriteLogNode("root.logTestDevice.oversize");
     logNode3.initBuffer(byteBuffers);
     ByteBuffer[] byteBuffers3 = new ByteBuffer[2];
     byteBuffers3[0] =
-            ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
+        ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
     byteBuffers3[1] =
-            ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
+        ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
     logNode3.initBuffer(byteBuffers3);
     caught = false;
     try {
@@ -400,7 +398,5 @@ public class WriteLogNodeTest {
     for (ByteBuffer byteBuffer : array) {
       MmapUtil.clean((MappedByteBuffer) byteBuffer);
     }
-
-
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
@@ -43,6 +43,8 @@ import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
@@ -298,6 +300,7 @@ public class WriteLogNodeTest {
     WriteLogNode logNode = new ExclusiveWriteLogNode("root.logTestDevice.oversize");
     logNode.initBuffer(byteBuffers);
 
+    int neededSize = 0;
     InsertRowPlan bwInsertPlan =
         new InsertRowPlan(
             new PartialPath("root.logTestDevice.oversize"),
@@ -313,6 +316,11 @@ public class WriteLogNodeTest {
       logNode.write(bwInsertPlan);
     } catch (IOException e) {
       caught = true;
+      Pattern r = Pattern.compile("\\d+");
+      Matcher m =  r.matcher(e.getMessage());
+      if(m.find()){
+        neededSize = Integer.valueOf(m.group());
+      }
     }
     assertTrue(caught);
 
@@ -346,5 +354,53 @@ public class WriteLogNodeTest {
     for (ByteBuffer byteBuffer : array) {
       MmapUtil.clean((MappedByteBuffer) byteBuffer);
     }
+
+
+    // try to set wal_buffer_size according to error message
+    IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(neededSize);
+    WriteLogNode logNode2 = new ExclusiveWriteLogNode("root.logTestDevice.oversize");
+    logNode2.initBuffer(byteBuffers);
+    ByteBuffer[] byteBuffers2 = new ByteBuffer[2];
+    byteBuffers2[0] =
+            ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
+    byteBuffers2[1] =
+            ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
+    logNode2.initBuffer(byteBuffers2);
+    caught = false;
+    try {
+      logNode2.write(bwInsertPlan);
+    } catch (IOException e) {
+      caught = true;
+    }
+    assertFalse(caught);
+    array = logNode2.delete();
+    for (ByteBuffer byteBuffer : array) {
+      MmapUtil.clean((MappedByteBuffer) byteBuffer);
+    }
+
+
+    // try to set wal_buffer_size less than error message
+    IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(neededSize-1);
+    WriteLogNode logNode3 = new ExclusiveWriteLogNode("root.logTestDevice.oversize");
+    logNode3.initBuffer(byteBuffers);
+    ByteBuffer[] byteBuffers3 = new ByteBuffer[2];
+    byteBuffers3[0] =
+            ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
+    byteBuffers3[1] =
+            ByteBuffer.allocateDirect(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
+    logNode3.initBuffer(byteBuffers3);
+    caught = false;
+    try {
+      logNode3.write(bwInsertPlan);
+    } catch (IOException e) {
+      caught = true;
+    }
+    assertTrue(caught);
+    array = logNode3.delete();
+    for (ByteBuffer byteBuffer : array) {
+      MmapUtil.clean((MappedByteBuffer) byteBuffer);
+    }
+
+
   }
 }


### PR DESCRIPTION
## Contributions:
* Print the actual size of plan when it exceeds the wal_buffer_size
  * Use `PhysicalPlan.serialize(DataOutputStream stream)`  to get actual size of plan after serialization. 
  * Print infomation in IOException message
* Add some test in `testOverSizedWAL` to verify the actual size of plan
  * If wal_buffer_size is less than actual size, it would throw IOException.
  * If wal_buffer_size is more than or equal to actual size, it would not throw IOException.