### PR TITLE
[IOTDB-2393] Distinguish client version via version nubmer in TSOpenSessionReq

### DIFF
--- a/client-cpp/src/main/Session.cpp
+++ b/client-cpp/src/main/Session.cpp
@@ -526,14 +526,6 @@ int8_t Session::getDataTypeNumber(TSDataType::TSDataType type) {
 
 string Session::getVersionString(Version::Version version) {
     switch (version) {
-        case Version::V_0_8:
-            return "V_0_8";
-        case Version::V_0_9:
-            return "V_0_9";
-        case Version::V_0_10:
-            return "V_0_10";
-        case Version::V_0_11:
-            return "V_0_11";
         case Version::V_0_12:
             return "V_0_12";
         case Version::V_0_13:

--- a/client-cpp/src/main/Session.cpp
+++ b/client-cpp/src/main/Session.cpp
@@ -524,6 +524,25 @@ int8_t Session::getDataTypeNumber(TSDataType::TSDataType type) {
     }
 }
 
+string Session::getVersionString(Version::Version version) {
+    switch (version) {
+        case Version::V_0_8:
+            return "V_0_8";
+        case Version::V_0_9:
+            return "V_0_9";
+        case Version::V_0_10:
+            return "V_0_10";
+        case Version::V_0_11:
+            return "V_0_11";
+        case Version::V_0_12:
+            return "V_0_12";
+        case Version::V_0_13:
+            return "V_0_13";
+        default:
+            return "V_0_12";
+    }
+}
+
 void Session::open() {
     open(false, DEFAULT_TIMEOUT_MS);
 }
@@ -556,10 +575,15 @@ void Session::open(bool enableRPCCompression, int connectionTimeoutInMs) {
         client = std::make_shared<TSIServiceClient>(protocol);
     }
 
+    std::map<std::string, std::string> configuration;
+    configuration["version"] = getVersionString(version);
+
     TSOpenSessionReq openReq;
     openReq.__set_username(username);
     openReq.__set_password(password);
     openReq.__set_zoneId(zoneId);
+    openReq.__set_configuration(configuration);
+
     try {
         TSOpenSessionResp openResp;
         client->openSession(openResp, openReq);

--- a/client-cpp/src/main/Session.h
+++ b/client-cpp/src/main/Session.h
@@ -100,7 +100,7 @@ public:
 
 namespace Version {
     enum Version {
-        V_0_8, V_0_9, V_0_10, V_0_11, V_0_12, V_0_13
+        V_0_12, V_0_13
     };
 }
 

--- a/client-cpp/src/main/Session.h
+++ b/client-cpp/src/main/Session.h
@@ -98,16 +98,24 @@ public:
     UnSupportedDataTypeException(const std::string &m) : message("UnSupported dataType: " + m) {}
 };
 
+namespace Version {
+    enum Version {
+        V_0_8, V_0_9, V_0_10, V_0_11, V_0_12, V_0_13
+    };
+}
+
 namespace CompressionType {
     enum CompressionType {
         UNCOMPRESSED, SNAPPY, GZIP, LZO, SDT, PAA, PLA, LZ4
     };
 }
+
 namespace TSDataType {
     enum TSDataType {
         BOOLEAN, INT32, INT64, FLOAT, DOUBLE, TEXT, NULLTYPE
     };
 }
+
 namespace TSEncoding {
     enum TSEncoding {
         PLAIN = 0,
@@ -121,6 +129,7 @@ namespace TSEncoding {
         GORILLA = 8
     };
 }
+
 namespace TSStatusCode {
     enum TSStatusCode {
         SUCCESS_STATUS = 200,
@@ -719,6 +728,7 @@ private:
     int fetchSize;
     const static int DEFAULT_FETCH_SIZE = 10000;
     const static int DEFAULT_TIMEOUT_MS = 0;
+    Version::Version version;
 
     bool checkSorted(const Tablet &tablet);
 
@@ -748,8 +758,10 @@ private:
         bool operator()(int i, int j) { return (timestamps[i] < timestamps[j]); };
     };
 
+    std::string getVersionString(Version::Version version);
+
 public:
-    Session(const std::string &host, int rpcPort) : username("user"), password("password") {
+    Session(const std::string &host, int rpcPort) : username("user"), password("password"), version(Version::V_0_13) {
         this->host = host;
         this->rpcPort = rpcPort;
     }
@@ -761,6 +773,7 @@ public:
         this->username = username;
         this->password = password;
         this->zoneId = "UTC+08:00";
+        this->version = Version::V_0_13;
     }
 
     Session(const std::string &host, int rpcPort, const std::string &username, const std::string &password,
@@ -771,6 +784,7 @@ public:
         this->password = password;
         this->fetchSize = fetchSize;
         this->zoneId = "UTC+08:00";
+        this->version = Version::V_0_13;
     }
 
     Session(const std::string &host, const std::string &rpcPort, const std::string &username = "user",
@@ -781,6 +795,7 @@ public:
         this->password = password;
         this->fetchSize = fetchSize;
         this->zoneId = "UTC+08:00";
+        this->version = Version::V_0_13;
     }
 
     ~Session();

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.session.SessionDataSet;
 import org.apache.iotdb.session.SessionDataSet.DataIterator;
 import org.apache.iotdb.session.template.MeasurementNode;
 import org.apache.iotdb.session.template.Template;
+import org.apache.iotdb.session.util.Version;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -57,7 +58,13 @@ public class SessionExample {
   public static void main(String[] args)
       throws IoTDBConnectionException, StatementExecutionException {
     session =
-        new Session.Builder().host(LOCAL_HOST).port(6667).username("root").password("root").build();
+        new Session.Builder()
+            .host(LOCAL_HOST)
+            .port(6667)
+            .username("root")
+            .password("root")
+            .version(Version.V_0_13)
+            .build();
     session.open(false);
 
     // set session fetchSize

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.session.SessionDataSet;
 import org.apache.iotdb.session.SessionDataSet.DataIterator;
 import org.apache.iotdb.session.template.MeasurementNode;
 import org.apache.iotdb.session.template.Template;
-import org.apache.iotdb.session.util.Version;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -58,13 +57,7 @@ public class SessionExample {
   public static void main(String[] args)
       throws IoTDBConnectionException, StatementExecutionException {
     session =
-        new Session.Builder()
-            .host(LOCAL_HOST)
-            .port(6667)
-            .username("root")
-            .password("root")
-            .version(Version.V_0_13)
-            .build();
+        new Session.Builder().host(LOCAL_HOST).port(6667).username("root").password("root").build();
     session.open(false);
 
     // set session fetchSize

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
@@ -44,6 +44,9 @@ public class Config {
   public static final int DEFAULT_FETCH_SIZE = 5000;
   static final int DEFAULT_CONNECTION_TIMEOUT_MS = 0;
 
+  public static String VERSION = "version";
+  static final Constant.Version DEFAULT_VERSION = Constant.Version.V_0_13;
+
   public static final String JDBC_DRIVER_NAME = "org.apache.iotdb.jdbc.IoTDBDriver";
 
   public static boolean rpcThriftCompressionEnable = false;

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Constant.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Constant.java
@@ -40,4 +40,14 @@ public class Constant {
       "* Num of Pages: %d, overlapped pages: %d (%.1f%%)";
   public static final String STATISTICS_RESULT_LINES = "* Lines of result: %d";
   public static final String STATISTICS_PRC_INFO = "* Num of RPC: %d, avg cost: %d ms";
+
+  // version number
+  public enum Version {
+    V_0_8,
+    V_0_9,
+    V_0_10,
+    V_0_11,
+    V_0_12,
+    V_0_13
+  }
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Constant.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Constant.java
@@ -43,10 +43,6 @@ public class Constant {
 
   // version number
   public enum Version {
-    V_0_8,
-    V_0_9,
-    V_0_10,
-    V_0_11,
     V_0_12,
     V_0_13
   }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -463,6 +463,7 @@ public class IoTDBConnection implements Connection {
     openReq.setUsername(params.getUsername());
     openReq.setPassword(params.getPassword());
     openReq.setZoneId(getTimeZone());
+    openReq.putToConfiguration("version", params.getVersion().toString());
 
     TSOpenSessionResp openResp = null;
     try {

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
@@ -28,6 +28,8 @@ public class IoTDBConnectionParams {
   private String seriesName = Config.DEFAULT_SERIES_NAME;
   private String username = Config.DEFAULT_USER;
   private String password = Config.DEFAULT_PASSWORD;
+
+  // The version number of the client which used for compatible in server
   private Constant.Version version = Config.DEFAULT_VERSION;
 
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
@@ -29,7 +29,7 @@ public class IoTDBConnectionParams {
   private String username = Config.DEFAULT_USER;
   private String password = Config.DEFAULT_PASSWORD;
 
-  // The version number of the client which used for compatible in server
+  // The version number of the client which used for compatibility in the server
   private Constant.Version version = Config.DEFAULT_VERSION;
 
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
@@ -28,6 +28,7 @@ public class IoTDBConnectionParams {
   private String seriesName = Config.DEFAULT_SERIES_NAME;
   private String username = Config.DEFAULT_USER;
   private String password = Config.DEFAULT_PASSWORD;
+  private Constant.Version version = Config.DEFAULT_VERSION;
 
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;
   private int thriftMaxFrameSize = RpcUtils.THRIFT_FRAME_MAX_SIZE;
@@ -98,5 +99,13 @@ public class IoTDBConnectionParams {
 
   public void setThriftMaxFrameSize(int thriftMaxFrameSize) {
     this.thriftMaxFrameSize = thriftMaxFrameSize;
+  }
+
+  public Constant.Version getVersion() {
+    return version;
+  }
+
+  public void setVersion(Constant.Version version) {
+    this.version = version;
   }
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
@@ -71,6 +71,9 @@ public class Utils {
       params.setThriftMaxFrameSize(
           Integer.parseInt(info.getProperty(Config.THRIFT_FRAME_MAX_SIZE)));
     }
+    if (info.containsKey(Config.VERSION)) {
+      params.setVersion(Constant.Version.valueOf(info.getProperty(Config.VERSION)));
+    }
 
     return params;
   }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -176,10 +176,6 @@ public class IoTDBConstant {
 
   // client version number
   public enum ClientVersion {
-    V_0_8,
-    V_0_9,
-    V_0_10,
-    V_0_11,
     V_0_12,
     V_0_13
   }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -173,4 +173,14 @@ public class IoTDBConstant {
 
   // compaction
   public static final String COMPACTION_TMP_FILE_SUFFIX = ".target";
+
+  // client version number
+  public enum ClientVersion {
+    V_0_8,
+    V_0_9,
+    V_0_10,
+    V_0_11,
+    V_0_12,
+    V_0_13
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.query.control;
 
+import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.query.dataset.UDTFDataSet;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
@@ -54,6 +55,10 @@ public class SessionManager {
   // (queryId -> QueryDataSet)
   private final Map<Long, QueryDataSet> queryIdToDataSet = new ConcurrentHashMap<>();
 
+  // (queryId -> client version number)
+  private final Map<Long, IoTDBConstant.ClientVersion> sessionIdToClientVersion =
+      new ConcurrentHashMap<>();
+
   protected SessionManager() {
     // singleton
   }
@@ -75,18 +80,21 @@ public class SessionManager {
     }
   }
 
-  public long requestSessionId(String username, String zoneId) {
+  public long requestSessionId(
+      String username, String zoneId, IoTDBConstant.ClientVersion clientVersion) {
     long sessionId = sessionIdGenerator.incrementAndGet();
 
     currSessionId.set(sessionId);
     sessionIdToUsername.put(sessionId, username);
     sessionIdToZoneId.put(sessionId, ZoneId.of(zoneId));
+    sessionIdToClientVersion.put(sessionId, clientVersion);
 
     return sessionId;
   }
 
   public boolean releaseSessionResource(long sessionId) {
     sessionIdToZoneId.remove(sessionId);
+    sessionIdToClientVersion.remove(sessionId);
 
     Set<Long> statementIdSet = sessionIdToStatementId.remove(sessionId);
     if (statementIdSet != null) {

--- a/server/src/main/java/org/apache/iotdb/db/service/basic/ServiceProvider.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/basic/ServiceProvider.java
@@ -145,7 +145,11 @@ public abstract class ServiceProvider {
   }
 
   public BasicOpenSessionResp openSession(
-      String username, String password, String zoneId, TSProtocolVersion tsProtocolVersion)
+      String username,
+      String password,
+      String zoneId,
+      TSProtocolVersion tsProtocolVersion,
+      IoTDBConstant.ClientVersion clientVersion)
       throws TException {
     BasicOpenSessionResp openSessionResp = new BasicOpenSessionResp();
 
@@ -179,7 +183,8 @@ public abstract class ServiceProvider {
       openSessionResp.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
       openSessionResp.setMessage("Login successfully");
 
-      sessionId = SESSION_MANAGER.requestSessionId(username, zoneId);
+      sessionId = SESSION_MANAGER.requestSessionId(username, zoneId, clientVersion);
+
       LOGGER.info(
           "{}: Login status: {}. User : {}, opens Session-{}",
           IoTDBConstant.GLOBAL_DB_NAME,
@@ -190,12 +195,19 @@ public abstract class ServiceProvider {
       openSessionResp.setMessage(loginMessage != null ? loginMessage : "Authentication failed.");
       openSessionResp.setCode(TSStatusCode.WRONG_LOGIN_PASSWORD_ERROR.getStatusCode());
 
-      sessionId = SESSION_MANAGER.requestSessionId(username, zoneId);
+      sessionId = SESSION_MANAGER.requestSessionId(username, zoneId, clientVersion);
       AUDIT_LOGGER.info("User {} opens Session failed with an incorrect password", username);
     }
 
     SessionTimeoutManager.getInstance().register(sessionId);
     return openSessionResp.sessionId(sessionId);
+  }
+
+  public BasicOpenSessionResp openSession(
+      String username, String password, String zoneId, TSProtocolVersion tsProtocolVersion)
+      throws TException {
+    return openSession(
+        username, password, zoneId, tsProtocolVersion, IoTDBConstant.ClientVersion.V_0_12);
   }
 
   public boolean closeSession(long sessionId) {

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -250,11 +250,21 @@ public class TSServiceImpl implements TSIService.Iface {
 
   @Override
   public TSOpenSessionResp openSession(TSOpenSessionReq req) throws TException {
+    IoTDBConstant.ClientVersion clientVersion = parseClientVersion(req);
     BasicOpenSessionResp openSessionResp =
-        serviceProvider.openSession(req.username, req.password, req.zoneId, req.client_protocol);
+        serviceProvider.openSession(
+            req.username, req.password, req.zoneId, req.client_protocol, clientVersion);
     TSStatus tsStatus = RpcUtils.getStatus(openSessionResp.getCode(), openSessionResp.getMessage());
     TSOpenSessionResp resp = new TSOpenSessionResp(tsStatus, CURRENT_RPC_VERSION);
     return resp.setSessionId(openSessionResp.getSessionId());
+  }
+
+  private IoTDBConstant.ClientVersion parseClientVersion(TSOpenSessionReq req) {
+    Map<String, String> configuration = req.configuration;
+    if (configuration != null && configuration.containsKey("version")) {
+      return IoTDBConstant.ClientVersion.valueOf(configuration.get("version"));
+    }
+    return IoTDBConstant.ClientVersion.V_0_12;
   }
 
   @Override

--- a/session/src/main/java/org/apache/iotdb/session/Config.java
+++ b/session/src/main/java/org/apache/iotdb/session/Config.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iotdb.session;
 
+import org.apache.iotdb.session.util.Version;
+
 public class Config {
 
   public static final String DEFAULT_HOST = "localhost";
@@ -42,4 +44,6 @@ public class Config {
   public static final int DEFAULT_MAX_FRAME_SIZE = 67108864;
 
   public static final int DEFAULT_SESSION_POOL_MAX_SIZE = 5;
+
+  public static final Version DEFAULT_VERSION = Version.V_0_13;
 }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -131,7 +131,7 @@ public class Session {
 
   protected boolean enableQueryRedirection = false;
 
-  // The version number of the client which used for compatible in server
+  // The version number of the client which used for compatibility in the server
   protected Version version;
 
   public Session(String host, int rpcPort) {

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -47,6 +47,7 @@ import org.apache.iotdb.session.template.Template;
 import org.apache.iotdb.session.template.TemplateQueryType;
 import org.apache.iotdb.session.util.SessionUtils;
 import org.apache.iotdb.session.util.ThreadUtils;
+import org.apache.iotdb.session.util.Version;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -130,6 +131,9 @@ public class Session {
 
   protected boolean enableQueryRedirection = false;
 
+  /** */
+  protected Version version;
+
   public Session(String host, int rpcPort) {
     this(
         host,
@@ -140,7 +144,8 @@ public class Session {
         null,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        Config.DEFAULT_CACHE_LEADER_MODE);
+        Config.DEFAULT_CACHE_LEADER_MODE,
+        Config.DEFAULT_VERSION);
   }
 
   public Session(String host, String rpcPort, String username, String password) {
@@ -153,7 +158,8 @@ public class Session {
         null,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        Config.DEFAULT_CACHE_LEADER_MODE);
+        Config.DEFAULT_CACHE_LEADER_MODE,
+        Config.DEFAULT_VERSION);
   }
 
   public Session(String host, int rpcPort, String username, String password) {
@@ -166,7 +172,8 @@ public class Session {
         null,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        Config.DEFAULT_CACHE_LEADER_MODE);
+        Config.DEFAULT_CACHE_LEADER_MODE,
+        Config.DEFAULT_VERSION);
   }
 
   public Session(String host, int rpcPort, String username, String password, int fetchSize) {
@@ -179,7 +186,8 @@ public class Session {
         null,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        Config.DEFAULT_CACHE_LEADER_MODE);
+        Config.DEFAULT_CACHE_LEADER_MODE,
+        Config.DEFAULT_VERSION);
   }
 
   public Session(
@@ -198,7 +206,8 @@ public class Session {
         null,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        Config.DEFAULT_CACHE_LEADER_MODE);
+        Config.DEFAULT_CACHE_LEADER_MODE,
+        Config.DEFAULT_VERSION);
     this.queryTimeoutInMs = queryTimeoutInMs;
   }
 
@@ -212,7 +221,8 @@ public class Session {
         zoneId,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        Config.DEFAULT_CACHE_LEADER_MODE);
+        Config.DEFAULT_CACHE_LEADER_MODE,
+        Config.DEFAULT_VERSION);
   }
 
   public Session(
@@ -226,7 +236,8 @@ public class Session {
         null,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        enableCacheLeader);
+        enableCacheLeader,
+        Config.DEFAULT_VERSION);
   }
 
   public Session(
@@ -246,7 +257,8 @@ public class Session {
         zoneId,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        enableCacheLeader);
+        enableCacheLeader,
+        Config.DEFAULT_VERSION);
   }
 
   @SuppressWarnings("squid:S107")
@@ -259,7 +271,8 @@ public class Session {
       ZoneId zoneId,
       int thriftDefaultBufferSize,
       int thriftMaxFrameSize,
-      boolean enableCacheLeader) {
+      boolean enableCacheLeader,
+      Version version) {
     this.defaultEndPoint = new EndPoint(host, rpcPort);
     this.username = username;
     this.password = password;
@@ -268,6 +281,7 @@ public class Session {
     this.thriftDefaultBufferSize = thriftDefaultBufferSize;
     this.thriftMaxFrameSize = thriftMaxFrameSize;
     this.enableCacheLeader = enableCacheLeader;
+    this.version = version;
   }
 
   public Session(List<String> nodeUrls, String username, String password) {
@@ -279,7 +293,8 @@ public class Session {
         null,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        Config.DEFAULT_CACHE_LEADER_MODE);
+        Config.DEFAULT_CACHE_LEADER_MODE,
+        Config.DEFAULT_VERSION);
   }
 
   /**
@@ -296,7 +311,8 @@ public class Session {
         null,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        Config.DEFAULT_CACHE_LEADER_MODE);
+        Config.DEFAULT_CACHE_LEADER_MODE,
+        Config.DEFAULT_VERSION);
   }
 
   public Session(List<String> nodeUrls, String username, String password, ZoneId zoneId) {
@@ -308,7 +324,8 @@ public class Session {
         zoneId,
         Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
         Config.DEFAULT_MAX_FRAME_SIZE,
-        Config.DEFAULT_CACHE_LEADER_MODE);
+        Config.DEFAULT_CACHE_LEADER_MODE,
+        Config.DEFAULT_VERSION);
   }
 
   public Session(
@@ -319,7 +336,8 @@ public class Session {
       ZoneId zoneId,
       int thriftDefaultBufferSize,
       int thriftMaxFrameSize,
-      boolean enableCacheLeader) {
+      boolean enableCacheLeader,
+      Version version) {
     this.nodeUrls = nodeUrls;
     this.username = username;
     this.password = password;
@@ -328,6 +346,7 @@ public class Session {
     this.thriftDefaultBufferSize = thriftDefaultBufferSize;
     this.thriftMaxFrameSize = thriftMaxFrameSize;
     this.enableCacheLeader = enableCacheLeader;
+    this.version = version;
   }
 
   public void setFetchSize(int fetchSize) {
@@ -336,6 +355,14 @@ public class Session {
 
   public int getFetchSize() {
     return this.fetchSize;
+  }
+
+  public Version getVersion() {
+    return version;
+  }
+
+  public void setVersion(Version version) {
+    this.version = version;
   }
 
   public synchronized void open() throws IoTDBConnectionException {
@@ -2248,6 +2275,8 @@ public class Session {
     private int thriftDefaultBufferSize = Config.DEFAULT_INITIAL_BUFFER_CAPACITY;
     private int thriftMaxFrameSize = Config.DEFAULT_MAX_FRAME_SIZE;
     private boolean enableCacheLeader = Config.DEFAULT_CACHE_LEADER_MODE;
+    private Version version = Config.DEFAULT_VERSION;
+
     List<String> nodeUrls = null;
 
     public Builder host(String host) {
@@ -2300,6 +2329,11 @@ public class Session {
       return this;
     }
 
+    public Builder version(Version version) {
+      this.version = version;
+      return this;
+    }
+
     public Session build() {
       if (nodeUrls != null
           && (!Config.DEFAULT_HOST.equals(host) || rpcPort != Config.DEFAULT_PORT)) {
@@ -2316,7 +2350,8 @@ public class Session {
             zoneId,
             thriftDefaultBufferSize,
             thriftMaxFrameSize,
-            enableCacheLeader);
+            enableCacheLeader,
+            version);
       }
 
       return new Session(
@@ -2328,7 +2363,8 @@ public class Session {
           zoneId,
           thriftDefaultBufferSize,
           thriftMaxFrameSize,
-          enableCacheLeader);
+          enableCacheLeader,
+          version);
     }
   }
 }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -131,7 +131,7 @@ public class Session {
 
   protected boolean enableQueryRedirection = false;
 
-  /** */
+  // The version number of the client which used for compatible in server
   protected Version version;
 
   public Session(String host, int rpcPort) {

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -126,6 +126,7 @@ public class SessionConnection {
     openReq.setUsername(session.username);
     openReq.setPassword(session.password);
     openReq.setZoneId(zoneId.toString());
+    openReq.putToConfiguration("version", session.version.toString());
 
     try {
       TSOpenSessionResp openResp = client.openSession(openReq);

--- a/session/src/main/java/org/apache/iotdb/session/util/Version.java
+++ b/session/src/main/java/org/apache/iotdb/session/util/Version.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.session.util;
+
+public enum Version {
+  V_0_8,
+  V_0_9,
+  V_0_10,
+  V_0_11,
+  V_0_12,
+  V_0_13
+}

--- a/session/src/main/java/org/apache/iotdb/session/util/Version.java
+++ b/session/src/main/java/org/apache/iotdb/session/util/Version.java
@@ -20,10 +20,6 @@
 package org.apache.iotdb.session.util;
 
 public enum Version {
-  V_0_8,
-  V_0_9,
-  V_0_10,
-  V_0_11,
   V_0_12,
   V_0_13
 }

--- a/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
@@ -1084,7 +1084,8 @@ public class SessionCacheLeaderUT {
           null,
           Config.DEFAULT_INITIAL_BUFFER_CAPACITY,
           Config.DEFAULT_MAX_FRAME_SIZE,
-          enableCacheLeader);
+          enableCacheLeader,
+          Config.DEFAULT_VERSION);
     }
 
     @Override

--- a/session/src/test/java/org/apache/iotdb/session/SessionTest.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionTest.java
@@ -523,7 +523,7 @@ public class SessionTest {
             .thriftMaxFrameSize(3)
             .enableCacheLeader(true)
             .zoneId(ZoneOffset.UTC)
-            .version(Version.V_0_13)
+            .version(Version.V_0_12)
             .build();
 
     assertEquals(1, session.fetchSize);
@@ -533,10 +533,11 @@ public class SessionTest {
     assertEquals(3, session.thriftMaxFrameSize);
     assertEquals(ZoneOffset.UTC, session.zoneId);
     assertTrue(session.enableCacheLeader);
-    assertEquals(Version.V_0_13, session.version);
+    assertEquals(Version.V_0_12, session.version);
 
     session = new Session.Builder().nodeUrls(Arrays.asList("aaa.com:12", "bbb.com:12")).build();
     assertEquals(Arrays.asList("aaa.com:12", "bbb.com:12"), session.nodeUrls);
+    assertEquals(Version.V_0_13, session.version);
 
     try {
       session =

--- a/session/src/test/java/org/apache/iotdb/session/SessionTest.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionTest.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.session.template.InternalNode;
 import org.apache.iotdb.session.template.MeasurementNode;
 import org.apache.iotdb.session.template.Template;
 import org.apache.iotdb.session.template.TemplateNode;
+import org.apache.iotdb.session.util.Version;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -522,6 +523,7 @@ public class SessionTest {
             .thriftMaxFrameSize(3)
             .enableCacheLeader(true)
             .zoneId(ZoneOffset.UTC)
+            .version(Version.V_0_13)
             .build();
 
     assertEquals(1, session.fetchSize);
@@ -531,6 +533,7 @@ public class SessionTest {
     assertEquals(3, session.thriftMaxFrameSize);
     assertEquals(ZoneOffset.UTC, session.zoneId);
     assertTrue(session.enableCacheLeader);
+    assertEquals(Version.V_0_13, session.version);
 
     session = new Session.Builder().nodeUrls(Arrays.asList("aaa.com:12", "bbb.com:12")).build();
     assertEquals(Arrays.asList("aaa.com:12", "bbb.com:12"), session.nodeUrls);


### PR DESCRIPTION
To be compatible with different version clients, we need to obtain the version number of the client in the IoTDB server.