### PR TITLE
Use safer SQL query to guarantee column order

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/iotdb/IoTDBInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/iotdb/IoTDBInterpreterTest.java
@@ -189,7 +189,8 @@ public class IoTDBInterpreterTest {
   public void testSelectColumnStatementWithTimeFilter() {
     InterpreterResult actual =
         interpreter.internalInterpret(
-            "select * from root.test.wf01.wt01 where time > 2 and time < 6", null);
+            "select temperature, status, hardware from root.test.wf01.wt01 where time > 2 and time < 6",
+            null);
     String gt =
         "Time\troot.test.wf01.wt01.temperature\troot.test.wf01.wt01.status\troot.test.wf01.wt01.hardware\n"
             + "3\t3.3\tfalse\t33.0\n"


### PR DESCRIPTION
## Description
The test `testSelectColumnStatementWithTimeFilter` fails under [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool which detects flakiness of usage with non-deterministic data structures. The failure behavior is defined by incorrect ordering of column data. 

### Reproduce
To reproduce:
```sh
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex 
    -pl zeppelin-interpreter 
    -Dtest=org.apache.zeppelin.iotdb.IoTDBInterpreterTest#testSelectColumnStatementWithTimeFilter  -DnondexRuns=10
```

### Issue
I suspect the cause comes from the query, whereas ```*``` makes the result order inconsistent.
```sql
select * from root.test.wf01.wt01 where time > 2 and time < 6
```

> From [ResultSet Iterators - SAP](https://help.sap.com/doc/saphelp_scm700_ehp02/7.0.2/en-US/eb/4a21346fb369429a1fce29cfb29f16/content.htm?no_cache=true):
> Open SQL/SQLJ prohibits to process the result set of a SELECT * query with a positional iterator. The reason is that Open SQL does not guarantee the order of the columns. It may be different at runtime and at design time.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
