### PR TITLE
[IOTDB-2442] Ignore CQ physical plan in sync receiver

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cq/ContinuousQueryTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cq/ContinuousQueryTask.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.logical.crud.QueryOperator;
 import org.apache.iotdb.db.qp.physical.crud.GroupByTimePlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertMultiTabletPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertTabletPlan;
 import org.apache.iotdb.db.qp.physical.sys.CreateContinuousQueryPlan;
 import org.apache.iotdb.db.qp.strategy.LogicalGenerator;
 import org.apache.iotdb.db.query.context.QueryContext;
@@ -146,8 +147,11 @@ public class ContinuousQueryTask extends WrappedRunnable {
             generateTargetPaths(queryDataSet.getPaths()),
             false);
     while (insertTabletPlansIterator.hasNext()) {
-      if (!serviceProvider.executeNonQuery(
-          new InsertMultiTabletPlan(insertTabletPlansIterator.next()))) {
+      List<InsertTabletPlan> insertTabletPlans = insertTabletPlansIterator.next();
+      if (insertTabletPlans.isEmpty()) {
+        continue;
+      }
+      if (!serviceProvider.executeNonQuery(new InsertMultiTabletPlan(insertTabletPlans))) {
         throw new ContinuousQueryException(
             String.format(
                 "failed to execute cq task %s, sql: %s",

--- a/server/src/main/java/org/apache/iotdb/db/engine/selectinto/InsertTabletPlansIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/selectinto/InsertTabletPlansIterator.java
@@ -168,7 +168,11 @@ public class InsertTabletPlansIterator {
 
     List<InsertTabletPlan> insertTabletPlans = new ArrayList<>();
     for (InsertTabletPlanGenerator insertTabletPlanGenerator : insertTabletPlanGenerators) {
-      insertTabletPlans.add(insertTabletPlanGenerator.generateInsertTabletPlan());
+      // all values can be null in a batch of the query dataset
+      InsertTabletPlan insertTabletPlan = insertTabletPlanGenerator.generateInsertTabletPlan();
+      if (insertTabletPlan.getColumns().length != 0) {
+        insertTabletPlans.add(insertTabletPlan);
+      }
     }
     return insertTabletPlans;
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -955,8 +955,11 @@ public class TSServiceImpl implements TSIService.Iface {
               selectIntoPlan.getIntoPaths(),
               selectIntoPlan.isIntoPathsAligned());
       while (insertTabletPlansIterator.hasNext()) {
-        TSStatus executionStatus =
-            insertTabletsInternally(insertTabletPlansIterator.next(), sessionId);
+        List<InsertTabletPlan> insertTabletPlans = insertTabletPlansIterator.next();
+        if (insertTabletPlans.isEmpty()) {
+          continue;
+        }
+        TSStatus executionStatus = insertTabletsInternally(insertTabletPlans, sessionId);
         if (executionStatus.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()
             && executionStatus.getCode() != TSStatusCode.NEED_REDIRECTION.getStatusCode()) {
           return RpcUtils.getTSExecuteStatementResp(executionStatus).setQueryId(queryId);

--- a/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
 import org.apache.iotdb.db.exception.SyncDeviceOwnerConflictException;
 import org.apache.iotdb.db.metadata.MetadataConstant;
 import org.apache.iotdb.db.metadata.logfile.MLogReader;
+import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.sync.conf.SyncConstant;
@@ -298,7 +299,10 @@ public class SyncServiceImpl implements SyncService.Iface {
             if (plan == null) {
               continue;
             }
-            IoTDB.metaManager.operation(plan);
+            if (plan.getOperatorType() != Operator.OperatorType.CREATE_CONTINUOUS_QUERY
+                && plan.getOperatorType() != Operator.OperatorType.DROP_CONTINUOUS_QUERY) {
+              IoTDB.metaManager.operation(plan);
+            }
           } catch (Exception e) {
             logger.error(
                 "Can not operate metadata operation {} for err:{}",


### PR DESCRIPTION
problem:
First, I used CQ in an IoTDB instance.Then I start to sync the data in this instance to a new iotdb.

I found a error when I try to start sync process. Please refer to below picture and help me to check this issue.Thanks!

error picture in receiver:
![image-2022-01-19-17-27-57-373](https://user-images.githubusercontent.com/87161145/150133299-082b8c65-5a10-4c11-9f62-11ecc0bc8f06.png)


The process of sync is to sync schema firstly, and when the physical plan of CQ is sent to receiver, the CQ will got nothing to select because the data is not sent to receiver at this moment.

solution:
Because the data produced by CQ in sender will be sent to receiver, so the CQ physical plan has no need to sync to receiver, just ignore this physical plan when loading schemas in receiver.