### PR TITLE
[IOTDB-2334] Unreasonable debug log level of python client Session

### DIFF
--- a/client-py/iotdb/Session.py
+++ b/client-py/iotdb/Session.py
@@ -753,5 +753,5 @@ class Session(object):
         if status.code == Session.SUCCESS_CODE:
             return 0
 
-        logger.debug("error status is", status)
+        logger.error("error status is", status)
         return -1


### PR DESCRIPTION
It‘s inappropriate to use debug level when error occurs in verify_success method, I change it to error level.