### PR TITLE
[IOTDB-2476] Fix concurrent bug during entityMNode replacement

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/InternalMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/InternalMNode.java
@@ -141,7 +141,7 @@ public class InternalMNode extends MNode {
    * @param newChildNode new child node
    */
   @Override
-  public void replaceChild(String oldChildName, IMNode newChildNode) {
+  public synchronized void replaceChild(String oldChildName, IMNode newChildNode) {
     IMNode oldChildNode = this.getChild(oldChildName);
     if (oldChildNode == null) {
       return;
@@ -170,8 +170,7 @@ public class InternalMNode extends MNode {
 
     newChildNode.setParent(this);
 
-    this.deleteChild(oldChildName);
-    this.addChild(newChildNode.getName(), newChildNode);
+    children.replace(oldChildName, newChildNode);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/InternalMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/InternalMNode.java
@@ -135,13 +135,16 @@ public class InternalMNode extends MNode {
   }
 
   /**
-   * replace a child of this mnode
+   * Replace a child of this mnode. New child's name must be the same as old child's name.
    *
    * @param oldChildName measurement name
    * @param newChildNode new child node
    */
   @Override
   public synchronized void replaceChild(String oldChildName, IMNode newChildNode) {
+    if (!oldChildName.equals(newChildNode.getName())) {
+      throw new RuntimeException("New child's name must be the same as old child's name!");
+    }
     IMNode oldChildNode = this.getChild(oldChildName);
     if (oldChildNode == null) {
       return;


### PR DESCRIPTION
## Description


### Problem
During concurrent timeseries auto creation, MTree will throw NPE.
See  IOTDB-2476

### Cause
The replacement operation of EntityMNode is not a synchronized operation, thus a thread will read a null between the deletion and addition, which is the existing implementation of repalcement.

### Solution
Use replace method of ConcurrentHashMap to make the node replacement a synchronized operation and make the replace method of MNode a synchronized operation.

