### PR TITLE
[IOTDB-2195] Control the concurrent query execution thread - Part 1

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -90,7 +90,7 @@ public abstract class PhysicalPlan {
 
   private static final String SERIALIZATION_UNIMPLEMENTED = "serialization unimplemented";
 
-  private boolean isQuery;
+  private boolean isQuery = false;
   private Operator.OperatorType operatorType;
   private static final int NULL_VALUE_LEN = -1;
 
@@ -110,17 +110,10 @@ public abstract class PhysicalPlan {
     return canBeSplit;
   }
 
-  protected PhysicalPlan(boolean isQuery) {
-    this.isQuery = isQuery;
-  }
+  protected PhysicalPlan() {}
 
-  protected PhysicalPlan(boolean isQuery, Operator.OperatorType operatorType) {
-    this.isQuery = isQuery;
+  protected PhysicalPlan(Operator.OperatorType operatorType) {
     this.operatorType = operatorType;
-  }
-
-  public String printQueryPlan() {
-    return "abstract plan";
   }
 
   public abstract List<? extends PartialPath> getPaths();

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AggregationPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AggregationPlan.java
@@ -81,7 +81,7 @@ public class AggregationPlan extends RawDataQueryPlan {
 
   @Override
   public List<TSDataType> getWideQueryHeaders(
-      List<String> respColumns, List<String> respSgColumns, Boolean isJdbcQuery, BitSet aliasList)
+      List<String> respColumns, List<String> respSgColumns, boolean isJdbcQuery, BitSet aliasList)
       throws MetadataException {
     List<TSDataType> seriesTypes = new ArrayList<>();
     List<String> aggregations = getAggregations();

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/DeletePartitionPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/DeletePartitionPlan.java
@@ -33,7 +33,7 @@ public class DeletePartitionPlan extends PhysicalPlan {
   private Set<Long> partitionId;
 
   public DeletePartitionPlan(PartialPath storageGroupName, Set<Long> partitionId) {
-    super(false, OperatorType.DELETE_PARTITION);
+    super(OperatorType.DELETE_PARTITION);
     this.storageGroupName = storageGroupName;
     this.partitionId = partitionId;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/DeletePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/DeletePlan.java
@@ -44,7 +44,7 @@ public class DeletePlan extends PhysicalPlan {
   private TimePartitionFilter partitionFilter;
 
   public DeletePlan() {
-    super(false, Operator.OperatorType.DELETE);
+    super(Operator.OperatorType.DELETE);
   }
 
   /**
@@ -55,7 +55,7 @@ public class DeletePlan extends PhysicalPlan {
    * @param path time series path
    */
   public DeletePlan(long startTime, long endTime, PartialPath path) {
-    super(false, Operator.OperatorType.DELETE);
+    super(Operator.OperatorType.DELETE);
     this.deleteStartTime = startTime;
     this.deleteEndTime = endTime;
     this.paths.add(path);
@@ -69,7 +69,7 @@ public class DeletePlan extends PhysicalPlan {
    * @param paths time series paths in List structure
    */
   public DeletePlan(long startTime, long endTime, List<PartialPath> paths) {
-    super(false, Operator.OperatorType.DELETE);
+    super(Operator.OperatorType.DELETE);
     this.deleteStartTime = startTime;
     this.deleteEndTime = endTime;
     this.paths = paths;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
@@ -46,7 +46,7 @@ public abstract class InsertPlan extends PhysicalPlan {
   List<Integer> failedIndices;
 
   public InsertPlan(Operator.OperatorType operatorType) {
-    super(false, operatorType);
+    super(operatorType);
     super.canBeSplit = false;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/LastQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/LastQueryPlan.java
@@ -35,7 +35,11 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 
 import org.apache.thrift.TException;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class LastQueryPlan extends RawDataQueryPlan {
 
@@ -66,7 +70,7 @@ public class LastQueryPlan extends RawDataQueryPlan {
 
   @Override
   public List<TSDataType> getWideQueryHeaders(
-      List<String> respColumns, List<String> respSgColumns, Boolean isJdbcQuery, BitSet aliasList)
+      List<String> respColumns, List<String> respSgColumns, boolean isJdbcQuery, BitSet aliasList)
       throws TException {
     throw new TException("unsupported query type: " + getOperatorType());
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryIndexPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryIndexPlan.java
@@ -41,7 +41,7 @@ public class QueryIndexPlan extends RawDataQueryPlan {
 
   @Override
   public List<TSDataType> getWideQueryHeaders(
-      List<String> respColumns, List<String> respSgColumns, Boolean isJdbcQuery, BitSet aliasList)
+      List<String> respColumns, List<String> respSgColumns, boolean isJdbcQuery, BitSet aliasList)
       throws TException {
     throw new TException("unsupported query type: " + getOperatorType());
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
@@ -103,6 +103,7 @@ public abstract class QueryPlan extends PhysicalPlan {
     List<TSDataType> seriesTypes = new ArrayList<>();
     for (int i = 0; i < resultColumns.size(); ++i) {
       if (isJdbcQuery) {
+        // Separate sgName from the name of resultColumn to reduce the network IO
         String sgName = IoTDB.metaManager.getBelongedStorageGroup(getPaths().get(i)).getFullPath();
         respSgColumns.add(sgName);
         if (resultColumns.get(i).getAlias() == null) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
@@ -35,7 +35,11 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import com.google.common.primitives.Bytes;
 import org.apache.thrift.TException;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public abstract class QueryPlan extends PhysicalPlan {
 
@@ -61,12 +65,8 @@ public abstract class QueryPlan extends PhysicalPlan {
   private boolean withoutAllNull;
 
   public QueryPlan() {
-    super(true);
-    setOperatorType(Operator.OperatorType.QUERY);
-  }
-
-  public QueryPlan(boolean isQuery, Operator.OperatorType operatorType) {
-    super(isQuery, operatorType);
+    super(Operator.OperatorType.QUERY);
+    setQuery(true);
   }
 
   public abstract void deduplicate(PhysicalGenerator physicalGenerator) throws MetadataException;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
@@ -71,6 +71,7 @@ public abstract class QueryPlan extends PhysicalPlan {
 
   public abstract void deduplicate(PhysicalGenerator physicalGenerator) throws MetadataException;
 
+  /** Construct TSExecuteStatementResp and the header of result set. */
   public TSExecuteStatementResp getTSExecuteStatementResp(boolean isJdbcQuery)
       throws TException, MetadataException {
     List<String> respColumns = new ArrayList<>();
@@ -97,7 +98,7 @@ public abstract class QueryPlan extends PhysicalPlan {
   }
 
   public List<TSDataType> getWideQueryHeaders(
-      List<String> respColumns, List<String> respSgColumns, Boolean isJdbcQuery, BitSet aliasList)
+      List<String> respColumns, List<String> respSgColumns, boolean isJdbcQuery, BitSet aliasList)
       throws TException, MetadataException {
     List<TSDataType> seriesTypes = new ArrayList<>();
     for (int i = 0; i < resultColumns.size(); ++i) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
@@ -71,7 +71,7 @@ public abstract class QueryPlan extends PhysicalPlan {
 
   public abstract void deduplicate(PhysicalGenerator physicalGenerator) throws MetadataException;
 
-  /** Construct TSExecuteStatementResp and the header of result set. */
+  /** Construct the header of result set. Return TSExecuteStatementResp. */
   public TSExecuteStatementResp getTSExecuteStatementResp(boolean isJdbcQuery)
       throws TException, MetadataException {
     List<String> respColumns = new ArrayList<>();

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.path.AlignedPath;
 import org.apache.iotdb.db.metadata.path.PartialPath;
-import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.strategy.PhysicalGenerator;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -51,10 +50,6 @@ public class RawDataQueryPlan extends QueryPlan {
 
   public RawDataQueryPlan() {
     super();
-  }
-
-  public RawDataQueryPlan(boolean isQuery, Operator.OperatorType operatorType) {
-    super(isQuery, operatorType);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/SelectIntoPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/SelectIntoPlan.java
@@ -38,11 +38,11 @@ public class SelectIntoPlan extends PhysicalPlan {
   private List<PartialPath> intoPaths;
 
   public SelectIntoPlan() {
-    super(false, OperatorType.SELECT_INTO);
+    super(OperatorType.SELECT_INTO);
   }
 
   public SelectIntoPlan(QueryPlan queryPlan, PartialPath fromPath, List<PartialPath> intoPaths) {
-    super(false, OperatorType.SELECT_INTO);
+    super(OperatorType.SELECT_INTO);
     this.queryPlan = queryPlan;
     this.fromPath = fromPath;
     this.intoPaths = intoPaths;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/UDTFPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/UDTFPlan.java
@@ -91,7 +91,7 @@ public class UDTFPlan extends RawDataQueryPlan implements UDFPlan {
 
   @Override
   public List<TSDataType> getWideQueryHeaders(
-      List<String> respColumns, List<String> respSgColumns, Boolean isJdbcQuery, BitSet aliasList) {
+      List<String> respColumns, List<String> respSgColumns, boolean isJdbcQuery, BitSet aliasList) {
     List<TSDataType> seriesTypes = new ArrayList<>();
     for (int i = 0; i < paths.size(); i++) {
       respColumns.add(resultColumns.get(i).getResultColumnName());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ActivateTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ActivateTemplatePlan.java
@@ -39,11 +39,11 @@ public class ActivateTemplatePlan extends PhysicalPlan {
   PartialPath prefixPath;
 
   public ActivateTemplatePlan() {
-    super(false, OperatorType.ACTIVATE_TEMPLATE);
+    super(OperatorType.ACTIVATE_TEMPLATE);
   }
 
   public ActivateTemplatePlan(PartialPath prefixPath) {
-    super(false, OperatorType.ACTIVATE_TEMPLATE);
+    super(OperatorType.ACTIVATE_TEMPLATE);
     this.prefixPath = prefixPath;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AlterTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AlterTimeSeriesPlan.java
@@ -62,7 +62,7 @@ public class AlterTimeSeriesPlan extends PhysicalPlan {
 
   /** used only for deserialize */
   public AlterTimeSeriesPlan() {
-    super(false, OperatorType.ALTER_TIMESERIES);
+    super(OperatorType.ALTER_TIMESERIES);
   }
 
   public AlterTimeSeriesPlan(
@@ -72,7 +72,7 @@ public class AlterTimeSeriesPlan extends PhysicalPlan {
       String alias,
       Map<String, String> tagsMap,
       Map<String, String> attributesMap) {
-    super(false, Operator.OperatorType.ALTER_TIMESERIES);
+    super(Operator.OperatorType.ALTER_TIMESERIES);
     this.path = path;
     this.alterType = alterType;
     this.alterMap = alterMap;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AppendTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AppendTemplatePlan.java
@@ -43,7 +43,7 @@ public class AppendTemplatePlan extends PhysicalPlan {
   CompressionType[] compressors;
 
   public AppendTemplatePlan() {
-    super(false, OperatorType.APPEND_TEMPLATE);
+    super(OperatorType.APPEND_TEMPLATE);
   }
 
   public AppendTemplatePlan(
@@ -53,7 +53,7 @@ public class AppendTemplatePlan extends PhysicalPlan {
       List<TSDataType> dataTypes,
       List<TSEncoding> encodings,
       List<CompressionType> compressors) {
-    super(false, OperatorType.APPEND_TEMPLATE);
+    super(OperatorType.APPEND_TEMPLATE);
     this.name = name;
     this.isAligned = isAligned;
     this.measurements = measurements.toArray(new String[0]);
@@ -69,7 +69,7 @@ public class AppendTemplatePlan extends PhysicalPlan {
       TSDataType[] dataTypes,
       TSEncoding[] encodings,
       CompressionType[] compressors) {
-    super(false, OperatorType.APPEND_TEMPLATE);
+    super(OperatorType.APPEND_TEMPLATE);
     this.name = name;
     this.isAligned = isAligned;
     this.measurements = measurements;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AuthorPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AuthorPlan.java
@@ -68,7 +68,7 @@ public class AuthorPlan extends PhysicalPlan {
       String[] authorizationList,
       PartialPath nodeName)
       throws AuthException {
-    super(false, Operator.OperatorType.AUTHOR);
+    super(Operator.OperatorType.AUTHOR);
     this.authorType = authorType;
     this.userName = userName;
     this.roleName = roleName;
@@ -139,7 +139,7 @@ public class AuthorPlan extends PhysicalPlan {
   }
 
   public AuthorPlan(OperatorType operatorType) throws IOException {
-    super(false, operatorType);
+    super(operatorType);
     setAuthorType(transformOperatorTypeToAuthorType(operatorType));
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AutoCreateDeviceMNodePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AutoCreateDeviceMNodePlan.java
@@ -39,16 +39,12 @@ public class AutoCreateDeviceMNodePlan extends PhysicalPlan {
   protected PartialPath path;
 
   public AutoCreateDeviceMNodePlan() {
-    super(false, Operator.OperatorType.AUTO_CREATE_DEVICE_MNODE);
+    super(Operator.OperatorType.AUTO_CREATE_DEVICE_MNODE);
   }
 
   public AutoCreateDeviceMNodePlan(PartialPath path) {
-    super(false, Operator.OperatorType.AUTO_CREATE_DEVICE_MNODE);
+    super(Operator.OperatorType.AUTO_CREATE_DEVICE_MNODE);
     this.path = path;
-  }
-
-  public AutoCreateDeviceMNodePlan(boolean isQuery, Operator.OperatorType operatorType) {
-    super(isQuery, operatorType);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ChangeAliasPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ChangeAliasPlan.java
@@ -36,11 +36,11 @@ public class ChangeAliasPlan extends PhysicalPlan {
   private String alias;
 
   public ChangeAliasPlan() {
-    super(false, Operator.OperatorType.CHANGE_ALIAS);
+    super(Operator.OperatorType.CHANGE_ALIAS);
   }
 
   public ChangeAliasPlan(PartialPath path, String alias) {
-    super(false, Operator.OperatorType.CHANGE_ALIAS);
+    super(Operator.OperatorType.CHANGE_ALIAS);
     this.path = path;
     this.alias = alias;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ChangeTagOffsetPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ChangeTagOffsetPlan.java
@@ -36,11 +36,11 @@ public class ChangeTagOffsetPlan extends PhysicalPlan {
   private long offset;
 
   public ChangeTagOffsetPlan() {
-    super(false, Operator.OperatorType.CHANGE_TAG_OFFSET);
+    super(Operator.OperatorType.CHANGE_TAG_OFFSET);
   }
 
   public ChangeTagOffsetPlan(PartialPath partialPath, long offset) {
-    super(false, Operator.OperatorType.CHANGE_TAG_OFFSET);
+    super(Operator.OperatorType.CHANGE_TAG_OFFSET);
     path = partialPath;
     this.offset = offset;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ClearCachePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ClearCachePlan.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class ClearCachePlan extends PhysicalPlan {
 
   public ClearCachePlan() {
-    super(false, OperatorType.CLEAR_CACHE);
+    super(OperatorType.CLEAR_CACHE);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateAlignedTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateAlignedTimeSeriesPlan.java
@@ -50,7 +50,7 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
   private List<String> aliasList;
 
   public CreateAlignedTimeSeriesPlan() {
-    super(false, Operator.OperatorType.CREATE_ALIGNED_TIMESERIES);
+    super(Operator.OperatorType.CREATE_ALIGNED_TIMESERIES);
     canBeSplit = false;
   }
 
@@ -61,7 +61,7 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
       List<TSEncoding> encodings,
       List<CompressionType> compressors,
       List<String> aliasList) {
-    super(false, Operator.OperatorType.CREATE_ALIGNED_TIMESERIES);
+    super(Operator.OperatorType.CREATE_ALIGNED_TIMESERIES);
     this.prefixPath = prefixPath;
     this.measurements = measurements;
     this.dataTypes = dataTypes;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateContinuousQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateContinuousQueryPlan.java
@@ -28,7 +28,8 @@ import org.apache.iotdb.db.qp.utils.DatetimeUtils;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
 
 public class CreateContinuousQueryPlan extends PhysicalPlan {
 
@@ -41,7 +42,7 @@ public class CreateContinuousQueryPlan extends PhysicalPlan {
   private long creationTimestamp;
 
   public CreateContinuousQueryPlan() {
-    super(false, Operator.OperatorType.CREATE_CONTINUOUS_QUERY);
+    super(Operator.OperatorType.CREATE_CONTINUOUS_QUERY);
   }
 
   public CreateContinuousQueryPlan(
@@ -51,7 +52,7 @@ public class CreateContinuousQueryPlan extends PhysicalPlan {
       long everyInterval,
       long forInterval,
       QueryOperator queryOperator) {
-    super(false, Operator.OperatorType.CREATE_CONTINUOUS_QUERY);
+    super(Operator.OperatorType.CREATE_CONTINUOUS_QUERY);
     this.querySql = querySql;
     this.continuousQueryName = continuousQueryName;
     this.targetPath = targetPath;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateFunctionPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateFunctionPlan.java
@@ -36,11 +36,11 @@ public class CreateFunctionPlan extends PhysicalPlan {
   private String className;
 
   public CreateFunctionPlan() {
-    super(false, OperatorType.CREATE_FUNCTION);
+    super(OperatorType.CREATE_FUNCTION);
   }
 
   public CreateFunctionPlan(String udfName, String className) {
-    super(false, OperatorType.CREATE_FUNCTION);
+    super(OperatorType.CREATE_FUNCTION);
     this.udfName = udfName;
     this.className = className;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateIndexPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateIndexPlan.java
@@ -41,13 +41,13 @@ public class CreateIndexPlan extends PhysicalPlan {
   private IndexType indexType;
 
   public CreateIndexPlan() {
-    super(false, OperatorType.CREATE_INDEX);
+    super(OperatorType.CREATE_INDEX);
     canBeSplit = false;
   }
 
   public CreateIndexPlan(
       List<PartialPath> paths, Map<String, String> props, long startTime, IndexType indexType) {
-    super(false, OperatorType.CREATE_INDEX);
+    super(OperatorType.CREATE_INDEX);
     this.paths = paths;
     this.props = props;
     time = startTime;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateMultiTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateMultiTimeSeriesPlan.java
@@ -65,7 +65,7 @@ public class CreateMultiTimeSeriesPlan extends PhysicalPlan implements BatchPlan
   private List<Integer> indexes;
 
   public CreateMultiTimeSeriesPlan() {
-    super(false, Operator.OperatorType.CREATE_MULTI_TIMESERIES);
+    super(Operator.OperatorType.CREATE_MULTI_TIMESERIES);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateSnapshotPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateSnapshotPlan.java
@@ -33,7 +33,7 @@ import java.util.List;
 public class CreateSnapshotPlan extends PhysicalPlan {
 
   public CreateSnapshotPlan() {
-    super(false, OperatorType.CREATE_SCHEMA_SNAPSHOT);
+    super(OperatorType.CREATE_SCHEMA_SNAPSHOT);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTemplatePlan.java
@@ -55,7 +55,7 @@ public class CreateTemplatePlan extends PhysicalPlan {
   private static final int NEW_PLAN = -1;
 
   public CreateTemplatePlan() {
-    super(false, OperatorType.CREATE_TEMPLATE);
+    super(OperatorType.CREATE_TEMPLATE);
   }
 
   public CreateTemplatePlan(
@@ -66,7 +66,7 @@ public class CreateTemplatePlan extends PhysicalPlan {
       List<List<CompressionType>> compressors) {
     // New constructor for tree-structured template where aligned measurements get individual
     // compressors
-    super(false, OperatorType.CREATE_TEMPLATE);
+    super(OperatorType.CREATE_TEMPLATE);
 
     this.name = name;
     schemaNames = null;
@@ -134,7 +134,7 @@ public class CreateTemplatePlan extends PhysicalPlan {
       TSDataType[][] dataTypes,
       TSEncoding[][] encodings,
       CompressionType[][] compressors) {
-    super(false, OperatorType.CREATE_TEMPLATE);
+    super(OperatorType.CREATE_TEMPLATE);
     this.name = name;
     this.schemaNames = null;
     this.measurements = measurements;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTimeSeriesPlan.java
@@ -49,7 +49,7 @@ public class CreateTimeSeriesPlan extends PhysicalPlan {
   private long tagOffset = -1;
 
   public CreateTimeSeriesPlan() {
-    super(false, Operator.OperatorType.CREATE_TIMESERIES);
+    super(Operator.OperatorType.CREATE_TIMESERIES);
     canBeSplit = false;
   }
 
@@ -62,7 +62,7 @@ public class CreateTimeSeriesPlan extends PhysicalPlan {
       Map<String, String> tags,
       Map<String, String> attributes,
       String alias) {
-    super(false, Operator.OperatorType.CREATE_TIMESERIES);
+    super(Operator.OperatorType.CREATE_TIMESERIES);
     this.path = path;
     this.dataType = dataType;
     this.encoding = encoding;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTriggerPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateTriggerPlan.java
@@ -55,7 +55,7 @@ public class CreateTriggerPlan extends PhysicalPlan {
   private boolean isStopped = false;
 
   public CreateTriggerPlan() {
-    super(false, OperatorType.CREATE_TRIGGER);
+    super(OperatorType.CREATE_TRIGGER);
     canBeSplit = false;
   }
 
@@ -65,7 +65,7 @@ public class CreateTriggerPlan extends PhysicalPlan {
       PartialPath fullPath,
       String className,
       Map<String, String> attributes) {
-    super(false, OperatorType.CREATE_TRIGGER);
+    super(OperatorType.CREATE_TRIGGER);
     this.triggerName = triggerName;
     this.event = event;
     this.fullPath = fullPath;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DataAuthPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DataAuthPlan.java
@@ -34,11 +34,11 @@ public class DataAuthPlan extends PhysicalPlan {
   private List<String> users;
 
   public DataAuthPlan(OperatorType operatorType) {
-    super(false, operatorType);
+    super(operatorType);
   }
 
   public DataAuthPlan(OperatorType operatorType, List<String> users) {
-    super(false, operatorType);
+    super(operatorType);
     this.users = users;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteStorageGroupPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteStorageGroupPlan.java
@@ -34,12 +34,12 @@ public class DeleteStorageGroupPlan extends PhysicalPlan {
   private List<PartialPath> deletePathList;
 
   public DeleteStorageGroupPlan(List<PartialPath> deletePathList) {
-    super(false, Operator.OperatorType.DELETE_STORAGE_GROUP);
+    super(Operator.OperatorType.DELETE_STORAGE_GROUP);
     this.deletePathList = deletePathList;
   }
 
   public DeleteStorageGroupPlan() {
-    super(false, Operator.OperatorType.DELETE_STORAGE_GROUP);
+    super(Operator.OperatorType.DELETE_STORAGE_GROUP);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DeleteTimeSeriesPlan.java
@@ -46,12 +46,12 @@ public class DeleteTimeSeriesPlan extends PhysicalPlan {
   private TimePartitionFilter partitionFilter;
 
   public DeleteTimeSeriesPlan(List<PartialPath> deletePathList) {
-    super(false, Operator.OperatorType.DELETE_TIMESERIES);
+    super(Operator.OperatorType.DELETE_TIMESERIES);
     this.deletePathList = deletePathList;
   }
 
   public DeleteTimeSeriesPlan() {
-    super(false, Operator.OperatorType.DELETE_TIMESERIES);
+    super(Operator.OperatorType.DELETE_TIMESERIES);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropContinuousQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropContinuousQueryPlan.java
@@ -33,11 +33,11 @@ public class DropContinuousQueryPlan extends PhysicalPlan {
   private String continuousQueryName;
 
   public DropContinuousQueryPlan() {
-    super(false, Operator.OperatorType.DROP_CONTINUOUS_QUERY);
+    super(Operator.OperatorType.DROP_CONTINUOUS_QUERY);
   }
 
   public DropContinuousQueryPlan(String continuousQueryName) {
-    super(false, Operator.OperatorType.DROP_CONTINUOUS_QUERY);
+    super(Operator.OperatorType.DROP_CONTINUOUS_QUERY);
     this.continuousQueryName = continuousQueryName;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropFunctionPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropFunctionPlan.java
@@ -35,11 +35,11 @@ public class DropFunctionPlan extends PhysicalPlan {
   private String udfName;
 
   public DropFunctionPlan() {
-    super(false, OperatorType.DROP_FUNCTION);
+    super(OperatorType.DROP_FUNCTION);
   }
 
   public DropFunctionPlan(String udfName) {
-    super(false, OperatorType.DROP_FUNCTION);
+    super(OperatorType.DROP_FUNCTION);
     this.udfName = udfName;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropIndexPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropIndexPlan.java
@@ -38,11 +38,11 @@ public class DropIndexPlan extends PhysicalPlan {
   private IndexType indexType;
 
   public DropIndexPlan() {
-    super(false, Operator.OperatorType.DROP_INDEX);
+    super(Operator.OperatorType.DROP_INDEX);
   }
 
   public DropIndexPlan(List<PartialPath> paths, IndexType indexType) {
-    super(false, OperatorType.DROP_INDEX);
+    super(OperatorType.DROP_INDEX);
     this.paths = paths;
     this.indexType = indexType;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropTriggerPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/DropTriggerPlan.java
@@ -35,12 +35,12 @@ public class DropTriggerPlan extends PhysicalPlan {
   private String triggerName;
 
   public DropTriggerPlan() {
-    super(false, OperatorType.DROP_TRIGGER);
+    super(OperatorType.DROP_TRIGGER);
     canBeSplit = false;
   }
 
   public DropTriggerPlan(String triggerName) {
-    super(false, OperatorType.DROP_TRIGGER);
+    super(OperatorType.DROP_TRIGGER);
     this.triggerName = triggerName;
     canBeSplit = false;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/FlushPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/FlushPlan.java
@@ -57,11 +57,11 @@ public class FlushPlan extends PhysicalPlan {
 
   /** only for deserialize */
   public FlushPlan() {
-    super(false, OperatorType.FLUSH);
+    super(OperatorType.FLUSH);
   }
 
   public FlushPlan(Boolean isSeq, List<PartialPath> storageGroups) {
-    super(false, OperatorType.FLUSH);
+    super(OperatorType.FLUSH);
     if (storageGroups == null) {
       this.storageGroupPartitionIds = null;
     } else {
@@ -78,7 +78,7 @@ public class FlushPlan extends PhysicalPlan {
       Boolean isSeq,
       boolean isSync,
       Map<PartialPath, List<Pair<Long, Boolean>>> storageGroupPartitionIds) {
-    super(false, OperatorType.FLUSH);
+    super(OperatorType.FLUSH);
     this.storageGroupPartitionIds = storageGroupPartitionIds;
     this.isSeq = isSeq;
     this.isSync = isSync;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/KillQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/KillQueryPlan.java
@@ -30,7 +30,7 @@ public class KillQueryPlan extends PhysicalPlan {
   private long queryId = -1;
 
   public KillQueryPlan(long queryId) {
-    super(false, OperatorType.KILL);
+    super(OperatorType.KILL);
     this.queryId = queryId;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/LoadConfigurationPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/LoadConfigurationPlan.java
@@ -45,7 +45,7 @@ public class LoadConfigurationPlan extends PhysicalPlan {
   public LoadConfigurationPlan(
       LoadConfigurationPlanType loadConfigurationPlanType, Properties[] propertiesArray)
       throws QueryProcessException {
-    super(false, OperatorType.LOAD_CONFIGURATION);
+    super(OperatorType.LOAD_CONFIGURATION);
     if (loadConfigurationPlanType != LoadConfigurationPlanType.GLOBAL) {
       throw new QueryProcessException(
           "The constructor with 2 parameters is for load global configuration");
@@ -59,7 +59,7 @@ public class LoadConfigurationPlan extends PhysicalPlan {
 
   public LoadConfigurationPlan(LoadConfigurationPlanType loadConfigurationPlanType)
       throws QueryProcessException {
-    super(false, OperatorType.LOAD_CONFIGURATION);
+    super(OperatorType.LOAD_CONFIGURATION);
     if (loadConfigurationPlanType != LoadConfigurationPlanType.LOCAL) {
       throw new QueryProcessException(
           "The constructor with 1 parameters is for load local configuration");
@@ -69,7 +69,7 @@ public class LoadConfigurationPlan extends PhysicalPlan {
 
   // only for deserialize
   public LoadConfigurationPlan() {
-    super(false, OperatorType.LOAD_CONFIGURATION);
+    super(OperatorType.LOAD_CONFIGURATION);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/LoadDataPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/LoadDataPlan.java
@@ -33,7 +33,7 @@ public class LoadDataPlan extends PhysicalPlan {
 
   /** Constructor of LoadDataPlan. */
   public LoadDataPlan(String inputFilePath, String measureType) {
-    super(false, Operator.OperatorType.LOAD_DATA);
+    super(Operator.OperatorType.LOAD_DATA);
     this.inputFilePath = inputFilePath;
     this.measureType = measureType;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/LogPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/LogPlan.java
@@ -34,17 +34,13 @@ public class LogPlan extends PhysicalPlan {
 
   private ByteBuffer log;
 
-  public LogPlan() {
-    super(false);
-  }
+  public LogPlan() {}
 
   public LogPlan(ByteBuffer log) {
-    super(false);
     this.log = log;
   }
 
   public LogPlan(LogPlan plan) {
-    super(false);
     this.log = IOUtils.clone(plan.log);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MNodePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MNodePlan.java
@@ -35,17 +35,17 @@ public class MNodePlan extends PhysicalPlan {
   protected int childSize;
 
   public MNodePlan() {
-    super(false, Operator.OperatorType.MNODE);
+    super(Operator.OperatorType.MNODE);
+  }
+
+  public MNodePlan(Operator.OperatorType operatorType) {
+    super(operatorType);
   }
 
   public MNodePlan(String name, int childSize) {
-    super(false, Operator.OperatorType.MNODE);
+    super(Operator.OperatorType.MNODE);
     this.name = name;
     this.childSize = childSize;
-  }
-
-  public MNodePlan(boolean isQuery, Operator.OperatorType operatorType) {
-    super(isQuery, operatorType);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MeasurementMNodePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MeasurementMNodePlan.java
@@ -37,12 +37,12 @@ public class MeasurementMNodePlan extends MNodePlan {
   private long offset;
 
   public MeasurementMNodePlan() {
-    super(false, Operator.OperatorType.MEASUREMENT_MNODE);
+    super(Operator.OperatorType.MEASUREMENT_MNODE);
   }
 
   public MeasurementMNodePlan(
       String name, String alias, long offset, int childSize, IMeasurementSchema schema) {
-    super(false, Operator.OperatorType.MEASUREMENT_MNODE);
+    super(Operator.OperatorType.MEASUREMENT_MNODE);
     this.name = name;
     this.alias = alias;
     this.offset = offset;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MergePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/MergePlan.java
@@ -32,11 +32,11 @@ import java.util.List;
 public class MergePlan extends PhysicalPlan {
 
   public MergePlan(OperatorType operatorType) {
-    super(false, operatorType);
+    super(operatorType);
   }
 
   public MergePlan() {
-    super(false, OperatorType.MERGE);
+    super(OperatorType.MERGE);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/OperateFilePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/OperateFilePlan.java
@@ -35,7 +35,7 @@ public class OperateFilePlan extends PhysicalPlan {
   private boolean verifyMetadata;
 
   public OperateFilePlan(File file, OperatorType operatorType) {
-    super(false, operatorType);
+    super(operatorType);
     this.file = file;
   }
 
@@ -54,7 +54,7 @@ public class OperateFilePlan extends PhysicalPlan {
       boolean autoCreateSchema,
       int sgLevel,
       boolean verifyMetadata) {
-    super(false, operatorType);
+    super(operatorType);
     this.file = file;
     this.autoCreateSchema = autoCreateSchema;
     this.sgLevel = sgLevel;
@@ -62,7 +62,7 @@ public class OperateFilePlan extends PhysicalPlan {
   }
 
   public OperateFilePlan(File file, File targetDir, OperatorType operatorType) {
-    super(false, operatorType);
+    super(operatorType);
     this.file = file;
     this.targetDir = targetDir;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/PruneTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/PruneTemplatePlan.java
@@ -36,11 +36,11 @@ public class PruneTemplatePlan extends PhysicalPlan {
   String[] prunedMeasurements;
 
   public PruneTemplatePlan() {
-    super(false, OperatorType.PRUNE_TEMPLATE);
+    super(OperatorType.PRUNE_TEMPLATE);
   }
 
   public PruneTemplatePlan(String name, List<String> prunedMeasurements) {
-    super(false, OperatorType.PRUNE_TEMPLATE);
+    super(OperatorType.PRUNE_TEMPLATE);
 
     this.name = name;
     this.prunedMeasurements = prunedMeasurements.toArray(new String[0]);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetStorageGroupPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetStorageGroupPlan.java
@@ -35,11 +35,11 @@ public class SetStorageGroupPlan extends PhysicalPlan {
   private PartialPath path;
 
   public SetStorageGroupPlan() {
-    super(false, Operator.OperatorType.SET_STORAGE_GROUP);
+    super(Operator.OperatorType.SET_STORAGE_GROUP);
   }
 
   public SetStorageGroupPlan(PartialPath path) {
-    super(false, Operator.OperatorType.SET_STORAGE_GROUP);
+    super(Operator.OperatorType.SET_STORAGE_GROUP);
     this.path = path;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetSystemModePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetSystemModePlan.java
@@ -36,11 +36,11 @@ public class SetSystemModePlan extends PhysicalPlan {
   private boolean isReadOnly;
 
   public SetSystemModePlan() {
-    super(false, OperatorType.SET_SYSTEM_MODE);
+    super(OperatorType.SET_SYSTEM_MODE);
   }
 
   public SetSystemModePlan(boolean isReadOnly) {
-    super(false, OperatorType.SET_SYSTEM_MODE);
+    super(OperatorType.SET_SYSTEM_MODE);
     this.isReadOnly = isReadOnly;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetTTLPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetTTLPlan.java
@@ -36,12 +36,12 @@ public class SetTTLPlan extends PhysicalPlan {
   private long dataTTL;
 
   public SetTTLPlan() {
-    super(false, OperatorType.TTL);
+    super(OperatorType.TTL);
   }
 
   public SetTTLPlan(PartialPath storageGroup, long dataTTL) {
     // set TTL
-    super(false, OperatorType.TTL);
+    super(OperatorType.TTL);
     this.storageGroup = storageGroup;
     this.dataTTL = dataTTL;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SetTemplatePlan.java
@@ -34,11 +34,11 @@ public class SetTemplatePlan extends PhysicalPlan {
   String prefixPath;
 
   public SetTemplatePlan() {
-    super(false, OperatorType.SET_TEMPLATE);
+    super(OperatorType.SET_TEMPLATE);
   }
 
   public SetTemplatePlan(String templateName, String prefixPath) {
-    super(false, OperatorType.SET_TEMPLATE);
+    super(OperatorType.SET_TEMPLATE);
     this.templateName = templateName;
     this.prefixPath = prefixPath;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SettlePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/SettlePlan.java
@@ -31,13 +31,13 @@ public class SettlePlan extends PhysicalPlan {
   boolean isSgPath;
 
   public SettlePlan(PartialPath sgPath) {
-    super(false, OperatorType.SETTLE);
+    super(OperatorType.SETTLE);
     this.sgPath = sgPath;
     setIsSgPath(true);
   }
 
   public SettlePlan(String tsFilePath) {
-    super(false, OperatorType.SETTLE);
+    super(OperatorType.SETTLE);
     this.tsFilePath = tsFilePath;
     setIsSgPath(false);
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowPlan.java
@@ -35,9 +35,9 @@ public class ShowPlan extends PhysicalPlan {
   private boolean hasLimit;
 
   public ShowPlan(ShowContentType showContentType) {
-    super(true);
+    super(OperatorType.SHOW);
+    setQuery(true);
     this.showContentType = showContentType;
-    setOperatorType(OperatorType.SHOW);
   }
 
   public ShowPlan(ShowContentType showContentType, PartialPath path) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StartTriggerPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StartTriggerPlan.java
@@ -35,12 +35,12 @@ public class StartTriggerPlan extends PhysicalPlan {
   private String triggerName;
 
   public StartTriggerPlan() {
-    super(false, OperatorType.START_TRIGGER);
+    super(OperatorType.START_TRIGGER);
     canBeSplit = false;
   }
 
   public StartTriggerPlan(String triggerName) {
-    super(false, OperatorType.START_TRIGGER);
+    super(OperatorType.START_TRIGGER);
     this.triggerName = triggerName;
     canBeSplit = false;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StopTriggerPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StopTriggerPlan.java
@@ -35,12 +35,12 @@ public class StopTriggerPlan extends PhysicalPlan {
   private String triggerName;
 
   public StopTriggerPlan() {
-    super(false, OperatorType.STOP_TRIGGER);
+    super(OperatorType.STOP_TRIGGER);
     canBeSplit = false;
   }
 
   public StopTriggerPlan(String triggerName) {
-    super(false, OperatorType.STOP_TRIGGER);
+    super(OperatorType.STOP_TRIGGER);
     this.triggerName = triggerName;
     canBeSplit = false;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StorageGroupMNodePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/StorageGroupMNodePlan.java
@@ -35,11 +35,11 @@ public class StorageGroupMNodePlan extends MNodePlan {
   private int alignedTimeseriesIndex;
 
   public StorageGroupMNodePlan() {
-    super(false, Operator.OperatorType.STORAGE_GROUP_MNODE);
+    super(Operator.OperatorType.STORAGE_GROUP_MNODE);
   }
 
   public StorageGroupMNodePlan(String name, long dataTTL, int childSize) {
-    super(false, Operator.OperatorType.STORAGE_GROUP_MNODE);
+    super(Operator.OperatorType.STORAGE_GROUP_MNODE);
     this.name = name;
     this.dataTTL = dataTTL;
     this.childSize = childSize;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/TracingPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/TracingPlan.java
@@ -30,7 +30,7 @@ public class TracingPlan extends PhysicalPlan {
   private boolean isTracingOn;
 
   public TracingPlan(boolean isTracingOn) {
-    super(false, OperatorType.TRACING);
+    super(OperatorType.TRACING);
     this.isTracingOn = isTracingOn;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/UnsetTemplatePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/UnsetTemplatePlan.java
@@ -36,11 +36,11 @@ public class UnsetTemplatePlan extends PhysicalPlan {
   String templateName;
 
   public UnsetTemplatePlan() {
-    super(false, Operator.OperatorType.UNSET_TEMPLATE);
+    super(Operator.OperatorType.UNSET_TEMPLATE);
   }
 
   public UnsetTemplatePlan(String prefixPath, String templateName) {
-    super(false, Operator.OperatorType.UNSET_TEMPLATE);
+    super(Operator.OperatorType.UNSET_TEMPLATE);
     this.prefixPath = prefixPath;
     this.templateName = templateName;
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/control/tracing/TracingManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/tracing/TracingManager.java
@@ -61,8 +61,10 @@ public class TracingManager {
     getTracingInfo(queryId).addOverlappedPageNum();
   }
 
-  public void setStartTime(long queryId, long startTime) {
+  public void setStartTime(long queryId, long startTime, String statement) {
     getTracingInfo(queryId).setStartTime(startTime);
+    registerActivity(
+        queryId, String.format(TracingConstant.ACTIVITY_START_EXECUTE, statement), startTime);
   }
 
   public void registerActivity(long queryId, String activity, long startTime) {

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -697,7 +697,7 @@ public class TSServiceImpl extends BasicServiceProvider implements TSIService.If
       } catch (RedirectException e) {
         if (plan.isEnableRedirect()) {
           EndPoint endPoint = e.getEndPoint();
-          redirectQueryToAnotherNode(resp, context, endPoint.ip, endPoint.port);
+          return redirectQueryToAnotherNode(resp, context, endPoint.ip, endPoint.port);
         } else {
           LOGGER.error(
               "execute {} error, if session does not support redirect, should not throw redirection exception.",


### PR DESCRIPTION
In this pr, 
1. Remove the isQuery flag from constructor of physicalPlan, only set it when it's true (QueryPlan, ShowPlan and some AuthorPlan).
2. Decouple the execution logic of QueryPlan from InternalExecuteQueryStatement, which mixes three plan before. 