### PR TITLE
[IOTDB-1950] Add Bloom Filter cache for query

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -537,8 +537,8 @@ timestamp_precision=ms
 # Datatype: boolean
 # meta_data_cache_enable=true
 # Read memory Allocation Ratio: BloomFilterCache, ChunkCache, TimeSeriesMetadataCache, memory used for constructing QueryDataSet and Free Memory Used in Query.
-# The parameter form is a:b:c:d:e, where a, b, c, d and e are integers. for example: 1:1:1:1:1 , 1:2:3:4:5
-# chunk_timeseriesmeta_free_memory_proportion=1:2:3:4:5
+# The parameter form is a:b:c:d:e, where a, b, c, d and e are integers. for example: 1:1:1:1:1 , 1:100:200:300:400
+# chunk_timeseriesmeta_free_memory_proportion=1:100:200:300:400
 
 # cache size for MManager.
 # This cache is used to improve insert speed where all path check and TSDataType will be cached in MManager with corresponding Path.

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -533,12 +533,12 @@ timestamp_precision=ms
 ### Metadata Cache Configuration
 ####################
 
-# whether to cache meta data(ChunkMetadata and TimeSeriesMetadata) or not.
+# whether to cache meta data(BloomFilter, ChunkMetadata and TimeSeriesMetadata) or not.
 # Datatype: boolean
 # meta_data_cache_enable=true
