### PR TITLE
Enhance exception handle logic that read metadata from tsfile in File…

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/FileTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/FileTimeIndex.java
@@ -93,9 +93,9 @@ public class FileTimeIndex implements ITimeIndex {
         logger.error("Can't read file {} from disk ", tsFilePath, e);
         throw new RuntimeException("Can't read file " + tsFilePath + " from disk");
       }
-    } catch (IOException e) {
-      logger.error("Can't read file {} from disk ", tsFilePath, e);
-      throw new RuntimeException("Can't read file " + tsFilePath + " from disk");
+    } catch (Exception e) {
+      logger.error("Failed to get devices from tsfile: {}", tsFilePath, e);
+      throw new RuntimeException("Failed to get devices from tsfile:: " + tsFilePath);
     }
   }
 


### PR DESCRIPTION
If some tsfile corrupted then parse for metadata should fail but we can't catch the exception here. Enchance the logic here to help locate if a tsfile corrupted.