### PR TITLE
Fix the bug that election in term n may increase to n+1 before send e…

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/DataHeartbeatThread.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/DataHeartbeatThread.java
@@ -52,7 +52,7 @@ public class DataHeartbeatThread extends HeartbeatThread {
    * to it. So the progress of meta logs is also examined.
    */
   @Override
-  void startElection() {
+  void startElection(long currentTerm) {
     // skip first few elections to let the header have a larger chance to become the leader, so
     // possibly each node will only be one leader at the same time
     if (!dataGroupMember.getThisNode().equals(dataGroupMember.getHeader().getNode())
@@ -63,6 +63,6 @@ public class DataHeartbeatThread extends HeartbeatThread {
     }
     electionRequest.setHeader(dataGroupMember.getHeader());
 
-    super.startElection();
+    super.startElection(currentTerm);
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/MetaHeartbeatThread.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/MetaHeartbeatThread.java
@@ -73,8 +73,8 @@ public class MetaHeartbeatThread extends HeartbeatThread {
   }
 
   @Override
-  void startElection() {
-    super.startElection();
+  void startElection(long currentTerm) {
+    super.startElection(currentTerm);
 
     if (localMetaMember.getCharacter() == NodeCharacter.LEADER) {
       // A new raft leader needs to have at least one log in its term for committing logs with older

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -1635,7 +1635,7 @@ public abstract class RaftMember {
       long currTerm = term.get();
       // confirm that the heartbeat of the new leader hasn't come
       if (currTerm < newTerm) {
-        logger.info("{} has update it's term to {}", getName(), newTerm);
+        logger.info("{} has update it's term from {} to {}", getName(), currTerm, newTerm);
         term.set(newTerm);
         setVoteFor(null);
         setCharacter(NodeCharacter.ELECTOR);


### PR DESCRIPTION
The log shows behaviors like below in meta group:

1. Node 09 run as follower in term 3.
2. Node 09 heartbeat timeout in term 3.
3. Node 09 update its term to 4
4. Node 09 update `voteFor` to null
5. Node 09 receive an election request from Node 08 in term 4, accept the election, become follower of the group in term 4.
6. Node 09 continue to election. but term is 5.

It's not right in the step 6 as Node 09 timed out in term 3, it should only start the election in term 4 instead of term 5. I think the behavior isn't by design although it didn't run into some wrong status.


[Attach log: meta.log](https://github.com/apache/iotdb/files/7466363/meta.log)
