### PR TITLE
Add ascending attribute as the judgment of whether the current calculation is completed in the group by query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/LocalGroupByExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/LocalGroupByExecutor.java
@@ -213,7 +213,12 @@ public class LocalGroupByExecutor implements GroupByExecutor {
     while (reader.hasNextFile()) {
       Statistics fileStatistics = reader.currentFileStatistics();
       if (fileStatistics.getStartTime() >= curEndTime) {
-        return results;
+        if (ascending) {
+          return results;
+        } else {
+          reader.skipCurrentFile();
+          continue;
+        }
       }
       // calc from fileMetaData
       if (reader.canUseCurrentFileStatistics()


### PR DESCRIPTION
We need to use `ascending` here, as the judgment of whether the current calculation is completed in the group by query. Otherwise, It may have bugs.