### PR TITLE
[To rel/0.12] Revert "Bump jackson-xc from 1.9.13 to 1.9.14-MULE-002"

### DIFF
--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -142,7 +142,7 @@
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-xc</artifactId>
-                <version>1.9.14-MULE-002</version>
+                <version>1.9.13</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
Reverts apache/iotdb#4272 to fix hive-connector issue
![55751636683969_ pic_hd](https://user-images.githubusercontent.com/25913899/141399412-7c474244-141d-4e66-98c8-5cd4b250a99d.jpg)

