### PR TITLE
[IOTDB-2365] Improve Vector performance: raw data query without value filter

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -76,35 +76,27 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
 
   @Override
   public BatchData getAllSatisfiedPageData(boolean ascending) throws IOException {
-    long[] timeBatch = timePageReader.nexTimeBatch();
-
-    // if the vector contains more than on sub sensor, the BatchData's DataType is Vector
-    List<TsPrimitiveType[]> valueBatchList = new ArrayList<>(valueCount);
-    for (ValuePageReader valuePageReader : valuePageReaderList) {
-      valueBatchList.add(
-          valuePageReader == null ? null : valuePageReader.nextValueBatch(timeBatch));
-    }
     BatchData pageData = BatchDataFactory.createBatchData(TSDataType.VECTOR, ascending, false);
-    boolean isNull;
-    // save the first not null value of each row
-    Object firstNotNullObject = null;
-    for (int i = 0; i < timeBatch.length; i++) {
-      // used to record whether the sub sensors are all null in current time
-      isNull = true;
+    int timeIndex = -1;
+    while (timePageReader.hasNextTime()) {
+      long timestamp = timePageReader.nextTime();
+      timeIndex++;
+      // if all the sub sensors' value are null in current row, just discard it
+      boolean isNull = true;
+      Object notNullObject = null;
       TsPrimitiveType[] v = new TsPrimitiveType[valueCount];
-      for (int j = 0; j < v.length; j++) {
-        v[j] = valueBatchList.get(j) == null ? null : valueBatchList.get(j)[i];
-        if (v[j] != null) {
+      for (int i = 0; i < v.length; i++) {
+        ValuePageReader pageReader = valuePageReaderList.get(i);
+        v[i] = pageReader == null ? null : pageReader.nextValue(timestamp, timeIndex);
+        if (v[i] != null) {
           isNull = false;
-          firstNotNullObject = v[j].getValue();
+          notNullObject = v[i].getValue();
         }
       }
-      // if all the sub sensors' value are null in current time
-      // or current row is not satisfied with the filter, just discard it
-      // TODO fix value filter firstNotNullObject, currently, if it's a value filter, it will only
-      // accept AlignedPath with only one sub sensor
-      if (!isNull && (filter == null || filter.satisfy(timeBatch[i], firstNotNullObject))) {
-        pageData.putVector(timeBatch[i], v);
+      // Currently, if it's a value filter, it will only accept AlignedPath with only one sub
+      // sensor
+      if (!isNull && (filter == null || filter.satisfy(timestamp, notNullObject))) {
+        pageData.putVector(timestamp, v);
       }
     }
     return pageData.flip();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/TimePageReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/TimePageReader.java
@@ -53,7 +53,15 @@ public class TimePageReader {
     this.timeBuffer = pageData;
   }
 
-  public long[] nexTimeBatch() throws IOException {
+  public boolean hasNextTime() throws IOException {
+    return timeDecoder.hasNext(timeBuffer);
+  }
+
+  public long nextTime() {
+    return timeDecoder.readLong(timeBuffer);
+  }
+
+  public long[] nextTimeBatch() throws IOException {
     long[] timeBatch = new long[(int) pageHeader.getStatistics().getCount()];
     int index = 0;
     while (timeDecoder.hasNext(timeBuffer)) {
@@ -68,7 +76,7 @@ public class TimePageReader {
    */
   public long[] getNextTimeBatch() throws IOException {
     if (pageHeader.getStatistics() != null) {
-      return nexTimeBatch();
+      return nextTimeBatch();
     } else {
       List<Long> timeList = new ArrayList<>();
       while (timeDecoder.hasNext(timeBuffer)) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/ValuePageReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/ValuePageReader.java
@@ -57,10 +57,6 @@ public class ValuePageReader {
 
   private int deleteCursor = 0;
 
-  public ValuePageReader(ByteBuffer pageData, TSDataType dataType, Decoder valueDecoder) {
-    this(null, pageData, dataType, valueDecoder);
-  }
-
   public ValuePageReader(
       PageHeader pageHeader, ByteBuffer pageData, TSDataType dataType, Decoder valueDecoder) {
     this.dataType = dataType;
@@ -135,6 +131,55 @@ public class ValuePageReader {
       }
     }
     return pageData.flip();
+  }
+
+  public TsPrimitiveType nextValue(long timestamp, int timeIndex) {
+    TsPrimitiveType resultValue = null;
+    if (valueBuffer == null || ((bitmap[timeIndex / 8] & 0xFF) & (MASK >>> (timeIndex % 8))) == 0) {
+      return null;
+    }
+    switch (dataType) {
+      case BOOLEAN:
+        boolean aBoolean = valueDecoder.readBoolean(valueBuffer);
+        if (!isDeleted(timestamp)) {
+          resultValue = new TsPrimitiveType.TsBoolean(aBoolean);
+        }
+        break;
+      case INT32:
+        int anInt = valueDecoder.readInt(valueBuffer);
+        if (!isDeleted(timestamp)) {
+          resultValue = new TsPrimitiveType.TsInt(anInt);
+        }
+        break;
+      case INT64:
+        long aLong = valueDecoder.readLong(valueBuffer);
+        if (!isDeleted(timestamp)) {
+          resultValue = new TsPrimitiveType.TsLong(aLong);
+        }
+        break;
+      case FLOAT:
+        float aFloat = valueDecoder.readFloat(valueBuffer);
+        if (!isDeleted(timestamp)) {
+          resultValue = new TsPrimitiveType.TsFloat(aFloat);
+        }
+        break;
+      case DOUBLE:
+        double aDouble = valueDecoder.readDouble(valueBuffer);
+        if (!isDeleted(timestamp)) {
+          resultValue = new TsPrimitiveType.TsDouble(aDouble);
+        }
+        break;
+      case TEXT:
+        Binary aBinary = valueDecoder.readBinary(valueBuffer);
+        if (!isDeleted(timestamp)) {
+          resultValue = new TsPrimitiveType.TsBinary(aBinary);
+        }
+        break;
+      default:
+        throw new UnSupportedDataTypeException(String.valueOf(dataType));
+    }
+
+    return resultValue;
   }
 
   /**


### PR DESCRIPTION
AlignedPageReader reads data twice in memory which leads to a bad perormance.



Performance test:

Environment:
MacOS, 6 cores 12 threads, with default configuration but close compaction.

Data:
1 storage group, 1 device, 10 time series, 100 million points each series.

Result:
SQL1 : select s1 from root.sg.d1
SQL2：select * from root.sg.d1 where time < 20000000

循环 20 次平均结果：
|                                                       | single_sensor_raw_query | 10_sensors_raw_query |
| ---------------------------------- | ----------------------- | ---------------------- |
| 对齐时间序列（未优化分支）               | 28698ms                 | 26349ms                |
| 对齐时间序列（raw_query 优化分支） | 24557ms                 | 23229ms                |
| 非对齐时间序列                                       | 20611ms                 | 22001ms                |

第一次查询无缓存结果：


 为什么单sensor时查询对齐序列比非对齐要慢？

- 对齐时间序列底部 time 和 value chunk 分开存储，因此对于单个 sensor 的查询，对齐时间序列需要查两个 chunk，而非对齐仅需要查一个chunk，所以性能会有损失。而当查询的时间序列为10个时，对齐序列需要查11个chunk，非对齐时间序列要查10个chunk，因此这种性能差距被缩小，符合实验结果。