### PR TITLE
[IOTDB-2501]Fix timestamp not updated bug in FirstValueAggrResult.updateResultUsingValues()

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/FirstValueAggrResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/FirstValueAggrResult.java
@@ -113,7 +113,7 @@ public class FirstValueAggrResult extends AggregateResult {
       return;
     }
     if (valueIterator.hasNext()) {
-	  timestamp = timestamps[valueIterator.getCurPos()];
+      timestamp = timestamps[valueIterator.getCurPos()];
       setValue(valueIterator.next());
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/FirstValueAggrResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/aggregation/impl/FirstValueAggrResult.java
@@ -113,6 +113,7 @@ public class FirstValueAggrResult extends AggregateResult {
       return;
     }
     if (valueIterator.hasNext()) {
+	  timestamp = timestamps[valueIterator.getCurPos()];
       setValue(valueIterator.next());
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/query/dataset/groupby/GroupByLevelDataSetTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/dataset/groupby/GroupByLevelDataSetTest.java
@@ -148,5 +148,14 @@ public class GroupByLevelDataSetTest {
 
     assertTrue(dataSet.hasNext());
     assertEquals("0\t1", dataSet.next().toString());
+
+    // with value filter
+    queryPlan =
+        (QueryPlan)
+            processor.parseSQLToPhysicalPlan(
+                "select count(s1),sum(s0),last_value(s0),first_value(s0) from root.** where s0!=0 or time<10 group by level=3");
+    dataSet = queryExecutor.processQuery(queryPlan, EnvironmentUtils.TEST_QUERY_CONTEXT);
+    assertTrue(dataSet.hasNext());
+    assertEquals("0\t590.0\t106\t120\t4", dataSet.next().toString());
   }
 }


### PR DESCRIPTION
## Description
Fix a bug in FirstValueAggrResult.updateResultUsingValues()
The behaviour of FirstValueAggrResult.updateResultUsingValues() and LastValueDescAggrResult.updateResultUsingValues() should be the same.

### Content
Update the timestamp of FirstValueAggrResult when the result is updated from ValueIterator.

### Problem caused by the bug

The result of first_value aggregation may be wrong when query with "value filter + group by level", since the merge() of FirstValueAggrResults is no-op when timestamps of two FirstValueAggrResults are both Long.MAX_VALUE.

### Test
Add a test case in GroupByLevelDataSetTest.java. The query statementis like "select first_value(s0) from root.** where s0!=0 or time<10 group by level=3". The result before the fix is wrong.