### PR TITLE
[IOTDB-2006] avoid NPE while calling the equals method of Object

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
@@ -523,7 +523,7 @@ public abstract class AbstractCli {
                     maxPrintRowCount));
             BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
             try {
-              if (br.readLine().equals("")) {
+              if ("".equals(br.readLine())) {
                 maxSizeList = new ArrayList<>(columnLength);
                 lists =
                     cacheResult(resultSet, maxSizeList, columnLength, resultSetMetaData, zoneId);

--- a/cli/src/main/java/org/apache/iotdb/tool/ExportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ExportCsv.java
@@ -328,7 +328,7 @@ public class ExportCsv extends AbstractCsvTool {
 
     if (needDataTypePrinted) {
       for (int i = 0; i < names.size(); i++) {
-        if (!names.get(i).equals("Time") && !names.get(i).equals("Device")) {
+        if (!"Time".equals(names.get(i)) && !"Device".equals(names.get(i))) {
           headers.add(String.format("%s(%s)", names.get(i), types.get(i)));
         } else {
           headers.add(names.get(i));
@@ -350,7 +350,7 @@ public class ExportCsv extends AbstractCsvTool {
           .forEach(
               field -> {
                 String fieldStringValue = field.getStringValue();
-                if (!field.getStringValue().equals("null")) {
+                if (!"null".equals(field.getStringValue())) {
                   if (field.getDataType() == TSDataType.TEXT
                       && !fieldStringValue.startsWith("root.")) {
                     fieldStringValue = "\"" + fieldStringValue + "\"";

--- a/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
@@ -319,7 +319,7 @@ public class ImportCsv extends AbstractCsvTool {
                         measurementName -> {
                           String header = deviceId + "." + measurementName;
                           String value = record.get(header);
-                          if (!value.equals("")) {
+                          if (!"".equals(value)) {
                             TSDataType type;
                             if (!headerTypeMap.containsKey(headerNameMap.get(header))) {
                               type = typeInfer(value);
@@ -436,7 +436,7 @@ public class ImportCsv extends AbstractCsvTool {
                             .forEach(
                                 measurement -> {
                                   String value = record.get(measurement);
-                                  if (!value.equals("")) {
+                                  if (!"".equals(value)) {
                                     TSDataType type;
                                     if (!headerTypeMap.containsKey(
                                         headerNameMap.get(measurement))) {
@@ -541,7 +541,7 @@ public class ImportCsv extends AbstractCsvTool {
     String regex = "(?<=\\()\\S+(?=\\))";
     Pattern pattern = Pattern.compile(regex);
     for (String headerName : headerNames) {
-      if (headerName.equals("Time") || headerName.equals("Device")) continue;
+      if ("Time".equals(headerName) || "Device".equals(headerName)) continue;
       Matcher matcher = pattern.matcher(headerName);
       String type;
       if (matcher.find()) {
@@ -653,7 +653,7 @@ public class ImportCsv extends AbstractCsvTool {
    */
   private static TSDataType typeInfer(String value) {
     if (value.contains("\"")) return TEXT;
-    else if (value.equals("true") || value.equals("false")) return BOOLEAN;
+    else if ("true".equals(value) || "false".equals(value)) return BOOLEAN;
     else if (!value.contains(".")) {
       try {
         Integer.valueOf(value);
@@ -684,7 +684,7 @@ public class ImportCsv extends AbstractCsvTool {
         case TEXT:
           return value.substring(1, value.length() - 1);
         case BOOLEAN:
-          if (!value.equals("true") && !value.equals("false")) {
+          if (!"true".equals(value) && !"false".equals(value)) {
             return null;
           }
           return Boolean.valueOf(value);

--- a/grafana/src/main/java/org/apache/iotdb/web/grafana/controller/DatabaseConnectController.java
+++ b/grafana/src/main/java/org/apache/iotdb/web/grafana/controller/DatabaseConnectController.java
@@ -123,9 +123,9 @@ public class DatabaseConnectController {
 
         JsonObject obj = new JsonObject();
         obj.addProperty("target", target);
-        if (type.equals("table")) {
+        if ("table".equals(type)) {
           setJsonTable(obj, target, timeRange);
-        } else if (type.equals("timeserie")) {
+        } else if ("timeserie".equals(type)) {
           setJsonTimeseries(obj, target, timeRange);
         }
         result.add(obj);

--- a/grafana/src/main/java/org/apache/iotdb/web/grafana/dao/impl/BasicDaoImpl.java
+++ b/grafana/src/main/java/org/apache/iotdb/web/grafana/dao/impl/BasicDaoImpl.java
@@ -148,7 +148,7 @@ public class BasicDaoImpl implements BasicDao {
     String columnName = "root." + s;
 
     String intervalLocal = getInterval(hours);
-    if (!intervalLocal.equals("")) {
+    if (!"".equals(intervalLocal)) {
       sql =
           String.format(
               "SELECT "

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
@@ -1063,7 +1063,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         m.put("type", listType.get(i));
         if (i == 2) {
           m.put("val", rs.getString(1));
-        } else if (fields[i].getSqlType().equals("INT32")) {
+        } else if ("INT32".equals(fields[i].getSqlType())) {
           m.put("val", 0);
         } else {
           m.put("val", "");

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
@@ -72,45 +72,45 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
     if (column < 1 || column > columnInfoList.size()) {
       throw new SQLException(Constant.METHOD_NOT_SUPPORTED);
     }
-    if (operationType.equals("SHOW")) {
-      if (listColumns.get(0).equals("count")) {
+    if ("SHOW".equals(operationType)) {
+      if ("count".equals(listColumns.get(0))) {
         return system_database;
-      } else if (listColumns.get(0).equals("storage group")
+      } else if ("storage group".equals(listColumns.get(0))
           && listColumns.size() > 1
-          && listColumns.get(1).equals("ttl")) {
+          && "ttl".equals(listColumns.get(1))) {
         return "";
-      } else if (listColumns.get(0).trim().equals("version") && listColumns.size() == 1) {
+      } else if ("version".equals(listColumns.get(0).trim()) && listColumns.size() == 1) {
         return system;
-      } else if (listColumns.get(0).equals("storage group")
-          || listColumns.get(0).equals("devices")
-          || listColumns.get(0).equals("child paths")
-          || listColumns.get(0).equals("child nodes")
-          || listColumns.get(0).equals("timeseries")) {
+      } else if ("storage group".equals(listColumns.get(0))
+          || "devices".equals(listColumns.get(0))
+          || "child paths".equals(listColumns.get(0))
+          || "child nodes".equals(listColumns.get(0))
+          || "timeseries".equals(listColumns.get(0))) {
         return system_schmea;
       }
-    } else if (operationType.equals("LIST_USER")) {
+    } else if ("LIST_USER".equals(operationType)) {
       return system_user;
-    } else if (operationType.equals("LIST_ROLE")) {
+    } else if ("LIST_ROLE".equals(operationType)) {
       return system_role;
-    } else if (operationType.equals("LIST_USER_PRIVILEGE")) {
+    } else if ("LIST_USER_PRIVILEGE".equals(operationType)) {
       return system_auths;
-    } else if (operationType.equals("LIST_ROLE_PRIVILEGE")) {
+    } else if ("LIST_ROLE_PRIVILEGE".equals(operationType)) {
       return system_auths;
-    } else if (operationType.equals("LIST_USER_ROLES")) {
+    } else if ("LIST_USER_ROLES".equals(operationType)) {
       return system_role;
-    } else if (operationType.equals("LIST_ROLE_USERS")) {
+    } else if ("LIST_ROLE_USERS".equals(operationType)) {
       return system_user;
-    } else if (operationType.equals("QUERY")) {
-      if ((columnName.toLowerCase().equals("time") && columnInfoList.size() != 2)
-          || columnName.toLowerCase().equals("timeseries")
-          || columnName.toLowerCase().equals("device")) {
+    } else if ("QUERY".equals(operationType)) {
+      if (("time".equals(columnName.toLowerCase()) && columnInfoList.size() != 2)
+          || "timeseries".equals(columnName.toLowerCase())
+          || "device".equals(columnName.toLowerCase())) {
         return system_null;
       } else if (columnInfoList.size() >= 2
-          && columnInfoList.get(0).toLowerCase().equals("time")
-          && columnInfoList.get(1).toLowerCase().equals("device")) {
+          && "time".equals(columnInfoList.get(0).toLowerCase())
+          && "device".equals(columnInfoList.get(1).toLowerCase())) {
         return system_null;
       }
-    } else if (!operationType.equals("FILL")) {
+    } else if (!"FILL".equals(operationType)) {
       return system_null;
     }
     if (nonAlign) {
@@ -216,12 +216,12 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
       columnType = columnTypeList.get(column - 1);
     }
     String typeString = columnType.toUpperCase();
-    if (typeString.equals("BOOLEAN")
-        || typeString.equals("INT32")
-        || typeString.equals("INT64")
-        || typeString.equals("FLOAT")
-        || typeString.equals("DOUBLE")
-        || typeString.equals("TEXT")) {
+    if ("BOOLEAN".equals(typeString)
+        || "INT32".equals(typeString)
+        || "INT64".equals(typeString)
+        || "FLOAT".equals(typeString)
+        || "DOUBLE".equals(typeString)
+        || "TEXT".equals(typeString)) {
       return typeString;
     }
     return null;

--- a/server/src/main/java/org/apache/iotdb/db/auth/authorizer/OpenIdAuthorizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/authorizer/OpenIdAuthorizer.java
@@ -124,7 +124,7 @@ public class OpenIdAuthorizer extends BasicAuthorizer {
     JSONArray keyList = (JSONArray) json.get("keys");
     for (Object key : keyList) {
       JSONObject k = (JSONObject) key;
-      if (k.get("use").equals("sig") && k.get("kty").equals("RSA")) {
+      if ("sig".equals(k.get("use")) && "RSA".equals(k.get("kty"))) {
         return k;
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1009,9 +1009,9 @@ public class IoTDBConfig {
   }
 
   public void setTimestampPrecision(String timestampPrecision) {
-    if (!(timestampPrecision.equals("ms")
-        || timestampPrecision.equals("us")
-        || timestampPrecision.equals("ns"))) {
+    if (!("ms".equals(timestampPrecision)
+        || "us".equals(timestampPrecision)
+        || "ns".equals(timestampPrecision))) {
       logger.error(
           "Wrong timestamp precision, please set as: ms, us or ns ! Current is: "
               + timestampPrecision);
@@ -1269,7 +1269,7 @@ public class IoTDBConfig {
   }
 
   public String getIoTDBMajorVersion(String version) {
-    return version.equals("UNKNOWN")
+    return "UNKNOWN".equals(version)
         ? "UNKNOWN"
         : version.split("\\.")[0] + "." + version.split("\\.")[1];
   }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
@@ -130,9 +130,9 @@ public class IoTDBConfigCheck {
     }
 
     // check time stamp precision
-    if (!(timestampPrecision.equals("ms")
-        || timestampPrecision.equals("us")
-        || timestampPrecision.equals("ns"))) {
+    if (!("ms".equals(timestampPrecision)
+        || "us".equals(timestampPrecision)
+        || "ns".equals(timestampPrecision))) {
       logger.error(
           "Wrong {}, please set as: ms, us or ns ! Current is: {}",
           TIMESTAMP_PRECISION_STRING,
@@ -248,7 +248,7 @@ public class IoTDBConfigCheck {
     }
 
     // virtual storage group num can only set to 1 when upgrading from old version
-    if (!virtualStorageGroupNum.equals("1")) {
+    if (!"1".equals(virtualStorageGroupNum)) {
       logger.error(
           "virtual storage group num cannot set to {} when upgrading from old version, "
               + "please set to 1 and restart",

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -32,7 +32,7 @@ public class IoTDBConstant {
           ? IoTDBConstant.class.getPackage().getImplementationVersion()
           : "UNKNOWN";
   public static final String MAJOR_VERSION =
-      VERSION.equals("UNKNOWN")
+      "UNKNOWN".equals(VERSION)
           ? "UNKNOWN"
           : VERSION.split("\\.")[0] + "." + VERSION.split("\\.")[1];
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossCompactionStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossCompactionStrategy.java
@@ -33,7 +33,7 @@ public enum CrossCompactionStrategy {
   INPLACE_COMPACTION;
 
   public static CrossCompactionStrategy getCrossCompactionStrategy(String name) {
-    if (name.equalsIgnoreCase("INPLACE_COMPACTION")) {
+    if ("INPLACE_COMPACTION".equalsIgnoreCase(name)) {
       return INPLACE_COMPACTION;
     }
     throw new RuntimeException("Illegal Cross Compaction Strategy " + name);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionStrategy.java
@@ -34,7 +34,7 @@ public enum InnerCompactionStrategy {
   SIZE_TIERED_COMPACTION;
 
   public static InnerCompactionStrategy getInnerCompactionStrategy(String name) {
-    if (name.equalsIgnoreCase("SIZE_TIERED_COMPACTION")) {
+    if ("SIZE_TIERED_COMPACTION".equalsIgnoreCase(name)) {
       return SIZE_TIERED_COMPACTION;
     }
     throw new RuntimeException("Illegal Compaction Strategy " + name);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -3264,13 +3264,14 @@ public class StorageGroupProcessor {
     } else {
       for (String tsFilePath : tsFilePaths) {
         File fileToBeSettled = new File(tsFilePath);
-        if (fileToBeSettled
-            .getParentFile()
-            .getParentFile()
-            .getParentFile()
-            .getParentFile()
-            .getName()
-            .equals("sequence")) {
+        if ("sequence"
+            .equals(
+                fileToBeSettled
+                    .getParentFile()
+                    .getParentFile()
+                    .getParentFile()
+                    .getParentFile()
+                    .getName())) {
           for (TsFileResource resource : tsFileManager.getTsFileList(true)) {
             if (resource.getTsFile().getAbsolutePath().equals(tsFilePath)) {
               resource.setSettleTsFileCallBack(this::settleTsFileCallBack);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogWriter.java
@@ -256,7 +256,7 @@ public class MLogWriter implements AutoCloseable {
       case "2":
         return new MeasurementMNodePlan(
             words[1],
-            words[2].equals("") ? null : words[2],
+            "".equals(words[2]) ? null : words[2],
             Long.parseLong(words[words.length - 2]),
             Integer.parseInt(words[words.length - 1]),
             new UnaryMeasurementSchema(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
@@ -228,7 +228,7 @@ public class Template {
       }
       for (int i = 0; i <= measurementNames.size() - 1; i++) {
         // find the parent and add nodes to template
-        if (prefix.equals("")) {
+        if ("".equals(prefix)) {
           leafNode =
               MeasurementMNode.getMeasurementMNode(null, measurementNames.get(i), schemas[i], null);
           directNodes.put(leafNode.getName(), leafNode);
@@ -319,7 +319,7 @@ public class Template {
   }
 
   public List<String> getMeasurementsUnderPath(String path) throws MetadataException {
-    if (path.equals("")) {
+    if ("".equals(path)) {
       return getAllMeasurementsPaths();
     }
     List<String> res = new ArrayList<>();

--- a/server/src/main/java/org/apache/iotdb/db/metrics/server/ServerArgument.java
+++ b/server/src/main/java/org/apache/iotdb/db/metrics/server/ServerArgument.java
@@ -264,26 +264,26 @@ public class ServerArgument {
         List<String> digitS2 = new ArrayList<>();
         digitS1.add(s1.replaceAll("\\D", ""));
         digitS2.add(s2.replaceAll("\\D", ""));
-        if (caption.equals("System Idle Process") || caption.equals("System")) {
+        if ("System Idle Process".equals(caption) || "System".equals(caption)) {
           if (s1.length() > 0) {
-            if (!digitS1.get(0).equals("") && digitS1.get(0) != null) {
+            if (!"".equals(digitS1.get(0)) && digitS1.get(0) != null) {
               idletime += Long.valueOf(digitS1.get(0)).longValue();
             }
           }
           if (s2.length() > 0) {
-            if (!digitS2.get(0).equals("") && digitS2.get(0) != null) {
+            if (!"".equals(digitS2.get(0)) && digitS2.get(0) != null) {
               idletime += Long.valueOf(digitS2.get(0)).longValue();
             }
           }
           continue;
         }
         if (s1.length() > 0) {
-          if (!digitS1.get(0).equals("") && digitS1.get(0) != null) {
+          if (!"".equals(digitS1.get(0)) && digitS1.get(0) != null) {
             kneltime += Long.valueOf(digitS1.get(0)).longValue();
           }
         }
         if (s2.length() > 0) {
-          if (!digitS2.get(0).equals("") && digitS2.get(0) != null) {
+          if (!"".equals(digitS2.get(0)) && digitS2.get(0) != null) {
             kneltime += Long.valueOf(digitS2.get(0)).longValue();
           }
         }

--- a/server/src/main/java/org/apache/iotdb/db/metrics/ui/MetricsPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metrics/ui/MetricsPage.java
@@ -164,7 +164,7 @@ public class MetricsPage {
                 + status
                 + "</td>"
                 + "<td>"
-                + ((errMsg == null || errMsg.equals("")) ? "== Parsed Physical Plan ==" : errMsg)
+                + ((errMsg == null || "".equals(errMsg)) ? "== Parsed Physical Plan ==" : errMsg)
                 + "<span class=\"expand-details\" onclick=\"this.parentNode.querySelector('.stacktrace-details').classList.toggle('collapsed')\">+ details</span>"
                 + "<div class=\"stacktrace-details collapsed\">"
                 + "<pre>"

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/InOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/InOperator.java
@@ -198,7 +198,7 @@ public class InOperator extends FunctionOperator {
 
     public static <T extends Comparable<T>> IUnaryExpression getUnaryExpression(
         Path path, Set<T> values, boolean not) {
-      if (path.equals("time")) {
+      if ("time".equals(path)) {
         return new GlobalTimeExpression(TimeFilter.in((Set<Long>) values, not));
       } else {
         return new SingleSeriesExpression(path, ValueFilter.in(values, not));

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/CreateTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/CreateTemplatePlan.java
@@ -241,7 +241,7 @@ public class CreateTemplatePlan extends PhysicalPlan {
         alignedEncodings.get(prefix).add(encoding);
         alignedCompressions.get(prefix).add(compressionType);
       } else {
-        if (prefix.equals("")) {
+        if ("".equals(prefix)) {
           measurements.add(Collections.singletonList(measurementName));
         } else {
           measurements.add(
@@ -260,7 +260,7 @@ public class CreateTemplatePlan extends PhysicalPlan {
       List<CompressionType> thisCompressors = new ArrayList<>();
 
       for (int i = 0; i < alignedPrefix.get(prefix).size(); i++) {
-        if (prefix.equals("")) {
+        if ("".equals(prefix)) {
           thisMeasurements.add(alignedPrefix.get(prefix).get(i));
         } else {
           thisMeasurements.add(

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -1912,7 +1912,7 @@ public class IoTDBSqlVisitor extends IoTDBSqlParserBaseVisitor<Operator> {
 
   /** function for parsing datetime literal. */
   public long parseDateFormat(String timestampStr) throws SQLParserException {
-    if (timestampStr == null || timestampStr.trim().equals("")) {
+    if (timestampStr == null || "".equals(timestampStr.trim())) {
       throw new SQLParserException("input timestamp cannot be empty");
     }
     if (timestampStr.equalsIgnoreCase(SQLConstant.NOW_FUNC)) {
@@ -1931,7 +1931,7 @@ public class IoTDBSqlVisitor extends IoTDBSqlParserBaseVisitor<Operator> {
   }
 
   public long parseDateFormat(String timestampStr, long currentTime) throws SQLParserException {
-    if (timestampStr == null || timestampStr.trim().equals("")) {
+    if (timestampStr == null || "".equals(timestampStr.trim())) {
       throw new SQLParserException("input timestamp cannot be empty");
     }
     if (timestampStr.equalsIgnoreCase(SQLConstant.NOW_FUNC)) {
@@ -1961,7 +1961,7 @@ public class IoTDBSqlVisitor extends IoTDBSqlParserBaseVisitor<Operator> {
     long time;
     time = parseDateFormat(ctx.getChild(0).getText());
     for (int i = 1; i < ctx.getChildCount(); i = i + 2) {
-      if (ctx.getChild(i).getText().equals("+")) {
+      if ("+".equals(ctx.getChild(i).getText())) {
         time += DatetimeUtils.convertDurationStrToLong(time, ctx.getChild(i + 1).getText());
       } else {
         time -= DatetimeUtils.convertDurationStrToLong(time, ctx.getChild(i + 1).getText());
@@ -1974,7 +1974,7 @@ public class IoTDBSqlVisitor extends IoTDBSqlParserBaseVisitor<Operator> {
     long time;
     time = parseDateFormat(ctx.getChild(0).getText(), currentTime);
     for (int i = 1; i < ctx.getChildCount(); i = i + 2) {
-      if (ctx.getChild(i).getText().equals("+")) {
+      if ("+".equals(ctx.getChild(i).getText())) {
         time += DatetimeUtils.convertDurationStrToLong(time, ctx.getChild(i + 1).getText());
       } else {
         time -= DatetimeUtils.convertDurationStrToLong(time, ctx.getChild(i + 1).getText());

--- a/server/src/main/java/org/apache/iotdb/db/qp/utils/DatetimeUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/utils/DatetimeUtils.java
@@ -459,7 +459,7 @@ public class DatetimeUtils {
     try {
       ZonedDateTime zonedDateTime = ZonedDateTime.parse(str, formatter);
       Instant instant = zonedDateTime.toInstant();
-      if (timestampPrecision.equals("us")) {
+      if ("us".equals(timestampPrecision)) {
         if (instant.getEpochSecond() < 0 && instant.getNano() > 0) {
           // adjustment can reduce the loss of the division
           long millis = Math.multiplyExact(instant.getEpochSecond() + 1, 1000_000);
@@ -469,7 +469,7 @@ public class DatetimeUtils {
           long millis = Math.multiplyExact(instant.getEpochSecond(), 1000_000);
           return Math.addExact(millis, instant.getNano() / 1000);
         }
-      } else if (timestampPrecision.equals("ns")) {
+      } else if ("ns".equals(timestampPrecision)) {
         long millis = Math.multiplyExact(instant.getEpochSecond(), 1000_000_000L);
         return Math.addExact(millis, instant.getNano());
       }
@@ -609,7 +609,7 @@ public class DatetimeUtils {
         break;
     }
 
-    if (timestampPrecision.equals("us")) {
+    if ("us".equals(timestampPrecision)) {
       if (unit.equals(DurationUnit.ns.toString())) {
         return value / 1000;
       } else if (unit.equals(DurationUnit.us.toString())) {
@@ -617,7 +617,7 @@ public class DatetimeUtils {
       } else {
         return res * 1000;
       }
-    } else if (timestampPrecision.equals("ns")) {
+    } else if ("ns".equals(timestampPrecision)) {
       if (unit.equals(DurationUnit.ns.toString())) {
         return value;
       } else if (unit.equals(DurationUnit.us.toString())) {
@@ -637,9 +637,9 @@ public class DatetimeUtils {
   }
 
   public static TimeUnit timestampPrecisionStringToTimeUnit(String timestampPrecision) {
-    if (timestampPrecision.equals("us")) {
+    if ("us".equals(timestampPrecision)) {
       return TimeUnit.MICROSECONDS;
-    } else if (timestampPrecision.equals("ns")) {
+    } else if ("ns".equals(timestampPrecision)) {
       return TimeUnit.NANOSECONDS;
     } else {
       return TimeUnit.MILLISECONDS;

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/builtin/UDTFCast.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/builtin/UDTFCast.java
@@ -247,7 +247,7 @@ public class UDTFCast implements UDTF {
         }
         return;
       case BOOLEAN:
-        collector.putBoolean(time, !(stringValue.equals("false") || stringValue.equals("")));
+        collector.putBoolean(time, !("false".equals(stringValue) || "".equals(stringValue)));
         return;
       case TEXT:
         collector.putBinary(time, value);

--- a/server/src/main/java/org/apache/iotdb/db/rest/filter/AuthorizationFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/rest/filter/AuthorizationFilter.java
@@ -51,7 +51,7 @@ public class AuthorizationFilter implements ContainerRequestFilter {
   @Override
   public void filter(ContainerRequestContext containerRequestContext) throws IOException {
     if ("OPTIONS".equals(containerRequestContext.getMethod())
-        || containerRequestContext.getUriInfo().getPath().equals("swagger.json")) {
+        || "swagger.json".equals(containerRequestContext.getUriInfo().getPath())) {
       return;
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/tools/IoTDBDataDirViewer.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/IoTDBDataDirViewer.java
@@ -64,8 +64,8 @@ public class IoTDBDataDirViewer {
         }
         List<File> fileList = Arrays.asList(seqAndUnseqDirs);
         fileList.sort((Comparator.comparing(File::getName)));
-        if (!seqAndUnseqDirs[0].getName().equals("sequence")
-            || !seqAndUnseqDirs[1].getName().equals("unsequence")) {
+        if (!"sequence".equals(seqAndUnseqDirs[0].getName())
+            || !"unsequence".equals(seqAndUnseqDirs[1].getName())) {
           throw new IOException(
               "Irregular data dir structure.There should be a sequence and unsequence directory "
                   + "under the data directory "

--- a/server/src/main/java/org/apache/iotdb/db/tools/settle/TsFileAndModSettleTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/settle/TsFileAndModSettleTool.java
@@ -226,7 +226,7 @@ public class TsFileAndModSettleTool {
               new FileReader(
                   FSFactoryProducer.getFSFactory().getFile(SettleLog.getSettleLogPath())))) {
         String line = null;
-        while ((line = settleLogReader.readLine()) != null && !line.equals("")) {
+        while ((line = settleLogReader.readLine()) != null && !"".equals(line)) {
           String oldFilePath = line.split(SettleLog.COMMA_SEPERATOR)[0];
           int settleCheckStatus = Integer.parseInt(line.split(SettleLog.COMMA_SEPERATOR)[1]);
           if (settleCheckStatus == SettleCheckStatus.SETTLE_SUCCESS.getCheckStatus()) {

--- a/server/src/main/java/org/apache/iotdb/db/tools/vis/TsFileExtractVisdata.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/vis/TsFileExtractVisdata.java
@@ -77,7 +77,7 @@ public class TsFileExtractVisdata {
     for (int i = 0; i < M - 1; i = i + 2) {
       inputPathList.add(args[i]);
       String indicator = args[i + 1].toLowerCase();
-      if (!indicator.equals("true") && !indicator.equals("false")) {
+      if (!"true".equals(indicator) && !"false".equals(indicator)) {
         throw new IOException("seqIndicator should be 'true' or 'false' (not case sensitive).");
       }
       seqIndicatorList.add(Boolean.parseBoolean(args[i + 1]));

--- a/server/src/main/java/org/apache/iotdb/db/tools/watermark/WatermarkDetector.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/watermark/WatermarkDetector.java
@@ -53,7 +53,7 @@ public class WatermarkDetector {
       throw new IOException("Parameter out of range.");
     }
 
-    if (!dataType.equals("int") && !dataType.equals("float") && !dataType.equals("double")) {
+    if (!"int".equals(dataType) && !"float".equals(dataType) && !"double".equals(dataType)) {
       throw new IOException("invalid parameter: supported data types are int/float/double");
     }
 
@@ -95,7 +95,7 @@ public class WatermarkDetector {
                 String.format("%s%d", secretKey, timestamp), embed_row_cycle)
             == 0) {
           String str = items[columnIndex];
-          if (str.equals("null")) {
+          if ("null".equals(str)) {
             continue;
           }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
@@ -44,7 +44,7 @@ public class TypeInferenceUtils {
   private TypeInferenceUtils() {}
 
   static boolean isNumber(String s) {
-    if (s == null || s.equals("NaN")) {
+    if (s == null || "NaN".equals(s)) {
       return false;
     }
     try {

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
@@ -231,7 +231,7 @@ public class RpcUtils {
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public static String parseLongToDateWithPrecision(
       DateTimeFormatter formatter, long timestamp, ZoneId zoneid, String timestampPrecision) {
-    if (timestampPrecision.equals("ms")) {
+    if ("ms".equals(timestampPrecision)) {
       long integerofDate = timestamp / 1000;
       StringBuilder digits = new StringBuilder(Long.toString(timestamp % 1000));
       ZonedDateTime dateTime =
@@ -244,7 +244,7 @@ public class RpcUtils {
         }
       }
       return datetime.substring(0, 19) + "." + digits + datetime.substring(19);
-    } else if (timestampPrecision.equals("us")) {
+    } else if ("us".equals(timestampPrecision)) {
       long integerofDate = timestamp / 1000_000;
       StringBuilder digits = new StringBuilder(Long.toString(timestamp % 1000_000));
       ZonedDateTime dateTime =

--- a/session/src/main/java/org/apache/iotdb/session/template/Template.java
+++ b/session/src/main/java/org/apache/iotdb/session/template/Template.java
@@ -97,7 +97,7 @@ public class Template {
       StringBuilder fullPath = new StringBuilder(prefix);
 
       if (!curNode.isMeasurement()) {
-        if (!prefix.equals("")) {
+        if (!"".equals(prefix)) {
           fullPath.append(TsFileConstant.PATH_SEPARATOR);
         }
         fullPath.append(curNode.getName());

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Path.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Path.java
@@ -110,7 +110,7 @@ public class Path implements Serializable, Comparable<Path> {
     }
     this.device = device;
     this.measurement = measurement;
-    if (!device.equals("")) {
+    if (!"".equals(device)) {
       this.fullPath = device + TsFileConstant.PATH_SEPARATOR + measurement;
     } else {
       fullPath = measurement;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/operator/Like.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/operator/Like.java
@@ -145,13 +145,13 @@ public class Like<T extends Comparable<T>> implements Filter {
     String out = "";
     for (int i = 0; i < value.length(); i++) {
       String ch = String.valueOf(value.charAt(i));
-      if (ch.equals("\\")) {
+      if ("\\".equals(ch)) {
         if (i < value.length() - 1) {
           String nextChar = String.valueOf(value.charAt(i + 1));
-          if (nextChar.equals("%") || nextChar.equals("_") || nextChar.equals("\\")) {
+          if ("%".equals(nextChar) || "_".equals(nextChar) || "\\".equals(nextChar)) {
             out = out + ch;
           }
-          if (nextChar.equals("\\")) i++;
+          if ("\\".equals(nextChar)) i++;
         }
       } else {
         out = out + ch;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -31,7 +31,7 @@ public class FilePathUtils {
 
   private static final String PATH_SPLIT_STRING =
       TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs() == FSType.LOCAL
-              && File.separator.equals("\\")
+              && "\\".equals(File.separator)
           ? "\\\\"
           : "/";
   public static final String FILE_NAME_SEPARATOR = "-";


### PR DESCRIPTION
## Description
JIRA: https://issues.apache.org/jira/browse/IOTDB-2006  
Since NullPointerException can possibly be thrown while calling the equals method of Object, equals should be invoked by a constant or an object that is definitely not null.