### PR TITLE
[IOTDB-2275] Don't compile grafana plugin when execute mvn clean package -pl distribution -am -DskipTests

### DIFF
--- a/docs/zh/UserGuide/Ecosystem Integration/Grafana Plugin.md
+++ b/docs/zh/UserGuide/Ecosystem Integration/Grafana Plugin.md
@@ -85,7 +85,7 @@ yarn build
 在 IoTDB 仓库的根目录下执行：
 
 ```shell
- mvn clean package -pl distribution -am -DskipTests 
+ mvn clean package -pl distribution -am -DskipTests -P compile-grafana-plugin
 ```
 
 如果编译成功，我们将看到 `distribution/target` 路径下包含了编译好的 Grafana 前端插件：

--- a/docs/zh/UserGuide/Ecosystem Integration/Grafana Plugin.md
+++ b/docs/zh/UserGuide/Ecosystem Integration/Grafana Plugin.md
@@ -64,7 +64,7 @@ git clone https://github.com/apache/iotdb.git
 * 使用 maven 编译，在 `grafana-plugin` 目录下执行：
 
 ```shell
-mvn install package
+mvn install package -P compile-grafana-plugin
 ```
 
 * 或使用 yarn 编译，在 `grafana-plugin` 目录下执行：

--- a/grafana-plugin/pom.xml
+++ b/grafana-plugin/pom.xml
@@ -31,66 +31,71 @@
     <name>IoTDB Grafana plugin</name>
     <description>IoTDB Grafana plugin</description>
     <packaging>pom</packaging>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <version>0.13</version>
-                <configuration>
-                    <excludes>
-                        <exclude>yarn.lock</exclude>
-                        <exclude>package.json</exclude>
-                        <exclude>tsconfig.json</exclude>
-                        <exclude>src/plugin.json</exclude>
-                    </excludes>
-                    <consoleOutput>false</consoleOutput>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>license-check</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.12.1</version>
-                <executions>
-                    <execution>
-                        <id>install node and yarn</id>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
+    <profiles>
+        <profile>
+            <id>compile-grafana-plugin</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <version>0.13</version>
                         <configuration>
-                            <nodeVersion>v16.13.1</nodeVersion>
-                            <yarnVersion>v1.22.17</yarnVersion>
+                            <excludes>
+                                <exclude>yarn.lock</exclude>
+                                <exclude>package.json</exclude>
+                                <exclude>tsconfig.json</exclude>
+                                <exclude>src/plugin.json</exclude>
+                            </excludes>
+                            <consoleOutput>false</consoleOutput>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>yarn install</id>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>install</arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>yarn build</id>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>build</arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+                        <executions>
+                            <execution>
+                                <id>license-check</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.12.1</version>
+                        <executions>
+                            <execution>
+                                <id>install node and yarn</id>
+                                <goals>
+                                    <goal>install-node-and-yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <nodeVersion>v16.13.1</nodeVersion>
+                                    <yarnVersion>v1.22.17</yarnVersion>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>yarn install</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>yarn build</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>build</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -685,6 +685,8 @@
                             <exclude>apache_iotdb.egg-info/**</exclude>
                             <!-- Java SPI uses files in resources/META-INF/services-->
                             <exclude>**/resources/META-INF/services/**</exclude>
+                            <!-- grafana plugin -->
+                            <exclude>**/yarn.lock</exclude>
                         </excludes>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
## Description

When execute `mvn clean package -pl distribution -am -DskipTests`, compiling grafana plugin may take too much time.

I think we should only build grafana plugin by adding `-P compile-grafana-plugin` in mvn command, like we deal with cpp-client.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