-# Read memory Allocation Ratio: ChunkCache, TimeSeriesMetadataCache, memory used for constructing QueryDataSet and Free Memory Used in Query.
-# The parameter form is a:b:c:d, where a, b, c and d are integers. for example: 1:1:1:1 , 1:2:3:4
-# chunk_timeseriesmeta_free_memory_proportion=1:2:3:4
+# Read memory Allocation Ratio: BloomFilterCache, ChunkCache, TimeSeriesMetadataCache, memory used for constructing QueryDataSet and Free Memory Used in Query.
+# The parameter form is a:b:c:d:e, where a, b, c, d and e are integers. for example: 1:1:1:1:1 , 1:2:3:4:5
+# chunk_timeseriesmeta_free_memory_proportion=1:2:3:4:5
 
 # cache size for MManager.
 # This cache is used to improve insert speed where all path check and TSDataType will be cached in MManager with corresponding Path.

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -119,7 +119,7 @@ public class IoTDBConfig {
   private long allocateMemoryForSchema = Runtime.getRuntime().maxMemory() * 1 / 10;
 
   /** Memory allocated for the read process besides cache */
-  private long allocateMemoryForReadWithoutCache = allocateMemoryForRead * 3 / 10;
+  private long allocateMemoryForReadWithoutCache = allocateMemoryForRead * 4 / 15;
 
   private volatile int maxQueryDeduplicatedPathNum = 1000;
 
@@ -409,15 +409,13 @@ public class IoTDBConfig {
   private boolean metaDataCacheEnable = true;
 
   /** Memory allocated for bloomFilter cache in read process */
-  // TODO: set from IoTDBDescriptor and iotdb-engine.properties
-  private long allocateMemoryForBloomFilterCache = allocateMemoryForRead / 10;
+  private long allocateMemoryForBloomFilterCache = allocateMemoryForRead / 15;
 
   /** Memory allocated for timeSeriesMetaData cache in read process */
-  //  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead / 5;
-  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead / 10;
+  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead * 3/ 15;
 
   /** Memory allocated for chunk cache in read process */
-  private long allocateMemoryForChunkCache = allocateMemoryForRead / 10;
+  private long allocateMemoryForChunkCache = allocateMemoryForRead * 2 / 15;
 
   /** Whether to enable Last cache */
   private boolean lastCacheEnable = true;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -408,8 +408,13 @@ public class IoTDBConfig {
   /** whether to cache meta data(ChunkMetaData and TsFileMetaData) or not. */
   private boolean metaDataCacheEnable = true;
 
+  /** Memory allocated for bloomFilter cache in read process */
+  // TODO: set from IoTDBDescriptor and iotdb-engine.properties
+  private long allocateMemoryForBloomFilterCache = allocateMemoryForRead / 10;
+
   /** Memory allocated for timeSeriesMetaData cache in read process */
-  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead / 5;
+  //  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead / 5;
+  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead / 10;
 
   /** Memory allocated for chunk cache in read process */
   private long allocateMemoryForChunkCache = allocateMemoryForRead / 10;
@@ -1720,6 +1725,14 @@ public class IoTDBConfig {
 
   public void setMetaDataCacheEnable(boolean metaDataCacheEnable) {
     this.metaDataCacheEnable = metaDataCacheEnable;
+  }
+
+  public long getAllocateMemoryForBloomFilterCache() {
+    return allocateMemoryForBloomFilterCache;
+  }
+
+  public void setAllocateMemoryForBloomFilterCache(long allocateMemoryForBloomFilterCache) {
+    this.allocateMemoryForBloomFilterCache = allocateMemoryForBloomFilterCache;
   }
 
   public long getAllocateMemoryForTimeSeriesMetaDataCache() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -119,7 +119,7 @@ public class IoTDBConfig {
   private long allocateMemoryForSchema = Runtime.getRuntime().maxMemory() * 1 / 10;
 
   /** Memory allocated for the read process besides cache */
-  private long allocateMemoryForReadWithoutCache = allocateMemoryForRead * 4 / 15;
+  private long allocateMemoryForReadWithoutCache = allocateMemoryForRead * 300 / 15;
 
   private volatile int maxQueryDeduplicatedPathNum = 1000;
 
@@ -409,13 +409,13 @@ public class IoTDBConfig {
   private boolean metaDataCacheEnable = true;
 
   /** Memory allocated for bloomFilter cache in read process */
-  private long allocateMemoryForBloomFilterCache = allocateMemoryForRead / 15;
+  private long allocateMemoryForBloomFilterCache = allocateMemoryForRead / 1001;
 
   /** Memory allocated for timeSeriesMetaData cache in read process */
-  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead * 3 / 15;
+  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead * 200 / 1001;
 
   /** Memory allocated for chunk cache in read process */
-  private long allocateMemoryForChunkCache = allocateMemoryForRead * 2 / 15;
+  private long allocateMemoryForChunkCache = allocateMemoryForRead * 100 / 1001;
 
   /** Whether to enable Last cache */
   private boolean lastCacheEnable = true;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -119,7 +119,7 @@ public class IoTDBConfig {
   private long allocateMemoryForSchema = Runtime.getRuntime().maxMemory() * 1 / 10;
 
   /** Memory allocated for the read process besides cache */
-  private long allocateMemoryForReadWithoutCache = allocateMemoryForRead * 300 / 15;
+  private long allocateMemoryForReadWithoutCache = allocateMemoryForRead * 300 / 1001;
 
   private volatile int maxQueryDeduplicatedPathNum = 1000;
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -412,7 +412,7 @@ public class IoTDBConfig {
   private long allocateMemoryForBloomFilterCache = allocateMemoryForRead / 15;
 
   /** Memory allocated for timeSeriesMetaData cache in read process */
-  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead * 3/ 15;
+  private long allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead * 3 / 15;
 
   /** Memory allocated for chunk cache in read process */
   private long allocateMemoryForChunkCache = allocateMemoryForRead * 2 / 15;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1262,12 +1262,14 @@ public class IoTDBDescriptor {
       long maxMemoryAvailable = conf.getAllocateMemoryForRead();
       if (proportionSum != 0) {
         try {
-          conf.setAllocateMemoryForChunkCache(
+          conf.setAllocateMemoryForBloomFilterCache(
               maxMemoryAvailable * Integer.parseInt(proportions[0].trim()) / proportionSum);
-          conf.setAllocateMemoryForTimeSeriesMetaDataCache(
+          conf.setAllocateMemoryForChunkCache(
               maxMemoryAvailable * Integer.parseInt(proportions[1].trim()) / proportionSum);
-          conf.setAllocateMemoryForReadWithoutCache(
+          conf.setAllocateMemoryForTimeSeriesMetaDataCache(
               maxMemoryAvailable * Integer.parseInt(proportions[2].trim()) / proportionSum);
+          conf.setAllocateMemoryForReadWithoutCache(
+              maxMemoryAvailable * Integer.parseInt(proportions[3].trim()) / proportionSum);
         } catch (Exception e) {
           throw new RuntimeException(
               "Each subsection of configuration item chunkmeta_chunk_timeseriesmeta_free_memory_proportion"

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/BloomFilterCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/BloomFilterCache.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.engine.cache;
+
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.query.control.FileReaderManager;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
+import org.apache.iotdb.tsfile.utils.BloomFilter;
+import org.apache.iotdb.tsfile.utils.RamUsageEstimator;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Weigher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/** This class is used to cache <code>BloomFilter</code> in IoTDB. The caching strategy is LRU. */
+public class BloomFilterCache {
+
+  private static final Logger logger = LoggerFactory.getLogger(BloomFilterCache.class);
+  private static final Logger DEBUG_LOGGER = LoggerFactory.getLogger("QUERY_DEBUG");
+  private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
+  private static final long MEMORY_THRESHOLD_IN_BLOOM_FILTER_CACHE =
+      config.getAllocateMemoryForBloomFilterCache();
+  private static final boolean CACHE_ENABLE = config.isMetaDataCacheEnable();
+
+  private final LoadingCache<String, BloomFilter> lruCache;
+
+  private BloomFilterCache() {
+    if (CACHE_ENABLE) {
+      logger.info("BloomFilterCache size = " + MEMORY_THRESHOLD_IN_BLOOM_FILTER_CACHE);
+    }
+    lruCache =
+        Caffeine.newBuilder()
+            .maximumWeight(MEMORY_THRESHOLD_IN_BLOOM_FILTER_CACHE)
+            .weigher(
+                (Weigher<String, BloomFilter>)
+                    (filePath, bloomFilter) ->
+                        (int)
+                            (RamUsageEstimator.NUM_BYTES_OBJECT_REF
+                                + RamUsageEstimator.sizeOf(bloomFilter))) // TODO: how to calculate?
+            .recordStats()
+            .build(
+                filePath -> {
+                  try {
+                    TsFileSequenceReader reader =
+                        FileReaderManager.getInstance().get(filePath, true);
+                    return reader.readBloomFilter();
+                  } catch (IOException e) {
+                    logger.error(
+                        "Something wrong happened in reading bloom filter in tsfile {}",
+                        filePath,
+                        e);
+                    throw e;
+                  }
+                });
+  }
+
+  public static BloomFilterCache getInstance() {
+    return BloomFilterCacheHolder.INSTANCE;
+  }
+
+  public BloomFilter get(String filePath) throws IOException {
+    return get(filePath, false);
+  }
+
+  public BloomFilter get(String filePath, boolean debug) throws IOException {
+    if (!CACHE_ENABLE) {
+      TsFileSequenceReader reader = FileReaderManager.getInstance().get(filePath, true);
+      return reader.readBloomFilter();
+    }
+
+    BloomFilter bloomFilter = lruCache.get(filePath);
+
+    if (debug) {
+      DEBUG_LOGGER.info("get bloomFilter from cache where filePath is: " + filePath);
+    }
+
+    return bloomFilter;
+  }
+
+  public double calculateChunkHitRatio() {
+    return lruCache.stats().hitRate();
+  }
+
+  public long getEvictionCount() {
+    return lruCache.stats().evictionCount();
+  }
+
+  public long getMaxMemory() {
+    return MEMORY_THRESHOLD_IN_BLOOM_FILTER_CACHE;
+  }
+
+  public double getAverageLoadPenalty() {
+    return lruCache.stats().averageLoadPenalty();
+  }
+
+  /** clear LRUCache. */
+  public void clear() {
+    lruCache.invalidateAll();
+    lruCache.cleanUp();
+  }
+
+  public void remove(String filePath) {
+    lruCache.invalidate(filePath);
+  }
+
+  /** singleton pattern. */
+  private static class BloomFilterCacheHolder {
+    private static final BloomFilterCache INSTANCE = new BloomFilterCache();
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/CacheHitRatioMonitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/CacheHitRatioMonitor.java
@@ -105,6 +105,31 @@ public class CacheHitRatioMonitor implements CacheHitRatioMonitorMXBean, IServic
     return TimeSeriesMetadataCache.getInstance().getAverageSize();
   }
 
+  @Override
+  public double getBloomFilterHitRatio() {
+    return BloomFilterCache.getInstance().calculateChunkHitRatio();
+  }
+
+  @Override
+  public long getBloomFilterCacheEvictionCount() {
+    return BloomFilterCache.getInstance().getEvictionCount();
+  }
+
+  @Override
+  public long getBloomFilterCacheMaxMemory() {
+    return BloomFilterCache.getInstance().getMaxMemory();
+  }
+
+  @Override
+  public double getBloomFilterCacheAverageLoadPenalty() {
+    return BloomFilterCache.getInstance().getAverageLoadPenalty();
+  }
+
+  @Override
+  public long getBloomFilterCacheAverageSize() {
+    return BloomFilterCache.getInstance().getAverageSize();
+  }
+
   public static CacheHitRatioMonitor getInstance() {
     return instance;
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/CacheHitRatioMonitorMXBean.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/CacheHitRatioMonitorMXBean.java
@@ -40,6 +40,16 @@ public interface CacheHitRatioMonitorMXBean {
 
   long getTimeSeriesMetaDataCacheAverageSize();
 
+  double getBloomFilterHitRatio();
+
+  long getBloomFilterCacheEvictionCount();
+
+  long getBloomFilterCacheMaxMemory();
+
+  double getBloomFilterCacheAverageLoadPenalty();
+
+  long getBloomFilterCacheAverageSize();
+
   long getTotalMemTableSize();
 
   double getFlushThershold();

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -118,9 +118,7 @@ public class TimeSeriesMetadataCache {
     if (!CACHE_ENABLE) {
       // bloom filter part
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-      BloomFilter bloomFilter =
-          BloomFilterCache.getInstance()
-              .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
+      BloomFilter bloomFilter = reader.readBloomFilter();
       if (bloomFilter != null
           && !bloomFilter.contains(key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement)) {
         return null;
@@ -147,7 +145,7 @@ public class TimeSeriesMetadataCache {
           TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
           BloomFilter bloomFilter =
               BloomFilterCache.getInstance()
-                  .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
+                  .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath), debug);
           if (bloomFilter != null && !bloomFilter.contains(path.getFullPath())) {
             if (debug) {
               DEBUG_LOGGER.info("TimeSeries meta data {} is filter by bloomFilter!", key);
@@ -214,9 +212,7 @@ public class TimeSeriesMetadataCache {
     if (!CACHE_ENABLE) {
       // bloom filter part
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-      BloomFilter bloomFilter =
-          BloomFilterCache.getInstance()
-              .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
+      BloomFilter bloomFilter = reader.readBloomFilter();
       if (bloomFilter != null
           && !bloomFilter.contains(key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement)) {
         return Collections.emptyList();
@@ -247,7 +243,7 @@ public class TimeSeriesMetadataCache {
           TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
           BloomFilter bloomFilter =
               BloomFilterCache.getInstance()
-                  .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
+                  .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath), debug);
           if (bloomFilter != null && !bloomFilter.contains(path.getFullPath())) {
             if (debug) {
               DEBUG_LOGGER.info("TimeSeries meta data {} is filter by bloomFilter!", key);

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -119,7 +119,9 @@ public class TimeSeriesMetadataCache {
       // bloom filter part
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
       //      BloomFilter bloomFilter = reader.readBloomFilter();
-      BloomFilter bloomFilter = BloomFilterCache.getInstance().get(key.filePath);
+      BloomFilter bloomFilter =
+          BloomFilterCache.getInstance()
+              .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
       if (bloomFilter != null
           && !bloomFilter.contains(key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement)) {
         return null;
@@ -145,7 +147,9 @@ public class TimeSeriesMetadataCache {
           // bloom filter part
           TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
           //          BloomFilter bloomFilter = reader.readBloomFilter();
-          BloomFilter bloomFilter = BloomFilterCache.getInstance().get(key.filePath);
+          BloomFilter bloomFilter =
+              BloomFilterCache.getInstance()
+                  .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
           if (bloomFilter != null && !bloomFilter.contains(path.getFullPath())) {
             if (debug) {
               DEBUG_LOGGER.info("TimeSeries meta data {} is filter by bloomFilter!", key);
@@ -213,7 +217,9 @@ public class TimeSeriesMetadataCache {
       // bloom filter part
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
       //      BloomFilter bloomFilter = reader.readBloomFilter();
-      BloomFilter bloomFilter = BloomFilterCache.getInstance().get(key.filePath);
+      BloomFilter bloomFilter =
+          BloomFilterCache.getInstance()
+              .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
       if (bloomFilter != null
           && !bloomFilter.contains(key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement)) {
         return Collections.emptyList();
@@ -243,7 +249,9 @@ public class TimeSeriesMetadataCache {
           // bloom filter part
           TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
           //          BloomFilter bloomFilter = reader.readBloomFilter();
-          BloomFilter bloomFilter = BloomFilterCache.getInstance().get(key.filePath);
+          BloomFilter bloomFilter =
+              BloomFilterCache.getInstance()
+                  .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
           if (bloomFilter != null && !bloomFilter.contains(path.getFullPath())) {
             if (debug) {
               DEBUG_LOGGER.info("TimeSeries meta data {} is filter by bloomFilter!", key);

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -118,7 +118,8 @@ public class TimeSeriesMetadataCache {
     if (!CACHE_ENABLE) {
       // bloom filter part
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-      BloomFilter bloomFilter = reader.readBloomFilter();
+      //      BloomFilter bloomFilter = reader.readBloomFilter();
+      BloomFilter bloomFilter = BloomFilterCache.getInstance().get(key.filePath);
       if (bloomFilter != null
           && !bloomFilter.contains(key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement)) {
         return null;
@@ -143,7 +144,8 @@ public class TimeSeriesMetadataCache {
           Path path = new Path(key.device, key.measurement);
           // bloom filter part
           TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-          BloomFilter bloomFilter = reader.readBloomFilter();
+          //          BloomFilter bloomFilter = reader.readBloomFilter();
+          BloomFilter bloomFilter = BloomFilterCache.getInstance().get(key.filePath);
           if (bloomFilter != null && !bloomFilter.contains(path.getFullPath())) {
             if (debug) {
               DEBUG_LOGGER.info("TimeSeries meta data {} is filter by bloomFilter!", key);
@@ -210,7 +212,8 @@ public class TimeSeriesMetadataCache {
     if (!CACHE_ENABLE) {
       // bloom filter part
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-      BloomFilter bloomFilter = reader.readBloomFilter();
+      //      BloomFilter bloomFilter = reader.readBloomFilter();
+      BloomFilter bloomFilter = BloomFilterCache.getInstance().get(key.filePath);
       if (bloomFilter != null
           && !bloomFilter.contains(key.device + IoTDBConstant.PATH_SEPARATOR + key.measurement)) {
         return Collections.emptyList();
@@ -239,7 +242,8 @@ public class TimeSeriesMetadataCache {
           Path path = new Path(key.device, key.measurement);
           // bloom filter part
           TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-          BloomFilter bloomFilter = reader.readBloomFilter();
+          //          BloomFilter bloomFilter = reader.readBloomFilter();
+          BloomFilter bloomFilter = BloomFilterCache.getInstance().get(key.filePath);
           if (bloomFilter != null && !bloomFilter.contains(path.getFullPath())) {
             if (debug) {
               DEBUG_LOGGER.info("TimeSeries meta data {} is filter by bloomFilter!", key);

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -118,7 +118,6 @@ public class TimeSeriesMetadataCache {
     if (!CACHE_ENABLE) {
       // bloom filter part
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-      //      BloomFilter bloomFilter = reader.readBloomFilter();
       BloomFilter bloomFilter =
           BloomFilterCache.getInstance()
               .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
@@ -146,7 +145,6 @@ public class TimeSeriesMetadataCache {
           Path path = new Path(key.device, key.measurement);
           // bloom filter part
           TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-          //          BloomFilter bloomFilter = reader.readBloomFilter();
           BloomFilter bloomFilter =
               BloomFilterCache.getInstance()
                   .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
@@ -216,7 +214,6 @@ public class TimeSeriesMetadataCache {
     if (!CACHE_ENABLE) {
       // bloom filter part
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-      //      BloomFilter bloomFilter = reader.readBloomFilter();
       BloomFilter bloomFilter =
           BloomFilterCache.getInstance()
               .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));
@@ -248,7 +245,6 @@ public class TimeSeriesMetadataCache {
           Path path = new Path(key.device, key.measurement);
           // bloom filter part
           TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-          //          BloomFilter bloomFilter = reader.readBloomFilter();
           BloomFilter bloomFilter =
               BloomFilterCache.getInstance()
                   .get(new BloomFilterCache.BloomFilterCacheKey(key.filePath));

--- a/server/src/test/java/org/apache/iotdb/db/engine/cache/BloomFilterCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/cache/BloomFilterCacheTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iotdb.db.engine.cache;
 
+import org.apache.iotdb.db.query.control.FileReaderManager;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
@@ -73,10 +75,12 @@ public class BloomFilterCacheTest {
   @After
   public void tearDown() {
     try {
+      // clear opened file streams
+      FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
       for (String filePath : pathList) {
         FileUtils.forceDelete(new File(filePath));
       }
-    } catch (IOException e) {
+    } catch (Exception e) {
       Assert.fail(e.getMessage());
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/cache/BloomFilterCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/cache/BloomFilterCacheTest.java
@@ -76,7 +76,8 @@ public class BloomFilterCacheTest {
     }
     // estimate weight and set allocated memory for bloom filter for test
     int estimateWeight = estimateWeight(pathList);
-    allocateMemoryForBloomFilterCache =IoTDBDescriptor.getInstance().getConfig().getAllocateMemoryForBloomFilterCache();
+    allocateMemoryForBloomFilterCache =
+        IoTDBDescriptor.getInstance().getConfig().getAllocateMemoryForBloomFilterCache();
     IoTDBDescriptor.getInstance()
         .getConfig()
         .setAllocateMemoryForBloomFilterCache(estimateWeight - 1);
@@ -90,8 +91,8 @@ public class BloomFilterCacheTest {
         FileUtils.forceDelete(new File(filePath));
       }
       IoTDBDescriptor.getInstance()
-                .getConfig()
-                .setAllocateMemoryForBloomFilterCache(allocateMemoryForBloomFilterCache);
+          .getConfig()
+          .setAllocateMemoryForBloomFilterCache(allocateMemoryForBloomFilterCache);
     } catch (IOException e) {
       Assert.fail(e.getMessage());
     }
@@ -120,7 +121,7 @@ public class BloomFilterCacheTest {
       Assert.assertNotEquals(null, bloomFilter);
       bloomFilterCache.remove(key);
       bloomFilter = bloomFilterCache.getIfPresent(key);
-        Assert.assertNull(bloomFilter);
+      Assert.assertNull(bloomFilter);
     } catch (IOException e) {
       Assert.fail();
       e.printStackTrace();
@@ -139,7 +140,7 @@ public class BloomFilterCacheTest {
       for (String path : pathList) {
         BloomFilterCache.BloomFilterCacheKey key = new BloomFilterCache.BloomFilterCacheKey(path);
         BloomFilter bloomFilter = bloomFilterCache.getIfPresent(key);
-          Assert.assertNull(bloomFilter);
+        Assert.assertNull(bloomFilter);
       }
     } catch (IOException e) {
       Assert.fail();
@@ -159,7 +160,7 @@ public class BloomFilterCacheTest {
       bloomFilterCache.clearUp();
       BloomFilterCache.BloomFilterCacheKey key =
           new BloomFilterCache.BloomFilterCacheKey(pathList.get(0));
-        Assert.assertNull(bloomFilterCache.getIfPresent(key));
+      Assert.assertNull(bloomFilterCache.getIfPresent(key));
       for (int i = 1; i < pathList.size(); i++) {
         key = new BloomFilterCache.BloomFilterCacheKey(pathList.get(i));
         Assert.assertNotEquals(null, bloomFilterCache.getIfPresent(key));
@@ -170,11 +171,12 @@ public class BloomFilterCacheTest {
     }
   }
 
-    /**
-     * estimate weight according to tsFile path
-     * @param pathList tsFile path list
-     * @return estimate weight
-     */
+  /**
+   * estimate weight according to tsFile path
+   *
+   * @param pathList tsFile path list
+   * @return estimate weight
+   */
   private int estimateWeight(List<String> pathList) throws IOException {
     int res = 0;
     for (String path : pathList) {
@@ -192,11 +194,12 @@ public class BloomFilterCacheTest {
     return res;
   }
 
-    /**
-     * construct tsFile for test
-     * @param path tsFile path
-     * @param device device in tsFile
-     */
+  /**
+   * construct tsFile for test
+   *
+   * @param path tsFile path
+   * @param device device in tsFile
+   */
   private void createTsFile(String path, String device) throws Exception {
     try {
       File f = FSFactoryProducer.getFSFactory().getFile(path);

--- a/server/src/test/java/org/apache/iotdb/db/engine/cache/BloomFilterCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/cache/BloomFilterCacheTest.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.engine.cache;
+
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.query.control.FileReaderManager;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
+import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.utils.BloomFilter;
+import org.apache.iotdb.tsfile.utils.FilePathUtils;
+import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.utils.RamUsageEstimator;
+import org.apache.iotdb.tsfile.write.TsFileWriter;
+import org.apache.iotdb.tsfile.write.record.Tablet;
+import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
+import org.apache.iotdb.tsfile.write.schema.Schema;
+import org.apache.iotdb.tsfile.write.schema.UnaryMeasurementSchema;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BloomFilterCacheTest {
+  List<String> pathList;
+  List<String> deviceList;
+  int pathSize = 3;
+  BloomFilterCache bloomFilterCache;
+
+  @Before
+  public void setUp() throws Exception {
+    // set up and create tsFile
+    pathList = new ArrayList<>();
+    deviceList = new ArrayList<>();
+    for (int i = 0; i < pathSize; i++) {
+      String path =
+          "target"
+              .concat(File.separator)
+              .concat("data")
+              .concat(File.separator)
+              .concat("data")
+              .concat(File.separator)
+              .concat("sequence")
+              .concat(File.separator)
+              .concat("root.sg" + (i + 1))
+              .concat(File.separator)
+              .concat("0")
+              .concat(File.separator)
+              .concat("0")
+              .concat(File.separator)
+              .concat("1-0-0-0.tsfile");
+      String device = "d" + (i + 1);
+      pathList.add(path);
+      deviceList.add(device);
+      createTsFile(path, device);
+    }
+    int estimateWeight = estimateWeight(pathList);
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setAllocateMemoryForBloomFilterCache(estimateWeight - 1);
+    bloomFilterCache = BloomFilterCache.getInstance();
+  }
+
+  @After
+  public void tearDown() {
+    try {
+      for (String filePath : pathList) {
+        FileUtils.forceDelete(new File(filePath));
+      }
+    } catch (IOException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGet() {
+    try {
+      for (String filePath : pathList) {
+        BloomFilter bloomFilter =
+            bloomFilterCache.get(new BloomFilterCache.BloomFilterCacheKey(filePath));
+        Assert.assertNotEquals(bloomFilter, null);
+      }
+    } catch (IOException e) {
+      Assert.fail();
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testRemove() {
+    try {
+      String path = pathList.get(0);
+      BloomFilterCache.BloomFilterCacheKey key = new BloomFilterCache.BloomFilterCacheKey(path);
+      BloomFilter bloomFilter = bloomFilterCache.get(key);
+      Assert.assertNotEquals(null, bloomFilter);
+      bloomFilterCache.remove(key);
+      bloomFilter = bloomFilterCache.getIfPresent(key);
+      Assert.assertEquals(null, bloomFilter);
+    } catch (IOException e) {
+      Assert.fail();
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testClear() {
+    try {
+      for (String path : pathList) {
+        BloomFilterCache.BloomFilterCacheKey key = new BloomFilterCache.BloomFilterCacheKey(path);
+        BloomFilter bloomFilter = bloomFilterCache.get(key);
+        Assert.assertNotEquals(null, bloomFilter);
+      }
+      bloomFilterCache.clear();
+      for (String path : pathList) {
+        BloomFilterCache.BloomFilterCacheKey key = new BloomFilterCache.BloomFilterCacheKey(path);
+        BloomFilter bloomFilter = bloomFilterCache.getIfPresent(key);
+        Assert.assertEquals(null, bloomFilter);
+      }
+    } catch (IOException e) {
+      Assert.fail();
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testEvict() {
+    try {
+      bloomFilterCache.clear();
+      for (String path : pathList) {
+        BloomFilterCache.BloomFilterCacheKey key = new BloomFilterCache.BloomFilterCacheKey(path);
+        BloomFilter bloomFilter = bloomFilterCache.get(key);
+        Assert.assertNotEquals(null, bloomFilter);
+      }
+      bloomFilterCache.clearUp();
+      BloomFilterCache.BloomFilterCacheKey key =
+          new BloomFilterCache.BloomFilterCacheKey(pathList.get(0));
+      Assert.assertEquals(null, bloomFilterCache.getIfPresent(key));
+      for (int i = 1; i < pathList.size(); i++) {
+        key = new BloomFilterCache.BloomFilterCacheKey(pathList.get(i));
+        Assert.assertNotEquals(null, bloomFilterCache.getIfPresent(key));
+      }
+    } catch (IOException e) {
+      Assert.fail();
+      e.printStackTrace();
+    }
+  }
+
+  private int estimateWeight(List<String> pathList) throws IOException {
+    int res = 0;
+    for (String path : pathList) {
+      TsFileSequenceReader reader = FileReaderManager.getInstance().get(path, true);
+      BloomFilterCache.BloomFilterCacheKey key = new BloomFilterCache.BloomFilterCacheKey(path);
+      Pair<String, long[]> tsFilePrefixPathAndTsFileVersionPair =
+          FilePathUtils.getTsFilePrefixPathAndTsFileVersionPair(path);
+      String tsFilePrefixPath = tsFilePrefixPathAndTsFileVersionPair.left;
+      res +=
+          (int)
+              (RamUsageEstimator.shallowSizeOf(key)
+                  + RamUsageEstimator.sizeOf(tsFilePrefixPath)
+                  + RamUsageEstimator.sizeOf(reader.readBloomFilter()));
+    }
+    return res;
+  }
+
+  private void createTsFile(String path, String device) throws Exception {
+    try {
+      File f = FSFactoryProducer.getFSFactory().getFile(path);
+      if (f.exists() && !f.delete()) {
+        throw new RuntimeException("can not delete " + f.getAbsolutePath());
+      }
+      Schema schema = new Schema();
+      String sensorPrefix = "sensor_";
+      // the number of rows to include in the tablet
+      int rowNum = 1000000;
+      // the number of values to include in the tablet
+      int sensorNum = 10;
+      List<IMeasurementSchema> measurementSchemas = new ArrayList<>();
+      // add measurements into file schema (all with INT64 data type)
+      for (int i = 0; i < sensorNum; i++) {
+        IMeasurementSchema measurementSchema =
+            new UnaryMeasurementSchema(
+                sensorPrefix + (i + 1), TSDataType.INT64, TSEncoding.TS_2DIFF);
+        measurementSchemas.add(measurementSchema);
+        schema.registerTimeseries(
+            new Path(device, sensorPrefix + (i + 1)),
+            new UnaryMeasurementSchema(
+                sensorPrefix + (i + 1), TSDataType.INT64, TSEncoding.TS_2DIFF));
+      }
+      // add measurements into TSFileWriter
+      try (TsFileWriter tsFileWriter = new TsFileWriter(f, schema)) {
+        // construct the tablet
+        Tablet tablet = new Tablet(device, measurementSchemas);
+        long[] timestamps = tablet.timestamps;
+        Object[] values = tablet.values;
+        long timestamp = 1;
+        long value = 1000000L;
+        for (int r = 0; r < rowNum; r++, value++) {
+          int row = tablet.rowSize++;
+          timestamps[row] = timestamp++;
+          for (int i = 0; i < sensorNum; i++) {
+            long[] sensor = (long[]) values[i];
+            sensor[row] = value;
+          }
+          // write Tablet to TsFile
+          if (tablet.rowSize == tablet.getMaxRowNumber()) {
+            tsFileWriter.write(tablet);
+            tablet.reset();
+          }
+        }
+        // write Tablet to TsFile
+        if (tablet.rowSize != 0) {
+          tsFileWriter.write(tablet);
+          tablet.reset();
+        }
+      }
+    } catch (Exception e) {
+      throw new Exception("meet error in TsFileWrite with tablet", e);
+    }
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/engine/cache/BloomFilterCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/cache/BloomFilterCacheTest.java
@@ -19,10 +19,10 @@
 package org.apache.iotdb.db.engine.cache;
 
 import org.apache.iotdb.db.query.control.FileReaderManager;
-import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.utils.BloomFilter;
 import org.apache.iotdb.tsfile.write.TsFileWriter;
@@ -91,7 +91,10 @@ public class BloomFilterCacheTest {
       for (String filePath : pathList) {
         BloomFilter bloomFilter =
             bloomFilterCache.get(new BloomFilterCache.BloomFilterCacheKey(filePath));
-        Assert.assertNotEquals(bloomFilter, null);
+        TsFileSequenceReader reader = FileReaderManager.getInstance().get(filePath, true);
+        BloomFilter bloomFilter1 = reader.readBloomFilter();
+        Assert.assertEquals(bloomFilter1, bloomFilter);
+        reader.close();
       }
     } catch (IOException e) {
       Assert.fail();
@@ -105,10 +108,13 @@ public class BloomFilterCacheTest {
       String path = pathList.get(0);
       BloomFilterCache.BloomFilterCacheKey key = new BloomFilterCache.BloomFilterCacheKey(path);
       BloomFilter bloomFilter = bloomFilterCache.get(key);
-      Assert.assertNotEquals(null, bloomFilter);
+      TsFileSequenceReader reader = FileReaderManager.getInstance().get(path, true);
+      BloomFilter bloomFilter1 = reader.readBloomFilter();
+      Assert.assertEquals(bloomFilter1, bloomFilter);
       bloomFilterCache.remove(key);
       bloomFilter = bloomFilterCache.getIfPresent(key);
       Assert.assertNull(bloomFilter);
+      reader.close();
     } catch (IOException e) {
       Assert.fail();
       e.printStackTrace();
@@ -121,7 +127,10 @@ public class BloomFilterCacheTest {
       for (String path : pathList) {
         BloomFilterCache.BloomFilterCacheKey key = new BloomFilterCache.BloomFilterCacheKey(path);
         BloomFilter bloomFilter = bloomFilterCache.get(key);
-        Assert.assertNotEquals(null, bloomFilter);
+        TsFileSequenceReader reader = FileReaderManager.getInstance().get(path, true);
+        BloomFilter bloomFilter1 = reader.readBloomFilter();
+        Assert.assertEquals(bloomFilter1, bloomFilter);
+        reader.close();
       }
       bloomFilterCache.clear();
       for (String path : pathList) {

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.conf.directories.DirectoryManager;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.cq.ContinuousQueryService;
 import org.apache.iotdb.db.engine.StorageEngine;
+import org.apache.iotdb.db.engine.cache.BloomFilterCache;
 import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
@@ -142,6 +143,7 @@ public class EnvironmentUtils {
     if (config.isMetaDataCacheEnable()) {
       ChunkCache.getInstance().clear();
       TimeSeriesMetadataCache.getInstance().clear();
+      BloomFilterCache.getInstance().clear();
     }
     // close metadata
     IoTDB.metaManager.clear();

--- a/spark-iotdb-connector/src/test/scala/org/apache/iotdb/spark/db/EnvironmentUtils.java
+++ b/spark-iotdb-connector/src/test/scala/org/apache/iotdb/spark/db/EnvironmentUtils.java
@@ -33,6 +33,7 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
 import org.apache.iotdb.db.engine.StorageEngine;
+import org.apache.iotdb.db.engine.cache.BloomFilterCache;
 import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.flush.FlushManager;
@@ -120,6 +121,7 @@ public class EnvironmentUtils {
     if (config.isMetaDataCacheEnable()) {
       ChunkCache.getInstance().clear();
       TimeSeriesMetadataCache.getInstance().clear();
+      BloomFilterCache.getInstance().clear();
     }
     // close metadata
     IoTDB.metaManager.clear();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BloomFilter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BloomFilter.java
@@ -20,7 +20,9 @@ package org.apache.iotdb.tsfile.utils;
 
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 
+import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Objects;
 
 public class BloomFilter {
 
@@ -127,6 +129,26 @@ public class BloomFilter {
     return bits.toByteArray();
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BloomFilter that = (BloomFilter) o;
+    return size == that.size
+        && hashFunctionSize == that.hashFunctionSize
+        && Objects.equals(bits, that.bits)
+        && Arrays.equals(func, that.func);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(size, hashFunctionSize, bits, func);
+  }
+
   private class HashFunction {
 
     private int cap;
@@ -139,6 +161,23 @@ public class BloomFilter {
 
     public int hash(String value) {
       return Math.abs(Murmur128Hash.hash(value, seed)) % cap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      HashFunction that = (HashFunction) o;
+      return cap == that.cap && seed == that.seed;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(cap, seed);
     }
   }
 }


### PR DESCRIPTION
### Contribution

* Add `BloomFilterCache` to cache bloom filter instead of read from TsFile directly
* Add `BloomFilterCacheTest`
* Update `iotdb-engine.properties` about allocated memory for BloomFilterCache 

[weekly test result](http://ise.thss.tsinghua.edu.cn/confluence/pages/viewpage.action?pageId=64526429)

[experiment result](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=195726609)