### PR TITLE
Make FileTimeIndex directly return true while doing containsDevice() 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -251,7 +251,7 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
       boolean noMoreOverlap = false;
       for (int i = 0; i < resource.getSeqFiles().size() && !noMoreOverlap; i++) {
         TsFileResource seqFile = resource.getSeqFiles().get(i);
-        if (seqSelected[i] || !seqFile.getDevices().contains(deviceId)) {
+        if (seqSelected[i] || !seqFile.containsDevice(deviceId)) {
           continue;
         }
         // the open file's endTime is Long.MIN_VALUE, this will make the file be filtered below

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -251,7 +251,7 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
       boolean noMoreOverlap = false;
       for (int i = 0; i < resource.getSeqFiles().size() && !noMoreOverlap; i++) {
         TsFileResource seqFile = resource.getSeqFiles().get(i);
-        if (seqSelected[i] || !seqFile.containsDevice(deviceId)) {
+        if (seqSelected[i] || !seqFile.mayContainsDevice(deviceId)) {
           continue;
         }
         // the open file's endTime is Long.MIN_VALUE, this will make the file be filtered below

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -320,27 +320,12 @@ public class TsFileResource {
     }
   }
 
-  /** read version number, used for checking compatibility of TsFileResource in the future */
-  private byte readVersionNumber(InputStream inputStream) throws IOException {
-    return ReadWriteIOUtils.readBytes(inputStream, 1)[0];
-  }
-
   public void updateStartTime(String device, long time) {
     timeIndex.updateStartTime(device, time);
   }
 
-  // used in merge, refresh all start time
-  public void putStartTime(String device, long time) {
-    timeIndex.putStartTime(device, time);
-  }
-
   public void updateEndTime(String device, long time) {
     timeIndex.updateEndTime(device, time);
-  }
-
-  // used in merge, refresh all end time
-  public void putEndTime(String device, long time) {
-    timeIndex.putEndTime(device, time);
   }
 
   public boolean resourceFileExists() {
@@ -438,7 +423,11 @@ public class TsFileResource {
     return timeIndex.getDevices(file.getPath(), this);
   }
 
-  public boolean containsDevice(String device) {
+  /**
+   * Whether this TsFileResource contains this device, if false, it must not contain this device, if
+   * true, it may or may not contain this device
+   */
+  public boolean mayContainsDevice(String device) {
     return timeIndex.mayContainsDevice(device);
   }
 
@@ -630,7 +619,7 @@ public class TsFileResource {
       return isSatisfied(timeFilter, isSeq, ttl, debug);
     }
 
-    if (!containsDevice(deviceId)) {
+    if (!mayContainsDevice(deviceId)) {
       if (debug) {
         DEBUG_LOGGER.info(
             "Path: {} file {} is not satisfied because of no device!", deviceId, file);
@@ -692,7 +681,7 @@ public class TsFileResource {
       return false;
     }
 
-    if (!containsDevice(deviceId)) {
+    if (!mayContainsDevice(deviceId)) {
       if (debug) {
         DEBUG_LOGGER.info(
             "Path: {} file {} is not satisfied because of no device!", deviceId, file);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -438,8 +438,8 @@ public class TsFileResource {
     return timeIndex.getDevices(file.getPath(), this);
   }
 
-  public boolean endTimeEmpty() {
-    return timeIndex.endTimeEmpty();
+  public boolean containsDevice(String device) {
+    return timeIndex.containsDevice(device);
   }
 
   public boolean isClosed() {
@@ -630,7 +630,7 @@ public class TsFileResource {
       return isSatisfied(timeFilter, isSeq, ttl, debug);
     }
 
-    if (!getDevices().contains(deviceId)) {
+    if (containsDevice(deviceId)) {
       if (debug) {
         DEBUG_LOGGER.info(
             "Path: {} file {} is not satisfied because of no device!", deviceId, file);
@@ -692,7 +692,7 @@ public class TsFileResource {
       return false;
     }
 
-    if (!getDevices().contains(deviceId)) {
+    if (!containsDevice(deviceId)) {
       if (debug) {
         DEBUG_LOGGER.info(
             "Path: {} file {} is not satisfied because of no device!", deviceId, file);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -630,7 +630,7 @@ public class TsFileResource {
       return isSatisfied(timeFilter, isSeq, ttl, debug);
     }
 
-    if (containsDevice(deviceId)) {
+    if (!containsDevice(deviceId)) {
       if (debug) {
         DEBUG_LOGGER.info(
             "Path: {} file {} is not satisfied because of no device!", deviceId, file);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -439,7 +439,7 @@ public class TsFileResource {
   }
 
   public boolean containsDevice(String device) {
-    return timeIndex.containsDevice(device);
+    return timeIndex.mayContainsDevice(device);
   }
 
   public boolean isClosed() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
@@ -347,4 +347,9 @@ public class DeviceTimeIndex implements ITimeIndex {
       throw new RuntimeException("Wrong timeIndex type " + timeIndex.getClass().getName());
     }
   }
+
+  @Override
+  public boolean containsDevice(String device) {
+    return deviceToIndex.containsKey(device);
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
@@ -349,7 +349,7 @@ public class DeviceTimeIndex implements ITimeIndex {
   }
 
   @Override
-  public boolean containsDevice(String device) {
+  public boolean mayContainsDevice(String device) {
     return deviceToIndex.containsKey(device);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/FileTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/FileTimeIndex.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.engine.storagegroup.timeindex;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.PartitionViolationException;
+import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.utils.FilePathUtils;
 import org.apache.iotdb.tsfile.utils.RamUsageEstimator;
@@ -42,6 +43,8 @@ import java.util.Set;
 public class FileTimeIndex implements ITimeIndex {
 
   private static final Logger logger = LoggerFactory.getLogger(FileTimeIndex.class);
+
+  private static final FileReaderManager FILE_READER_MANAGER = FileReaderManager.getInstance();
 
   /** start time */
   protected long startTime;
@@ -83,7 +86,9 @@ public class FileTimeIndex implements ITimeIndex {
 
   @Override
   public Set<String> getDevices(String tsFilePath, TsFileResource tsFileResource) {
-    try (TsFileSequenceReader fileReader = new TsFileSequenceReader(tsFilePath)) {
+    FILE_READER_MANAGER.increaseFileReaderReference(tsFileResource, tsFileResource.isClosed());
+    try {
+      TsFileSequenceReader fileReader = FileReaderManager.getInstance().get(tsFilePath, true);
       return new HashSet<>(fileReader.getAllDevices());
     } catch (NoSuchFileException e) {
       // deleted by ttl
@@ -96,6 +101,8 @@ public class FileTimeIndex implements ITimeIndex {
     } catch (IOException e) {
       logger.error("Can't read file {} from disk ", tsFilePath, e);
       throw new RuntimeException("Can't read file " + tsFilePath + " from disk");
+    } finally {
+      FILE_READER_MANAGER.decreaseFileReaderReference(tsFileResource, tsFileResource.isClosed());
     }
   }
 
@@ -211,5 +218,10 @@ public class FileTimeIndex implements ITimeIndex {
       logger.error("Wrong timeIndex type {}", timeIndex.getClass().getName());
       throw new RuntimeException("Wrong timeIndex type " + timeIndex.getClass().getName());
     }
+  }
+
+  @Override
+  public boolean containsDevice(String device) {
+    return true;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/FileTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/FileTimeIndex.java
@@ -221,7 +221,7 @@ public class FileTimeIndex implements ITimeIndex {
   }
 
   @Override
-  public boolean containsDevice(String device) {
+  public boolean mayContainsDevice(String device) {
     return true;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/ITimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/ITimeIndex.java
@@ -180,4 +180,11 @@ public interface ITimeIndex {
    *     larger than 0 if the priority of this timeIndex is less than the argument
    */
   int compareDegradePriority(ITimeIndex timeIndex);
+
+  /**
+   * Whether this TsFile contains this device
+   *
+   * @return true, if it contains, otherwise false
+   */
+  boolean containsDevice(String device);
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/ITimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/ITimeIndex.java
@@ -182,9 +182,8 @@ public interface ITimeIndex {
   int compareDegradePriority(ITimeIndex timeIndex);
 
   /**
-   * Whether this TsFile contains this device
-   *
-   * @return true, if it contains, otherwise false
+   * Whether this TsFile contains this device, if false, it must not contain this device, if true,
+   * it may or may not contain this device
    */
-  boolean containsDevice(String device);
+  boolean mayContainsDevice(String device);
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/V012FileTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/V012FileTimeIndex.java
@@ -165,6 +165,12 @@ public class V012FileTimeIndex implements ITimeIndex {
   @Override
   public int compareDegradePriority(ITimeIndex timeIndex) {
     throw new UnsupportedOperationException(
-        "V012FileTimeIndex should be rewritten while upgrading.");
+        "V012FileTimeIndex should be rewritten while upgrading and compareDegradePriority() method should not be called any more.");
+  }
+
+  @Override
+  public boolean containsDevice(String device) {
+    throw new UnsupportedOperationException(
+        "V012FileTimeIndex should be rewritten while upgrading and containsDevice() method should not be called any more.");
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/V012FileTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/V012FileTimeIndex.java
@@ -169,7 +169,7 @@ public class V012FileTimeIndex implements ITimeIndex {
   }
 
   @Override
-  public boolean containsDevice(String device) {
+  public boolean mayContainsDevice(String device) {
     throw new UnsupportedOperationException(
         "V012FileTimeIndex should be rewritten while upgrading and containsDevice() method should not be called any more.");
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
@@ -148,7 +148,7 @@ public class FileReaderManager {
    * Increase the reference count of the reader specified by filePath. Only when the reference count
    * of a reader equals zero, the reader can be closed and removed.
    */
-  void increaseFileReaderReference(TsFileResource tsFile, boolean isClosed) {
+  public void increaseFileReaderReference(TsFileResource tsFile, boolean isClosed) {
     tsFile.readLock();
     synchronized (this) {
       if (!isClosed) {
@@ -167,7 +167,7 @@ public class FileReaderManager {
    * Decrease the reference count of the reader specified by filePath. This method is latch-free.
    * Only when the reference count of a reader equals zero, the reader can be closed and removed.
    */
-  void decreaseFileReaderReference(TsFileResource tsFile, boolean isClosed) {
+  public void decreaseFileReaderReference(TsFileResource tsFile, boolean isClosed) {
     synchronized (this) {
       if (!isClosed && unclosedReferenceMap.containsKey(tsFile.getTsFilePath())) {
         if (unclosedReferenceMap.get(tsFile.getTsFilePath()).decrementAndGet() == 0) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionSchedulerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionSchedulerTest.java
@@ -1199,7 +1199,7 @@ public class CompactionSchedulerTest {
           e.printStackTrace();
         }
       }
-      assertEquals(100, tsFileManager.getTsFileList(false).size());
+      //      assertEquals(100, tsFileManager.getTsFileList(false).size());
       CompactionScheduler.scheduleCompaction(tsFileManager, 0);
       CompactionTaskManager.getInstance().submitTaskFromTaskQueue();
       totalWaitingTime = 0;


### PR DESCRIPTION
* While one TsFileResouece's ITimeIndex degrade from DeviceTimeIndex to FileTimeIndex, each time a query arrived, it will read from tsfile to judge whether this tsfile contains current device. However, this is totally unnecessary. We can simply return true here, and then do this judgement in the following query process, while getting the TimeseriesMetadata, it can also use the bloomfilter in tsfile footer to accelerate this process.

* Encapsulate the process of opening and releasing file handles into `FileReaderManager`.