### PR TITLE
Fix aligned bug of metadata module

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
+++ b/integration/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
@@ -1255,8 +1255,8 @@ public class IoTDBSessionSimpleIT {
     values.add("1.0");
     values.add("2.0");
 
-    session.insertRecord("root.sg.loc.area", 1L, measurements, values);
-    session.insertRecord("root.sg.loc", 1L, measurements, values);
+    session.insertAlignedRecord("root.sg.loc.area", 1L, measurements, values);
+    session.insertAlignedRecord("root.sg.loc", 1L, measurements, values);
 
     dataSet = session.executeQueryStatement("show timeseries");
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1855,11 +1855,22 @@ public class MManager {
     IMNode deviceMNode = getDeviceNodeWithAutoCreate(devicePath);
 
     // check insert non-aligned InsertPlan for aligned timeseries
-    if (plan.isAligned() && deviceMNode.isEntity() && !deviceMNode.getAsEntityMNode().isAligned()) {
-      throw new MetadataException(
-          String.format(
-              "Timeseries under path [%s] is not aligned , please set InsertPlan.isAligned() = false",
-              plan.getDevicePath()));
+    if (deviceMNode.isEntity()) {
+      if (plan.isAligned()) {
+        if (!deviceMNode.getAsEntityMNode().isAligned()) {
+          throw new MetadataException(
+              String.format(
+                  "Timeseries under path [%s] is not aligned , please set InsertPlan.isAligned() = false",
+                  plan.getDevicePath()));
+        }
+      } else {
+        if (deviceMNode.getAsEntityMNode().isAligned()) {
+          throw new MetadataException(
+              String.format(
+                  "Timeseries under path [%s] is aligned , please set InsertPlan.isAligned() = true",
+                  plan.getDevicePath()));
+        }
+      }
     }
 
     // 2. get schema of each measurement

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -1834,7 +1834,29 @@ public class MManagerBasicTest {
           Arrays.asList(
               TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
           Arrays.asList(compressionType, compressionType, compressionType));
+    } catch (Exception e) {
+      fail();
+    }
 
+    try {
+      manager.createTimeseries(
+          new CreateTimeSeriesPlan(
+              new PartialPath("root.laptop.d1.aligned_device.s4"),
+              TSDataType.valueOf("FLOAT"),
+              TSEncoding.valueOf("RLE"),
+              compressionType,
+              null,
+              null,
+              null,
+              null));
+      fail();
+    } catch (Exception e) {
+      Assert.assertEquals(
+          "Timeseries under this entity is aligned, please use createAlignedTimeseries or change entity. (Path: root.laptop.d1.aligned_device)",
+          e.getMessage());
+    }
+
+    try {
       // construct an insertRowPlan with mismatched data type
       long time = 1L;
       TSDataType[] dataTypes =
@@ -1858,8 +1880,8 @@ public class MManagerBasicTest {
 
       // call getSeriesSchemasAndReadLockDevice
       manager.getSeriesSchemasAndReadLockDevice(insertRowPlan);
+      fail();
     } catch (Exception e) {
-      e.printStackTrace();
       Assert.assertEquals(
           "Timeseries under path [root.laptop.d1.aligned_device] is aligned , please set InsertPlan.isAligned() = true",
           e.getMessage());
@@ -1920,7 +1942,29 @@ public class MManagerBasicTest {
           TSEncoding.valueOf("RLE"),
           compressionType,
           Collections.emptyMap());
+    } catch (Exception e) {
+      fail();
+    }
 
+    try {
+      manager.createAlignedTimeSeries(
+          new PartialPath("root.laptop.d1.aligned_device"),
+          Arrays.asList("s3", "s4", "s5"),
+          Arrays.asList(
+              TSDataType.valueOf("FLOAT"),
+              TSDataType.valueOf("INT64"),
+              TSDataType.valueOf("INT32")),
+          Arrays.asList(
+              TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
+          Arrays.asList(compressionType, compressionType, compressionType));
+      fail();
+    } catch (Exception e) {
+      Assert.assertEquals(
+          "Timeseries under this entity is not aligned, please use createTimeseries or change entity. (Path: root.laptop.d1.aligned_device)",
+          e.getMessage());
+    }
+
+    try {
       // construct an insertRowPlan with mismatched data type
       long time = 1L;
       TSDataType[] dataTypes = new TSDataType[] {TSDataType.INT32, TSDataType.INT64};
@@ -1942,8 +1986,8 @@ public class MManagerBasicTest {
 
       // call getSeriesSchemasAndReadLockDevice
       manager.getSeriesSchemasAndReadLockDevice(insertRowPlan);
+      fail();
     } catch (Exception e) {
-      e.printStackTrace();
       Assert.assertEquals(
           "Timeseries under path [root.laptop.d1.aligned_device] is not aligned , please set InsertPlan.isAligned() = false",
           e.getMessage());


### PR DESCRIPTION
## Description

Forbid use createTimeseries to create aligned timeseries or create new timeseries under aligned device.
Forbid use createAlignedTimeseries to create nonAligned timeseries or create new timeseries under nonAligned device.
Forbid use aligned InsertPlan to insert nonAligned timeseries data.
Forbid use nonAligned InsertPlan to insert aligned timeseries data.