### PR TITLE
[IOTDB-2381] Fix deadlock caused by incorrect buffer pool size counter

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
@@ -311,17 +311,16 @@ public class VirtualStorageGroupProcessor {
         // if the queue is empty and current size is less than MAX_BYTEBUFFER_NUM
         // we can construct another two more new byte buffer
         try {
-          currentWalPoolSize += 2;
           res[0] = ByteBuffer.allocateDirect(WAL_BUFFER_SIZE);
           res[1] = ByteBuffer.allocateDirect(WAL_BUFFER_SIZE);
+          currentWalPoolSize += 2;
         } catch (OutOfMemoryError e) {
+          logger.error("Allocate ByteBuffers error", e);
           if (res[0] != null) {
             MmapUtil.clean((MappedByteBuffer) res[0]);
-            currentWalPoolSize -= 1;
           }
           if (res[1] != null) {
             MmapUtil.clean((MappedByteBuffer) res[1]);
-            currentWalPoolSize -= 1;
           }
           return null;
         }


### PR DESCRIPTION
See JIRA: https://issues.apache.org/jira/browse/IOTDB-2381