### PR TITLE
[IOTDB-2457] Fix write is blocked after set time_index_level=FILE_TIME_INDEX

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -319,11 +319,6 @@ timestamp_precision=ms
 # Datatype: int
 # virtual_storage_group_num = 1
 
-# Level of TimeIndex, which records the start time and end time of TsFileResource. Currently,
-# DEVICE_TIME_INDEX and FILE_TIME_INDEX are supported, and could not be changed after first set.
-# Datatype: TimeIndexLevel
-# time_index_level=DEVICE_TIME_INDEX
-
 ####################
 ### Memory Control Configuration
 ####################


### PR DESCRIPTION
It's a mistake, we should not let users to set `FILE_TIME_INDEX`, we only support automatically degraded from `DEVICE_TIME_INDEX` to `FILE_TIME_INDEX`.