### PR TITLE
[IOTDB-2323] Fix remove lock file in syncClient error

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
@@ -181,7 +181,7 @@ public class SyncClient implements ISyncClient {
                         fileLock.release();
                         randomAccessFile2.close();
                       } catch (Exception e) {
-                        logger.error("Unable to remove lock file: {}", lockFile, e);
+                        // logger.error("Unable to remove lock file: {}", lockFile, e);
                       }
                     }));
         return true;

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
@@ -63,6 +63,7 @@ import java.io.RandomAccessFile;
 import java.math.BigInteger;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileLock;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -180,8 +181,9 @@ public class SyncClient implements ISyncClient {
                       try {
                         fileLock.release();
                         randomAccessFile2.close();
+                      } catch (ClosedChannelException e) {
                       } catch (Exception e) {
-                        // logger.error("Unable to remove lock file: {}", lockFile, e);
+                        logger.error("Unable to remove lock file: {}", lockFile, e);
                       }
                     }));
         return true;


### PR DESCRIPTION
Problem:
When I try to use "ctrl+c"to exit a sync task,I met an error like below:[Connection refused is right,because the receiver does not started correctly ]

2022-01-10 11:43:00,105 [Thread-1] ERROR o.a.i.d.s.s.t.SyncClient:184 - Unable to remove lock file: /home/cluster/apache-iotdb-0.13.0-SNAPSHOT-all-bin/data/system/sync/172.20.70.25_5555/sync_lock
java.nio.channels.ClosedChannelException: null
        at sun.nio.ch.FileLockImpl.release(FileLockImpl.java:58)
        at org.apache.iotdb.db.sync.sender.transfer.SyncClient.lambda$lockInstance$0(SyncClient.java:181)
        at java.lang.Thread.run(Thread.java:748)

Solution:
  remove the error log, this error will not affect the process of sync