### PR TITLE
[IOTDB-2417]Cross compaction selector bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/InplaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/InplaceCompactionSelector.java
@@ -31,7 +31,6 @@ import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
 import org.apache.iotdb.db.exception.MergeException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,19 +131,21 @@ public class InplaceCompactionSelector extends AbstractCrossSpaceCompactionSelec
       // cached during selection
       mergeResource.setCacheDeviceMeta(true);
 
-      AbstractCompactionTask compactionTask =
-          taskFactory.createTask(
-              logicalStorageGroupName,
-              virtualGroupId,
-              timePartition,
-              mergeResource,
-              storageGroupDir,
-              sequenceFileList,
-              unsequenceFileList,
-              mergeFiles[0],
-              mergeFiles[1],
-              fileSelector.getConcurrentMergeNum());
-      CompactionTaskManager.getInstance().addTaskToWaitingQueue(compactionTask);
+      if (mergeFiles[0].size() > 0 && mergeFiles[1].size() > 0) {
+        AbstractCompactionTask compactionTask =
+            taskFactory.createTask(
+                logicalStorageGroupName,
+                virtualGroupId,
+                timePartition,
+                mergeResource,
+                storageGroupDir,
+                sequenceFileList,
+                unsequenceFileList,
+                mergeFiles[0],
+                mergeFiles[1],
+                fileSelector.getConcurrentMergeNum());
+        CompactionTaskManager.getInstance().addTaskToWaitingQueue(compactionTask);
+      }
       taskSubmitted = true;
       LOGGER.info(
           "{} [Compaction] submit a task with {} sequence file and {} unseq files",

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/InplaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/InplaceCompactionSelector.java
@@ -146,13 +146,14 @@ public class InplaceCompactionSelector extends AbstractCrossSpaceCompactionSelec
                 mergeFiles[1],
                 fileSelector.getConcurrentMergeNum());
         CompactionTaskManager.getInstance().addTaskToWaitingQueue(compactionTask);
+        taskSubmitted = true;
+        LOGGER.info(
+            "{} [Compaction] submit a task with {} sequence file and {} unseq files",
+            logicalStorageGroupName + "-" + virtualGroupId,
+            mergeResource.getSeqFiles().size(),
+            mergeResource.getUnseqFiles().size());
       }
-      taskSubmitted = true;
-      LOGGER.info(
-          "{} [Compaction] submit a task with {} sequence file and {} unseq files",
-          logicalStorageGroupName + "-" + virtualGroupId,
-          mergeResource.getSeqFiles().size(),
-          mergeResource.getUnseqFiles().size());
+
     } catch (MergeException | IOException e) {
       LOGGER.error("{} cannot select file for cross space compaction", logicalStorageGroupName, e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/InplaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/inplace/InplaceCompactionSelector.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
 import org.apache.iotdb.db.exception.MergeException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
When all source files are being merged, cross compaction may select the source seq file list and source unseq file list, which is empty. 