### PR TITLE
[IOTDB-2027] Rollback invalid entry after wal writing failure

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mqtt/PublishHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mqtt/PublishHandler.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.db.qp.executor.IPlanExecutor;
 import org.apache.iotdb.db.qp.executor.PlanExecutor;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
 import io.moquette.interception.AbstractInterceptHandler;
 import io.moquette.interception.messages.InterceptPublishMessage;
@@ -93,16 +92,15 @@ public class PublishHandler extends AbstractInterceptHandler {
         continue;
       }
 
-      InsertRowPlan plan = new InsertRowPlan();
-      plan.setTime(event.getTimestamp());
-      plan.setMeasurements(event.getMeasurements().toArray(new String[0]));
-      plan.setValues(event.getValues().toArray(new Object[0]));
-      plan.setDataTypes(new TSDataType[event.getValues().size()]);
-      plan.setNeedInferType(true);
-
       boolean status = false;
       try {
-        plan.setDeviceId(new PartialPath(event.getDevice()));
+        PartialPath path = new PartialPath(event.getDevice());
+        InsertRowPlan plan =
+            new InsertRowPlan(
+                path,
+                event.getTimestamp(),
+                event.getMeasurements().toArray(new String[0]),
+                event.getValues().toArray(new String[0]));
         status = executeNonQuery(plan);
       } catch (Exception e) {
         LOG.warn(

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -73,6 +73,9 @@ import org.apache.iotdb.db.qp.physical.sys.StorageGroupMNodePlan;
 import org.apache.iotdb.db.qp.utils.EmptyOutputStream;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -82,6 +85,7 @@ import java.util.List;
 
 /** This class is a abstract class for all type of PhysicalPlan. */
 public abstract class PhysicalPlan {
+  private static final Logger logger = LoggerFactory.getLogger(PhysicalPlan.class);
 
   private static final String SERIALIZATION_UNIMPLEMENTED = "serialization unimplemented";
 
@@ -182,11 +186,28 @@ public abstract class PhysicalPlan {
 
   /**
    * Serialize the plan into the given buffer. This is provided for WAL, so fields that can be
-   * recovered will not be serialized.
+   * recovered will not be serialized. If error occurs when serializing this plan, the buffer will
+   * be reset.
    *
    * @param buffer
    */
   public void serialize(ByteBuffer buffer) {
+    buffer.mark();
+    try {
+      serializeImpl(buffer);
+    } catch (UnsupportedOperationException e) {
+      // ignore and throw
+      throw e;
+    } catch (Exception e) {
+      logger.error(
+          "Rollback buffer because error occurs when serializing this physical plan, please check it {}",
+          this);
+      buffer.reset();
+      throw e;
+    }
+  }
+
+  protected void serializeImpl(ByteBuffer buffer) {
     throw new UnsupportedOperationException(SERIALIZATION_UNIMPLEMENTED);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -200,9 +200,7 @@ public abstract class PhysicalPlan {
       throw e;
     } catch (Exception e) {
       logger.error(
-          "Rollback buffer because error occurs when serializing this physical plan, see plan details in the debug log.");
-      // use info level to log plan because the error log may too large
-      logger.debug("Meet error when serializing this physical plan, please check it {}.", this);
+          "Rollback buffer entry because error occurs when serializing this physical plan.", e);
       buffer.reset();
       throw e;
     }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -200,8 +200,9 @@ public abstract class PhysicalPlan {
       throw e;
     } catch (Exception e) {
       logger.error(
-          "Rollback buffer because error occurs when serializing this physical plan, please check it {}",
-          this);
+          "Rollback buffer because error occurs when serializing this physical plan, see plan details in the debug log.");
+      // use info level to log plan because the error log may too large
+      logger.debug("Meet error when serializing this physical plan, please check it {}.", this);
       buffer.reset();
       throw e;
     }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/DeletePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/DeletePlan.java
@@ -151,7 +151,7 @@ public class DeletePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.DELETE.ordinal();
     buffer.put((byte) type);
     buffer.putLong(deleteStartTime);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletPlan.java
@@ -258,7 +258,7 @@ public class InsertMultiTabletPlan extends InsertPlan implements BatchPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.MULTI_BATCH_INSERT.ordinal();
     buffer.put((byte) type);
     buffer.putInt(insertTabletPlanList.size());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
@@ -481,7 +481,7 @@ public class InsertRowPlan extends InsertPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.INSERT.ordinal();
     buffer.put((byte) type);
     subSerialize(buffer);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsOfOneDevicePlan.java
@@ -159,7 +159,7 @@ public class InsertRowsOfOneDevicePlan extends InsertPlan implements BatchPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.BATCH_INSERT_ONE_DEVICE.ordinal();
     buffer.put((byte) type);
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowsPlan.java
@@ -168,7 +168,7 @@ public class InsertRowsPlan extends InsertPlan implements BatchPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.BATCH_INSERT_ROWS.ordinal();
     buffer.put((byte) type);
     buffer.putInt(insertRowPlanList.size());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
@@ -247,7 +247,7 @@ public class InsertTabletPlan extends InsertPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.BATCHINSERT.ordinal();
     buffer.put((byte) type);
     subSerialize(buffer);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/SelectIntoPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/SelectIntoPlan.java
@@ -68,7 +68,7 @@ public class SelectIntoPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.SELECT_INTO.ordinal());
 
     queryPlan.serialize(buffer);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ActivateTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ActivateTemplatePlan.java
@@ -57,7 +57,7 @@ public class ActivateTemplatePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.ACTIVATE_TEMPLATE.ordinal());
     ReadWriteIOUtils.write(prefixPath.getFullPath(), buffer);
     buffer.putLong(index);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AppendTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AppendTemplatePlan.java
@@ -107,7 +107,7 @@ public class AppendTemplatePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.APPEND_TEMPLATE.ordinal());
 
     ReadWriteIOUtils.write(name, buffer);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AuthorPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AuthorPlan.java
