### PR TITLE
[ISSUE-4314] [docs] fix the Url of 'Get started quickly' 

### DIFF
--- a/docs/Development/ContributeGuide.md
+++ b/docs/Development/ContributeGuide.md
@@ -31,7 +31,7 @@ Code library for go language: https://github.com/apache/iotdb-client-go
 
 Library for resources (project's documents, compiler, etc): https://github.com/apache/iotdb-bin-resources
 
-Get started quickly：http://iotdb.apache.org/UserGuide/master/Get%20Started/QuickStart.html
+Get started quickly：http://iotdb.apache.org/UserGuide/Master/QuickStart/QuickStart.html
 
 Jira Task Management：https://issues.apache.org/jira/projects/IOTDB/issues
 


### PR DESCRIPTION
## 描述
修复了/docs/deployment/ContributeGuide.md中‘Get started quickly’路径不正确的问题。



