### PR TITLE
Disable merge commit button by default

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,7 +31,6 @@ github:
   features:
     wiki: true
     issues: true
-  
   github:
     enabled_merge_buttons:
       # enable squash button:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,3 +31,12 @@ github:
   features:
     wiki: true
     issues: true
+  
+  github:
+    enabled_merge_buttons:
+      # enable squash button:
+      squash:  true
+      # enable merge button:
+      merge:   false
+      # disable rebase button:
+      rebase:  true


### PR DESCRIPTION
## Description

When we merge PR to a main branch, I think we should always use squash merge option. Therefore, I disabled the merge commit and the rebase merge buttons.