### PR TITLE
[To rel/0.12] [IOTDB-2072] Implement IoTDBArrayList to reduce mem usage in TVList

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -384,7 +384,9 @@ public class TsFileProcessor {
       // Estimate Object[] Of IoTDBArrayList in TVList mem Increment
       // there are 2 array lists in TVList
       memIncrements[0] +=
-          ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1) * (NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER) * 2;
+          ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1)
+              * (NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER)
+              * 2;
     } else {
       int currentChunkPointNum = workMemTable.getCurrentChunkPointNum(deviceId, measurement);
       if (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE == 0) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -80,6 +80,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.iotdb.tsfile.utils.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+import static org.apache.iotdb.tsfile.utils.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
 
 @SuppressWarnings("java:S1135") // ignore todos
 public class TsFileProcessor {
@@ -317,7 +318,7 @@ public class TsFileProcessor {
         memTableIncrement += TVList.tvListArrayMemSize(insertRowPlan.getDataTypes()[i]);
         // Estimate Object[] Of IoTDBArrayList in TVList mem Increment
         // there are 2 array lists in TVList
-        memTableIncrement += NUM_BYTES_ARRAY_HEADER * 2;
+        memTableIncrement += (NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER) * 2;
       } else {
         // here currentChunkPointNum >= 1
         int currentChunkPointNum =
@@ -326,7 +327,7 @@ public class TsFileProcessor {
         memTableIncrement +=
             (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE) == 0
                 ? TVList.tvListArrayMemSize(insertRowPlan.getDataTypes()[i])
-                    + NUM_BYTES_ARRAY_HEADER * 2
+                    + (NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER) * 2
                 : 0;
       }
       // TEXT data mem size
@@ -383,7 +384,7 @@ public class TsFileProcessor {
       // Estimate Object[] Of IoTDBArrayList in TVList mem Increment
       // there are 2 array lists in TVList
       memIncrements[0] +=
-          ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1) * NUM_BYTES_ARRAY_HEADER * 2;
+          ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1) * (NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER) * 2;
     } else {
       int currentChunkPointNum = workMemTable.getCurrentChunkPointNum(deviceId, measurement);
       if (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE == 0) {
@@ -392,8 +393,8 @@ public class TsFileProcessor {
                 * TVList.tvListArrayMemSize(dataType);
         // Estimate Object[] Of IoTDBArrayList in TVList mem Increment
         memIncrements[0] +=
-            ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1)
-                * (NUM_BYTES_ARRAY_HEADER * 1.5)
+            (long) ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1)
+                * (NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER)
                 * 2;
       } else {
         int acquireArray =
@@ -402,7 +403,7 @@ public class TsFileProcessor {
         memIncrements[0] +=
             acquireArray == 0 ? 0 : acquireArray * TVList.tvListArrayMemSize(dataType);
         // Estimate Object[] Of IoTDBArrayList in TVList mem Increment
-        memIncrements[0] += acquireArray * (NUM_BYTES_ARRAY_HEADER * 1.5) * 2;
+        memIncrements[0] += acquireArray * (NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER) * 2;
       }
     }
     // TEXT data size

--- a/server/src/main/java/org/apache/iotdb/db/utils/IoTDBArrayList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/IoTDBArrayList.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class IoTDBArrayList<E> extends ArrayList<E> {
+
+  private static final int DEFAULT_CAPACITY = 1;
+  private static final Object[] EMPTY_ELEMENTDATA = new Object[0];
+  private static final Object[] DEFAULTCAPACITY_EMPTY_ELEMENTDATA = new Object[0];
+  transient Object[] elementData;
+  private int size;
+  private static final int MAX_ARRAY_SIZE = 2147483639;
+
+  public IoTDBArrayList(int initialCapacity) {
+    super();
+    if (initialCapacity > 0) {
+      this.elementData = new Object[initialCapacity];
+    } else {
+      if (initialCapacity != 0) {
+        throw new IllegalArgumentException("Illegal Capacity: " + initialCapacity);
+      }
+
+      this.elementData = EMPTY_ELEMENTDATA;
+    }
+  }
+
+  public IoTDBArrayList() {
+    super();
+    this.elementData = DEFAULTCAPACITY_EMPTY_ELEMENTDATA;
+  }
+
+  private Object[] grow(int minCapacity) {
+    return this.elementData = Arrays.copyOf(this.elementData, this.newCapacity(minCapacity));
+  }
+
+  private Object[] grow() {
+    return this.grow(this.size + 1);
+  }
+
+  @Override
+  public int size() {
+    return this.size;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return this.size == 0;
+  }
+
+  @Override
+  public E get(int index) {
+    return this.elementData(index);
+  }
+
+  E elementData(int index) {
+    return (E) this.elementData[index];
+  }
+
+  public E set(int index, E element) {
+    E oldValue = this.elementData(index);
+    this.elementData[index] = element;
+    return oldValue;
+  }
+
+  private void add(E e, Object[] elementData, int s) {
+    if (s == elementData.length) {
+      elementData = this.grow();
+    }
+
+    elementData[s] = e;
+    this.size = s + 1;
+  }
+
+  public boolean add(E e) {
+    ++this.modCount;
+    this.add(e, this.elementData, this.size);
+    return true;
+  }
+
+  public void add(int index, E element) {
+    ++this.modCount;
+    int s;
+    Object[] elementData;
+    if ((s = this.size) == (elementData = this.elementData).length) {
+      elementData = this.grow();
+    }
+
+    System.arraycopy(elementData, index, elementData, index + 1, s - index);
+    elementData[index] = element;
+    this.size = s + 1;
+  }
+
+  private int newCapacity(int minCapacity) {
+    int oldCapacity = this.elementData.length;
+    int newCapacity = oldCapacity + 1;
+    if (newCapacity - minCapacity <= 0) {
+      if (this.elementData == DEFAULTCAPACITY_EMPTY_ELEMENTDATA) {
+        return Math.max(1, minCapacity);
+      } else if (minCapacity < 0) {
+        throw new OutOfMemoryError();
+      } else {
+        return minCapacity;
+      }
+    } else {
+      return newCapacity - 2147483639 <= 0 ? newCapacity : hugeCapacity(minCapacity);
+    }
+  }
+
+  private static int hugeCapacity(int minCapacity) {
+    if (minCapacity < 0) {
+      throw new OutOfMemoryError();
+    } else {
+      return minCapacity > 2147483639 ? 2147483647 : 2147483639;
+    }
+  }
+
+  @Override
+  public E remove(int index) {
+    Object[] es = this.elementData;
+    E oldValue = (E) es[index];
+    this.fastRemove(es, index);
+    return oldValue;
+  }
+
+  private void fastRemove(Object[] es, int i) {
+    ++this.modCount;
+    int newSize;
+    if ((newSize = this.size - 1) > i) {
+      System.arraycopy(es, i + 1, es, i, newSize - i);
+    }
+
+    es[this.size = newSize] = null;
+  }
+
+  @Override
+  public void clear() {
+    ++this.modCount;
+    Object[] es = this.elementData;
+    int to = this.size;
+
+    for (int i = this.size = 0; i < to; ++i) {
+      es[i] = null;
+    }
+    trimToSize();
+  }
+
+  @Override
+  public void trimToSize() {
+    ++this.modCount;
+    if (this.size < this.elementData.length) {
+      this.elementData =
+          this.size == 0 ? EMPTY_ELEMENTDATA : Arrays.copyOf(this.elementData, this.size);
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/utils/IoTDBArrayList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/IoTDBArrayList.java
@@ -76,6 +76,7 @@ public class IoTDBArrayList<E> extends ArrayList<E> {
     return (E) this.elementData[index];
   }
 
+  @Override
   public E set(int index, E element) {
     E oldValue = this.elementData(index);
     this.elementData[index] = element;
@@ -91,12 +92,14 @@ public class IoTDBArrayList<E> extends ArrayList<E> {
     this.size = s + 1;
   }
 
+  @Override
   public boolean add(E e) {
     ++this.modCount;
     this.add(e, this.elementData, this.size);
     return true;
   }
 
+  @Override
   public void add(int index, E element) {
     ++this.modCount;
     int s;

--- a/server/src/main/java/org/apache/iotdb/db/utils/IoTDBArrayList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/IoTDBArrayList.java
@@ -27,10 +27,16 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+/**
+ * This class is copied and modified from ArrayList JDK11 and used for TVList only. Change the size
+ * enlargement method from 'newSize = oldSize >> 1' to 'newSize = oldSize + 4'. Change the clear()
+ * method by adding automatic trimToSize(). Notice: Do not call the method that not in this class!!
+ */
+@SuppressWarnings(
+    "java:S2177") // Suppress Child class methods named for parent class methods should be overrides
 public class IoTDBArrayList<E> extends ArrayList<E> {
 
   private static final int DEFAULT_CAPACITY = 1;
-  private static final Object[] EMPTY_ELEMENTDATA = new Object[0];
   private static final Object[] DEFAULTCAPACITY_EMPTY_ELEMENTDATA = new Object[0];
   transient Object[] elementData;
   private int size;
@@ -44,7 +50,7 @@ public class IoTDBArrayList<E> extends ArrayList<E> {
         throw new IllegalArgumentException("Illegal Capacity: " + initialCapacity);
       }
 
-      this.elementData = EMPTY_ELEMENTDATA;
+      this.elementData = DEFAULTCAPACITY_EMPTY_ELEMENTDATA;
     }
   }
 
@@ -75,7 +81,7 @@ public class IoTDBArrayList<E> extends ArrayList<E> {
     return this.elementData(index);
   }
 
-  E elementData(int index) {
+  private E elementData(int index) {
     return (E) this.elementData[index];
   }
 
@@ -175,7 +181,9 @@ public class IoTDBArrayList<E> extends ArrayList<E> {
     ++this.modCount;
     if (this.size < this.elementData.length) {
       this.elementData =
-          this.size == 0 ? EMPTY_ELEMENTDATA : Arrays.copyOf(this.elementData, this.size);
+          this.size == 0
+              ? DEFAULTCAPACITY_EMPTY_ELEMENTDATA
+              : Arrays.copyOf(this.elementData, this.size);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/MemUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/MemUtils.java
@@ -66,14 +66,13 @@ public class MemUtils {
   }
 
   public static long getBinarySize(Binary value) {
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + RamUsageEstimator.sizeOf(value.getValues());
+    return RamUsageEstimator.sizeOf(value);
   }
 
   public static long getBinaryColumnSize(Binary[] column, int start, int end) {
     long memSize = 0;
-    memSize += (end - start) * RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
     for (int i = start; i < end; i++) {
-      memSize += RamUsageEstimator.sizeOf(column[i].getValues());
+      memSize += RamUsageEstimator.sizeOf(column[i]);
     }
     return memSize;
   }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
@@ -19,13 +19,13 @@
 package org.apache.iotdb.db.utils.datastructure;
 
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.db.utils.IoTDBArrayList;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
@@ -40,7 +40,7 @@ public class BinaryTVList extends TVList {
 
   BinaryTVList() {
     super();
-    values = new ArrayList<>();
+    values = new IoTDBArrayList<>();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
@@ -19,12 +19,12 @@
 package org.apache.iotdb.db.utils.datastructure;
 
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.db.utils.IoTDBArrayList;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
@@ -39,7 +39,7 @@ public class BooleanTVList extends TVList {
 
   BooleanTVList() {
     super();
-    values = new ArrayList<>();
+    values = new IoTDBArrayList<>();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
@@ -19,13 +19,13 @@
 package org.apache.iotdb.db.utils.datastructure;
 
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.db.utils.IoTDBArrayList;
 import org.apache.iotdb.db.utils.MathUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
@@ -40,7 +40,7 @@ public class DoubleTVList extends TVList {
 
   DoubleTVList() {
     super();
-    values = new ArrayList<>();
+    values = new IoTDBArrayList<>();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
@@ -19,13 +19,13 @@
 package org.apache.iotdb.db.utils.datastructure;
 
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.db.utils.IoTDBArrayList;
 import org.apache.iotdb.db.utils.MathUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
@@ -40,7 +40,7 @@ public class FloatTVList extends TVList {
 
   FloatTVList() {
     super();
-    values = new ArrayList<>();
+    values = new IoTDBArrayList<>();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
@@ -19,12 +19,12 @@
 package org.apache.iotdb.db.utils.datastructure;
 
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.db.utils.IoTDBArrayList;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
@@ -39,7 +39,7 @@ public class IntTVList extends TVList {
 
   IntTVList() {
     super();
-    values = new ArrayList<>();
+    values = new IoTDBArrayList<>();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
@@ -19,12 +19,12 @@
 package org.apache.iotdb.db.utils.datastructure;
 
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.db.utils.IoTDBArrayList;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
@@ -39,7 +39,7 @@ public class LongTVList extends TVList {
 
   LongTVList() {
     super();
-    values = new ArrayList<>();
+    values = new IoTDBArrayList<>();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.utils.datastructure;
 
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.db.utils.IoTDBArrayList;
 import org.apache.iotdb.db.utils.TestOnly;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -29,7 +30,6 @@ import org.apache.iotdb.tsfile.read.reader.IPointReader;
 import org.apache.iotdb.tsfile.utils.Binary;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -53,7 +53,7 @@ public abstract class TVList {
   private long version;
 
   public TVList() {
-    timestamps = new ArrayList<>();
+    timestamps = new IoTDBArrayList<>();
     size = 0;
     minTime = Long.MAX_VALUE;
     referenceCount = new AtomicInteger();


### PR DESCRIPTION
## Description

Currently, we use ArrayList to store primitive arrays in TVList. The Object array (reference and array header) in arrayList is not calculated in the MemControl module. 

Also, after release the TVList, the actual Object array in arrayList is not trimmed. If a longer TVList reused by a shorter TVList, the memory is wasted. 

Beside, the ArrayList of JDK enlarge the size by the method `newSize = oldSize >> 1`, which enlarges more array size when the TVList size is large.

Therefore, I modified the ArrayList to IoTDBArrayList to reduce the memory usage of TVList.

Use ArrayList:

```java
    List<int[]> list = new ArrayList<>();
    for (int i = 0; i < 312; i++) {
      int[] ints = new int[32];
      list.add(ints);
    }

    // size of Object ref
    System.out.println(RamUsageEstimator.sizeOf(list) - 312 * RamUsageEstimator.sizeOf(list.get(0)));
    // size of ArrayHeader
    System.out.println(312 * RamUsageEstimator.sizeOf(list.get(0)) - 312 * Integer.BYTES * 32);
    // current way to calculate TVList mem size
    System.out.println(RamUsageEstimator.sizeOf(list) - 312 * Integer.BYTES * 32);
    list.clear();
    // after clear, the arraylist will be in TVListCache and be reused
    System.out.println(RamUsageEstimator.sizeOf(list));
```
result: 
```
1504
4992
6496
1504
```
Use IoTDBArrayList:
```java
    List<int[]> list = new IoTDBArrayList<>();
    for (int i = 0; i < 312; i++) {
      int[] ints = new int[32];
      list.add(ints);
    }

    // size of Object ref
    System.out.println(RamUsageEstimator.sizeOf(list) - 312 * RamUsageEstimator.sizeOf(list.get(0)));
    // size of ArrayHeader
    System.out.println(312 * RamUsageEstimator.sizeOf(list.get(0)) - 312 * Integer.BYTES * 32);
    // current way to calculate TVList mem size
    System.out.println(RamUsageEstimator.sizeOf(list) - 312 * Integer.BYTES * 32);
    list.clear();
    // after clear, the arraylist will be in TVListCache and be reused
    System.out.println(RamUsageEstimator.sizeOf(list));
```
result:
```
1312 // NUM_BYTES_OBJECT_REF * 312
4992  // NUM_BYTES_ARRAY_HEADER * 312
6304 // (NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER) * 312
64
```


