### PR TITLE
[IOTDB-2414][IOTDB-2419]Fix partial insert failure exception message && Fix three level aligned path query bug

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertMultiRowIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBInsertMultiRowIT.java
@@ -38,6 +38,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 /**
  * @Author: Architect @Date: 2021-03-30 18:36 @Description: This class is initially intend to test
  * the issue of IOTDB-924
@@ -124,5 +127,20 @@ public class IoTDBInsertMultiRowIT {
   public void testInsertWithTimesColumns() throws SQLException {
     Statement st1 = connection.createStatement();
     st1.execute("insert into root.t1.wf01.wt01(timestamp) values(1)");
+  }
+
+  @Test
+  public void testInsertMultiRowWithMisMatchDataType() {
+    try {
+      Statement st1 = connection.createStatement();
+      st1.execute(
+          "insert into root.t1.wf01.wt01(timestamp, temperature) values(1, 1.0) (2, 'hello'), (3, true)");
+      fail();
+    } catch (SQLException e) {
+      assertEquals(
+          "org.apache.iotdb.db.exception.StorageEngineException: failed to insert measurements [temperature] caused by For input string: \"'hello'\";"
+              + "org.apache.iotdb.db.exception.StorageEngineException: failed to insert measurements [temperature] caused by For input string: \"true\";",
+          e.getMessage());
+    }
   }
 }

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IOTDBInsertAlignedValuesIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IOTDBInsertAlignedValuesIT.java
@@ -342,4 +342,18 @@ public class IOTDBInsertAlignedValuesIT {
       Assert.assertEquals(100, rowCount);
     }
   }
+
+  @Test
+  public void testInsertAlignedValuesWithThreeLevelPath() throws SQLException {
+    Statement st0 = connection.createStatement();
+    st0.execute("insert into root.sg_device(time, status) aligned values (4000, true)");
+    st0.close();
+
+    Statement st1 = connection.createStatement();
+
+    ResultSet rs = st1.executeQuery("select ** from root");
+    rs.next();
+    Assert.assertEquals(true, rs.getBoolean(2));
+    st1.close();
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/path/AlignedPath.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/path/AlignedPath.java
@@ -62,6 +62,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -122,6 +123,10 @@ public class AlignedPath extends PartialPath {
     super(vectorPath);
     measurementList = new ArrayList<>();
     schemaList = new ArrayList<>();
+  }
+
+  public PartialPath getDevicePath() {
+    return new PartialPath(Arrays.copyOf(nodes, nodes.length));
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/InsertOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/InsertOperator.java
@@ -110,7 +110,7 @@ public class InsertOperator extends Operator {
                 measurementsNum, valueLists.get(i).length));
       }
       InsertRowPlan insertRowPlan =
-          new InsertRowPlan(device, times[i], measurementList, valueLists.get(i));
+          new InsertRowPlan(device, times[i], measurementList.clone(), valueLists.get(i));
       insertRowPlan.setAligned(isAligned);
       insertRowsPlan.addOneInsertRowPlan(insertRowPlan, i);
     }


### PR DESCRIPTION
## Description


### Fix partial insert failure exception message
see IOTDB-2414

solution: make each insertRowPlan in insertRowsPlan not share measurements array

### Fix three level aligned path query bug
see IOTDB-2419

solution: override the getDevicePath in AlignedPath

