### PR TITLE
[IOTDB-2065] TsFileSequenceReader will be cached for 100s even no longer used

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
@@ -185,10 +185,12 @@ public class FileReaderManager {
       }
 
       TsFileSequenceReader reader = readerMap.get(tsFilePath);
-      try {
-        reader.close();
-      } catch (IOException e) {
-        logger.error("Can not close TsFileSequenceReader {} !", reader.getFileName(), e);
+      if (reader != null) {
+        try {
+          reader.close();
+        } catch (IOException e) {
+          logger.error("Can not close TsFileSequenceReader {} !", reader.getFileName(), e);
+        }
       }
       readerMap.remove(tsFilePath);
       refMap.remove(tsFilePath);

--- a/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
@@ -18,11 +18,7 @@
  */
 package org.apache.iotdb.db.query.control;
 
-import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
-import org.apache.iotdb.db.service.IService;
-import org.apache.iotdb.db.service.ServiceType;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.UnClosedTsFileReader;
@@ -35,15 +31,13 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * FileReaderManager is a singleton, which is used to manage all file readers(opened file streams)
  * to ensure that each file is opened at most once.
  */
-public class FileReaderManager implements IService {
+public class FileReaderManager {
 
   private static final Logger logger = LoggerFactory.getLogger(FileReaderManager.class);
   private static final Logger resourceLogger = LoggerFactory.getLogger("FileMonitor");
@@ -73,16 +67,11 @@ public class FileReaderManager implements IService {
    */
   private Map<String, AtomicInteger> unclosedReferenceMap;
 
-  private ScheduledExecutorService executorService;
-
   private FileReaderManager() {
     closedFileReaderMap = new ConcurrentHashMap<>();
     unclosedFileReaderMap = new ConcurrentHashMap<>();
     closedReferenceMap = new ConcurrentHashMap<>();
     unclosedReferenceMap = new ConcurrentHashMap<>();
-    executorService = IoTDBThreadPoolFactory.newScheduledThreadPool(1, "open-files-manager");
-
-    clearUnUsedFilesInFixTime();
   }
 
   public static FileReaderManager getInstance() {
@@ -99,44 +88,6 @@ public class FileReaderManager implements IService {
     reader = unclosedFileReaderMap.remove(filePath);
     if (reader != null) {
       reader.close();
-    }
-  }
-
-  private void clearUnUsedFilesInFixTime() {
-    long examinePeriod = IoTDBDescriptor.getInstance().getConfig().getCacheFileReaderClearPeriod();
-    executorService.scheduleAtFixedRate(
-        () -> {
-          synchronized (this) {
-            clearMap(closedFileReaderMap, closedReferenceMap);
-            clearMap(unclosedFileReaderMap, unclosedReferenceMap);
-          }
-        },
-        0,
-        examinePeriod,
-        TimeUnit.MILLISECONDS);
-  }
-
-  private void clearMap(
-      Map<String, TsFileSequenceReader> readerMap, Map<String, AtomicInteger> refMap) {
-    Iterator<Map.Entry<String, TsFileSequenceReader>> iterator = readerMap.entrySet().iterator();
-    while (iterator.hasNext()) {
-      Map.Entry<String, TsFileSequenceReader> entry = iterator.next();
-      TsFileSequenceReader reader = entry.getValue();
-      AtomicInteger refAtom = refMap.get(entry.getKey());
-
-      if (refAtom != null && refAtom.get() == 0) {
-        try {
-          reader.close();
-        } catch (IOException e) {
-          logger.error("Can not close TsFileSequenceReader {} !", reader.getFileName(), e);
-        }
-        iterator.remove();
-        refMap.remove(entry.getKey());
-        if (resourceLogger.isDebugEnabled()) {
-          resourceLogger.debug(
-              "{} TsFileReader is closed because of no reference.", entry.getKey());
-        }
-      }
     }
   }
 
@@ -279,31 +230,6 @@ public class FileReaderManager implements IService {
   public synchronized boolean contains(TsFileResource tsFile, boolean isClosed) {
     return (isClosed && closedFileReaderMap.containsKey(tsFile.getTsFilePath()))
         || (!isClosed && unclosedFileReaderMap.containsKey(tsFile.getTsFilePath()));
-  }
-
-  @Override
-  public void start() {
-    // Do nothing
-  }
-
-  @Override
-  public void stop() {
-    if (executorService == null || executorService.isShutdown()) {
-      return;
-    }
-
-    executorService.shutdown();
-    try {
-      executorService.awaitTermination(10, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      logger.error("StatMonitor timing service could not be shutdown.", e);
-      Thread.currentThread().interrupt();
-    }
-  }
-
-  @Override
-  public ServiceType getID() {
-    return ServiceType.FILE_READER_MANAGER_SERVICE;
   }
 
   private static class FileReaderManagerHelper {

--- a/server/src/test/java/org/apache/iotdb/db/engine/cache/ChunkCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/cache/ChunkCacheTest.java
@@ -234,6 +234,5 @@ public class ChunkCacheTest {
       resourceFile.delete();
     }
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
-    FileReaderManager.getInstance().stop();
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeTest.java
@@ -173,7 +173,6 @@ abstract class MergeTest {
     }
 
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
-    FileReaderManager.getInstance().stop();
   }
 
   void prepareFile(TsFileResource tsFileResource, long timeOffset, long ptNum, long valueOffset)

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionTest.java
@@ -205,7 +205,6 @@ public abstract class InnerCompactionTest {
       resourceFile.delete();
     }
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
-    FileReaderManager.getInstance().stop();
   }
 
   void prepareFile(TsFileResource tsFileResource, long timeOffset, long ptNum, long valueOffset)

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
@@ -310,7 +310,6 @@ public class SizeTieredCompactionRecoverTest {
       resourceFile.delete();
     }
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
-    FileReaderManager.getInstance().stop();
   }
 
   /** Target file uncompleted, source files and log exists */

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTest.java
@@ -202,7 +202,6 @@ public class SizeTieredCompactionTest {
       resourceFile.delete();
     }
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
-    FileReaderManager.getInstance().stop();
   }
 
   void prepareFile(TsFileResource tsFileResource, long timeOffset, long ptNum, long valueOffset)

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/utils/CompactionClearUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/utils/CompactionClearUtils.java
@@ -54,6 +54,5 @@ public class CompactionClearUtils {
       modsFile.delete();
     }
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
-    FileReaderManager.getInstance().stop();
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/query/control/FileReaderManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/control/FileReaderManagerTest.java
@@ -117,24 +117,13 @@ public class FileReaderManagerTest {
     t1.join();
     t2.join();
 
+    Thread.sleep(1000);
+    // Since we have closed the reader after reading the file, it should be false that the file is
+    // still contained by manager
     for (int i = 1; i <= MAX_FILE_SIZE; i++) {
       TsFileResource tsFile = new TsFileResource(SystemFileFactory.INSTANCE.getFile(filePath + i));
-      Assert.assertTrue(manager.contains(tsFile, false));
+      Assert.assertFalse(manager.contains(tsFile, false));
     }
-
-    // the code below is not valid because the cacheFileReaderClearPeriod config in this class is
-    // not valid
-
-    // TimeUnit.SECONDS.sleep(5);
-    //
-    // for (int i = 1; i <= MAX_FILE_SIZE; i++) {
-    //
-    // if (i == 4 || i == 5 || i == 6) {
-    // Assert.assertTrue(manager.contains(filePath + i));
-    // } else {
-    // Assert.assertFalse(manager.contains(filePath + i));
-    // }
-    // }
 
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     for (int i = 1; i < MAX_FILE_SIZE; i++) {

--- a/server/src/test/java/org/apache/iotdb/db/query/reader/series/SeriesReaderTestUtil.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/reader/series/SeriesReaderTestUtil.java
@@ -205,6 +205,5 @@ public class SeriesReaderTestUtil {
     }
 
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
-    FileReaderManager.getInstance().stop();
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/rescon/ResourceManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/rescon/ResourceManagerTest.java
@@ -149,7 +149,6 @@ public class ResourceManagerTest {
       resourceFile.delete();
     }
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
-    FileReaderManager.getInstance().stop();
   }
 
   void prepareFile(TsFileResource tsFileResource, long timeOffset, long ptNum, long valueOffset)


### PR DESCRIPTION
In FileReaderManager, we cached all opened TsFileSequenceReader and maintain an usage count for each reader.

We register a timed thread (cacheFileReaderClearPeriod=100s) to check if a reader is no longer used.

We could check and release the reader when we decrease its usage count in endQuery.