### PR TITLE
[To rel/0.12] Fix connection refused using session when users forget to set client ip

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/ClusterMain.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/ClusterMain.java
@@ -96,6 +96,13 @@ public class ClusterMain {
       return;
     }
 
+    // if client ip is the default address, set it same with internal ip
+    if (IoTDBDescriptor.getInstance().getConfig().getRpcAddress().equals("0.0.0.0")) {
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setRpcAddress(ClusterDescriptor.getInstance().getConfig().getInternalIp());
+    }
+
     String mode = args[0];
 
     logger.info("Running mode {}", mode);

--- a/docs/UserGuide/Cluster/Cluster-Setup-Example.md
+++ b/docs/UserGuide/Cluster/Cluster-Setup-Example.md
@@ -202,7 +202,7 @@ internal\_ip = *A\_private\_Ip* (or *B\_private\_Ip*, *C\_private\_Ip*)
 
 ***iotdb-engine.properties***
 
-rpc\_address = *A\_public\_Ip* (or *B\_private\_Ip*, *C\_public\_Ip*)
+rpc\_address = *A\_public\_Ip* (or *B\_public\_Ip*, *C\_public\_Ip*)
 
 ### Start IoTDB cluster
 

--- a/docs/zh/UserGuide/Cluster/Cluster-Setup-Example.md
+++ b/docs/zh/UserGuide/Cluster/Cluster-Setup-Example.md
@@ -204,7 +204,7 @@ internal\_ip = *A\_private\_Ip* (or *B\_private\_Ip*, *C\_private\_Ip*)
 
 ***iotdb-engine.properties***
 
-rpc\_address = *A\_public\_Ip* (or *B\_private\_Ip*, *C\_public\_Ip*)
+rpc\_address = *A\_public\_Ip* (or *B\_public\_Ip*, *C\_public\_Ip*)
 
 ### 启动IoTDB集群
 


### PR DESCRIPTION
Users only set internal ip in iotdb-cluster.properties, and they often forget to set the rpc_address (public ip) in iotdb-engine.properties. So the rpc address is the default value(0.0.0.0). Session will cache the 0.0.0.0 endpoint when an insertPlan is redirected. 
We want internal ip as private ip and rpc_address as public ip. So if the rpc_address is not set, set it the same with internal ip.