### PR TITLE
[Discussions-4763]Restructure export/import csv tool;

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -80,6 +80,15 @@
             <artifactId>commons-csv</artifactId>
             <version>1.9.0</version>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/cli/src/assembly/resources/tools/export-csv-new.bat
+++ b/cli/src/assembly/resources/tools/export-csv-new.bat
@@ -1,0 +1,56 @@
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
+
+@echo off
+echo ````````````````````````````````````````````````
+echo Starting IoTDB Client New Export Script
+echo ````````````````````````````````````````````````
+
+if "%OS%" == "Windows_NT" setlocal
+
+pushd %~dp0..
+if NOT DEFINED IOTDB_CLI_HOME set IOTDB_CLI_HOME=%CD%
+popd
+
+if NOT DEFINED MAIN_CLASS set MAIN_CLASS=org.apache.iotdb.tool.ExportCsvNew
+if NOT DEFINED JAVA_HOME goto :err
+
+@REM -----------------------------------------------------------------------------
+@REM JVM Opts we'll use in legacy run or installation
+set JAVA_OPTS=-ea^
+ -DIOTDB_CLI_HOME=%IOTDB_CLI_HOME%
+
+@REM ***** CLASSPATH library setting *****
+set CLASSPATH=%IOTDB_CLI_HOME%\lib\*
+
+REM -----------------------------------------------------------------------------
+
+"%JAVA_HOME%\bin\java" -DIOTDB_CLI_HOME=%IOTDB_CLI_HOME% %JAVA_OPTS% -cp %CLASSPATH% %MAIN_CLASS% %*
+
+goto finally
+
+
+:err
+echo JAVA_HOME environment variable must be set!
+pause
+
+@REM -----------------------------------------------------------------------------
+:finally
+
+ENDLOCAL

