### PR TITLE
Use statistics of time column in canUseCurrent*Statistics() method in AlignedSeriesAggregateReader

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
@@ -37,11 +37,11 @@ import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.dataset.SingleDataSet;
 import org.apache.iotdb.db.query.factory.AggregateResultFactory;
 import org.apache.iotdb.db.query.filter.TsFileFilter;
+import org.apache.iotdb.db.query.reader.series.AlignedSeriesAggregateReader;
 import org.apache.iotdb.db.query.reader.series.IAggregateReader;
 import org.apache.iotdb.db.query.reader.series.IReaderByTimestamp;
 import org.apache.iotdb.db.query.reader.series.SeriesAggregateReader;
 import org.apache.iotdb.db.query.reader.series.SeriesReaderByTimestamp;
-import org.apache.iotdb.db.query.reader.series.VectorSeriesAggregateReader;
 import org.apache.iotdb.db.query.timegenerator.ServerTimeGenerator;
 import org.apache.iotdb.db.utils.QueryUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -305,8 +305,8 @@ public class AggregationExecutor {
     timeFilter = queryDataSource.updateFilterUsingTTL(timeFilter);
 
     if (!isAggregateResultEmpty(ascAggregateResultList)) {
-      VectorSeriesAggregateReader seriesReader =
-          new VectorSeriesAggregateReader(
+      AlignedSeriesAggregateReader seriesReader =
+          new AlignedSeriesAggregateReader(
               seriesPath,
               measurements,
               tsDataType,
@@ -319,8 +319,8 @@ public class AggregationExecutor {
       aggregateFromVectorReader(seriesReader, ascAggregateResultList);
     }
     if (!isAggregateResultEmpty(descAggregateResultList)) {
-      VectorSeriesAggregateReader seriesReader =
-          new VectorSeriesAggregateReader(
+      AlignedSeriesAggregateReader seriesReader =
+          new AlignedSeriesAggregateReader(
               seriesPath,
               measurements,
               tsDataType,
@@ -389,7 +389,7 @@ public class AggregationExecutor {
   }
 
   private static void aggregateFromVectorReader(
-      VectorSeriesAggregateReader seriesReader, List<List<AggregateResult>> aggregateResultList)
+      AlignedSeriesAggregateReader seriesReader, List<List<AggregateResult>> aggregateResultList)
       throws QueryProcessException, IOException {
     int remainingToCalculate = 0;
     List<boolean[]> isCalculatedArray = new ArrayList<>();
@@ -508,7 +508,7 @@ public class AggregationExecutor {
   }
 
   private static int aggregateVectorPages(
-      VectorSeriesAggregateReader seriesReader,
+      AlignedSeriesAggregateReader seriesReader,
       List<List<AggregateResult>> aggregateResultList,
       List<boolean[]> isCalculatedArray,
       int remainingToCalculate)

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/MemAlignedPageReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/MemAlignedPageReader.java
@@ -88,6 +88,11 @@ public class MemAlignedPageReader implements IPageReader, IAlignedPageReader {
   }
 
   @Override
+  public Statistics getTimeStatistics() {
+    return chunkMetadata.getTimeStatistics();
+  }
+
+  @Override
   public void setFilter(Filter filter) {
     if (valueFilter == null) {
       this.valueFilter = filter;

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/AlignedSeriesAggregateReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/AlignedSeriesAggregateReader.java
@@ -31,9 +31,9 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import java.io.IOException;
 import java.util.Set;
 
-public class VectorSeriesAggregateReader implements IAggregateReader {
+public class AlignedSeriesAggregateReader implements IAggregateReader {
 
-  private final SeriesReader seriesReader;
+  private final AlignedSeriesReader seriesReader;
   /**
    * Used to locate the subSensor that we are traversing now. Use hasNextSubSeries() method to check
    * if we have more sub series in one loop. And use nextSeries() method to move to next sub series.
@@ -42,7 +42,7 @@ public class VectorSeriesAggregateReader implements IAggregateReader {
 
   private final int subSensorSize;
 
-  public VectorSeriesAggregateReader(
+  public AlignedSeriesAggregateReader(
       AlignedPath seriesPath,
       Set<String> allSensors,
       TSDataType dataType,

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
@@ -285,9 +285,16 @@ public class SeriesReader {
 
   Statistics currentFileStatistics(int index) throws IOException {
     if (!(firstTimeSeriesMetadata instanceof AlignedTimeSeriesMetadata)) {
-      throw new IOException("Can only get statistics by index from vectorTimeSeriesMetaData");
+      throw new IOException("Can only get statistics by index from alignedTimeSeriesMetaData");
     }
     return ((AlignedTimeSeriesMetadata) firstTimeSeriesMetadata).getStatistics(index);
+  }
+
+  public Statistics currentFileTimeStatistics() throws IOException {
+    if (!(firstTimeSeriesMetadata instanceof AlignedTimeSeriesMetadata)) {
+      throw new IOException("Can only get statistics of time column from alignedChunkMetaData");
+    }
+    return ((AlignedTimeSeriesMetadata) firstTimeSeriesMetadata).getTimeStatistics();
   }
 
   boolean currentFileModified() throws IOException {
@@ -421,6 +428,13 @@ public class SeriesReader {
       throw new IOException("Can only get statistics by index from vectorChunkMetaData");
     }
     return ((AlignedChunkMetadata) firstChunkMetadata).getStatistics(index);
+  }
+
+  Statistics currentChunkTimeStatistics() throws IOException {
+    if (!(firstChunkMetadata instanceof AlignedChunkMetadata)) {
+      throw new IOException("Can only get statistics of time column from alignedChunkMetaData");
+    }
+    return ((AlignedChunkMetadata) firstChunkMetadata).getTimeStatistics();
   }
 
   boolean currentChunkModified() throws IOException {
@@ -657,6 +671,16 @@ public class SeriesReader {
       throw new IOException("Can only get statistics by index from AlignedPageReader");
     }
     return firstPageReader.getStatistics(index);
+  }
+
+  Statistics currentPageTimeStatistics() throws IOException {
+    if (firstPageReader == null) {
+      return null;
+    }
+    if (!(firstPageReader.isAlignedPageReader())) {
+      throw new IOException("Can only get statistics of time column from AlignedPageReader");
+    }
+    return firstPageReader.getTimeStatistics();
   }
 
   boolean currentPageModified() throws IOException {
@@ -1100,6 +1124,13 @@ public class SeriesReader {
         throw new IOException("Can only get statistics by index from AlignedPageReader");
       }
       return ((IAlignedPageReader) data).getStatistics(index);
+    }
+
+    Statistics getTimeStatistics() throws IOException {
+      if (!(data instanceof IAlignedPageReader)) {
+        throw new IOException("Can only get statistics of time column from AlignedPageReader");
+      }
+      return ((IAlignedPageReader) data).getTimeStatistics();
     }
 
     BatchData getAllSatisfiedPageData(boolean ascending) throws IOException {

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/VectorSeriesAggregateReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/VectorSeriesAggregateReader.java
@@ -78,7 +78,7 @@ public class VectorSeriesAggregateReader implements IAggregateReader {
 
   @Override
   public boolean canUseCurrentFileStatistics() throws IOException {
-    Statistics fileStatistics = currentFileStatistics();
+    Statistics fileStatistics = seriesReader.currentFileTimeStatistics();
     return !seriesReader.isFileOverlapped()
         && containedByTimeFilter(fileStatistics)
         && !seriesReader.currentFileModified();
@@ -101,7 +101,7 @@ public class VectorSeriesAggregateReader implements IAggregateReader {
 
   @Override
   public boolean canUseCurrentChunkStatistics() throws IOException {
-    Statistics chunkStatistics = currentChunkStatistics();
+    Statistics chunkStatistics = seriesReader.currentChunkTimeStatistics();
     return !seriesReader.isChunkOverlapped()
         && containedByTimeFilter(chunkStatistics)
         && !seriesReader.currentChunkModified();
@@ -124,7 +124,7 @@ public class VectorSeriesAggregateReader implements IAggregateReader {
 
   @Override
   public boolean canUseCurrentPageStatistics() throws IOException {
-    Statistics currentPageStatistics = currentPageStatistics();
+    Statistics currentPageStatistics = seriesReader.currentPageTimeStatistics();
     if (currentPageStatistics == null) {
       return false;
     }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/AlignedChunkMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/AlignedChunkMetadata.java
@@ -54,6 +54,10 @@ public class AlignedChunkMetadata implements IChunkMetadata {
     return v == null ? null : v.getStatistics();
   }
 
+  public Statistics getTimeStatistics() {
+    return timeChunkMetadata.getStatistics();
+  }
+
   @Override
   public boolean isModified() {
     return timeChunkMetadata.isModified();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/AlignedTimeSeriesMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/AlignedTimeSeriesMetadata.java
@@ -56,6 +56,10 @@ public class AlignedTimeSeriesMetadata implements ITimeSeriesMetadata {
     return v == null ? null : v.getStatistics();
   }
 
+  public Statistics getTimeStatistics() {
+    return timeseriesMetadata.getStatistics();
+  }
+
   @Override
   public boolean isModified() {
     return timeseriesMetadata.isModified();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/IAlignedPageReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/IAlignedPageReader.java
@@ -23,4 +23,6 @@ import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 public interface IAlignedPageReader {
 
   Statistics getStatistics(int index);
+
+  Statistics getTimeStatistics();
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -132,6 +132,11 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
   }
 
   @Override
+  public Statistics getTimeStatistics() {
+    return timePageReader.getStatistics();
+  }
+
+  @Override
   public void setFilter(Filter filter) {
     if (this.filter == null) {
       this.filter = filter;


### PR DESCRIPTION
In aggregation, we need to judge whether we can use the current file/chunk/page statistics for calculations. For aligned timeseries, we should use the statistics of the time column for judgment.