### PR TITLE
[IoTDB-2490] Fix some metrics bugs

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorInfo.java
@@ -44,7 +44,11 @@ public class TsFileProcessorInfo {
     if (MetricConfigDescriptor.getInstance().getMetricConfig().getEnableMetric()) {
       MetricsService.getInstance()
           .getMetricManager()
-          .getOrCreateGauge(Metric.MEM.toString(), Tag.NAME.toString(), "chunkMetaData")
+          .getOrCreateGauge(
+              Metric.MEM.toString(),
+              Tag.NAME.toString(),
+              "chunkMetaData_"
+                  + storageGroupInfo.getVirtualStorageGroupProcessor().getLogicalStorageGroupName())
           .incr(cost);
     }
   }
@@ -56,7 +60,11 @@ public class TsFileProcessorInfo {
     if (MetricConfigDescriptor.getInstance().getMetricConfig().getEnableMetric()) {
       MetricsService.getInstance()
           .getMetricManager()
-          .getOrCreateGauge(Metric.MEM.toString(), Tag.NAME.toString(), "chunkMetaData")
+          .getOrCreateGauge(
+              Metric.MEM.toString(),
+              Tag.NAME.toString(),
+              "chunkMetaData_"
+                  + storageGroupInfo.getVirtualStorageGroupProcessor().getLogicalStorageGroupName())
           .decr(cost);
     }
   }
@@ -64,12 +72,16 @@ public class TsFileProcessorInfo {
   /** called when closing TSP */
   public void clear() {
     storageGroupInfo.releaseStorageGroupMemCost(memCost);
-    memCost = 0L;
     if (MetricConfigDescriptor.getInstance().getMetricConfig().getEnableMetric()) {
       MetricsService.getInstance()
           .getMetricManager()
-          .getOrCreateGauge(Metric.MEM.toString(), Tag.NAME.toString(), "chunkMetaData")
+          .getOrCreateGauge(
+              Metric.MEM.toString(),
+              Tag.NAME.toString(),
+              "chunkMetaData_"
+                  + storageGroupInfo.getVirtualStorageGroupProcessor().getLogicalStorageGroupName())
           .decr(memCost);
     }
+    memCost = 0L;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
@@ -417,10 +417,10 @@ public class VirtualStorageGroupProcessor {
           .getMetricManager()
           .getOrCreateAutoGauge(
               Metric.MEM.toString(),
-              storageGroupInfo.getMemCost(),
-              Long::longValue,
+              storageGroupInfo,
+              StorageGroupInfo::getMemCost,
               Tag.NAME.toString(),
-              "storageGroup");
+              "storageGroup_" + getLogicalStorageGroupName());
     }
 
     // start trim task at last

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -120,6 +120,7 @@ public class IoTDB implements IoTDBMBean {
 
     Runtime.getRuntime().addShutdownHook(new IoTDBShutdownHook());
     setUncaughtExceptionHandler();
+    registerManager.register(MetricsService.getInstance());
     logger.info("recover the schema...");
     initMManager();
     initServiceProvider();
@@ -133,7 +134,6 @@ public class IoTDB implements IoTDBMBean {
     registerManager.register(TemporaryQueryDataFileService.getInstance());
     registerManager.register(UDFClassLoaderManager.getInstance());
     registerManager.register(UDFRegistrationService.getInstance());
-    registerManager.register(MetricsService.getInstance());
 
     // in cluster mode, RPC service is not enabled.
     if (IoTDBDescriptor.getInstance().getConfig().isEnableRpcService()) {


### PR DESCRIPTION
Fix some metrics bugs:
1. Memory size of mtree、current number of timeseries/sg/deivces is always 0.
2. Memory size of sg is always 0
3. Memory size of chunkMetaData continuously increase

jira: https://issues.apache.org/jira/browse/IOTDB-2490