### PR TITLE
[IOTDB-2412] Fetch Result Task is not taken account into query execution control

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -1011,7 +1011,6 @@ public class TSServiceImpl implements TSIService.Iface {
       Thread.currentThread().interrupt();
       return RpcUtils.getTSFetchResultsResp(onQueryException(e, OperationType.FETCH_RESULTS));
     } catch (Exception e) {
-      SESSION_MANAGER.releaseQueryResourceNoExceptions(req.queryId);
       return RpcUtils.getTSFetchResultsResp(onQueryException(e, OperationType.FETCH_RESULTS));
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -235,6 +235,57 @@ public class TSServiceImpl implements TSIService.Iface {
     }
   }
 
+  protected class FetchResultsTask implements Callable<TSFetchResultsResp> {
+
+    private final long sessionId;
+    private final long queryId;
+    private final int fetchSize;
+    private final boolean isAlign;
+
+    public FetchResultsTask(long sessionId, long queryId, int fetchSize, boolean isAlign) {
+      this.sessionId = sessionId;
+      this.queryId = queryId;
+      this.fetchSize = fetchSize;
+      this.isAlign = isAlign;
+    }
+
+    @Override
+    public TSFetchResultsResp call() throws Exception {
+      QueryDataSet queryDataSet = SESSION_MANAGER.getDataset(queryId);
+      TSFetchResultsResp resp = RpcUtils.getTSFetchResultsResp(TSStatusCode.SUCCESS_STATUS);
+      if (isAlign) {
+        TSQueryDataSet result =
+            fillRpcReturnData(fetchSize, queryDataSet, SESSION_MANAGER.getUsername(sessionId));
+        boolean hasResultSet = result.bufferForTime().limit() != 0;
+        if (!hasResultSet) {
+          SESSION_MANAGER.releaseQueryResourceNoExceptions(queryId);
+        }
+        resp.setHasResultSet(hasResultSet);
+        resp.setQueryDataSet(result);
+        resp.setIsAlign(true);
+      } else {
+        TSQueryNonAlignDataSet nonAlignResult =
+            fillRpcNonAlignReturnData(
+                fetchSize, queryDataSet, SESSION_MANAGER.getUsername(sessionId));
+        boolean hasResultSet = false;
+        for (ByteBuffer timeBuffer : nonAlignResult.getTimeList()) {
+          if (timeBuffer.limit() != 0) {
+            hasResultSet = true;
+            break;
+          }
+        }
+        if (!hasResultSet) {
+          SESSION_MANAGER.releaseQueryResourceNoExceptions(queryId);
+        }
+        resp.setHasResultSet(hasResultSet);
+        resp.setNonAlignQueryDataSet(nonAlignResult);
+        resp.setIsAlign(false);
+      }
+      QUERY_TIME_MANAGER.unRegisterQuery(queryId, false);
+      return resp;
+    }
+  }
+
   // main logger
   private static final Logger LOGGER = LoggerFactory.getLogger(TSServiceImpl.class);
 
@@ -946,47 +997,10 @@ public class TSServiceImpl implements TSIService.Iface {
             RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, "Has not executed query"));
       }
 
-      serviceProvider.genQueryContext(
-          req.queryId, false, System.currentTimeMillis(), req.statement, req.timeout);
-
-      QueryDataSet queryDataSet = SESSION_MANAGER.getDataset(req.queryId);
-      if (req.isAlign) {
-        TSQueryDataSet result =
-            fillRpcReturnData(
-                req.fetchSize, queryDataSet, SESSION_MANAGER.getUsername(req.sessionId));
-        boolean hasResultSet = result.bufferForTime().limit() != 0;
-        if (!hasResultSet) {
-          SESSION_MANAGER.releaseQueryResourceNoExceptions(req.queryId);
-        }
-        TSFetchResultsResp resp = RpcUtils.getTSFetchResultsResp(TSStatusCode.SUCCESS_STATUS);
-        resp.setHasResultSet(hasResultSet);
-        resp.setQueryDataSet(result);
-        resp.setIsAlign(true);
-
-        QUERY_TIME_MANAGER.unRegisterQuery(req.queryId, false);
-        return resp;
-      } else {
-        TSQueryNonAlignDataSet nonAlignResult =
-            fillRpcNonAlignReturnData(
-                req.fetchSize, queryDataSet, SESSION_MANAGER.getUsername(req.sessionId));
-        boolean hasResultSet = false;
-        for (ByteBuffer timeBuffer : nonAlignResult.getTimeList()) {
-          if (timeBuffer.limit() != 0) {
-            hasResultSet = true;
-            break;
-          }
-        }
-        if (!hasResultSet) {
-          SESSION_MANAGER.removeDataset(req.queryId);
-        }
-        TSFetchResultsResp resp = RpcUtils.getTSFetchResultsResp(TSStatusCode.SUCCESS_STATUS);
-        resp.setHasResultSet(hasResultSet);
-        resp.setNonAlignQueryDataSet(nonAlignResult);
-        resp.setIsAlign(false);
-
-        QUERY_TIME_MANAGER.unRegisterQuery(req.queryId, false);
-        return resp;
-      }
+      Future<TSFetchResultsResp> resp =
+          QueryTaskManager.getInstance()
+              .submit(new FetchResultsTask(req.sessionId, req.queryId, req.fetchSize, req.isAlign));
+      return resp.get();
     } catch (InterruptedException e) {
       LOGGER.error(INFO_INTERRUPT_ERROR, req, e);
       Thread.currentThread().interrupt();


### PR DESCRIPTION
Now we control the query execution thread, but we forgot the fecthResult interface, which means we cannot take control of that. When the client fetches the second batch, the query threads will increase to the connection numbers.

Related PR: #4660 & #4664 