### PR TITLE
[IOTDB-2027] Ignore too many WAL BufferOverflow log

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -78,6 +78,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -197,6 +198,9 @@ public abstract class PhysicalPlan {
       serializeImpl(buffer);
     } catch (UnsupportedOperationException e) {
       // ignore and throw
+      throw e;
+    } catch (BufferOverflowException e) {
+      buffer.reset();
       throw e;
     } catch (Exception e) {
       logger.error(

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -76,6 +76,8 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
 
   private final AtomicBoolean deleted = new AtomicBoolean(false);
 
+  private int bufferOverflowNum = 0;
+
   /**
    * constructor of ExclusiveWriteLogNode.
    *
@@ -129,6 +131,12 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
     try {
       plan.serialize(logBufferWorking);
     } catch (BufferOverflowException e) {
+      bufferOverflowNum++;
+      if (bufferOverflowNum > 200) {
+        logger.info(
+            "WAL bytebuffer overflows too many times. If this occurs frequently, please increase wal_buffer_size.");
+        bufferOverflowNum = 0;
+      }
       sync();
       plan.serialize(logBufferWorking);
     }


### PR DESCRIPTION
There are too many 'WAL BufferOverflow' in the log, ignore it until it reaches specific amount.