@@ -325,7 +325,7 @@ public class AuthorPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = this.getPlanType(super.getOperatorType());
     buffer.put((byte) type);
     buffer.putInt(authorType.ordinal());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AutoCreateDeviceMNodePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AutoCreateDeviceMNodePlan.java
@@ -61,7 +61,7 @@ public class AutoCreateDeviceMNodePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.AUTO_CREATE_DEVICE_MNODE.ordinal());
     putString(buffer, path.getFullPath());
     buffer.putLong(index);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ChangeAliasPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ChangeAliasPlan.java
@@ -71,7 +71,7 @@ public class ChangeAliasPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.CHANGE_ALIAS.ordinal();
     buffer.put((byte) type);
     putString(buffer, path.getFullPath());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ChangeTagOffsetPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ChangeTagOffsetPlan.java
@@ -71,7 +71,7 @@ public class ChangeTagOffsetPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.CHANGE_TAG_OFFSET.ordinal();
     buffer.put((byte) type);
     putString(buffer, path.getFullPath());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ClearCachePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ClearCachePlan.java
@@ -46,7 +46,7 @@ public class ClearCachePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.CLEARCACHE.ordinal());
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateAlignedTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateAlignedTimeSeriesPlan.java
@@ -173,7 +173,7 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.CREATE_ALIGNED_TIMESERIES.ordinal());
     byte[] bytes = prefixPath.getFullPath().getBytes();
     buffer.putInt(bytes.length);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateContinuousQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateContinuousQueryPlan.java
@@ -123,7 +123,7 @@ public class CreateContinuousQueryPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.CREATE_CONTINUOUS_QUERY.ordinal());
     ReadWriteIOUtils.write(continuousQueryName, buffer);
     ReadWriteIOUtils.write(querySql, buffer);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateIndexPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateIndexPlan.java
@@ -112,7 +112,7 @@ public class CreateIndexPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.CREATE_INDEX.ordinal();
     buffer.put((byte) type);
     buffer.put((byte) indexType.serialize());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateMultiTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateMultiTimeSeriesPlan.java
@@ -223,7 +223,7 @@ public class CreateMultiTimeSeriesPlan extends PhysicalPlan implements BatchPlan
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.CREATE_MULTI_TIMESERIES.ordinal();
     buffer.put((byte) type);
     buffer.putInt(paths.size());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateSnapshotPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateSnapshotPlan.java
@@ -47,7 +47,7 @@ public class CreateSnapshotPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.CREATE_SNAPSHOT.ordinal());
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTemplatePlan.java
@@ -281,7 +281,7 @@ public class CreateTemplatePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.CREATE_TEMPLATE.ordinal());
 
     ReadWriteIOUtils.write(name, buffer);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTimeSeriesPlan.java
@@ -208,7 +208,7 @@ public class CreateTimeSeriesPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.CREATE_TIMESERIES.ordinal());
     byte[] bytes = path.getFullPath().getBytes();
     buffer.putInt(bytes.length);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTriggerPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTriggerPlan.java
@@ -128,7 +128,7 @@ public class CreateTriggerPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.CREATE_TRIGGER.ordinal());
 
     putString(buffer, triggerName);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DataAuthPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DataAuthPlan.java
@@ -65,7 +65,7 @@ public class DataAuthPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = this.getPlanType(super.getOperatorType());
     buffer.put((byte) type);
     buffer.putInt(users.size());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteStorageGroupPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteStorageGroupPlan.java
