### PR TITLE
[IOTDB-2440] Fix the query result is incorrect when using Template with aligned timeseries 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
@@ -249,11 +249,16 @@ public class Template {
       String[] nodeNames,
       TSDataType[] dataTypes,
       TSEncoding[] encodings,
-      CompressionType[] compressors) throws IllegalPathException{
+      CompressionType[] compressors)
+      throws IllegalPathException {
     MeasurementSchema[] schemas = new MeasurementSchema[nodeNames.length];
     for (int i = 0; i < nodeNames.length; i++) {
-      schemas[i] = new MeasurementSchema(
-          new PartialPath(nodeNames[i]).getMeasurement(), dataTypes[i], encodings[i], compressors[i]);
+      schemas[i] =
+          new MeasurementSchema(
+              new PartialPath(nodeNames[i]).getMeasurement(),
+              dataTypes[i],
+              encodings[i],
+              compressors[i]);
     }
     return schemas;
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.metadata.mnode.IEntityMNode;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
 import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
+import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.metadata.utils.MetaUtils;
 import org.apache.iotdb.db.qp.physical.sys.CreateTemplatePlan;
 import org.apache.iotdb.db.utils.SerializeUtils;
@@ -248,10 +249,11 @@ public class Template {
       String[] nodeNames,
       TSDataType[] dataTypes,
       TSEncoding[] encodings,
-      CompressionType[] compressors) {
+      CompressionType[] compressors) throws IllegalPathException{
     MeasurementSchema[] schemas = new MeasurementSchema[nodeNames.length];
     for (int i = 0; i < nodeNames.length; i++) {
-      schemas[i] = new MeasurementSchema(nodeNames[i], dataTypes[i], encodings[i], compressors[i]);
+      schemas[i] = new MeasurementSchema(
+          new PartialPath(nodeNames[i]).getMeasurement(), dataTypes[i], encodings[i], compressors[i]);
     }
     return schemas;
   }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -894,13 +894,13 @@ public class MManagerBasicTest {
 
     Set<String> allSchema = new HashSet<>();
     for (IMeasurementSchema schema : node.getSchemaTemplate().getSchemaMap().values()) {
-      allSchema.add("root.sg1.d1" + TsFileConstant.PATH_SEPARATOR + schema.getMeasurementId());
+      allSchema.add("root.sg1.d1.vector" + TsFileConstant.PATH_SEPARATOR + schema.getMeasurementId());
     }
     for (MeasurementPath measurementPath :
-        manager.getMeasurementPaths(new PartialPath("root.sg1.d1.**"))) {
+        manager.getMeasurementPaths(new PartialPath("root.sg1.**"))) {
       allSchema.remove(measurementPath.toString());
     }
-
+    allSchema.remove("root.sg1.d1.vector.s11");
     assertTrue(allSchema.isEmpty());
 
     IMeasurementMNode mNode = manager.getMeasurementMNode(new PartialPath("root.sg1.d1.s11"));

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -894,7 +894,8 @@ public class MManagerBasicTest {
 
     Set<String> allSchema = new HashSet<>();
     for (IMeasurementSchema schema : node.getSchemaTemplate().getSchemaMap().values()) {
-      allSchema.add("root.sg1.d1.vector" + TsFileConstant.PATH_SEPARATOR + schema.getMeasurementId());
+      allSchema.add(
+          "root.sg1.d1.vector" + TsFileConstant.PATH_SEPARATOR + schema.getMeasurementId());
     }
     for (MeasurementPath measurementPath :
         manager.getMeasurementPaths(new PartialPath("root.sg1.**"))) {

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/InsertRowPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/InsertRowPlanTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.qp.physical;
 
+import org.apache.commons.compress.archivers.ar.ArArchiveEntry;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
@@ -104,6 +105,94 @@ public class InsertRowPlanTest {
       RowRecord record = dataSet.next();
       Assert.assertEquals(3, record.getFields().size());
     }
+  }
+
+  @Test
+  public void testInsertRowPlanWithTreeSchemaTemplate() throws QueryProcessException, MetadataException, InterruptedException,
+  QueryFilterOptimizationException, StorageEngineException, IOException {
+    List<List<String>> measurementList = new ArrayList<>();
+    List<String> v1 = Arrays.asList("GPS.s1", "GPS.s2", "GPS.s3");
+    measurementList.add(v1);
+    List<String> v2 = Arrays.asList("GPS2.s4", "GPS2.s5");
+    measurementList.add(v2);
+    measurementList.add(Collections.singletonList("s6"));
+
+    List<List<TSDataType>> dataTypesList = new ArrayList<>();
+    List<TSDataType> d1 = Arrays.asList(TSDataType.DOUBLE, TSDataType.FLOAT, TSDataType.INT64);
+    dataTypesList.add(d1);
+    List<TSDataType> d2 = Arrays.asList(TSDataType.INT32, TSDataType.BOOLEAN);
+    dataTypesList.add(d2);
+    dataTypesList.add(Collections.singletonList(TSDataType.TEXT));
+
+    List<List<TSEncoding>> encodingList = new ArrayList<>();
+    List<TSEncoding> e1 = Arrays.asList(TSEncoding.PLAIN, TSEncoding.PLAIN, TSEncoding.PLAIN);
+    encodingList.add(e1);
+    List<TSEncoding> e2 = Arrays.asList(TSEncoding.PLAIN, TSEncoding.PLAIN);
+    encodingList.add(e2);
+    encodingList.add(Collections.singletonList(TSEncoding.PLAIN));
+
+    List<List<CompressionType>> compressionTypes = new ArrayList<>();
+    compressionTypes.add(Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY, CompressionType.SNAPPY));
+    compressionTypes.add(Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
+    compressionTypes.add(Arrays.asList(CompressionType.SNAPPY));
+
+    CreateTemplatePlan plan =
+        new CreateTemplatePlan(
+            "templateN", measurementList, dataTypesList, encodingList, compressionTypes);
+
+    IoTDB.metaManager.createSchemaTemplate(plan);
+    IoTDB.metaManager.setSchemaTemplate(new SetTemplatePlan("templateN", "root.isp.d1"));
+
+    IoTDBDescriptor.getInstance().getConfig().setAutoCreateSchemaEnabled(false);
+
+    InsertRowPlan rowPlan = getInsertAlignedRowPlan(111L);
+    PlanExecutor executor = new PlanExecutor();
+
+    executor.insert(rowPlan);
+    rowPlan = getInsertAlignedRowPlan(112L);
+    executor.insert(rowPlan);
+    rowPlan = getInsertAlignedRowPlan(113L);
+    executor.insert(rowPlan);
+
+    QueryPlan queryPlan =
+        (QueryPlan) processor.parseSQLToPhysicalPlan("select * from root.isp.d1.GPS");
+    QueryDataSet dataSet = executor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
+
+    Assert.assertEquals(1, dataSet.getPaths().size());
+    int resSize = 0;
+    while (dataSet.hasNext()) {
+      Assert.assertEquals(3, dataSet.next().getFields().size());
+      resSize++;
+    }
+    Assert.assertEquals(3, resSize);
+
+    TSDataType[] dataTypes =
+        new TSDataType[] {TSDataType.TEXT};
+
+    String[] columns = new String[1];
+    columns[0] = "a";
+
+    rowPlan = new InsertRowPlan(
+        new PartialPath("root.isp.d1"),
+        1111L,
+        new String[] {"s6"},
+        dataTypes,
+        columns,
+        false);
+    executor.insert(rowPlan);
+
+    queryPlan =
+        (QueryPlan) processor.parseSQLToPhysicalPlan("select * from root.isp.d1");
+    dataSet = executor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
+    Assert.assertEquals(1, dataSet.getPaths().size());
+    Assert.assertEquals(true, dataSet.hasNext());
+
+    queryPlan =
+        (QueryPlan) processor.parseSQLToPhysicalPlan("select * from root.isp.d1.**");
+    dataSet = executor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
+    Assert.assertEquals(2, dataSet.getPaths().size());
+    Assert.assertEquals(true, dataSet.hasNext());
+    Assert.assertEquals(5, dataSet.next().getFields().size());
   }
 
   @Test
@@ -250,9 +339,10 @@ public class InsertRowPlanTest {
     executor.insert(rowPlan);
 
     QueryPlan queryPlan =
-        (QueryPlan) processor.parseSQLToPhysicalPlan("select s1 from root.isp.d1.GPS");
+        (QueryPlan) processor.parseSQLToPhysicalPlan("select * from root.isp.d1.GPS");
     QueryDataSet dataSet = executor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
     Assert.assertEquals(1, dataSet.getPaths().size());
+    Assert.assertEquals(true, dataSet.hasNext());
     while (dataSet.hasNext()) {
       RowRecord record = dataSet.next();
       Assert.assertEquals(3, record.getFields().size());
@@ -288,7 +378,10 @@ public class InsertRowPlanTest {
   }
 
   private InsertRowPlan getInsertAlignedRowPlan() throws IllegalPathException {
-    long time = 110L;
+    return getInsertAlignedRowPlan(110L);
+  }
+
+  private InsertRowPlan getInsertAlignedRowPlan(long time) throws IllegalPathException {
     TSDataType[] dataTypes =
         new TSDataType[] {TSDataType.DOUBLE, TSDataType.FLOAT, TSDataType.INT64};
 

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/InsertRowPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/InsertRowPlanTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.qp.physical;
 
-import org.apache.commons.compress.archivers.ar.ArArchiveEntry;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
@@ -108,8 +107,9 @@ public class InsertRowPlanTest {
   }
 
   @Test
-  public void testInsertRowPlanWithTreeSchemaTemplate() throws QueryProcessException, MetadataException, InterruptedException,
-  QueryFilterOptimizationException, StorageEngineException, IOException {
+  public void testInsertRowPlanWithTreeSchemaTemplate()
+      throws QueryProcessException, MetadataException, InterruptedException,
+          QueryFilterOptimizationException, StorageEngineException, IOException {
     List<List<String>> measurementList = new ArrayList<>();
     List<String> v1 = Arrays.asList("GPS.s1", "GPS.s2", "GPS.s3");
     measurementList.add(v1);
@@ -132,7 +132,8 @@ public class InsertRowPlanTest {
     encodingList.add(Collections.singletonList(TSEncoding.PLAIN));
 
     List<List<CompressionType>> compressionTypes = new ArrayList<>();
-    compressionTypes.add(Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY, CompressionType.SNAPPY));
+    compressionTypes.add(
+        Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY, CompressionType.SNAPPY));
     compressionTypes.add(Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
     compressionTypes.add(Arrays.asList(CompressionType.SNAPPY));
 
@@ -166,29 +167,22 @@ public class InsertRowPlanTest {
     }
     Assert.assertEquals(3, resSize);
 
-    TSDataType[] dataTypes =
-        new TSDataType[] {TSDataType.TEXT};
+    TSDataType[] dataTypes = new TSDataType[] {TSDataType.TEXT};
 
     String[] columns = new String[1];
     columns[0] = "a";
 
-    rowPlan = new InsertRowPlan(
-        new PartialPath("root.isp.d1"),
-        1111L,
-        new String[] {"s6"},
-        dataTypes,
-        columns,
-        false);
+    rowPlan =
+        new InsertRowPlan(
+            new PartialPath("root.isp.d1"), 1111L, new String[] {"s6"}, dataTypes, columns, false);
     executor.insert(rowPlan);
 
-    queryPlan =
-        (QueryPlan) processor.parseSQLToPhysicalPlan("select * from root.isp.d1");
+    queryPlan = (QueryPlan) processor.parseSQLToPhysicalPlan("select * from root.isp.d1");
     dataSet = executor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
     Assert.assertEquals(1, dataSet.getPaths().size());
     Assert.assertEquals(true, dataSet.hasNext());
 
-    queryPlan =
-        (QueryPlan) processor.parseSQLToPhysicalPlan("select * from root.isp.d1.**");
+    queryPlan = (QueryPlan) processor.parseSQLToPhysicalPlan("select * from root.isp.d1.**");
     dataSet = executor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
     Assert.assertEquals(2, dataSet.getPaths().size());
     Assert.assertEquals(true, dataSet.hasNext());


### PR DESCRIPTION
Fix bug about measurement path in template.

JIRA: https://issues.apache.org/jira/browse/IOTDB-2440

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