--- a/cli/src/assembly/resources/tools/export-csv-new.sh
+++ b/cli/src/assembly/resources/tools/export-csv-new.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+echo ------------------------------------------
+echo Starting IoTDB Client New Export Script
+echo ------------------------------------------
+
+if [ -z "${IOTDB_CLI_HOME}" ]; then
+    export IOTDB_CLI_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+fi
+
+if [ -n "$JAVA_HOME" ]; then
+    for java in "$JAVA_HOME"/bin/amd64/java "$JAVA_HOME"/bin/java; do
+        if [ -x "$java" ]; then
+            JAVA="$java"
+            break
+        fi
+    done
+else
+    JAVA=java
+fi
+
+if [ -z $JAVA ] ; then
+    echo Unable to find java executable. Check JAVA_HOME and PATH environment variables.  > /dev/stderr
+    exit 1;
+fi
+
+CLASSPATH=""
+for f in ${IOTDB_CLI_HOME}/lib/*.jar; do
+    CLASSPATH=${CLASSPATH}":"$f
+done
+
+MAIN_CLASS=org.apache.iotdb.tool.ExportCsvNew
+
+"$JAVA" -DIOTDB_CLI_HOME=${IOTDB_CLI_HOME} -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
+exit $?

--- a/cli/src/assembly/resources/tools/import-csv-new.bat
+++ b/cli/src/assembly/resources/tools/import-csv-new.bat
@@ -1,0 +1,57 @@
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
+
+@echo off
+echo ````````````````````````````````````````````````
+echo Starting IoTDB Client New Import Script
+echo ````````````````````````````````````````````````
+
+if "%OS%" == "Windows_NT" setlocal
+
+pushd %~dp0..
+if NOT DEFINED IOTDB_CLI_HOME set IOTDB_CLI_HOME=%CD%
+popd
+
+if NOT DEFINED MAIN_CLASS set MAIN_CLASS=org.apache.iotdb.tool.ImportCsvNew
+if NOT DEFINED JAVA_HOME goto :err
+
+@REM -----------------------------------------------------------------------------
+@REM JVM Opts we'll use in legacy run or installation
+set JAVA_OPTS=-ea^
+ -DIOTDB_CLI_HOME=%IOTDB_CLI_HOME%
+
+@REM ***** CLASSPATH library setting *****
+set CLASSPATH=%IOTDB_CLI_HOME%\lib\*
+
+REM -----------------------------------------------------------------------------
+
+"%JAVA_HOME%\bin\java" -DIOTDB_CLI_HOME=%IOTDB_CLI_HOME% %JAVA_OPTS% -cp %CLASSPATH% %MAIN_CLASS% %*
+
+goto finally
+
+
+:err
+echo JAVA_HOME environment variable must be set!
+pause
+
+
+@REM -----------------------------------------------------------------------------
+:finally
+
+ENDLOCAL

--- a/cli/src/assembly/resources/tools/import-csv-new.sh
+++ b/cli/src/assembly/resources/tools/import-csv-new.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+echo ------------------------------------------
+echo Starting IoTDB Client New Import Script
+echo ------------------------------------------
+
+if [ -z "${IOTDB_CLI_HOME}" ]; then
+    export IOTDB_CLI_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+fi
+
+if [ -n "$JAVA_HOME" ]; then
+    for java in "$JAVA_HOME"/bin/amd64/java "$JAVA_HOME"/bin/java; do
+        if [ -x "$java" ]; then
+            JAVA="$java"
+            break
+        fi
+    done
+else
+    JAVA=java
+fi
+
+if [ -z $JAVA ] ; then
+    echo Unable to find java executable. Check JAVA_HOME and PATH environment variables.  > /dev/stderr
+    exit 1;
+fi
+
+CLASSPATH=""
+for f in ${IOTDB_CLI_HOME}/lib/*.jar; do
+    CLASSPATH=${CLASSPATH}":"$f
+done
+
+MAIN_CLASS=org.apache.iotdb.tool.ImportCsvNew
+
+"$JAVA" -DIOTDB_CLI_HOME=${IOTDB_CLI_HOME} -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
+exit $?

--- a/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
@@ -55,6 +55,9 @@ public abstract class AbstractCsvTool {
   protected static final String TIME_FORMAT_ARGS = "tf";
   protected static final String TIME_FORMAT_NAME = "timeformat";
 
+  protected static final String COMPRESS_ARGS = "c";
+  protected static final String COMPRESS_NAME = "compress";
+
   protected static final String TIME_ZONE_ARGS = "tz";
   protected static final String TIME_ZONE_NAME = "timeZone";
   protected static final int MAX_HELP_CONSOLE_WIDTH = 92;
@@ -110,6 +113,8 @@ public abstract class AbstractCsvTool {
   protected static Session session;
 
   public AbstractCsvTool() {}
+
+  protected static CompressMode compressMode = CompressMode.PLAIN;
 
   protected static String checkRequiredArg(String arg, String name, CommandLine commandLine)
       throws ArgsErrorException {

--- a/cli/src/main/java/org/apache/iotdb/tool/CompressMode.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/CompressMode.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.tool;
+
+public enum CompressMode {
+  PLAIN("plain", ".csv"),
+  SNAPPY("snappy", ".snappy"),
+  GZIP("gzip", ".gz");
+
+  private final String value;
+
+  private final String suffix;
+
+  private CompressMode(String value, String suffix) {
+    this.value = value;
+    this.suffix = suffix;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public String getSuffix() {
+    return suffix;
+  }
+
+  public static CompressMode forValue(String value) {
+    if (value == null) {
+      return PLAIN;
+    }
+    switch (value) {
+      case "plain":
+        return PLAIN;
+      case "snappy":
+        return SNAPPY;
+      case "gzip":
+        return GZIP;
+      default:
+        return PLAIN;
+    }
+  }
+}

--- a/cli/src/main/java/org/apache/iotdb/tool/CompressUtil.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/CompressUtil.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.tool;
+
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.xerial.snappy.SnappyFramedInputStream;
+import org.xerial.snappy.SnappyFramedOutputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+public class CompressUtil {
+
+  public static void snappyCompress(InputStream fi, OutputStream fo) {
+
+    byte[] buffer = new byte[1024 * 1024 * 8];
+    SnappyFramedOutputStream sout = null;
+    try {
+      sout = new SnappyFramedOutputStream(fo);
+      while (true) {
+        int count = fi.read(buffer, 0, buffer.length);
+        if (count == -1) {
+          break;
+        }
+        sout.write(buffer, 0, count);
+      }
+      sout.flush();
+    } catch (Throwable ex) {
+      ex.printStackTrace();
+    } finally {
+      if (sout != null) {
+        try {
+          sout.close();
+        } catch (Exception e) {
+        }
+      }
+      if (fi != null) {
+        try {
+          fi.close();
+        } catch (Exception x) {
+        }
+      }
+    }
+  }
+
+  public static void snappyUncompress(InputStream fi, OutputStream fo)
+      throws UnsupportedEncodingException, IOException {
+    byte[] buffer = new byte[1024 * 1024 * 8];
+    SnappyFramedInputStream sin = null;
+    try {
+      sin = new SnappyFramedInputStream(fi);
+
+      while (true) {
+        int count = sin.read(buffer, 0, buffer.length);
+        if (count == -1) {
+          break;
+        }
+        fo.write(buffer, 0, count);
+      }
+      fo.flush();
+    } catch (Throwable ex) {
+      ex.printStackTrace();
+    } finally {
+      if (sin != null) {
+        try {
+          sin.close();
+        } catch (Exception x) {
+        }
+      }
+      if (fi != null) {
+        try {
+          fi.close();
+        } catch (Exception x) {
+        }
+      }
+    }
+  }
+
+  public static void gzipCompress(InputStream fi, OutputStream fo) {
+
+    byte[] buffer = new byte[1024 * 1024 * 8];
+    GzipCompressorOutputStream sout = null;
+    try {
+      sout = new GzipCompressorOutputStream(fo);
+      while (true) {
+        int count = fi.read(buffer, 0, buffer.length);
+        if (count == -1) {
+          break;
+        }
+        sout.write(buffer, 0, count);
+      }
+      sout.flush();
+    } catch (Throwable ex) {
+      ex.printStackTrace();
+    } finally {
+      if (sout != null) {
+        try {
+          sout.close();
+        } catch (Exception e) {
+        }
+      }
+      if (fi != null) {
+        try {
+          fi.close();
+        } catch (Exception x) {
+        }
+      }
+    }
+  }
+
+  public static void gzipUncompress(InputStream fi, OutputStream fo)
+      throws UnsupportedEncodingException, IOException {
+    byte[] buffer = new byte[1024 * 1024 * 8];
+    GzipCompressorInputStream sin = null;
+    try {
+      sin = new GzipCompressorInputStream(fi);
+
+      while (true) {
+        int count = sin.read(buffer, 0, buffer.length);
+        if (count == -1) {
+          break;
+        }
+        fo.write(buffer, 0, count);
+      }
+      fo.flush();
+    } catch (Throwable ex) {
+      ex.printStackTrace();
+    } finally {
+      if (sin != null) {
+        try {
+          sin.close();
+        } catch (Exception x) {
+        }
+      }
+      if (fi != null) {
+        try {
+          fi.close();
+        } catch (Exception x) {
+        }
+      }
+    }
+  }
+}

--- a/cli/src/main/java/org/apache/iotdb/tool/CsvModel.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/CsvModel.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tool;
+
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CsvModel {
+
+  private int count;
+
+  private String deviceId;
+
+  private List<Long> times;
+
+  private List<List<TSDataType>> typesList;
+
+  private List<List<Object>> valuesList;
+
+  private List<List<String>> measurementsList;
+
+  public int getCount() {
+    return count;
+  }
+
+  public void setCount(int count) {
+    this.count = count;
+  }
+
+  public String getDeviceId() {
+    return deviceId;
+  }
+
+  public void setDeviceId(String deviceId) {
+    this.deviceId = deviceId;
+  }
+
+  public List<Long> getTimes() {
+    if (times == null) {
+      times = new ArrayList<>();
+    }
+    return times;
+  }
+
+  public void setTimes(List<Long> times) {
+    this.times = times;
+  }
+
+  public List<List<TSDataType>> getTypesList() {
+    if (typesList == null) {
+      typesList = new ArrayList<>();
+    }
+    return typesList;
+  }
+
+  public void setTypesList(List<List<TSDataType>> typesList) {
+    this.typesList = typesList;
+  }
+
+  public List<List<Object>> getValuesList() {
+    if (valuesList == null) {
+      valuesList = new ArrayList<>();
+    }
+    return valuesList;
+  }
+
+  public void setValuesList(List<List<Object>> valuesList) {
+    this.valuesList = valuesList;
+  }
+
+  public List<List<String>> getMeasurementsList() {
+    if (measurementsList == null) {
+      measurementsList = new ArrayList<>();
+    }
+    return measurementsList;
+  }
+
+  public void setMeasurementsList(List<List<String>> measurementsList) {
+    this.measurementsList = measurementsList;
+  }
+}

--- a/cli/src/main/java/org/apache/iotdb/tool/ExportCsvNew.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ExportCsvNew.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.tool;
+
+import org.apache.iotdb.exception.ArgsErrorException;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.session.Session;
+import org.apache.iotdb.session.SessionDataSet;
+import org.apache.iotdb.session.SessionDataSet.DataIterator;
+
+import jline.console.ConsoleReader;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.thrift.annotation.Nullable;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.PrintWriter;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class ExportCsvNew extends AbstractCsvTool {
+
+  public static Log logger = LogFactory.getLog(ExportCsvNew.class);
+
+  private static final String TARGET_DIR_ARGS = "td";
+  private static final String TARGET_DIR_NAME = "targetDirectory";
+
+  private static final String TARGET_FILE_ARGS = "f";
+  private static final String TARGET_FILE_NAME = "targetFile";
+
+  private static final String SQL_FILE_ARGS = "s";
+  private static final String SQL_FILE_NAME = "sqlfile";
+
+  private static final String DATA_TYPE_ARGS = "datatype";
+  private static final String DATA_TYPE_NAME = "datatype";
+
+  private static final String QUERY_COMMAND_ARGS = "q";
+  private static final String QUERY_COMMAND_NAME = "queryCommand";
+
+  private static final String TSFILEDB_CLI_PREFIX = "ExportCsv";
+
+  private static final String DUMP_FILE_NAME_DEFAULT = "dump";
+  private static String targetFile = DUMP_FILE_NAME_DEFAULT;
+
+  public static final int POINT_FEEDBACK_SIZE = 10_000_000;
+
+  private static String targetDirectory;
+
+  private static Boolean needDataTypePrinted;
+
+  private static String queryCommand;
+
+  /** main function of export csv tool. */
+  public static void main(String[] args) throws IOException {
+    Options options = createOptions();
+    HelpFormatter hf = new HelpFormatter();
+    CommandLine commandLine;
+    CommandLineParser parser = new DefaultParser();
+    hf.setOptionComparator(null); // avoid reordering
+    hf.setWidth(MAX_HELP_CONSOLE_WIDTH);
+
+    if (args == null || args.length == 0) {
+      System.out.println("Too few params input, please check the following hint.");
+      hf.printHelp(TSFILEDB_CLI_PREFIX, options, true);
+      return;
+    }
+    try {
+      commandLine = parser.parse(options, args);
+    } catch (ParseException e) {
+      System.out.println(e.getMessage());
+      hf.printHelp(TSFILEDB_CLI_PREFIX, options, true);
+      return;
+    }
+    if (commandLine.hasOption(HELP_ARGS)) {
+      hf.printHelp(TSFILEDB_CLI_PREFIX, options, true);
+      return;
+    }
+
+    try {
+      parseBasicParams(commandLine);
+      parseSpecialParams(commandLine);
+      if (!checkTimeFormat()) {
+        return;
+      }
+
+      session = new Session(host, Integer.parseInt(port), username, password);
+      session.open(false);
+      setTimeZone();
+
+      if (queryCommand == null) {
+        String sqlFile = commandLine.getOptionValue(SQL_FILE_ARGS);
+        String sql;
+
+        if (sqlFile == null) {
+          ConsoleReader reader = new ConsoleReader();
+          reader.setExpandEvents(false);
+          sql = reader.readLine(TSFILEDB_CLI_PREFIX + "> please input query: ");
+          System.out.println(sql);
+          String[] values = sql.trim().split(";");
+          for (int i = 0; i < values.length; i++) {
+            dumpResult(values[i], i);
+          }
+          reader.close();
+        } else {
+          dumpFromSqlFile(sqlFile);
+        }
+      } else {
+        dumpResult(queryCommand, 0);
+      }
+
+    } catch (IOException e) {
+      System.out.println("Failed to operate on file, because " + e.getMessage());
+    } catch (ArgsErrorException e) {
+      System.out.println("Invalid args: " + e.getMessage());
+    } catch (IoTDBConnectionException | StatementExecutionException e) {
+      System.out.println("Connect failed because " + e.getMessage());
+    } finally {
+      if (session != null) {
+        try {
+          session.close();
+        } catch (IoTDBConnectionException e) {
+          System.out.println(
+              "Encounter an error when closing session, error is: " + e.getMessage());
+        }
+      }
+    }
+  }
+
+  private static void parseSpecialParams(CommandLine commandLine) throws ArgsErrorException {
+    targetDirectory = checkRequiredArg(TARGET_DIR_ARGS, TARGET_DIR_NAME, commandLine);
+    targetFile = commandLine.getOptionValue(TARGET_FILE_ARGS);
+    needDataTypePrinted = Boolean.valueOf(commandLine.getOptionValue(DATA_TYPE_ARGS));
+    queryCommand = commandLine.getOptionValue(QUERY_COMMAND_ARGS);
+
+    if (needDataTypePrinted == null) {
+      needDataTypePrinted = true;
+    }
+    if (targetFile == null) {
+      targetFile = DUMP_FILE_NAME_DEFAULT;
+    }
+    timeFormat = commandLine.getOptionValue(TIME_FORMAT_ARGS);
+    if (timeFormat == null) {
+      timeFormat = "default";
+    }
+    timeZoneID = commandLine.getOptionValue(TIME_ZONE_ARGS);
+    if (!targetDirectory.endsWith("/") && !targetDirectory.endsWith("\\")) {
+      targetDirectory += File.separator;
+    }
+    String compressAlgorithm = commandLine.getOptionValue(COMPRESS_ARGS);
+    compressMode = CompressMode.forValue(compressAlgorithm);
+  }
+
+  /**
+   * commandline option create.
+   *
+   * @return object Options
+   */
+  private static Options createOptions() {
+    Options options = createNewOptions();
+
+    Option opTargetFile =
+        Option.builder(TARGET_DIR_ARGS)
+            .required()
+            .argName(TARGET_DIR_NAME)
+            .hasArg()
+            .desc("Target File Directory (required)")
+            .build();
+    options.addOption(opTargetFile);
+
+    Option targetFileName =
+        Option.builder(TARGET_FILE_ARGS)
+            .argName(TARGET_FILE_NAME)
+            .hasArg()
+            .desc("Export file name (optional)")
+            .build();
+    options.addOption(targetFileName);
+
+    Option opSqlFile =
+        Option.builder(SQL_FILE_ARGS)
+            .argName(SQL_FILE_NAME)
+            .hasArg()
+            .desc("SQL File Path (optional)")
+            .build();
+    options.addOption(opSqlFile);
+
+    Option opTimeFormat =
+        Option.builder(TIME_FORMAT_ARGS)
+            .argName(TIME_FORMAT_NAME)
+            .hasArg()
+            .desc(
+                "Output time Format in csv file. "
+                    + "You can choose 1) timestamp, number, long 2) ISO8601, default 3) "
+                    + "user-defined pattern like yyyy-MM-dd\\ HH:mm:ss, default ISO8601 (optional)")
+            .build();
+    options.addOption(opTimeFormat);
+
+    Option opTimeZone =
+        Option.builder(TIME_ZONE_ARGS)
+            .argName(TIME_ZONE_NAME)
+            .hasArg()
+            .desc("Time Zone eg. +08:00 or -01:00 (optional)")
+            .build();
+    options.addOption(opTimeZone);
+
+    Option opDataType =
+        Option.builder(DATA_TYPE_ARGS)
+            .argName(DATA_TYPE_NAME)
+            .hasArg()
+            .desc(
+                "Will the data type of timeseries be printed in the head line of the CSV file?"
+                    + '\n'
+                    + "You can choose true) or false) . (optional)")
+            .build();
+    options.addOption(opDataType);
+
+    Option opQuery =
+        Option.builder(QUERY_COMMAND_ARGS)
+            .argName(QUERY_COMMAND_NAME)
+            .hasArg()
+            .desc("The query command that you want to execute. (optional)")
+            .build();
+    options.addOption(opQuery);
+
+    Option opHelp =
+        Option.builder(HELP_ARGS)
+            .longOpt(HELP_ARGS)
+            .hasArg(false)
+            .desc("Display help information")
+            .build();
+    options.addOption(opHelp);
+
+    Option opCompress =
+        Option.builder(COMPRESS_ARGS)
+            .longOpt(COMPRESS_NAME)
+            .argName(COMPRESS_NAME)
+            .hasArg()
+            .desc("Type algorithm for compress, snappy or gzip is available. (optional)")
+            .build();
+    options.addOption(opCompress);
+
+    return options;
+  }
+
+  /**
+   * This method will be called, if the query commands are written in a sql file.
+   *
+   * @param filePath
+   * @throws IOException
+   */
+  private static void dumpFromSqlFile(String filePath) throws IOException {
+    try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
+      String sql;
+      int index = 0;
+      while ((sql = reader.readLine()) != null) {
+        dumpResult(sql, index);
+        index++;
+      }
+    }
+  }
+
+  /**
+   * Dump files from database to CSV file.
+   *
+   * @param sql export the result of executing the sql
+   * @param index use to create dump file name
+   */
+  private static void dumpResult(String sql, int index) {
+    String path =
+        new StringBuilder(targetDirectory)
+            .append(targetFile)
+            .append(index)
+            .append(".csv")
+            .toString();
+    try {
+      SessionDataSet sessionDataSet = session.executeQueryStatement(sql);
+      if (!CompressMode.PLAIN.equals(compressMode)) {
+        path = new StringBuilder(path).append(compressMode.getSuffix()).toString();
+        PipedInputStream input = new PipedInputStream();
+        final PipedOutputStream out = new PipedOutputStream((PipedInputStream) input);
+        new Thread(
+                new Runnable() {
+                  public void run() {
+                    try {
+                      writeCsvFile(null, sessionDataSet, out);
+                    } catch (Exception e) {
+                    }
+                  }
+                })
+            .start();
+        OutputStream out2 = new FileOutputStream(new File(path));
+        if (CompressMode.GZIP.equals(compressMode)) {
+          CompressUtil.gzipCompress(input, out2);
+        } else if (CompressMode.SNAPPY.equals(compressMode)) {
+          CompressUtil.snappyCompress(input, out2);
+        }
+      } else {
+        writeCsvFile(null, sessionDataSet, new FileOutputStream(new File(path)));
+      }
+      System.out.println("Export completely!");
+    } catch (Exception e) {
+      System.out.println("Cannot dump result because: " + e.getMessage());
+    }
+  }
+
+  private static Boolean writeCsvFile(
+      @Nullable List<String> headerNames, SessionDataSet sessionDataSet, OutputStream out)
+      throws Exception {
+
+    List<String> columnNameList = sessionDataSet.getColumnNames();
+    List<String> columnTypeList = sessionDataSet.getColumnTypes();
+
+    DataIterator it = sessionDataSet.iterator();
+    CSVPrinter printer = CSVFormat.DEFAULT.print(new PrintWriter(out, true));
+    if (headerNames != null) {
+      printer.printRecord(headerNames);
+      printer.println();
+    }
+
+    for (int i = 0; i < columnNameList.size(); i++) {
+      String name = columnNameList.get(i);
+      if ("Time".equals(name)) {
+        printer.print(name);
+      } else {
+        String type = columnTypeList.get(i);
+        if (needDataTypePrinted && !"Device".equals(name)) {
+          printer.print(new StringBuilder(name).append("(").append(type).append(")").toString());
+        } else {
+          printer.print(name);
+        }
+      }
+    }
+    printer.println();
+    int length = columnNameList.size();
+    Long[] finishedCount = new Long[] {0L, 0L}; // 0: finishRowCount; 1: finishPointCountTemp;
+    while (it.next()) {
+      for (int i = 0; i < length; i++) {
+        String s = columnNameList.get(i);
+        Object o = it.getObject(s);
+        if (i == 0 && o != null) {
+          try {
+            Long ol = Long.valueOf(o.toString());
+            String t = timeTrans(ol);
+            printer.print(t);
+          } catch (Exception e) {
+            printer.print(null);
+          }
+        } else {
+          printer.print(o);
+        }
+      }
+      printer.println();
+      ongoingFeedback(finishedCount, length);
+    }
+    printer.flush();
+    printer.close();
+    finishFeedback(finishedCount, length);
+    return true;
+  }
+
+  private static void ongoingFeedback(Long[] finishedCount, long length) {
+    finishedCount[0]++;
+    finishedCount[1] += (length - 1);
+    if (finishedCount[1] >= POINT_FEEDBACK_SIZE) {
+      finishedCount[1] = finishedCount[1] % POINT_FEEDBACK_SIZE;
+      logger.warn(
+          "Exported "
+              + (length - 1) * finishedCount[0]
+              + " points in "
+              + finishedCount[0]
+              + " rows");
+    }
+  }
+
+  private static void finishFeedback(Long[] finishedCount, long length) {
+    logger.warn(
+        "Export finish, total "
+            + (length - 1) * finishedCount[0]
+            + " points in "
+            + finishedCount[0]
+            + " rows");
+  }
+
+  public static String timeTrans(Long time) {
+    String timestampPrecision = "ms";
+    switch (timeFormat) {
+      case "default":
+        return RpcUtils.parseLongToDateWithPrecision(
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME, time, zoneId, timestampPrecision);
+      case "timestamp":
+      case "long":
+      case "number":
+        return String.valueOf(time);
+      default:
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(time), zoneId)
+            .format(DateTimeFormatter.ofPattern(timeFormat));
+    }
+  }
+}

