### PR TITLE
[IOTDB-2333] Python client: the todf method throws exception

### DIFF
--- a/client-py/iotdb/utils/IoTDBConstants.py
+++ b/client-py/iotdb/utils/IoTDBConstants.py
@@ -33,6 +33,9 @@ class TSDataType(Enum):
     def __eq__(self, other) -> bool:
         return self.value == other.value
 
+    def __hash__(self):
+        return self.value
+
 
 @unique
 class TSEncoding(Enum):
@@ -51,6 +54,9 @@ class TSEncoding(Enum):
     def __eq__(self, other) -> bool:
         return self.value == other.value
 
+    def __hash__(self):
+        return self.value
+
 
 @unique
 class Compressor(Enum):
@@ -67,3 +73,6 @@ class Compressor(Enum):
     # https://bugs.python.org/issue30545
     def __eq__(self, other) -> bool:
         return self.value == other.value
+
+    def __hash__(self):
+        return self.value


### PR DESCRIPTION
if you define __eq__, the default __hash__ (namely, hashing the address of the object in memory) goes away. This is important because hashing needs to be consistent with equality: equal objects need to hash the same.

The solution is simple: just define __hash__ along with defining __eq__.

See IOTDB-2333 for more detail.

See also: https://docs.python.org/3.1/reference/datamodel.html#object.__hash__