### PR TITLE
[To rel/0.12][IOTDB-2124] the filtering condition does not take efffect for last query in cluster

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncClientAdaptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/client/sync/SyncClientAdaptor.java
@@ -496,6 +496,7 @@ public class SyncClientAdaptor {
       AsyncDataClient client,
       List<PartialPath> seriesPaths,
       List<Integer> dataTypeOrdinals,
+      Filter timeFilter,
       QueryContext context,
       Map<String, Set<String>> deviceMeasurements,
       Node header)
@@ -510,7 +511,9 @@ public class SyncClientAdaptor {
             deviceMeasurements,
             header,
             client.getNode());
-
+    if (timeFilter != null) {
+      request.setFilterBytes(SerializeUtils.serializeFilter(timeFilter));
+    }
     client.last(request, handler);
     return handler.getResult(RaftServer.getReadOperationTimeoutMS());
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutor.java
@@ -43,6 +43,8 @@ import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.expression.IExpression;
+import org.apache.iotdb.tsfile.read.expression.impl.GlobalTimeExpression;
+import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.apache.thrift.TException;
@@ -247,11 +249,14 @@ public class ClusterLastQueryExecutor extends LastQueryExecutor {
         logger.warn("can not get client for node= {}", node);
         return null;
       }
+      Filter timeFilter =
+          (expression == null) ? null : ((GlobalTimeExpression) expression).getFilter();
       buffer =
           SyncClientAdaptor.last(
               asyncDataClient,
               seriesPaths,
               dataTypeOrdinals,
+              timeFilter,
               context,
               queryPlan.getDeviceToMeasurements(),
               group.getHeader());
@@ -263,14 +268,20 @@ public class ClusterLastQueryExecutor extends LastQueryExecutor {
           metaGroupMember
               .getClientProvider()
               .getSyncDataClient(node, RaftServer.getReadOperationTimeoutMS())) {
-        return client.last(
+        LastQueryRequest lastQueryRequest =
             new LastQueryRequest(
                 PartialPath.toStringList(seriesPaths),
                 dataTypeOrdinals,
                 context.getQueryId(),
                 queryPlan.getDeviceToMeasurements(),
                 group.getHeader(),
-                client.getNode()));
+                client.getNode());
+        Filter timeFilter =
+            (expression == null) ? null : ((GlobalTimeExpression) expression).getFilter();
+        if (timeFilter != null) {
+          lastQueryRequest.setFilterBytes(SerializeUtils.serializeFilter(timeFilter));
+        }
+        return client.last(lastQueryRequest);
       } catch (IOException e) {
         logger.warn("can not get client for node= {}", node);
         return null;

--- a/cluster/src/test/java/org/apache/iotdb/cluster/client/sync/SyncClientAdaptorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/client/sync/SyncClientAdaptorTest.java
@@ -423,6 +423,7 @@ public class SyncClientAdaptorTest {
             dataClient,
             Collections.singletonList(new PartialPath("1")),
             Collections.singletonList(TSDataType.INT64.ordinal()),
+            null,
             new QueryContext(),
             Collections.emptyMap(),
             TestUtils.getNode(0)));

--- a/cluster/src/test/java/org/apache/iotdb/cluster/common/TestAsyncDataClient.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/common/TestAsyncDataClient.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.cluster.rpc.thrift.ExecutNonQueryReq;
 import org.apache.iotdb.cluster.rpc.thrift.GetAggrResultRequest;
 import org.apache.iotdb.cluster.rpc.thrift.GetAllPathsResult;
 import org.apache.iotdb.cluster.rpc.thrift.GroupByRequest;
+import org.apache.iotdb.cluster.rpc.thrift.LastQueryRequest;
 import org.apache.iotdb.cluster.rpc.thrift.MultSeriesQueryRequest;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.rpc.thrift.PreviousFillRequest;
@@ -282,6 +283,16 @@ public class TestAsyncDataClient extends AsyncDataClient {
               new DataAsyncService(dataGroupMemberMap.get(header))
                   .getAllMeasurementSchema(header, planBinary, resultHandler);
             })
+        .start();
+  }
+
+  @Override
+  public void last(LastQueryRequest request, AsyncMethodCallback<ByteBuffer> resultHandler)
+      throws TException {
+    new Thread(
+            () ->
+                new DataAsyncService(dataGroupMemberMap.get(request.getHeader()))
+                    .last(request, resultHandler))
         .start();
   }
 }

