### PR TITLE
[IOTDB-2421] Optimize serialize method in PhysicalPlan class

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -191,7 +191,7 @@ public abstract class PhysicalPlan {
    *
    * @param buffer
    */
-  public void serialize(ByteBuffer buffer) {
+  public final void serialize(ByteBuffer buffer) {
     buffer.mark();
     try {
       serializeImpl(buffer);


### PR DESCRIPTION
The serialize method cannot be overwritten. If it is overwritten, reset will be affected.Therefore, you need to set this method to final.