### PR TITLE
[ISSUE-4858] Fix incorrect configuration for TriggerLogWriter

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/trigger/service/TriggerLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/trigger/service/TriggerLogWriter.java
@@ -39,7 +39,7 @@ public class TriggerLogWriter implements AutoCloseable {
   private final ILogWriter logWriter;
 
   public TriggerLogWriter(String logFilePath) throws IOException {
-    logBuffer = ByteBuffer.allocate(IoTDBDescriptor.getInstance().getConfig().getMlogBufferSize());
+    logBuffer = ByteBuffer.allocate(IoTDBDescriptor.getInstance().getConfig().getTlogBufferSize());
     logFile = SystemFileFactory.INSTANCE.getFile(logFilePath);
     logWriter = new LogWriter(logFile, false);
   }


### PR DESCRIPTION
This PR fix the incorrect log buffer size for TriggerLogWriter as mentioned by #4858.
