### PR TITLE
[IOTDB-2023] Fix serializing and deserializing bugs of Filters

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/factory/FilterFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/factory/FilterFactory.java
@@ -19,11 +19,13 @@
 package org.apache.iotdb.tsfile.read.filter.factory;
 
 import org.apache.iotdb.tsfile.read.filter.GroupByFilter;
+import org.apache.iotdb.tsfile.read.filter.GroupByMonthFilter;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.filter.operator.AndFilter;
 import org.apache.iotdb.tsfile.read.filter.operator.Eq;
 import org.apache.iotdb.tsfile.read.filter.operator.Gt;
 import org.apache.iotdb.tsfile.read.filter.operator.GtEq;
+import org.apache.iotdb.tsfile.read.filter.operator.In;
 import org.apache.iotdb.tsfile.read.filter.operator.Lt;
 import org.apache.iotdb.tsfile.read.filter.operator.LtEq;
 import org.apache.iotdb.tsfile.read.filter.operator.NotEq;
@@ -78,8 +80,14 @@ public class FilterFactory {
       case LTEQ:
         filter = new LtEq<>();
         break;
+      case IN:
+        filter = new In<>();
+        break;
       case GROUP_BY:
         filter = new GroupByFilter();
+        break;
+      case GROUP_BY_MONTH:
+        filter = new GroupByMonthFilter();
         break;
       default:
         throw new UnsupportedOperationException("Unknown filter type " + id);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/factory/FilterSerializeId.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/factory/FilterSerializeId.java
@@ -23,6 +23,7 @@ public enum FilterSerializeId {
   AND,
   EQ,
   GROUP_BY,
+  GROUP_BY_MONTH,
   GT,
   GTEQ,
   LT,

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/operator/In.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/filter/operator/In.java
@@ -88,7 +88,7 @@ public class In<T extends Comparable<T>> implements Filter {
       outputStream.write(getSerializeId().ordinal());
       outputStream.write(filterType.ordinal());
       ReadWriteIOUtils.write(not, outputStream);
-      outputStream.write(values.size());
+      ReadWriteIOUtils.write(values.size(), outputStream);
       for (T value : values) {
         ReadWriteIOUtils.writeObject(value, outputStream);
       }
@@ -101,10 +101,19 @@ public class In<T extends Comparable<T>> implements Filter {
   public void deserialize(ByteBuffer buffer) {
     filterType = FilterType.values()[buffer.get()];
     not = ReadWriteIOUtils.readBool(buffer);
-    values = new HashSet<>();
-    for (int i = 0; i < buffer.get(); i++) {
+    int size = ReadWriteIOUtils.readInt(buffer);
+    values = new HashSet<>(size);
+    for (int i = 0; i < size; i++) {
       values.add((T) ReadWriteIOUtils.readObject(buffer));
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof In
+        && ((In<?>) o).filterType == filterType
+        && ((In<?>) o).values.equals(values)
+        && ((In<?>) o).not == not;
   }
 
   @Override

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/filter/FilterSerializeTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/filter/FilterSerializeTest.java
@@ -26,6 +26,9 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,7 +44,10 @@ public class FilterSerializeTest {
           ValueFilter.lt(0.1),
           ValueFilter.ltEq(0.01f),
           ValueFilter.not(ValueFilter.eq(true)),
-          ValueFilter.notEq(false)
+          ValueFilter.notEq(false),
+          ValueFilter.notEq(false),
+          ValueFilter.in(new HashSet<>(Arrays.asList("a", "b")), false),
+          ValueFilter.in(new HashSet<>(Arrays.asList("c", "d")), true),
         };
     for (Filter filter : filters) {
       validateSerialization(filter);
@@ -58,7 +64,10 @@ public class FilterSerializeTest {
           TimeFilter.lt(4),
           TimeFilter.ltEq(5),
           TimeFilter.not(ValueFilter.eq(6)),
-          TimeFilter.notEq(7)
+          TimeFilter.notEq(7),
+          TimeFilter.notEq(7),
+          TimeFilter.in(new HashSet<>(Arrays.asList(1L, 2L)), false),
+          TimeFilter.in(new HashSet<>(Arrays.asList(3L, 4L)), true),
         };
     for (Filter filter : filters) {
       validateSerialization(filter);
@@ -82,6 +91,18 @@ public class FilterSerializeTest {
     Filter[] filters =
         new Filter[] {
           new GroupByFilter(1, 2, 3, 4), new GroupByFilter(4, 3, 2, 1),
+        };
+    for (Filter filter : filters) {
+      validateSerialization(filter);
+    }
+  }
+
+  @Test
+  public void testGroupByMonthFilter() {
+    Filter[] filters =
+        new Filter[] {
+          new GroupByMonthFilter(1, 2, 3, 4, true, false, TimeZone.getTimeZone("Asia/Shanghai")),
+          new GroupByMonthFilter(4, 3, 2, 1, false, true, TimeZone.getTimeZone("Atlantic/Faeroe")),
         };
     for (Filter filter : filters) {
       validateSerialization(filter);


### PR DESCRIPTION
See JIRA: https://issues.apache.org/jira/browse/IOTDB-2023

The following bugs have been fixed:
1. `GroupByMonthFilter`: It inherits `GroupByMonth` filter but doesn't override `getSerializeId()`, which returns `FilterSerializeId.GROUP_BY` and causes the deserializing instance being `GroupByFilter`.
2. `In`: Not supported in `FilterFactory`.
3. `In`: In the serializing and  deserializing method, we should use `ReadWriteUtils.write()` and `ReadWriteUtils.readInt()`. As `buffer.get()` and `stream.write()` handle only 1 byte.