--- a/cli/src/main/java/org/apache/iotdb/tool/ImportCsvNew.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ImportCsvNew.java
@@ -1,0 +1,622 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tool;
+
+import org.apache.iotdb.exception.ArgsErrorException;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.session.Session;
+import org.apache.iotdb.session.SessionDataSet;
+import org.apache.iotdb.session.SessionDataSet.DataIterator;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.thrift.annotation.Nullable;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.apache.iotdb.tsfile.file.metadata.enums.TSDataType.BOOLEAN;
+import static org.apache.iotdb.tsfile.file.metadata.enums.TSDataType.DOUBLE;
+import static org.apache.iotdb.tsfile.file.metadata.enums.TSDataType.FLOAT;
+import static org.apache.iotdb.tsfile.file.metadata.enums.TSDataType.INT32;
+import static org.apache.iotdb.tsfile.file.metadata.enums.TSDataType.INT64;
+import static org.apache.iotdb.tsfile.file.metadata.enums.TSDataType.TEXT;
+
+public class ImportCsvNew extends AbstractCsvTool {
+
+  public static Log logger = LogFactory.getLog(ImportCsvNew.class);
+
+  private static final String FILE_ARGS = "f";
+  private static final String FILE_NAME = "file or folder";
+
+  private static final String FAILED_FILE_ARGS = "fd";
+  private static final String FAILED_FILE_NAME = "failed file directory";
+
+  private static final String CSV_SUFFIXS = ".csv";
+  private static final String TXT_SUFFIXS = ".txt";
+
+  private static final String TSFILEDB_CLI_PREFIX = "ImportCsv";
+
+  private static String targetPath;
+  private static String failedFileDirectory = null;
+  private static List<DateTimeFormatter> fmts = new LinkedList<>();
+  private static DateTimeFormatter fmt = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS");
+
+  public static final int POINT_FEEDBACK_SIZE = 1_000_000;
+
+  static {
+    fmts.add(fmt);
+  }
+
+  /**
+   * create the commandline options.
+   *
+   * @return object Options
+   */
+  private static Options createOptions() {
+    Options options = createNewOptions();
+
+    Option opFile =
+        Option.builder(FILE_ARGS)
+            .required()
+            .argName(FILE_NAME)
+            .hasArg()
+            .desc(
+                "If input a file path, load a csv file, "
+                    + "otherwise load all csv file under this directory (required)")
+            .build();
+    options.addOption(opFile);
+
+    Option opFailedFile =
+        Option.builder(FAILED_FILE_ARGS)
+            .argName(FAILED_FILE_NAME)
+            .hasArg()
+            .desc(
+                "Specifying a directory to save failed file, default YOUR_CSV_FILE_PATH (optional)")
+            .build();
+    options.addOption(opFailedFile);
+
+    Option opHelp =
+        Option.builder(HELP_ARGS)
+            .longOpt(HELP_ARGS)
+            .hasArg(false)
+            .desc("Display help information")
+            .build();
+    options.addOption(opHelp);
+
+    Option opTimeZone =
+        Option.builder(TIME_ZONE_ARGS)
+            .argName(TIME_ZONE_NAME)
+            .hasArg()
+            .desc("Time Zone eg. +08:00 or -01:00 (optional)")
+            .build();
+    options.addOption(opTimeZone);
+
+    Option opCompress =
+        Option.builder(COMPRESS_ARGS)
+            .longOpt(COMPRESS_NAME)
+            .argName(COMPRESS_NAME)
+            .hasArg()
+            .desc("Type algorithm for compress, snappy or gzip is available. (optional)")
+            .build();
+    options.addOption(opCompress);
+
+    return options;
+  }
+
+  /**
+   * parse optional params
+   *
+   * @param commandLine
+   */
+  private static void parseSpecialParams(CommandLine commandLine) {
+    timeZoneID = commandLine.getOptionValue(TIME_ZONE_ARGS);
+    targetPath = commandLine.getOptionValue(FILE_ARGS);
+    if (commandLine.getOptionValue(FAILED_FILE_ARGS) != null) {
+      failedFileDirectory = commandLine.getOptionValue(FAILED_FILE_ARGS);
+      File file = new File(failedFileDirectory);
+      if (!file.isDirectory()) {
+        file.mkdir();
+        failedFileDirectory = file.getAbsolutePath() + File.separator;
+      }
+    }
+    String compressAlgorithm = commandLine.getOptionValue(COMPRESS_ARGS);
+    if (compressAlgorithm == null) {
+      if (targetPath.endsWith(".gz")) {
+        compressMode = CompressMode.GZIP;
+      } else if (targetPath.endsWith(".snappy")) {
+        compressMode = CompressMode.SNAPPY;
+      } else {
+        compressMode = CompressMode.PLAIN;
+      }
+    } else {
+      compressMode = CompressMode.forValue(compressAlgorithm);
+    }
+  }
+
+  public static void main(String[] args) throws IOException, IoTDBConnectionException {
+
+    Options options = createOptions();
+    HelpFormatter hf = new HelpFormatter();
+    hf.setOptionComparator(null);
+    hf.setWidth(MAX_HELP_CONSOLE_WIDTH);
+    CommandLine commandLine;
+    CommandLineParser parser = new DefaultParser();
+
+    if (args == null || args.length == 0) {
+      System.out.println("Too few params input, please check the following hint.");
+      hf.printHelp(TSFILEDB_CLI_PREFIX, options, true);
+      return;
+    }
+    try {
+      commandLine = parser.parse(options, args);
+    } catch (org.apache.commons.cli.ParseException e) {
+      System.out.println("Parse error: " + e.getMessage());
+      hf.printHelp(TSFILEDB_CLI_PREFIX, options, true);
+      return;
+    }
+    if (commandLine.hasOption(HELP_ARGS)) {
+      hf.printHelp(TSFILEDB_CLI_PREFIX, options, true);
+      return;
+    }
+
+    try {
+      parseBasicParams(commandLine);
+      String filename = commandLine.getOptionValue(FILE_ARGS);
+      if (filename == null) {
+        hf.printHelp(TSFILEDB_CLI_PREFIX, options, true);
+        return;
+      }
+      parseSpecialParams(commandLine);
+    } catch (ArgsErrorException e) {
+      System.out.println("Args error: " + e.getMessage());
+    } catch (Exception e) {
+      System.out.println("Encounter an error, because: " + e.getMessage());
+    }
+
+    importFromTargetPath(host, Integer.valueOf(port), username, password, targetPath, timeZoneID);
+  }
+
+  /**
+   * Specifying a CSV file or a directory including CSV files that you want to import. This method
+   * can be offered to console cli to implement importing CSV file by command.
+   *
+   * @param host
+   * @param port
+   * @param username
+   * @param password
+   * @param targetPath a CSV file or a directory including CSV files
+   * @param timeZone
+   * @throws IoTDBConnectionException
+   */
+  public static void importFromTargetPath(
+      String host, int port, String username, String password, String targetPath, String timeZone)
+      throws IoTDBConnectionException {
+    try {
+      session = new Session(host, Integer.valueOf(port), username, password, false);
+      session.open(false);
+      timeZoneID = timeZone;
+      setTimeZone();
+
+      File file = new File(targetPath);
+      if (file.isFile()) {
+        importFromSingleFileNew(file);
+      } else if (file.isDirectory()) {
+        File[] files = file.listFiles();
+        if (files == null) {
+          return;
+        }
+
+        for (File subFile : files) {
+          if (subFile.isFile()) {
+            importFromSingleFileNew(subFile);
+          }
+        }
+      } else {
+        System.out.println("File not found!");
+      }
+    } catch (IoTDBConnectionException | StatementExecutionException e) {
+      System.out.println("Encounter an error when connecting to server, because " + e.getMessage());
+    } finally {
+      if (session != null) {
+        session.close();
+      }
+    }
+  }
+
+  private static void importFromSingleFileNew(File file) {
+
+    if (CompressMode.PLAIN.equals(compressMode)) {
+      if (!file.getName().endsWith(CSV_SUFFIXS) && !file.getName().endsWith(TXT_SUFFIXS)) {
+        System.out.println("The file name must end with \".csv\" or \".txt\"!");
+        System.exit(0);
+      }
+    } else if (!file.getName().endsWith(compressMode.getSuffix())) {
+      System.out.println("The file name must end with \"" + compressMode.getSuffix() + "\"!");
+      System.exit(0);
+    }
+    try {
+      Stream<CSVRecord> csvRecords = readCsvFile(file.getAbsolutePath()).stream();
+      writeDataAlignedByTime(csvRecords);
+    } catch (IOException e) {
+      System.out.println("CSV file read exception because: " + e.getMessage());
+    }
+  }
+
+  private static void writeDataAlignedByTime(Stream<CSVRecord> records) {
+
+    @SuppressWarnings("unchecked")
+    List<String>[] headerNames = new LinkedList[1];
+
+    HashMap<String, List<String>> deviceAndMeasurementNames = new HashMap<>();
+    HashMap<String, TSDataType> headerTypeMap = new HashMap<>();
+    HashMap<String, String> headerNameMap = new HashMap<>();
+
+    Map<String, CsvModel> m = new HashMap<>();
+
+    boolean[] booleanArray = {
+      true, false
+    }; // [0]: first or not; [1]: header contains "Device" or not;
+    Long[] finishedCount = {0L, 0L}; // 0: finishRowCount; 1: finishPointCountTemp;
+    try {
+      records.forEach(
+          record -> {
+            if (booleanArray[0]) {
+              booleanArray[0] = false;
+              headerNames[0] = new LinkedList<>();
+              Map<String, String> map = record.toMap();
+              headerNames[0].addAll(map.keySet());
+
+              if (headerNames[0].contains("Device")) {
+                booleanArray[1] = true;
+              }
+              parseHeaders(headerNames[0], deviceAndMeasurementNames, headerTypeMap, headerNameMap);
+            }
+            int length = deviceAndMeasurementNames.size();
+            String d = null;
+            if (booleanArray[1]) {
+              d = record.get("Device");
+            }
+            String timeStr = record.get("Time");
+            for (Map.Entry<String, List<String>> e : deviceAndMeasurementNames.entrySet()) {
+              String measurement = e.getKey();
+              String measurementKey =
+                  booleanArray[1]
+                      ? new StringBuilder(d).append(".").append(measurement).toString()
+                      : measurement;
+              if (!m.containsKey(measurementKey)) {
+                m.put(measurementKey, new CsvModel());
+              }
+              CsvModel cm = m.get(measurementKey);
+              List<String> l = e.getValue();
+              List<String> devices = new LinkedList<String>();
+              List<TSDataType> types = new LinkedList<TSDataType>();
+              List<Object> values = new LinkedList<Object>();
+              Long time = 0L;
+              if (timeStr.indexOf('+') >= 0) {
+                timeStr = timeStr.substring(0, timeStr.indexOf('+'));
+              }
+              timeStr = timeStr.replaceAll("T", " ");
+              if (timeStr.indexOf(' ') == -1) {
+                try {
+                  time = Long.parseLong(timeStr);
+                } catch (Exception e1) {
+                }
+              } else {
+                try {
+                  time = fmt.parseDateTime(timeStr).toDate().getTime();
+                } catch (Exception e2) {
+                }
+              }
+
+              for (int i = 0; i < l.size(); i++) {
+                if (!measurement.equals(e.getKey())) {
+                  continue;
+                }
+                String ee = l.get(i);
+                String header = ee;
+                if (!booleanArray[1]) {
+                  header = new StringBuilder(e.getKey()).append(".").append(ee).toString();
+                }
+                String raw = record.get(header);
+                if (raw != null && !"".equals(raw)) {
+                  String device = ee;
+                  if (ee.indexOf('(') > -1) {
+                    device = ee.substring(0, ee.indexOf('('));
+                  }
+                  devices.add(device);
+                  TSDataType type = headerTypeMap.get(headerNameMap.get(header));
+                  types.add(type);
+                  Object value = typeTrans(raw, type);
+                  values.add(value);
+                } else {
+                }
+              }
+              if (!devices.isEmpty()) {
+                if (booleanArray[1]) {
+                  cm.setDeviceId(d);
+                } else {
+                  cm.setDeviceId(e.getKey());
+                }
+                addLine(
+                    cm.getTimes(),
+                    cm.getMeasurementsList(),
+                    cm.getTypesList(),
+                    cm.getValuesList(),
+                    time,
+                    devices,
+                    types,
+                    values);
+              }
+              finishedCount[1]++;
+            }
+            ongoingFeedback(finishedCount, length);
+          });
+    } catch (Exception e) {
+    }
+    for (Map.Entry<String, CsvModel> e2 : m.entrySet()) {
+      CsvModel cm = e2.getValue();
+      if (cm.getTimes().size() != 0) {
+        logger.warn(
+            "device " + e2.getKey() + " totally import " + cm.getTimes().size() + " points");
+        try {
+          session.insertRecordsOfOneDevice(
+              cm.getDeviceId(),
+              cm.getTimes(),
+              cm.getMeasurementsList(),
+              cm.getTypesList(),
+              cm.getValuesList());
+        } catch (IoTDBConnectionException | StatementExecutionException e1) {
+        }
+      }
+    }
+    finishFeedback(finishedCount);
+  }
+
+  private static void ongoingFeedback(Long[] finishedCount, int length) {
+    finishedCount[0]++;
+    if (finishedCount[1] >= POINT_FEEDBACK_SIZE) {
+      finishedCount[1] = finishedCount[1] % POINT_FEEDBACK_SIZE;
+      logger.warn("Imported " + finishedCount[0] + " rows");
+    }
+  }
+
+  private static void finishFeedback(Long[] finishedCount) {
+    logger.warn("Import finish, total " + finishedCount[0] + " rows");
+  }
+
+  private static void addLine(
+      List<Long> times,
+      List<List<String>> measurements,
+      List<List<TSDataType>> datatypes,
+      List<List<Object>> values,
+      long time,
+      List<String> s1,
+      List<TSDataType> s1type,
+      List<Object> value2) {
+
+    List<String> tmpMeasurements = new ArrayList<>();
+    List<TSDataType> tmpDataTypes = new ArrayList<>();
+    List<Object> tmpValues = new ArrayList<>();
+    for (int i = 0; i < s1.size(); i++) {
+      tmpMeasurements.add(s1.get(i));
+      tmpDataTypes.add(s1type.get(i));
+      tmpValues.add(value2.get(i));
+    }
+    times.add(time);
+    measurements.add(tmpMeasurements);
+    datatypes.add(tmpDataTypes);
+    values.add(tmpValues);
+  }
+
+  /**
+   * read data from the CSV file
+   *
+   * @param path
+   * @return
+   * @throws IOException
+   */
+  @SuppressWarnings("deprecation")
+  private static CSVParser readCsvFile(String path) throws IOException {
+    InputStream input = null;
+    if (!CompressMode.PLAIN.equals(compressMode)) {
+      input = new PipedInputStream();
+      final PipedOutputStream out = new PipedOutputStream((PipedInputStream) input);
+
+      new Thread(
+              new Runnable() {
+                public void run() {
+                  try {
+                    if (CompressMode.GZIP.equals(compressMode)) {
+                      CompressUtil.gzipUncompress(new FileInputStream(path), out);
+                    } else if (CompressMode.SNAPPY.equals(compressMode)) {
+                      CompressUtil.snappyUncompress(new FileInputStream(path), out);
+                    }
+                  } catch (IOException e) {
+                    e.printStackTrace();
+                  }
+                }
+              })
+          .start();
+      return CSVFormat.EXCEL
+          .withFirstRecordAsHeader()
+          .withQuote('\'')
+          .withEscape('\\')
+          .withIgnoreEmptyLines()
+          .parse(new InputStreamReader(input));
+    } else {
+      input = new FileInputStream(path);
+      return CSVFormat.EXCEL
+          .withFirstRecordAsHeader()
+          .withQuote('\'')
+          .withEscape('\\')
+          .withIgnoreEmptyLines()
+          .parse(new InputStreamReader(input));
+    }
+  }
+
+  /**
+   * parse deviceNames, measurementNames(aligned by time), headerType from headers
+   *
+   * @param headerNames
+   * @param deviceAndMeasurementNames
+   * @param headerTypeMap
+   * @param headerNameMap
+   */
+  private static void parseHeaders(
+      List<String> headerNames,
+      @Nullable HashMap<String, List<String>> deviceAndMeasurementNames,
+      HashMap<String, TSDataType> headerTypeMap,
+      HashMap<String, String> headerNameMap) {
+    String regex = "(?<=\\()\\S+(?=\\))";
+    Pattern pattern = Pattern.compile(regex);
+    Map<String, String> columnTypeMap = null;
+    for (String headerName : headerNames) {
+      if (headerName.equals("Time") || headerName.equals("Device")) continue;
+      Matcher matcher = pattern.matcher(headerName);
+      String type;
+      if (matcher.find()) {
+        type = matcher.group();
+        String headerNameWithoutType =
+            headerName.replace("(" + type + ")", "").replaceAll("\\s+", "");
+        headerNameMap.put(headerName, headerNameWithoutType);
+        headerTypeMap.put(headerNameWithoutType, getType(type));
+      } else {
+        if (columnTypeMap == null) {
+          columnTypeMap = buildColumnTypeMap();
+        }
+        headerNameMap.put(headerName, headerName);
+        headerTypeMap.put(headerName, getType(columnTypeMap.get(headerName)));
+      }
+      String[] split = headerName.split("\\.");
+      String measurementName = split[split.length - 1];
+      String deviceName = headerName.replace("." + measurementName, "");
+      if (deviceAndMeasurementNames != null) {
+        if (!deviceAndMeasurementNames.containsKey(deviceName)) {
+          deviceAndMeasurementNames.put(deviceName, new ArrayList<>());
+        }
+        deviceAndMeasurementNames.get(deviceName).add(measurementName);
+      }
+    }
+  }
+
+  private static Map<String, String> buildColumnTypeMap() {
+    Map<String, String> columnTypeMap = new HashMap<>();
+    try {
+      SessionDataSet sessionDataSet = session.executeQueryStatement("show timeseries");
+      DataIterator it = sessionDataSet.iterator();
+      while (it.next()) {
+        columnTypeMap.put(it.getString("timeseries"), it.getString("dataType"));
+      }
+    } catch (StatementExecutionException | IoTDBConnectionException e) {
+      e.printStackTrace();
+    }
+    return columnTypeMap;
+  }
+
+  /**
+   * return the TSDataType
+   *
+   * @param typeStr
+   * @return
+   */
+  private static TSDataType getType(String typeStr) {
+    if (typeStr == null) {
+      return TEXT;
+    }
+    switch (typeStr) {
+      case "TEXT":
+        return TEXT;
+      case "BOOLEAN":
+        return BOOLEAN;
+      case "INT32":
+        return INT32;
+      case "INT64":
+        return INT64;
+      case "FLOAT":
+        return FLOAT;
+      case "DOUBLE":
+        return DOUBLE;
+      default:
+        return TEXT;
+    }
+  }
+
+  /**
+   * @param value
+   * @param type
+   * @return
+   */
+  private static Object typeTrans(String value, TSDataType type) {
+    try {
+      switch (type) {
+        case TEXT:
+          if (value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2) {
+            value = value.substring(1, value.length() - 1);
+            value = value.replaceAll("\"\"", "\"");
+          }
+          return value;
+        case BOOLEAN:
+          if (!value.equals("true") && !value.equals("false")) {
+            return null;
+          }
+          return Boolean.valueOf(value);
+        case INT32:
+          return Integer.valueOf(value);
+        case INT64:
+          return Long.valueOf(value);
+        case FLOAT:
+          return Float.valueOf(value);
+        case DOUBLE:
+          return Double.valueOf(value);
+        default:
+          return null;
+      }
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Hello, everyone. I recently used iotdb in the production environment and found that the import tool is almost unusable in the real scene. I studied this piece of code and found that the stream was not used correctly, so I refactored it, and I also added some other functions. What I do is as follows:

1. Optimize the implementation of import, so that the records in the backup file can be read into the memory, written to the database, and moved out of the memory line by line. The new tool no longer has any requirements on the size of the backup file;
2. Added compression options. It is a common behavior to compress while exporting. At the same time, importing from compressed files should also be supported. At present, I have implemented it in two ways: gzip and snappy;
3. There is corresponding progress feedback when importing/exporting. At present, I use feedback every time I export 10 million points or import 1 million points, so that no matter what type of data, I can have a suitable feedback rhythm;

Because the original code is almost completely unused, the new tools are named export-csv-new and import-csv-new, which coexist with existing tools;