### PR TITLE
[IOTDB-2435] CI fails on testCreateAlignedTimeseries() because data generator is not stopped in a CQ's test

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBContinuousQueryIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBContinuousQueryIT.java
@@ -261,6 +261,8 @@ public class IoTDBContinuousQueryIT {
               + "GROUP BY time(1s) END");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("duplicated"));
+    } finally {
+      stopDataGenerator();
     }
   }
 


### PR DESCRIPTION
See IOTDB-2435 for more detail.