### PR TITLE
[IOTDB-1997] Fix bug of descending aggregation query

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
@@ -707,33 +707,30 @@ public class LocalQueryExecutor {
 
     ClusterQueryUtils.checkPathExistence(path);
     List<AggregateResult> results = new ArrayList<>();
+    List<AggregateResult> ascResults = new ArrayList<>();
+    List<AggregateResult> descResults = new ArrayList<>();
     for (String aggregation : aggregations) {
-      results.add(AggregateResultFactory.getAggrResultByName(aggregation, dataType, ascending));
+      AggregateResult ar =
+          AggregateResultFactory.getAggrResultByName(aggregation, dataType, ascending);
+      if (ar.isAscending()) {
+        ascResults.add(ar);
+      } else {
+        descResults.add(ar);
+      }
+      results.add(ar);
     }
     List<Integer> nodeSlots =
         ((SlotPartitionTable) dataGroupMember.getMetaGroupMember().getPartitionTable())
             .getNodeSlots(dataGroupMember.getHeader());
-    if (ascending) {
-      AggregationExecutor.aggregateOneSeries(
-          path,
-          allSensors,
-          context,
-          timeFilter,
-          dataType,
-          results,
-          null,
-          new SlotTsFileFilter(nodeSlots));
-    } else {
-      AggregationExecutor.aggregateOneSeries(
-          path,
-          allSensors,
-          context,
-          timeFilter,
-          dataType,
-          null,
-          results,
-          new SlotTsFileFilter(nodeSlots));
-    }
+    AggregationExecutor.aggregateOneSeries(
+        path,
+        allSensors,
+        context,
+        timeFilter,
+        dataType,
+        ascResults,
+        descResults,
+        new SlotTsFileFilter(nodeSlots));
     return results;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/aggregation/AggregateResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/aggregation/AggregateResult.java
@@ -70,7 +70,8 @@ public abstract class AggregateResult {
       throws QueryProcessException;
 
   /**
-   * Aggregate results cannot be calculated using Statistics directly, using the data in each page
+   * Aggregate results cannot be calculated using Statistics directly, using the data in each page.
+   * This method is used in global aggregation query.
    *
    * @param batchIterator the data in Page
    */
@@ -78,7 +79,8 @@ public abstract class AggregateResult {
       throws IOException, QueryProcessException;
 
   /**
-   * Aggregate results cannot be calculated using Statistics directly, using the data in each page
+   * Aggregate results cannot be calculated using Statistics directly, using the data in each page.
+   * This method is used in GROUP BY aggregation query.
    *
    * @param batchIterator the data in Page
    * @param minBound calculate points whose time >= bound
@@ -311,6 +313,10 @@ public abstract class AggregateResult {
     return aggregationType;
   }
 
+  /**
+   * Whether the AggregationResult accepts data in time ascending order, if it returns false, the
+   * data should be passed in time descending order.
+   */
   public boolean isAscending() {
     return true;
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/FirstValueAggrResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/FirstValueAggrResult.java
@@ -65,13 +65,7 @@ public class FirstValueAggrResult extends AggregateResult {
 
   @Override
   public void updateResultFromPageData(IBatchDataIterator batchIterator) {
-    if (hasFinalResult()) {
-      return;
-    }
-    if (batchIterator.hasNext()) {
-      setValue(batchIterator.currentValue());
-      timestamp = batchIterator.currentTime();
-    }
+    updateResultFromPageData(batchIterator, Long.MIN_VALUE, Long.MAX_VALUE);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/FirstValueDescAggrResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/FirstValueDescAggrResult.java
@@ -76,6 +76,11 @@ public class FirstValueDescAggrResult extends FirstValueAggrResult {
   }
 
   @Override
+  public boolean isAscending() {
+    return false;
+  }
+
+  @Override
   public boolean hasFinalResult() {
     return false;
   }

--- a/server/src/test/java/org/apache/iotdb/db/query/aggregation/DescAggregateResultTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/aggregation/DescAggregateResultTest.java
@@ -24,6 +24,9 @@ import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.db.query.factory.AggregateResultFactory;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
+import org.apache.iotdb.tsfile.read.common.BatchData;
+import org.apache.iotdb.tsfile.read.common.BatchDataFactory;
+import org.apache.iotdb.tsfile.read.common.IBatchDataIterator;
 import org.apache.iotdb.tsfile.utils.Binary;
 
 import org.junit.Assert;
@@ -56,6 +59,21 @@ public class DescAggregateResultTest {
     ByteBuffer byteBuffer = ByteBuffer.wrap(outputStream.toByteArray());
     AggregateResult result = AggregateResult.deserializeFrom(byteBuffer);
     Assert.assertEquals(10L, (long) result.getResult());
+
+    maxTimeDescAggrResult.reset();
+    BatchData batchData = BatchDataFactory.createBatchData(TSDataType.FLOAT, false, false);
+    batchData.putFloat(1, 1.0F);
+    batchData.putFloat(2, 2.0F);
+    batchData.putFloat(3, 3.0F);
+    batchData.putFloat(4, 4.0F);
+    batchData.putFloat(5, 5.0F);
+    batchData.resetBatchData();
+    IBatchDataIterator it = batchData.getBatchDataIterator();
+    maxTimeDescAggrResult.updateResultFromPageData(it);
+    Assert.assertEquals(5L, maxTimeDescAggrResult.getResult());
+    it.reset();
+    maxTimeDescAggrResult.updateResultFromPageData(it, 2, 5);
+    Assert.assertEquals(5L, maxTimeDescAggrResult.getResult());
   }
 
   @Test
@@ -78,6 +96,21 @@ public class DescAggregateResultTest {
     ByteBuffer byteBuffer = ByteBuffer.wrap(outputStream.toByteArray());
     AggregateResult result = AggregateResult.deserializeFrom(byteBuffer);
     Assert.assertEquals(1L, (long) result.getResult());
+
+    minTimeDescAggrResult.reset();
+    BatchData batchData = BatchDataFactory.createBatchData(TSDataType.FLOAT, false, false);
+    batchData.putFloat(1, 1.0F);
+    batchData.putFloat(2, 2.0F);
+    batchData.putFloat(3, 3.0F);
+    batchData.putFloat(4, 4.0F);
+    batchData.putFloat(5, 5.0F);
+    batchData.resetBatchData();
+    IBatchDataIterator it = batchData.getBatchDataIterator();
+    minTimeDescAggrResult.updateResultFromPageData(it);
+    Assert.assertEquals(1L, minTimeDescAggrResult.getResult());
+    it.reset();
+    minTimeDescAggrResult.updateResultFromPageData(it, 1, 3);
+    Assert.assertEquals(1L, minTimeDescAggrResult.getResult());
   }
 
   @Test
@@ -101,6 +134,21 @@ public class DescAggregateResultTest {
     ByteBuffer byteBuffer = ByteBuffer.wrap(outputStream.toByteArray());
     AggregateResult result = AggregateResult.deserializeFrom(byteBuffer);
     Assert.assertEquals(false, result.getResult());
+
+    firstValueDescAggrResult.reset();
+    BatchData batchData = BatchDataFactory.createBatchData(TSDataType.BOOLEAN, false, false);
+    batchData.putBoolean(1, true);
+    batchData.putBoolean(2, false);
+    batchData.putBoolean(3, false);
+    batchData.putBoolean(4, true);
+    batchData.putBoolean(5, false);
+    batchData.resetBatchData();
+    IBatchDataIterator it = batchData.getBatchDataIterator();
+    firstValueDescAggrResult.updateResultFromPageData(it);
+    Assert.assertTrue((boolean) firstValueDescAggrResult.getResult());
+    it.reset();
+    firstValueDescAggrResult.updateResultFromPageData(it, 1, 3);
+    Assert.assertTrue((boolean) firstValueDescAggrResult.getResult());
   }
 
   @Test
@@ -123,5 +171,20 @@ public class DescAggregateResultTest {
     ByteBuffer byteBuffer = ByteBuffer.wrap(outputStream.toByteArray());
     AggregateResult result = AggregateResult.deserializeFrom(byteBuffer);
     Assert.assertEquals("last", String.valueOf(result.getResult()));
+
+    lastValueDescAggrResult.reset();
+    BatchData batchData = BatchDataFactory.createBatchData(TSDataType.TEXT, false, false);
+    batchData.putBinary(1L, new Binary("a"));
+    batchData.putBinary(2L, new Binary("b"));
+    batchData.putBinary(3L, new Binary("c"));
+    batchData.putBinary(4L, new Binary("d"));
+    batchData.putBinary(5L, new Binary("e"));
+    batchData.resetBatchData();
+    IBatchDataIterator it = batchData.getBatchDataIterator();
+    lastValueDescAggrResult.updateResultFromPageData(it);
+    Assert.assertEquals("e", ((Binary) lastValueDescAggrResult.getResult()).getStringValue());
+    it.reset();
+    lastValueDescAggrResult.updateResultFromPageData(it, 3, 5);
+    Assert.assertEquals("e", ((Binary) lastValueDescAggrResult.getResult()).getStringValue());
   }
 }


### PR DESCRIPTION
See JIRA https://issues.apache.org/jira/browse/IOTDB-1997
The following bugs are fixed:
1. LocalQueryExecutor passes `AggregationResult` list into an ascending and decending one to create proper reader with the `AggregationResult.isAscending()`.
2. Fix the bug of `FirstValueDescAggrResult` implementation.
3. Add java doc and unit test cases.