### PR TITLE
[IOTDB-2256][IOTDB-2318] Fix permission check bug while query with non timeseries & Fix doc

### DIFF
--- a/docs/UserGuide/Appendix/SQL-Reference.md
+++ b/docs/UserGuide/Appendix/SQL-Reference.md
@@ -921,6 +921,14 @@ path=‘root’ (DOT identifier)*
 Eg: IoTDB > LIST PRIVILEGES USER sgcc_wirte_user ON root.sgcc;
 ```
 
+* List Privileges of Roles
+
+```
+LIST ROLE PRIVILEGES <roleName>
+roleName:=identifier
+Eg: IoTDB > LIST ROLE PRIVILEGES actor;
+```
+
 * List Privileges of Roles(On Specific Path)
 
 ```
@@ -936,14 +944,6 @@ Eg: IoTDB > LIST PRIVILEGES ROLE wirte_role ON root.sgcc;
 LIST USER PRIVILEGES <username> ;   
 username:=identifier  
 Eg: IoTDB > LIST USER PRIVILEGES tempuser;
-```
-
-* List Privileges of Roles
-
-```
-LIST ROLE PRIVILEGES <roleName>
-roleName:=identifier
-Eg: IoTDB > LIST ROLE PRIVILEGES actor;
 ```
 
 * List Roles of Users

--- a/docs/UserGuide/IoTDB-SQL-Language/DML-Data-Manipulation-Language.md
+++ b/docs/UserGuide/IoTDB-SQL-Language/DML-Data-Manipulation-Language.md
@@ -1630,7 +1630,7 @@ The result set is：
 IoTDB provides [LIMIT/SLIMIT](../Appendix/SQL-Reference.md) clause and [OFFSET/SOFFSET](../Appendix/SQL-Reference.md) 
 clause in order to make users have more control over query results. 
 The use of LIMIT and SLIMIT clauses allows users to control the number of rows and columns of query results, 
-and the use of OFFSET and SOFSET clauses allows users to set the starting position of the results for display.
+and the use of OFFSET and SOFFSET clauses allows users to set the starting position of the results for display.
 
 Note that the LIMIT and OFFSET are not supported in group by query.
 

--- a/docs/zh/UserGuide/Appendix/SQL-Reference.md
+++ b/docs/zh/UserGuide/Appendix/SQL-Reference.md
@@ -915,6 +915,14 @@ Eg: IoTDB > LIST PRIVILEGES USER sgcc_wirte_user ON root.sgcc;
 * 列出角色权限
 
 ```
+LIST ROLE PRIVILEGES <roleName>
+roleName:=identifier
+Eg: IoTDB > LIST ROLE PRIVILEGES actor;
+```
+
+* 列出角色在具体路径上的权限
+
+```
 LIST PRIVILEGES ROLE <roleName> ON <path>;    
 roleName:=identifier  
 path=‘root’ (DOT identifier)*
@@ -927,14 +935,6 @@ Eg: IoTDB > LIST PRIVILEGES ROLE wirte_role ON root.sgcc;
 LIST USER PRIVILEGES <username> ;   
 username:=identifier  
 Eg: IoTDB > LIST USER PRIVILEGES tempuser;
