### PR TITLE
Fixed flaky tests

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/partition/slot/SlotPartitionTable.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/partition/slot/SlotPartitionTable.java
@@ -48,6 +48,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -76,7 +77,8 @@ public class SlotPartitionTable implements PartitionTable {
 
   // The following fields are used for determining which node a data item belongs to.
   // the slots held by each node
-  private Map<RaftNode, List<Integer>> nodeSlotMap = new ConcurrentHashMap<>();
+  private Map<RaftNode, List<Integer>> nodeSlotMap =
+      Collections.synchronizedMap(new LinkedHashMap());
   // each slot is managed by whom
   private RaftNode[] slotNodes = new RaftNode[ClusterConstant.SLOT_NUM];
   // the nodes that each slot belongs to before a new node is added, used for the new node to

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/mult/RemoteMultSeriesReader.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/mult/RemoteMultSeriesReader.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -53,7 +54,7 @@ public class RemoteMultSeriesReader extends AbstractMultPointReader {
 
   private MultDataSourceInfo sourceInfo;
 
-  private Map<String, Queue<BatchData>> cachedBatchs;
+  private Map<String, Queue<BatchData>> cachedBatchs = new LinkedHashMap<>();
 
   private AtomicReference<Map<String, ByteBuffer>> fetchResult = new AtomicReference<>();
   private GenericHandler<Map<String, ByteBuffer>> handler;
@@ -70,7 +71,7 @@ public class RemoteMultSeriesReader extends AbstractMultPointReader {
     this.currentBatchDatas = Maps.newHashMap();
     this.batchStrategy = new DefaultBatchStrategy();
 
-    this.cachedBatchs = Maps.newHashMap();
+    this.cachedBatchs = Maps.newLinkedHashMap();
     this.pathToDataType = Maps.newHashMap();
     for (int i = 0; i < sourceInfo.getPartialPaths().size(); i++) {
       String fullPath = sourceInfo.getPartialPaths().get(i).getExactFullPath();


### PR DESCRIPTION
## Description
Fixed a flaky test causes by non-deterministic concurrent map

### Reason of change
Folllowing tests are flaky and failing:
```
org.apache.iotdb.cluster.log.snapshot.PullSnapshotTaskTest#testWithRetry
org.apache.iotdb.cluster.log.snapshot.MetaSimpleSnapshotTest#testSerialize
org.apache.iotdb.cluster.query.reader.mult.AssignPathManagedMergeReaderTest#testMultManagerMergeRemoteSeriesReader
org.apache.iotdb.cluster.query.reader.mult.RemoteMultSeriesReaderTest#testSyncMultSeriesReader 
org.apache.iotdb.cluster.query.reader.mult.RemoteMultSeriesReaderTest#testAsyncMultSeriesReader
```
when running 
`mvn -pl cluster edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=*TESTNAME*
`
The tests are flaky because in `serialize()` method, it uses a concurrent map to store `nodeSlot` which returns
non deterministic results for each run. To fix this, I changed the concurrent map to `Collections.synchronizedMap(new LinkedHashMap())` to ensure the orders and the threads' safety instead of just using `LinkedHashMap()`.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [X] been self-reviewed.
    - [X] concurrent read
    - [X] concurrent write
    - [X] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
