### PR TITLE
[IOTDB-2433] Fix insert aligned timeseries performance reduction

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBDeletionIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBDeletionIT.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.itbase.category.LocalStandaloneTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBDeletionIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBDeletionIT.java
@@ -189,7 +189,6 @@ public class IoTDBDeletionIT {
   }
 
   @Test
-  @Ignore // TODO
   public void testMerge() throws SQLException {
     prepareMerge();
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,9 +168,9 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
   }
 
   private int[] checkColumnsInInsertPlan(List<IMeasurementSchema> schemaListInInsertPlan) {
-    List<String> measurementIdsInInsertPlan = new ArrayList<>();
+    Map<String, Integer> measurementIdsInInsertPlan = new HashMap<>();
     for (int i = 0; i < schemaListInInsertPlan.size(); i++) {
-      measurementIdsInInsertPlan.add(schemaListInInsertPlan.get(i).getMeasurementId());
+      measurementIdsInInsertPlan.put(schemaListInInsertPlan.get(i).getMeasurementId(), i);
       if (!containsMeasurement(schemaListInInsertPlan.get(i).getMeasurementId())) {
         this.measurementIndexMap.put(
             schemaListInInsertPlan.get(i).getMeasurementId(), measurementIndexMap.size());
@@ -180,7 +181,7 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
     int[] columnIndexArray = new int[measurementIndexMap.size()];
     measurementIndexMap.forEach(
         (measurementId, i) -> {
-          columnIndexArray[i] = measurementIdsInInsertPlan.indexOf(measurementId);
+          columnIndexArray[i] = measurementIdsInInsertPlan.getOrDefault(measurementId, -1);
         });
     return columnIndexArray;
   }


### PR DESCRIPTION
## Description

There is code logic optimization. When insert aligned time series data and check the measurements order in insertPlan, we can use the HashMap instead of the ArrayList. 

The indexOf method in ArrayList seems taking too much time.... :(

<img width="1325" alt="Screen Shot 2022-01-25 at 9 43 22 AM" src="https://user-images.githubusercontent.com/25913899/150902201-b4a0b947-ceb8-47c5-97d2-77e889cea3b7.png">