@@ -60,7 +60,7 @@ public class DeleteStorageGroupPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.DELETE_STORAGE_GROUP.ordinal();
     buffer.put((byte) type);
     buffer.putInt(this.getPaths().size());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteTimeSeriesPlan.java
@@ -84,7 +84,7 @@ public class DeleteTimeSeriesPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.DELETE_TIMESERIES.ordinal();
     buffer.put((byte) type);
     buffer.putInt(deletePathList.size());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropContinuousQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropContinuousQueryPlan.java
@@ -51,7 +51,7 @@ public class DropContinuousQueryPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.DROP_CONTINUOUS_QUERY.ordinal());
     ReadWriteIOUtils.write(continuousQueryName, buffer);
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropIndexPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropIndexPlan.java
@@ -79,7 +79,7 @@ public class DropIndexPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.DROP_INDEX.ordinal();
     buffer.put((byte) type);
     buffer.put((byte) indexType.serialize());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropTriggerPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropTriggerPlan.java
@@ -62,7 +62,7 @@ public class DropTriggerPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.DROP_TRIGGER.ordinal());
 
     putString(buffer, triggerName);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/FlushPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/FlushPlan.java
@@ -148,7 +148,7 @@ public class FlushPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.FLUSH.ordinal();
     buffer.put((byte) type);
     if (isSeq == null) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MNodePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MNodePlan.java
@@ -70,7 +70,7 @@ public class MNodePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.MNODE.ordinal());
     putString(buffer, name);
     buffer.putInt(childSize);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MeasurementMNodePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MeasurementMNodePlan.java
@@ -56,7 +56,7 @@ public class MeasurementMNodePlan extends MNodePlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.MEASUREMENT_MNODE.ordinal());
 
     putString(buffer, name);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MergePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MergePlan.java
@@ -50,7 +50,7 @@ public class MergePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.MERGE.ordinal());
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/PruneTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/PruneTemplatePlan.java
@@ -59,7 +59,7 @@ public class PruneTemplatePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.PRUNE_TEMPLATE.ordinal());
 
     ReadWriteIOUtils.write(name, buffer);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetStorageGroupPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetStorageGroupPlan.java
@@ -64,7 +64,7 @@ public class SetStorageGroupPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.SET_STORAGE_GROUP.ordinal());
     putString(buffer, path.getFullPath());
     buffer.putLong(index);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetSystemModePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetSystemModePlan.java
@@ -62,7 +62,7 @@ public class SetSystemModePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.SET_SYSTEM_MODE.ordinal());
 
     ReadWriteIOUtils.write(isReadOnly, buffer);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetTTLPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetTTLPlan.java
@@ -67,7 +67,7 @@ public class SetTTLPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     int type = PhysicalPlanType.TTL.ordinal();
     buffer.put((byte) type);
     buffer.putLong(dataTTL);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetTemplatePlan.java
@@ -65,7 +65,7 @@ public class SetTemplatePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.SET_TEMPLATE.ordinal());
 
     ReadWriteIOUtils.write(templateName, buffer);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StartTriggerPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StartTriggerPlan.java
@@ -62,7 +62,7 @@ public class StartTriggerPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.START_TRIGGER.ordinal());
 
     putString(buffer, triggerName);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StopTriggerPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StopTriggerPlan.java
@@ -62,7 +62,7 @@ public class StopTriggerPlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.STOP_TRIGGER.ordinal());
 
     putString(buffer, triggerName);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StorageGroupMNodePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StorageGroupMNodePlan.java
@@ -67,7 +67,7 @@ public class StorageGroupMNodePlan extends MNodePlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.STORAGE_GROUP_MNODE.ordinal());
     putString(buffer, name);
     buffer.putLong(dataTTL);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/UnsetTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/UnsetTemplatePlan.java
