### PR TITLE
[IOTDB-2406] Incorrect docs; Incorrect error-log

### DIFF
--- a/docs/UserGuide/System-Tools/Load-External-Tsfile.md
+++ b/docs/UserGuide/System-Tools/Load-External-Tsfile.md
@@ -73,22 +73,20 @@ Examples:
 
 #### remove a tsfile
 
-The command to delete a tsfile is: `remove "<path>"`.
+The command to delete a tsfile is: `remove '<path>'`.
 
 This command deletes a tsfile by specifying the file path. The specific implementation is to delete the tsfile and its corresponding `.resource` and` .modification` files.
 
 Examples:
 
-* `remove 'root.vehicle/1575028885956-101-0.tsfile'`
-* `remove '1575028885956-101-0.tsfile'`
+* `remove '/Users/Desktop/data/data/root.vehicle/0/0/1575028885956-101-0.tsfile'`
 
 #### unload a tsfile and move it to a target directory
 
-The command to unload a tsfile and move it to target directory is: `unload "<path>" "<dir>"`.
+The command to unload a tsfile and move it to target directory is: `unload '<path>' '<dir>'`.
 
 This command unload a tsfile and move it to a target directory by specifying tsfile path and the target directory(absolute path). The specific implementation is to remove the tsfile from the engine and move the tsfile file and its corresponding `.resource` file to the target directory.
 
 Examples:
 
-* `unload 'root.vehicle/1575029224130-101-0.tsfile' '/data/data/tmp'`
-* `unload '1575029224130-101-0.tsfile' '/data/data/tmp'`
+* `unload '/Users/Desktop/data/data/root.vehicle/0/0/1575028885956-101-0.tsfile' '/data/data/tmp'`

--- a/docs/zh/UserGuide/System-Tools/Load-External-Tsfile.md
+++ b/docs/zh/UserGuide/System-Tools/Load-External-Tsfile.md
@@ -31,7 +31,7 @@
 
 #### 加载 tsfile 文件
 
-加载 tsfile 文件的指令为：`load <path/dir> [autoregister=true/false][,sglevel=int][,verify=true/false]`
+加载 tsfile 文件的指令为：`load '<path/dir>' [autoregister=true/false][,sglevel=int][,verify=true/false]`
 
 该指令有两种用法：
 
@@ -74,22 +74,20 @@ VERIFY 选项表示是否对载入的 tsfile 中的所有时间序列进行元�
 
 #### 删除 tsfile 文件
 
-删除 tsfile 文件的指令为：`remove "<path>"`
+删除 tsfile 文件的指令为：`remove '<path>'`
 
 该指令通过指定文件路径删除 tsfile 文件，具体做法是将该 tsfile 和其对应的`.resource`和`.modification`文件全部删除。
 
 示例：
 
-* `remove 'root.vehicle/1575028885956-101-0.tsfile'`
-* `remove '1575028885956-101-0.tsfile'`
+* `remove '/Users/Desktop/data/data/root.vehicle/0/0/1575028885956-101-0.tsfile'`
 
 #### 卸载 tsfile 文件至指定目录
 
-卸载 tsfile 文件的指令为：`unload "<path>" "<dir>"`
+卸载 tsfile 文件的指令为：`unload '<path>' '<dir>'`
 
 该指令将指定路径的 tsfile 文件卸载并移动至目标文件夹（绝对路径）中，具体做法是在引擎中卸载该 tsfile，并将该 tsfile 文件和其对应的`.resource`文件移动到目标文件夹下
 
 示例：
 
