### PR TITLE
[IOTDB-2506] Refine the lock granularity of query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/tag/TagManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/tag/TagManager.java
@@ -172,23 +172,26 @@ public class TagManager {
         Map<VirtualStorageGroupProcessor, List<PartialPath>> processorToSeriesMap =
             lockListAndProcessorToSeriesMapPair.right;
 
-        // init QueryDataSource cache
-        QueryResourceManager.getInstance()
-            .initQueryDataSourceCache(processorToSeriesMap, context, null);
-
         try {
-          allMatchedNodes =
-              allMatchedNodes.stream()
-                  .sorted(
-                      Comparator.comparingLong(
-                              (IMeasurementMNode mNode) ->
-                                  LastCacheManager.getLastTimeStamp(mNode, context))
-                          .reversed()
-                          .thenComparing(IMNode::getFullPath))
-                  .collect(toList());
+          // init QueryDataSource cache
+          QueryResourceManager.getInstance()
+              .initQueryDataSourceCache(processorToSeriesMap, context, null);
+        } catch (Exception e) {
+          logger.error("Meet error when init QueryDataSource ", e);
+          throw new QueryProcessException("Meet error when init QueryDataSource.", e);
         } finally {
           StorageEngine.getInstance().mergeUnLock(list);
         }
+
+        allMatchedNodes =
+            allMatchedNodes.stream()
+                .sorted(
+                    Comparator.comparingLong(
+                            (IMeasurementMNode mNode) ->
+                                LastCacheManager.getLastTimeStamp(mNode, context))
+                        .reversed()
+                        .thenComparing(IMNode::getFullPath))
+                .collect(toList());
       } catch (StorageEngineException | QueryProcessException e) {
         throw new MetadataException(e);
       }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/AggregationExecutor.java