@@ -67,7 +67,7 @@ public class UnsetTemplatePlan extends PhysicalPlan {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
+  public void serializeImpl(ByteBuffer buffer) {
     buffer.put((byte) PhysicalPlanType.UNSET_TEMPLATE.ordinal());
 
     ReadWriteIOUtils.write(prefixPath, buffer);

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -126,11 +126,9 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
   }
 
   private void putLog(PhysicalPlan plan) {
-    logBufferWorking.mark();
     try {
       plan.serialize(logBufferWorking);
     } catch (BufferOverflowException e) {
-      logBufferWorking.reset();
       sync();
       plan.serialize(logBufferWorking);
     }

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
@@ -28,34 +28,8 @@ import org.apache.iotdb.db.exception.runtime.SQLParserException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.qp.Planner;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
-import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
-import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
-import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
-import org.apache.iotdb.db.qp.physical.crud.GroupByTimeFillPlan;
-import org.apache.iotdb.db.qp.physical.crud.GroupByTimePlan;
-import org.apache.iotdb.db.qp.physical.crud.LastQueryPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
-import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
-import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
-import org.apache.iotdb.db.qp.physical.sys.AuthorPlan;
-import org.apache.iotdb.db.qp.physical.sys.CreateContinuousQueryPlan;
-import org.apache.iotdb.db.qp.physical.sys.CreateFunctionPlan;
-import org.apache.iotdb.db.qp.physical.sys.CreateTimeSeriesPlan;
-import org.apache.iotdb.db.qp.physical.sys.CreateTriggerPlan;
-import org.apache.iotdb.db.qp.physical.sys.DataAuthPlan;
-import org.apache.iotdb.db.qp.physical.sys.DropContinuousQueryPlan;
-import org.apache.iotdb.db.qp.physical.sys.DropFunctionPlan;
-import org.apache.iotdb.db.qp.physical.sys.DropTriggerPlan;
-import org.apache.iotdb.db.qp.physical.sys.LoadConfigurationPlan;
-import org.apache.iotdb.db.qp.physical.sys.OperateFilePlan;
-import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
-import org.apache.iotdb.db.qp.physical.sys.ShowContinuousQueriesPlan;
-import org.apache.iotdb.db.qp.physical.sys.ShowFunctionsPlan;
-import org.apache.iotdb.db.qp.physical.sys.ShowPlan;
-import org.apache.iotdb.db.qp.physical.sys.ShowPlan.ShowContentType;
-import org.apache.iotdb.db.qp.physical.sys.ShowTriggersPlan;
-import org.apache.iotdb.db.qp.physical.sys.StartTriggerPlan;
-import org.apache.iotdb.db.qp.physical.sys.StopTriggerPlan;
+import org.apache.iotdb.db.qp.physical.crud.*;
+import org.apache.iotdb.db.qp.physical.sys.*;
 import org.apache.iotdb.db.query.executor.fill.LinearFill;
 import org.apache.iotdb.db.query.executor.fill.PreviousFill;
 import org.apache.iotdb.db.query.udf.service.UDFRegistrationService;
@@ -80,6 +54,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1211,7 +1186,7 @@ public class PhysicalPlanTest {
 
     ShowTriggersPlan plan = (ShowTriggersPlan) processor.parseSQLToPhysicalPlan(sql);
     Assert.assertTrue(plan.isQuery());
-    Assert.assertEquals(ShowContentType.TRIGGERS, plan.getShowContentType());
+    Assert.assertEquals(ShowPlan.ShowContentType.TRIGGERS, plan.getShowContentType());
   }
 
   @Test
@@ -1424,7 +1399,7 @@ public class PhysicalPlanTest {
 
     ShowFunctionsPlan plan = (ShowFunctionsPlan) processor.parseSQLToPhysicalPlan(sql);
     Assert.assertTrue(plan.isQuery());
-    Assert.assertEquals(ShowContentType.FUNCTIONS, plan.getShowContentType());
+    Assert.assertEquals(ShowPlan.ShowContentType.FUNCTIONS, plan.getShowContentType());
   }
 
   @Test
@@ -1449,5 +1424,32 @@ public class PhysicalPlanTest {
     IExpression expect =
         new SingleSeriesExpression(new Path("root.vehicle.d5", "s1"), ValueFilter.like("string*"));
     assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testSerializationError() {
+    ShowDevicesPlan plan = new ShowDevicesPlan();
+
+    ByteBuffer byteBuffer = ByteBuffer.allocate(10);
+    plan.serialize(byteBuffer);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSerializationRollback() {
+    InsertRowPlan plan = new InsertRowPlan();
+    // only serialize time
+    plan.setTime(0L);
+
+    ByteBuffer byteBuffer = ByteBuffer.allocate(10000);
+    byteBuffer.putInt(0);
+    long position = byteBuffer.position();
+
+    try {
+      plan.serialize(byteBuffer);
+    } catch (NullPointerException e) {
+      Assert.assertEquals(position, byteBuffer.position());
+      throw e;
+    }
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
@@ -1426,7 +1426,6 @@ public class PhysicalPlanTest {
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
-
   @Test(expected = UnsupportedOperationException.class)
   public void testSerializationError() {
     ShowDevicesPlan plan = new ShowDevicesPlan();


### PR DESCRIPTION
1. I rollback PhysicalPlan in its serialize method by wrapping serializeImpl method, its children classes will implement serializeImpl method rather than serialize method.
2. MQTT PublishHandler will not use default constructor to construct InsertRowPlan because it doesn't ensure the number of measurements and the number of values are same.