### PR TITLE
[DRAFT][IOTDB-1849] Support Sprintz encoding

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/SprintzDecoder.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/SprintzDecoder.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.tsfile.encoding.decoder;
+
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.utils.BytesUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.apache.iotdb.tsfile.encoding.huffmanForByte.huffmanCompression;
+
+
+
+/** decoder for block of integer using Sprintz encoding
+ * 1. Given the size and dimension of sample, we first huffman decode the entire buffer
+ * 2. Retrieve header and payload
+ * 3. if header is 0, read run length to find the number of 0-error block
+ *    predict the rest of block
+ * 4. Otherwise, for each sample, we first make a prediction and add the errors to the prediction
+ * */
+public class SprintzDecoder extends Decoder {
+    protected int dimensionality;
+    protected int blockSize;
+    private static final Logger logger = LoggerFactory.getLogger(SprintzDecoder.class);
+
+    /**indicates which prediction function to calculate errors
+    * 0 -> delta
+    * 1 -> Fast integer regression
+    * */
+    protected int mode;
+
+    /** actual result = errors + previous values
+     * for the first sample in the block, previousValue is the last element of previous block
+     * */
+    protected int[] previousValues;
+
+    /**indicates whether current buffer involves all zero blocks*/
+    protected boolean isRLE;
+
+    /** numElement is the total number of elements
+     * numCount counts how many elements have output*/
+    protected int numElements;
+    protected int numCount;
+
+    /**store the decoded value */
+    protected int[][] validValue;
+
+    /**number of bits to encode each column*/
+    protected int[] headerBits;
+    protected byte[] payloadList;
+
+    /*a buffer to save the byte values of input stream*/
+    private byte[] blockBuffer;
+
+
+    /** constructor.*/
+    public SprintzDecoder(int blockSize, int dimensionality) {
+        super(TSEncoding.SPRINTZ);
+        this.blockSize = blockSize;
+        this.dimensionality = dimensionality;
+        this.validValue = new int[blockSize][dimensionality];;
+        this.previousValues = new int[dimensionality];
+        this.headerBits = new int[dimensionality];
+        this.numElements = blockSize * dimensionality;
+        this.numCount = 0;
+        isRLE = false;
+        reset();
+    }
+
+
+    @Override
+    public void reset() {
+        isRLE = false;
+        Arrays.fill(headerBits,0);
+        numCount = 0;
+        for (int[] row: validValue)
+            Arrays.fill(row, 0);
+    }
+
+
+    /**huffman decode buffer to get header and payload*/
+    protected void retrieveHeaderAndPayloads(ByteBuffer buffer) throws IOException{
+        huffmanCompression hc= new huffmanCompression();
+    }
+
+    /**unpack integers from byte array buf
+     * each integer is stored into buf with indicated width
+     * store the results into values
+     * */
+    public void unpackColumns(byte[] buf, int[] values, int width) {
+        int byteIdx = 0;
+        long buffer = 0;
+        // total bits which have read from 'buf' to 'buffer'. i.e.,
+        // number of available bits to be decoded.
+        int totalBits = 0;
+        int valueIdx = 0;
+
+        while (valueIdx < values.length) {
+            // If current available bits are not enough to decode one Integer,
+            // then add next byte from buf to 'buffer' until totalBits >= width
+            while (totalBits < width) {
+                buffer = (buffer << 8) | (buf[byteIdx] & 0xFF);
+                byteIdx++;
+                totalBits += 8;
+            }
+
+            // If current available bits are enough to decode one Integer,
+            // then decode one Integer one by one until left bits in 'buffer' is
+            // not enough to decode one Integer.
+            while (totalBits >= width && valueIdx < 8) {
+                values[valueIdx] = (int) (buffer >>> (totalBits - width));
+                valueIdx++;
+                totalBits -= width;
+                buffer = buffer & ((1 << totalBits) - 1);
+            }
+        }
+    }
+
+
+    /**
+     * Check whether there is number left for reading.
+     *
+     * @param buffer decoded data saved in ByteBuffer
+     * @return true or false to indicate whether there is number left
+     * @throws IOException cannot check next value
+     */
+    @Override
+    public boolean hasNext(ByteBuffer buffer) throws IOException {
+        return buffer.remaining() > 0;
+    }
+
+
+    /** read the next data in the buffer*/
+    public void readNext(ByteBuffer buffer) throws IOException{
+        if (hasNext(buffer)){
+            blockBuffer = new byte[buffer.remaining()];
+        }
+        System.out.println(blockBuffer.length);
+    }
+
+
+    /**reverse delta encode
+     * prediction[i][j] = prediction[i-1][j]
+     * validValue[i][j] = prediction[i][j] + errors[i][j]
+     * where errors are derived from payloads
+     * */
+    public void deltaPrediction(){
+    }
+
+
+    /** read an integer from InputStream*/
+    @Override
+    public int readInt(ByteBuffer buffer) {
+        try {
+            readNext(buffer);
+        }catch (IOException e){logger.error("error when reading encoding number");}
+
+        /*check RLE by checking the first 'dimensionality' bytes*/
+        if (checkRLE()){
+            int numberZeroBlock =  BytesUtils.bytesToInt(new byte[]{blockBuffer[dimensionality]});
+            System.out.println("the number of zero block is, "+numberZeroBlock);
+            deltaPrediction();
+        }
+
+        /*if not RLE*/
+        if (numCount < numElements){
+            numCount ++;
+            //make a prediction based on 'previousValue'
+            deltaPrediction();
+            reset();
+        }
+
+        /* i * dimensionality + j = numCount */
+        return validValue[(int)(numCount/dimensionality)][numCount - dimensionality*(int)(numCount/dimensionality)];
+    }
+
+
+    /* check for RLE*/
+    protected boolean checkRLE(){
+        if (blockBuffer.length < dimensionality){return false;}
+        else{
+            for (int i = 0; i < dimensionality; i++){
+                if(blockBuffer[i] != 0){
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+}

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/SprintzDecoder.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/SprintzDecoder.java
@@ -135,7 +135,6 @@ public class SprintzDecoder extends Decoder {
         }
     }
 
-
     /**
      * Check whether there is number left for reading.
      *

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/SprintzEncoder.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/SprintzEncoder.java
@@ -211,7 +211,7 @@ public class SprintzEncoder extends Encoder{
         writePayload(columnBits);
 
         /*huffman encode*/
-        /*need fix
+        /*
         huffmanCompression hc= new huffmanCompression();
         hc.buildHuffmanTree(bytesBuffer);
         byte[] huffmanBuffer = hc.huffmanCompress(bytesBuffer);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/SprintzEncoder.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/SprintzEncoder.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tsfile.encoding.encoder;
+
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+//import org.apache.iotdb.tsfile.encoding.huffmanForByte.huffmanCompression;
+//import org.apache.iotdb.tsfile.encoding.huffmanForByte.huffmanNode;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.iotdb.tsfile.utils.BytesUtils;
+import org.jetbrains.annotations.NotNull;
+
+
+
+/**
+ * Sprintz encoder consists of four steps:
+ * 1. Forecasting. There are four types of predictive coding commonly in use:
+ *    predictive filtering, delta coding, double-delta coding, XOR-based encoding.
+ *    In the original paper, it compares the results of delta encoding and FIRE encoding.
+ *    The result shows that delta encoding is more efficient while FIRE yields better compression
+ * 2. Bit-packing of the errors and prepending a header.
+ * 3. Run-length encoding if all errors are zero. Writing out the number of non-zero blocks.
+ * 4. Huffman codes the headers and payloads.
+ */
+public class SprintzEncoder extends Encoder{
+
+    /** the number of data point to pack together*/
+    protected int blockSize;
+
+    /** the number of features for each data point*/
+    protected int dimensionality;
+
+    /** Since each compression encode a block,
+     * while we could only encode one integer at a time
+     * we store all elements into a list*/
+    protected List<Integer> values;
+
+    /** store errors of prediction after zigzag encoding*/
+    protected int[][] errors;
+
+    /** tracing the number of all-zero block for RLE*/
+    protected int zeroBlockCount;
+
+    protected ByteArrayOutputStream cache;
+
+    /** used for calculating delta
+     * for the first sample in the block, previousValue is the last element of previous block
+     * */
+    protected int[] previousValues;
+
+    /** indicates whether RLE is running */
+    private boolean isRLE;
+
+    /** A buffer that stores the values of errors after prediction+RLE+bit-packing
+    * and before huffman encoding*/
+    private List<byte[]> bytesBuffer;
+
+
+    /** constructor.*/
+    public SprintzEncoder(int blockSize, int dimensionality) {
+        super(TSEncoding.SPRINTZ);
+        this.blockSize = blockSize;
+        this.dimensionality = dimensionality;
+        this.previousValues = new int[dimensionality];
+        this.errors = new int[blockSize][dimensionality];
+        this.values = new ArrayList<>();
+        this.zeroBlockCount = 0;
+        this.isRLE = false;
+        bytesBuffer = new ArrayList<>();
+        reset();
+    }
+
+    public void setPreviousValues(int[] previousValues){
+        this.previousValues = Arrays.copyOf(previousValues, previousValues.length);
+    }
+
+    public List<byte[]> getBytesBuffer(){return bytesBuffer;}
+
+
+    /** prediction error using delta followed by zigzag encode*/
+    public boolean CalculateErrorUsingDelta(){
+        /*we first convert values into a 2D array*/
+        boolean allZero = true;
+
+        int[][] tempValue = new int[blockSize][dimensionality];
+        for (int i = 0; i < blockSize; i++){
+            for (int j =0; j < dimensionality; j++){
+                tempValue[i][j] = values.get(i*dimensionality + j);
+            }
+        }
+
+        /*calculating error*/
+        for (int i = 0; i < blockSize; i++){
+            for (int j =0; j < dimensionality; j++){
+                int error = tempValue[i][j] - previousValues[j];
+                if (error != 0){
+                    allZero = false;
+                }
+                /*zigzag error*/
+                error =  (error <<1) ^ (error >>31);
+                errors[i][j] = error;
+                previousValues[j] = tempValue[i][j];
+            }
+        }
+
+        System.out.println("Errors after zigzag encoding are:");
+        for (int i = 0; i < blockSize; i++){
+            for (int j =0; j < dimensionality; j++) {
+                System.out.print(errors[i][j]);
+            }
+            System.out.println();
+        }
+        return allZero;
+    }
+
+
+    /**
+     *Get the length of value in bit
+     */
+    private int getIntWidth(int value){
+        return 32-Integer.numberOfLeadingZeros(value);
+    }
+
+
+    /**
+     *Calculate the minimum required bit-width to encode integers in column i
+     *Inputs: columnIndex - the index of column to find bit-width
+     */
+    protected int calculateColumnRequiredBits(int columnIndex){
+        int columnWidth = 0;
+        for (int i = 0; i < blockSize; i++){
+            columnWidth = Math.max(columnWidth, getIntWidth(errors[i][columnIndex]));
+        }
+        return columnWidth;
+    }
+
+
+    @Override
+    public void encode(int value, ByteArrayOutputStream out){
+        values.add(value);
+    }
+
+
+    /**
+     * encode errors to bytesBuffer
+     * Sprintz encoder consists of Header + Align + Byte-Aligned column-Major Payload
+     * Since the bit-width of each dimension is the same, the total length of buffer is the same
+     */
+    public void encodeBlockBuffer(){
+        /* find errors*/
+        isRLE = CalculateErrorUsingDelta();
+        System.out.println(isRLE);
+
+        /* if predictions for the entire block have no errors*/
+        if (isRLE){
+            /*keep reading until we find a new block with some errors not zero*/
+            zeroBlockCount += 1;
+            reset();
+            return;
+        }
+
+        /* if a RLE just stop, write D 0s as header into buff
+        * and number of all-zero blocks as payloads in byte into buff*/
+        if (!isRLE & zeroBlockCount >0){
+            byte[] RLEHeader = new byte[dimensionality];
+            Arrays.fill(RLEHeader, (byte)0);
+            byte[] RLEPayload = BytesUtils.intToBytes(zeroBlockCount);
+            bytesBuffer.add(RLEHeader);
+            bytesBuffer.add(RLEPayload);
+            zeroBlockCount = 0;
+            reset();
+        }
+
+
+        /* the number of bits required for each column*/
+        int[] columnBits = new int[dimensionality];
+        /* the number of bits to encode headers*/
+        int headerBits = 0;
+        for (int i = 0; i < dimensionality; i++){
+            columnBits[i] = calculateColumnRequiredBits(i);
+            int lengthBit = (int) Math.ceil(Math.log(columnBits[i])/Math.log(2.0));
+            headerBits = Math.max(lengthBit,headerBits);
+        }
+
+        System.out.println("the number of bits to encode each column in header is: "+ headerBits);
+
+        /* Write header and payload to bytesbuffer*/
+        writeHeader(columnBits,headerBits);
+        writePayload(columnBits);
+
+        /*huffman encode*/
+        /*need fix
+        huffmanCompression hc= new huffmanCompression();
+        hc.buildHuffmanTree(bytesBuffer);
+        byte[] huffmanBuffer = hc.huffmanCompress(bytesBuffer);
+        for (byte b: huffmanBuffer){cache.write(b);}
+        */
+
+        /*write to stream*/
+        for (byte[] bytes : bytesBuffer) {
+            cache.write(bytes, 0, bytes.length);
+        }
+    }
+
+
+
+    /**
+     * bit-pack each column of error together,
+     * the number of bits required for each element in a column is the same, which is nbits
+     * values - a list of integer to encode
+     * width - bit width of element in values
+     * buf - where we store the bytes after packing, the size of buf = size of values * width / 8
+     * */
+    public void packColumns(int[] values,byte[] buf, int width){
+        int bufIdx = 0;
+        int valueIdx = 0;
+        // remaining bits for the current unfinished Integer
+        int leftBit = 0;
+
+        while (valueIdx < values.length) {
+            // 32 bit to store final results
+            int buffer = 0;
+            // available bits in buffer
+            int leftSize = 32;
+
+            // encode the left bits of current Integer to 'buffer'
+            if (leftBit > 0) {
+                buffer |= (values[valueIdx] << (32 - leftBit));
+                leftSize -= leftBit;
+                leftBit = 0;
+                valueIdx++;
+            }
+
+            while (leftSize >= width && valueIdx < values.length) {
+                // encode one Integer to the 'buffer'
+                buffer |= (values[valueIdx] << (leftSize - width));
+                leftSize -= width;
+                valueIdx++;
+            }
+            // If the remaining space of the buffer can not save the bits for one Integer,
+            if (leftSize > 0 && valueIdx < values.length) {
+                // put the first 'leftSize' bits of the Integer into remaining space of the
+                // buffer
+                buffer |= (values[valueIdx] >>> (width - leftSize));
+                leftBit = width - leftSize;
+            }
+
+            // put the buffer into the final result
+            for (int j = 0; j < buf.length; j++) {
+                buf[bufIdx] = (byte) ((buffer >>> ((3 - j) * 8)) & 0xFF);
+                bufIdx++;
+                if (bufIdx >= width) {
+                    return;
+                }
+            }
+        }
+    }
+
+
+
+    /** write headers to bytesbuffer
+     * values - bit width of each column.
+     * bitWidth - number of bits required to encode values
+     * */
+    protected void writeHeader(int @NotNull [] values, int bitWidth){
+        int length = (int)Math.ceil(dimensionality * bitWidth / 8.0);
+        //the size of buf = size of values * width / 8
+        byte[] headerBuffer = new byte[length];
+        packColumns(values, headerBuffer, bitWidth);
+        bytesBuffer.add(headerBuffer);
+    }
+
+
+
+    /** write payloads to bytesbuffer
+     * columnBits - the number of bits for each column, if columnBits[0] is not zero,
+     *              we bit-pack the entire column and add to bytesBuffer; otherwise,
+     *              we ignore the column.
+     *              If all columns are zero, we write the number of zero as payload.
+     * */
+    protected void writePayload(int[] columnBits){
+        if (zeroBlockCount > 0){
+           bytesBuffer.add(new byte[]{(byte)zeroBlockCount});
+        }
+
+        for (int i = 0; i< dimensionality; i++){
+            /*if the entire column is 0, skip it*/
+            if (columnBits[i] == 0){
+                continue;
+            }
+            int[] column_values = new int[blockSize];
+            for (int j = 0; j < blockSize; j++){
+                column_values[j] = errors[j][i];
+            }
+            int length = (int)Math.ceil(blockSize * columnBits[i] / 8.0);
+            byte[] payloadBuffer = new byte[length];
+            packColumns(column_values, payloadBuffer, columnBits[i]);
+            bytesBuffer.add(payloadBuffer);
+        }
+    }
+
+
+
+    /** clear buffers*/
+    protected void reset(){
+        cache = new ByteArrayOutputStream();
+        isRLE = false;
+        bytesBuffer.clear();
+        //Arrays.fill(previousValues, 0);
+        this.values = new ArrayList<>();
+        for (int[] row: errors)
+            Arrays.fill(row, 0);
+    }
+
+
+    /**
+     * Write all values buffered in memory cache to OutputStream.
+     * * @param out - ByteArrayOutputStream
+     * @throws IOException cannot flush to OutputStream
+     */
+    @Override
+    public void flush(ByteArrayOutputStream out) throws IOException{
+        encodeBlockBuffer();
+        //write to out
+        cache.writeTo(out);
+        reset();
+    }
+
+
+
+    /**
+     * When encoder accepts a new incoming data point, the maximal possible size in byte it takes to
+     * store in memory.*/
+    @Override
+    public int getOneItemMaxSize() {
+        /*When encoding the first element and the error takes 4 bytes.
+        * header: 4 bytes
+        * itself: 4 bytes
+        * */
+        return 8;
+    }
+
+    /**
+     * return the maximal size of possible memory occupied by current encoder
+     * */
+    @Override
+    public long getMaxByteSize() {
+        if (errors == null) {
+            return 0;
+        }
+        /* When all the errors takes 4 bytes to encode
+         * headers: dimensionality * 4
+         * payload: blockSize * dimensionality * 4
+         * */
+        return ((long)dimensionality*4+(long)4*blockSize*dimensionality);
+    }
+
+}

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/SprintzEncoder.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/SprintzEncoder.java
@@ -225,7 +225,6 @@ public class SprintzEncoder extends Encoder{
     }
 
 
-
     /**
      * bit-pack each column of error together,
      * the number of bits required for each element in a column is the same, which is nbits

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/huffmanForByte/huffmanCompression.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/huffmanForByte/huffmanCompression.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tsfile.encoding.huffmanForByte;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Huffman compression encode bytes data
+ * It first calculates the frequency of every byte in a byte array,
+ * it then creates a binary tree using the frequency with shorter bit length
+ * finally return the encoded message with sufficient information.
+ * */
+public class huffmanCompression {
+
+    /*a dictionary to map each byte*/
+    public static List<String> dictionary = new ArrayList<>();
+    private huffmanNode root;
+
+    public huffmanCompression(){}
+
+    public huffmanNode getRoot(){return root;}
+
+
+    /** build huffmanTree from bytesBuffer*/
+    public void buildHuffmanTree(List<byte[]> bytesBuffer){
+        List<Byte> uniqueByte = getUniqueBytes(bytesBuffer);
+        List<Integer> frequency = getFrequency(bytesBuffer,uniqueByte);
+        huffmanNode tempRoot = null;
+
+        /*a list to store all huffman nodes*/
+        List<huffmanNode> nodeList = new ArrayList<>();
+
+        /*create huffman node for each character*/
+        for (int i = 0; i< uniqueByte.size(); i++){
+            huffmanNode node = new huffmanNode(frequency.get(i), uniqueByte.get(i),null,null);
+            nodeList.add(node);
+        }
+
+        /*sort node list based on frequency*/
+        nodeList = sortNode(nodeList);
+
+        /*loop to merge two smallest frequency nodes together*/
+        while(nodeList.size() >1){
+            /*join the two least frequent nodes*/
+            huffmanNode minNode = nodeList.get(0);
+            nodeList.remove(0);
+            huffmanNode secondMinNode = nodeList.get(0);
+            nodeList.remove(0);
+            /*the value is set to 11111111*/
+            huffmanNode huffmanNodeJoint = new huffmanNode(minNode.frequency+secondMinNode.frequency,
+                    (byte)0xFF,minNode,secondMinNode);
+            tempRoot = huffmanNodeJoint;
+            nodeList.add(tempRoot);
+            nodeList = sortNode(nodeList);
+        }
+
+        for (huffmanNode node:nodeList){
+            System.out.println(node.character +" has frequency of: " + node.frequency);
+        }
+        /*create a dictionary of codes*/
+        createDictionary(tempRoot,"");
+        root = tempRoot;
+    }
+
+
+
+    /** compress byte array.
+     * Using a huffman tree to match a code for each byte,
+     * output byte array*/
+    public byte[] huffmanCompress(List<byte[]> bytesBuffer){
+
+        String code = "";
+
+        /*translate each byte in bytes buffer*/
+        for (byte[] byteList: bytesBuffer){
+            for (byte b: byteList){
+                for (String word: dictionary){
+                    if (word.getBytes()[0] == b){
+                        code = code + word.substring(1);
+                    }
+                }
+            }
+        }
+        /*since the code is string, we convert it back to binary*/
+        return getBinary(code);
+    }
+
+
+    /** decompress byte array.
+     * Using a huffman tree to output the translated code,
+     * encodedBytes is a Byte Array we just encode*/
+    public byte[] huffmanDecompress(huffmanNode root,byte[] encodedBytes){
+        String decompress = "";
+        huffmanNode rootCopy = root;
+        String bitString = getString(encodedBytes);
+        for(Character character : bitString.toCharArray()){
+            if (character == '0') {
+                root = root.left;
+            }
+            else if(character == '1') {
+                root = root.right;
+            }
+            if(root.right == null && root.left == null){
+                if(root.character == (byte)0xFF){
+                    decompress = decompress + "\n";
+                }
+                else {
+                    decompress = decompress + root.character;
+                }
+                root = rootCopy;
+            }
+        }
+
+        return getBinary(decompress);
+    }
+
+
+
+    /**get the number of unique bytes in a buffer
+     * bytesBuffer: a list of byte array
+     * */
+    public List<Byte> getUniqueBytes(List<byte[]> bytesBuffer){
+        List<Byte> uniqueBytes = new ArrayList<>();
+        for (byte[] byteList: bytesBuffer){
+            for (byte b: byteList){
+                if (!uniqueBytes.contains(b)){
+                    uniqueBytes.add(b);
+                    System.out.println("one unique byte is: " + b);
+                }
+            }
+        }
+        System.out.println("the number of unique byte is: "+uniqueBytes.size());
+        return uniqueBytes;
+    }
+
+
+    /**get the frequency of each Byte
+     *allBytes is a list of all unique characters
+     */
+    public List<Integer> getFrequency(List<byte[]> bytesBuffer, List<Byte> allBytes){
+        List<Integer> frequency = new ArrayList<>();
+        for (Byte B: allBytes){
+            int counter = 0;
+            for (byte[] byteList: bytesBuffer){
+                for (byte b: byteList){
+                    if (b == B){
+                        counter += 1;
+                    }
+                }
+            }
+            frequency.add(counter);
+        }
+        return frequency;
+    }
+
+
+    /**sort huffman node so that the lowest frequency node comes first*/
+    public List<huffmanNode> sortNode(List<huffmanNode> nodeList){
+        for (int i =0;i<nodeList.size();i++){
+            int pos = i;
+            for (int j = i; j < nodeList.size(); j++){
+                if (nodeList.get(j).frequency < nodeList.get(pos).frequency){
+                    pos = j;
+                }
+            }
+            huffmanNode minNode = nodeList.get(pos);
+            nodeList.set(pos,nodeList.get(i));
+            nodeList.set(i, minNode);
+        }
+        return nodeList;
+    }
+
+
+    /**assigning code for each byte*/
+    public void createDictionary(huffmanNode root, String code){
+        /*a byte is found*/
+        if (root.left == null && root.right == null){
+            dictionary.add(root.character+code);
+            return;
+        }
+        /*recursively find code for elements in each subtree*/
+        createDictionary(root.left,code+"0");
+        createDictionary(root.right,code+"1");
+    }
+
+
+    /**produce a array of byte from encoding string*/
+    public byte[] getBinary(String encodedString){
+        StringBuilder sBuilder = new StringBuilder(encodedString);
+        while (sBuilder.length() % 8 != 0) {
+            sBuilder.append('0');
+        }
+        encodedString = sBuilder.toString();
+
+        // a byte array to store the bit version of encodedString
+        byte[] ByteCode = new byte[encodedString.length() / 8];
+
+        // split string into 8 bits per byte and store in array
+        for (int i = 0; i < encodedString.length(); i++) {
+            char c = encodedString.charAt(i);
+            if (c == '1') {
+                ByteCode[i >> 3] |= 0x80 >> (i & 0x7);
+            }
+        }
+        return ByteCode;
+    }
+
+
+    /**produce a string from encoded byte array*/
+    static @NotNull String getString(byte[] bytes) {
+        StringBuilder builder = new StringBuilder(bytes.length * Byte.SIZE);
+
+        for (int i = 0; i < Byte.SIZE * bytes.length; i++) {
+            // build string back of bits
+            builder.append((bytes[i / Byte.SIZE] << i % Byte.SIZE & 0x80) == 0 ? '0' : '1');
+        }
+        return builder.toString();
+    }
+
+
+}

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/huffmanForByte/huffmanCompression.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/huffmanForByte/huffmanCompression.java
@@ -39,7 +39,6 @@ public class huffmanCompression {
 
     public huffmanNode getRoot(){return root;}
 
-
     /** build huffmanTree from bytesBuffer*/
     public void buildHuffmanTree(List<byte[]> bytesBuffer){
         List<Byte> uniqueByte = getUniqueBytes(bytesBuffer);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/huffmanForByte/huffmanNode.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/huffmanForByte/huffmanNode.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tsfile.encoding.huffmanForByte;
+
+
+
+/** Base unit of huffman Tree*/
+public class huffmanNode{
+    int frequency;
+    /* we treat each byte as a character*/
+    byte character;
+    huffmanNode left;
+    huffmanNode right;
+
+    /** constructor*/
+    public huffmanNode(int frequency, byte character, huffmanNode left, huffmanNode right){
+        this.frequency = frequency;
+        this.character = character;
+        this.left = left;
+        this.right = right;
+    }
+}

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/huffmanForByte/huffmanNode.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/huffmanForByte/huffmanNode.java
@@ -19,8 +19,6 @@
 
 package org.apache.iotdb.tsfile.encoding.huffmanForByte;
 
-
-
 /** Base unit of huffman Tree*/
 public class huffmanNode{
     int frequency;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/TSEncoding.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/TSEncoding.java
@@ -27,7 +27,9 @@ public enum TSEncoding {
   BITMAP((byte) 5),
   GORILLA_V1((byte) 6),
   REGULAR((byte) 7),
-  GORILLA((byte) 8);
+  GORILLA((byte) 8),
+  SPRINTZ((byte) 9);
+
 
   private final byte type;
 
@@ -65,6 +67,8 @@ public enum TSEncoding {
         return TSEncoding.REGULAR;
       case 8:
         return TSEncoding.GORILLA;
+      case 9:
+        return TSEncoding.SPRINTZ;
       default:
         throw new IllegalArgumentException("Invalid input: " + encoding);
     }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/encoding/decoder/SprintzDecoderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/encoding/decoder/SprintzDecoderTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tsfile.encoding.decoder;
+
+import org.apache.iotdb.tsfile.encoding.encoder.SprintzEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.iotdb.tsfile.encoding.huffmanForByte.huffmanCompression;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+public class SprintzDecoderTest {
+
+    /** total number of test data, in total 100 blocks*/
+    private int dataLength = 3000;
+    private int blockSize = 10;
+    private int dimensionality = 3;
+
+    @Before
+    public void setUp(){
+    }
+
+    /** helper function for test encode and decode*/
+    public void testEncode(int[][] input, int blockSize, int dimensionality) throws IOException{
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SprintzEncoder encoder = new SprintzEncoder(blockSize,dimensionality);
+        /** encoder*/
+        for (int i = 0; i < dataLength; i++){
+            for (int j = 0; j < dimensionality; j++){
+                encoder.encode(input[i][j], out);
+            }
+            encoder.flush(out);
+        }
+        ByteBuffer buffer = ByteBuffer.wrap(out.toByteArray());
+        SprintzDecoder decoder = new SprintzDecoder(blockSize,dimensionality);
+
+        /*decode*/
+        for (int i = 0; i < dataLength; i++){
+            for (int j = 0; j < dimensionality; j++){
+                int value =  decoder.readInt(buffer);
+                assertEquals(value, input[i][j]);
+            }
+        }
+    }
+
+
+    @Test
+    public void testHuffmanEncode(){
+        List<byte[]> temp = new ArrayList<>();
+        byte[] b1 = {123,10,22,34};
+        byte[] b2 = {123,10,22};
+        byte[] b3 = {123,10};
+        byte[] b4 = {123};
+        temp.add(b1);
+        temp.add(b2);
+        temp.add(b3);
+        temp.add(b4);
+        for (byte[] bytes : temp){
+            for (byte b:bytes){
+                System.out.print(b);
+                System.out.print('-');
+            }
+        }
+        huffmanCompression hc= new huffmanCompression();
+        hc.buildHuffmanTree(temp);
+
+        for (String s: hc.dictionary){
+            byte[] sByte = s.getBytes();
+            for (byte b :sByte){
+                System.out.print(b);
+                System.out.print('|');
+            }
+            System.out.println();
+        }
+        byte[] compressedArray = hc.huffmanCompress(temp);
+        for (byte b : compressedArray){
+            System.out.print(b);
+            System.out.print('-');
+        }
+
+        byte[] decompressArray = hc.huffmanDecompress(hc.getRoot(),compressedArray);
+        for (byte b : decompressArray){
+            System.out.print(b);
+            System.out.print('-');
+        }
+    }
+
+
+    @Test
+    public void testDecodeSingleBlock() throws IOException{
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SprintzEncoder encoder = new SprintzEncoder(4,3);
+        int[] values = {5,2,104,10,2,103,15,2,102,20,2,101};
+        //int[] values = {-3,2,104,-3,2,104,-3,2,104,-3,2,104};
+        byte[] trueValue = {-96,-128,-126,-108,-96,112};
+        for (int i : values){
+            encoder.encode(i, out);
+        }
+        encoder.setPreviousValues(new int[]{-3,2,104});
+        boolean result;
+        encoder.flush(out);
+        byte[] encodedBuffer = out.toByteArray();
+        for (byte b: encodedBuffer){
+            System.out.print(b);
+        }
+
+        SprintzDecoder decoder = new SprintzDecoder(4,3);
+        decoder.readInt(ByteBuffer.wrap(encodedBuffer));
+
+    }
+
+
+    @Test
+    public void testEncodeSingleBlock() throws IOException{
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SprintzEncoder encoder = new SprintzEncoder(4,3);
+
+        /* previous value = -3 2 104
+        *  5 | 2 | 104                       16 | 0 | 0
+        *  10| 2 | 103    -delta encoding->  10 | 0 | 1  ->  header 101000001-------
+        *  15| 2 | 102                       10 | 0 | 1  ->  payload 100000101001010010100111
+        *  20| 2 | 101                       10 | 0 | 1
+        *                                    (5) (0) {1}
+        *                   number of bits required for each column
+        * */
+
+        int[] values = {5,2,104,10,2,103,15,2,102,20,2,101};
+        byte[] trueValue = {-96,-128,-126,-108,-96,112};
+        for (int i : values){
+            encoder.encode(i, out);
+        }
+        encoder.setPreviousValues(new int[]{-3,2,104});
+        boolean result;
+
+        encoder.encodeBlockBuffer();
+        int count = 0;
+        System.out.println("Test header and payload");
+        for (byte[] bytes : encoder.getBytesBuffer()){
+            for (byte b:bytes){
+                assertEquals(b, trueValue[count]);
+                System.out.print(b);
+                count++;
+            }
+        }
+
+        //test flush
+        System.out.println("Test flush");
+        encoder.flush(out);
+        byte[] encodedBuffer = out.toByteArray();
+        for (byte b: encodedBuffer){
+            System.out.print(b);
+        }
+
+        int[] values2 = {25,2,100,30,2,99,35,2,98,40,2,97};
+        for (int i : values2){
+            encoder.encode(i, out);
+        }
+        encoder.flush(out);
+        byte[] encodedBuffer2 = out.toByteArray();
+        for (byte b: encodedBuffer2){
+            System.out.print(b);
+        }
+    }
+
+
+    @Test
+    public void testBitPack(){
+        SprintzEncoder encoder = new SprintzEncoder(4,3);
+        /* 10000010|10010100|10100000*/
+        SprintzDecoder decoder = new SprintzDecoder(4,3);
+        int[] values = {16,10,10,10};
+        byte[] results = {-126,-108,-96};
+        byte[] buf = new byte[3];
+        encoder.packColumns(values, buf, 5);
+        for (int i = 0; i<buf.length; i++){
+            System.out.println(buf[i]);
+            assertEquals(results[i], buf[i]);
+        }
+
+        int[] unpackValues = new int[4];
+        decoder.unpackColumns(buf,unpackValues,5);
+        for (int i =0; i< unpackValues.length; i++){
+            System.out.println(unpackValues[i]);
+            assertEquals(values[i], unpackValues[i]);
+        }
+    }
+
+    @Test
+    public void testReadInt() throws IOException{
+    }
+
+
+}

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/encoding/decoder/SprintzDecoderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/encoding/decoder/SprintzDecoderTest.java
@@ -130,7 +130,6 @@ public class SprintzDecoderTest {
 
         SprintzDecoder decoder = new SprintzDecoder(4,3);
         decoder.readInt(ByteBuffer.wrap(encodedBuffer));
-
     }
 
 


### PR DESCRIPTION
Support Sprintz encoding

A complete Sprintz encoding consists of 
-> delta encoding   (done)
-> Fast integer regression. (on working) 
-> RLE of zero block (done)
-> Huffman encode (small bug)

The file of SprintzDecoder is incomplete, still on working.

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read
    - [] concurrent write
    - [] concurrent read and write 
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. 
- [x] added or updated version, __license__, or notice information
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [] added integration tests.
- [] been tested in a test IoTDB cluster.

