### PR TITLE
[To rel/0.12] [IOTDB-2221] Accelerate query by reducing the number of files in QueryDataSource

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterUDTFQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterUDTFQueryExecutor.java
@@ -67,7 +67,7 @@ public class ClusterUDTFQueryExecutor extends ClusterDataQueryExecutor {
             new ArrayList<>(udtfPlan.getDeduplicatedPaths()),
             timestampGenerator.hasOrNode());
     List<IReaderByTimestamp> readersOfSelectedSeries =
-        initSeriesReaderByTimestamp(context, udtfPlan, cached);
+        initSeriesReaderByTimestamp(context, udtfPlan, cached, timestampGenerator.getTimeFilter());
     return new UDTFAlignByTimeDataSet(
         context,
         udtfPlan,
@@ -98,7 +98,7 @@ public class ClusterUDTFQueryExecutor extends ClusterDataQueryExecutor {
             new ArrayList<>(udtfPlan.getDeduplicatedPaths()),
             timestampGenerator.hasOrNode());
     List<IReaderByTimestamp> readersOfSelectedSeries =
-        initSeriesReaderByTimestamp(context, udtfPlan, cached);
+        initSeriesReaderByTimestamp(context, udtfPlan, cached, timestampGenerator.getTimeFilter());
     return new UDTFNonAlignDataSet(
         context,
         udtfPlan,

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/LocalQueryExecutor.java
@@ -60,6 +60,7 @@ import org.apache.iotdb.db.query.factory.AggregateResultFactory;
 import org.apache.iotdb.db.query.reader.series.IReaderByTimestamp;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.SerializeUtils;
+import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.common.BatchData;
@@ -773,7 +774,14 @@ public class LocalQueryExecutor {
             aggregationTypeOrdinals,
             queryContext,
             ascending);
-    if (!executor.isEmpty()) {
+    boolean isEmpty;
+    try {
+      isEmpty = executor.isEmpty();
+    } catch (IOException e) {
+      logger.error("Something wrong happened", e);
+      throw new QueryProcessException(e, TSStatusCode.INTERNAL_SERVER_ERROR.ordinal());
+    }
+    if (!isEmpty) {
       long executorId = queryManager.registerGroupByExecutor(executor);
       logger.debug(
           "{}: Build a GroupByExecutor of {} for {}, executorId: {}",

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/member/DataGroupMemberTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/member/DataGroupMemberTest.java
@@ -1164,18 +1164,16 @@ public class DataGroupMemberTest extends BaseMember {
         request.timeFilterBytes.position(0);
         new DataAsyncService(dataGroupMember).getGroupByExecutor(request, handler);
         executorId = resultRef.get();
-        // TODO: This test is uncompleted because of shared QueryDataSource (IOTDB-2101)
-        // assertEquals(-1L, (long) executorId);
+        assertEquals(-1L, (long) executorId);
 
         // fetch result
-        //        aggrResultRef = new AtomicReference<>();
-        //        aggrResultHandler = new GenericHandler<>(TestUtils.getNode(0), aggrResultRef);
-        //        new DataAsyncService(dataGroupMember)
-        //            .getGroupByResult(TestUtils.getNode(30), executorId, 0, 20,
-        // aggrResultHandler);
-        //
-        //        byteBuffers = aggrResultRef.get();
-        //        assertNull(byteBuffers);
+        aggrResultRef = new AtomicReference<>();
+        aggrResultHandler = new GenericHandler<>(TestUtils.getNode(0), aggrResultRef);
+        new DataAsyncService(dataGroupMember)
+            .getGroupByResult(TestUtils.getNode(30), executorId, 0, 20, aggrResultHandler);
+
+        byteBuffers = aggrResultRef.get();
+        assertNull(byteBuffers);
       } finally {
         dataGroupMember.closeLogManager();
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -1062,8 +1062,10 @@ public class StorageEngine implements IService {
       List<PartialPath> pathList, QueryContext context, Filter timeFilter)
       throws StorageEngineException, QueryProcessException {
     Map<StorageGroupProcessor, List<PartialPath>> map = new HashMap<>();
+    Set<String> selectedDevices = new HashSet<>();
     for (PartialPath path : pathList) {
       map.computeIfAbsent(getProcessor(path.getDevicePath()), key -> new ArrayList<>()).add(path);
+      selectedDevices.add(path.getDevice());
     }
     List<StorageGroupProcessor> list =
         map.keySet().stream()
@@ -1072,7 +1074,12 @@ public class StorageEngine implements IService {
     list.forEach(StorageGroupProcessor::readLock);
 
     // init QueryDataSource
-    QueryResourceManager.getInstance().initQueryDataSource(map, context, timeFilter);
+    QueryResourceManager.getInstance()
+        .initQueryDataSource(
+            map,
+            selectedDevices.size() == 1 ? selectedDevices.iterator().next() : null,
+            context,
+            timeFilter);
 
     return list;
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -1062,10 +1062,8 @@ public class StorageEngine implements IService {
       List<PartialPath> pathList, QueryContext context, Filter timeFilter)
       throws StorageEngineException, QueryProcessException {
     Map<StorageGroupProcessor, List<PartialPath>> map = new HashMap<>();
-    Set<String> selectedDevices = new HashSet<>();
     for (PartialPath path : pathList) {
       map.computeIfAbsent(getProcessor(path.getDevicePath()), key -> new ArrayList<>()).add(path);
-      selectedDevices.add(path.getDevice());
     }
     List<StorageGroupProcessor> list =
         map.keySet().stream()
@@ -1074,12 +1072,7 @@ public class StorageEngine implements IService {
     list.forEach(StorageGroupProcessor::readLock);
 
     // init QueryDataSource
-    QueryResourceManager.getInstance()
-        .initQueryDataSource(
-            map,
-            selectedDevices.size() == 1 ? selectedDevices.iterator().next() : null,
-            context,
-            timeFilter);
+    QueryResourceManager.getInstance().initQueryDataSource(map, context, timeFilter);
 
     return list;
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1574,6 +1574,7 @@ public class StorageGroupProcessor {
 
   public QueryDataSource query(
       List<PartialPath> pathList,
+      String singleDeviceId,
       QueryContext context,
       QueryFileManager filePathsManager,
       Filter timeFilter)
@@ -1585,6 +1586,7 @@ public class StorageGroupProcessor {
               tsFileManagement.getTsFileList(true),
               upgradeSeqFileList,
               pathList,
+              singleDeviceId,
               context,
               timeFilter,
               true);
@@ -1593,6 +1595,7 @@ public class StorageGroupProcessor {
               tsFileManagement.getTsFileList(false),
               upgradeUnseqFileList,
               pathList,
+              singleDeviceId,
               context,
               timeFilter,
               false);
@@ -1642,6 +1645,7 @@ public class StorageGroupProcessor {
       Collection<TsFileResource> tsFileResources,
       List<TsFileResource> upgradeTsFileResources,
       List<PartialPath> pathList,
+      String singleDeviceId,
       QueryContext context,
       Filter timeFilter,
       boolean isSeq)
@@ -1664,7 +1668,8 @@ public class StorageGroupProcessor {
 
     // for upgrade files and old files must be closed
     for (TsFileResource tsFileResource : upgradeTsFileResources) {
-      if (!tsFileResource.isSatisfied(timeFilter, isSeq, dataTTL, context.isDebug())) {
+      if (!tsFileResource.isSatisfied(
+          singleDeviceId, timeFilter, isSeq, dataTTL, context.isDebug())) {
         continue;
       }
       closeQueryLock.readLock().lock();
@@ -1676,7 +1681,8 @@ public class StorageGroupProcessor {
     }
 
     for (TsFileResource tsFileResource : tsFileResources) {
-      if (!tsFileResource.isSatisfied(timeFilter, isSeq, dataTTL, context.isDebug())) {
+      if (!tsFileResource.isSatisfied(
+          singleDeviceId, timeFilter, isSeq, dataTTL, context.isDebug())) {
         continue;
       }
       closeQueryLock.readLock().lock();

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1572,6 +1572,16 @@ public class StorageGroupProcessor {
     }
   }
 
+  /**
+   * build query data source by searching all tsfile which fit in query filter
+   *
+   * @param pathList data paths
+   * @param context query context
+   * @param timeFilter time filter
+   * @param singleDeviceId selected deviceId (not null only when all the selected series are under
+   *     the same device)
+   * @return query data source
+   */
   public QueryDataSource query(
       List<PartialPath> pathList,
       String singleDeviceId,

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -644,7 +644,7 @@ public class TsFileResource {
   }
 
   /** @return true if the TsFile lives beyond TTL */
-  public boolean isSatisfied(Filter timeFilter, boolean isSeq, long ttl, boolean debug) {
+  private boolean isSatisfied(Filter timeFilter, boolean isSeq, long ttl, boolean debug) {
     long startTime = getFileStartTime();
     long endTime = closed || !isSeq ? getFileEndTime() : Long.MAX_VALUE;
 
@@ -665,7 +665,7 @@ public class TsFileResource {
     return true;
   }
 
-  /** @return true if the device is contained in the TsFile and it lives beyond TTL */
+  /** @return true if the device is contained in the TsFile */
   public boolean isSatisfied(
       String deviceId, Filter timeFilter, TsFileFilter fileFilter, boolean isSeq, boolean debug) {
     if (fileFilter != null && fileFilter.fileNotSatisfy(this)) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -608,6 +608,41 @@ public class TsFileResource {
     return timeIndex.stillLives(timeLowerBound);
   }
 
+  public boolean isSatisfied(
+      String deviceId, Filter timeFilter, boolean isSeq, long ttl, boolean debug) {
+    if (deviceId == null) {
+      return isSatisfied(timeFilter, isSeq, ttl, debug);
+    }
+
+    if (!getDevices().contains(deviceId)) {
+      if (debug) {
+        DEBUG_LOGGER.info(
+            "Path: {} file {} is not satisfied because of no device!", deviceId, file);
+      }
+      return false;
+    }
+
+    long startTime = getStartTime(deviceId);
+    long endTime = closed || !isSeq ? getEndTime(deviceId) : Long.MAX_VALUE;
+
+    if (!isAlive(endTime, ttl)) {
+      if (debug) {
+        DEBUG_LOGGER.info("file {} is not satisfied because of ttl!", file);
+      }
+      return false;
+    }
+
+    if (timeFilter != null) {
+      boolean res = timeFilter.satisfyStartEndTime(startTime, endTime);
+      if (debug && !res) {
+        DEBUG_LOGGER.info(
+            "Path: {} file {} is not satisfied because of time filter!", deviceId, fsFactory);
+      }
+      return res;
+    }
+    return true;
+  }
+
   /** @return true if the TsFile lives beyond TTL */
   public boolean isSatisfied(Filter timeFilter, boolean isSeq, long ttl, boolean debug) {
     long startTime = getFileStartTime();
@@ -632,12 +667,7 @@ public class TsFileResource {
 
   /** @return true if the device is contained in the TsFile and it lives beyond TTL */
   public boolean isSatisfied(
-      String deviceId,
-      Filter timeFilter,
-      TsFileFilter fileFilter,
-      boolean isSeq,
-      long ttl,
-      boolean debug) {
+      String deviceId, Filter timeFilter, TsFileFilter fileFilter, boolean isSeq, boolean debug) {
     if (fileFilter != null && fileFilter.fileNotSatisfy(this)) {
       if (debug) {
         DEBUG_LOGGER.info(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -831,11 +831,11 @@ public class MManager {
         Map<StorageGroupProcessor, List<PartialPath>> processorToSeriesMap =
             lockListAndProcessorToSeriesMapPair.right;
 
-        // init QueryDataSource Cache
-        QueryResourceManager.getInstance()
-            .initQueryDataSourceCache(processorToSeriesMap, context, null);
-
         try {
+          // init QueryDataSource Cache
+          QueryResourceManager.getInstance()
+              .initQueryDataSourceCache(processorToSeriesMap, context, null);
+
           allMatchedNodes =
               allMatchedNodes.stream()
                   .sorted(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.*;
 import org.apache.iotdb.db.qp.physical.sys.*;
 import org.apache.iotdb.db.query.context.QueryContext;
+import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.dataset.ShowDevicesResult;
 import org.apache.iotdb.db.query.dataset.ShowTimeSeriesResult;
 import org.apache.iotdb.db.rescon.MemTableManager;
@@ -821,12 +822,19 @@ public class MManager {
     if (plan.isOrderByHeat()) {
       List<StorageGroupProcessor> list;
       try {
-        list =
-            StorageEngine.getInstance()
-                .mergeLockAndInitQueryDataSource(
-                    allMatchedNodes.stream().map(MNode::getPartialPath).collect(toList()),
-                    context,
-                    null);
+        Pair<List<StorageGroupProcessor>, Map<StorageGroupProcessor, List<PartialPath>>>
+            lockListAndProcessorToSeriesMapPair =
+                StorageEngine.getInstance()
+                    .mergeLock(
+                        allMatchedNodes.stream().map(MNode::getPartialPath).collect(toList()));
+        list = lockListAndProcessorToSeriesMapPair.left;
+        Map<StorageGroupProcessor, List<PartialPath>> processorToSeriesMap =
+            lockListAndProcessorToSeriesMapPair.right;
+
+        // init QueryDataSource Cache
+        QueryResourceManager.getInstance()
+            .initQueryDataSourceCache(processorToSeriesMap, context, null);
+
         try {
           allMatchedNodes =
               allMatchedNodes.stream()

--- a/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
@@ -111,7 +111,7 @@ public class QueryResourceManager {
    * @param processorToSeriesMap Key: processor of the virtual storage group. Value: selected series
    *     under the virtual storage group
    */
-  public void initQueryDataSource(
+  public void initQueryDataSourceCache(
       Map<StorageGroupProcessor, List<PartialPath>> processorToSeriesMap,
       QueryContext context,
       Filter timeFilter)

--- a/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
@@ -38,7 +38,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -109,9 +113,12 @@ public class QueryResourceManager {
    *
    * @param processorToSeriesMap Key: processor of the virtual storage group. Value: selected series
    *     under the virtual storage group
+   * @param singleDeviceId selected deviceId (not null only when the selected series is under the
+   *     same device)
    */
   public void initQueryDataSource(
       Map<StorageGroupProcessor, List<PartialPath>> processorToSeriesMap,
+      String singleDeviceId,
       QueryContext context,
       Filter timeFilter)
       throws QueryProcessException {
@@ -124,7 +131,7 @@ public class QueryResourceManager {
       String storageGroupPath = processor.getStorageGroupPath();
 
       QueryDataSource cachedQueryDataSource =
-          processor.query(pathList, context, filePathsManager, timeFilter);
+          processor.query(pathList, singleDeviceId, context, filePathsManager, timeFilter);
       cachedQueryDataSourcesMap
           .computeIfAbsent(queryId, k -> new HashMap<>())
           .put(storageGroupPath, cachedQueryDataSource);
@@ -150,7 +157,11 @@ public class QueryResourceManager {
           StorageEngine.getInstance().getProcessor(selectedPath.getDevicePath());
       cachedQueryDataSource =
           processor.query(
-              Collections.singletonList(selectedPath), context, filePathsManager, timeFilter);
+              Collections.singletonList(selectedPath),
+              selectedPath.getDevice(),
+              context,
+              filePathsManager,
+              timeFilter);
       cachedQueryDataSourcesMap
           .computeIfAbsent(queryId, k -> new HashMap<>())
           .put(storageGroupPath, cachedQueryDataSource);

--- a/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
@@ -113,8 +113,8 @@ public class QueryResourceManager {
    *
    * @param processorToSeriesMap Key: processor of the virtual storage group. Value: selected series
    *     under the virtual storage group
-   * @param singleDeviceId selected deviceId (not null only when the selected series is under the
-   *     same device)
+   * @param singleDeviceId selected deviceId (not null only when all the selected series are under
+   *     the same device)
    */
   public void initQueryDataSource(
       Map<StorageGroupProcessor, List<PartialPath>> processorToSeriesMap,

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/LocalGroupByExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/LocalGroupByExecutor.java
@@ -88,9 +88,8 @@ public class LocalGroupByExecutor implements GroupByExecutor {
     this.ascending = ascending;
   }
 
-  public boolean isEmpty() {
-    return queryDataSource.getSeqResources().isEmpty()
-        && queryDataSource.getUnseqResources().isEmpty();
+  public boolean isEmpty() throws IOException {
+    return !reader.hasNextFile();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
@@ -365,7 +365,8 @@ public class AggregationExecutor {
     try {
       // init QueryDataSource Cache
       QueryResourceManager.getInstance()
-          .initQueryDataSourceCache(processorToSeriesMap, context, null);
+          .initQueryDataSourceCache(
+              processorToSeriesMap, context, timestampGenerator.getTimeFilter());
 
       for (int i = 0; i < selectedSeries.size(); i++) {
         PartialPath path = selectedSeries.get(i);

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/RawDataQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/RawDataQueryExecutor.java
@@ -159,7 +159,7 @@ public class RawDataQueryExecutor {
             new ArrayList<>(queryPlan.getDeduplicatedPaths()),
             timestampGenerator.hasOrNode());
     List<IReaderByTimestamp> readersOfSelectedSeries =
-        initSeriesReaderByTimestamp(context, queryPlan, cached);
+        initSeriesReaderByTimestamp(context, queryPlan, cached, timestampGenerator.getTimeFilter());
     return new RawQueryDataSetWithValueFilter(
         queryPlan.getDeduplicatedPaths(),
         queryPlan.getDeduplicatedDataTypes(),
@@ -170,7 +170,7 @@ public class RawDataQueryExecutor {
   }
 
   protected List<IReaderByTimestamp> initSeriesReaderByTimestamp(
-      QueryContext context, RawDataQueryPlan queryPlan, List<Boolean> cached)
+      QueryContext context, RawDataQueryPlan queryPlan, List<Boolean> cached, Filter timeFilter)
       throws QueryProcessException, StorageEngineException {
     List<IReaderByTimestamp> readersOfSelectedSeries = new ArrayList<>();
 
@@ -184,7 +184,7 @@ public class RawDataQueryExecutor {
     try {
       // init QueryDataSource Cache
       QueryResourceManager.getInstance()
-          .initQueryDataSourceCache(processorToSeriesMap, context, null);
+          .initQueryDataSourceCache(processorToSeriesMap, context, timeFilter);
       for (int i = 0; i < queryPlan.getDeduplicatedPaths().size(); i++) {
         if (cached.get(i)) {
           readersOfSelectedSeries.add(null);

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/RawDataQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/RawDataQueryExecutor.java
@@ -40,10 +40,12 @@ import org.apache.iotdb.tsfile.read.expression.impl.GlobalTimeExpression;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.read.query.timegenerator.TimeGenerator;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.apache.iotdb.tsfile.read.query.executor.ExecutorWithTimeGenerator.markFilterdPaths;
@@ -98,10 +100,18 @@ public class RawDataQueryExecutor {
     }
 
     List<ManagedSeriesReader> readersOfSelectedSeries = new ArrayList<>();
-    List<StorageGroupProcessor> list =
-        StorageEngine.getInstance()
-            .mergeLockAndInitQueryDataSource(queryPlan.getDeduplicatedPaths(), context, timeFilter);
+
+    Pair<List<StorageGroupProcessor>, Map<StorageGroupProcessor, List<PartialPath>>>
+        lockListAndProcessorToSeriesMapPair =
+            StorageEngine.getInstance().mergeLock(queryPlan.getDeduplicatedPaths());
+    List<StorageGroupProcessor> lockList = lockListAndProcessorToSeriesMapPair.left;
+    Map<StorageGroupProcessor, List<PartialPath>> processorToSeriesMap =
+        lockListAndProcessorToSeriesMapPair.right;
+
     try {
+      // init QueryDataSource cache
+      QueryResourceManager.getInstance()
+          .initQueryDataSourceCache(processorToSeriesMap, context, timeFilter);
       for (int i = 0; i < queryPlan.getDeduplicatedPaths().size(); i++) {
         PartialPath path = queryPlan.getDeduplicatedPaths().get(i);
         TSDataType dataType = queryPlan.getDeduplicatedDataTypes().get(i);
@@ -124,7 +134,7 @@ public class RawDataQueryExecutor {
         readersOfSelectedSeries.add(reader);
       }
     } finally {
-      StorageEngine.getInstance().mergeUnLock(list);
+      StorageEngine.getInstance().mergeUnLock(lockList);
     }
     return readersOfSelectedSeries;
   }
@@ -163,10 +173,18 @@ public class RawDataQueryExecutor {
       QueryContext context, RawDataQueryPlan queryPlan, List<Boolean> cached)
       throws QueryProcessException, StorageEngineException {
     List<IReaderByTimestamp> readersOfSelectedSeries = new ArrayList<>();
-    List<StorageGroupProcessor> list =
-        StorageEngine.getInstance()
-            .mergeLockAndInitQueryDataSource(queryPlan.getDeduplicatedPaths(), context, null);
+
+    Pair<List<StorageGroupProcessor>, Map<StorageGroupProcessor, List<PartialPath>>>
+        lockListAndProcessorToSeriesMapPair =
+            StorageEngine.getInstance().mergeLock(queryPlan.getDeduplicatedPaths());
+    List<StorageGroupProcessor> lockList = lockListAndProcessorToSeriesMapPair.left;
+    Map<StorageGroupProcessor, List<PartialPath>> processorToSeriesMap =
+        lockListAndProcessorToSeriesMapPair.right;
+
     try {
+      // init QueryDataSource Cache
+      QueryResourceManager.getInstance()
+          .initQueryDataSourceCache(processorToSeriesMap, context, null);
       for (int i = 0; i < queryPlan.getDeduplicatedPaths().size(); i++) {
         if (cached.get(i)) {
           readersOfSelectedSeries.add(null);
@@ -182,7 +200,7 @@ public class RawDataQueryExecutor {
         readersOfSelectedSeries.add(seriesReaderByTimestamp);
       }
     } finally {
-      StorageEngine.getInstance().mergeUnLock(list);
+      StorageEngine.getInstance().mergeUnLock(lockList);
     }
     return readersOfSelectedSeries;
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/UDTFQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/UDTFQueryExecutor.java
@@ -65,7 +65,7 @@ public class UDTFQueryExecutor extends RawDataQueryExecutor {
             new ArrayList<>(udtfPlan.getDeduplicatedPaths()),
             timestampGenerator.hasOrNode());
     List<IReaderByTimestamp> readersOfSelectedSeries =
-        initSeriesReaderByTimestamp(context, udtfPlan, cached);
+        initSeriesReaderByTimestamp(context, udtfPlan, cached, timestampGenerator.getTimeFilter());
     return new UDTFAlignByTimeDataSet(
         context,
         udtfPlan,
@@ -96,7 +96,7 @@ public class UDTFQueryExecutor extends RawDataQueryExecutor {
             new ArrayList<>(udtfPlan.getDeduplicatedPaths()),
             timestampGenerator.hasOrNode());
     List<IReaderByTimestamp> readersOfSelectedSeries =
-        initSeriesReaderByTimestamp(context, udtfPlan, cached);
+        initSeriesReaderByTimestamp(context, udtfPlan, cached, timestampGenerator.getTimeFilter());
     return new UDTFNonAlignDataSet(
         context,
         udtfPlan,

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
@@ -1157,12 +1157,7 @@ public class SeriesReader {
         TsFileResource tsFileResource = dataSource.getSeqResourceByIndex(curSeqFileIndex);
         if (tsFileResource != null
             && tsFileResource.isSatisfied(
-                seriesPath.getDevice(),
-                timeFilter,
-                fileFilter,
-                true,
-                dataSource.getDataTTL(),
-                context.isDebug())) {
+                seriesPath.getDevice(), timeFilter, fileFilter, true, context.isDebug())) {
           break;
         }
         curSeqFileIndex--;
@@ -1176,12 +1171,7 @@ public class SeriesReader {
         TsFileResource tsFileResource = dataSource.getUnseqResourceByIndex(curUnseqFileIndex);
         if (tsFileResource != null
             && tsFileResource.isSatisfied(
-                seriesPath.getDevice(),
-                timeFilter,
-                fileFilter,
-                false,
-                dataSource.getDataTTL(),
-                context.isDebug())) {
+                seriesPath.getDevice(), timeFilter, fileFilter, false, context.isDebug())) {
           break;
         }
         curUnseqFileIndex++;
@@ -1290,12 +1280,7 @@ public class SeriesReader {
         TsFileResource tsFileResource = dataSource.getSeqResourceByIndex(curSeqFileIndex);
         if (tsFileResource != null
             && tsFileResource.isSatisfied(
-                seriesPath.getDevice(),
-                timeFilter,
-                fileFilter,
-                true,
-                dataSource.getDataTTL(),
-                context.isDebug())) {
+                seriesPath.getDevice(), timeFilter, fileFilter, true, context.isDebug())) {
           break;
         }
         curSeqFileIndex++;
@@ -1309,12 +1294,7 @@ public class SeriesReader {
         TsFileResource tsFileResource = dataSource.getUnseqResourceByIndex(curUnseqFileIndex);
         if (tsFileResource != null
             && tsFileResource.isSatisfied(
-                seriesPath.getDevice(),
-                timeFilter,
-                fileFilter,
-                false,
-                dataSource.getDataTTL(),
-                context.isDebug())) {
+                seriesPath.getDevice(), timeFilter, fileFilter, false, context.isDebug())) {
           break;
         }
         curUnseqFileIndex++;

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/ConcurrentMergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/ConcurrentMergeTest.java
@@ -117,6 +117,7 @@ public class ConcurrentMergeTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
@@ -168,6 +168,7 @@ public class StorageGroupProcessorTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);
@@ -201,6 +202,7 @@ public class StorageGroupProcessorTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);
@@ -266,6 +268,7 @@ public class StorageGroupProcessorTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);
@@ -300,6 +303,7 @@ public class StorageGroupProcessorTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);
@@ -343,6 +347,7 @@ public class StorageGroupProcessorTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);
@@ -428,6 +433,7 @@ public class StorageGroupProcessorTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);
@@ -513,6 +519,7 @@ public class StorageGroupProcessorTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);
@@ -598,6 +605,7 @@ public class StorageGroupProcessorTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);
@@ -640,6 +648,7 @@ public class StorageGroupProcessorTest {
     QueryDataSource queryDataSource =
         processor.query(
             Collections.singletonList(new PartialPath(deviceId, measurementId)),
+            deviceId,
             context,
             null,
             null);

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
@@ -224,6 +224,7 @@ public class TTLTest {
     QueryDataSource dataSource =
         storageGroupProcessor.query(
             Collections.singletonList(new PartialPath(sg1, s1)),
+            sg1,
             EnvironmentUtils.TEST_QUERY_CONTEXT,
             null,
             null);
@@ -238,6 +239,7 @@ public class TTLTest {
     dataSource =
         storageGroupProcessor.query(
             Collections.singletonList(new PartialPath(sg1, s1)),
+            sg1,
             EnvironmentUtils.TEST_QUERY_CONTEXT,
             null,
             null);
@@ -276,6 +278,7 @@ public class TTLTest {
     dataSource =
         storageGroupProcessor.query(
             Collections.singletonList(new PartialPath(sg1, s1)),
+            sg1,
             EnvironmentUtils.TEST_QUERY_CONTEXT,
             null,
             null);

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryWithComplexValueFilterIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryWithComplexValueFilterIT.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.Assert.fail;
+
+public class IoTDBQueryWithComplexValueFilterIT {
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvironmentUtils.closeStatMonitor();
+    EnvironmentUtils.envSetUp();
+    prepareData();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void testRawQuery1() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      boolean hasResultSet =
+          statement.execute(
+              "select s1 from root.sg1.d1 where (time > 400 and s1 <= 600) or (s2 > 300 and time <= 500)");
+      Assert.assertTrue(hasResultSet);
+
+      ResultSet resultSet = statement.getResultSet();
+      int cnt = 0;
+
+      while (resultSet.next()) {
+        cnt++;
+      }
+
+      Assert.assertEquals(300, cnt);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testRawQuery2() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      boolean hasResultSet =
+          statement.execute(
+              "select s1 from root.sg1.d1 where (time > 400 and s1 <= 600) and (s2 > 300 and time <= 500)");
+      Assert.assertTrue(hasResultSet);
+
+      ResultSet resultSet = statement.getResultSet();
+      int cnt = 0;
+
+      while (resultSet.next()) {
+        cnt++;
+      }
+
+      Assert.assertEquals(100, cnt);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  private static void prepareData() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("create storage group root.sg1");
+      statement.execute("create timeseries root.sg1.d1.s1 with datatype=INT32,encoding=PLAIN");
+      statement.execute("create timeseries root.sg1.d1.s2 with datatype=DOUBLE,encoding=PLAIN");
+      for (int i = 0; i < 1000; i++) {
+        statement.execute(
+            String.format(
+                "insert into root.sg1.d1(time,s1,s2) values(%d,%d,%f)", i, i, (double) i));
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGenerator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGenerator.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.tsfile.read.expression.ExpressionType;
 import org.apache.iotdb.tsfile.read.expression.IBinaryExpression;
 import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.SingleSeriesExpression;
+import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.query.timegenerator.node.AndNode;
 import org.apache.iotdb.tsfile.read.query.timegenerator.node.LeafNode;
 import org.apache.iotdb.tsfile.read.query.timegenerator.node.Node;
@@ -132,4 +133,6 @@ public abstract class TimeGenerator {
   }
 
   protected abstract boolean isAscending();
+
+  public abstract Filter getTimeFilter();
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/timegenerator/TsFileTimeGenerator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/timegenerator/TsFileTimeGenerator.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.tsfile.read.controller.IChunkLoader;
 import org.apache.iotdb.tsfile.read.controller.IMetadataQuerier;
 import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.SingleSeriesExpression;
+import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 import org.apache.iotdb.tsfile.read.reader.series.FileSeriesReader;
 
@@ -54,5 +55,10 @@ public class TsFileTimeGenerator extends TimeGenerator {
   @Override
   protected boolean isAscending() {
     return true;
+  }
+
+  @Override
+  public Filter getTimeFilter() {
+    return null;
   }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/FakedTimeGenerator.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/FakedTimeGenerator.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.BinaryExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.SingleSeriesExpression;
 import org.apache.iotdb.tsfile.read.filter.TimeFilter;
+import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.filter.factory.FilterFactory;
 import org.apache.iotdb.tsfile.read.query.timegenerator.TimeGenerator;
 
@@ -59,6 +60,11 @@ public class FakedTimeGenerator extends TimeGenerator {
   @Override
   protected boolean isAscending() {
     return true;
+  }
+
+  @Override
+  public Filter getTimeFilter() {
+    return null;
   }
 
   @Test


### PR DESCRIPTION
In this PR,
1. When all the selected series are under the same device, we use the time range of the device to filter QueryDataSource.
2. In query with value filter, we construct time filter from expression to filter QueryDataSource.