### PR TITLE
[IOTDB-2363] LEVEL can be specified at non-last level in metadata queries

### DIFF
--- a/docs/UserGuide/IoTDB-SQL-Language/DDL-Data-Definition-Language.md
+++ b/docs/UserGuide/IoTDB-SQL-Language/DDL-Data-Definition-Language.md
@@ -412,12 +412,17 @@ Example：
 
 ### Count Nodes
 
-IoTDB is able to use `COUNT NODES <PathPattern> LEVEL=<INTEGER>` to count the number of nodes at the given level in current Metadata Tree. This could be used to query the number of devices. The usage are as follows:
+IoTDB is able to use `COUNT NODES <PathPattern> LEVEL=<INTEGER>` to count the number of nodes at
+ the given level in current Metadata Tree considering a given pattern. IoTDB will find paths that
+  match the pattern and counts distinct nodes at the specified level among the matched paths.
+  This could be used to query the number of devices with specified measurements. The usage are as
+   follows:
 
 ```
 IoTDB > COUNT NODES root.** LEVEL=2
 IoTDB > COUNT NODES root.ln.** LEVEL=2
 IoTDB > COUNT NODES root.ln.wf01.** LEVEL=3
+IoTDB > COUNT NODES root.**.temperature LEVEL=3
 ```
 
 As for the above mentioned example and Metadata tree, you can get following results:
@@ -443,6 +448,14 @@ It costs 0.002s
 |count|
 +-----+
 |    1|
++-----+
+Total line number = 1
+It costs 0.002s
+
++-----+
+|count|
++-----+
+|    2|
 +-----+
 Total line number = 1
 It costs 0.002s

--- a/docs/zh/UserGuide/IoTDB-SQL-Language/DDL-Data-Definition-Language.md
+++ b/docs/zh/UserGuide/IoTDB-SQL-Language/DDL-Data-Definition-Language.md
@@ -421,12 +421,14 @@ SHOW CHILD NODES pathPattern
 
 ### 统计节点数
 
-IoTDB 支持使用`COUNT NODES <PathPattern> LEVEL=<INTEGER>`来统计当前 Metadata 树下指定层级的节点个数，这条语句可以用来统计设备数。例如：
+IoTDB 支持使用`COUNT NODES <PathPattern> LEVEL=<INTEGER>`来统计当前 Metadata
+ 树下满足某路径模式的路径中指定层级的节点个数。这条语句可以用来统计带有特定采样点的设备数。例如：
 
 ```
 IoTDB > COUNT NODES root.** LEVEL=2
 IoTDB > COUNT NODES root.ln.** LEVEL=2
 IoTDB > COUNT NODES root.ln.wf01.* LEVEL=3
+IoTDB > COUNT NODES root.**.temperature LEVEL=3
 ```
 
 对于上面提到的例子和 Metadata Tree，你可以获得如下结果：
@@ -452,6 +454,14 @@ It costs 0.002s
 |count|
 +-----+
 |    1|
++-----+
+Total line number = 1
+It costs 0.002s
+
++-----+
+|count|
++-----+
+|    2|
 +-----+
 Total line number = 1
 It costs 0.002s

--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
@@ -578,7 +578,7 @@ public class IoTDBMetadataFetchIT {
             "COUNT NODES root.ln.wf01.* level=3",
             "COUNT NODES root.ln.wf01.* level=4"
           };