-```
-
-* 列出角色权限
-
-```
-LIST ROLE PRIVILEGES <roleName>
-roleName:=identifier
-Eg: IoTDB > LIST ROLE PRIVILEGES actor;
 ```
 
 * 列出用户角色 

--- a/docs/zh/UserGuide/IoTDB-SQL-Language/DML-Data-Manipulation-Language.md
+++ b/docs/zh/UserGuide/IoTDB-SQL-Language/DML-Data-Manipulation-Language.md
@@ -1642,7 +1642,7 @@ select s1 as temperature, s2 as speed from root.ln.wf01.wt01;
 ### 结果集行列输出控制 (LIMIT & OFFSET)
 
 IoTDB 提供 [LIMIT/SLIMIT](../Appendix/SQL-Reference.md) 子句和 [OFFSET/SOFFSET](../Appendix/SQL-Reference.md) 子句，以使用户可以更好地控制查询结果。使用 LIMIT 和 SLIMIT 子句可让用户控制查询结果的行数和列数，
-并且使用 OFFSET 和 SOFSET 子句允许用户设置结果显示的起始位置。
+并且使用 OFFSET 和 SOFFSET 子句允许用户设置结果显示的起始位置。
 
 请注意，按组查询不支持 LIMIT 和 OFFSET。
 

--- a/integration/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
@@ -100,13 +100,8 @@ public class IoTDBAuthorizationIT {
         }
         assertTrue(caught);
 
-        caught = false;
-        try {
-          userStmt.execute("SELECT * from root.a");
-        } catch (SQLException e) {
-          caught = true;
-        }
-        assertTrue(caught);
+        // empty result timeseries set doesn't need authority check
+        userStmt.execute("SELECT * from root.a");
 
         caught = false;
         try {
@@ -154,11 +149,15 @@ public class IoTDBAuthorizationIT {
 
         caught = false;
         try {
-          userStmt.execute("SELECT * from root.b");
+          userStmt.execute("SELECT * from root.a");
         } catch (SQLException e) {
+          // user has no authority on root.a
           caught = true;
         }
         assertTrue(caught);
+
+        // empty result timeseries set doesn't need authority check
+        userStmt.execute("SELECT * from root.b");
 
         caught = false;
         try {

--- a/integration/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1176,6 +1177,28 @@ public class IoTDBAuthorizationIT {
             userStatement.executeQuery(
                 "SELECT s1, s1, s1 - s3, s2 * sin(s1), s1 + 1 / 2 * sin(s1), sin(s1), sin(s1) FROM root.test")) {
       assertTrue(resultSet.next());
+    }
+  }
+
+  @Test
+  public void testEmptySetAuthorityCheck() throws ClassNotFoundException, SQLException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection adminConnection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement adminStatement = adminConnection.createStatement()) {
+      adminStatement.execute("CREATE USER a_application 'a_application'");
+      adminStatement.execute("GRANT USER a_application PRIVILEGES READ_TIMESERIES on root.ln;");
+
+      adminStatement.execute("INSERT INTO root.ln.wt01.wf01(time, s1) VALUES(1, 2)");
+    }
+
+    try (Connection userConnection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "a_application", "a_application");
+        Statement userStatement = userConnection.createStatement();
+        ResultSet resultSet = userStatement.executeQuery("SELECT * FROM root.ln.*")) {
+      assertFalse(resultSet.next());
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -700,8 +700,10 @@ public class TSServiceImpl extends BasicServiceProvider implements TSIService.If
           SQLException, IOException, InterruptedException, QueryFilterOptimizationException,
           AuthException {
     // check permissions
-    if (!plan.getAuthPaths().isEmpty()
-        && !checkAuthorization(plan.getAuthPaths(), plan, username)) {
+    List<? extends PartialPath> authPaths = plan.getAuthPaths();
+    if (authPaths != null
+        && !authPaths.isEmpty()
+        && !checkAuthorization(authPaths, plan, username)) {
       return RpcUtils.getTSExecuteStatementResp(
           RpcUtils.getStatus(
               TSStatusCode.NO_PERMISSION_ERROR,

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -700,7 +700,8 @@ public class TSServiceImpl extends BasicServiceProvider implements TSIService.If
           SQLException, IOException, InterruptedException, QueryFilterOptimizationException,
           AuthException {
     // check permissions
-    if (!checkAuthorization(plan.getAuthPaths(), plan, username)) {
+    if (!plan.getAuthPaths().isEmpty()
+        && !checkAuthorization(plan.getAuthPaths(), plan, username)) {
       return RpcUtils.getTSExecuteStatementResp(
           RpcUtils.getStatus(
               TSStatusCode.NO_PERMISSION_ERROR,


### PR DESCRIPTION
## Description


### Problem
When authority module checks a query plan with empty path sets, which is caused by path pattern matching non timeseries, the system will return "user no permission", which should not happen.

### Solution
Add check on path nums before authority check. If empty path sets, authority check is unnecessary.

### Others
Fix some mistakes in UserGuide doc
