### PR TITLE
[To rel/0.12][ISSUE-3335] Fix the bug of start-cli.sh -e mode can't work with wild card *

### DIFF
--- a/cli/src/assembly/resources/sbin/start-cli.sh
+++ b/cli/src/assembly/resources/sbin/start-cli.sh
@@ -75,6 +75,7 @@ esac
 
 # echo $PARAMETERS
 
+set -o noglob
 exec "$JAVA" -cp "$CLASSPATH" "$MAIN_CLASS" $PARAMETERS
 
 


### PR DESCRIPTION
Co-authored-by: wangjunqing <wangjunqing.wjq@alibaba-inc.com>
cp #3336 