-      String[] standards = new String[] {"3,\n", "1,\n", "0,\n", "0,\n", "2,\n", "0,\n"};
+      String[] standards = new String[] {"3,\n", "1,\n", "1,\n", "1,\n", "2,\n", "0,\n"};
       for (int n = 0; n < sqls.length; n++) {
         String sql = sqls[n];
         String standard = standards[n];

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MNodeCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MNodeCollector.java
@@ -27,11 +27,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * This class defines any node in MTree as potential target node.
- * On finding a path matching the given pattern, if a level is specified and the path is longer
- * than the specified level, MNodeLevelCounter finds the node of the specified level on the path
- * and process it. The same node will not be processed more than once.
- * If a level is not given, the current node is processed.
+ * This class defines any node in MTree as potential target node. On finding a path matching the
+ * given pattern, if a level is specified and the path is longer than the specified level,
+ * MNodeLevelCounter finds the node of the specified level on the path and process it. The same node
+ * will not be processed more than once. If a level is not given, the current node is processed.
  */
 public abstract class MNodeCollector<T> extends CollectorTraverser<T> {
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MNodeCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MNodeCollector.java
@@ -26,7 +26,13 @@ import org.apache.iotdb.db.metadata.path.PartialPath;
 import java.util.HashSet;
 import java.util.Set;
 
-// This class defines any node in MTree as potential target node.
+/**
+ * This class defines any node in MTree as potential target node.
+ * On finding a path matching the given pattern, if a level is specified and the path is longer
+ * than the specified level, MNodeLevelCounter finds the node of the specified level on the path
+ * and process it. The same node will not be processed more than once.
+ * If a level is not given, the current node is processed.
+ */
 public abstract class MNodeCollector<T> extends CollectorTraverser<T> {
 
   // traverse for specific storage group

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MNodeLevelCounter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MNodeLevelCounter.java
@@ -25,7 +25,14 @@ import org.apache.iotdb.db.metadata.path.PartialPath;
 import java.util.HashSet;
 import java.util.Set;
 
-// This node implements node count function.
+//
+
+/**
+ * This Traverser implements node count function.
+ * On finding a path matching the given pattern, if the path is longer than the specified level,
+ * MNodeLevelCounter finds the node of the specified level on the path and counts it. The same node
+ * will not be counted more than once.
+ */
 public class MNodeLevelCounter extends CounterTraverser {
 
   // level query option

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MNodeLevelCounter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MNodeLevelCounter.java
@@ -22,11 +22,16 @@ import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 
+import java.util.HashSet;
+import java.util.Set;
+
 // This node implements node count function.
 public class MNodeLevelCounter extends CounterTraverser {
 
   // level query option
   protected int targetLevel;
+
+  private Set<IMNode> processedNodes = new HashSet<>();
 
   public MNodeLevelCounter(IMNode startNode, PartialPath path, int targetLevel)
       throws MetadataException {
@@ -41,11 +46,19 @@ public class MNodeLevelCounter extends CounterTraverser {
 
   @Override
   protected boolean processFullMatchedMNode(IMNode node, int idx, int level) {
-    if (level == targetLevel) {
-      count++;
-      return true;
-    } else {
+    // move the cursor the given level when matched
+    if (level < targetLevel) {
       return false;
     }
+    while (level > targetLevel) {
+      node = node.getParent();
+      level--;
+    }
+    // record processed node so they will not be processed twice
+    if (!processedNodes.contains(node)) {
+      processedNodes.add(node);
+      count++;
+    }
+    return true;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MNodeLevelCounter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MNodeLevelCounter.java
@@ -28,10 +28,9 @@ import java.util.Set;
 //
 
 /**
- * This Traverser implements node count function.
- * On finding a path matching the given pattern, if the path is longer than the specified level,
- * MNodeLevelCounter finds the node of the specified level on the path and counts it. The same node
- * will not be counted more than once.
+ * This Traverser implements node count function. On finding a path matching the given pattern, if
+ * the path is longer than the specified level, MNodeLevelCounter finds the node of the specified
+ * level on the path and counts it. The same node will not be counted more than once.
  */
 public class MNodeLevelCounter extends CounterTraverser {
 

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -446,9 +446,9 @@ public class MTreeTest {
       Set<String> result1 = root.getChildNodeNameInNextLevel(new PartialPath("root.a.d0"));
       Set<String> result2 = root.getChildNodeNameInNextLevel(new PartialPath("root.a"));
       Set<String> result3 = root.getChildNodeNameInNextLevel(new PartialPath("root"));
-      assertEquals(result1, new HashSet<>(Arrays.asList("s0", "s1")));
-      assertEquals(result2, new HashSet<>(Arrays.asList("d0", "d5")));
-      assertEquals(result3, new HashSet<>(Arrays.asList("a")));
+      assertEquals(new HashSet<>(Arrays.asList("s0", "s1")), result1);
+      assertEquals(new HashSet<>(Arrays.asList("d0", "d5")), result2);
+      assertEquals(new HashSet<>(Collections.singletonList("a")), result3);
 
       // if child node is nll   will return  null HashSet
       Set<String> result5 = root.getChildNodeNameInNextLevel(new PartialPath("root.a.d5"));
@@ -693,6 +693,9 @@ public class MTreeTest {
       assertEquals(2, root.getAllTimeseriesCount(new PartialPath("root.laptop.*.s1")));
       assertEquals(0, root.getAllTimeseriesCount(new PartialPath("root.laptop.d1.s3")));
 
+      assertEquals(1, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.**.s1"), 1));
+      assertEquals(1, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.*.*"), 1));
+      assertEquals(2, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.*.*"), 2));
       assertEquals(2, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.*"), 2));
       assertEquals(4, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.*.*"), 3));
       assertEquals(2, root.getNodesCountInGivenLevel(new PartialPath("root.laptop.**"), 2));
@@ -935,6 +938,10 @@ public class MTreeTest {
         2, root.getNodesListInGivenLevel(new PartialPath("root.**"), 3, filter).size());
     Assert.assertEquals(
         2, root.getNodesListInGivenLevel(new PartialPath("root.*.*"), 2, null).size());
+    Assert.assertEquals(
+        2, root.getNodesListInGivenLevel(new PartialPath("root.*.*"), 1, null).size());
+    Assert.assertEquals(
+        2, root.getNodesListInGivenLevel(new PartialPath("root.*.*.s1"), 2, null).size());
     Assert.assertEquals(
         1, root.getNodesListInGivenLevel(new PartialPath("root.*.**"), 2, filter).size());
   }


### PR DESCRIPTION
Please refer to https://issues.apache.org/jira/browse/IOTDB-2363.
Before:
![image](https://user-images.githubusercontent.com/23610645/149604812-25bcc388-ece5-439b-88da-0be239610f61.png)

After:
![image](https://user-images.githubusercontent.com/23610645/149604817-4dd77e13-7f4b-469e-8214-ae1798f6053f.png)
