### PR TITLE
[IOTDB-2237] coverage check encludes influxdb target 

### DIFF
--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -71,6 +71,7 @@
                         <exclude>org/apache/iotdb/service/sync/thrift/*</exclude>
                         <exclude>org/apache/iotdb/service/rpc/thrift/*</exclude>
                         <exclude>org/apache/iotdb/cluster/rpc/thrift/*</exclude>
+                        <exclude>org/apache/iotdb/protocol/influxdb/rpc/thrift/*</exclude>
                         <exclude>org/apache/iotdb/db/qp/sql/*</exclude>
                     </excludes>
                     <rules>

--- a/pom.xml
+++ b/pom.xml
@@ -732,6 +732,7 @@
                         <sourceDirectory>thrift/target/generated-sources/thrift</sourceDirectory>
                         <sourceDirectory>thrift-sync/target/generated-sources/thrift</sourceDirectory>
                         <sourceDirectory>thrift-cluster/target/generated-sources/thrift</sourceDirectory>
+                        <sourceDirectory>thrift-influxdb/target/generated-sources/thrift</sourceDirectory>
                         <sourceDirectory>openapi/target/generated-sources/java/src/gen/java</sourceDirectory>
                         <sourceDirectory>openapi/target/generated-sources/java/src/main/java</sourceDirectory>
                         <sourceDirectory>spark-iotdb-connector/src/main/scala</sourceDirectory>


### PR DESCRIPTION
Failed to fix the CI last time (see #4690) because of the missing declaration of thrift-influxdb/target/thrift

Let's have another try.
