### PR TITLE
[IOTDB-1877] Fix Sync recovery and reconnection bugs in both sender and receiver

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1260,6 +1260,20 @@ public class IoTDBConfig {
     this.languageVersion = languageVersion;
   }
 
+  public String getIoTDBVersion() {
+    return IoTDBConstant.VERSION;
+  }
+
+  public String getIoTDBMajorVersion() {
+    return IoTDBConstant.MAJOR_VERSION;
+  }
+
+  public String getIoTDBMajorVersion(String version) {
+    return version.equals("UNKNOWN")
+        ? "UNKNOWN"
+        : version.split("\\.")[0] + "." + version.split("\\.")[1];
+  }
+
   public String getIpWhiteList() {
     return ipWhiteList;
   }

--- a/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
@@ -20,7 +20,6 @@ package org.apache.iotdb.db.sync.receiver.transfer;
 
 import org.apache.iotdb.db.concurrent.ThreadName;
 import org.apache.iotdb.db.conf.IoTDBConfig;
-import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
@@ -78,11 +77,11 @@ public class SyncServiceImpl implements SyncService.Iface {
   public SyncStatus check(ConfirmInfo info) {
     String ipAddress = info.address, uuid = info.uuid;
     Thread.currentThread().setName(ThreadName.SYNC_SERVER.getName());
-    if (!getMajorVersion(info.version).equals(IoTDBConstant.MAJOR_VERSION)) {
+    if (!config.getIoTDBMajorVersion(info.version).equals(config.getIoTDBMajorVersion())) {
       return getErrorResult(
           String.format(
               "Version mismatch: the sender <%s>, the receiver <%s>",
-              info.version, IoTDBConstant.MAJOR_VERSION));
+              info.version, config.getIoTDBVersion()));
     }
     if (info.partitionInterval
         != IoTDBDescriptor.getInstance().getConfig().getPartitionInterval()) {
@@ -104,12 +103,6 @@ public class SyncServiceImpl implements SyncService.Iface {
       return getErrorResult(
           "Sender IP is not in the white list of receiver IP and synchronization tasks are not allowed.");
     }
-  }
-
-  private String getMajorVersion(String version) {
-    return version.equals("UNKNOWN")
-        ? "UNKNOWN"
-        : version.split("\\.")[0] + "." + version.split("\\.")[1];
   }
 
   private boolean checkRecovery() {
@@ -173,6 +166,7 @@ public class SyncServiceImpl implements SyncService.Iface {
   public SyncStatus syncDeletedFileName(String fileInfo) {
     String filePath = currentSG.get() + File.separator + getFilePathByFileInfo(fileInfo);
     try {
+      syncLog.get().startSyncDeletedFilesName();
       syncLog.get().finishSyncDeletedFileName(new File(getSyncDataPath(), filePath));
       FileLoaderManager.getInstance()
           .getFileLoader(senderName.get())
@@ -200,7 +194,7 @@ public class SyncServiceImpl implements SyncService.Iface {
     File file;
     String filePath = fileInfo;
     try {
-      if (currentSG.get() == null) { // schema mlog.txt file
+      if (fileInfo.equals(MetadataConstant.METADATA_LOG)) { // schema mlog.txt file
         file = new File(getSyncDataPath(), filePath);
       } else {
         filePath = currentSG.get() + File.separator + getFilePathByFileInfo(fileInfo);


### PR DESCRIPTION
recovery bug in sender:

recovery is invalid in sender.
some tsfiles maybe re-sender to receiver.
some tsfiles maybe be deleted on receiver twice.
now make the recovery valid in sender
reconnection bug in sender and receiver:

reconnection is invalid both in sender and receiver
maybe cause the receiver delete some tsfile which should not be deleted, because the log in receiver is wrong when time partition and vg is enable.
maybe cause the sender can not connect to the receiver after the reconnection, because some info in receiver is missing after reconnection.
now the reconnect can be set correctly.
remove some debug info in receiver

cherry pick from #4217 