### PR TITLE
[IOTDB-2161] Get timeseries by device in merge process

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/manage/CrossSpaceMergeResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/manage/CrossSpaceMergeResource.java
@@ -107,12 +107,8 @@ public class CrossSpaceMergeResource {
     chunkWriterCache.clear();
   }
 
-  public IMeasurementSchema getSchema(PartialPath path) {
-    try {
-      return IoTDB.metaManager.getSeriesSchema(path);
-    } catch (MetadataException e) {
-      return null;
-    }
+  public IMeasurementSchema getSchema(PartialPath path) throws MetadataException {
+    return IoTDB.metaManager.getSeriesSchema(path);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
@@ -139,7 +139,7 @@ public class CrossSpaceMergeTask implements Callable<Void> {
     inplaceCompactionLogger.logFiles(resource);
 
     Set<PartialPath> unmergedDevice =
-        IoTDB.metaManager.getMatchedDeviceByPrex(new PartialPath(storageGroupName), true);
+        IoTDB.metaManager.getMatchedDeviceByPrefix(new PartialPath(storageGroupName), true);
     inplaceCompactionLogger.logMergeStart();
 
     chunkTask =

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
@@ -142,9 +142,11 @@ public class CrossSpaceMergeTask implements Callable<Void> {
 
     List<List<MeasurementPath>> unmergedSeries = new ArrayList<>();
     Set<PartialPath> devices =
-        IoTDB.metaManager.getMatchedDevices(new PartialPath(
-            storageGroupName + IoTDBConstant.PATH_SEPARATOR
-                + IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD));
+        IoTDB.metaManager.getMatchedDevices(
+            new PartialPath(
+                storageGroupName
+                    + IoTDBConstant.PATH_SEPARATOR
+                    + IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD));
     for (PartialPath path : devices) {
       unmergedSeries.add(IoTDB.metaManager.getAllMeasurementByDevicePath(path));
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
@@ -139,13 +139,9 @@ public class CrossSpaceMergeTask implements Callable<Void> {
     long totalFileSize =
         MergeUtils.collectFileSizes(resource.getSeqFiles(), resource.getUnseqFiles());
     inplaceCompactionLogger = new InplaceCompactionLogger(storageGroupSysDir);
-
     inplaceCompactionLogger.logFiles(resource);
 
-    //    Map<PartialPath, IMeasurementSchema> measurementSchemaMap =
-    //        IoTDB.metaManager.getAllMeasurementSchemaByPrefix(new PartialPath(storageGroupName));
     List<List<IMNode>> unmergedSeries = new ArrayList<>();
-
     Set<PartialPath> devices =
         IoTDB.metaManager.getMatchedDevices(new PartialPath(storageGroupName));
     for (PartialPath path : devices) {
@@ -157,7 +153,6 @@ public class CrossSpaceMergeTask implements Callable<Void> {
         }
       }
       unmergedSeries.add(unmergedByDevice);
-      IoTDB.metaManager.getMeasurementMNode(path);
     }
     inplaceCompactionLogger.logMergeStart();
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
@@ -139,7 +139,7 @@ public class CrossSpaceMergeTask implements Callable<Void> {
     inplaceCompactionLogger.logFiles(resource);
 
     Set<PartialPath> unmergedDevice =
-        IoTDB.metaManager.getMatchedDevicesByPrex(new PartialPath(storageGroupName), true);
+        IoTDB.metaManager.getMatchedDeviceByPrex(new PartialPath(storageGroupName), true);
     inplaceCompactionLogger.logMergeStart();
 
     chunkTask =

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/CrossSpaceMergeTask.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.engine.compaction.cross.inplace.task;
 
-import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.engine.compaction.cross.inplace.manage.CrossSpaceMergeContext;
 import org.apache.iotdb.db.engine.compaction.cross.inplace.manage.CrossSpaceMergeResource;
 import org.apache.iotdb.db.engine.compaction.cross.inplace.recover.InplaceCompactionLogger;
@@ -140,11 +139,7 @@ public class CrossSpaceMergeTask implements Callable<Void> {
     inplaceCompactionLogger.logFiles(resource);
 
     Set<PartialPath> unmergedDevice =
-        IoTDB.metaManager.getMatchedDevices(
-            new PartialPath(
-                storageGroupName
-                    + IoTDBConstant.PATH_SEPARATOR
-                    + IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD));
+        IoTDB.metaManager.getMatchedDevicesByPrex(new PartialPath(storageGroupName), true);
     inplaceCompactionLogger.logMergeStart();
 
     chunkTask =

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
@@ -29,7 +29,7 @@ import org.apache.iotdb.db.engine.compaction.cross.inplace.selector.NaivePathSel
 import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
-import org.apache.iotdb.db.metadata.mnode.IMNode;
+import org.apache.iotdb.db.metadata.path.MeasurementPath;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.utils.MergeUtils;
 import org.apache.iotdb.db.utils.MergeUtils.MetaListEntry;
@@ -133,15 +133,13 @@ public class MergeMultiChunkTask {
       mergeContext.getUnmergedChunkStartTimes().put(seqFile, new HashMap<>());
     }
     // merge each series and write data into each seqFile's corresponding temp merge file
-    for (List<IMNode> nodesBydevice : (List<List<IMNode>>) unmergedSeries) {
+    for (List<MeasurementPath> measurementpathByDevice :
+        (List<List<MeasurementPath>>) unmergedSeries) {
       if (logger.isInfoEnabled()) {
-        logger.info("{} starts to merge {} series", taskName, nodesBydevice.size());
+        logger.info("{} starts to merge {} series", taskName, measurementpathByDevice.size());
       }
       // TODO: use statistics of queries to better rearrange series
-      List<PartialPath> pathList = new ArrayList<>();
-      for (IMNode node : nodesBydevice) {
-        pathList.add(node.getPartialPath());
-      }
+      List<PartialPath> pathList = new ArrayList<>(measurementpathByDevice);
       IMergePathSelector pathSelector = new NaivePathSelector(pathList, concurrentMergeSeriesNum);
       while (pathSelector.hasNext()) {
         currMergingPaths = pathSelector.next();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
@@ -133,7 +133,6 @@ public class MergeMultiChunkTask {
       mergeContext.getUnmergedChunkStartTimes().put(seqFile, new HashMap<>());
     }
     // merge each series and write data into each seqFile's corresponding temp merge file
-    //    List<List<PartialPath>> devicePaths = MergeUtils.splitPathsByDevice(unmergedSeries);
     for (List<IMNode> nodesBydevice : (List<List<IMNode>>) unmergedSeries) {
       if (logger.isInfoEnabled()) {
         logger.info("{} starts to merge {} series", taskName, nodesBydevice.size());

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
@@ -87,7 +87,7 @@ public class MergeMultiChunkTask {
 
   private AtomicInteger mergedChunkNum = new AtomicInteger();
   private AtomicInteger unmergedChunkNum = new AtomicInteger();
-  private int mergedSeriesCnt;
+  private int mergedDeviceCnt;
   private double progress;
 
   private int concurrentMergeSeriesNum;
@@ -134,6 +134,7 @@ public class MergeMultiChunkTask {
       // record the unmergeChunkStartTime for each sensor in each file
       mergeContext.getUnmergedChunkStartTimes().put(seqFile, new HashMap<>());
     }
+    mergedDeviceCnt = 0;
     // merge each series and write data into each seqFile's corresponding temp merge file
     for (PartialPath device : unmergedDevice) {
       // TODO: use statistics of queries to better rearrange series
@@ -166,9 +167,9 @@ public class MergeMultiChunkTask {
           Thread.currentThread().interrupt();
           return;
         }
-        mergedSeriesCnt += currMergingPaths.size();
-        logMergeProgress();
       }
+      mergedDeviceCnt++;
+      logMergeProgress();
       measurementChunkMetadataListMapIteratorCache.clear();
       chunkMetadataListCacheForMerge.clear();
     }
@@ -181,16 +182,16 @@ public class MergeMultiChunkTask {
 
   private void logMergeProgress() {
     if (logger.isInfoEnabled()) {
-      double newProgress = 100 * mergedSeriesCnt / (double) (unmergedDevice.size());
+      double newProgress = 100 * mergedDeviceCnt / (double) (unmergedDevice.size());
       if (newProgress - progress >= 10.0) {
         progress = newProgress;
-        logger.info("{} has merged {}% series", taskName, progress);
+        logger.info("{} has merged {}% devices", taskName, progress);
       }
     }
   }
 
   public String getProgress() {
-    return String.format("Processed %d/%d series", mergedSeriesCnt, unmergedDevice.size());
+    return String.format("Processed %d/%d devices", mergedDeviceCnt, unmergedDevice.size());
   }
 
   private void mergePaths() throws IOException {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -140,6 +141,7 @@ public class MergeMultiChunkTask {
       }
       // TODO: use statistics of queries to better rearrange series
       List<PartialPath> pathList = new ArrayList<>(measurementpathByDevice);
+      Collections.sort(pathList);
       IMergePathSelector pathSelector = new NaivePathSelector(pathList, concurrentMergeSeriesNum);
       while (pathSelector.hasNext()) {
         currMergingPaths = pathSelector.next();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
@@ -213,7 +213,8 @@ public class MergeMultiChunkTask {
     return maxSensor;
   }
 
-  private void pathsMergeOneFile(int seqFileIdx, IPointReader[] unseqReaders) throws IOException {
+  private void pathsMergeOneFile(int seqFileIdx, IPointReader[] unseqReaders)
+      throws IOException, MetadataException {
     TsFileResource currTsFile = resource.getSeqFiles().get(seqFileIdx);
     // all paths in one call are from the same device
     String deviceId = currMergingPaths.get(0).getDevice();
@@ -631,7 +632,7 @@ public class MergeMultiChunkTask {
     }
 
     @SuppressWarnings("java:S2445") // avoid reading the same reader concurrently
-    private void mergeChunkHeap() throws IOException {
+    private void mergeChunkHeap() throws IOException, MetadataException {
       while (!chunkIdxHeap.isEmpty()) {
         int pathIdx = chunkIdxHeap.poll();
         PartialPath path = currMergingPaths.get(pathIdx);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/task/MergeMultiChunkTask.java
@@ -149,13 +149,6 @@ public class MergeMultiChunkTask {
       // just for unit tests, we need to consider whether there is a need to exist
       Collections.sort(measurementPathListByDevice);
 
-      if (logger.isInfoEnabled()) {
-        logger.info(
-            "{}-{} starts to merge {} series",
-            taskName,
-            device.getDevice(),
-            measurementPathListByDevice.size());
-      }
       IMergePathSelector pathSelector =
           new NaivePathSelector(measurementPathListByDevice, concurrentMergeSeriesNum);
       while (pathSelector.hasNext()) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1061,6 +1061,18 @@ public class MManager {
   }
 
   /**
+   * Get all device paths matching the path pattern by prefix.
+   *
+   * @param pathPattern the pattern of the target devices.
+   * @param isPrefixMatch whether to use prefix matching
+   * @return A HashSet instance which stores devices paths matching the given path pattern.
+   */
+  public Set<PartialPath> getMatchedDevicesByPrex(PartialPath pathPattern, boolean isPrefixMatch)
+      throws MetadataException {
+    return mtree.getDevices(pathPattern, isPrefixMatch);
+  }
+
+  /**
    * Get all device paths and according storage group paths as ShowDevicesResult.
    *
    * @param plan ShowDevicesPlan which contains the path pattern and restriction params.

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1067,7 +1067,7 @@ public class MManager {
    * @param isPrefixMatch whether to use prefix matching
    * @return A HashSet instance which stores devices paths matching the given path pattern.
    */
-  public Set<PartialPath> getMatchedDeviceByPrex(PartialPath pathPattern, boolean isPrefixMatch)
+  public Set<PartialPath> getMatchedDeviceByPrefix(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     return mtree.getDevices(pathPattern, isPrefixMatch);
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1276,7 +1276,7 @@ public class MManager {
     return mtree.getAllStorageGroupNodes();
   }
 
-  IMNode getDeviceNode(PartialPath path) throws MetadataException {
+  public IMNode getDeviceNode(PartialPath path) throws MetadataException {
     IMNode node;
     try {
       node = mNodeCache.get(path);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1067,7 +1067,7 @@ public class MManager {
    * @param isPrefixMatch whether to use prefix matching
    * @return A HashSet instance which stores devices paths matching the given path pattern.
    */
-  public Set<PartialPath> getMatchedDevicesByPrex(PartialPath pathPattern, boolean isPrefixMatch)
+  public Set<PartialPath> getMatchedDeviceByPrex(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     return mtree.getDevices(pathPattern, isPrefixMatch);
   }


### PR DESCRIPTION
When we take all `partialPath`, we may have too much. Therefore, obtain the path by device first.
In a later commit, we might simplify `RecoveryMergeTask`