### PR TITLE
[To rel/0.12][IOTDB-2282] fix tag recover bug after tag update

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -399,9 +399,16 @@ public class MManager {
               plan.getAlias());
 
       // update tag index
-      if (plan.getTags() != null) {
+      Map<String, String> tagMap = null;
+      if (offset != -1) {
+        // offset != -1 means the timeseries has already been created and now system is recovering
+        tagMap = tagLogFile.readTag(config.getTagAttributeTotalSize(), offset);
+      } else if (plan.getTags() != null) {
+        tagMap = plan.getTags();
+      }
+      if (tagMap != null) {
         // tag key, tag value
-        for (Entry<String, String> entry : plan.getTags().entrySet()) {
+        for (Entry<String, String> entry : tagMap.entrySet()) {
           if (entry.getKey() == null || entry.getValue() == null) {
             continue;
           }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -404,6 +404,7 @@ public class MManager {
         // offset != -1 means the timeseries has already been created and now system is recovering
         tagMap = tagLogFile.readTag(config.getTagAttributeTotalSize(), offset);
       } else if (plan.getTags() != null) {
+        // the tags only in plan means creating timeseries
         tagMap = plan.getTags();
       }
       if (tagMap != null) {


### PR DESCRIPTION
## Description


### Problem
Currently, the tagIndex in metadata module uses mlog to recover.

However, if user alters one timeseries' tag, the tag will only be updated to the tagLogFile rather than mlog.

Thus, after tag update operation, the recover won't use the up-to-date tag information in tagLogFile but use the outdated tag information in mlog.

### Solution
use tagLogFile to recover tagIndex rather than mlog
