### PR TITLE
[IoTDB-2017][metric] Add a new gauge implement

### DIFF
--- a/metrics/dropwizard-metrics/src/test/java/org/apache/iotdb/metrics/dropwizard/DropwizardMetricManagerTest.java
+++ b/metrics/dropwizard-metrics/src/test/java/org/apache/iotdb/metrics/dropwizard/DropwizardMetricManagerTest.java
@@ -28,6 +28,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -70,6 +71,23 @@ public class DropwizardMetricManagerTest {
     assertNotNull(gauge1);
     Gauge gauge2 = metricManager.getOrCreateGauge("gauge_test", "tag1", "tag2");
     assertEquals(gauge1, gauge2);
+  }
+
+  @Test
+  public void testAutoGauge() {
+    List<Integer> list = new ArrayList<>();
+    Gauge autoGauge =
+        metricManager.getOrCreateAutoGauge("autoGaugeMetric", list, List::size, "tagk", "tagv");
+    assertEquals(0L, autoGauge.value());
+    list.add(1);
+    assertEquals(1L, autoGauge.value());
+    list.clear();
+    assertEquals(0L, autoGauge.value());
+    list.add(1);
+    assertEquals(1L, autoGauge.value());
+    list = null;
+    System.gc();
+    assertEquals(0L, autoGauge.value());
   }
 
   @Test

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/MetricManager.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/MetricManager.java
@@ -42,9 +42,9 @@ public interface MetricManager {
   /**
    * Get Gauge If exists, then return or create one to return
    *
-   * This type of gauge will keep a weak reference of the obj, so it will not prevent the obj's gc.
-   * NOTICE: When the obj has already been cleared by gc when you call the gauge's value(), then you
-   * will get 0L;
+   * <p>This type of gauge will keep a weak reference of the obj, so it will not prevent the obj's
+   * gc. NOTICE: When the obj has already been cleared by gc when you call the gauge's value(), then
+   * you will get 0L;
    *
    * @param obj which will be monitored automatically
    * @param mapper use which to map the obj to a long value

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/MetricManager.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/MetricManager.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.metrics.utils.PredefinedMetric;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.ToLongFunction;
 
 public interface MetricManager {
   /**
@@ -37,6 +38,18 @@ public interface MetricManager {
    * @param tags string appear in pairs, like sg="ln" will be "sg", "ln"
    */
   Counter getOrCreateCounter(String metric, String... tags);
+
+  /**
+   * Get Gauge If exists, then return or create one to return
+   *
+   * This type of gauge will keep a weak reference of the obj, so it will not prevent the obj's gc.
+   * NOTICE: When the obj has already been cleared by gc when you call the gauge's value(), then you
+   * will get 0L;
+   *
+   * @param obj which will be monitored automatically
+   * @param mapper use which to map the obj to a long value
+   */
+  <T> Gauge getOrCreateAutoGauge(String metric, T obj, ToLongFunction<T> mapper, String... tags);
 
   /**
    * Get Gauge If exists, then return or create one to return

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/impl/DoNothingGauge.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/impl/DoNothingGauge.java
@@ -28,6 +28,12 @@ public class DoNothingGauge implements Gauge {
   }
 
   @Override
+  public void incr(long value) {}
+
+  @Override
+  public void decr(long value) {}
+
+  @Override
   public void set(long value) {
     // do nothing
   }

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/impl/DoNothingMetricManager.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/impl/DoNothingMetricManager.java
@@ -20,13 +20,18 @@
 package org.apache.iotdb.metrics.impl;
 
 import org.apache.iotdb.metrics.MetricManager;
-import org.apache.iotdb.metrics.type.*;
+import org.apache.iotdb.metrics.type.Counter;
+import org.apache.iotdb.metrics.type.Gauge;
+import org.apache.iotdb.metrics.type.Histogram;
+import org.apache.iotdb.metrics.type.Rate;
+import org.apache.iotdb.metrics.type.Timer;
 import org.apache.iotdb.metrics.utils.PredefinedMetric;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.ToLongFunction;
 
 public class DoNothingMetricManager implements MetricManager {
 
@@ -39,6 +44,12 @@ public class DoNothingMetricManager implements MetricManager {
   @Override
   public Counter getOrCreateCounter(String metric, String... tags) {
     return doNothingCounter;
+  }
+
+  @Override
+  public <T> Gauge getOrCreateAutoGauge(
+      String metric, T obj, ToLongFunction<T> mapper, String... tags) {
+    return doNothingGauge;
   }
 
   @Override

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/type/Gauge.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/type/Gauge.java
@@ -25,4 +25,8 @@ public interface Gauge extends IMetric {
 
   /** Get value stored in gauge */
   long value();
+
+  void incr(long value);
+
+  void decr(long value);
 }

