### PR TITLE
[To rel/0.12][IOTDB-2027] Ignore too many WAL BufferOverflow log

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -63,6 +63,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -162,6 +163,9 @@ public abstract class PhysicalPlan {
       serializeImpl(buffer);
     } catch (UnsupportedOperationException e) {
       // ignore and throw
+      throw e;
+    } catch (BufferOverflowException e) {
+      buffer.reset();
       throw e;
     } catch (Exception e) {
       logger.error(

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -77,6 +77,8 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
 
   private final AtomicBoolean deleted = new AtomicBoolean(false);
 
+  private int bufferOverNum = 0;
+
   /**
    * constructor of ExclusiveWriteLogNode.
    *
@@ -123,7 +125,12 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
     try {
       plan.serialize(logBufferWorking);
     } catch (BufferOverflowException e) {
-      logger.info("WAL BufferOverflow !");
+      bufferOverNum++;
+      if (bufferedLogNum > 200) {
+        logger.info(
+            "WAL bytebuffer overflows too many times. If this occurs frequently, please increase wal_buffer_size.");
+        bufferedLogNum = 0;
+      }
       sync();
       plan.serialize(logBufferWorking);
     }

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -77,7 +77,7 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
 
   private final AtomicBoolean deleted = new AtomicBoolean(false);
 
-  private int bufferOverNum = 0;
+  private int bufferOverflowNum = 0;
 
   /**
    * constructor of ExclusiveWriteLogNode.
@@ -125,11 +125,11 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
     try {
       plan.serialize(logBufferWorking);
     } catch (BufferOverflowException e) {
-      bufferOverNum++;
-      if (bufferedLogNum > 200) {
+      bufferOverflowNum++;
+      if (bufferOverflowNum > 200) {
         logger.info(
             "WAL bytebuffer overflows too many times. If this occurs frequently, please increase wal_buffer_size.");
-        bufferedLogNum = 0;
+        bufferOverflowNum = 0;
       }
       sync();
       plan.serialize(logBufferWorking);

--- a/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
@@ -321,4 +321,53 @@ public class WriteLogNodeTest {
       MmapUtil.clean((MappedByteBuffer) byteBuffer);
     }
   }
+
+  @Test
+  public void testBufferOverflowAndRewrite() throws IOException, IllegalPathException {
+    String identifier = "root.logTestDevice";
+
+    InsertRowPlan insertPlan =
+        new InsertRowPlan(
+            new PartialPath(identifier),
+            100,
+            new String[] {"s1", "s2", "s3", "s4"},
+            new TSDataType[] {
+              TSDataType.DOUBLE, TSDataType.INT64, TSDataType.TEXT, TSDataType.BOOLEAN
+            },
+            new String[] {"1.0", "15", "str", "false"});
+
+    // get InsertRowPlan byte size
+    ByteBuffer tmpBuffer =
+        ByteBuffer.allocate(IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
+    insertPlan.serialize(tmpBuffer);
+    int size = tmpBuffer.position();
+    // allocate buffers
+    ByteBuffer[] byteBuffers = new ByteBuffer[2];
+    byteBuffers[0] = ByteBuffer.allocateDirect(size + 1);
+    byteBuffers[1] = ByteBuffer.allocateDirect(size + 1);
+    WriteLogNode logNode = new ExclusiveWriteLogNode(identifier);
+    logNode.initBuffer(byteBuffers);
+    // write InsertRowPlan to WAL buffer
+    logNode.write(insertPlan);
+    insertPlan.setTime(200);
+    logNode.write(insertPlan);
+
+    logNode.close();
+
+    File walFile =
+        new File(config.getWalDir() + File.separator + identifier + File.separator + "wal1");
+    assertTrue(walFile.exists());
+
+    ILogReader reader = logNode.getLogReader();
+    insertPlan.setTime(100);
+    assertEquals(insertPlan, reader.next());
+    insertPlan.setTime(200);
+    assertEquals(insertPlan, reader.next());
+    reader.close();
+
+    ByteBuffer[] array = logNode.delete();
+    for (ByteBuffer byteBuffer : array) {
+      MmapUtil.clean((MappedByteBuffer) byteBuffer);
+    }
+  }
 }


### PR DESCRIPTION
There are too many  'WAL BufferOverflow' in the log, ignore it until it reaches specific amount.