### PR TITLE
Rethrow other exceptions in query main thread

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/RawQueryDataSetWithoutValueFilter.java
@@ -554,6 +554,8 @@ public class RawQueryDataSetWithoutValueFilter extends QueryDataSet
         throw (IOException) exceptionBatchData.getThrowable();
       } else if (exceptionBatchData.getThrowable() instanceof RuntimeException) {
         throw (RuntimeException) exceptionBatchData.getThrowable();
+      } else {
+        throw new RuntimeException("some other unknown errors!");
       }
 
     } else { // there are more batch data in this time series queue


### PR DESCRIPTION
## Description

Currently, if the sub thread throw an Error like `OutOfMemoryError`, the main thread won't exit, it will blocked on the `take` operation of `BlockingQueue`.

## Solution

Anytime we got the `ExceptionBatchData`, we should rethrow it.
