### PR TITLE
[IOTDB-2062] UDF Framework: Potential Memory Leak in `SingleInputColumnSingleReferenceIntermediateLayer`

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/exception/query/QueryProcessException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/query/QueryProcessException.java
@@ -38,6 +38,10 @@ public class QueryProcessException extends IoTDBException {
     super(message, errorCode);
   }
 
+  public QueryProcessException(String message, Throwable cause) {
+    super(message, cause, TSStatusCode.QUERY_PROCESS_ERROR.getStatusCode());
+  }
+
   public QueryProcessException(IoTDBException e) {
     super(e, e.getErrorCode(), e.isUserException());
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/core/executor/UDTFExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/core/executor/UDTFExecutor.java
@@ -107,7 +107,8 @@ public class UDTFExecutor {
     throw new QueryProcessException(
         String.format(
                 "Error occurred during executing UDTF#%s: %s", methodName, System.lineSeparator())
-            + e);
+            + e,
+        e);
   }
 
   public FunctionExpression getExpression() {

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/core/executor/UDTFExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/core/executor/UDTFExecutor.java
@@ -32,10 +32,15 @@ import org.apache.iotdb.db.query.udf.datastructure.tv.ElasticSerializableTVList;
 import org.apache.iotdb.db.query.udf.service.UDFRegistrationService;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.ZoneId;
 import java.util.Map;
 
 public class UDTFExecutor {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UDTFExecutor.class);
 
   protected final FunctionExpression expression;
   protected final UDTFConfigurations configurations;
@@ -104,11 +109,11 @@ public class UDTFExecutor {
   }
 
   private void onError(String methodName, Exception e) throws QueryProcessException {
+    LOGGER.warn("Error occurred during executing UDTF", e);
     throw new QueryProcessException(
         String.format(
                 "Error occurred during executing UDTF#%s: %s", methodName, System.lineSeparator())
-            + e,
-        e);
+            + e);
   }
 
   public FunctionExpression getExpression() {

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/SingleInputColumnSingleReferenceIntermediateLayer.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/SingleInputColumnSingleReferenceIntermediateLayer.java
@@ -144,6 +144,8 @@ public class SingleInputColumnSingleReferenceIntermediateLayer extends Intermedi
       @Override
       public void readyForNext() {
         hasCached = false;
+
+        tvList.setEvictionUpperBound(beginIndex + 1);
       }
 
       @Override
@@ -234,6 +236,8 @@ public class SingleInputColumnSingleReferenceIntermediateLayer extends Intermedi
       public void readyForNext() {
         hasCached = false;
         nextWindowTimeBegin += slidingStep;
+
+        tvList.setEvictionUpperBound(nextIndexBegin + 1);
       }
 
       @Override


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/IOTDB-2062.

The variable tvList in SingleInputColumnSingleReferenceIntermediateLayer#constructRowSlidingSizeWindowReader() and SingleInputColumnSingleReferenceIntermediateLayer#constructRowSlidingTimeWindowReader() will materialize all iteration data until the end of the query, which may trigger useless memory control actions (resulting in meaningless file IO).

It's obviously a bug and results in low query throughput when query data is large.

![image](https://user-images.githubusercontent.com/30497621/143521794-25c65067-9b40-4e60-bbc9-be1281b0b88b.png)
