### PR TITLE
[IOTDB-1859] CI fails on coveralls caused by openapi generated files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -729,6 +729,7 @@
                         <sourceDirectory>thrift/target/generated-sources/thrift</sourceDirectory>
                         <sourceDirectory>thrift-sync/target/generated-sources/thrift</sourceDirectory>
                         <sourceDirectory>thrift-cluster/target/generated-sources/thrift</sourceDirectory>
+                        <sourceDirectory>openapi/target/generated-sources/java</sourceDirectory>
                         <sourceDirectory>spark-iotdb-connector/src/main/scala</sourceDirectory>
                         <sourceDirectory>spark-tsfile/src/main/scala</sourceDirectory>
                     </sourceDirectories>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30497621/141398133-6581a66b-a059-4ba4-bafd-df2c58aa463a.png)