### PR TITLE
remove incorrect img in TSDB-Comparison

### DIFF
--- a/docs/UserGuide/Reference/TSDB-Comparison.md
+++ b/docs/UserGuide/Reference/TSDB-Comparison.md
@@ -326,12 +326,6 @@ The write throughput (points/second) is:
 ![Batch Size with Write Throughput (points/second)](https://user-images.githubusercontent.com/24886743/106251391-df1b9f80-624f-11eb-9f1f-66823839acba.png)
 <span id = "exp1"> <center>Figure 1. Batch Size with Write throughput (points/second) IoTDB v0.11.1</center></span>
 
-
-The write delay (ms) is:
-
-![Batch Size with Write Delay (ms)](https://user-images.githubusercontent.com/24886743/118790013-f1395080-b8c7-11eb-9e22-3310fa4ec804.png)
-<center>Figure 2. Batch Size with Write Delay (ms) IoTDB v0.11.1</center>
-
 * client num:
 
 The client num is distributed from 1 to 50.

--- a/docs/zh/UserGuide/Reference/TSDB-Comparison.md
+++ b/docs/zh/UserGuide/Reference/TSDB-Comparison.md
@@ -289,12 +289,6 @@ IoTDB 拥有许多其它时间序列数据库不支持的强大功能。
 
 <center>Figure 1. Batch Size with Write throughput (points/second) IoTDB v0.11.1</center>
 
-写入延迟（ms）如下图所示：
-
-![Batch Size with Write Delay (ms)](https://user-images.githubusercontent.com/24886743/106251391-df1b9f80-624f-11eb-9f1f-66823839acba.png)
-
-<center>Figure 2. Batch Size with Write Delay (ms) IoTDB v0.11.1</center>
-
 ###### 改变 client num
 
 client num 从 1 到 50 变化。IoTDB 使用 batch insertion API，batch size 是 100（每次调用 write API 写 100 个数据点）。


### PR DESCRIPTION
The figure should be the write latency, however, it is a throughput figure.