### PR TITLE
[IOTDB-2102] Push down limit to ReadTask in RawDataSetWithoutValueFilter

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
@@ -632,6 +632,7 @@ public class RawQueryDataSetWithoutValueFilter extends QueryDataSet
         } else {
           record.addField(cachedBatchDataArray[seriesIndex].currentValue(), dataType);
         }
+        cacheNext(seriesIndex);
       }
     }
 


### PR DESCRIPTION
If we use limit 1 while select ** from root, the sub thread is not noticed that we only need one result, so it works until the blockingQueue is filled, which wastes lots of resource.
Therefore, we push down limit to ReadTask in RawDataSetWithoutValueFilter.
