### PR TITLE
[IOTDB-2123] Accelerate recovery process

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -790,7 +790,7 @@ public class StorageGroupProcessor {
         if (TsFileResource.getInnerCompactionCount(tsFileResource.getTsFile().getName()) > 0) {
           writer =
               recoverPerformer.recover(false, this::getWalDirectByteBuffer, this::releaseWalBuffer);
-          if (writer.hasCrashed()) {
+          if (writer != null || writer.hasCrashed()) {
             tsFileManager.addForRecover(tsFileResource, isSeq);
           } else {
             tsFileResource.setClosed(true);
@@ -803,7 +803,7 @@ public class StorageGroupProcessor {
               recoverPerformer.recover(true, this::getWalDirectByteBuffer, this::releaseWalBuffer);
         }
 
-        if (i != tsFiles.size() - 1 || !writer.canWrite()) {
+        if (i != tsFiles.size() - 1 || writer == null || !writer.canWrite()) {
           // not the last file or cannot write, just close it
           tsFileResource.close();
           tsFileResourceManager.registerSealedTsFileResource(tsFileResource);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -790,7 +790,7 @@ public class StorageGroupProcessor {
         if (TsFileResource.getInnerCompactionCount(tsFileResource.getTsFile().getName()) > 0) {
           writer =
               recoverPerformer.recover(false, this::getWalDirectByteBuffer, this::releaseWalBuffer);
-          if (writer != null || writer.hasCrashed()) {
+          if (writer != null && writer.hasCrashed()) {
             tsFileManager.addForRecover(tsFileResource, isSeq);
           } else {
             tsFileResource.setClosed(true);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1148,8 +1148,8 @@ public class TsFileProcessor {
   private void endFile() throws IOException, TsFileProcessorException {
     logger.info("Start to end file {}", tsFileResource);
     long closeStartTime = System.currentTimeMillis();
-    tsFileResource.serialize();
     writer.endFile();
+    tsFileResource.serialize();
     logger.info("Ended file {}", tsFileResource);
 
     // remove this processor from Closing list in StorageGroupProcessor,

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -236,8 +236,8 @@ public class TsFileResource {
   /** deserialize from disk */
   public void deserialize() throws IOException {
     try (InputStream inputStream = fsFactory.getBufferedInputStream(file + RESOURCE_SUFFIX)) {
-      readVersionNumber(inputStream);
-      timeIndexType = ReadWriteIOUtils.readBytes(inputStream, 1)[0];
+      // The first byte is VERSION_NUMBER, second byte is timeIndexType.
+      timeIndexType = ReadWriteIOUtils.readBytes(inputStream, 2)[1];
       timeIndex = TimeIndexLevel.valueOf(timeIndexType).getTimeIndex().deserialize(inputStream);
       maxPlanIndex = ReadWriteIOUtils.readLong(inputStream);
       minPlanIndex = ReadWriteIOUtils.readLong(inputStream);

--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
@@ -297,8 +297,8 @@ public class TsFileRecoverPerformer {
         tsFileResource.updatePlanIndexes(recoverMemTable.getMaxPlanIndex());
       }
 
-      tsFileResource.serialize();
       restorableTsFileIOWriter.endFile();
+      tsFileResource.serialize();
 
       // otherwise this file is not closed before crush, do nothing so we can continue writing
       // into it

--- a/server/src/test/java/org/apache/iotdb/db/writelog/recover/RecoverResourceFromReaderTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/recover/RecoverResourceFromReaderTest.java
@@ -29,7 +29,6 @@ import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.StorageGroupProcessorException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
-import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.db.utils.MmapUtil;
@@ -47,6 +46,7 @@ import org.apache.iotdb.tsfile.write.record.TSRecord;
 import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
 import org.apache.iotdb.tsfile.write.schema.Schema;
 import org.apache.iotdb.tsfile.write.schema.UnaryMeasurementSchema;
+import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -155,8 +155,9 @@ public class RecoverResourceFromReaderTest {
     }
 
     writer.flushAllChunkGroups();
+    // In TSP, first endFile and then serialize TsFileResource
+    writer.getIOWriter().endFile();
     writer.getIOWriter().close();
-
     node =
         MultiFileLogNodeManager.getInstance()
             .getNode(
@@ -171,41 +172,6 @@ public class RecoverResourceFromReaderTest {
                           IoTDBDescriptor.getInstance().getConfig().getWalBufferSize() / 2);
                   return byteBuffers;
                 });
-    for (int i = 0; i < 10; i++) {
-      for (int j = 0; j < 10; j++) {
-        String[] measurements = new String[10];
-        String[] values = new String[10];
-        TSDataType[] types = new TSDataType[10];
-        for (int k = 0; k < 10; k++) {
-          measurements[k] = "sensor" + k;
-          types[k] = TSDataType.INT64;
-          values[k] = String.valueOf(k + 10);
-        }
-        InsertRowPlan insertRowPlan =
-            new InsertRowPlan(
-                new PartialPath("root.sg.device" + j), i, measurements, types, values);
-        node.write(insertRowPlan);
-      }
-      node.notifyStartFlush();
-    }
-    InsertRowPlan insertRowPlan =
-        new InsertRowPlan(
-            new PartialPath("root.sg.device99"),
-            1,
-            new String[] {"sensor4"},
-            new TSDataType[] {TSDataType.INT64},
-            new String[] {"4"});
-    node.write(insertRowPlan);
-    insertRowPlan =
-        new InsertRowPlan(
-            new PartialPath("root.sg.device99"),
-            300,
-            new String[] {"sensor2"},
-            new TSDataType[] {TSDataType.INT64},
-            new String[] {"2"});
-    node.write(insertRowPlan);
-    node.close();
-
     resource = new TsFileResource(tsF);
   }
 
@@ -234,8 +200,8 @@ public class RecoverResourceFromReaderTest {
 
     TsFileRecoverPerformer performer =
         new TsFileRecoverPerformer(logNodePrefix, resource, false, false);
-    performer
-        .recover(
+    RestorableTsFileIOWriter writer =
+        performer.recover(
             true,
             () -> {
               ByteBuffer[] byteBuffers = new ByteBuffer[2];
@@ -251,10 +217,12 @@ public class RecoverResourceFromReaderTest {
               for (ByteBuffer byteBuffer : byteBuffers) {
                 MmapUtil.clean((MappedByteBuffer) byteBuffer);
               }
-            })
-        .close();
-    assertEquals(1, resource.getStartTime("root.sg.device99"));
-    assertEquals(300, resource.getEndTime("root.sg.device99"));
+            });
+    if (writer != null) {
+      writer.close();
+    }
+    assertEquals(2, resource.getStartTime("root.sg.device99"));
+    assertEquals(100, resource.getEndTime("root.sg.device99"));
     for (int i = 0; i < 10; i++) {
       assertEquals(0, resource.getStartTime("root.sg.device" + i));
       assertEquals(9, resource.getEndTime("root.sg.device" + i));


### PR DESCRIPTION
## Description

Two changes to accelerate recovery process.

1. Change the sequence of endTsFile and serialize TsFile resource. Ending Tsfile first and then serializing TsFileResource.

2. When recovering, if a TsFileResource found, do not check the TsFile.

The reason is if we find a TsFileResource, it means the TsFile is ended. Skipping check the TsFile can save a lot of time of recovery process.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
