### PR TITLE
[To rel/0.12][ISSUE-4293] SessionPool: InterruptedException is not properly handled in synchronized wait()

### DIFF
--- a/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -238,8 +238,7 @@ public class SessionPool {
             }
           }
         } catch (InterruptedException e) {
-          logger.error("the SessionPool is damaged", e);
-          Thread.currentThread().interrupt();
+          // wake up from this.wait(1000) by this.notify()
         }
 
         session = queue.poll();


### PR DESCRIPTION
For more detail, please see [ISSUE-4293](https://github.com/apache/iotdb/issues/4293).

Root cause: InterruptedException is not properly handled in synchronized wait().

![image](https://user-images.githubusercontent.com/30497621/139833244-4ac51bc9-a0c5-4698-9225-f72d7080806c.png)
