### PR TITLE
[IOTDB-2510] Reconstructing the password encryption mode

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -924,3 +924,9 @@ timestamp_precision=ms
 ####################
 # Datatype: float
 # group_by_fill_cache_size_in_mb=1.0
+
+####################
+### password encrypt Configuration
+####################
+# iotdb_server_encrypt_decrypt_provider=org.apache.iotdb.db.security.encrypt.MessageDigestEncrypt
+# iotdb_server_encrypt_decrypt_provider_parameter=

--- a/server/src/main/java/org/apache/iotdb/db/auth/authorizer/BasicAuthorizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/authorizer/BasicAuthorizer.java
@@ -106,7 +106,7 @@ public abstract class BasicAuthorizer implements IAuthorizer, IService {
     User user = userManager.getUser(username);
     return user != null
         && password != null
-        && user.getPassword().equals(AuthUtils.encryptPassword(password));
+        && AuthUtils.validatePassword(password, user.getPassword());
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -794,6 +794,13 @@ public class IoTDBConfig {
    */
   private boolean enableIDTableLogFile = false;
 
+  /** Encryption provider class */
+  private String encryptDecryptProvider =
+      "org.apache.iotdb.db.security.encrypt.MessageDigestEncrypt";
+
+  /** Encryption provided class parameter */
+  private String encryptDecryptProviderParameter;
+
   public IoTDBConfig() {
     // empty constructor
   }
@@ -2490,5 +2497,21 @@ public class IoTDBConfig {
 
   public void setEnableIDTableLogFile(boolean enableIDTableLogFile) {
     this.enableIDTableLogFile = enableIDTableLogFile;
+  }
+
+  public String getEncryptDecryptProvider() {
+    return encryptDecryptProvider;
+  }
+
+  public void setEncryptDecryptProvider(String encryptDecryptProvider) {
+    this.encryptDecryptProvider = encryptDecryptProvider;
+  }
+
+  public String getEncryptDecryptProviderParameter() {
+    return encryptDecryptProviderParameter;
+  }
+
+  public void setEncryptDecryptProviderParameter(String encryptDecryptProviderParameter) {
+    this.encryptDecryptProviderParameter = encryptDecryptProviderParameter;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -759,6 +759,15 @@ public class IoTDBDescriptor {
                   "insert_multi_tablet_enable_multithreading_column_threshold",
                   String.valueOf(conf.getInsertMultiTabletEnableMultithreadingColumnThreshold()))));
 
+      conf.setEncryptDecryptProvider(
+          properties.getProperty(
+              "iotdb_server_encrypt_decrypt_provider", conf.getEncryptDecryptProvider()));
+
+      conf.setEncryptDecryptProviderParameter(
+          properties.getProperty(
+              "iotdb_server_encrypt_decrypt_provider_parameter",
+              conf.getEncryptDecryptProviderParameter()));
+
       // At the same time, set TSFileConfig
       TSFileDescriptor.getInstance()
           .getConfig()

--- a/server/src/main/java/org/apache/iotdb/db/security/encrypt/AsymmetricEncrypt.java
+++ b/server/src/main/java/org/apache/iotdb/db/security/encrypt/AsymmetricEncrypt.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.security.encrypt;
+
+public interface AsymmetricEncrypt {
+
+  /**
+   * init some providerParameter
+   *
+   * @param providerParameters encrypt need some parameters
+   */
+  void init(String providerParameters);
+
+  /**
+   * encrypt a password
+   *
+   * @param originPassword password to be crypt
+   * @return encrypt password
+   */
+  String encrypt(String originPassword);
+
+  /**
+   * validate originPassword and encryptPassword
+   *
+   * @param originPassword origin password
+   * @param encryptPassword encrypt password
+   * @return true if validate success
+   */
+  boolean validate(String originPassword, String encryptPassword);
+}

--- a/server/src/main/java/org/apache/iotdb/db/security/encrypt/AsymmetricEncryptFactory.java
+++ b/server/src/main/java/org/apache/iotdb/db/security/encrypt/AsymmetricEncryptFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.security.encrypt;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class AsymmetricEncryptFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AsymmetricEncryptFactory.class);
+
+  private static volatile AsymmetricEncrypt asymmetricEncrypt;
+
+  /**
+   * load encrypt provider class for encrypt or decrypt password
+   *
+   * @param providerClassName encrypt class name
+   * @param providerParameter provider parameter
+   * @return AsymmetricEncrypt instance
+   */
+  public static AsymmetricEncrypt getEncryptProvider(
+      String providerClassName, String providerParameter) {
+    if (asymmetricEncrypt == null) {
+      synchronized (AsymmetricEncrypt.class) {
+        if (asymmetricEncrypt == null) {
+
+          try {
+            Class providerClass =
+                getClassLoaderForClass(AsymmetricEncrypt.class).loadClass(providerClassName);
+            asymmetricEncrypt =
+                (AsymmetricEncrypt) providerClass.getDeclaredConstructor().newInstance();
+            asymmetricEncrypt.init(providerParameter);
+          } catch (ClassNotFoundException
+              | NoSuchMethodException
+              | InstantiationException
+              | IllegalAccessException
+              | InvocationTargetException e) {
+            LOGGER.error("Failed to load encryption class", e);
+            throw new EncryptDecryptException(e);
+          }
+        }
+      }
+    }
+    return asymmetricEncrypt;
+  }
+
+  private static ClassLoader getClassLoaderForClass(Class<?> c) {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    if (cl == null) {
+      cl = c.getClassLoader();
+    }
+    if (cl == null) {
+      cl = ClassLoader.getSystemClassLoader();
+    }
+    if (cl == null) {
+      throw new EncryptDecryptException("A ClassLoader to load the class could not be determined.");
+    }
+    return cl;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/security/encrypt/EncryptDecryptException.java
+++ b/server/src/main/java/org/apache/iotdb/db/security/encrypt/EncryptDecryptException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.security.encrypt;
+
+public class EncryptDecryptException extends RuntimeException {
+
+  public EncryptDecryptException(Throwable e) {
+    super("Encrypt or decrypt failed.", e);
+  }
+
+  public EncryptDecryptException(String message) {
+    super(message);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/security/encrypt/MessageDigestEncrypt.java
+++ b/server/src/main/java/org/apache/iotdb/db/security/encrypt/MessageDigestEncrypt.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.security.encrypt;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class MessageDigestEncrypt implements AsymmetricEncrypt {
+  private static final Logger logger = LoggerFactory.getLogger(MessageDigestEncrypt.class);
+
+  private static final String ENCRYPT_ALGORITHM = "MD5";
+  private static final String STRING_ENCODING = "utf-8";
+
+  @Override
+  public void init(String providerParameters) {
+    return;
+  }
+
+  @Override
+  public String encrypt(String originPassword) {
+    try {
+      MessageDigest messageDigest = MessageDigest.getInstance(ENCRYPT_ALGORITHM);
+      messageDigest.update(originPassword.getBytes(STRING_ENCODING));
+      return new String(messageDigest.digest(), STRING_ENCODING);
+    } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+      logger.error("meet error while encrypting password.", e);
+      return originPassword;
+    }
+  }
+
+  @Override
+  public boolean validate(String originPassword, String encryptPassword) {
+    if (originPassword == null) {
+      return false;
+    }
+    return encrypt(originPassword).equals(encryptPassword);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/utils/AuthUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/AuthUtils.java
@@ -22,13 +22,12 @@ import org.apache.iotdb.db.auth.AuthException;
 import org.apache.iotdb.db.auth.entity.PathPrivilege;
 import org.apache.iotdb.db.auth.entity.PrivilegeType;
 import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.security.encrypt.AsymmetricEncryptFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.UnsupportedEncodingException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -169,14 +168,17 @@ public class AuthUtils {
    * @return encrypted password if success
    */
   public static String encryptPassword(String password) {
-    try {
-      MessageDigest messageDigest = MessageDigest.getInstance(ENCRYPT_ALGORITHM);
-      messageDigest.update(password.getBytes(STRING_ENCODING));
-      return new String(messageDigest.digest(), STRING_ENCODING);
-    } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
-      logger.error("meet error while encrypting password.", e);
-      return password;
-    }
+    return AsymmetricEncryptFactory.getEncryptProvider(
+            IoTDBDescriptor.getInstance().getConfig().getEncryptDecryptProvider(),
+            IoTDBDescriptor.getInstance().getConfig().getEncryptDecryptProviderParameter())
+        .encrypt(password);
+  }
+
+  public static boolean validatePassword(String originPassword, String encryptPassword) {
+    return AsymmetricEncryptFactory.getEncryptProvider(
+            IoTDBDescriptor.getInstance().getConfig().getEncryptDecryptProvider(),
+            IoTDBDescriptor.getInstance().getConfig().getEncryptDecryptProviderParameter())
+        .validate(originPassword, encryptPassword);
   }
 
   /**

--- a/server/src/test/java/org/apache/iotdb/db/auth/user/LocalFileUserManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/auth/user/LocalFileUserManagerTest.java
@@ -96,7 +96,7 @@ public class LocalFileUserManagerTest {
     for (User user1 : users) {
       user = manager.getUser(user1.getName());
       assertEquals(user1.getName(), user.getName());
-      assertEquals(AuthUtils.encryptPassword(user1.getPassword()), user.getPassword());
+      assertTrue(AuthUtils.validatePassword(user.getPassword(), user1.getPassword()));
     }
 
     assertFalse(manager.createUser(users[0].getName(), users[0].getPassword()));
@@ -171,7 +171,7 @@ public class LocalFileUserManagerTest {
     assertTrue(manager.updateUserPassword(user.getName(), newPassword));
     assertFalse(manager.updateUserPassword(user.getName(), illegalPW));
     user = manager.getUser(user.getName());
-    assertEquals(AuthUtils.encryptPassword(newPassword), user.getPassword());
+    assertTrue(AuthUtils.validatePassword(newPassword, user.getPassword()));
     caught = false;
     try {
       manager.updateUserPassword("not a user", newPassword);

--- a/server/src/test/java/org/apache/iotdb/db/security/encrypt/MessageDigestEncryptTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/security/encrypt/MessageDigestEncryptTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.security.encrypt;
+
+import org.apache.iotdb.db.auth.AuthException;
+import org.apache.iotdb.db.auth.entity.PathPrivilege;
+import org.apache.iotdb.db.auth.entity.User;
+import org.apache.iotdb.db.auth.user.LocalFileUserManager;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.constant.TestConstant;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MessageDigestEncryptTest {
+  private static final String providerClass =
+      "org.apache.iotdb.db.security.encrypt.MessageDigestEncrypt";
+
+  private File testFolder;
+  private LocalFileUserManager manager;
+  private MessageDigestEncrypt messageDigestEncrypt = new MessageDigestEncrypt();
+
+  @Before
+  public void setUp() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setEncryptDecryptProvider(providerClass);
+    EnvironmentUtils.envSetUp();
+    testFolder = new File(TestConstant.BASE_OUTPUT_PATH.concat("test"));
+    testFolder.mkdirs();
+    manager = new LocalFileUserManager(testFolder.getPath());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    FileUtils.deleteDirectory(testFolder);
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void testMessageDigestEncrypt() throws AuthException {
+    User[] users = new User[5];
+    for (int i = 0; i < users.length; i++) {
+      users[i] = new User("user" + i, "password" + i);
+      for (int j = 0; j <= i; j++) {
+        PathPrivilege pathPrivilege = new PathPrivilege("root.a.b.c" + j);
+        pathPrivilege.getPrivileges().add(j);
+        users[i].getPrivilegeList().add(pathPrivilege);
+        users[i].getRoleList().add("role" + j);
+      }
+    }
+
+    // create
+    User user = manager.getUser(users[0].getName());
+    assertNull(user);
+    for (User user1 : users) {
+      assertTrue(manager.createUser(user1.getName(), user1.getPassword()));
+    }
+    for (User user1 : users) {
+      user = manager.getUser(user1.getName());
+      assertEquals(user1.getName(), user.getName());
+      assertEquals(messageDigestEncrypt.encrypt(user1.getPassword()), user.getPassword());
+    }
+  }
+
+  @Test
+  public void testMessageDigestValidatePassword() {
+    String password = "root";
+    assertTrue(messageDigestEncrypt.validate(password, messageDigestEncrypt.encrypt(password)));
+  }
+}


### PR DESCRIPTION
1. We can adapt to different password encryption modes based on our requirements. 
2. MD5 is not a secure encryption mode and can be decrypted.