### PR TITLE
[To rel/0.12][IOTDB-1990] Fix uncheck null result by calling IReaderByTimestamp.getValuesInTimestamps()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,6 +65,7 @@
 * [IOTDB-1872] Fix data increases abnormally after IoTDB restarts
 * [IOTDB-1975] OOM caused by that MaxQueryDeduplicatedPathNum doesn't take effect
 * [IOTDB-1983] Fix DescReadWriteBatchData serializing bug
+* [IOTDB-1990] Fix unchecked null result by calling IReaderByTimestamp.getValuesInTimestamps()
 * fix merge ClassCastException: MeasurementMNode
 * change sync version check to major version
 * init dummyIndex after restart cluster

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterFillExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/fill/ClusterFillExecutor.java
@@ -90,7 +90,7 @@ public class ClusterFillExecutor extends FillQueryExecutor {
               plan.isAscending());
 
       Object[] results = reader.getValuesInTimestamps(new long[] {queryTime}, 1);
-      if (results[0] != null) {
+      if (results != null && results[0] != null) {
         ret.add(new TimeValuePair(queryTime, TsPrimitiveType.getByType(dataType, results[0])));
       } else {
         ret.add(null);

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithValueFilter.java
@@ -117,7 +117,7 @@ public class RawQueryDataSetWithValueFilter extends QueryDataSet implements UDFI
 
       // 3. use values in results to fill row record
       for (int j = 0; j < cachedTimeCnt; j++) {
-        if (results[j] == null) {
+        if (results == null || results[j] == null) {
           rowRecords[j].addField(null);
         } else {
           hasField[j] = true;
@@ -193,7 +193,7 @@ public class RawQueryDataSetWithValueFilter extends QueryDataSet implements UDFI
 
       // 3. use values in results to fill row record
       for (int j = 0; j < cachedTimeCnt; j++) {
-        if (results[j] != null) {
+        if (results != null && results[j] != null) {
           hasField[j] = true;
           rowsInObject[j][i] = results[j];
         }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
@@ -444,8 +444,10 @@ public class AggregationExecutor {
                 .updateResultUsingTimestamps(timeArray, timeArrayLength, entry.getKey());
           } else {
             Object[] values = entry.getKey().getValuesInTimestamps(timeArray, timeArrayLength);
-            for (Integer i : entry.getValue()) {
-              aggregateResults.get(i).updateResultUsingValues(timeArray, timeArrayLength, values);
+            if (values != null) {
+              for (Integer i : entry.getValue()) {
+                aggregateResults.get(i).updateResultUsingValues(timeArray, timeArrayLength, values);
+              }
             }
           }
         }


### PR DESCRIPTION
The cherry-pick of #4358 

JIRA: https://issues.apache.org/jira/browse/IOTDB-1990