### PR TITLE
[IOTDB-2043] refactor: remove haveSorted param from Session

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
+++ b/integration/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
@@ -731,7 +731,7 @@ public class IoTDBSessionSimpleIT {
     session.close();
   }
 
-  @Test(expected = BatchExecutionException.class)
+  @Test
   public void testInsertOneDeviceRecordsWithIncorrectOrder()
       throws IoTDBConnectionException, StatementExecutionException {
     session = new Session("127.0.0.1", 6667, "root", "root");

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -1189,7 +1189,7 @@ public class Session {
    *
    * <p>Each row could have same deviceId but different time, number of measurements
    *
-   * @param haveSorted whether the times have been sorted
+   * @param haveSorted deprecated, whether the times have been sorted
    * @see Session#insertTablet(Tablet)
    */
   public void insertRecordsOfOneDevice(
@@ -1242,7 +1242,7 @@ public class Session {
    *
    * <p>Each row could have same prefixPath but different time, number of measurements
    *
-   * @param haveSorted whether the times have been sorted
+   * @param haveSorted deprecated, whether the times have been sorted
    * @see Session#insertTablet(Tablet)
    */
   public void insertAlignedRecordsOfOneDevice(
@@ -1290,12 +1290,7 @@ public class Session {
           "times, measurementsList and valuesList's size should be equal");
     }
 
-    if (haveSorted) {
-      if (!checkSorted(times)) {
-        throw new BatchExecutionException(
-            "Times in InsertOneDeviceRecords are not in ascending order");
-      }
-    } else {
+    if (!checkSorted(times)) {
       // sort
       Integer[] index = new Integer[times.size()];
       for (int i = 0; i < times.size(); i++) {
@@ -1422,7 +1417,7 @@ public class Session {
    * insert a Tablet
    *
    * @param tablet data batch
-   * @param sorted whether times in Tablet are in ascending order
+   * @param sorted deprecated, whether times in Tablet are in ascending order
    */
   public void insertTablet(Tablet tablet, boolean sorted)
       throws IoTDBConnectionException, StatementExecutionException {
@@ -1454,7 +1449,7 @@ public class Session {
    * insert the aligned timeseries data of a device.
    *
    * @param tablet data batch
-   * @param sorted whether times in Tablet are in ascending order
+   * @param sorted deprecated, whether times in Tablet are in ascending order
    */
   public void insertAlignedTablet(Tablet tablet, boolean sorted)
       throws IoTDBConnectionException, StatementExecutionException {
@@ -1464,9 +1459,7 @@ public class Session {
 
   private TSInsertTabletReq genTSInsertTabletReq(Tablet tablet, boolean sorted)
       throws BatchExecutionException {
-    if (sorted) {
-      checkSortedThrowable(tablet);
-    } else {
+    if (!checkSorted(tablet)) {
       sortTablet(tablet);
     }
 
@@ -1503,7 +1496,7 @@ public class Session {
    * measurements is the same.
    *
    * @param tablets data batch in multiple device
-   * @param sorted whether times in each Tablet are in ascending order
+   * @param sorted deprecated, whether times in each Tablet are in ascending order
    */
   public void insertTablets(Map<String, Tablet> tablets, boolean sorted)
       throws IoTDBConnectionException, StatementExecutionException {
@@ -1540,7 +1533,7 @@ public class Session {
    * measurements is the same.
    *
    * @param tablets data batch in multiple device
-   * @param sorted whether times in each Tablet are in ascending order
+   * @param sorted deprecated, whether times in each Tablet are in ascending order
    */
   public void insertAlignedTablets(Map<String, Tablet> tablets, boolean sorted)
       throws IoTDBConnectionException, StatementExecutionException {
@@ -1581,9 +1574,7 @@ public class Session {
 
   private void updateTSInsertTabletsReq(TSInsertTabletsReq request, Tablet tablet, boolean sorted)
       throws BatchExecutionException {
-    if (sorted) {
-      checkSortedThrowable(tablet);
-    } else {
+    if (!checkSorted(tablet)) {
       sortTablet(tablet);
     }
     request.addToPrefixPaths(tablet.prefixPath);


### PR DESCRIPTION
## Description
For some methods in Session, we have a haveSorted parameter to indicate whether multi records are in ascending order of time.

This parameter is useless, we could check this by ourselves.
(1) checkSorted
(2) if not sorted, we could sort it.

## What
1. Delete `haveSorted` param in `insertRecordsOfOneDevice, insertAlignedRecordsOfOneDevice`. Since currently there are two overloaded version of `insertRecordsOfOneDevice, insertAlignedRecordsOfOneDevice` and they only differ in `haveSorted` param, so I merged two overloaded version into a single interface
2. Change the caller usages of above methods


