### PR TITLE
[IOTDB-2433] Fix aligned timeseries mem control bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunkGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunkGroup.java
@@ -61,6 +61,10 @@ public class AlignedWritableMemChunkGroup implements IWritableMemChunkGroup {
 
   @Override
   public boolean contains(String measurement) {
+    // used for calculate memtable size
+    if ("".equals(measurement)) {
+      return true;
+    }
     return memChunk.containsMeasurement(measurement);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunkGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunkGroup.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.engine.memtable;
 
+import org.apache.iotdb.db.metadata.path.AlignedPath;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.tsfile.utils.BitMap;
 import org.apache.iotdb.tsfile.utils.Pair;
@@ -59,10 +60,14 @@ public class AlignedWritableMemChunkGroup implements IWritableMemChunkGroup {
     return memChunk.count();
   }
 
+  /**
+   * Check whether this MemChunkGroup contains a measurement. If a VECTOR_PLACEHOLDER passed from
+   * outer, always return true because AlignedMemChunkGroup existing.
+   */
   @Override
   public boolean contains(String measurement) {
     // used for calculate memtable size
-    if ("".equals(measurement)) {
+    if (AlignedPath.VECTOR_PLACEHOLDER.equals(measurement)) {
       return true;
     }
     return memChunk.containsMeasurement(measurement);


### PR DESCRIPTION
## Description

This bug causes aligned timeseries memtable is much more smaller than normal.

Before
<img width="1471" alt="Screen Shot 2022-01-18 at 7 22 06 PM" src="https://user-images.githubusercontent.com/25913899/149931684-6eb4d480-1181-42df-b130-c6bff9d8326c.png">
After

<img width="1417" alt="Screen Shot 2022-01-18 at 7 31 36 PM" src="https://user-images.githubusercontent.com/25913899/149931910-70def94b-0bb6-4e41-b3f5-cef64b54ed9b.png">

Non_alignedTimeseries
<img width="1468" alt="Screen Shot 2022-01-18 at 7 17 12 PM" src="https://user-images.githubusercontent.com/25913899/149932125-39dc6cca-2bbd-4de9-95b0-ba3c5faabe76.png">


