### PR TITLE
[IOTDB-2068] GZIP compressor meets ArrayIndexOutOfBoundsException

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/exception/compress/GZIPCompressOverflowException.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/exception/compress/GZIPCompressOverflowException.java
@@ -1,0 +1,8 @@
+package org.apache.iotdb.tsfile.exception.compress;
+
+public class GZIPCompressOverflowException extends RuntimeException {
+
+  public GZIPCompressOverflowException() {
+    super("compressed data is larger than the given byte container.");
+  }
+}

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/exception/compress/GZIPCompressOverflowException.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/exception/compress/GZIPCompressOverflowException.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.iotdb.tsfile.exception.compress;
 
 public class GZIPCompressOverflowException extends RuntimeException {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/PageWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/PageWriter.java
@@ -216,6 +216,10 @@ public class PageWriter {
 
     if (compressor.getType().equals(CompressionType.UNCOMPRESSED)) {
       compressedSize = uncompressedSize;
+    } else if (compressor.getType().equals(CompressionType.GZIP)) {
+      compressedBytes =
+          compressor.compress(pageData.array(), pageData.position(), uncompressedSize);
+      compressedSize = compressedBytes.length;
     } else {
       compressedBytes = new byte[compressor.getMaxBytesForCompression(uncompressedSize)];
       // data is never a directByteBuffer now, so we can use data.array()

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/TimePageWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/TimePageWriter.java
@@ -107,6 +107,10 @@ public class TimePageWriter {
 
     if (compressor.getType().equals(CompressionType.UNCOMPRESSED)) {
       compressedSize = uncompressedSize;
+    } else if (compressor.getType().equals(CompressionType.GZIP)) {
+      compressedBytes =
+          compressor.compress(pageData.array(), pageData.position(), uncompressedSize);
+      compressedSize = compressedBytes.length;
     } else {
       compressedBytes = new byte[compressor.getMaxBytesForCompression(uncompressedSize)];
       // data is never a directByteBuffer now, so we can use data.array()

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/ValuePageWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/ValuePageWriter.java
@@ -237,6 +237,10 @@ public class ValuePageWriter {
 
     if (compressor.getType().equals(CompressionType.UNCOMPRESSED)) {
       compressedSize = uncompressedSize;
+    } else if (compressor.getType().equals(CompressionType.GZIP)) {
+      compressedBytes =
+          compressor.compress(pageData.array(), pageData.position(), uncompressedSize);
+      compressedSize = compressedBytes.length;
     } else {
       compressedBytes = new byte[compressor.getMaxBytesForCompression(uncompressedSize)];
       // data is never a directByteBuffer now, so we can use data.array()

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/GZIPTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/GZIPTest.java
@@ -52,13 +52,28 @@ public class GZIPTest {
   public void tearDown() {}
 
   @Test
-  public void testBytes() throws IOException {
+  public void testBytes1() throws IOException {
     int n = 500000;
     String input = randomString(n);
     byte[] uncom = input.getBytes(StandardCharsets.UTF_8);
     byte[] compressed = ICompressor.GZIPCompress.compress(uncom);
     byte[] uncompressed = ICompressor.GZIPCompress.uncompress(compressed);
 
+    Assert.assertArrayEquals(uncom, uncompressed);
+  }
+
+  @Test
+  public void testBytes2() throws IOException {
+    ICompressor.GZIPCompressor compressor = new ICompressor.GZIPCompressor();
+    IUnCompressor.GZIPUnCompressor unCompressor = new IUnCompressor.GZIPUnCompressor();
+
+    int n = 500000;
+    String input = randomString(n);
+    byte[] uncom = input.getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = compressor.compress(uncom, 0, uncom.length);
+    // length should be same
+    Assert.assertEquals(compressor.compress(uncom).length, compressed.length);
+    byte[] uncompressed = unCompressor.uncompress(compressed);
     Assert.assertArrayEquals(uncom, uncompressed);
   }
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/LZ4Test.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/LZ4Test.java
@@ -47,7 +47,7 @@ public class LZ4Test {
   public void tearDown() {}
 
   @Test
-  public void testBytes() throws IOException {
+  public void testBytes1() throws IOException {
     String input = randomString(2000000);
     byte[] uncom = input.getBytes(StandardCharsets.UTF_8);
     long time = System.currentTimeMillis();
@@ -63,6 +63,21 @@ public class LZ4Test {
     unCompressor.uncompress(compressed, 0, compressed.length, uncompressed, 0);
     System.out.println("decompression time cost:" + (System.currentTimeMillis() - time));
 
+    Assert.assertArrayEquals(uncom, uncompressed);
+  }
+
+  @Test
+  public void testBytes2() throws IOException {
+    ICompressor.IOTDBLZ4Compressor compressor = new ICompressor.IOTDBLZ4Compressor();
+    IUnCompressor.LZ4UnCompressor unCompressor = new IUnCompressor.LZ4UnCompressor();
+
+    int n = 500000;
+    String input = randomString(n);
+    byte[] uncom = input.getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = compressor.compress(uncom, 0, uncom.length);
+    // length should be same
+    Assert.assertEquals(compressor.compress(uncom).length, compressed.length);
+    byte[] uncompressed = unCompressor.uncompress(compressed);
     Assert.assertArrayEquals(uncom, uncompressed);
   }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/SnappyTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/SnappyTest.java
@@ -48,7 +48,7 @@ public class SnappyTest {
   public void tearDown() {}
 
   @Test
-  public void testBytes() throws IOException {
+  public void testBytes1() throws IOException {
     int n = 500000;
     String input = randomString(n);
     byte[] uncom = input.getBytes(StandardCharsets.UTF_8);
@@ -60,6 +60,21 @@ public class SnappyTest {
     byte[] uncompressed = Snappy.uncompress(compressed);
     System.out.println("decompression time cost:" + ((System.nanoTime() - time)) / 1000 / 1000);
 
+    Assert.assertArrayEquals(uncom, uncompressed);
+  }
+
+  @Test
+  public void testBytes2() throws IOException {
+    ICompressor.SnappyCompressor compressor = new ICompressor.SnappyCompressor();
+    IUnCompressor.SnappyUnCompressor unCompressor = new IUnCompressor.SnappyUnCompressor();
+
+    int n = 500000;
+    String input = randomString(n);
+    byte[] uncom = input.getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = compressor.compress(uncom, 0, uncom.length);
+    // length should be same
+    Assert.assertEquals(compressor.compress(uncom).length, compressed.length);
+    byte[] uncompressed = unCompressor.uncompress(compressed);
     Assert.assertArrayEquals(uncom, uncompressed);
   }
 


### PR DESCRIPTION
The return value of GZIPCompressor.getMaxBytesForCompression method is ambiguous, so i add GZIPCompressOverflowException and  a new compress interface.