-* `unload 'root.vehicle/1575029224130-101-0.tsfile' '/data/data/tmp'`
-* `unload '1575029224130-101-0.tsfile' '/data/data/tmp'`
+* `unload '/Users/Desktop/data/data/root.vehicle/0/0/1575028885956-101-0.tsfile' '/data/data/tmp'`

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -950,8 +950,19 @@ public class StorageEngine implements IService {
    * @param file internal file
    * @return sg name
    */
-  public String getSgByEngineFile(File file) {
-    return file.getParentFile().getParentFile().getParentFile().getName();
+  public String getSgByEngineFile(File file) throws IllegalPathException {
+    File dataDir =
+        file.getParentFile().getParentFile().getParentFile().getParentFile().getParentFile();
+    if (dataDir.exists()) {
+      String[] dataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();
+      for (String dir : dataDirs) {
+        File f = new File(dir);
+        if (dataDir.getAbsolutePath().equals(f.getAbsolutePath())) {
+          return file.getParentFile().getParentFile().getParentFile().getName();
+        }
+      }
+    }
+    throw new IllegalPathException(file.getAbsolutePath(), "it's not an internal tsfile.");
   }
 
   /** @return TsFiles (seq or unseq) grouped by their storage group and partition number. */

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -948,7 +948,10 @@ public class StorageEngine implements IService {
    * files which are not loaded.
    *
    * @param file internal file
+   * @param needCheck check if the tsfile is an internal TsFile. If you make sure it is inside, no
+   *     need to check
    * @return sg name
+   * @throws IllegalPathException throw if tsfile is not an internal TsFile
    */
   public String getSgByEngineFile(File file, boolean needCheck) throws IllegalPathException {
     if (needCheck) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -909,7 +909,7 @@ public class StorageEngine implements IService {
 
   public void loadNewTsFileForSync(TsFileResource newTsFileResource)
       throws StorageEngineException, LoadFileException, IllegalPathException {
-    getProcessorDirectly(new PartialPath(getSgByEngineFile(newTsFileResource.getTsFile())))
+    getProcessorDirectly(new PartialPath(getSgByEngineFile(newTsFileResource.getTsFile(), false)))
         .loadNewTsFileForSync(newTsFileResource);
   }
 
@@ -927,19 +927,19 @@ public class StorageEngine implements IService {
 
   public boolean deleteTsfileForSync(File deletedTsfile)
       throws StorageEngineException, IllegalPathException {
-    return getProcessorDirectly(new PartialPath(getSgByEngineFile(deletedTsfile)))
+    return getProcessorDirectly(new PartialPath(getSgByEngineFile(deletedTsfile, false)))
         .deleteTsfile(deletedTsfile);
   }
 
   public boolean deleteTsfile(File deletedTsfile)
       throws StorageEngineException, IllegalPathException {
-    return getProcessorDirectly(new PartialPath(getSgByEngineFile(deletedTsfile)))
+    return getProcessorDirectly(new PartialPath(getSgByEngineFile(deletedTsfile, true)))
         .deleteTsfile(deletedTsfile);
   }
 
   public boolean unloadTsfile(File tsfileToBeUnloaded, File targetDir)
       throws StorageEngineException, IllegalPathException {
-    return getProcessorDirectly(new PartialPath(getSgByEngineFile(tsfileToBeUnloaded)))
+    return getProcessorDirectly(new PartialPath(getSgByEngineFile(tsfileToBeUnloaded, true)))
         .unloadTsfile(tsfileToBeUnloaded, targetDir);
   }
 
@@ -950,19 +950,23 @@ public class StorageEngine implements IService {
    * @param file internal file
    * @return sg name
    */
-  public String getSgByEngineFile(File file) throws IllegalPathException {
-    File dataDir =
-        file.getParentFile().getParentFile().getParentFile().getParentFile().getParentFile();
-    if (dataDir.exists()) {
-      String[] dataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();
-      for (String dir : dataDirs) {
-        File f = new File(dir);
-        if (dataDir.getAbsolutePath().equals(f.getAbsolutePath())) {
-          return file.getParentFile().getParentFile().getParentFile().getName();
+  public String getSgByEngineFile(File file, boolean needCheck) throws IllegalPathException {
+    if (needCheck) {
+      File dataDir =
+          file.getParentFile().getParentFile().getParentFile().getParentFile().getParentFile();
+      if (dataDir.exists()) {
+        String[] dataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();
+        for (String dir : dataDirs) {
+          File f = new File(dir);
+          if (dataDir.getAbsolutePath().equals(f.getAbsolutePath())) {
+            return file.getParentFile().getParentFile().getParentFile().getName();
+          }
         }
       }
+      throw new IllegalPathException(file.getAbsolutePath(), "it's not an internal tsfile.");
+    } else {
+      return file.getParentFile().getParentFile().getParentFile().getName();
     }
-    throw new IllegalPathException(file.getAbsolutePath(), "it's not an internal tsfile.");
   }
 
   /** @return TsFiles (seq or unseq) grouped by their storage group and partition number. */

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1113,7 +1113,7 @@ public class PlanExecutor implements IPlanExecutor {
     File file = plan.getFile();
     if (!file.exists()) {
       throw new QueryProcessException(
-          String.format("File path %s doesn't exists.", file.getPath()));
+          String.format("File path '%s' doesn't exists.", file.getPath()));
     }
     if (file.isDirectory()) {
       loadDir(file, plan);
@@ -1359,9 +1359,9 @@ public class PlanExecutor implements IPlanExecutor {
 
   private void operateRemoveFile(OperateFilePlan plan) throws QueryProcessException {
     try {
-      if (!StorageEngine.getInstance().deleteTsfile(plan.getFile())) {
+      if (!plan.getFile().exists() || !StorageEngine.getInstance().deleteTsfile(plan.getFile())) {
         throw new QueryProcessException(
-            String.format("File %s doesn't exist.", plan.getFile().getName()));
+            String.format("File '%s' doesn't exist.", plan.getFile().getAbsolutePath()));
       }
     } catch (StorageEngineException | IllegalPathException e) {
       throw new QueryProcessException(
@@ -1372,18 +1372,19 @@ public class PlanExecutor implements IPlanExecutor {
   private void operateUnloadFile(OperateFilePlan plan) throws QueryProcessException {
     if (!plan.getTargetDir().exists() || !plan.getTargetDir().isDirectory()) {
       throw new QueryProcessException(
-          String.format("Target dir %s is invalid.", plan.getTargetDir().getPath()));
+          String.format("Target dir '%s' is invalid.", plan.getTargetDir().getAbsolutePath()));
     }
     try {
-      if (!StorageEngine.getInstance().unloadTsfile(plan.getFile(), plan.getTargetDir())) {
+      if (!plan.getFile().exists()
+          || !StorageEngine.getInstance().unloadTsfile(plan.getFile(), plan.getTargetDir())) {
         throw new QueryProcessException(
-            String.format("File %s doesn't exist.", plan.getFile().getName()));
+            String.format("File '%s' doesn't exist.", plan.getFile().getAbsolutePath()));
       }
     } catch (StorageEngineException | IllegalPathException e) {
       throw new QueryProcessException(
           String.format(
-              "Cannot unload file %s to target directory %s because %s",
-              plan.getFile().getPath(), plan.getTargetDir().getPath(), e.getMessage()));
+              "Cannot unload file '%s' to target directory '%s' because %s",
+              plan.getFile().getAbsolutePath(), plan.getTargetDir().getPath(), e.getMessage()));
     }
   }
 


### PR DESCRIPTION
1. Fix incorrect docs

   * " -> '
   * use absolute path as example 

2. Use more accurate error messages

   * if target file doesn't exist

     ```
     IoTDB> load '/root.sg1/1642237791044-1-0-0.tsfile'
     Msg: 411: File path '/root.sg1/1642237791044-1-0-0.tsfile' doesn't exists.
     
     IoTDB> unload '/Users/chenyanze/projects/JavaProjects/iotdb/iotdb/data/data/root.sg1/0/0' '/'
     Msg: 411: File '/Users/chenyanze/projects/JavaProjects/iotdb/iotdb/data/data/root.sg1/0/0' doesn't exist.
     ```

   * if remove/unload file exists but not an internal tsfile

     ```
     IoTDB> unload '/Users/chenyanze/projects/JavaProjects/iotdb/iotdb/data/data/sequence/root.sg1/0/0' '/'
     Msg: 411: Cannot unload file '/Users/chenyanze/projects/JavaProjects/iotdb/iotdb/data/data/sequence/root.sg1/0/0' to target directory '/' because /Users/chenyanze/projects/JavaProjects/iotdb/iotdb/data/data/sequence/root.sg1/0/0 is not a legal path, because it's not an internal tsfile.
     ```

     

