### PR TITLE
[IOTDB-2205] Optimize unaligned int/long read/write functions in BytesUtils

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BytesUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BytesUtils.java
@@ -79,7 +79,7 @@ public class BytesUtils {
    * convert an integer to a byte array which length is width, then copy this array to the parameter
    * result from pos.
    *
-   * @param srcNum input integer variable. All but the lowest {@code width} bits are 0. 
+   * @param srcNum input integer variable. All but the lowest {@code width} bits are 0.
    * @param result byte array to convert
    * @param pos start position
    * @param width bit-width
@@ -509,7 +509,7 @@ public class BytesUtils {
    * convert a long to a byte array which length is width, then copy this array to the parameter
    * result from pos.
    *
-   * @param srcNum input long variable. All but the lowest {@code width} bits are 0. 
+   * @param srcNum input long variable. All but the lowest {@code width} bits are 0.
    * @param result byte array to convert
    * @param pos start position
    * @param width bit-width

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BytesUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BytesUtils.java
@@ -79,15 +79,12 @@ public class BytesUtils {
    * convert an integer to a byte array which length is width, then copy this array to the parameter
    * result from pos.
    *
-   * @param srcNum input integer variable
+   * @param srcNum input integer variable. All but the lowest {@code width} bits are 0. 
    * @param result byte array to convert
    * @param pos start position
    * @param width bit-width
    */
   public static void intToBytes(int srcNum, byte[] result, int pos, int width) {
-    if (width < 32) {
-      srcNum = srcNum & ~(-1 << width);
-    }
     int cnt = pos & 0x07;
     int index = pos >> 3;
     try {
@@ -509,18 +506,15 @@ public class BytesUtils {
   }
 
   /**
-   * convert an long to a byte array which length is width, then copy this array to the parameter
+   * convert a long to a byte array which length is width, then copy this array to the parameter
    * result from pos.
    *
-   * @param srcNum input long variable
+   * @param srcNum input long variable. All but the lowest {@code width} bits are 0. 
    * @param result byte array to convert
    * @param pos start position
    * @param width bit-width
    */
   public static void longToBytes(long srcNum, byte[] result, int pos, int width) {
-    if (width < 64) {
-      srcNum = srcNum & ~(-1L << width);
-    }
     int cnt = pos & 0x07;
     int index = pos >> 3;
     try {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BytesUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BytesUtils.java
@@ -85,20 +85,35 @@ public class BytesUtils {
    * @param width bit-width
    */
   public static void intToBytes(int srcNum, byte[] result, int pos, int width) {
-    int temp = 0;
-    for (int i = 0; i < width; i++) {
-      temp = (pos + width - 1 - i) / 8;
-      try {
-        result[temp] = setByteN(result[temp], pos + width - 1 - i, getIntN(srcNum, i));
-      } catch (Exception e) {
-        LOG.error(
-            "tsfile-common BytesUtils: cannot convert an integer {} to a byte array, "
-                + "pos {}, width {}",
-            srcNum,
-            pos,
-            width,
-            e);
+    if (width < 32) {
+      srcNum = srcNum & ~(-1 << width);
+    }
+    int cnt = pos % 8;
+    int index = pos / 8;
+    try {
+      while (width > 0) {
+        int m = width + cnt >= 8 ? 8 - cnt : width;
+        width -= m;
+        int mask = 1 << (8 - cnt);
+        cnt += m;
+        byte y = (byte) (srcNum >> width);
+        y = (byte) (y << (8 - cnt));
+        mask = ~(mask - (1 << (8 - cnt)));
+        result[index] = (byte) (result[index] & mask | y);
+        srcNum = srcNum & ~(-1 << width);
+        if (cnt == 8) {
+          index++;
+          cnt = 0;
+        }
       }
+    } catch (Exception e) {
+      LOG.error(
+          "tsfile-common BytesUtils: cannot convert an integer {} to a byte array, "
+              + "pos {}, width {}",
+          srcNum,
+          pos,
+          width,
+          e);
     }
   }
 
@@ -187,15 +202,23 @@ public class BytesUtils {
    * @return integer variable
    */
   public static int bytesToInt(byte[] result, int pos, int width) {
-
-    int value = 0;
-    int temp = 0;
-
-    for (int i = 0; i < width; i++) {
-      temp = (pos + width - 1 - i) / 8;
-      value = setIntN(value, i, getByteN(result[temp], pos + width - 1 - i));
+    int ret = 0;
+    int cnt = pos % 8;
+    int index = pos / 8;
+    while (width > 0) {
+      int m = width + cnt >= 8 ? 8 - cnt : width;
+      width -= m;
+      ret = ret << m;
+      byte y = (byte) (result[index] & (0xff >> cnt));
+      y = (byte) ((y & 0xff) >>> (8 - cnt - m));
+      ret = ret | (y & 0xff);
+      cnt += m;
+      if (cnt == 8) {
+        cnt = 0;
+        index++;
+      }
     }
-    return value;
+    return ret;
   }
 
   /**
@@ -495,19 +518,35 @@ public class BytesUtils {
    * @param width bit-width
    */
   public static void longToBytes(long srcNum, byte[] result, int pos, int width) {
-    int temp = 0;
-    for (int i = 0; i < width; i++) {
-      temp = (pos + width - 1 - i) / 8;
-      try {
-        result[temp] = setByteN(result[temp], pos + width - 1 - i, getLongN(srcNum, i));
-      } catch (Exception e) {
-        LOG.error(
-            "tsfile-common BytesUtils: cannot convert a long {} to a byte array, pos {}, width {}",
-            srcNum,
-            pos,
-            width,
-            e);
+    if (width < 64) {
+      srcNum = srcNum & ~(-1L << width);
+    }
+    int cnt = pos % 8;
+    int index = pos / 8;
+    try {
+      while (width > 0) {
+        int m = width + cnt >= 8 ? 8 - cnt : width;
+        width -= m;
+        int mask = 1 << (8 - cnt);
+        cnt += m;
+        byte y = (byte) (srcNum >> width);
+        y = (byte) (y << (8 - cnt));
+        mask = ~(mask - (1 << (8 - cnt)));
+        result[index] = (byte) (result[index] & mask | y);
+        srcNum = srcNum & ~(-1L << width);
+        if (cnt == 8) {
+          index++;
+          cnt = 0;
+        }
       }
+    } catch (Exception e) {
+      LOG.error(
+          "tsfile-common BytesUtils: cannot convert a long {} to a byte array, "
+              + "pos {}, width {}",
+          srcNum,
+          pos,
+          width,
+          e);
     }
   }
 
@@ -550,13 +589,23 @@ public class BytesUtils {
    * @return long variable
    */
   public static long bytesToLong(byte[] result, int pos, int width) {
-    long value = 0;
-    int temp = 0;
-    for (int i = 0; i < width; i++) {
-      temp = (pos + width - 1 - i) / 8;
-      value = setLongN(value, i, getByteN(result[temp], pos + width - 1 - i));
+    long ret = 0;
+    int cnt = pos % 8;
+    int index = pos / 8;
+    while (width > 0) {
+      int m = width + cnt >= 8 ? 8 - cnt : width;
+      width -= m;
+      ret = ret << m;
+      byte y = (byte) (result[index] & (0xff >> cnt));
+      y = (byte) ((y & 0xff) >>> (8 - cnt - m));
+      ret = ret | (y & 0xff);
+      cnt += m;
+      if (cnt == 8) {
+        cnt = 0;
+        index++;
+      }
     }
-    return value;
+    return ret;
   }
 
   /**

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BytesUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BytesUtils.java
@@ -88,8 +88,8 @@ public class BytesUtils {
     if (width < 32) {
       srcNum = srcNum & ~(-1 << width);
     }
-    int cnt = pos % 8;
-    int index = pos / 8;
+    int cnt = pos & 0x07;
+    int index = pos >> 3;
     try {
       while (width > 0) {
         int m = width + cnt >= 8 ? 8 - cnt : width;
@@ -203,8 +203,8 @@ public class BytesUtils {
    */
   public static int bytesToInt(byte[] result, int pos, int width) {
     int ret = 0;
-    int cnt = pos % 8;
-    int index = pos / 8;
+    int cnt = pos & 0x07;
+    int index = pos >> 3;
     while (width > 0) {
       int m = width + cnt >= 8 ? 8 - cnt : width;
       width -= m;
@@ -521,8 +521,8 @@ public class BytesUtils {
     if (width < 64) {
       srcNum = srcNum & ~(-1L << width);
     }
-    int cnt = pos % 8;
-    int index = pos / 8;
+    int cnt = pos & 0x07;
+    int index = pos >> 3;
     try {
       while (width > 0) {
         int m = width + cnt >= 8 ? 8 - cnt : width;
@@ -590,8 +590,8 @@ public class BytesUtils {
    */
   public static long bytesToLong(byte[] result, int pos, int width) {
     long ret = 0;
-    int cnt = pos % 8;
-    int index = pos / 8;
+    int cnt = pos & 0x07;
+    int index = pos >> 3;
     while (width > 0) {
       int m = width + cnt >= 8 ? 8 - cnt : width;
       width -= m;


### PR DESCRIPTION
注意到在现有的代码中，BytesUtils中非对齐的int/long的读写函数一次循环只能处理一个比特，效率较低，可以对其进行优化，使得一次循环可以处理一个字节。

该优化改动了下面的函数：
+ void longToBytes(long srcNum, byte[] result, int pos, int width)
+ void intToBytes(int srcNum, byte[] result, int pos, int width)
+ long bytesToLong(byte[] result, int pos, int width)
+ int bytesToInt(byte[] result, int pos, int width)

通过对用例的查找，发现该优化将会对使用TS_2DIFF编码的数据读写产生影响。

单元性能测试表明，该优化可以提高函数接近5倍的性能。总体性能测试表明，对于采用TS_2DIFF编码且不压缩的INT32/INT64数据，该优化可以减少约40%的读取时间开销。

--------------------------------------------------------------------------------------------------------------------------

In the current codes, the read and write functions of unaligned int/long in BytesUtils can only process one bit per loop, which is inefficient. It can be optimized to one byte per loop.

The following functions are optimized:
+ void longToBytes(long srcNum, byte[] result, int pos, int width)
+ void intToBytes(int srcNum, byte[] result, int pos, int width)
+ long bytesToLong(byte[] result, int pos, int width)
+ int bytesToInt(byte[] result, int pos, int width)

Through the use case search, the optimization influences the reading and writing of data encoded by TS_2DIFF.

In the unit performance test, the optimized functions are about 5x faster the current ones. In the overall test, about 40% time cost is reduced in the query of the uncompressed TS_2DIFF-coded INT32/INT64 data due to the optimization .