### PR TITLE
[IOTDB-2058] Query is blocked without sub-query-threads exist

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
@@ -116,12 +116,12 @@ public class RawQueryDataSetWithoutValueFilter extends QueryDataSet
             e,
             String.format(
                 "Something gets wrong while reading from the series reader %s: ", pathName));
-      } catch (Exception e) {
+      } catch (Throwable e) {
         putExceptionBatchData(e, "Something gets wrong: ");
       }
     }
 
-    private void putExceptionBatchData(Exception e, String logMessage) {
+    private void putExceptionBatchData(Throwable e, String logMessage) {
       try {
         LOGGER.error(logMessage, e);
         reader.setHasRemaining(false);
@@ -517,11 +517,11 @@ public class RawQueryDataSetWithoutValueFilter extends QueryDataSet
     } else if (batchData instanceof ExceptionBatchData) {
       // exception happened in producer thread
       ExceptionBatchData exceptionBatchData = (ExceptionBatchData) batchData;
-      LOGGER.error("exception happened in producer thread", exceptionBatchData.getException());
-      if (exceptionBatchData.getException() instanceof IOException) {
-        throw (IOException) exceptionBatchData.getException();
-      } else if (exceptionBatchData.getException() instanceof RuntimeException) {
-        throw (RuntimeException) exceptionBatchData.getException();
+      LOGGER.error("exception happened in producer thread", exceptionBatchData.getThrowable());
+      if (exceptionBatchData.getThrowable() instanceof IOException) {
+        throw (IOException) exceptionBatchData.getThrowable();
+      } else if (exceptionBatchData.getThrowable() instanceof RuntimeException) {
+        throw (RuntimeException) exceptionBatchData.getThrowable();
       }
 
     } else { // there are more batch data in this time series queue

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/ExceptionBatchData.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/ExceptionBatchData.java
@@ -20,10 +20,10 @@ package org.apache.iotdb.tsfile.read.common;
 
 public class ExceptionBatchData extends BatchData {
 
-  private Exception exception;
+  private Throwable throwable;
 
-  public ExceptionBatchData(Exception exception) {
-    this.exception = exception;
+  public ExceptionBatchData(Throwable throwable) {
+    this.throwable = throwable;
   }
 
   @Override
@@ -31,7 +31,7 @@ public class ExceptionBatchData extends BatchData {
     throw new UnsupportedOperationException("hasCurrent is not supported for ExceptionBatchData");
   }
 
-  public Exception getException() {
-    return exception;
+  public Throwable getThrowable() {
+    return throwable;
   }
 }


### PR DESCRIPTION
In an IoTDB Instance, the query main thread is blocking. We could see the queryId using show query proceslist. However, we couldn't see the sub query thread of the blocked query in the jstack file.


![image](https://user-images.githubusercontent.com/34242296/143397298-eaadd094-d956-4a0b-9d3b-aa90390ce712.png)

 

This may be due to that the sub-thread is dead because some error（not catched by Exception）
