### PR TITLE
[IOTDB-2209] Fix logback CVE-2021-42550 issue

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -290,8 +290,8 @@ org.slf4j:jcl-over-slf4j:1.7.25
 EPL 1.0
 ------------
 com.h2database:h2-mvstore:1.4.199
-ch.qos.logback:logback-classic:1.2.3
-ch.qos.logback:logback-core:1.2.3
+ch.qos.logback:logback-classic:1.2.10
+ch.qos.logback:logback-core:1.2.10
 
 
 CDDL 1.1

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <hive2.version>2.3.6</hive2.version>
         <junit.version>4.13.2</junit.version>
         <slf4j.version>1.7.12</slf4j.version>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.2.10</logback.version>
         <joda.version>2.9.9</joda.version>
         <spark.version>2.4.3</spark.version>
         <flink.version>1.14.0</flink.version>


### PR DESCRIPTION
## Description

There is a cve report about logback version < 1.2.9. 

See https://cve.report/CVE-2021-42550