### PR TITLE
[IOTDB-2465][imple] fix implement of snapshot of dropwizard to UniformReservoir.

### DIFF
--- a/metrics/dropwizard-metrics/src/main/java/org/apache/iotdb/metrics/dropwizard/DropwizardMetricManager.java
+++ b/metrics/dropwizard-metrics/src/main/java/org/apache/iotdb/metrics/dropwizard/DropwizardMetricManager.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.metrics.utils.PredefinedMetric;
 
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.UniformReservoir;
 import com.codahale.metrics.jvm.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,8 @@ public class DropwizardMetricManager implements MetricManager {
 
   com.codahale.metrics.MetricRegistry metricRegistry;
   MetricConfig metricConfig = MetricConfigDescriptor.getInstance().getMetricConfig();
+  MetricRegistry.MetricSupplier<com.codahale.metrics.Timer> metricSupplier =
+      () -> new com.codahale.metrics.Timer(new UniformReservoir());
 
   /** init the field with dropwizard library. */
   public DropwizardMetricManager() {
@@ -156,7 +159,8 @@ public class DropwizardMetricManager implements MetricManager {
     MetricName name = new MetricName(metric, tags);
     IMetric m =
         currentMeters.computeIfAbsent(
-            name, key -> new DropwizardTimer(metricRegistry.timer(name.toFlatString())));
+            name,
+            key -> new DropwizardTimer(metricRegistry.timer(name.toFlatString(), metricSupplier)));
     if (m instanceof Timer) {
       return (Timer) m;
     }
@@ -241,7 +245,8 @@ public class DropwizardMetricManager implements MetricManager {
     MetricName name = new MetricName(metric, tags);
     IMetric m =
         currentMeters.computeIfAbsent(
-            name, key -> new DropwizardTimer(metricRegistry.timer(name.toFlatString())));
+            name,
+            key -> new DropwizardTimer(metricRegistry.timer(name.toFlatString(), metricSupplier)));
 
     if (m instanceof Timer) {
       ((Timer) m).update(delta, timeUnit);

--- a/metrics/dropwizard-metrics/src/test/java/org/apache/iotdb/metrics/dropwizard/DropwizardMetricManagerTest.java
+++ b/metrics/dropwizard-metrics/src/test/java/org/apache/iotdb/metrics/dropwizard/DropwizardMetricManagerTest.java
@@ -174,6 +174,11 @@ public class DropwizardMetricManagerTest {
     metricManager.timer(2L, TimeUnit.MINUTES, "timer_mark", "tag1", "tag2");
     metricManager.timer(4L, TimeUnit.MINUTES, "timer_" + "mark", "tag1", "tag2");
     metricManager.timer(6L, TimeUnit.MINUTES, "timer_mark", "tag1", "tag2");
+    try {
+      Thread.sleep(1000);
+    } catch (Exception e) {
+      // do nothing
+    }
     metricManager.timer(8L, TimeUnit.MINUTES, "timer_mark", "tag1", "tag2");
     metricManager.timer(10L, TimeUnit.MINUTES, "timer_mark", "tag1", "tag2");
     assertEquals(5, timer.getImmutableRate().getCount());


### PR DESCRIPTION
When run CI, there are following problems:

![image](https://user-images.githubusercontent.com/46039728/150483715-8c410cc4-a45a-492c-8155-bb3b1eb750b2.png)

It's because the implementation of snapshot for dropwizard use wighted one as default, so I change to uniform one now.