### PR TITLE
[IOTDB-2288] Modify serializing an empty page

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IOTDBInsertAlignedValuesIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IOTDBInsertAlignedValuesIT.java
@@ -317,7 +317,7 @@ public class IOTDBInsertAlignedValuesIT {
       ResultSet rs1 = st2.executeQuery("select S3 from root.lz.dev.GPS");
       int rowCount = 0;
       while (rs1.next()) {
-        Assert.assertEquals(rowCount, rs1.getInt(2));
+        Assert.assertEquals(rowCount + 49, rs1.getInt(2));
         rowCount++;
       }
       Assert.assertEquals(51, rowCount);

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IOTDBInsertAlignedValuesIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IOTDBInsertAlignedValuesIT.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.itbase.category.LocalStandaloneTest;
 import org.apache.iotdb.jdbc.Config;
 import org.apache.iotdb.jdbc.IoTDBSQLException;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -222,6 +223,120 @@ public class IOTDBInsertAlignedValuesIT {
       Assert.fail();
     } catch (IoTDBSQLException e) {
       Assert.assertEquals(313, e.getErrorCode());
+    }
+  }
+
+  @Test
+  public void testInsertAlignedWithEmptyPage() throws SQLException {
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(2);
+    try (Statement st1 = connection.createStatement()) {
+      st1.execute(
+          "CREATE ALIGNED TIMESERIES root.lz.dev.GPS(S1 INT32 encoding=PLAIN compressor=SNAPPY, S2 INT32 encoding=PLAIN compressor=SNAPPY, S3 INT32 encoding=PLAIN compressor=SNAPPY) ");
+      for (int i = 0; i < 100; i++) {
+        if (i == 99) {
+          st1.execute(
+              "insert into root.lz.dev.GPS(time,S1,S3) aligned values("
+                  + i
+                  + ","
+                  + i
+                  + ","
+                  + i
+                  + ")");
+        } else {
+          st1.execute(
+              "insert into root.lz.dev.GPS(time,S1,S2) aligned values("
+                  + i
+                  + ","
+                  + i
+                  + ","
+                  + i
+                  + ")");
+        }
+      }
+      st1.execute("flush");
+    }
+    try (Statement st2 = connection.createStatement()) {
+      ResultSet rs1 = st2.executeQuery("select S3 from root.lz.dev.GPS");
+      int rowCount = 0;
+      while (rs1.next()) {
+        Assert.assertEquals(99, rs1.getInt(2));
+        rowCount++;
+      }
+      Assert.assertEquals(1, rowCount);
+
+      rs1 = st2.executeQuery("select S2 from root.lz.dev.GPS");
+      rowCount = 0;
+      while (rs1.next()) {
+        Assert.assertEquals(rowCount, rs1.getInt(2));
+        rowCount++;
+      }
+      Assert.assertEquals(99, rowCount);
+
+      rs1 = st2.executeQuery("select S1 from root.lz.dev.GPS");
+      rowCount = 0;
+      while (rs1.next()) {
+        Assert.assertEquals(rowCount, rs1.getInt(2));
+        rowCount++;
+      }
+      Assert.assertEquals(100, rowCount);
+    }
+  }
+
+  @Test
+  public void testInsertAlignedWithEmptyPage2() throws SQLException {
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(4);
+    try (Statement st1 = connection.createStatement()) {
+      st1.execute(
+          "CREATE ALIGNED TIMESERIES root.lz.dev.GPS(S1 INT32 encoding=PLAIN compressor=SNAPPY, S2 INT32 encoding=PLAIN compressor=SNAPPY, S3 INT32 encoding=PLAIN compressor=SNAPPY) ");
+      for (int i = 0; i < 100; i++) {
+        if (i >= 49) {
+          st1.execute(
+              "insert into root.lz.dev.GPS(time,S1,S2,S3) aligned values("
+                  + i
+                  + ","
+                  + i
+                  + ","
+                  + i
+                  + ","
+                  + i
+                  + ")");
+        } else {
+          st1.execute(
+              "insert into root.lz.dev.GPS(time,S1,S2) aligned values("
+                  + i
+                  + ","
+                  + i
+                  + ","
+                  + i
+                  + ")");
+        }
+      }
+      st1.execute("flush");
+    }
+    try (Statement st2 = connection.createStatement()) {
+      ResultSet rs1 = st2.executeQuery("select S3 from root.lz.dev.GPS");
+      int rowCount = 0;
+      while (rs1.next()) {
+        Assert.assertEquals(rowCount, rs1.getInt(2));
+        rowCount++;
+      }
+      Assert.assertEquals(51, rowCount);
+
+      rs1 = st2.executeQuery("select S2 from root.lz.dev.GPS");
+      rowCount = 0;
+      while (rs1.next()) {
+        Assert.assertEquals(rowCount, rs1.getInt(2));
+        rowCount++;
+      }
+      Assert.assertEquals(100, rowCount);
+
+      rs1 = st2.executeQuery("select S1 from root.lz.dev.GPS");
+      rowCount = 0;
+      while (rs1.next()) {
+        Assert.assertEquals(rowCount, rs1.getInt(2));
+        rowCount++;
+      }
+      Assert.assertEquals(100, rowCount);
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
@@ -157,7 +157,9 @@ public class ValueChunkWriter {
   public void writePageToPageBuffer() {
     try {
       if (numOfPages == 0) { // record the firstPageStatistics
-        this.firstPageStatistics = pageWriter.getStatistics();
+        if (pageWriter.getStatistics().getCount() != 0) { // empty page
+          this.firstPageStatistics = pageWriter.getStatistics();
+        }
         this.sizeWithoutStatistic = pageWriter.writePageHeaderAndDataIntoBuff(pageBuffer, true);
       } else if (numOfPages == 1) { // put the firstPageStatistics into pageBuffer
         if (firstPageStatistics != null) { // Consider previous page is an empty page

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
@@ -156,8 +156,9 @@ public class ValueChunkWriter {
 
   public void writePageToPageBuffer() {
     try {
-      if (numOfPages == 0) { // record the firstPageStatistics
-        if (pageWriter.getStatistics().getCount() != 0) { // empty page
+      if (numOfPages == 0) {
+        if (pageWriter.getStatistics().getCount() != 0) {
+          // record the firstPageStatistics if it is not empty page
           this.firstPageStatistics = pageWriter.getStatistics();
         }
         this.sizeWithoutStatistic = pageWriter.writePageHeaderAndDataIntoBuff(pageBuffer, true);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/ValuePageWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/ValuePageWriter.java
@@ -228,6 +228,9 @@ public class ValuePageWriter {
       throws IOException {
     if (size == 0) {
       return 0;
+    } else if (statistics.getCount() == 0) {
+      // this page is full of null point data
+      return writeEmptyPageIntoBuff(pageBuffer);
     }
 
     ByteBuffer pageData = getUncompressedBytes();


### PR DESCRIPTION
At present, when the server flush the aligned timeseries, it serializes the pageHeader, size, and bitmap of the page if there is an empty page. To save disk space, we serialize only an unCompressedSize of 0 when meeting an empty page.