### PR TITLE
[IOTDB-1950] Add Bloom Filter cache for query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/BloomFilterCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/BloomFilterCache.java
@@ -170,14 +170,15 @@ public class BloomFilterCache {
         return false;
       }
       BloomFilterCache.BloomFilterCacheKey that = (BloomFilterCache.BloomFilterCacheKey) o;
-      return tsFileVersion == that.tsFileVersion
+      return filePath.equals(that.filePath)
+          && tsFileVersion == that.tsFileVersion
           && compactionVersion == that.compactionVersion
           && tsFilePrefixPath.equals(that.tsFilePrefixPath);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(tsFilePrefixPath, tsFileVersion, compactionVersion);
+      return Objects.hash(filePath, tsFilePrefixPath, tsFileVersion, compactionVersion);
     }
   }
 


### PR DESCRIPTION
BloomFilterCache doesn't store elements correctly, due to the wrong implement of equals() method.