### PR TITLE
[To rel/0.12] Rethrow other exceptions in query main thread

### DIFF
--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>0.12.5-SNAPSHOT</version>
+        <version>0.12.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>iotdb-code-coverage</artifactId>

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
@@ -458,6 +458,8 @@ public class RawQueryDataSetWithoutValueFilter extends QueryDataSet
         throw (IOException) exceptionBatchData.getThrowable();
       } else if (exceptionBatchData.getThrowable() instanceof RuntimeException) {
         throw (RuntimeException) exceptionBatchData.getThrowable();
+      } else {
+        throw new RuntimeException("some other unknown errors!");
       }
 
     } else { // there are more batch data in this time series queue

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>iotdb-parent</artifactId>
         <groupId>org.apache.iotdb</groupId>
-        <version>0.12.5-SNAPSHOT</version>
+        <version>0.12.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Description

Currently, if the sub thread throw an Error like `OutOfMemoryError`, the main thread won't exit, it will blocked on the `take` operation of `BlockingQueue`.

## Solution

Anytime we got the `ExceptionBatchData`, we should rethrow it.