--- a/metrics/micrometer-metrics/src/main/java/org/apache/iotdb/metrics/micrometer/type/MicrometerAutoGauge.java
+++ b/metrics/micrometer-metrics/src/main/java/org/apache/iotdb/metrics/micrometer/type/MicrometerAutoGauge.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.metrics.micrometer.type;
+
+import org.apache.iotdb.metrics.type.Gauge;
+
+import io.micrometer.core.instrument.Tags;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.WeakReference;
+import java.util.function.ToLongFunction;
+
+public class MicrometerAutoGauge<T> implements Gauge {
+  private final WeakReference<T> refObject;
+  private final ToLongFunction<T> mapper;
+
+  public MicrometerAutoGauge(
+      io.micrometer.core.instrument.MeterRegistry meterRegistry,
+      String metricName,
+      T object,
+      ToLongFunction<T> mapper,
+      String... tags) {
+    LoggerFactory.getLogger(MicrometerAutoGauge.class).info("{},{}", metricName, tags);
+    this.refObject =
+        new WeakReference<>(
+            meterRegistry.gauge(
+                metricName, Tags.of(tags), object, value -> (double) mapper.applyAsLong(value)));
+    this.mapper = mapper;
+  }
+
+  @Override
+  public void set(long value) {
+    throw new UnsupportedOperationException("unsupported manually updating an exist obj's state");
+  }
+
+  @Override
+  public long value() {
+    if (refObject.get() == null) {
+      return 0L;
+    }
+    return mapper.applyAsLong(refObject.get());
+  }
+
+  @Override
+  public void incr(long value) {
+    throw new UnsupportedOperationException("unsupported manually updating an exist obj's state");
+  }
+
+  @Override
+  public void decr(long value) {
+    throw new UnsupportedOperationException("unsupported manually updating an exist obj's state");
+  }
+}

--- a/metrics/micrometer-metrics/src/main/java/org/apache/iotdb/metrics/micrometer/type/MicrometerGauge.java
+++ b/metrics/micrometer-metrics/src/main/java/org/apache/iotdb/metrics/micrometer/type/MicrometerGauge.java
@@ -41,6 +41,16 @@ public class MicrometerGauge implements Gauge {
   }
 
   @Override
+  public void incr(long value) {
+    atomicLong.addAndGet(value);
+  }
+
+  @Override
+  public void decr(long value) {
+    atomicLong.addAndGet(-value);
+  }
+
+  @Override
   public void set(long value) {
     atomicLong.set(value);
   }

--- a/metrics/micrometer-metrics/src/test/java/org/apache/iotdb/metrics/micrometer/MicrometerMetricManagerTest.java
+++ b/metrics/micrometer-metrics/src/test/java/org/apache/iotdb/metrics/micrometer/MicrometerMetricManagerTest.java
@@ -21,25 +21,31 @@ package org.apache.iotdb.metrics.micrometer;
 
 import org.apache.iotdb.metrics.MetricManager;
 import org.apache.iotdb.metrics.MetricService;
+import org.apache.iotdb.metrics.type.Gauge;
 import org.apache.iotdb.metrics.type.Timer;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 public class MicrometerMetricManagerTest {
+  static MetricManager metricManager;
 
   @BeforeClass
   public static void init() {
     System.setProperty("line.separator", "\n");
     // set up path of yml
     System.setProperty("IOTDB_CONF", "src/test/resources");
+    metricManager = MetricService.getMetricManager();
   }
 
   private void getOrCreateDifferentMetricsWithSameName() {
-    MetricManager metricManager = MetricService.getMetricManager();
     Timer timer = metricManager.getOrCreateTimer("metric", "tag1", "tag2");
     assertNotNull(timer);
     metricManager.getOrCreateCounter("metric", "tag1", "tag2");
@@ -48,5 +54,22 @@ public class MicrometerMetricManagerTest {
   @Test
   public void getOrCreateDifferentMetricsWithSameNameTest() {
     assertThrows(IllegalArgumentException.class, this::getOrCreateDifferentMetricsWithSameName);
+  }
+
+  @Test
+  public void testAutoGauge() {
+    List<Integer> list = new ArrayList<>();
+    Gauge autoGauge =
+        metricManager.getOrCreateAutoGauge("autoGaugeMetric", list, List::size, "tagk", "tagv");
+    assertEquals(0L, autoGauge.value());
+    list.add(1);
+    assertEquals(1L, autoGauge.value());
+    list.clear();
+    assertEquals(0L, autoGauge.value());
+    list.add(1);
+    assertEquals(1L, autoGauge.value());
+    list = null;
+    System.gc();
+    assertEquals(0L, autoGauge.value());
   }
 }


### PR DESCRIPTION
## Description
I did two things in this pr
1. Add a new gauge implement
    In some instance, say, we want to monitor a list or a queue's size, it's not convenient and has low performance to set the value every time the list or queue's size changed.
    The new gauge implement is designed for this instance.
2. Add incr and decr method for gauge interface.
   In some cases, we may need to get the current value, add or decrease , then put it back. 
   Since the current `setValue` method cannot guarantee the atomicity of this operation, I added incr and decr method to the gauge interface.
    
related jira : https://issues.apache.org/jira/browse/IOTDB-2017
