### PR TITLE
[IOTDB-2098] Fix priority of cross space task

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskComparator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskComparator.java
@@ -104,6 +104,6 @@ public class CompactionTaskComparator implements Comparator<AbstractCompactionTa
     }
     // we prefer the task with more unsequence files
     // because this type of tasks reduce more unsequence files
-    return o1.getSelectedUnsequenceFiles().size() - o2.getSelectedUnsequenceFiles().size();
+    return o2.getSelectedUnsequenceFiles().size() - o1.getSelectedUnsequenceFiles().size();
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionTaskComparatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionTaskComparatorTest.java
@@ -202,6 +202,7 @@ public class CompactionTaskComparatorTest {
   /** Test the comparation of cross space compaction task */
   @Test
   public void testComparationOfCrossSpaceTask() {
+    // the priority of the tasks in this array are created from highest to lowest
     AbstractCompactionTask[] crossCompactionTasks = new AbstractCompactionTask[200];
     for (int i = 0; i < 100; ++i) {
       List<TsFileResource> sequenceResources = new ArrayList<>();
@@ -226,7 +227,7 @@ public class CompactionTaskComparatorTest {
             new FakedTsFileResource(new File(String.format("%d-%d-0-0.tsfile", i + j, i + j)), j));
       }
       List<TsFileResource> unsequenceResources = new ArrayList<>();
-      for (int j = 100; j < i + 1; ++j) {
+      for (int j = 199; j >= i; --j) {
         unsequenceResources.add(
             new FakedTsFileResource(new File(String.format("%d-%d-0-0.tsfile", i + j, i + j)), j));
       }


### PR DESCRIPTION
We specify that when two compaction tasks have the same number of seqFiles, the task with more unseqFiles has higher priority. But the current CompactionTaskComparator is written backwards, and part of the CI should be modified.