### PR TITLE
[IOTDB-2349] An exception should be thrown when aggregate function and data type do not match

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryMemoryControlIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryMemoryControlIT.java
@@ -44,21 +44,21 @@ public class IoTDBQueryMemoryControlIT {
   private static final String[] sqls =
       new String[] {
         "set storage group to root.ln",
-        "create timeseries root.ln.wf01.wt01 with datatype=BOOLEAN,encoding=PLAIN",
-        "create timeseries root.ln.wf01.wt02 with datatype=BOOLEAN,encoding=PLAIN",
-        "create timeseries root.ln.wf01.wt03 with datatype=BOOLEAN,encoding=PLAIN",
-        "create timeseries root.ln.wf01.wt04 with datatype=BOOLEAN,encoding=PLAIN",
-        "create timeseries root.ln.wf01.wt05 with datatype=BOOLEAN,encoding=PLAIN",
+        "create timeseries root.ln.wf01.wt01 with datatype=INT32,encoding=PLAIN",
+        "create timeseries root.ln.wf01.wt02 with datatype=INT32,encoding=PLAIN",
+        "create timeseries root.ln.wf01.wt03 with datatype=INT32,encoding=PLAIN",
+        "create timeseries root.ln.wf01.wt04 with datatype=INT32,encoding=PLAIN",
+        "create timeseries root.ln.wf01.wt05 with datatype=INT32,encoding=PLAIN",
         "create timeseries root.ln.wf02.wt01 with datatype=FLOAT,encoding=RLE",
         "create timeseries root.ln.wf02.wt02 with datatype=FLOAT,encoding=RLE",
         "create timeseries root.ln.wf02.wt03 with datatype=FLOAT,encoding=RLE",
         "create timeseries root.ln.wf02.wt04 with datatype=FLOAT,encoding=RLE",
         "create timeseries root.ln.wf02.wt05 with datatype=FLOAT,encoding=RLE",
-        "create timeseries root.ln.wf03.wt01 with datatype=TEXT,encoding=PLAIN",
-        "create timeseries root.ln.wf03.wt02 with datatype=TEXT,encoding=PLAIN",
-        "create timeseries root.ln.wf03.wt03 with datatype=TEXT,encoding=PLAIN",
-        "create timeseries root.ln.wf03.wt04 with datatype=TEXT,encoding=PLAIN",
-        "create timeseries root.ln.wf03.wt05 with datatype=TEXT,encoding=PLAIN",
+        "create timeseries root.ln.wf03.wt01 with datatype=DOUBLE,encoding=PLAIN",
+        "create timeseries root.ln.wf03.wt02 with datatype=DOUBLE,encoding=PLAIN",
+        "create timeseries root.ln.wf03.wt03 with datatype=DOUBLE,encoding=PLAIN",
+        "create timeseries root.ln.wf03.wt04 with datatype=DOUBLE,encoding=PLAIN",
+        "create timeseries root.ln.wf03.wt05 with datatype=DOUBLE,encoding=PLAIN",
       };
 
   @BeforeClass

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
@@ -768,7 +768,9 @@ public class IoTDBAggregationIT {
       } catch (Exception e) {
         Assert.assertTrue(
             e.getMessage(),
-            e.getMessage().contains("Unsupported data type in aggregation AVG : TEXT"));
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
       try {
         statement.execute(
@@ -779,7 +781,9 @@ public class IoTDBAggregationIT {
         }
       } catch (Exception e) {
         Assert.assertTrue(
-            e.getMessage().contains("Unsupported data type in aggregation SUM : TEXT"));
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
       try {
         statement.execute(
@@ -790,7 +794,9 @@ public class IoTDBAggregationIT {
         }
       } catch (Exception e) {
         Assert.assertTrue(
-            e.getMessage().contains("Unsupported data type in aggregation AVG : BOOLEAN"));
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
       try {
         statement.execute(
@@ -802,7 +808,9 @@ public class IoTDBAggregationIT {
       } catch (Exception e) {
         Assert.assertTrue(
             e.getMessage(),
-            e.getMessage().contains("Unsupported data type in aggregation SUM : BOOLEAN"));
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
       try {
         statement.execute("SELECT avg(status) FROM root.ln.wf01.wt01");
@@ -812,7 +820,10 @@ public class IoTDBAggregationIT {
         }
       } catch (Exception e) {
         Assert.assertTrue(
-            e.getMessage(), e.getMessage().contains("Boolean statistics does not support: avg"));
+            e.getMessage(),
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
     } catch (Exception e) {
       e.printStackTrace();

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationLargeDataIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationLargeDataIT.java
@@ -486,14 +486,13 @@ public class IoTDBAggregationLargeDataIT {
 
   @Test
   public void minValueAggreWithSingleFilterTest() {
-    String[] retArray = new String[] {"0,0,0,0.0,B,true"};
+    String[] retArray = new String[] {"0,0,0,0.0"};
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
       boolean hasResultSet =
           statement.execute(
-              "select min_value(s0),min_value(s1),min_value(s2),"
-                  + "min_value(s3),min_value(s4) from root.vehicle.d0 "
+              "select min_value(s0),min_value(s1),min_value(s2) from root.vehicle.d0 "
                   + "where s1 < 50000 and s1 != 100");
 
       if (hasResultSet) {
@@ -507,11 +506,7 @@ public class IoTDBAggregationLargeDataIT {
                     + ","
                     + resultSet.getString(minValue(d0s1))
                     + ","
-                    + resultSet.getString(minValue(d0s2))
-                    + ","
-                    + resultSet.getString(minValue(d0s3))
-                    + ","
-                    + resultSet.getString(minValue(d0s4));
+                    + resultSet.getString(minValue(d0s2));
             Assert.assertEquals(ans, retArray[cnt]);
             cnt++;
           }
@@ -521,8 +516,7 @@ public class IoTDBAggregationLargeDataIT {
 
       hasResultSet =
           statement.execute(
-              "select min_value(s0),min_value(s1),min_value(s2),"
-                  + "min_value(s3),min_value(s4) from root.vehicle.d0 "
+              "select min_value(s0),min_value(s1),min_value(s2) from root.vehicle.d0 "
                   + "where s1 < 50000 and s1 != 100 order by time desc");
 
       if (hasResultSet) {
@@ -536,11 +530,7 @@ public class IoTDBAggregationLargeDataIT {
                     + ","
                     + resultSet.getString(minValue(d0s1))
                     + ","
-                    + resultSet.getString(minValue(d0s2))
-                    + ","
-                    + resultSet.getString(minValue(d0s3))
-                    + ","
-                    + resultSet.getString(minValue(d0s4));
+                    + resultSet.getString(minValue(d0s2));
             Assert.assertEquals(ans, retArray[cnt]);
             cnt++;
           }
@@ -555,15 +545,14 @@ public class IoTDBAggregationLargeDataIT {
 
   @Test
   public void maxValueAggreWithSingleFilterTest() {
-    String[] retArray = new String[] {"0,99,40000,122.0,fffff,true"};
+    String[] retArray = new String[] {"0,99,40000,122.0"};
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
 
       boolean hasResultSet =
           statement.execute(
-              "select max_value(s0),max_value(s1),max_value(s2),"
-                  + "max_value(s3),max_value(s4) from root.vehicle.d0 "
+              "select max_value(s0),max_value(s1),max_value(s2) from root.vehicle.d0 "
                   + "where s1 < 50000 and s1 != 100");
 
       if (hasResultSet) {
@@ -577,11 +566,7 @@ public class IoTDBAggregationLargeDataIT {
                     + ","
                     + resultSet.getString(maxValue(d0s1))
                     + ","
-                    + resultSet.getString(maxValue(d0s2))
-                    + ","
-                    + resultSet.getString(maxValue(d0s3))
-                    + ","
-                    + resultSet.getString(maxValue(d0s4));
+                    + resultSet.getString(maxValue(d0s2));
             Assert.assertEquals(ans, retArray[cnt]);
             cnt++;
           }
@@ -591,8 +576,7 @@ public class IoTDBAggregationLargeDataIT {
 
       hasResultSet =
           statement.execute(
-              "select max_value(s0),max_value(s1),max_value(s2),"
-                  + "max_value(s3),max_value(s4) from root.vehicle.d0 "
+              "select max_value(s0),max_value(s1),max_value(s2) from root.vehicle.d0 "
                   + "where s1 < 50000 and s1 != 100 order by time desc");
 
       if (hasResultSet) {
@@ -606,11 +590,7 @@ public class IoTDBAggregationLargeDataIT {
                     + ","
                     + resultSet.getString(maxValue(d0s1))
                     + ","
-                    + resultSet.getString(maxValue(d0s2))
-                    + ","
-                    + resultSet.getString(maxValue(d0s3))
-                    + ","
-                    + resultSet.getString(maxValue(d0s4));
+                    + resultSet.getString(maxValue(d0s2));
             Assert.assertEquals(ans, retArray[cnt]);
             cnt++;
           }

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationSmallDataIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationSmallDataIT.java
@@ -212,7 +212,10 @@ public class IoTDBAggregationSmallDataIT {
             "SELECT max_value(d0.s0),max_value(d1.s1),max_value(d0.s3) FROM root.vehicle");
         fail();
       } catch (IoTDBSQLException e) {
-        Assert.assertTrue(e.toString().contains("Binary statistics does not support: max"));
+        Assert.assertTrue(
+            e.toString()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
 
       boolean hasResultSet =
@@ -249,7 +252,10 @@ public class IoTDBAggregationSmallDataIT {
         statement.execute("SELECT extreme(d0.s0),extreme(d1.s1),extreme(d0.s3) FROM root.vehicle");
         fail();
       } catch (IoTDBSQLException e) {
-        Assert.assertTrue(e.toString().contains("Binary statistics does not support: max"));
+        Assert.assertTrue(
+            e.toString()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
 
       boolean hasResultSet =
@@ -608,14 +614,14 @@ public class IoTDBAggregationSmallDataIT {
 
   @Test
   public void minValueWithMultiValueFiltersTest() {
-    String[] retArray = new String[] {"0,90,180,2.22,ddddd,true"};
+    String[] retArray = new String[] {"0,90,180,2.22"};
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
       boolean hasResultSet =
           statement.execute(
-              "SELECT min_value(s0),min_value(s1),min_value(s2),"
-                  + "min_value(s3),min_value(s4) FROM root.vehicle.d0 WHERE s1 < 50000 AND s1 != 100");
+              "SELECT min_value(s0),min_value(s1),min_value(s2) FROM root.vehicle.d0 "
+                  + "WHERE s1 < 50000 AND s1 != 100");
       Assert.assertTrue(hasResultSet);
 
       try (ResultSet resultSet = statement.getResultSet()) {
@@ -628,11 +634,7 @@ public class IoTDBAggregationSmallDataIT {
                   + ","
                   + resultSet.getString(minValue(d0s1))
                   + ","
-                  + resultSet.getString(minValue(d0s2))
-                  + ","
-                  + resultSet.getString(minValue(d0s3))
-                  + ","
-                  + resultSet.getString(minValue(d0s4));
+                  + resultSet.getString(minValue(d0s2));
           Assert.assertEquals(ans, retArray[cnt]);
           cnt++;
         }
@@ -647,14 +649,13 @@ public class IoTDBAggregationSmallDataIT {
 
   @Test
   public void maxValueWithMultiValueFiltersTest() {
-    String[] retArray = new String[] {"0,99,40000,11.11,fffff,true"};
+    String[] retArray = new String[] {"0,99,40000,11.11"};
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
       boolean hasResultSet =
           statement.execute(
-              "SELECT max_value(s0),max_value(s1),max_value(s2),"
-                  + "max_value(s3),max_value(s4) FROM root.vehicle.d0 "
+              "SELECT max_value(s0),max_value(s1),max_value(s2) FROM root.vehicle.d0 "
                   + "WHERE s1 < 50000 AND s1 != 100");
 
       Assert.assertTrue(hasResultSet);
@@ -668,11 +669,7 @@ public class IoTDBAggregationSmallDataIT {
                   + ","
                   + resultSet.getString(maxValue(d0s1))
                   + ","
-                  + resultSet.getString(maxValue(d0s2))
-                  + ","
-                  + resultSet.getString(maxValue(d0s3))
-                  + ","
-                  + resultSet.getString(maxValue(d0s4));
+                  + resultSet.getString(maxValue(d0s2));
           Assert.assertEquals(retArray[cnt], ans);
           cnt++;
         }

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBUserDefinedAggregationFunctionIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBUserDefinedAggregationFunctionIT.java
@@ -611,7 +611,9 @@ public class IoTDBUserDefinedAggregationFunctionIT {
         }
       } catch (Exception e) {
         Assert.assertTrue(
-            e.getMessage().contains("Unsupported data type in aggregation AVG : TEXT"));
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
       try {
         statement.execute(
@@ -622,7 +624,9 @@ public class IoTDBUserDefinedAggregationFunctionIT {
         }
       } catch (Exception e) {
         Assert.assertTrue(
-            e.getMessage().contains("Unsupported data type in aggregation SUM : TEXT"));
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
       try {
         statement.execute(
@@ -633,7 +637,9 @@ public class IoTDBUserDefinedAggregationFunctionIT {
         }
       } catch (Exception e) {
         Assert.assertTrue(
-            e.getMessage().contains("Unsupported data type in aggregation AVG : BOOLEAN"));
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
       try {
         statement.execute(
@@ -644,7 +650,9 @@ public class IoTDBUserDefinedAggregationFunctionIT {
         }
       } catch (Exception e) {
         Assert.assertTrue(
-            e.getMessage().contains("Unsupported data type in aggregation SUM : BOOLEAN"));
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
       try {
         statement.execute("SELECT avg(status)+2 FROM root.ln.wf01.wt01");
@@ -653,7 +661,10 @@ public class IoTDBUserDefinedAggregationFunctionIT {
           fail();
         }
       } catch (Exception e) {
-        Assert.assertTrue(e.getMessage().contains("Boolean statistics does not support: avg"));
+        Assert.assertTrue(
+            e.getMessage()
+                .contains(
+                    "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]"));
       }
     } catch (Exception e) {
       e.printStackTrace();

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/AggregationQueryOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/AggregationQueryOperator.java
@@ -93,6 +93,7 @@ public class AggregationQueryOperator extends QueryOperator {
         isAlignByDevice()
             ? this.generateAlignByDevicePlan(generator)
             : super.generateRawDataQueryPlan(generator, initAggregationPlan(new AggregationPlan()));
+
     if (!verifyAllAggregationDataTypesMatched(
         isAlignByDevice()
             ? ((AlignByDevicePlan) plan).getAggregationPlan()
@@ -100,6 +101,7 @@ public class AggregationQueryOperator extends QueryOperator {
       throw new LogicalOperatorException(
           "Aggregate functions [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE]");
     }
+
     return plan;
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/TSDataType.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/TSDataType.java
@@ -121,4 +121,22 @@ public enum TSDataType {
   public byte serialize() {
     return type;
   }
+
+  /** @return whether a numeric datatype */
+  public boolean isNumeric() {
+    switch (this) {
+      case INT32:
+      case INT64:
+      case FLOAT:
+      case DOUBLE:
+        return true;
+        // For text: return the size of reference here
+      case BOOLEAN:
+      case TEXT:
+      case VECTOR:
+        return false;
+      default:
+        throw new UnSupportedDataTypeException(this.toString());
+    }
+  }
 }


### PR DESCRIPTION
Aggregate [AVG, SUM, EXTREME, MIN_VALUE, MAX_VALUE] only support numeric data types [INT32, INT64, FLOAT, DOUBLE].