### PR TITLE
[IOTDB-2171, To Rel/0.12] Check the timeseries legitimacy when create timeseries

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanner.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanner.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.Planner;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
+import org.apache.iotdb.db.qp.strategy.LogicalGenerator;
 import org.apache.iotdb.db.qp.strategy.PhysicalGenerator;
 import org.apache.iotdb.db.qp.strategy.optimizer.ConcatPathOptimizer;
 
@@ -34,7 +35,7 @@ public class ClusterPlanner extends Planner {
   @Override
   public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr, ZoneId zoneId, int fetchSize)
       throws QueryProcessException {
-    Operator operator = logicalGenerator.generate(sqlStr, zoneId);
+    Operator operator = LogicalGenerator.generate(sqlStr, zoneId);
     operator = logicalOptimize(operator);
     PhysicalGenerator physicalGenerator = new ClusterPhysicalGenerator();
     return physicalGenerator.transformToPhysicalPlan(operator, fetchSize);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -43,6 +43,7 @@ import org.apache.iotdb.db.qp.physical.sys.MeasurementMNodePlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowDevicesPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
 import org.apache.iotdb.db.qp.physical.sys.StorageGroupMNodePlan;
+import org.apache.iotdb.db.qp.strategy.LogicalGenerator;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.dataset.ShowDevicesResult;
@@ -222,7 +223,11 @@ public class MTree implements Serializable {
     if (nodeNames.length <= 2 || !nodeNames[0].equals(root.getName())) {
       throw new IllegalPathException(path.getFullPath());
     }
-    checkTimeseries(path);
+    long startTime = System.nanoTime();
+    LogicalGenerator.checkCreateTimeseriesGrammar(path.getFullPath());
+    long endTime = System.nanoTime();
+    logger.error("qihouliang, cost={}", (endTime-startTime));
+//    checkTimeseries(path);
     MNode cur = root;
     boolean hasSetStorageGroup = false;
     Template upperTemplate = cur.getDeviceTemplate();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -223,11 +223,7 @@ public class MTree implements Serializable {
     if (nodeNames.length <= 2 || !nodeNames[0].equals(root.getName())) {
       throw new IllegalPathException(path.getFullPath());
     }
-    long startTime = System.nanoTime();
     LogicalGenerator.checkCreateTimeseriesGrammar(path.getFullPath());
-    long endTime = System.nanoTime();
-    logger.error("qihouliang, cost={}", (endTime-startTime));
-//    checkTimeseries(path);
     MNode cur = root;
     boolean hasSetStorageGroup = false;
     Template upperTemplate = cur.getDeviceTemplate();

--- a/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
@@ -52,11 +52,11 @@ import static org.apache.iotdb.db.conf.IoTDBConstant.TIME;
 /** provide a integration method for other user. */
 public class Planner {
 
-  protected LogicalGenerator logicalGenerator;
-
-  public Planner() {
-    this.logicalGenerator = new LogicalGenerator();
-  }
+//  protected LogicalGenerator logicalGenerator;
+//
+//  public Planner() {
+//    this.logicalGenerator = new LogicalGenerator();
+//  }
 
   @TestOnly
   public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr) throws QueryProcessException {
@@ -66,7 +66,7 @@ public class Planner {
   /** @param fetchSize this parameter only take effect when it is a query plan */
   public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr, ZoneId zoneId, int fetchSize)
       throws QueryProcessException {
-    Operator operator = logicalGenerator.generate(sqlStr, zoneId);
+    Operator operator = LogicalGenerator.generate(sqlStr, zoneId);
     operator = logicalOptimize(operator);
     PhysicalGenerator physicalGenerator = new PhysicalGenerator();
     return physicalGenerator.transformToPhysicalPlan(operator, fetchSize);

--- a/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
@@ -52,12 +52,6 @@ import static org.apache.iotdb.db.conf.IoTDBConstant.TIME;
 /** provide a integration method for other user. */
 public class Planner {
 
-//  protected LogicalGenerator logicalGenerator;
-//
-//  public Planner() {
-//    this.logicalGenerator = new LogicalGenerator();
-//  }
-
   @TestOnly
   public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr) throws QueryProcessException {
     return parseSQLToPhysicalPlan(sqlStr, ZoneId.systemDefault(), 1024);

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -35,9 +35,9 @@ import java.time.ZoneId;
 /** LogicalGenerator. */
 public class LogicalGenerator {
 
-  public LogicalGenerator() {}
+  private LogicalGenerator() {}
 
-  public Operator generate(String sql, ZoneId zoneId) throws ParseCancellationException {
+  public static Operator generate(String sql, ZoneId zoneId) throws ParseCancellationException {
     IoTDBSqlVisitor ioTDBSqlVisitor = new IoTDBSqlVisitor();
     ioTDBSqlVisitor.setZoneId(zoneId);
     CharStream charStream1 = CharStreams.fromString(sql);
@@ -66,5 +66,10 @@ public class LogicalGenerator {
       // if we parse ok, it's LL not SLL
     }
     return ioTDBSqlVisitor.visit(tree);
+  }
+
+  public static void checkCreateTimeseriesGrammar(String sql) throws ParseCancellationException {
+    String checkSql = "SHOW TIMESERIES " + sql;
+    generate(checkSql, ZoneId.systemDefault());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/logical/IndexLogicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/logical/IndexLogicalPlanTest.java
@@ -41,18 +41,11 @@ import static org.apache.iotdb.db.index.common.IndexConstant.TOP_K;
 
 public class IndexLogicalPlanTest {
 
-  private LogicalGenerator generator;
-
-  @Before
-  public void before() {
-    generator = new LogicalGenerator();
-  }
-
   @Test
   public void testParseCreateIndexWholeMatching() {
     String sqlStr =
         "CREATE INDEX ON root.Ery.*.Glu WHERE time > 50 WITH INDEX=RTREE_PAA, PAA_dim=8";
-    Operator op = generator.generate(sqlStr, ZoneId.systemDefault());
+    Operator op = LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(CreateIndexOperator.class, op.getClass());
     CreateIndexOperator createOperator = (CreateIndexOperator) op;
     Assert.assertEquals(OperatorType.CREATE_INDEX, createOperator.getType());
@@ -68,7 +61,7 @@ public class IndexLogicalPlanTest {
   @Test
   public void testParseCreateIndexSubMatching() {
     String sqlStr = "CREATE INDEX ON root.Wind.AZQ02.Speed WITH INDEX=ELB_INDEX, BLOCK_SIZE=5";
-    Operator op = generator.generate(sqlStr, ZoneId.systemDefault());
+    Operator op = LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(CreateIndexOperator.class, op.getClass());
     CreateIndexOperator createOperator = (CreateIndexOperator) op;
     Assert.assertEquals(OperatorType.CREATE_INDEX, createOperator.getType());
@@ -84,7 +77,7 @@ public class IndexLogicalPlanTest {
   @Test
   public void testParseDropIndexWholeMatching() {
     String sqlStr = "DROP INDEX RTREE_PAA ON root.Ery.*.Glu";
-    Operator op = generator.generate(sqlStr, ZoneId.systemDefault());
+    Operator op = LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(DropIndexOperator.class, op.getClass());
     DropIndexOperator dropIndexOperator = (DropIndexOperator) op;
     Assert.assertEquals(OperatorType.DROP_INDEX, dropIndexOperator.getType());
@@ -97,7 +90,7 @@ public class IndexLogicalPlanTest {
   @Test
   public void testParseDropIndexSubMatching() {
     String sqlStr = "DROP INDEX ELB_INDEX ON root.Wind.AZQ02.Speed";
-    Operator op = generator.generate(sqlStr, ZoneId.systemDefault());
+    Operator op = LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(DropIndexOperator.class, op.getClass());
     DropIndexOperator dropIndexOperator = (DropIndexOperator) op;
     Assert.assertEquals(OperatorType.DROP_INDEX, dropIndexOperator.getType());
@@ -112,7 +105,7 @@ public class IndexLogicalPlanTest {
   public void testParseQueryIndexWholeMatching() {
     String sqlStr =
         "SELECT TOP 2 Glu FROM root.Ery.* WHERE Glu LIKE (0, 120, 20, 80, 120, 100, 80, 0)";
-    Operator op = generator.generate(sqlStr, ZoneId.systemDefault());
+    Operator op = LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, op.getClass());
     QueryOperator queryOperator = (QueryOperator) op;
     Assert.assertEquals(OperatorType.QUERY, queryOperator.getType());
@@ -134,7 +127,7 @@ public class IndexLogicalPlanTest {
             + "CONTAIN (15, 14, 12, 12, 12, 11) WITH TOLERANCE 1 "
             + "CONCAT (10, 20, 25, 24, 14, 8) WITH TOLERANCE 2 "
             + "CONCAT  (8, 9, 10, 14, 15, 15) WITH TOLERANCE 1";
-    Operator op = generator.generate(sqlStr, ZoneId.systemDefault());
+    Operator op = LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, op.getClass());
     QueryOperator queryOperator = (QueryOperator) op;
     Assert.assertEquals(OperatorType.QUERY, queryOperator.getType());

--- a/server/src/test/java/org/apache/iotdb/db/qp/logical/IndexLogicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/logical/IndexLogicalPlanTest.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.db.qp.logical.sys.DropIndexOperator;
 import org.apache.iotdb.db.qp.strategy.LogicalGenerator;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.time.ZoneId;

--- a/server/src/test/java/org/apache/iotdb/db/qp/logical/LogicalPlanSmallTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/logical/LogicalPlanSmallTest.java
@@ -33,7 +33,6 @@ import org.apache.iotdb.db.service.IoTDB;
 
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.time.ZoneId;
@@ -41,18 +40,11 @@ import java.util.ArrayList;
 
 public class LogicalPlanSmallTest {
 
-  private LogicalGenerator logicalGenerator;
-
-  @Before
-  public void before() {
-    logicalGenerator = new LogicalGenerator();
-  }
-
   @Test
   public void testLimit() {
     String sqlStr = "select * from root.vehicle.d1 limit 10";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
     Assert.assertEquals(10, ((QueryOperator) operator).getRowLimit());
     Assert.assertEquals(0, ((QueryOperator) operator).getRowOffset());
@@ -64,7 +56,7 @@ public class LogicalPlanSmallTest {
   public void testOffset() {
     String sqlStr = "select * from root.vehicle.d1 limit 10 offset 20";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
     Assert.assertEquals(10, ((QueryOperator) operator).getRowLimit());
     Assert.assertEquals(20, ((QueryOperator) operator).getRowOffset());
@@ -76,7 +68,7 @@ public class LogicalPlanSmallTest {
   public void testSlimit() {
     String sqlStr = "select * from root.vehicle.d1 limit 10 slimit 1";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
     Assert.assertEquals(10, ((QueryOperator) operator).getRowLimit());
     Assert.assertEquals(0, ((QueryOperator) operator).getRowOffset());
@@ -89,7 +81,7 @@ public class LogicalPlanSmallTest {
     String sqlStr =
         "select * from root.vehicle.d1 where s1 < 20 and time <= now() limit 50 slimit 10 soffset 100";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
     Assert.assertEquals(50, ((QueryOperator) operator).getRowLimit());
     Assert.assertEquals(0, ((QueryOperator) operator).getRowOffset());
@@ -102,7 +94,7 @@ public class LogicalPlanSmallTest {
     String sqlStr =
         "select * from root.vehicle.d1 where s1 < 20 and timestamp <= now() limit 50 slimit 10 soffset 100";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
     Assert.assertEquals(50, ((QueryOperator) operator).getRowLimit());
     Assert.assertEquals(0, ((QueryOperator) operator).getRowOffset());
@@ -115,7 +107,7 @@ public class LogicalPlanSmallTest {
     String sqlStr =
         "select * from root.vehicle.d1 where s1 < 20 and time <= now() limit 1111111111111111111111";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     // expected to throw SQLParserException: Out of range. LIMIT <N>: N should be Int32.
   }
 
@@ -123,7 +115,7 @@ public class LogicalPlanSmallTest {
   public void testLimitNotPositive() {
     String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() limit 0";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     // expected to throw SQLParserException: LIMIT <N>: N should be greater than 0.
   }
 
@@ -133,7 +125,7 @@ public class LogicalPlanSmallTest {
         "select * from root.vehicle.d1 where s1 < 20 and time <= now() "
             + "limit 1 offset 1111111111111111111111";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     // expected to throw SQLParserException: Out of range. OFFSET <OFFSETValue>: OFFSETValue should
     // be Int32.
   }
@@ -143,7 +135,7 @@ public class LogicalPlanSmallTest {
     String sqlStr =
         "select * from root.vehicle.d1 where s1 < 20 and time <= now() limit 1 offset -1";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     // expected to throw SQLParserException: OFFSET <OFFSETValue>: OFFSETValue should >= 0.
   }
 
@@ -152,7 +144,7 @@ public class LogicalPlanSmallTest {
     String sqlStr =
         "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 1111111111111111111111";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     // expected to throw SQLParserException: Out of range. SLIMIT <SN>: SN should be Int32.
   }
 
@@ -160,7 +152,7 @@ public class LogicalPlanSmallTest {
   public void testSlimitNotPositive() {
     String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 0";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     // expected to throw SQLParserException: SLIMIT <SN>: SN should be greater than 0.
   }
 
@@ -170,7 +162,7 @@ public class LogicalPlanSmallTest {
         "select * from root.vehicle.d1 where s1 < 20 and time <= now() "
             + "slimit 1 soffset 1111111111111111111111";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     // expected to throw SQLParserException: Out of range. SOFFSET <SOFFSETValue>: SOFFSETValue
     // should be Int32.
   }
@@ -180,7 +172,7 @@ public class LogicalPlanSmallTest {
     String sqlStr =
         "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 1 soffset 1";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(1, ((QueryOperator) operator).getSeriesOffset());
     Assert.assertEquals(1, ((QueryOperator) operator).getSeriesLimit());
   }
@@ -190,7 +182,7 @@ public class LogicalPlanSmallTest {
     String sqlStr =
         "select s1 from root.vehicle.d1 where s1 < 20 and time <= now() slimit 2 soffset 1";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     IoTDB.metaManager.init();
     ConcatPathOptimizer concatPathOptimizer = new ConcatPathOptimizer();
     concatPathOptimizer.transform(operator);
@@ -203,7 +195,7 @@ public class LogicalPlanSmallTest {
   public void testDeleteStorageGroup() throws IllegalPathException {
     String sqlStr = "delete storage group root.vehicle.d1";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(DeleteStorageGroupOperator.class, operator.getClass());
     PartialPath path = new PartialPath("root.vehicle.d1");
     Assert.assertEquals(path, ((DeleteStorageGroupOperator) operator).getDeletePathList().get(0));
@@ -213,7 +205,7 @@ public class LogicalPlanSmallTest {
   public void testDisableAlign() {
     String sqlStr = "select * from root.vehicle disable align";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
     Assert.assertFalse(((QueryOperator) operator).isAlignByTime());
   }
@@ -222,7 +214,7 @@ public class LogicalPlanSmallTest {
   public void testNotDisableAlign() {
     String sqlStr = "select * from root.vehicle";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
     Assert.assertTrue(((QueryOperator) operator).isAlignByTime());
   }
@@ -231,19 +223,19 @@ public class LogicalPlanSmallTest {
   public void testDisableAlignConflictAlignByDevice() {
     String sqlStr = "select * from root.vehicle disable align align by device";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr, ZoneId.systemDefault());
   }
 
   @Test
   public void testChineseCharacter() throws IllegalPathException {
     String sqlStr1 = "set storage group to root.一级";
     RootOperator operator =
-        (RootOperator) logicalGenerator.generate(sqlStr1, ZoneId.systemDefault());
+        (RootOperator) LogicalGenerator.generate(sqlStr1, ZoneId.systemDefault());
     Assert.assertEquals(SetStorageGroupOperator.class, operator.getClass());
     Assert.assertEquals(new PartialPath("root.一级"), ((SetStorageGroupOperator) operator).getPath());
 
     String sqlStr2 = "select * from root.一级.设备1 limit 10 offset 20";
-    operator = (RootOperator) logicalGenerator.generate(sqlStr2, ZoneId.systemDefault());
+    operator = (RootOperator) LogicalGenerator.generate(sqlStr2, ZoneId.systemDefault());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
     ArrayList<PartialPath> paths = new ArrayList<>();
     paths.add(new PartialPath("*"));
@@ -263,7 +255,7 @@ public class LogicalPlanSmallTest {
               + "FIRST_VALUE.SUM.LAST_VALUE.LAST.DISABLE.ALIGN.COMPRESSION.TIME.ATTRIBUTES.TAGS.RENAME.FULL.CLEAR.CACHE."
               + "SNAPSHOT.FOR.SCHEMA.TRACING.OFF where time>=1 and time < 3";
 
-      Operator op = logicalGenerator.generate(sql, ZoneId.systemDefault());
+      Operator op = LogicalGenerator.generate(sql, ZoneId.systemDefault());
       Assert.assertEquals(DeleteDataOperator.class, op.getClass());
     } catch (ParseCancellationException ignored) {
     }
@@ -272,7 +264,7 @@ public class LogicalPlanSmallTest {
   @Test
   public void testRangeDelete() throws IllegalPathException {
     String sql1 = "delete from root.d1.s1 where time>=1 and time < 3";
-    Operator op = logicalGenerator.generate(sql1, ZoneId.systemDefault());
+    Operator op = LogicalGenerator.generate(sql1, ZoneId.systemDefault());
     Assert.assertEquals(DeleteDataOperator.class, op.getClass());
     ArrayList<PartialPath> paths = new ArrayList<>();
     paths.add(new PartialPath("root.d1.s1"));
@@ -281,37 +273,37 @@ public class LogicalPlanSmallTest {
     Assert.assertEquals(2, ((DeleteDataOperator) op).getEndTime());
 
     String sql2 = "delete from root.d1.s1 where time>=1";
-    op = logicalGenerator.generate(sql2, ZoneId.systemDefault());
+    op = LogicalGenerator.generate(sql2, ZoneId.systemDefault());
     Assert.assertEquals(paths, ((DeleteDataOperator) op).getSelectedPaths());
     Assert.assertEquals(1, ((DeleteDataOperator) op).getStartTime());
     Assert.assertEquals(Long.MAX_VALUE, ((DeleteDataOperator) op).getEndTime());
 
     String sql3 = "delete from root.d1.s1 where time>1";
-    op = logicalGenerator.generate(sql3, ZoneId.systemDefault());
+    op = LogicalGenerator.generate(sql3, ZoneId.systemDefault());
     Assert.assertEquals(paths, ((DeleteDataOperator) op).getSelectedPaths());
     Assert.assertEquals(2, ((DeleteDataOperator) op).getStartTime());
     Assert.assertEquals(Long.MAX_VALUE, ((DeleteDataOperator) op).getEndTime());
 
     String sql4 = "delete from root.d1.s1 where time <= 1";
-    op = logicalGenerator.generate(sql4, ZoneId.systemDefault());
+    op = LogicalGenerator.generate(sql4, ZoneId.systemDefault());
     Assert.assertEquals(paths, ((DeleteDataOperator) op).getSelectedPaths());
     Assert.assertEquals(Long.MIN_VALUE, ((DeleteDataOperator) op).getStartTime());
     Assert.assertEquals(1, ((DeleteDataOperator) op).getEndTime());
 
     String sql5 = "delete from root.d1.s1 where time<1";
-    op = logicalGenerator.generate(sql5, ZoneId.systemDefault());
+    op = LogicalGenerator.generate(sql5, ZoneId.systemDefault());
     Assert.assertEquals(paths, ((DeleteDataOperator) op).getSelectedPaths());
     Assert.assertEquals(Long.MIN_VALUE, ((DeleteDataOperator) op).getStartTime());
     Assert.assertEquals(0, ((DeleteDataOperator) op).getEndTime());
 
     String sql6 = "delete from root.d1.s1 where time = 3";
-    op = logicalGenerator.generate(sql6, ZoneId.systemDefault());
+    op = LogicalGenerator.generate(sql6, ZoneId.systemDefault());
     Assert.assertEquals(paths, ((DeleteDataOperator) op).getSelectedPaths());
     Assert.assertEquals(3, ((DeleteDataOperator) op).getStartTime());
     Assert.assertEquals(3, ((DeleteDataOperator) op).getEndTime());
 
     String sql7 = "delete from root.d1.s1 where time > 5 and time >= 2";
-    op = logicalGenerator.generate(sql7, ZoneId.systemDefault());
+    op = LogicalGenerator.generate(sql7, ZoneId.systemDefault());
     Assert.assertEquals(paths, ((DeleteDataOperator) op).getSelectedPaths());
     Assert.assertEquals(6, ((DeleteDataOperator) op).getStartTime());
     Assert.assertEquals(Long.MAX_VALUE, ((DeleteDataOperator) op).getEndTime());
@@ -322,7 +314,7 @@ public class LogicalPlanSmallTest {
     String sql = "delete from root.d1.s1 where time>=1 and time < 3 or time >1";
     String errorMsg = null;
     try {
-      logicalGenerator.generate(sql, ZoneId.systemDefault());
+      LogicalGenerator.generate(sql, ZoneId.systemDefault());
     } catch (SQLParserException e) {
       errorMsg = e.getMessage();
     }
@@ -334,7 +326,7 @@ public class LogicalPlanSmallTest {
     sql = "delete from root.d1.s1 where time>=1 or time < 3";
     errorMsg = null;
     try {
-      logicalGenerator.generate(sql, ZoneId.systemDefault());
+      LogicalGenerator.generate(sql, ZoneId.systemDefault());
     } catch (SQLParserException e) {
       errorMsg = e.getMessage();
     }
@@ -346,7 +338,7 @@ public class LogicalPlanSmallTest {
     String sql7 = "delete from root.d1.s1 where time = 1 and time < -1";
     errorMsg = null;
     try {
-      logicalGenerator.generate(sql7, ZoneId.systemDefault());
+      LogicalGenerator.generate(sql7, ZoneId.systemDefault());
     } catch (RuntimeException e) {
       errorMsg = e.getMessage();
     }
@@ -355,7 +347,7 @@ public class LogicalPlanSmallTest {
     sql = "delete from root.d1.s1 where time > 5 and time <= 0";
     errorMsg = null;
     try {
-      logicalGenerator.generate(sql, ZoneId.systemDefault());
+      LogicalGenerator.generate(sql, ZoneId.systemDefault());
     } catch (SQLParserException e) {
       errorMsg = e.getMessage();
     }

--- a/session/src/test/java/org/apache/iotdb/session/SessionUT.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionUT.java
@@ -199,4 +199,56 @@ public class SessionUT {
     session.setQueryTimeout(60000);
     Assert.assertEquals(60000, session.getQueryTimeout());
   }
+
+  @Test
+  public void testCreateTimeseriesWithWrongTimeseries()
+      throws IoTDBConnectionException, StatementExecutionException {
+    session = new Session("127.0.0.1", 6667, "root", "root", null);
+    session.open();
+
+    String deviceId = "root.sg1.d1";
+    try {
+      session.createTimeseries(
+          deviceId + ".s1 _wrong_sensor",
+          TSDataType.INT64,
+          TSEncoding.RLE,
+          CompressionType.UNCOMPRESSED);
+    } catch (StatementExecutionException e) {
+      Assert.assertTrue(
+          e.getMessage().contains("extraneous input '_wrong_sensor' expecting {<EOF>, ';"));
+    }
+  }
+
+  @Test
+  public void testInsertWithWrongTimeseries()
+      throws IoTDBConnectionException, StatementExecutionException {
+    session = new Session("127.0.0.1", 6667, "root", "root", null);
+    session.open();
+
+    String deviceId = "root.sg1.d1";
+    List<String> measurements = new ArrayList<>();
+    measurements.add("s3 _wrong_sensor");
+    List<String> deviceIds = new ArrayList<>();
+    List<List<String>> measurementsList = new ArrayList<>();
+    List<List<Object>> valuesList = new ArrayList<>();
+    List<Long> timestamps = new ArrayList<>();
+    List<List<TSDataType>> typesList = new ArrayList<>();
+
+    List<Object> values = new ArrayList<>();
+    List<TSDataType> types = new ArrayList<>();
+    values.add(1L);
+    types.add(TSDataType.INT64);
+    deviceIds.add(deviceId);
+    measurementsList.add(measurements);
+    valuesList.add(values);
+    typesList.add(types);
+    timestamps.add(10000l);
+
+    try {
+      session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
+    } catch (StatementExecutionException e) {
+      Assert.assertTrue(
+          e.getMessage().contains("extraneous input '_wrong_sensor' expecting {<EOF>, ';"));
+    }
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IOTDB-2171

Performance Test:
create 1 million timeseries in one session client, calculate the total cost time.

Testing environment:
macOS
The time unit is milliseconds


  | 1000000 | 100000 | 10000
-- | -- | -- | --
new | 54835 | 6274 | 1186
old | 46704 | 5270 | 1118

From the test result, we can see that the new version will be slower than the old version, which also makes sense because, in this pr, we use antlr to check the grammar, which will cost more time.  However, the benefit is that when we check ourselves， we always miss some situations and are inaccurate but antlr can ensure this.

Any ideas about this?


































