### PR TITLE
[IOTDB-2347] Fix aligned timeseries auto create bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1947,7 +1947,9 @@ public class MManager {
             internalCreateTimeseries(devicePath.concatNode(measurement), plan.getDataTypes()[loc]);
           } else {
             internalAlignedCreateTimeseries(
-                devicePath, Arrays.asList(measurementList), Arrays.asList(plan.getDataTypes()));
+                devicePath,
+                Collections.singletonList(measurement),
+                Collections.singletonList(plan.getDataTypes()[loc]));
           }
           // after creating timeseries, the deviceMNode has been replaced by a new entityMNode
           deviceMNode = mtree.getNodeByPath(devicePath);

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -2047,6 +2047,51 @@ public class MManagerBasicTest {
   }
 
   @Test
+  public void testAutoCreateAlignedTimeseriesWhileInsert() {
+    MManager manager = IoTDB.metaManager;
+
+    try {
+      long time = 1L;
+      TSDataType[] dataTypes = new TSDataType[] {TSDataType.INT32, TSDataType.INT32};
+
+      String[] columns = new String[2];
+      columns[0] = "1";
+      columns[1] = "2";
+
+      InsertRowPlan insertRowPlan =
+          new InsertRowPlan(
+              new PartialPath("root.laptop.d1.aligned_device"),
+              time,
+              new String[] {"s1", "s2"},
+              dataTypes,
+              columns,
+              true);
+      insertRowPlan.setMeasurementMNodes(
+          new IMeasurementMNode[insertRowPlan.getMeasurements().length]);
+
+      manager.getSeriesSchemasAndReadLockDevice(insertRowPlan);
+
+      assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.aligned_device.s1")));
+      assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.aligned_device.s2")));
+
+      insertRowPlan.setMeasurements(new String[] {"s3", "s4"});
+      manager.getSeriesSchemasAndReadLockDevice(insertRowPlan);
+      assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.aligned_device.s3")));
+      assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.aligned_device.s4")));
+
+      insertRowPlan.setMeasurements(new String[] {"s2", "s5"});
+      manager.getSeriesSchemasAndReadLockDevice(insertRowPlan);
+      assertTrue(manager.isPathExist(new PartialPath("root.laptop.d1.aligned_device.s5")));
+
+      insertRowPlan.setMeasurements(new String[] {"s2", "s3"});
+      manager.getSeriesSchemasAndReadLockDevice(insertRowPlan);
+
+    } catch (MetadataException | IOException e) {
+      fail();
+    }
+  }
+
+  @Test
   public void testGetStorageGroupNodeByPath() {
     MManager manager = IoTDB.metaManager;
     PartialPath partialPath = null;


### PR DESCRIPTION
## Description


### Problem
When trying to auto create aligned timeseries during insertion, MManager will throw PathAlreadyExistException if one of the timeseries in aligned InsertPlan already exists, which should be ignored and should not impact the auto creation of the rest timeseries.


### Solution
Check each timeseries in aligned InsertPlan and try auto create one by one.

 