### PR TITLE
[To rel/0.12][IOTDB-2152] PyClient: Override __eq__() of TSDataType, TSEncoding and Compressor to avoid unexpected comparation behaviour

### DIFF
--- a/client-py/iotdb/utils/IoTDBConstants.py
+++ b/client-py/iotdb/utils/IoTDBConstants.py
@@ -28,6 +28,11 @@ class TSDataType(Enum):
     DOUBLE = 4
     TEXT = 5
 
+    # this method is implemented to avoid the issue reported by:
+    # https://bugs.python.org/issue30545
+    def __eq__(self, other) -> bool:
+        return self.value == other.value
+
 
 @unique
 class TSEncoding(Enum):
@@ -41,6 +46,11 @@ class TSEncoding(Enum):
     REGULAR = 7
     GORILLA = 8
 
+    # this method is implemented to avoid the issue reported by:
+    # https://bugs.python.org/issue30545
+    def __eq__(self, other) -> bool:
+        return self.value == other.value
+
 
 @unique
 class Compressor(Enum):
@@ -52,3 +62,8 @@ class Compressor(Enum):
     PAA = 5
     PLA = 6
     LZ4 = 7
+
+    # this method is implemented to avoid the issue reported by:
+    # https://bugs.python.org/issue30545
+    def __eq__(self, other) -> bool:
+        return self.value == other.value


### PR DESCRIPTION
See IOTDB-2152.