### PR TITLE
[IOTDB-2004] change initial assignment of Long to uppercase L

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/udf/builtin/UDTFCast.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/builtin/UDTFCast.java
@@ -126,7 +126,7 @@ public class UDTFCast implements UDTF {
         collector.putDouble(time, value);
         return;
       case BOOLEAN:
-        collector.putBoolean(time, value != 0l);
+        collector.putBoolean(time, value != 0L);
         return;
       case TEXT:
         collector.putString(time, String.valueOf(value));


### PR DESCRIPTION
## Description

In the initial assignment of long or Long, uppercase L must be used instead of lowercase l. Lowercase is easy to confuse with the number 1 and cause misunderstandings.