### PR TITLE
Add compaction version in cache key

### DIFF
--- a/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSInput.java
+++ b/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSInput.java
@@ -139,4 +139,9 @@ public class HDFSInput implements TsFileInput {
     fsDataInputStream.seek(srcPosition);
     return res;
   }
+
+  @Override
+  public String getFilePath() {
+    return path.toString();
+  }
 }

--- a/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
+++ b/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
@@ -37,6 +37,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -53,7 +54,20 @@ public class TSFHadoopTest {
   private TSFInputFormat inputFormat = null;
 
   private final String tsfilePath =
-      TestConstant.BASE_OUTPUT_PATH.concat("data/data/sequence/root.sg1/0/0/1-0-0-0.tsfile");
+      TestConstant.BASE_OUTPUT_PATH
+          .concat("data")
+          .concat(File.separator)
+          .concat("data")
+          .concat(File.separator)
+          .concat("sequence")
+          .concat(File.separator)
+          .concat("root.sg1")
+          .concat(File.separator)
+          .concat("0")
+          .concat(File.separator)
+          .concat("0")
+          .concat(File.separator)
+          .concat("1-0-0-0.tsfile");
 
   @Before
   public void setUp() {

--- a/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
+++ b/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
@@ -18,16 +18,10 @@
  */
 package org.apache.iotdb.hadoop.tsfile;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.iotdb.hadoop.fileSystem.HDFSInput;
+import org.apache.iotdb.hadoop.tsfile.constant.TestConstant;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.FloatWritable;
@@ -39,12 +33,20 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
-import org.apache.iotdb.hadoop.fileSystem.HDFSInput;
-import org.apache.iotdb.hadoop.tsfile.constant.TestConstant;
-import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TSFHadoopTest {
 

--- a/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
+++ b/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
@@ -18,10 +18,16 @@
  */
 package org.apache.iotdb.hadoop.tsfile;
 
-import org.apache.iotdb.hadoop.fileSystem.HDFSInput;
-import org.apache.iotdb.hadoop.tsfile.constant.TestConstant;
-import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.FloatWritable;
@@ -33,20 +39,12 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.apache.iotdb.hadoop.fileSystem.HDFSInput;
+import org.apache.iotdb.hadoop.tsfile.constant.TestConstant;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class TSFHadoopTest {
 
@@ -169,7 +167,12 @@ public class TSFHadoopTest {
       TSFRecordReader recordReader = new TSFRecordReader();
       TaskAttemptContextImpl attemptContextImpl =
           new TaskAttemptContextImpl(job.getConfiguration(), new TaskAttemptID());
-      recordReader.initialize(inputSplits.get(0), attemptContextImpl);
+      try {
+        recordReader.initialize(inputSplits.get(0), attemptContextImpl);
+      } catch (Exception e) {
+        e.printStackTrace();
+        fail();
+      }
       System.out.println(inputSplits.get(0));
       long value = 1000000L;
       while (recordReader.nextKeyValue()) {

--- a/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
+++ b/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
@@ -18,17 +18,12 @@
  */
 package org.apache.iotdb.hadoop.tsfile;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.iotdb.hadoop.fileSystem.HDFSInput;
+import org.apache.iotdb.hadoop.tsfile.constant.TestConstant;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.fileSystem.FSType;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.FloatWritable;
@@ -40,14 +35,21 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
-import org.apache.iotdb.hadoop.fileSystem.HDFSInput;
-import org.apache.iotdb.hadoop.tsfile.constant.TestConstant;
-import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
-import org.apache.iotdb.tsfile.fileSystem.FSType;
-import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TSFHadoopTest {
 
@@ -77,14 +79,11 @@ public class TSFHadoopTest {
     System.out.println("tsfilePath: " + tsfilePath);
     TsFileTestHelper.deleteTsFile(tsfilePath);
     inputFormat = new TSFInputFormat();
-    beforeFSType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
-    TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(FSType.HDFS);
   }
 
   @After
   public void tearDown() {
     TsFileTestHelper.deleteTsFile(tsfilePath);
-    TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(beforeFSType);
   }
 
   @Test
@@ -152,6 +151,8 @@ public class TSFHadoopTest {
       // set input path to the job
       TSFInputFormat.setInputPaths(job, tsfilePath);
       List<InputSplit> inputSplits = inputFormat.getSplits(job);
+      beforeFSType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
+      TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(FSType.HDFS);
       TsFileSequenceReader reader =
           new TsFileSequenceReader(new HDFSInput(tsfilePath, job.getConfiguration()));
       System.out.println(reader.readFileMetadata());
@@ -163,6 +164,8 @@ public class TSFHadoopTest {
     } catch (IOException e) {
       e.printStackTrace();
       fail(e.getMessage());
+    } finally {
+      TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(beforeFSType);
     }
   }
 
@@ -180,6 +183,8 @@ public class TSFHadoopTest {
       TSFInputFormat.setReadDeviceId(job, false);
       TSFInputFormat.setReadTime(job, false);
       List<InputSplit> inputSplits = inputFormat.getSplits(job);
+      beforeFSType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
+      TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(FSType.HDFS);
       TsFileSequenceReader reader =
           new TsFileSequenceReader(new HDFSInput(tsfilePath, job.getConfiguration()));
 
@@ -217,6 +222,8 @@ public class TSFHadoopTest {
     } catch (IOException | TSFHadoopException | InterruptedException e) {
       e.printStackTrace();
       fail(e.getMessage());
+    } finally {
+      TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(beforeFSType);
     }
   }
 }

--- a/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
+++ b/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
@@ -22,7 +22,13 @@ import org.apache.iotdb.hadoop.fileSystem.HDFSInput;
 import org.apache.iotdb.hadoop.tsfile.constant.TestConstant;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 
-import org.apache.hadoop.io.*;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
@@ -32,15 +38,22 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TSFHadoopTest {
 
   private TSFInputFormat inputFormat = null;
 
-  private String tsfilePath = TestConstant.BASE_OUTPUT_PATH.concat("example_mr.tsfile");
+  private final String tsfilePath =
+      TestConstant.BASE_OUTPUT_PATH.concat("data/data/sequence/root.sg1/0/0/1-0-0-0.tsfile");
 
   @Before
   public void setUp() {

--- a/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
+++ b/hadoop/src/test/java/org/apache/iotdb/hadoop/tsfile/TSFHadoopTest.java
@@ -72,6 +72,7 @@ public class TSFHadoopTest {
   @Before
   public void setUp() {
 
+    System.out.println("tsfilePath: " + tsfilePath);
     TsFileTestHelper.deleteTsFile(tsfilePath);
     inputFormat = new TSFInputFormat();
   }

--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -177,7 +177,7 @@
         <repository>
             <id>for_pentaho</id>
             <name>public.nexus.pentaho.org</name>
-            <url>http://maven.aliyun.com/nexus/content/groups/public</url>
+            <url>http://conjars.org/repo</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>

--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -177,7 +177,7 @@
         <repository>
             <id>for_pentaho</id>
             <name>public.nexus.pentaho.org</name>
-            <url>https://public.nexus.pentaho.org/repository/proxy-public-3rd-party-release</url>
+            <url>http://maven.aliyun.com/nexus/content/groups/public</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>

--- a/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveInputFormatTest.java
+++ b/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveInputFormatTest.java
@@ -18,9 +18,12 @@
  */
 package org.apache.iotdb.hive;
 
-import org.apache.iotdb.hadoop.tsfile.TSFInputSplit;
-import org.apache.iotdb.hive.constant.TestConstant;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.MapWritable;
 import org.apache.hadoop.io.NullWritable;
@@ -28,20 +31,34 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.iotdb.hadoop.tsfile.TSFInputSplit;
+import org.apache.iotdb.hive.constant.TestConstant;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.fileSystem.FSType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
-
-import static org.junit.Assert.*;
 
 public class TSFHiveInputFormatTest {
 
   private TSFInputSplit inputSplit;
   private TSFHiveInputFormat inputFormat;
   private JobConf job;
-  private String filePath = TestConstant.BASE_OUTPUT_PATH.concat("test.tsfile");
+  private FSType beforeFSType;
+  private final String filePath = TestConstant.BASE_OUTPUT_PATH
+      .concat("data")
+      .concat(File.separator)
+      .concat("data")
+      .concat(File.separator)
+      .concat("sequence")
+      .concat(File.separator)
+      .concat("root.sg1")
+      .concat(File.separator)
+      .concat("0")
+      .concat(File.separator)
+      .concat("0")
+      .concat(File.separator)
+      .concat("1-0-0-0.tsfile");
 
   @Before
   public void setUp() {
@@ -54,11 +71,14 @@ public class TSFHiveInputFormatTest {
     Path path = new Path(jobPath);
     String[] hosts = {"127.0.0.1"};
     inputSplit = new TSFInputSplit(path, hosts, 0, 3727688L);
+    beforeFSType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
+    TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(FSType.HDFS);
   }
 
   @After
   public void tearDown() {
     TsFileTestHelper.deleteTsFile(filePath);
+    TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(beforeFSType);
   }
 
   @Test

--- a/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveInputFormatTest.java
+++ b/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveInputFormatTest.java
@@ -18,12 +18,11 @@
  */
 package org.apache.iotdb.hive;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.iotdb.hadoop.tsfile.TSFInputSplit;
+import org.apache.iotdb.hive.constant.TestConstant;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.fileSystem.FSType;
 
-import java.io.File;
-import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.MapWritable;
 import org.apache.hadoop.io.NullWritable;
@@ -31,13 +30,16 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
-import org.apache.iotdb.hadoop.tsfile.TSFInputSplit;
-import org.apache.iotdb.hive.constant.TestConstant;
-import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
-import org.apache.iotdb.tsfile.fileSystem.FSType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TSFHiveInputFormatTest {
 
@@ -45,20 +47,21 @@ public class TSFHiveInputFormatTest {
   private TSFHiveInputFormat inputFormat;
   private JobConf job;
   private FSType beforeFSType;
-  private final String filePath = TestConstant.BASE_OUTPUT_PATH
-      .concat("data")
-      .concat(File.separator)
-      .concat("data")
-      .concat(File.separator)
-      .concat("sequence")
-      .concat(File.separator)
-      .concat("root.sg1")
-      .concat(File.separator)
-      .concat("0")
-      .concat(File.separator)
-      .concat("0")
-      .concat(File.separator)
-      .concat("1-0-0-0.tsfile");
+  private final String filePath =
+      TestConstant.BASE_OUTPUT_PATH
+          .concat("data")
+          .concat(File.separator)
+          .concat("data")
+          .concat(File.separator)
+          .concat("sequence")
+          .concat(File.separator)
+          .concat("root.sg1")
+          .concat(File.separator)
+          .concat("0")
+          .concat(File.separator)
+          .concat("0")
+          .concat(File.separator)
+          .concat("1-0-0-0.tsfile");
 
   @Before
   public void setUp() {

--- a/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveRecordReaderTest.java
+++ b/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveRecordReaderTest.java
@@ -18,28 +18,28 @@
  */
 package org.apache.iotdb.hive;
 
-import org.apache.iotdb.hadoop.tsfile.TSFInputSplit;
-import org.apache.iotdb.hive.constant.TestConstant;
-
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.LongWritable;
-import org.apache.hadoop.io.MapWritable;
-import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.mapred.JobConf;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
-
 import static org.apache.iotdb.hadoop.tsfile.TSFInputFormat.READ_DELTAOBJECTS;
 import static org.apache.iotdb.hadoop.tsfile.TSFInputFormat.READ_MEASUREMENTID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.MapWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.iotdb.hadoop.tsfile.TSFInputSplit;
+import org.apache.iotdb.hive.constant.TestConstant;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.fileSystem.FSType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class TSFHiveRecordReaderTest {
 
@@ -59,6 +59,8 @@ public class TSFHiveRecordReaderTest {
           .concat("0")
           .concat(File.separator)
           .concat("1-0-0-0.tsfile");
+  private FSType beforeFSType;
+
 
   @Before
   public void setUp() throws IOException {
@@ -83,11 +85,14 @@ public class TSFHiveRecordReaderTest {
     }; // configure reading which measurementIds
     job.set(READ_MEASUREMENTID, String.join(",", measurementIds));
     tsfHiveRecordReader = new TSFHiveRecordReader(inputSplit, job);
+    beforeFSType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
+    TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(FSType.HDFS);
   }
 
   @After
   public void tearDown() {
     TsFileTestHelper.deleteTsFile(filePath);
+    TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(beforeFSType);
   }
 
   @Test

--- a/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveRecordReaderTest.java
+++ b/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveRecordReaderTest.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 
 import static org.apache.iotdb.hadoop.tsfile.TSFInputFormat.READ_DELTAOBJECTS;
@@ -43,8 +44,21 @@ import static org.junit.Assert.fail;
 public class TSFHiveRecordReaderTest {
 
   private TSFHiveRecordReader tsfHiveRecordReader;
-  private String filePath =
-      TestConstant.BASE_OUTPUT_PATH.concat("data/data/sequence/root.sg1/0/0/1-0-0-0.tsfile");
+  private final String filePath =
+      TestConstant.BASE_OUTPUT_PATH
+          .concat("data")
+          .concat(File.separator)
+          .concat("data")
+          .concat(File.separator)
+          .concat("sequence")
+          .concat(File.separator)
+          .concat("root.sg1")
+          .concat(File.separator)
+          .concat("0")
+          .concat(File.separator)
+          .concat("0")
+          .concat(File.separator)
+          .concat("1-0-0-0.tsfile");
 
   @Before
   public void setUp() throws IOException {

--- a/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveRecordReaderTest.java
+++ b/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveRecordReaderTest.java
@@ -35,12 +35,16 @@ import java.io.IOException;
 
 import static org.apache.iotdb.hadoop.tsfile.TSFInputFormat.READ_DELTAOBJECTS;
 import static org.apache.iotdb.hadoop.tsfile.TSFInputFormat.READ_MEASUREMENTID;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TSFHiveRecordReaderTest {
 
   private TSFHiveRecordReader tsfHiveRecordReader;
-  private String filePath = TestConstant.BASE_OUTPUT_PATH.concat("test.tsfile");
+  private String filePath =
+      TestConstant.BASE_OUTPUT_PATH.concat("data/data/sequence/root.sg1/0/0/1-0-0-0.tsfile");
 
   @Before
   public void setUp() throws IOException {

--- a/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveRecordReaderTest.java
+++ b/hive-connector/src/test/java/org/apache/iotdb/hive/TSFHiveRecordReaderTest.java
@@ -18,28 +18,30 @@
  */
 package org.apache.iotdb.hive;
 
-import static org.apache.iotdb.hadoop.tsfile.TSFInputFormat.READ_DELTAOBJECTS;
-import static org.apache.iotdb.hadoop.tsfile.TSFInputFormat.READ_MEASUREMENTID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.iotdb.hadoop.tsfile.TSFInputSplit;
+import org.apache.iotdb.hive.constant.TestConstant;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.fileSystem.FSType;
 
-import java.io.File;
-import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.MapWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.iotdb.hadoop.tsfile.TSFInputSplit;
-import org.apache.iotdb.hive.constant.TestConstant;
-import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
-import org.apache.iotdb.tsfile.fileSystem.FSType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.apache.iotdb.hadoop.tsfile.TSFInputFormat.READ_DELTAOBJECTS;
+import static org.apache.iotdb.hadoop.tsfile.TSFInputFormat.READ_MEASUREMENTID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TSFHiveRecordReaderTest {
 
@@ -61,13 +63,14 @@ public class TSFHiveRecordReaderTest {
           .concat("1-0-0-0.tsfile");
   private FSType beforeFSType;
 
-
   @Before
   public void setUp() throws IOException {
     TsFileTestHelper.writeTsFile(filePath);
     JobConf job = new JobConf();
     Path path = new Path(filePath);
     String[] hosts = {"127.0.0.1"};
+    beforeFSType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
+    TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(FSType.HDFS);
     TSFInputSplit inputSplit = new TSFInputSplit(path, hosts, 0, 3727528L);
     String[] deviceIds = {"device_1"}; // configure reading which deviceIds
     job.set(READ_DELTAOBJECTS, String.join(",", deviceIds));
@@ -85,8 +88,6 @@ public class TSFHiveRecordReaderTest {
     }; // configure reading which measurementIds
     job.set(READ_MEASUREMENTID, String.join(",", measurementIds));
     tsfHiveRecordReader = new TSFHiveRecordReader(inputSplit, job);
-    beforeFSType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
-    TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(FSType.HDFS);
   }
 
   @After

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -402,15 +402,18 @@ public class TimeSeriesMetadataCache {
     private final String filePath;
     private final String tsFilePrefixPath;
     private final long tsFileVersion;
+    // high 32 bit is compaction level, low 32 bit is merge count
+    private final long compactionVersion;
     private final String device;
     private final String measurement;
 
     public TimeSeriesMetadataCacheKey(String filePath, String device, String measurement) {
       this.filePath = filePath;
-      Pair<String, Long> tsFilePrefixPathAndTsFileVersionPair =
+      Pair<String, long[]> tsFilePrefixPathAndTsFileVersionPair =
           FilePathUtils.getTsFilePrefixPathAndTsFileVersionPair(filePath);
       this.tsFilePrefixPath = tsFilePrefixPathAndTsFileVersionPair.left;
-      this.tsFileVersion = tsFilePrefixPathAndTsFileVersionPair.right;
+      this.tsFileVersion = tsFilePrefixPathAndTsFileVersionPair.right[0];
+      this.compactionVersion = tsFilePrefixPathAndTsFileVersionPair.right[1];
       this.device = device;
       this.measurement = measurement;
     }
@@ -427,12 +430,13 @@ public class TimeSeriesMetadataCache {
       return Objects.equals(measurement, that.measurement)
           && Objects.equals(device, that.device)
           && tsFileVersion == that.tsFileVersion
+          && compactionVersion == that.compactionVersion
           && tsFilePrefixPath.equals(that.tsFilePrefixPath);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(tsFilePrefixPath, tsFileVersion, device, measurement);
+      return Objects.hash(tsFilePrefixPath, tsFileVersion, compactionVersion, device, measurement);
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/cache/ChunkCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/cache/ChunkCacheTest.java
@@ -49,7 +49,9 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.apache.iotdb.db.conf.IoTDBConstant.PATH_SEPARATOR;
 import static org.junit.Assert.assertTrue;
@@ -122,8 +124,8 @@ public class ChunkCacheTest {
     Assert.assertEquals(chunk1.getHeader(), chunk2.getHeader());
     Assert.assertEquals(chunk1.getData(), chunk2.getData());
 
-    chunkMetadataKey.setFilePath(null);
     try {
+      chunkMetadataKey.setFilePath(null);
       chunkCache.get(chunkMetadataKey);
       fail();
     } catch (NullPointerException e) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionCacheTest.java
@@ -128,8 +128,8 @@ public class InnerCompactionCacheTest extends InnerCompactionTest {
             CompactionTaskManager.currentTaskNum);
     sizeTieredCompactionTask.call();
 
-    firstChunkMetadata.setFilePath(null);
     try {
+      firstChunkMetadata.setFilePath(null);
       ChunkCache.getInstance().get(firstChunkMetadata);
       fail();
     } catch (NullPointerException e) {

--- a/server/src/test/java/org/apache/iotdb/db/tools/TsFileSketchToolTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/tools/TsFileSketchToolTest.java
@@ -41,7 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TsFileSketchToolTest {
-  String path = "test.tsfile";
+  String path = "data/data/sequence/root.sg1/0/0/1-0-0-0.tsfile";
   String sketchOut = "sketch.out";
   String device = "root.device_0";
 

--- a/server/src/test/java/org/apache/iotdb/db/tools/TsFileSketchToolTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/tools/TsFileSketchToolTest.java
@@ -41,7 +41,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TsFileSketchToolTest {
-  String path = "data/data/sequence/root.sg1/0/0/1-0-0-0.tsfile";
+  String path =
+      "data"
+          .concat(File.separator)
+          .concat("data")
+          .concat(File.separator)
+          .concat("sequence")
+          .concat(File.separator)
+          .concat("root.sg1")
+          .concat(File.separator)
+          .concat("0")
+          .concat(File.separator)
+          .concat("0")
+          .concat(File.separator)
+          .concat("1-0-0-0.tsfile");;
   String sketchOut = "sketch.out";
   String device = "root.device_0";
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileOutputFactory/LocalFSOutputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileOutputFactory/LocalFSOutputFactory.java
@@ -36,7 +36,9 @@ public class LocalFSOutputFactory implements FileOutputFactory {
   @Override
   public TsFileOutput getTsFileOutput(String filePath, boolean append) {
     try {
-      return new LocalTsFileOutput(new FileOutputStream(new File(filePath), append));
+      File file = new File(filePath);
+      file.getParentFile().mkdirs();
+      return new LocalTsFileOutput(new FileOutputStream(file, append));
     } catch (IOException e) {
       logger.error("Failed to get TsFile output of file: {}, ", filePath, e);
       return null;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -162,6 +162,7 @@ public class TsFileSequenceReader implements AutoCloseable {
    */
   public TsFileSequenceReader(TsFileInput input, boolean loadMetadataSize) throws IOException {
     this.tsFileInput = input;
+    this.file = input.getFilePath();
     try {
       if (loadMetadataSize) { // NOTE no autoRepair here
         loadMetadataSize();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/LocalTsFileInput.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/LocalTsFileInput.java
@@ -148,4 +148,9 @@ public class LocalTsFileInput implements TsFileInput {
     strBuffer.get(bytes, 0, strLength);
     return new String(bytes, 0, strLength);
   }
+
+  @Override
+  public String getFilePath() {
+    return filePath;
+  }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/TsFileInput.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/TsFileInput.java
@@ -127,4 +127,6 @@ public interface TsFileInput {
 
   /** read a string from the Input at the given position */
   String readVarIntString(long offset) throws IOException;
+
+  String getFilePath();
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -19,14 +19,12 @@
 
 package org.apache.iotdb.tsfile.utils;
 
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
+
+import java.io.File;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
-
-import java.io.File;
-import java.util.Arrays;
-
-import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 
 public class FilePathUtils {
 
@@ -140,24 +138,14 @@ public class FilePathUtils {
    */
   public static Pair<String, long[]> getTsFilePrefixPathAndTsFileVersionPair(
       String tsFileAbsolutePath) {
-    String[] pathSegments = null;
-    try {
-      pathSegments = splitTsFilePath(tsFileAbsolutePath);
-      int pathLength = pathSegments.length;
-      return new Pair<>(
-          pathSegments[pathLength - 4]
-              + File.separator
-              + pathSegments[pathLength - 3]
-              + File.separator
-              + pathSegments[pathLength - 2],
-          splitAndGetVersionArray(pathSegments[pathLength - 1]));
-    } catch (Exception e) {
-      System.out.println("pathSegments: " + Arrays.toString(pathSegments));
-      System.out.println("path: " + tsFileAbsolutePath);
-      System.out.println("PATH_SPLIT_STRING: " + PATH_SPLIT_STRING);
-      System.out.println("separator: " + File.separator);
-
-      throw e;
-    }
+    String[] pathSegments = splitTsFilePath(tsFileAbsolutePath);
+    int pathLength = pathSegments.length;
+    return new Pair<>(
+        pathSegments[pathLength - 4]
+            + File.separator
+            + pathSegments[pathLength - 3]
+            + File.separator
+            + pathSegments[pathLength - 2],
+        splitAndGetVersionArray(pathSegments[pathLength - 1]));
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -113,7 +113,8 @@ public class FilePathUtils {
 
   /**
    * @return a long array whose length is 2, the first long value is tsfile version, second long
-   *     value is compaction version, high 32 bit is in-space compaction count, low 32 bit is cross-space compaction count
+   *     value is compaction version, high 32 bit is in-space compaction count, low 32 bit is
+   *     cross-space compaction count
    */
   private static long[] splitAndGetVersionArray(String tsFileName) {
     String[] names = tsFileName.split(FILE_NAME_SEPARATOR);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -19,11 +19,11 @@
 
 package org.apache.iotdb.tsfile.utils;
 
-import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 
 import java.io.File;
-
-import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
+import java.util.Arrays;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 
 public class FilePathUtils {
 
@@ -133,14 +133,22 @@ public class FilePathUtils {
    */
   public static Pair<String, long[]> getTsFilePrefixPathAndTsFileVersionPair(
       String tsFileAbsolutePath) {
-    String[] pathSegments = splitTsFilePath(tsFileAbsolutePath);
-    int pathLength = pathSegments.length;
-    return new Pair<>(
-        pathSegments[pathLength - 4]
-            + File.separator
-            + pathSegments[pathLength - 3]
-            + File.separator
-            + pathSegments[pathLength - 2],
-        splitAndGetVersionArray(pathSegments[pathLength - 1]));
+    String[] pathSegments = null;
+    try {
+      pathSegments = splitTsFilePath(tsFileAbsolutePath);
+      int pathLength = pathSegments.length;
+      return new Pair<>(
+          pathSegments[pathLength - 4]
+              + File.separator
+              + pathSegments[pathLength - 3]
+              + File.separator
+              + pathSegments[pathLength - 2],
+          splitAndGetVersionArray(pathSegments[pathLength - 1]));
+    } catch (Exception e) {
+      System.out.println("pathSegments: " + Arrays.toString(pathSegments));
+      System.out.println("path: " + tsFileAbsolutePath);
+      throw e;
+    }
+
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -23,6 +23,8 @@ import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 
 import java.io.File;
 
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
+
 public class FilePathUtils {
 
   private static final String PATH_SPLIT_STRING = File.separator.equals("\\") ? "\\\\" : "/";
@@ -103,6 +105,19 @@ public class FilePathUtils {
     return Long.parseLong(names[1]);
   }
 
+  public static long[] splitAndGetVersionArray(String tsFileName) {
+    String[] names = tsFileName.split(FILE_NAME_SEPARATOR);
+    long[] versionArray = new long[2];
+    if (names.length != 4) {
+      return versionArray;
+    }
+    versionArray[0] = Long.parseLong(names[1]);
+    versionArray[1] =
+        (Long.parseLong(names[2]) << 32)
+            | Long.parseLong(names[3].substring(0, names[3].length() - TSFILE_SUFFIX.length()));
+    return versionArray;
+  }
+
   public static Pair<String, Long> getLogicalSgNameAndTimePartitionIdPair(
       String tsFileAbsolutePath) {
     String[] pathSegments = splitTsFilePath(tsFileAbsolutePath);
@@ -111,7 +126,12 @@ public class FilePathUtils {
         Long.parseLong(pathSegments[pathSegments.length - 2]));
   }
 
-  public static Pair<String, Long> getTsFilePrefixPathAndTsFileVersionPair(
+  /**
+   * pair.left tsFilePrefixPath, like data/data/sequence/root.sg1/0/0 pair.right is a long array
+   * whose length is 2 pair.right[0] is tsfile version pair.right[1] is compaction version, high 32
+   * bit is compaction level, low 32 bit is merge count
+   */
+  public static Pair<String, long[]> getTsFilePrefixPathAndTsFileVersionPair(
       String tsFileAbsolutePath) {
     String[] pathSegments = splitTsFilePath(tsFileAbsolutePath);
     int pathLength = pathSegments.length;
@@ -121,6 +141,6 @@ public class FilePathUtils {
             + pathSegments[pathLength - 3]
             + File.separator
             + pathSegments[pathLength - 2],
-        splitAndGetTsFileVersion(pathSegments[pathLength - 1]));
+        splitAndGetVersionArray(pathSegments[pathLength - 1]));
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -19,11 +19,12 @@
 
 package org.apache.iotdb.tsfile.utils;
 
-import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 
 import java.io.File;
 import java.util.Arrays;
-import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
+
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 
 public class FilePathUtils {
 
@@ -149,6 +150,5 @@ public class FilePathUtils {
       System.out.println("path: " + tsFileAbsolutePath);
       throw e;
     }
-
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -148,6 +148,7 @@ public class FilePathUtils {
     } catch (Exception e) {
       System.out.println("pathSegments: " + Arrays.toString(pathSegments));
       System.out.println("path: " + tsFileAbsolutePath);
+      System.out.println("PATH_SPLIT_STRING: " + PATH_SPLIT_STRING);
       throw e;
     }
   }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -19,7 +19,9 @@
 
 package org.apache.iotdb.tsfile.utils;
 
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
+import org.apache.iotdb.tsfile.fileSystem.FSType;
 
 import java.io.File;
 import java.util.Arrays;
@@ -28,7 +30,11 @@ import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFF
 
 public class FilePathUtils {
 
-  private static final String PATH_SPLIT_STRING = File.separator.equals("\\") ? "\\\\" : "/";
+  private static final String PATH_SPLIT_STRING =
+      TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs() == FSType.LOCAL
+              && File.separator.equals("\\")
+          ? "\\\\"
+          : "/";
   public static final String FILE_NAME_SEPARATOR = "-";
 
   private FilePathUtils() {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -149,6 +149,8 @@ public class FilePathUtils {
       System.out.println("pathSegments: " + Arrays.toString(pathSegments));
       System.out.println("path: " + tsFileAbsolutePath);
       System.out.println("PATH_SPLIT_STRING: " + PATH_SPLIT_STRING);
+      System.out.println("separator: " + File.separator);
+
       throw e;
     }
   }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -113,7 +113,7 @@ public class FilePathUtils {
 
   /**
    * @return a long array whose length is 2, the first long value is tsfile version, second long
-   *     value is compaction version, high 32 bit is compaction level, low 32 bit is merge count
+   *     value is compaction version, high 32 bit is in-space compaction count, low 32 bit is cross-space compaction count
    */
   private static long[] splitAndGetVersionArray(String tsFileName) {
     String[] names = tsFileName.split(FILE_NAME_SEPARATOR);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -19,12 +19,13 @@
 
 package org.apache.iotdb.tsfile.utils;
 
-import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
-
-import java.io.File;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
+
+import java.io.File;
+
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 
 public class FilePathUtils {
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -111,7 +111,11 @@ public class FilePathUtils {
     return Long.parseLong(names[1]);
   }
 
-  public static long[] splitAndGetVersionArray(String tsFileName) {
+  /**
+   * @return a long array whose length is 2, the first long value is tsfile version, second long
+   *     value is compaction version, high 32 bit is compaction level, low 32 bit is merge count
+   */
+  private static long[] splitAndGetVersionArray(String tsFileName) {
     String[] names = tsFileName.split(FILE_NAME_SEPARATOR);
     long[] versionArray = new long[2];
     if (names.length != 4) {


### PR DESCRIPTION
In current IoTDB, after compaction finished, it will clear all the query cache, because the old file and the new file share the same key in query cache and there is no way to remove the exact old file entry in query cache.

However, we can add the compaction version into the cache entry key so that the new file generated by compaction will has a new entry instead of sharing the same key as the old file. In this way, we can avoid clearing all query cache after each compaction.