### PR TITLE
[IOTDB-2196] Support double star ** in group by level

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationByLevelIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationByLevelIT.java
@@ -276,12 +276,22 @@ public class IoTDBAggregationByLevelIT {
 
   @Test
   public void countStarGroupByLevelTest() throws Exception {
-    String[] retArray = new String[] {"17", "8"};
+    String[] retArray = new String[] {"17", "17", "8"};
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
       statement.execute("select count(*) from root.*.* GROUP BY level=0");
 
       int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans = resultSet.getString(TestConstant.count("root.*.*.*"));
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+      }
+
+      statement.execute("select count(**) from root GROUP BY level=0");
+
       try (ResultSet resultSet = statement.getResultSet()) {
         while (resultSet.next()) {
           String ans = resultSet.getString(TestConstant.count("root.*.*.*"));

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBAggregationGroupByLevelIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBAggregationGroupByLevelIT.java
@@ -31,14 +31,22 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @Category({LocalStandaloneTest.class})
 public class IoTDBAggregationGroupByLevelIT {
+
   private static final double DELTA = 1e-6;
   private static final double NULL = Double.MIN_VALUE;
   protected static boolean enableSeqSpaceCompaction;

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -44,6 +44,7 @@ import java.util.Map.Entry;
 
 public abstract class AbstractMemTable implements IMemTable {
 
+  /** DeviceId -> chunkGroup(MeasurementId -> chunk) */
   private final Map<String, IWritableMemChunkGroup> memTableMap;
   /**
    * The initial value is true because we want calculate the text data size when recover memTable!!

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/unary/FunctionExpression.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/unary/FunctionExpression.java
@@ -125,7 +125,8 @@ public class FunctionExpression extends Expression {
 
   public boolean isCountStar() {
     return getPaths().size() == 1
-        && paths.get(0).getTailNode().equals(IoTDBConstant.ONE_LEVEL_PATH_WILDCARD)
+        && (paths.get(0).getTailNode().equals(IoTDBConstant.ONE_LEVEL_PATH_WILDCARD)
+            || paths.get(0).getTailNode().equals(IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD))
         && functionName.equals(IoTDBConstant.COLUMN_COUNT);
   }
 


### PR DESCRIPTION
Only support this before:
![image](https://user-images.githubusercontent.com/34242296/147308795-0e202dfb-d052-4837-a9b3-5755a865ef7c.png)

Implement this now:
![image](https://user-images.githubusercontent.com/34242296/147308771-488277d5-c071-4b62-bddc-3c08f9d40f8f.png)

