### PR TITLE
Tentative PR: Fix flaky tests in IoTDBInterpreterTest.java

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/iotdb/IoTDBInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/iotdb/IoTDBInterpreterTest.java
@@ -332,9 +332,12 @@ public class IoTDBInterpreterTest {
   public void testShowDevices() {
     InterpreterResult actual = interpreter.internalInterpret("show devices", null);
     String gt = "devices\n" + "root.test.wf02.wt02\n" + "root.test.wf01.wt01";
+    String gt_alternative = "devices\n" + "root.test.wf01.wt01\n" + "root.test.wf02.wt02";
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
-    Assert.assertEquals(gt, actual.message().get(0).getData());
+    Assert.assertTrue(
+        gt == actual.message().get(0).getData()
+            || gt_alternative == actual.message().get(0).getData());
   }
 
   @Test
@@ -345,10 +348,16 @@ public class IoTDBInterpreterTest {
         "devices\tstorage group\n"
             + "root.test.wf02.wt02\troot.test.wf02\n"
             + "root.test.wf01.wt01\troot.test.wf01";
+    String gt_alternative =
+        "devices\tstorage group\n"
+            + "root.test.wf01.wt01\troot.test.wf01\n"
+            + "root.test.wf02.wt02\troot.test.wf02";
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
     System.out.println(actual.message().get(0).getData());
-    Assert.assertEquals(gt, actual.message().get(0).getData());
+    Assert.assertTrue(
+        gt == actual.message().get(0).getData()
+            || gt_alternative == actual.message().get(0).getData());
   }
 
   @Test
@@ -356,9 +365,13 @@ public class IoTDBInterpreterTest {
     interpreter.internalInterpret("SET TTL TO root.test.wf01 12345", null);
     InterpreterResult actual = interpreter.internalInterpret("SHOW ALL TTL", null);
     String gt = "storage group\tttl\n" + "root.test.wf02\tnull\n" + "root.test.wf01\t12345";
+    String gt_alternative =
+        "storage group\tttl\n" + "root.test.wf01\t12345\n" + "root.test.wf02\tnull";
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
-    Assert.assertEquals(gt, actual.message().get(0).getData());
+    Assert.assertTrue(
+        gt == actual.message().get(0).getData()
+            || gt_alternative == actual.message().get(0).getData());
   }
 
   @Test
@@ -375,9 +388,12 @@ public class IoTDBInterpreterTest {
   public void testShowStorageGroup() {
     InterpreterResult actual = interpreter.internalInterpret("SHOW STORAGE GROUP", null);
     String gt = "storage group\n" + "root.test.wf02\n" + "root.test.wf01";
+    String gt_alternative = "storage group\n" + "root.test.wf01\n" + "root.test.wf02";
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
-    Assert.assertEquals(gt, actual.message().get(0).getData());
+    Assert.assertTrue(
+        gt == actual.message().get(0).getData()
+            || gt_alternative == actual.message().get(0).getData());
   }
 
   @Test


### PR DESCRIPTION
## Description
`actual.message().get(0).getData()` returns the string that does not guarantee the order of its elements. For instance, given a sql string  `String gt = "devices\n" + "root.test.wf02.wt02\n" + "root.test.wf01.wt01"`, the interpreter can return either 
`"devices\n" + "root.test.wf01.wt01\n" + "root.test.wf02.wt02"` or "devices\n" + "root.test.wf02.wt02\n" + "root.test.wf01.wt01"`. This is especially true when the command being interpreted involve multiple lines (like the string in `testShowTimeseries`). Because the order of the returned string is indeterministic, its unit test is almost guaranteed to fail each time. 

Here I fixed the flaky issue found in `testShowDevices`, `testShowDevicesWithSg`,`testShowAllTTL` and `testShowStorageGroup` functions under `zeppelin-interpreter/src/test/java/org/apache/zeppelin/iotdb/IoTDBInterpreterTest.java`. I would love to have some feedback on whether this would be appropriate and if not, how we can address this in a more elegant way. For instance, maybe we want to sort the string as well as the result fetched from the interpret and then do the comparison, if we only care about the elements are matching rather than the specific order that they are returned. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
