### PR TITLE
[IOTDB-2448] unload doesn't work correctly: it's not an internal tsfile

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
@@ -199,7 +199,9 @@ public class IoTDBLoadExternalTsfileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("unload '%s' '%s'", resource.getTsFilePath(), tmpDir));
+        // test unload using relative path
+        statement.execute(
+            String.format("unload '%s' '%s'", "./" + resource.getTsFilePath(), tmpDir));
       }
       assertEquals(
           0,

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBLoadExternalAlignedTsFileIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBLoadExternalAlignedTsFileIT.java
@@ -201,7 +201,9 @@ public class IoTDBLoadExternalAlignedTsFileIT {
         tmpDir.mkdirs();
       }
       for (TsFileResource resource : resources) {
-        statement.execute(String.format("unload '%s' '%s'", resource.getTsFilePath(), tmpDir));
+        // test unload using relative path
+        statement.execute(
+            String.format("unload '%s' '%s'", "./" + resource.getTsFilePath(), tmpDir));
       }
       assertEquals(
           0,

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -72,6 +72,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.*;
@@ -913,9 +915,12 @@ public class StorageEngine implements IService {
       if (dataDir.exists()) {
         String[] dataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();
         for (String dir : dataDirs) {
-          File f = new File(dir);
-          if (dataDir.getAbsolutePath().equals(f.getAbsolutePath())) {
-            return file.getParentFile().getParentFile().getParentFile().getName();
+          try {
+            if (Files.isSameFile(Paths.get(dir), dataDir.toPath())) {
+              return file.getParentFile().getParentFile().getParentFile().getName();
+            }
+          } catch (IOException e) {
+            throw new IllegalPathException(file.getAbsolutePath(), e.getMessage());
           }
         }
       }


### PR DESCRIPTION
* It caused by the wrong way of files' comparison in `getSgByEngineFile`.

* Use `Files.isSameFile()` instead of comparing strings of absolute paths.