### PR TITLE
[IOTDB-2433] Fix aligned timeseries mem control bug 2

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -349,9 +349,9 @@ public abstract class AbstractMemTable implements IMemTable {
   }
 
   @Override
-  public long getCurrentChunkPointNum(IDeviceID deviceId, String measurement) {
+  public long getCurrentTVListSize(IDeviceID deviceId, String measurement) {
     IWritableMemChunkGroup memChunkGroup = memTableMap.get(deviceId);
-    return memChunkGroup.getCurrentChunkPointNum(measurement);
+    return memChunkGroup.getCurrentTVListSize(measurement);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
@@ -192,11 +192,11 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
 
   @Override
   public long count() {
-    return (long) list.size() * measurementIndexMap.size();
+    return (long) list.rowCount() * measurementIndexMap.size();
   }
 
   public long alignedListSize() {
-    return list.size();
+    return list.rowCount();
   }
 
   @Override
@@ -270,11 +270,11 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
   public void encode(IChunkWriter chunkWriter) {
     AlignedChunkWriterImpl alignedChunkWriter = (AlignedChunkWriterImpl) chunkWriter;
     List<Integer> timeDuplicateAlignedRowIndexList = null;
-    for (int sortedRowIndex = 0; sortedRowIndex < list.size(); sortedRowIndex++) {
+    for (int sortedRowIndex = 0; sortedRowIndex < list.rowCount(); sortedRowIndex++) {
       long time = list.getTime(sortedRowIndex);
 
       // skip duplicated data
-      if ((sortedRowIndex + 1 < list.size() && (time == list.getTime(sortedRowIndex + 1)))) {
+      if ((sortedRowIndex + 1 < list.rowCount() && (time == list.getTime(sortedRowIndex + 1)))) {
         // record the time duplicated row index list for vector type
         if (timeDuplicateAlignedRowIndexList == null) {
           timeDuplicateAlignedRowIndexList = new ArrayList<>();
@@ -340,7 +340,7 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
 
   @Override
   public long getFirstPoint() {
-    if (list.size() == 0) {
+    if (list.rowCount() == 0) {
       return Long.MAX_VALUE;
     }
     return getSortedTvListForQuery().getTimeValuePair(0).getTimestamp();
@@ -348,11 +348,11 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
 
   @Override
   public long getLastPoint() {
-    if (list.size() == 0) {
+    if (list.rowCount() == 0) {
       return Long.MIN_VALUE;
     }
     return getSortedTvListForQuery()
-        .getTimeValuePair(getSortedTvListForQuery().size() - 1)
+        .getTimeValuePair(getSortedTvListForQuery().rowCount() - 1)
         .getTimestamp();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunkGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunkGroup.java
@@ -111,7 +111,7 @@ public class AlignedWritableMemChunkGroup implements IWritableMemChunkGroup {
 
   @Override
   public long getCurrentTVListSize(String measurement) {
-    return memChunk.getTVList().size();
+    return memChunk.getTVList().rowCount();
   }
 
   public AlignedWritableMemChunk getAlignedMemChunk() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunkGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunkGroup.java
@@ -110,8 +110,8 @@ public class AlignedWritableMemChunkGroup implements IWritableMemChunkGroup {
   }
 
   @Override
-  public long getCurrentChunkPointNum(String measurement) {
-    return memChunk.count();
+  public long getCurrentTVListSize(String measurement) {
+    return memChunk.getTVList().size();
   }
 
   public AlignedWritableMemChunk getAlignedMemChunk() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
@@ -155,7 +155,7 @@ public interface IMemTable {
   boolean checkIfChunkDoesNotExist(IDeviceID deviceId, String measurement);
 
   /** only used when mem control enabled */
-  long getCurrentChunkPointNum(IDeviceID deviceId, String measurement);
+  long getCurrentTVListSize(IDeviceID deviceId, String measurement);
 
   /** only used when mem control enabled */
   void addTextDataSize(long textDataIncrement);

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/IWritableMemChunkGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/IWritableMemChunkGroup.java
@@ -49,5 +49,5 @@ public interface IWritableMemChunkGroup {
   int delete(
       PartialPath originalPath, PartialPath devicePath, long startTimestamp, long endTimestamp);
 
-  long getCurrentChunkPointNum(String measurement);
+  long getCurrentTVListSize(String measurement);
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunk.java
@@ -227,7 +227,7 @@ public class WritableMemChunk implements IWritableMemChunk {
 
   @Override
   public long count() {
-    return list.size();
+    return list.rowCount();
   }
 
   @Override
@@ -242,7 +242,7 @@ public class WritableMemChunk implements IWritableMemChunk {
 
   @Override
   public long getFirstPoint() {
-    if (list.size() == 0) {
+    if (list.rowCount() == 0) {
       return Long.MAX_VALUE;
     }
     return getSortedTvListForQuery().getTimeValuePair(0).getTimestamp();
@@ -250,11 +250,11 @@ public class WritableMemChunk implements IWritableMemChunk {
 
   @Override
   public long getLastPoint() {
-    if (list.size() == 0) {
+    if (list.rowCount() == 0) {
       return Long.MIN_VALUE;
     }
     return getSortedTvListForQuery()
-        .getTimeValuePair(getSortedTvListForQuery().size() - 1)
+        .getTimeValuePair(getSortedTvListForQuery().rowCount() - 1)
         .getTimestamp();
   }
 
@@ -270,7 +270,7 @@ public class WritableMemChunk implements IWritableMemChunk {
 
   @Override
   public String toString() {
-    int size = list.size();
+    int size = list.rowCount();
     int firstIndex = 0;
     int lastIndex = size - 1;
     long minTime = Long.MAX_VALUE;
@@ -305,16 +305,16 @@ public class WritableMemChunk implements IWritableMemChunk {
 
     ChunkWriterImpl chunkWriterImpl = (ChunkWriterImpl) chunkWriter;
 
-    for (int sortedRowIndex = 0; sortedRowIndex < list.size(); sortedRowIndex++) {
+    for (int sortedRowIndex = 0; sortedRowIndex < list.rowCount(); sortedRowIndex++) {
       long time = list.getTime(sortedRowIndex);
 
       // skip duplicated data
-      if ((sortedRowIndex + 1 < list.size() && (time == list.getTime(sortedRowIndex + 1)))) {
+      if ((sortedRowIndex + 1 < list.rowCount() && (time == list.getTime(sortedRowIndex + 1)))) {
         continue;
       }
 
       // store last point for SDT
-      if (sortedRowIndex + 1 == list.size()) {
+      if (sortedRowIndex + 1 == list.rowCount()) {
         ((ChunkWriterImpl) chunkWriterImpl).setLastPoint(true);
       }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunkGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunkGroup.java
@@ -132,6 +132,6 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
 
   @Override
   public long getCurrentTVListSize(String measurement) {
-    return memChunkMap.get(measurement).getTVList().size();
+    return memChunkMap.get(measurement).getTVList().rowCount();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunkGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunkGroup.java
@@ -131,7 +131,7 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
   }
 
   @Override
-  public long getCurrentChunkPointNum(String measurement) {
-    return memChunkMap.get(measurement).count();
+  public long getCurrentTVListSize(String measurement) {
+    return memChunkMap.get(measurement).getTVList().size();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/querycontext/AlignedReadOnlyMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/querycontext/AlignedReadOnlyMemChunk.java
@@ -95,7 +95,7 @@ public class AlignedReadOnlyMemChunk extends ReadOnlyMemChunk {
         new ChunkMetadata(measurementUid, TSDataType.VECTOR, 0, timeStatistics);
     List<IChunkMetadata> valueChunkMetadataList = new ArrayList<>();
     // update time chunk
-    for (int row = 0; row < alignedChunkData.size(); row++) {
+    for (int row = 0; row < alignedChunkData.rowCount(); row++) {
       timeStatistics.update(alignedChunkData.getTime(row));
     }
     timeStatistics.setEmpty(false);
@@ -110,7 +110,7 @@ public class AlignedReadOnlyMemChunk extends ReadOnlyMemChunk {
         valueStatistics.setEmpty(true);
         continue;
       }
-      for (int row = 0; row < alignedChunkData.size(); row++) {
+      for (int row = 0; row < alignedChunkData.rowCount(); row++) {
         long time = alignedChunkData.getTime(row);
         int originRowIndex = alignedChunkData.getValueIndex(row);
         boolean isNull = alignedChunkData.isValueMarked(originRowIndex, column);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -369,7 +369,7 @@ public class TsFileProcessor {
       } else {
         // here currentChunkPointNum >= 1
         long currentChunkPointNum =
-            workMemTable.getCurrentChunkPointNum(deviceID, insertRowPlan.getMeasurements()[i]);
+            workMemTable.getCurrentTVListSize(deviceID, insertRowPlan.getMeasurements()[i]);
         memTableIncrement +=
             (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE) == 0
                 ? TVList.tvListArrayMemCost(insertRowPlan.getDataTypes()[i])
@@ -409,7 +409,7 @@ public class TsFileProcessor {
     } else {
       // here currentChunkPointNum >= 1
       long currentChunkPointNum =
-          workMemTable.getCurrentChunkPointNum(deviceID, AlignedPath.VECTOR_PLACEHOLDER);
+          workMemTable.getCurrentTVListSize(deviceID, AlignedPath.VECTOR_PLACEHOLDER);
       memTableIncrement +=
           (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE) == 0
               ? AlignedTVList.alignedTvListArrayMemCost(insertRowPlan.getDataTypes())
@@ -518,7 +518,7 @@ public class TsFileProcessor {
           ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1)
               * TVList.tvListArrayMemCost(dataType);
     } else {
-      long currentChunkPointNum = workMemTable.getCurrentChunkPointNum(deviceId, measurement);
+      long currentChunkPointNum = workMemTable.getCurrentTVListSize(deviceId, measurement);
       if (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE == 0) {
         memIncrements[0] +=
             ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1)
@@ -558,7 +558,7 @@ public class TsFileProcessor {
               * AlignedTVList.alignedTvListArrayMemCost(dataTypes);
     } else {
       int currentChunkPointNum =
-          (int) workMemTable.getCurrentChunkPointNum(deviceId, AlignedPath.VECTOR_PLACEHOLDER);
+          (int) workMemTable.getCurrentTVListSize(deviceId, AlignedPath.VECTOR_PLACEHOLDER);
       if (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE == 0) {
         memIncrements[0] +=
             ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1)

--- a/server/src/main/java/org/apache/iotdb/db/metadata/path/AlignedPath.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/path/AlignedPath.java
@@ -414,7 +414,7 @@ public class AlignedPath extends PartialPath {
     }
     // get sorted tv list is synchronized so different query can get right sorted list reference
     TVList alignedTvListCopy = alignedMemChunk.getSortedTvListForQuery(schemaList);
-    int curSize = alignedTvListCopy.size();
+    int curSize = alignedTvListCopy.rowCount();
     List<List<TimeRange>> deletionList = null;
     if (modsToMemtable != null) {
       deletionList = constructDeletionList(memTable, modsToMemtable, timeLowerBound);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/path/MeasurementPath.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/path/MeasurementPath.java
@@ -269,7 +269,7 @@ public class MeasurementPath extends PartialPath {
     IWritableMemChunk memChunk = memTableMap.get(deviceID).getMemChunkMap().get(getMeasurement());
     // get sorted tv list is synchronized so different query can get right sorted list reference
     TVList chunkCopy = memChunk.getSortedTvListForQuery();
-    int curSize = chunkCopy.size();
+    int curSize = chunkCopy.rowCount();
     List<TimeRange> deletionList = null;
     if (modsToMemtable != null) {
       deletionList = constructDeletionList(memTable, modsToMemtable, timeLowerBound);

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -80,8 +80,8 @@ public class AlignedTVList extends TVList {
   @Override
   public void putAlignedValue(long timestamp, Object[] value, int[] columnIndexArray) {
     checkExpansion();
-    int arrayIndex = size / ARRAY_SIZE;
-    int elementIndex = size % ARRAY_SIZE;
+    int arrayIndex = rowCount / ARRAY_SIZE;
+    int elementIndex = rowCount % ARRAY_SIZE;
     minTime = Math.min(minTime, timestamp);
     timestamps.get(arrayIndex)[elementIndex] = timestamp;
     for (int i = 0; i < values.size(); i++) {
@@ -119,9 +119,9 @@ public class AlignedTVList extends TVList {
           break;
       }
     }
-    indices.get(arrayIndex)[elementIndex] = size;
-    size++;
-    if (sorted && size > 1 && timestamp < getTime(size - 2)) {
+    indices.get(arrayIndex)[elementIndex] = rowCount;
+    rowCount++;
+    if (sorted && rowCount > 1 && timestamp < getTime(rowCount - 2)) {
       sorted = false;
     }
   }
@@ -139,7 +139,7 @@ public class AlignedTVList extends TVList {
 
   private Object getAlignedValueForQuery(
       int index, Integer floatPrecision, List<TSEncoding> encodingList) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -169,7 +169,7 @@ public class AlignedTVList extends TVList {
       int[] validIndexesForTimeDuplicatedRows,
       Integer floatPrecision,
       List<TSEncoding> encodingList) {
-    if (valueIndex >= size) {
+    if (valueIndex >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(valueIndex);
     }
     TsPrimitiveType[] vector = new TsPrimitiveType[values.size()];
@@ -261,7 +261,7 @@ public class AlignedTVList extends TVList {
     alignedTvList.indices = this.indices;
     alignedTvList.values = values;
     alignedTvList.bitMaps = bitMaps;
-    alignedTvList.size = this.size;
+    alignedTvList.rowCount = this.rowCount;
     return alignedTvList;
   }
 
@@ -300,7 +300,7 @@ public class AlignedTVList extends TVList {
       BitMap bitMap = new BitMap(ARRAY_SIZE);
       // last bitmap should be marked to the tslist size's position
       if (i == timestamps.size() - 1) {
-        for (int j = 0; j < size % ARRAY_SIZE; j++) {
+        for (int j = 0; j < rowCount % ARRAY_SIZE; j++) {
           bitMap.mark(j);
         }
       } else {
@@ -405,7 +405,7 @@ public class AlignedTVList extends TVList {
    * @return boolean
    */
   public boolean isValueMarked(int rowIndex, int columnIndex) {
-    if (rowIndex >= size) {
+    if (rowIndex >= rowCount) {
       return false;
     }
     if (bitMaps == null
@@ -447,7 +447,7 @@ public class AlignedTVList extends TVList {
   public Pair<Integer, Boolean> delete(long lowerBound, long upperBound, int columnIndex) {
     int deletedNumber = 0;
     boolean deleteColumn = true;
-    for (int i = 0; i < size; i++) {
+    for (int i = 0; i < rowCount; i++) {
       long time = getTime(i);
       if (time >= lowerBound && time <= upperBound) {
         int originRowIndex = getValueIndex(i);
@@ -557,14 +557,15 @@ public class AlignedTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null || sortedTimestamps.length < rowCount) {
       sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
     }
-    if (sortedIndices == null || sortedIndices.length < size) {
-      sortedIndices = (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, size);
+    if (sortedIndices == null || sortedIndices.length < rowCount) {
+      sortedIndices =
+          (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, rowCount);
     }
-    sort(0, size);
+    sort(0, rowCount);
     clearSortedValue();
     clearSortedTime();
     sorted = true;
@@ -660,7 +661,7 @@ public class AlignedTVList extends TVList {
    */
   @Override
   public int getValueIndex(int index) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -730,15 +731,15 @@ public class AlignedTVList extends TVList {
 
     while (idx < end) {
       int inputRemaining = end - idx;
-      int arrayIdx = size / ARRAY_SIZE;
-      int elementIdx = size % ARRAY_SIZE;
+      int arrayIdx = rowCount / ARRAY_SIZE;
+      int elementIdx = rowCount % ARRAY_SIZE;
       int internalRemaining = ARRAY_SIZE - elementIdx;
       if (internalRemaining >= inputRemaining) {
         // the remaining inputs can fit the last array, copy all remaining inputs into last array
         System.arraycopy(time, idx, timestamps.get(arrayIdx), elementIdx, inputRemaining);
         arrayCopy(value, idx, arrayIdx, elementIdx, inputRemaining, columnIndexArray);
         for (int i = 0; i < inputRemaining; i++) {
-          indices.get(arrayIdx)[elementIdx + i] = size;
+          indices.get(arrayIdx)[elementIdx + i] = rowCount;
           for (int j = 0; j < values.size(); j++) {
             if (columnIndexArray[j] < 0
                 || bitMaps != null
@@ -747,7 +748,7 @@ public class AlignedTVList extends TVList {
               markNullValue(j, arrayIdx, elementIdx + i);
             }
           }
-          size++;
+          rowCount++;
         }
         break;
       } else {
@@ -756,7 +757,7 @@ public class AlignedTVList extends TVList {
         System.arraycopy(time, idx, timestamps.get(arrayIdx), elementIdx, internalRemaining);
         arrayCopy(value, idx, arrayIdx, elementIdx, internalRemaining, columnIndexArray);
         for (int i = 0; i < internalRemaining; i++) {
-          indices.get(arrayIdx)[elementIdx + i] = size;
+          indices.get(arrayIdx)[elementIdx + i] = rowCount;
           for (int j = 0; j < values.size(); j++) {
             if (columnIndexArray[j] < 0
                 || bitMaps != null
@@ -765,7 +766,7 @@ public class AlignedTVList extends TVList {
               markNullValue(j, arrayIdx, elementIdx + i);
             }
           }
-          size++;
+          rowCount++;
         }
         idx += internalRemaining;
         checkExpansion();
@@ -878,7 +879,7 @@ public class AlignedTVList extends TVList {
   }
 
   public void clear() {
-    size = 0;
+    rowCount = 0;
     sorted = true;
     minTime = Long.MAX_VALUE;
     clearTime();
@@ -941,7 +942,7 @@ public class AlignedTVList extends TVList {
       List<Integer> timeDuplicatedAlignedRowIndexList = null;
       while (cur < iteSize) {
         long time = getTime(cur);
-        if (cur + 1 < size() && (time == getTime(cur + 1))) {
+        if (cur + 1 < rowCount() && (time == getTime(cur + 1))) {
           if (timeDuplicatedAlignedRowIndexList == null) {
             timeDuplicatedAlignedRowIndexList = new ArrayList<>();
             timeDuplicatedAlignedRowIndexList.add(getValueIndex(cur));

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
@@ -49,20 +49,20 @@ public class BinaryTVList extends TVList {
   @Override
   public void putBinary(long timestamp, Binary value) {
     checkExpansion();
-    int arrayIndex = size / ARRAY_SIZE;
-    int elementIndex = size % ARRAY_SIZE;
+    int arrayIndex = rowCount / ARRAY_SIZE;
+    int elementIndex = rowCount % ARRAY_SIZE;
     minTime = Math.min(minTime, timestamp);
     timestamps.get(arrayIndex)[elementIndex] = timestamp;
     values.get(arrayIndex)[elementIndex] = value;
-    size++;
-    if (sorted && size > 1 && timestamp < getTime(size - 2)) {
+    rowCount++;
+    if (sorted && rowCount > 1 && timestamp < getTime(rowCount - 2)) {
       sorted = false;
     }
   }
 
   @Override
   public Binary getBinary(int index) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -71,7 +71,7 @@ public class BinaryTVList extends TVList {
   }
 
   protected void set(int index, long timestamp, Binary value) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -98,15 +98,15 @@ public class BinaryTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null || sortedTimestamps.length < rowCount) {
       sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < rowCount) {
       sortedValues =
-          (Binary[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.TEXT, size);
+          (Binary[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.TEXT, rowCount);
     }
-    sort(0, size);
+    sort(0, rowCount);
     clearSortedValue();
     clearSortedTime();
     sorted = true;
@@ -219,15 +219,15 @@ public class BinaryTVList extends TVList {
 
     while (idx < end) {
       int inputRemaining = end - idx;
-      int arrayIdx = size / ARRAY_SIZE;
-      int elementIdx = size % ARRAY_SIZE;
+      int arrayIdx = rowCount / ARRAY_SIZE;
+      int elementIdx = rowCount % ARRAY_SIZE;
       int internalRemaining = ARRAY_SIZE - elementIdx;
       if (internalRemaining >= inputRemaining) {
         // the remaining inputs can fit the last array, copy all remaining inputs into last array
         System.arraycopy(
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, inputRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, inputRemaining);
-        size += inputRemaining;
+        rowCount += inputRemaining;
         break;
       } else {
         // the remaining inputs cannot fit the last array, fill the last array and create a new
@@ -236,7 +236,7 @@ public class BinaryTVList extends TVList {
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, internalRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, internalRemaining);
         idx += internalRemaining;
-        size += internalRemaining;
+        rowCount += internalRemaining;
         checkExpansion();
       }
     }
@@ -268,7 +268,7 @@ public class BinaryTVList extends TVList {
       }
     }
     minTime = Math.min(inPutMinTime, minTime);
-    sorted = sorted && inputSorted && (size == 0 || inPutMinTime >= getTime(size - 1));
+    sorted = sorted && inputSorted && (rowCount == 0 || inPutMinTime >= getTime(rowCount - 1));
     return nullCnt;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
@@ -48,20 +48,20 @@ public class BooleanTVList extends TVList {
   @Override
   public void putBoolean(long timestamp, boolean value) {
     checkExpansion();
-    int arrayIndex = size / ARRAY_SIZE;
-    int elementIndex = size % ARRAY_SIZE;
+    int arrayIndex = rowCount / ARRAY_SIZE;
+    int elementIndex = rowCount % ARRAY_SIZE;
     minTime = Math.min(minTime, timestamp);
     timestamps.get(arrayIndex)[elementIndex] = timestamp;
     values.get(arrayIndex)[elementIndex] = value;
-    size++;
-    if (sorted && size > 1 && timestamp < getTime(size - 2)) {
+    rowCount++;
+    if (sorted && rowCount > 1 && timestamp < getTime(rowCount - 2)) {
       sorted = false;
     }
   }
 
   @Override
   public boolean getBoolean(int index) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -70,7 +70,7 @@ public class BooleanTVList extends TVList {
   }
 
   protected void set(int index, long timestamp, boolean value) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -97,15 +97,15 @@ public class BooleanTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null || sortedTimestamps.length < rowCount) {
       sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < rowCount) {
       sortedValues =
-          (boolean[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.BOOLEAN, size);
+          (boolean[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.BOOLEAN, rowCount);
     }
-    sort(0, size);
+    sort(0, rowCount);
     clearSortedValue();
     clearSortedTime();
     sorted = true;
@@ -219,15 +219,15 @@ public class BooleanTVList extends TVList {
 
     while (idx < end) {
       int inputRemaining = end - idx;
-      int arrayIdx = size / ARRAY_SIZE;
-      int elementIdx = size % ARRAY_SIZE;
+      int arrayIdx = rowCount / ARRAY_SIZE;
+      int elementIdx = rowCount % ARRAY_SIZE;
       int internalRemaining = ARRAY_SIZE - elementIdx;
       if (internalRemaining >= inputRemaining) {
         // the remaining inputs can fit the last array, copy all remaining inputs into last array
         System.arraycopy(
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, inputRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, inputRemaining);
-        size += inputRemaining;
+        rowCount += inputRemaining;
         break;
       } else {
         // the remaining inputs cannot fit the last array, fill the last array and create a new
@@ -236,7 +236,7 @@ public class BooleanTVList extends TVList {
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, internalRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, internalRemaining);
         idx += internalRemaining;
-        size += internalRemaining;
+        rowCount += internalRemaining;
         checkExpansion();
       }
     }
@@ -268,7 +268,7 @@ public class BooleanTVList extends TVList {
       }
     }
     minTime = Math.min(inPutMinTime, minTime);
-    sorted = sorted && inputSorted && (size == 0 || inPutMinTime >= getTime(size - 1));
+    sorted = sorted && inputSorted && (rowCount == 0 || inPutMinTime >= getTime(rowCount - 1));
     return nullCnt;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
@@ -49,20 +49,20 @@ public class DoubleTVList extends TVList {
   @Override
   public void putDouble(long timestamp, double value) {
     checkExpansion();
-    int arrayIndex = size / ARRAY_SIZE;
-    int elementIndex = size % ARRAY_SIZE;
+    int arrayIndex = rowCount / ARRAY_SIZE;
+    int elementIndex = rowCount % ARRAY_SIZE;
     minTime = Math.min(minTime, timestamp);
     timestamps.get(arrayIndex)[elementIndex] = timestamp;
     values.get(arrayIndex)[elementIndex] = value;
-    size++;
-    if (sorted && size > 1 && timestamp < getTime(size - 2)) {
+    rowCount++;
+    if (sorted && rowCount > 1 && timestamp < getTime(rowCount - 2)) {
       sorted = false;
     }
   }
 
   @Override
   public double getDouble(int index) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -71,7 +71,7 @@ public class DoubleTVList extends TVList {
   }
 
   protected void set(int index, long timestamp, double value) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -98,15 +98,15 @@ public class DoubleTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null || sortedTimestamps.length < rowCount) {
       sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < rowCount) {
       sortedValues =
-          (double[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.DOUBLE, size);
+          (double[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.DOUBLE, rowCount);
     }
-    sort(0, size);
+    sort(0, rowCount);
     clearSortedValue();
     clearSortedTime();
     sorted = true;
@@ -223,15 +223,15 @@ public class DoubleTVList extends TVList {
 
     while (idx < end) {
       int inputRemaining = end - idx;
-      int arrayIdx = size / ARRAY_SIZE;
-      int elementIdx = size % ARRAY_SIZE;
+      int arrayIdx = rowCount / ARRAY_SIZE;
+      int elementIdx = rowCount % ARRAY_SIZE;
       int internalRemaining = ARRAY_SIZE - elementIdx;
       if (internalRemaining >= inputRemaining) {
         // the remaining inputs can fit the last array, copy all remaining inputs into last array
         System.arraycopy(
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, inputRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, inputRemaining);
-        size += inputRemaining;
+        rowCount += inputRemaining;
         break;
       } else {
         // the remaining inputs cannot fit the last array, fill the last array and create a new
@@ -240,7 +240,7 @@ public class DoubleTVList extends TVList {
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, internalRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, internalRemaining);
         idx += internalRemaining;
-        size += internalRemaining;
+        rowCount += internalRemaining;
         checkExpansion();
       }
     }
@@ -272,7 +272,7 @@ public class DoubleTVList extends TVList {
       }
     }
     minTime = Math.min(inPutMinTime, minTime);
-    sorted = sorted && inputSorted && (size == 0 || inPutMinTime >= getTime(size - 1));
+    sorted = sorted && inputSorted && (rowCount == 0 || inPutMinTime >= getTime(rowCount - 1));
     return nullCnt;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
@@ -49,20 +49,20 @@ public class FloatTVList extends TVList {
   @Override
   public void putFloat(long timestamp, float value) {
     checkExpansion();
-    int arrayIndex = size / ARRAY_SIZE;
-    int elementIndex = size % ARRAY_SIZE;
+    int arrayIndex = rowCount / ARRAY_SIZE;
+    int elementIndex = rowCount % ARRAY_SIZE;
     minTime = Math.min(minTime, timestamp);
     timestamps.get(arrayIndex)[elementIndex] = timestamp;
     values.get(arrayIndex)[elementIndex] = value;
-    size++;
-    if (sorted && size > 1 && timestamp < getTime(size - 2)) {
+    rowCount++;
+    if (sorted && rowCount > 1 && timestamp < getTime(rowCount - 2)) {
       sorted = false;
     }
   }
 
   @Override
   public float getFloat(int index) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -71,7 +71,7 @@ public class FloatTVList extends TVList {
   }
 
   protected void set(int index, long timestamp, float value) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -98,15 +98,15 @@ public class FloatTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null || sortedTimestamps.length < rowCount) {
       sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < rowCount) {
       sortedValues =
-          (float[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.FLOAT, size);
+          (float[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.FLOAT, rowCount);
     }
-    sort(0, size);
+    sort(0, rowCount);
     clearSortedValue();
     clearSortedTime();
     sorted = true;
@@ -223,15 +223,15 @@ public class FloatTVList extends TVList {
 
     while (idx < end) {
       int inputRemaining = end - idx;
-      int arrayIdx = size / ARRAY_SIZE;
-      int elementIdx = size % ARRAY_SIZE;
+      int arrayIdx = rowCount / ARRAY_SIZE;
+      int elementIdx = rowCount % ARRAY_SIZE;
       int internalRemaining = ARRAY_SIZE - elementIdx;
       if (internalRemaining >= inputRemaining) {
         // the remaining inputs can fit the last array, copy all remaining inputs into last array
         System.arraycopy(
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, inputRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, inputRemaining);
-        size += inputRemaining;
+        rowCount += inputRemaining;
         break;
       } else {
         // the remaining inputs cannot fit the last array, fill the last array and create a new
@@ -240,7 +240,7 @@ public class FloatTVList extends TVList {
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, internalRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, internalRemaining);
         idx += internalRemaining;
-        size += internalRemaining;
+        rowCount += internalRemaining;
         checkExpansion();
       }
     }
@@ -272,7 +272,7 @@ public class FloatTVList extends TVList {
       }
     }
     minTime = Math.min(inPutMinTime, minTime);
-    sorted = sorted && inputSorted && (size == 0 || inPutMinTime >= getTime(size - 1));
+    sorted = sorted && inputSorted && (rowCount == 0 || inPutMinTime >= getTime(rowCount - 1));
     return nullCnt;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
@@ -48,20 +48,20 @@ public class IntTVList extends TVList {
   @Override
   public void putInt(long timestamp, int value) {
     checkExpansion();
-    int arrayIndex = size / ARRAY_SIZE;
-    int elementIndex = size % ARRAY_SIZE;
+    int arrayIndex = rowCount / ARRAY_SIZE;
+    int elementIndex = rowCount % ARRAY_SIZE;
     minTime = Math.min(minTime, timestamp);
     timestamps.get(arrayIndex)[elementIndex] = timestamp;
     values.get(arrayIndex)[elementIndex] = value;
-    size++;
-    if (sorted && size > 1 && timestamp < getTime(size - 2)) {
+    rowCount++;
+    if (sorted && rowCount > 1 && timestamp < getTime(rowCount - 2)) {
       sorted = false;
     }
   }
 
   @Override
   public int getInt(int index) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -70,7 +70,7 @@ public class IntTVList extends TVList {
   }
 
   protected void set(int index, long timestamp, int value) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -97,14 +97,15 @@ public class IntTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null || sortedTimestamps.length < rowCount) {
       sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
     }
-    if (sortedValues == null || sortedValues.length < size) {
-      sortedValues = (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, size);
+    if (sortedValues == null || sortedValues.length < rowCount) {
+      sortedValues =
+          (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, rowCount);
     }
-    sort(0, size);
+    sort(0, rowCount);
     clearSortedValue();
     clearSortedTime();
     sorted = true;
@@ -217,15 +218,15 @@ public class IntTVList extends TVList {
 
     while (idx < end) {
       int inputRemaining = end - idx;
-      int arrayIdx = size / ARRAY_SIZE;
-      int elementIdx = size % ARRAY_SIZE;
+      int arrayIdx = rowCount / ARRAY_SIZE;
+      int elementIdx = rowCount % ARRAY_SIZE;
       int internalRemaining = ARRAY_SIZE - elementIdx;
       if (internalRemaining >= inputRemaining) {
         // the remaining inputs can fit the last array, copy all remaining inputs into last array
         System.arraycopy(
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, inputRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, inputRemaining);
-        size += inputRemaining;
+        rowCount += inputRemaining;
         break;
       } else {
         // the remaining inputs cannot fit the last array, fill the last array and create a new
@@ -234,7 +235,7 @@ public class IntTVList extends TVList {
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, internalRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, internalRemaining);
         idx += internalRemaining;
-        size += internalRemaining;
+        rowCount += internalRemaining;
         checkExpansion();
       }
     }
@@ -266,7 +267,7 @@ public class IntTVList extends TVList {
       }
     }
     minTime = Math.min(inPutMinTime, minTime);
-    sorted = sorted && inputSorted && (size == 0 || inPutMinTime >= getTime(size - 1));
+    sorted = sorted && inputSorted && (rowCount == 0 || inPutMinTime >= getTime(rowCount - 1));
     return nullCnt;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
@@ -48,20 +48,20 @@ public class LongTVList extends TVList {
   @Override
   public void putLong(long timestamp, long value) {
     checkExpansion();
-    int arrayIndex = size / ARRAY_SIZE;
-    int elementIndex = size % ARRAY_SIZE;
+    int arrayIndex = rowCount / ARRAY_SIZE;
+    int elementIndex = rowCount % ARRAY_SIZE;
     minTime = Math.min(minTime, timestamp);
     timestamps.get(arrayIndex)[elementIndex] = timestamp;
     values.get(arrayIndex)[elementIndex] = value;
-    size++;
-    if (sorted && size > 1 && timestamp < getTime(size - 2)) {
+    rowCount++;
+    if (sorted && rowCount > 1 && timestamp < getTime(rowCount - 2)) {
       sorted = false;
     }
   }
 
   @Override
   public long getLong(int index) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -70,7 +70,7 @@ public class LongTVList extends TVList {
   }
 
   protected void set(int index, long timestamp, long value) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -97,14 +97,15 @@ public class LongTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null || sortedTimestamps.length < rowCount) {
       sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
     }
-    if (sortedValues == null || sortedValues.length < size) {
-      sortedValues = (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
+    if (sortedValues == null || sortedValues.length < rowCount) {
+      sortedValues =
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
     }
-    sort(0, size);
+    sort(0, rowCount);
     clearSortedValue();
     clearSortedTime();
     sorted = true;
@@ -217,15 +218,15 @@ public class LongTVList extends TVList {
 
     while (idx < end) {
       int inputRemaining = end - idx;
-      int arrayIdx = size / ARRAY_SIZE;
-      int elementIdx = size % ARRAY_SIZE;
+      int arrayIdx = rowCount / ARRAY_SIZE;
+      int elementIdx = rowCount % ARRAY_SIZE;
       int internalRemaining = ARRAY_SIZE - elementIdx;
       if (internalRemaining >= inputRemaining) {
         // the remaining inputs can fit the last array, copy all remaining inputs into last array
         System.arraycopy(
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, inputRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, inputRemaining);
-        size += inputRemaining;
+        rowCount += inputRemaining;
         break;
       } else {
         // the remaining inputs cannot fit the last array, fill the last array and create a new
@@ -234,7 +235,7 @@ public class LongTVList extends TVList {
             time, idx - timeIdxOffset, timestamps.get(arrayIdx), elementIdx, internalRemaining);
         System.arraycopy(value, idx, values.get(arrayIdx), elementIdx, internalRemaining);
         idx += internalRemaining;
-        size += internalRemaining;
+        rowCount += internalRemaining;
         checkExpansion();
       }
     }
@@ -266,7 +267,7 @@ public class LongTVList extends TVList {
       }
     }
     minTime = Math.min(inPutMinTime, minTime);
-    sorted = sorted && inputSorted && (size == 0 || inPutMinTime >= getTime(size - 1));
+    sorted = sorted && inputSorted && (rowCount == 0 || inPutMinTime >= getTime(rowCount - 1));
     return nullCnt;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
@@ -45,7 +45,7 @@ public abstract class TVList {
   // list of timestamp array, add 1 when expanded -> data point timestamp array
   // index relation: arrayIndex -> elementIndex
   protected List<long[]> timestamps;
-  protected int size;
+  protected int rowCount;
 
   protected long[][] sortedTimestamps;
   protected boolean sorted = true;
@@ -59,7 +59,7 @@ public abstract class TVList {
 
   public TVList() {
     timestamps = new ArrayList<>();
-    size = 0;
+    rowCount = 0;
     minTime = Long.MAX_VALUE;
     referenceCount = new AtomicInteger();
   }
@@ -109,12 +109,12 @@ public abstract class TVList {
     return referenceCount.get();
   }
 
-  public int size() {
-    return size;
+  public int rowCount() {
+    return rowCount;
   }
 
   public long getTime(int index) {
-    if (index >= size) {
+    if (index >= rowCount) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     int arrayIndex = index / ARRAY_SIZE;
@@ -256,15 +256,15 @@ public abstract class TVList {
   public int delete(long lowerBound, long upperBound) {
     int newSize = 0;
     minTime = Long.MAX_VALUE;
-    for (int i = 0; i < size; i++) {
+    for (int i = 0; i < rowCount; i++) {
       long time = getTime(i);
       if (time < lowerBound || time > upperBound) {
         set(i, newSize++);
         minTime = Math.min(time, minTime);
       }
     }
-    int deletedNumber = size - newSize;
-    size = newSize;
+    int deletedNumber = rowCount - newSize;
+    rowCount = newSize;
     // release primitive arrays that are empty
     int newArrayNum = newSize / ARRAY_SIZE;
     if (newSize % ARRAY_SIZE != 0) {
@@ -282,13 +282,13 @@ public abstract class TVList {
     for (long[] timestampArray : timestamps) {
       cloneList.timestamps.add(cloneTime(timestampArray));
     }
-    cloneList.size = size;
+    cloneList.rowCount = rowCount;
     cloneList.sorted = sorted;
     cloneList.minTime = minTime;
   }
 
   public void clear() {
-    size = 0;
+    rowCount = 0;
     sorted = true;
     minTime = Long.MAX_VALUE;
     clearTime();
@@ -322,7 +322,7 @@ public abstract class TVList {
   abstract void clearSortedValue();
 
   protected void checkExpansion() {
-    if ((size % ARRAY_SIZE) == 0) {
+    if ((rowCount % ARRAY_SIZE) == 0) {
       expandValues();
       timestamps.add((long[]) getPrimitiveArraysByType(TSDataType.INT64));
     }
@@ -501,7 +501,7 @@ public abstract class TVList {
       }
     }
     minTime = Math.min(inPutMinTime, minTime);
-    sorted = sorted && inputSorted && (size == 0 || inPutMinTime >= getTime(size - 1));
+    sorted = sorted && inputSorted && (rowCount == 0 || inPutMinTime >= getTime(rowCount - 1));
   }
 
   /** for log */
@@ -544,7 +544,7 @@ public abstract class TVList {
     private List<TimeRange> deletionList;
 
     public Ite() {
-      this.iteSize = TVList.this.size;
+      this.iteSize = TVList.this.rowCount;
     }
 
     public Ite(int floatPrecision, TSEncoding encoding, int size, List<TimeRange> deletionList) {
@@ -562,7 +562,7 @@ public abstract class TVList {
 
       while (cur < iteSize) {
         long time = getTime(cur);
-        if (isPointDeleted(time) || (cur + 1 < size() && (time == getTime(cur + 1)))) {
+        if (isPointDeleted(time) || (cur + 1 < rowCount() && (time == getTime(cur + 1)))) {
           cur++;
           continue;
         }
@@ -616,6 +616,6 @@ public abstract class TVList {
   public abstract TSDataType getDataType();
 
   public long getLastTime() {
-    return getTime(size - 1);
+    return getTime(rowCount - 1);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/BinaryTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/BinaryTVListTest.java
@@ -36,7 +36,7 @@ public class BinaryTVListTest {
     for (int i = 0; i < 1000; i++) {
       tvList.putBinary(i, Binary.valueOf(String.valueOf(i)));
     }
-    for (int i = 0; i < tvList.size; i++) {
+    for (int i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(String.valueOf(i), tvList.getBinary(i).toString());
       Assert.assertEquals(i, tvList.getTime(i));
     }
@@ -53,8 +53,8 @@ public class BinaryTVListTest {
     }
     tvList.putBinaries(
         ArrayUtils.toPrimitive(timeList.toArray(new Long[0])), binaryList, null, 0, 1000);
-    for (long i = 0; i < tvList.size; i++) {
-      Assert.assertEquals(tvList.size - i, tvList.getTime((int) i));
+    for (long i = 0; i < tvList.rowCount; i++) {
+      Assert.assertEquals(tvList.rowCount - i, tvList.getTime((int) i));
     }
   }
 
@@ -103,7 +103,7 @@ public class BinaryTVListTest {
         ArrayUtils.toPrimitive(timeList.toArray(new Long[0])), binaryList, bitMap, 0, 1000);
     tvList.sort();
     BinaryTVList clonedTvList = tvList.clone();
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(tvList.getBinary((int) i), clonedTvList.getBinary((int) i));
       Assert.assertEquals(tvList.getTime((int) i), clonedTvList.getTime((int) i));
     }

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/BooleanTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/BooleanTVListTest.java
@@ -37,11 +37,11 @@ public class BooleanTVListTest {
     for (int i = 50; i < 100; i++) {
       tvList.putBoolean(i, false);
     }
-    for (int i = 0; i < tvList.size / 2; i++) {
+    for (int i = 0; i < tvList.rowCount / 2; i++) {
       Assert.assertTrue(tvList.getBoolean(i));
       Assert.assertEquals(i, tvList.getTime(i));
     }
-    for (int i = tvList.size / 2 + 1; i < tvList.size; i++) {
+    for (int i = tvList.rowCount / 2 + 1; i < tvList.rowCount; i++) {
       Assert.assertFalse(tvList.getBoolean(i));
       Assert.assertEquals(i, tvList.getTime(i));
     }
@@ -62,8 +62,8 @@ public class BooleanTVListTest {
         null,
         0,
         1000);
-    for (long i = 0; i < tvList.size; i++) {
-      Assert.assertEquals(tvList.size - i, tvList.getTime((int) i));
+    for (long i = 0; i < tvList.rowCount; i++) {
+      Assert.assertEquals(tvList.rowCount - i, tvList.getTime((int) i));
     }
   }
 
@@ -119,7 +119,7 @@ public class BooleanTVListTest {
         1000);
     tvList.sort();
     BooleanTVList clonedTvList = tvList.clone();
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(tvList.getBoolean((int) i), clonedTvList.getBoolean((int) i));
       Assert.assertEquals(tvList.getTime((int) i), clonedTvList.getTime((int) i));
     }

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/DoubleTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/DoubleTVListTest.java
@@ -37,7 +37,7 @@ public class DoubleTVListTest {
       tvList.putDouble(i, i);
     }
     tvList.sort();
-    for (int i = 0; i < tvList.size; i++) {
+    for (int i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(i, tvList.getDouble(i), delta);
       Assert.assertEquals(i, tvList.getTime(i));
     }
@@ -50,7 +50,7 @@ public class DoubleTVListTest {
       tvList.putDouble(i, i);
     }
     tvList.sort();
-    for (int i = 0; i < tvList.size; i++) {
+    for (int i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(i, tvList.getDouble(i), delta);
       Assert.assertEquals(i, tvList.getTime(i));
     }
@@ -71,9 +71,9 @@ public class DoubleTVListTest {
         null,
         0,
         1000);
-    for (long i = 0; i < tvList.size; i++) {
-      Assert.assertEquals((double) tvList.size - i, tvList.getDouble((int) i), delta);
-      Assert.assertEquals(tvList.size - i, tvList.getTime((int) i));
+    for (long i = 0; i < tvList.rowCount; i++) {
+      Assert.assertEquals((double) tvList.rowCount - i, tvList.getDouble((int) i), delta);
+      Assert.assertEquals(tvList.rowCount - i, tvList.getTime((int) i));
     }
   }
 
@@ -129,7 +129,7 @@ public class DoubleTVListTest {
         1000);
     tvList.sort();
     DoubleTVList clonedTvList = tvList.clone();
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(tvList.getDouble((int) i), clonedTvList.getDouble((int) i), delta);
       Assert.assertEquals(tvList.getTime((int) i), clonedTvList.getTime((int) i));
     }

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/FloatTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/FloatTVListTest.java
@@ -37,7 +37,7 @@ public class FloatTVListTest {
       tvList.putFloat(i, (float) i);
     }
     tvList.sort();
-    for (int i = 0; i < tvList.size; i++) {
+    for (int i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals((float) i, tvList.getFloat(i), delta);
       Assert.assertEquals(i, tvList.getTime(i));
     }
@@ -50,7 +50,7 @@ public class FloatTVListTest {
       tvList.putFloat(i, (float) i);
     }
     tvList.sort();
-    for (int i = 0; i < tvList.size; i++) {
+    for (int i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals((float) i, tvList.getFloat(i), delta);
       Assert.assertEquals(i, tvList.getTime(i));
     }
@@ -71,9 +71,9 @@ public class FloatTVListTest {
         null,
         0,
         1000);
-    for (long i = 0; i < tvList.size; i++) {
-      Assert.assertEquals((float) tvList.size - i, tvList.getFloat((int) i), delta);
-      Assert.assertEquals(tvList.size - i, tvList.getTime((int) i));
+    for (long i = 0; i < tvList.rowCount; i++) {
+      Assert.assertEquals((float) tvList.rowCount - i, tvList.getFloat((int) i), delta);
+      Assert.assertEquals(tvList.rowCount - i, tvList.getTime((int) i));
     }
   }
 
@@ -129,7 +129,7 @@ public class FloatTVListTest {
         1000);
     tvList.sort();
     FloatTVList clonedTvList = tvList.clone();
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(tvList.getFloat((int) i), clonedTvList.getFloat((int) i), delta);
       Assert.assertEquals(tvList.getTime((int) i), clonedTvList.getTime((int) i));
     }

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/IntTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/IntTVListTest.java
@@ -36,7 +36,7 @@ public class IntTVListTest {
       tvList.putInt(i, i);
     }
     tvList.sort();
-    for (int i = 0; i < tvList.size; i++) {
+    for (int i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(i, tvList.getInt(i));
       Assert.assertEquals(i, tvList.getTime(i));
     }
@@ -49,7 +49,7 @@ public class IntTVListTest {
       tvList.putInt(i, i);
     }
     tvList.sort();
-    for (int i = 0; i < tvList.size; i++) {
+    for (int i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(i, tvList.getInt(i));
       Assert.assertEquals(i, tvList.getTime(i));
     }
@@ -70,9 +70,9 @@ public class IntTVListTest {
         null,
         0,
         1000);
-    for (long i = 0; i < tvList.size; i++) {
-      Assert.assertEquals(tvList.size - i, tvList.getInt((int) i));
-      Assert.assertEquals(tvList.size - i, tvList.getTime((int) i));
+    for (long i = 0; i < tvList.rowCount; i++) {
+      Assert.assertEquals(tvList.rowCount - i, tvList.getInt((int) i));
+      Assert.assertEquals(tvList.rowCount - i, tvList.getTime((int) i));
     }
   }
 
@@ -128,7 +128,7 @@ public class IntTVListTest {
         1000);
     tvList.sort();
     IntTVList clonedTvList = tvList.clone();
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(tvList.getInt((int) i), clonedTvList.getInt((int) i));
       Assert.assertEquals(tvList.getTime((int) i), clonedTvList.getTime((int) i));
     }

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/LongTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/LongTVListTest.java
@@ -39,7 +39,7 @@ public class LongTVListTest {
       tvList.putLong(i, i);
     }
     tvList.sort();
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(i, tvList.getLong((int) i));
       Assert.assertEquals(i, tvList.getTime((int) i));
     }
@@ -52,7 +52,7 @@ public class LongTVListTest {
       tvList.putLong(i, i);
     }
     tvList.sort();
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(i, tvList.getLong((int) i));
       Assert.assertEquals(i, tvList.getTime((int) i));
     }
@@ -71,7 +71,7 @@ public class LongTVListTest {
     }
     tvList.sort();
     inputs.sort(TimeValuePair::compareTo);
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(inputs.get((int) i).getTimestamp(), tvList.getTime((int) i));
       Assert.assertEquals(inputs.get((int) i).getValue().getLong(), tvList.getLong((int) i));
     }
@@ -92,9 +92,9 @@ public class LongTVListTest {
         null,
         0,
         1000);
-    for (long i = 0; i < tvList.size; i++) {
-      Assert.assertEquals(tvList.size - i, tvList.getLong((int) i));
-      Assert.assertEquals(tvList.size - i, tvList.getTime((int) i));
+    for (long i = 0; i < tvList.rowCount; i++) {
+      Assert.assertEquals(tvList.rowCount - i, tvList.getLong((int) i));
+      Assert.assertEquals(tvList.rowCount - i, tvList.getTime((int) i));
     }
   }
 
@@ -150,7 +150,7 @@ public class LongTVListTest {
         1000);
     tvList.sort();
     LongTVList clonedTvList = tvList.clone();
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(tvList.getLong((int) i), clonedTvList.getLong((int) i));
       Assert.assertEquals(tvList.getTime((int) i), clonedTvList.getTime((int) i));
     }

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/VectorTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/VectorTVListTest.java
@@ -47,7 +47,7 @@ public class VectorTVListTest {
       }
       tvList.putAlignedValue(i, value, columnOrder);
     }
-    for (int i = 0; i < tvList.size; i++) {
+    for (int i = 0; i < tvList.rowCount; i++) {
       StringBuilder builder = new StringBuilder("[");
       builder.append(String.valueOf(i));
       for (int j = 1; j < 5; j++) {
@@ -84,7 +84,7 @@ public class VectorTVListTest {
       tvList.putAlignedValue(i, value, columnOrder);
     }
     tvList.sort();
-    for (int i = 0; i < tvList.size; i++) {
+    for (int i = 0; i < tvList.rowCount; i++) {
       StringBuilder builder = new StringBuilder("[");
       builder.append("false, 100, 1000, 0.1, 0.2, Test");
       builder.append("]");
@@ -118,8 +118,8 @@ public class VectorTVListTest {
         columnOrder,
         0,
         1000);
-    for (long i = 0; i < tvList.size; i++) {
-      Assert.assertEquals(tvList.size - i, tvList.getTime((int) i));
+    for (long i = 0; i < tvList.rowCount; i++) {
+      Assert.assertEquals(tvList.rowCount - i, tvList.getTime((int) i));
     }
   }
 
@@ -153,8 +153,8 @@ public class VectorTVListTest {
         columnOrder,
         0,
         1000);
-    for (long i = 0; i < tvList.size; i++) {
-      Assert.assertEquals(tvList.size - i, tvList.getTime((int) i));
+    for (long i = 0; i < tvList.rowCount; i++) {
+      Assert.assertEquals(tvList.rowCount - i, tvList.getTime((int) i));
       if (i % 100 == 0) {
         Assert.assertEquals(
             "[null, null, null, null, null]", tvList.getAlignedValue((int) i).toString());
@@ -194,7 +194,7 @@ public class VectorTVListTest {
         1000);
 
     AlignedTVList clonedTvList = tvList.clone();
-    for (long i = 0; i < tvList.size; i++) {
+    for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(tvList.getTime((int) i), clonedTvList.getTime((int) i));
       Assert.assertEquals(
           tvList.getAlignedValue((int) i).toString(),


### PR DESCRIPTION
## Description



This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