--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/last/ClusterLastQueryExecutorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.cluster.query.last;
+
+import org.apache.iotdb.cluster.common.TestUtils;
+import org.apache.iotdb.cluster.query.BaseQueryTest;
+import org.apache.iotdb.cluster.query.RemoteQueryContext;
+import org.apache.iotdb.db.exception.StorageEngineException;
+import org.apache.iotdb.db.exception.metadata.IllegalPathException;
+import org.apache.iotdb.db.exception.query.QueryProcessException;
+import org.apache.iotdb.db.metadata.PartialPath;
+import org.apache.iotdb.db.qp.physical.crud.LastQueryPlan;
+import org.apache.iotdb.db.query.context.QueryContext;
+import org.apache.iotdb.db.query.control.QueryResourceManager;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.Field;
+import org.apache.iotdb.tsfile.read.common.RowRecord;
+import org.apache.iotdb.tsfile.read.expression.IExpression;
+import org.apache.iotdb.tsfile.read.expression.impl.GlobalTimeExpression;
+import org.apache.iotdb.tsfile.read.filter.TimeFilter;
+import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ClusterLastQueryExecutorTest extends BaseQueryTest {
+
+  @Test
+  public void testLastQueryTimeFilter()
+      throws QueryProcessException, StorageEngineException, IOException, IllegalPathException {
+    LastQueryPlan plan = new LastQueryPlan();
+    plan.setDeduplicatedPaths(
+        Collections.singletonList(new PartialPath(TestUtils.getTestSeries(0, 10))));
+    plan.setDeduplicatedDataTypes(Collections.singletonList(TSDataType.DOUBLE));
+    plan.setPaths(plan.getDeduplicatedPaths());
+    plan.setDataTypes(plan.getDeduplicatedDataTypes());
+    IExpression expression = new GlobalTimeExpression(TimeFilter.gtEq(Long.MAX_VALUE));
+    plan.setExpression(expression);
+    QueryContext context =
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
+
+    try {
+      ClusterLastQueryExecutor lastQueryExecutor =
+          new ClusterLastQueryExecutor(plan, testMetaMember);
+      QueryDataSet queryDataSet = lastQueryExecutor.execute(context, plan);
+      assertFalse(queryDataSet.hasNext());
+    } finally {
+      QueryResourceManager.getInstance().endQuery(context.getQueryId());
+    }
+  }
+
+  @Test
+  public void testLastQueryNoTimeFilter()
+      throws QueryProcessException, StorageEngineException, IOException, IllegalPathException {
+    LastQueryPlan plan = new LastQueryPlan();
+    plan.setDeduplicatedPaths(
+        Collections.singletonList(new PartialPath(TestUtils.getTestSeries(0, 10))));
+    plan.setDeduplicatedDataTypes(Collections.singletonList(TSDataType.DOUBLE));
+    plan.setPaths(plan.getDeduplicatedPaths());
+    plan.setDataTypes(plan.getDeduplicatedDataTypes());
+    QueryContext context =
+        new RemoteQueryContext(QueryResourceManager.getInstance().assignQueryId(true));
+
+    try {
+      ClusterLastQueryExecutor lastQueryExecutor =
+          new ClusterLastQueryExecutor(plan, testMetaMember);
+      QueryDataSet queryDataSet = lastQueryExecutor.execute(context, plan);
+      assertTrue(queryDataSet.hasNext());
+      RowRecord record = queryDataSet.next();
+      List<Field> fields = record.getFields();
+      Assert.assertEquals(
+          (double) 10.0, Double.parseDouble(fields.get(1).getStringValue()), 0.000001);
+    } finally {
+      QueryResourceManager.getInstance().endQuery(context.getQueryId());
+    }
+  }
+}


### PR DESCRIPTION
cherry pick https://github.com/apache/iotdb/pull/4539

After enable_last_cache is disabled, the filter criteria are not pushed to the remote node. As a result, the query result is incorrect.

5 node , 3 rep in cluster

enable_last_cache = false

insert into root.sg1.d1(time,s1) values(1,1);

flush;

select last s1 from root.sg1.d1 where time > 1;

the query result is incorrect.

reason :
the filter criteria are not pushed to the remote node. As a result, the query result is incorrect.