@@ -59,6 +59,9 @@ import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.read.query.timegenerator.TimeGenerator;
 import org.apache.iotdb.tsfile.utils.Pair;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,6 +76,8 @@ import static org.apache.iotdb.tsfile.read.query.executor.ExecutorWithTimeGenera
 
 @SuppressWarnings("java:S1135") // ignore todos
 public class AggregationExecutor {
+
+  private static final Logger logger = LoggerFactory.getLogger(AggregationExecutor.class);
 
   private List<PartialPath> selectedSeries;
   protected List<TSDataType> dataTypes;
@@ -132,26 +137,29 @@ public class AggregationExecutor {
       // init QueryDataSource Cache
       QueryResourceManager.getInstance()
           .initQueryDataSourceCache(processorToSeriesMap, context, timeFilter);
-
-      for (Map.Entry<PartialPath, List<Integer>> entry : pathToAggrIndexesMap.entrySet()) {
-        PartialPath seriesPath = entry.getKey();
-        aggregateOneSeries(
-            seriesPath,
-            entry.getValue(),
-            aggregationPlan.getAllMeasurementsInDevice(seriesPath.getDevice()),
-            timeFilter);
-      }
-      for (Map.Entry<AlignedPath, List<List<Integer>>> entry :
-          alignedPathToAggrIndexesMap.entrySet()) {
-        AlignedPath alignedPath = entry.getKey();
-        aggregateOneAlignedSeries(
-            alignedPath,
-            entry.getValue(),
-            aggregationPlan.getAllMeasurementsInDevice(alignedPath.getDevice()),
-            timeFilter);
-      }
+    } catch (Exception e) {
+      logger.error("Meet error when init QueryDataSource ", e);
+      throw new QueryProcessException("Meet error when init QueryDataSource.", e);
     } finally {
       StorageEngine.getInstance().mergeUnLock(lockList);
+    }
+
+    for (Map.Entry<PartialPath, List<Integer>> entry : pathToAggrIndexesMap.entrySet()) {
+      PartialPath seriesPath = entry.getKey();
+      aggregateOneSeries(
+          seriesPath,
+          entry.getValue(),
+          aggregationPlan.getAllMeasurementsInDevice(seriesPath.getDevice()),
+          timeFilter);
+    }
+    for (Map.Entry<AlignedPath, List<List<Integer>>> entry :
+        alignedPathToAggrIndexesMap.entrySet()) {
+      AlignedPath alignedPath = entry.getKey();
+      aggregateOneAlignedSeries(
+          alignedPath,
+          entry.getValue(),
+          aggregationPlan.getAllMeasurementsInDevice(alignedPath.getDevice()),
+          timeFilter);
     }
 
     return constructDataSet(Arrays.asList(aggregateResultList), aggregationPlan);
@@ -639,25 +647,29 @@ public class AggregationExecutor {
       QueryResourceManager.getInstance()
           .initQueryDataSourceCache(
               processorToSeriesMap, context, timestampGenerator.getTimeFilter());
-
-      for (PartialPath path : pathToAggrIndexesMap.keySet()) {
-        IReaderByTimestamp seriesReaderByTimestamp =
-            getReaderByTime(path, queryPlan, path.getSeriesType(), context);
-        readerToAggrIndexesMap.put(
-            seriesReaderByTimestamp, Collections.singletonList(pathToAggrIndexesMap.get(path)));
-      }
-      // assign null to be friendly for GC
-      pathToAggrIndexesMap = null;
-      for (AlignedPath vectorPath : alignedPathToAggrIndexesMap.keySet()) {
-        IReaderByTimestamp seriesReaderByTimestamp =
-            getReaderByTime(vectorPath, queryPlan, vectorPath.getSeriesType(), context);
-        readerToAggrIndexesMap.put(
-            seriesReaderByTimestamp, alignedPathToAggrIndexesMap.get(vectorPath));
-      }
-      alignedPathToAggrIndexesMap = null;
+    } catch (Exception e) {
+      logger.error("Meet error when init QueryDataSource ", e);
+      throw new QueryProcessException("Meet error when init QueryDataSource.", e);
     } finally {
       StorageEngine.getInstance().mergeUnLock(lockList);
     }
+
+    for (PartialPath path : pathToAggrIndexesMap.keySet()) {
+      IReaderByTimestamp seriesReaderByTimestamp =
+          getReaderByTime(path, queryPlan, path.getSeriesType(), context);
+      readerToAggrIndexesMap.put(
+          seriesReaderByTimestamp, Collections.singletonList(pathToAggrIndexesMap.get(path)));
+    }
+    // assign null to be friendly for GC
+    pathToAggrIndexesMap = null;
+    for (AlignedPath vectorPath : alignedPathToAggrIndexesMap.keySet()) {
+      IReaderByTimestamp seriesReaderByTimestamp =
+          getReaderByTime(vectorPath, queryPlan, vectorPath.getSeriesType(), context);
+      readerToAggrIndexesMap.put(
+          seriesReaderByTimestamp, alignedPathToAggrIndexesMap.get(vectorPath));
+    }
+    // assign null to be friendly for GC
+    alignedPathToAggrIndexesMap = null;
 
     for (int i = 0; i < selectedSeries.size(); i++) {
       aggregateResultList[i] =

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -188,26 +188,29 @@ public class LastQueryExecutor {
       // init QueryDataSource Cache
       QueryResourceManager.getInstance()
           .initQueryDataSourceCache(processorToSeriesMap, context, filter);
-
-      for (int i = 0; i < nonCachedPaths.size(); i++) {
-        QueryDataSource dataSource =
-            QueryResourceManager.getInstance()
-                .getQueryDataSource(nonCachedPaths.get(i), context, filter, ascending);
-        LastPointReader lastReader =
-            nonCachedPaths
-                .get(i)
-                .createLastPointReader(
-                    nonCachedDataTypes.get(i),
-                    deviceMeasurementsMap.getOrDefault(
-                        nonCachedPaths.get(i).getDevice(), new HashSet<>()),
-                    context,
-                    dataSource,
-                    Long.MAX_VALUE,
-                    filter);
-        readerList.add(lastReader);
-      }
+    } catch (Exception e) {
+      logger.error("Meet error when init QueryDataSource ", e);
+      throw new QueryProcessException("Meet error when init QueryDataSource.", e);
     } finally {
       StorageEngine.getInstance().mergeUnLock(lockList);
+    }
+
+    for (int i = 0; i < nonCachedPaths.size(); i++) {
+      QueryDataSource dataSource =
+          QueryResourceManager.getInstance()
+              .getQueryDataSource(nonCachedPaths.get(i), context, filter, ascending);
+      LastPointReader lastReader =
+          nonCachedPaths
+              .get(i)
+              .createLastPointReader(
+                  nonCachedDataTypes.get(i),
+                  deviceMeasurementsMap.getOrDefault(
+                      nonCachedPaths.get(i).getDevice(), new HashSet<>()),
+                  context,
+                  dataSource,
+                  Long.MAX_VALUE,
+                  filter);
+      readerList.add(lastReader);
     }
 
     // Compute Last result for the rest series paths by scanning Tsfiles

--- a/server/src/main/java/org/apache/iotdb/db/query/timegenerator/ServerTimeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/timegenerator/ServerTimeGenerator.java
@@ -43,6 +43,9 @@ import org.apache.iotdb.tsfile.read.query.timegenerator.TimeGenerator;
 import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 import org.apache.iotdb.tsfile.utils.Pair;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +56,8 @@ import java.util.Map;
  * s3 < 0 and time > 100", this class can iterate back to every timestamp of the query.
  */
 public class ServerTimeGenerator extends TimeGenerator {
+
+  private static final Logger logger = LoggerFactory.getLogger(ServerTimeGenerator.class);
 
   protected QueryContext context;
   protected RawDataQueryPlan queryPlan;
@@ -90,11 +95,13 @@ public class ServerTimeGenerator extends TimeGenerator {
       // init QueryDataSource Cache
       QueryResourceManager.getInstance()
           .initQueryDataSourceCache(processorToSeriesMap, context, timeFilter);
-
-      operatorNode = construct(expression);
+    } catch (Exception e) {
+      logger.error("Meet error when init QueryDataSource ", e);
+      throw new QueryProcessException("Meet error when init QueryDataSource.", e);
     } finally {
       StorageEngine.getInstance().mergeUnLock(lockList);
     }
+    operatorNode = construct(expression);
   }
 
   /**


### PR DESCRIPTION
Currently, the data aggregation process will hold the readlock of storage group, which blocks insertion.
We need to separate the getQueryDataSource (holding readlock of sg) with reading data in aggregation.