### PR TITLE
[IOTDB-2498] Fix cli history filename too long when using OpenID

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/cli/utils/JlineUtils.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/utils/JlineUtils.java
@@ -80,7 +80,7 @@ public class JlineUtils {
             + "-"
             + port
             + "-"
-            + username;
+            + username.hashCode();
     builder.variable(LineReader.HISTORY_FILE, new File(historyFilePath));
 
     // TODO: since the lexer doesn't produce tokens for quotation marks, disable the highlighter to


### PR DESCRIPTION
## Description
See IOTDB-2498
