### PR TITLE
[IOTDB-2500] [ query & cross-compaction ] cross-compaction stuck

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
@@ -363,13 +363,13 @@ public class CompactionUtils {
       List<TsFileResource> selectedUnSeqTsFileResourceList)
       throws IOException {
     for (TsFileResource seqFile : selectedSeqTsFileResourceList) {
-      ModificationFile modificationFile = ModificationFile.getCompactionMods(seqFile);
+      ModificationFile modificationFile = seqFile.getCompactionModFile();
       if (modificationFile.exists()) {
         modificationFile.remove();
       }
     }
     for (TsFileResource unseqFile : selectedUnSeqTsFileResourceList) {
-      ModificationFile modificationFile = ModificationFile.getCompactionMods(unseqFile);
+      ModificationFile modificationFile = unseqFile.getCompactionModFile();
       if (modificationFile.exists()) {
         modificationFile.remove();
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
@@ -48,14 +48,12 @@ import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -162,6 +160,7 @@ public class CompactionUtils {
     MultiTsFileDeviceIterator.MeasurementIterator measurementIterator =
         deviceIterator.iterateNotAlignedSeries(device, false);
     Set<String> allMeasurements = measurementIterator.getAllMeasurements();
+    Set<String> allMeasurementSet = new HashSet<>(allMeasurements);
     for (String measurement : allMeasurements) {
       List<IMeasurementSchema> measurementSchemas = new ArrayList<>();
       measurementSchemas.add(
@@ -172,7 +171,7 @@ public class CompactionUtils {
               device,
               Collections.singletonList(measurement),
               measurementSchemas,
-              new HashSet<>(allMeasurements),
+              allMeasurementSet,
               queryContext,
               queryDataSource,
               false);
@@ -359,46 +358,20 @@ public class CompactionUtils {
     targetFile.getModFile().close();
   }
 
-  public static void removeCompactionModification(
+  public static void deleteCompactionModsFile(
       List<TsFileResource> selectedSeqTsFileResourceList,
-      List<TsFileResource> selectedUnSeqTsFileResourceList,
-      String fullStorageGroupName) {
-    try {
-      for (TsFileResource seqFile : selectedSeqTsFileResourceList) {
-        ModificationFile.getCompactionMods(seqFile).remove();
+      List<TsFileResource> selectedUnSeqTsFileResourceList)
+      throws IOException {
+    for (TsFileResource seqFile : selectedSeqTsFileResourceList) {
+      ModificationFile modificationFile = ModificationFile.getCompactionMods(seqFile);
+      if (modificationFile.exists()) {
+        modificationFile.remove();
       }
-      for (TsFileResource unseqFile : selectedUnSeqTsFileResourceList) {
-        ModificationFile.getCompactionMods(unseqFile).remove();
-      }
-    } catch (IOException e) {
-      logger.error("{} cannot remove merging modification ", fullStorageGroupName, e);
     }
-  }
-
-  /**
-   * This method is called to recover modifications while an exception occurs during compaction. It
-   * appends new modifications of each selected tsfile to its corresponding old mods file and delete
-   * the compaction mods file.
-   *
-   * @param selectedTsFileResources
-   * @throws IOException
-   */
-  public static void appendNewModificationsToOldModsFile(
-      List<TsFileResource> selectedTsFileResources) throws IOException {
-    for (TsFileResource sourceFile : selectedTsFileResources) {
-      // if there are modifications to this seqFile during compaction
-      if (sourceFile.getCompactionModFile().exists()) {
-        ModificationFile compactionModificationFile =
-            ModificationFile.getCompactionMods(sourceFile);
-        Collection<Modification> newModification = compactionModificationFile.getModifications();
-        compactionModificationFile.close();
-        // write the new modifications to its old modification file
-        try (ModificationFile oldModificationFile = sourceFile.getModFile()) {
-          for (Modification modification : newModification) {
-            oldModificationFile.write(modification);
-          }
-        }
-        FileUtils.delete(new File(ModificationFile.getCompactionMods(sourceFile).getFilePath()));
+    for (TsFileResource unseqFile : selectedUnSeqTsFileResourceList) {
+      ModificationFile modificationFile = ModificationFile.getCompactionMods(unseqFile);
+      if (modificationFile.exists()) {
+        modificationFile.remove();
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
@@ -359,6 +359,22 @@ public class CompactionUtils {
     targetFile.getModFile().close();
   }
 
+  public static void removeCompactionModification(
+      List<TsFileResource> selectedSeqTsFileResourceList,
+      List<TsFileResource> selectedUnSeqTsFileResourceList,
+      String fullStorageGroupName) {
+    try {
+      for (TsFileResource seqFile : selectedSeqTsFileResourceList) {
+        ModificationFile.getCompactionMods(seqFile).remove();
+      }
+      for (TsFileResource unseqFile : selectedUnSeqTsFileResourceList) {
+        ModificationFile.getCompactionMods(unseqFile).remove();
+      }
+    } catch (IOException e) {
+      logger.error("{} cannot remove merging modification ", fullStorageGroupName, e);
+    }
+  }
+
   /**
    * This method is called to recover modifications while an exception occurs during compaction. It
    * appends new modifications of each selected tsfile to its corresponding old mods file and delete

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionHandler.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
 import org.apache.iotdb.db.rescon.TsFileResourceManager;
-import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -143,35 +142,7 @@ public class CrossSpaceCompactionExceptionHandler {
     tsFileManager.writeLock("CrossSpaceCompactionExceptionHandler");
     try {
       for (TsFileResource targetTsFile : targetTsFiles) {
-        // delete target files and tmp target files
-        TsFileResource tmpTargetTsFile;
-        if (targetTsFile.getTsFilePath().endsWith(IoTDBConstant.CROSS_COMPACTION_TMP_FILE_SUFFIX)) {
-          tmpTargetTsFile = targetTsFile;
-          targetTsFile =
-              new TsFileResource(
-                  new File(
-                      tmpTargetTsFile
-                          .getTsFilePath()
-                          .replace(
-                              IoTDBConstant.CROSS_COMPACTION_TMP_FILE_SUFFIX,
-                              TsFileConstant.TSFILE_SUFFIX)));
-        } else {
-          tmpTargetTsFile =
-              new TsFileResource(
-                  new File(
-                      targetTsFile
-                          .getTsFilePath()
-                          .replace(
-                              TsFileConstant.TSFILE_SUFFIX,
-                              IoTDBConstant.CROSS_COMPACTION_TMP_FILE_SUFFIX)));
-        }
-        if (!tmpTargetTsFile.remove()) {
-          LOGGER.error(
-              "{} [Compaction][Exception] failed to delete tmp target tsfile {} when handling exception",
-              storageGroup,
-              tmpTargetTsFile);
-          removeAllTargetFile = false;
-        }
+        // delete target files
         if (!targetTsFile.remove()) {
           LOGGER.error(
               "{} [Compaction][Exception] failed to delete target tsfile {} when handling exception",

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionHandler.java
@@ -143,6 +143,7 @@ public class CrossSpaceCompactionExceptionHandler {
     try {
       for (TsFileResource targetTsFile : targetTsFiles) {
         // delete target files
+        targetTsFile.writeLock();
         if (!targetTsFile.remove()) {
           LOGGER.error(
               "{} [Compaction][Exception] failed to delete target tsfile {} when handling exception",
@@ -150,6 +151,7 @@ public class CrossSpaceCompactionExceptionHandler {
               targetTsFile);
           removeAllTargetFile = false;
         }
+        targetTsFile.writeUnlock();
 
         // remove target tsfile resource in memory
         if (targetTsFile.isFileInList()) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/recover/RewriteCrossSpaceCompactionLogAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/recover/RewriteCrossSpaceCompactionLogAnalyzer.java
@@ -42,7 +42,7 @@ public class RewriteCrossSpaceCompactionLogAnalyzer {
   private boolean isSeq = false;
   private boolean isFirstMagicStringExisted = false;
 
-  boolean isAllTargetFilesExisted = false;
+  boolean isEndMagicStringExisted = false;
 
   public RewriteCrossSpaceCompactionLogAnalyzer(File logFile) {
     this.logFile = logFile;
@@ -61,7 +61,7 @@ public class RewriteCrossSpaceCompactionLogAnalyzer {
             if (magicCount == 0) {
               isFirstMagicStringExisted = true;
             } else {
-              isAllTargetFilesExisted = true;
+              isEndMagicStringExisted = true;
             }
             magicCount++;
             break;
@@ -100,8 +100,8 @@ public class RewriteCrossSpaceCompactionLogAnalyzer {
     return targetFileInfos;
   }
 
-  public boolean isAllTargetFilesExisted() {
-    return isAllTargetFilesExisted;
+  public boolean isEndMagicStringExisted() {
+    return isEndMagicStringExisted;
   }
 
   public boolean isFirstMagicStringExisted() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -259,9 +259,9 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
         long seqEndTime = seqFile.getEndTime(deviceId);
         long seqStartTime = seqFile.getStartTime(deviceId);
         if (unseqEndTime < seqStartTime) {
-          // if time range in unseq file is 10-20, seq file is 30-40, if this unseq file has no
-          // overlapped seq files, then select this seq file or skip this seq file and there is no
-          // more overlap later.
+          // Suppose the time range in unseq file is 10-20, seq file is 30-40. If this unseq file
+          // has no overlapped seq files, then select this seq file. Otherwise, skip this seq file.
+          // There is no more overlap later.
           if (tmpSelectedSeqFiles.size() == 0) {
             tmpSelectedSeqFiles.add(i);
           }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -259,8 +259,12 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
         long seqEndTime = seqFile.getEndTime(deviceId);
         long seqStartTime = seqFile.getStartTime(deviceId);
         if (unseqEndTime < seqStartTime) {
-          // if time range in unseq file is 10-20, seq file is 30-40, then skip this seq file and
-          // there is no more overlap later.
+          // if time range in unseq file is 10-20, seq file is 30-40, if this unseq file has no
+          // overlapped seq files, then select this seq file or skip this seq file and there is no
+          // more overlap later.
+          if (tmpSelectedSeqFiles.size() == 0) {
+            tmpSelectedSeqFiles.add(i);
+          }
           noMoreOverlap = true;
         } else if (!seqFile.isClosed()) {
           // we cannot make sure whether unclosed file has overlap or not, so we just add it.

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossCompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossCompactionRecoverTask.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -137,8 +138,8 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
   }
 
   /**
-   * All source files exist: (1) delete all the target files and tmp target files (2) append new
-   * modifications to old mods files
+   * All source files exist: (1) delete all the target files and tmp target files (2) delete
+   * compaction mods files.
    */
   private boolean handleWithAllSourceFilesExist(
       List<TsFileIdentifier> targetFileIdentifiers,
@@ -177,16 +178,16 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
       }
     }
 
-    // deal with compaction modification
+    // delete compaction mods files
     List<TsFileResource> sourceTsFileResourceList = new ArrayList<>();
     for (TsFileIdentifier sourceFileIdentifier : sourceFileIdentifiers) {
       sourceTsFileResourceList.add(new TsFileResource(sourceFileIdentifier.getFileFromDataDirs()));
     }
     try {
-      CompactionUtils.appendNewModificationsToOldModsFile(sourceTsFileResourceList);
+      CompactionUtils.deleteCompactionModsFile(sourceTsFileResourceList, Collections.emptyList());
     } catch (Throwable e) {
       LOGGER.error(
-          "{} Exception occurs while handling exception, set allowCompaction to false",
+          "{} [Compaction][Recover] Exception occurs while deleting compaction mods file, set allowCompaction to false",
           fullStorageGroupName,
           e);
       return false;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
@@ -156,7 +156,13 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
       CompactionUtils.combineModsInCompaction(
           selectedSeqTsFileResourceList, selectedUnSeqTsFileResourceList, targetTsfileResourceList);
 
-      updateTsFileResource();
+      // update tsfile resource in memory
+      tsFileManager.replace(
+          selectedSeqTsFileResourceList,
+          selectedUnSeqTsFileResourceList,
+          targetTsfileResourceList,
+          timePartition,
+          true);
 
       releaseReadAndLockWrite(selectedSeqTsFileResourceList);
       releaseReadAndLockWrite(selectedUnSeqTsFileResourceList);
@@ -174,15 +180,6 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
           fullStorageGroupName,
           (System.currentTimeMillis() - startTime) / 1000);
     }
-  }
-
-  private void updateTsFileResource() throws IOException {
-    tsFileManager.replace(
-        selectedSeqTsFileResourceList,
-        selectedUnSeqTsFileResourceList,
-        targetTsfileResourceList,
-        timePartition,
-        true);
   }
 
   private boolean addReadLock(List<TsFileResource> tsFileResourceList) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
@@ -24,10 +24,10 @@ import org.apache.iotdb.db.engine.compaction.cross.AbstractCrossSpaceCompactionT
 import org.apache.iotdb.db.engine.compaction.cross.CrossSpaceCompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.recover.RewriteCrossSpaceCompactionLogger;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
-import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.query.control.FileReaderManager;
@@ -51,11 +51,12 @@ import static org.apache.iotdb.db.engine.compaction.cross.rewrite.recover.Rewrit
 import static org.apache.iotdb.db.engine.compaction.cross.rewrite.recover.RewriteCrossSpaceCompactionLogger.STR_UNSEQ_FILES;
 
 public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactionTask {
-
   private static final Logger logger =
       LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
   protected List<TsFileResource> selectedSeqTsFileResourceList;
   protected List<TsFileResource> selectedUnSeqTsFileResourceList;
+  protected TsFileResourceList seqTsFileResourceList;
+  protected TsFileResourceList unseqTsFileResourceList;
   protected TsFileManager tsFileManager;
   private File logFile;
 
@@ -79,6 +80,8 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
         selectedUnSeqTsFileResourceList);
     this.selectedSeqTsFileResourceList = selectedSeqTsFileResourceList;
     this.selectedUnSeqTsFileResourceList = selectedUnSeqTsFileResourceList;
+    this.seqTsFileResourceList = tsFileManager.getSequenceListByTimePartition(timePartition);
+    this.unseqTsFileResourceList = tsFileManager.getUnsequenceListByTimePartition(timePartition);
     this.tsFileManager = tsFileManager;
   }
 
@@ -150,17 +153,19 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
       compactionLogger.logStringInfo(MAGIC_STRING);
       compactionLogger.close();
 
-      releaseReadAndLockWrite(selectedSeqTsFileResourceList);
-      releaseReadAndLockWrite(selectedUnSeqTsFileResourceList);
-
       CompactionUtils.combineModsInCompaction(
           selectedSeqTsFileResourceList, selectedUnSeqTsFileResourceList, targetTsfileResourceList);
 
+      updateTsFileResource();
+
+      releaseReadAndLockWrite(selectedSeqTsFileResourceList);
+      releaseReadAndLockWrite(selectedUnSeqTsFileResourceList);
+
       deleteOldFiles(selectedSeqTsFileResourceList);
       deleteOldFiles(selectedUnSeqTsFileResourceList);
-      removeCompactionModification();
+      CompactionUtils.removeCompactionModification(
+          selectedSeqTsFileResourceList, selectedUnSeqTsFileResourceList, fullStorageGroupName);
 
-      updateTsFileResource();
       if (logFile.exists()) {
         FileUtils.delete(logFile);
       }
@@ -172,18 +177,22 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
   }
 
   private void updateTsFileResource() throws IOException {
+    seqTsFileResourceList.writeLock();
+    unseqTsFileResourceList.writeLock();
     for (TsFileResource resource : selectedSeqTsFileResourceList) {
       TsFileResourceManager.getInstance().removeTsFileResource(resource);
-      tsFileManager.remove(resource, true);
+      seqTsFileResourceList.remove(resource);
     }
     for (TsFileResource resource : selectedUnSeqTsFileResourceList) {
       TsFileResourceManager.getInstance().removeTsFileResource(resource);
-      tsFileManager.remove(resource, false);
+      unseqTsFileResourceList.remove(resource);
     }
     for (TsFileResource resource : targetTsfileResourceList) {
-      tsFileManager.getSequenceListByTimePartition(timePartition).keepOrderInsert(resource);
       TsFileResourceManager.getInstance().registerSealedTsFileResource(resource);
+      seqTsFileResourceList.keepOrderInsert(resource);
     }
+    seqTsFileResourceList.writeUnlock();
+    unseqTsFileResourceList.writeUnlock();
   }
 
   private boolean addReadLock(List<TsFileResource> tsFileResourceList) {
@@ -230,7 +239,7 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
     holdWriteLockList.clear();
   }
 
-  void deleteOldFiles(List<TsFileResource> tsFileResourceList) throws IOException {
+  private void deleteOldFiles(List<TsFileResource> tsFileResourceList) throws IOException {
     for (TsFileResource tsFileResource : tsFileResourceList) {
       FileReaderManager.getInstance().closeFileAndRemoveReader(tsFileResource.getTsFilePath());
       tsFileResource.setDeleted(true);
@@ -243,19 +252,6 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
 
   public String getStorageGroupName() {
     return fullStorageGroupName;
-  }
-
-  private void removeCompactionModification() {
-    try {
-      for (TsFileResource seqFile : selectedSeqTsFileResourceList) {
-        ModificationFile.getCompactionMods(seqFile).remove();
-      }
-      for (TsFileResource unseqFile : selectedUnSeqTsFileResourceList) {
-        ModificationFile.getCompactionMods(unseqFile).remove();
-      }
-    } catch (IOException e) {
-      logger.error("{} cannot remove merging modification ", fullStorageGroupName, e);
-    }
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
@@ -181,7 +181,8 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
         selectedSeqTsFileResourceList,
         selectedUnSeqTsFileResourceList,
         targetTsfileResourceList,
-        timePartition);
+        timePartition,
+        true);
   }
 
   private boolean addReadLock(List<TsFileResource> tsFileResourceList) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionHandler.java
@@ -241,17 +241,11 @@ public class InnerSpaceCompactionExceptionHandler {
                 fullStorageGroupName,
                 sourceFile);
             handleSuccess = false;
-          } else {
-            tsFileResourceList.remove(sourceFile);
           }
         }
-
         InnerSpaceCompactionUtils.deleteModificationForSourceFile(
             selectedTsFileResourceList, fullStorageGroupName);
 
-        if (!tsFileResourceList.contains(targetTsFile)) {
-          tsFileResourceList.keepOrderInsert(targetTsFile);
-        }
       } else {
         // target file is not complete, and some source file is lost
         // some data is lost

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTask.java
@@ -146,7 +146,12 @@ public class SizeTieredCompactionRecoverTask extends SizeTieredCompactionTask {
           }
           handleSuccess =
               InnerSpaceCompactionExceptionHandler.handleWhenAllSourceFilesExist(
-                  fullStorageGroupName, targetResource, sourceResources, tsFileResourceList, true);
+                  fullStorageGroupName,
+                  targetResource,
+                  sourceResources,
+                  tsFileResourceList,
+                  tsFileManager,
+                  true);
         } else {
           handleSuccess = handleWithoutAllSourceFilesExist(sourceFileIdentifiers);
         }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTask.java
@@ -149,13 +149,15 @@ public class SizeTieredCompactionTask extends AbstractInnerSpaceCompactionTask {
             selectedTsFileResourceList,
             Collections.emptyList(),
             Collections.singletonList(targetTsFileResource),
-            timePartition);
+            timePartition,
+            true);
       } else {
         tsFileManager.replace(
             Collections.emptyList(),
             selectedTsFileResourceList,
             Collections.singletonList(targetTsFileResource),
-            timePartition);
+            timePartition,
+            false);
       }
 
       LOGGER.info(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTask.java
@@ -144,11 +144,19 @@ public class SizeTieredCompactionTask extends AbstractInnerSpaceCompactionTask {
       }
 
       // replace the old files with new file, the new is in same position as the old
-      tsFileManager.replace(
-          selectedTsFileResourceList,
-          Collections.emptyList(),
-          Collections.singletonList(targetTsFileResource),
-          timePartition);
+      if (sequence) {
+        tsFileManager.replace(
+            selectedTsFileResourceList,
+            Collections.emptyList(),
+            Collections.singletonList(targetTsFileResource),
+            timePartition);
+      } else {
+        tsFileManager.replace(
+            Collections.emptyList(),
+            selectedTsFileResourceList,
+            Collections.singletonList(targetTsFileResource),
+            timePartition);
+      }
 
       LOGGER.info(
           "{} [Compaction] Compacted target files, try to get the write lock of source files",

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
@@ -177,29 +177,20 @@ public class TsFileManager {
       List<TsFileResource> seqFileResources,
       List<TsFileResource> unseqFileResources,
       List<TsFileResource> targetFileResources,
-      long timePartition)
+      long timePartition,
+      boolean isTargetSequence)
       throws IOException {
     writeLock("replace");
     try {
       for (TsFileResource tsFileResource : seqFileResources) {
-        for (Map.Entry<Long, TsFileResourceList> entry : sequenceFiles.entrySet()) {
-          if (entry.getValue().contains(tsFileResource)) {
-            entry.getValue().remove(tsFileResource);
-            TsFileResourceManager.getInstance().removeTsFileResource(tsFileResource);
-            break;
-          }
-        }
+        sequenceFiles.get(timePartition).remove(tsFileResource);
+        TsFileResourceManager.getInstance().removeTsFileResource(tsFileResource);
       }
       for (TsFileResource tsFileResource : unseqFileResources) {
-        for (Map.Entry<Long, TsFileResourceList> entry : unsequenceFiles.entrySet()) {
-          if (entry.getValue().contains(tsFileResource)) {
-            entry.getValue().remove(tsFileResource);
-            TsFileResourceManager.getInstance().removeTsFileResource(tsFileResource);
-            break;
-          }
-        }
+        unsequenceFiles.get(timePartition).remove(tsFileResource);
+        TsFileResourceManager.getInstance().removeTsFileResource(tsFileResource);
       }
-      if (unseqFileResources.size() == 0 || seqFileResources.size() != 0) {
+      if (isTargetSequence) {
         // seq inner space compaction or cross space compaction
         for (TsFileResource resource : targetFileResources) {
           TsFileResourceManager.getInstance().registerSealedTsFileResource(resource);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
@@ -183,12 +183,14 @@ public class TsFileManager {
     writeLock("replace");
     try {
       for (TsFileResource tsFileResource : seqFileResources) {
-        sequenceFiles.get(timePartition).remove(tsFileResource);
-        TsFileResourceManager.getInstance().removeTsFileResource(tsFileResource);
+        if (sequenceFiles.get(timePartition).remove(tsFileResource)) {
+          TsFileResourceManager.getInstance().removeTsFileResource(tsFileResource);
+        }
       }
       for (TsFileResource tsFileResource : unseqFileResources) {
-        unsequenceFiles.get(timePartition).remove(tsFileResource);
-        TsFileResourceManager.getInstance().removeTsFileResource(tsFileResource);
+        if (unsequenceFiles.get(timePartition).remove(tsFileResource)) {
+          TsFileResourceManager.getInstance().removeTsFileResource(tsFileResource);
+        }
       }
       if (isTargetSequence) {
         // seq inner space compaction or cross space compaction

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
@@ -172,6 +172,7 @@ public class TsFileManager {
     }
   }
 
+  /** This method is called after compaction to update memory. */
   public void replace(
       List<TsFileResource> seqFileResources,
       List<TsFileResource> unseqFileResources,
@@ -198,10 +199,20 @@ public class TsFileManager {
           }
         }
       }
-      for (TsFileResource resource : targetFileResources) {
-        TsFileResourceManager.getInstance().registerSealedTsFileResource(resource);
-        sequenceFiles.get(timePartition).keepOrderInsert(resource);
+      if (unseqFileResources.size() == 0 || seqFileResources.size() != 0) {
+        // seq inner space compaction or cross space compaction
+        for (TsFileResource resource : targetFileResources) {
+          TsFileResourceManager.getInstance().registerSealedTsFileResource(resource);
+          sequenceFiles.get(timePartition).keepOrderInsert(resource);
+        }
+      } else {
+        // unseq inner space compaction
+        for (TsFileResource resource : targetFileResources) {
+          TsFileResourceManager.getInstance().registerSealedTsFileResource(resource);
+          unsequenceFiles.get(timePartition).keepOrderInsert(resource);
+        }
       }
+
     } finally {
       writeUnlock();
     }

--- a/server/src/main/java/org/apache/iotdb/db/rescon/TsFileResourceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/TsFileResourceManager.java
@@ -60,19 +60,23 @@ public class TsFileResourceManager {
    * memory cost is larger than threshold, degradation is triggered.
    */
   public synchronized void registerSealedTsFileResource(TsFileResource tsFileResource) {
-    sealedTsFileResources.add(tsFileResource);
-    totalTimeIndexMemCost += tsFileResource.calculateRamSize();
-    chooseTsFileResourceToDegrade();
+    if (!sealedTsFileResources.contains(tsFileResource)) {
+      sealedTsFileResources.add(tsFileResource);
+      totalTimeIndexMemCost += tsFileResource.calculateRamSize();
+      chooseTsFileResourceToDegrade();
+    }
   }
 
   /** delete the TsFileResource in PriorityQueue when the source file is deleted */
   public synchronized void removeTsFileResource(TsFileResource tsFileResource) {
-    sealedTsFileResources.remove(tsFileResource);
-    if (TimeIndexLevel.valueOf(tsFileResource.getTimeIndexType())
-        == TimeIndexLevel.FILE_TIME_INDEX) {
-      totalTimeIndexMemCost -= tsFileResource.calculateRamSize();
-    } else {
-      totalTimeIndexMemCost -= tsFileResource.getRamSize();
+    if (sealedTsFileResources.contains(tsFileResource)) {
+      sealedTsFileResources.remove(tsFileResource);
+      if (TimeIndexLevel.valueOf(tsFileResource.getTimeIndexType())
+          == TimeIndexLevel.FILE_TIME_INDEX) {
+        totalTimeIndexMemCost -= tsFileResource.calculateRamSize();
+      } else {
+        totalTimeIndexMemCost -= tsFileResource.getRamSize();
+      }
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionTest.java
@@ -102,7 +102,8 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
         targetResources,
         seqResources,
         unseqResources,
-        tsFileManager);
+        tsFileManager,
+        0L);
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -174,7 +175,8 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
         targetResources,
         seqResources,
         unseqResources,
-        tsFileManager);
+        tsFileManager,
+        0L);
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -256,7 +258,8 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
         targetResources,
         seqResources,
         unseqResources,
-        tsFileManager);
+        tsFileManager,
+        0L);
     // all source file should not exist
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.getTsFile().exists());
@@ -356,7 +359,8 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
         targetResources,
         seqResources,
         unseqResources,
-        tsFileManager);
+        tsFileManager,
+        0L);
     // All source file should not exist. All compaction mods file and old mods file of each source
     // file should not exist
     for (TsFileResource resource : seqResources) {
@@ -460,7 +464,8 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
         targetResources,
         seqResources,
         unseqResources,
-        tsFileManager);
+        tsFileManager,
+        0L);
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionTest.java
@@ -513,12 +513,12 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
     for (TsFileResource resource : seqResources) {
       resource.resetModFile();
       Assert.assertTrue(resource.getModFile().exists());
-      Assert.assertEquals(2, resource.getModFile().getModifications().size());
+      Assert.assertEquals(1, resource.getModFile().getModifications().size());
     }
     for (TsFileResource resource : unseqResources) {
       resource.resetModFile();
       Assert.assertTrue(resource.getModFile().exists());
-      Assert.assertEquals(2, resource.getModFile().getModifications().size());
+      Assert.assertEquals(1, resource.getModFile().getModifications().size());
     }
 
     // compaction log file should not exist

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionTest.java
@@ -135,6 +135,9 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
                       + TsFileResource.RESOURCE_SUFFIX)
               .exists());
     }
+    Assert.assertEquals(4, tsFileManager.getSequenceListByTimePartition(0).size());
+    Assert.assertEquals(5, tsFileManager.getUnsequenceListByTimePartition(0).size());
+    Assert.assertTrue(tsFileManager.isAllowCompaction());
   }
 
   @Test
@@ -204,6 +207,9 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
                       + TsFileResource.RESOURCE_SUFFIX)
               .exists());
     }
+    Assert.assertEquals(4, tsFileManager.getSequenceListByTimePartition(0).size());
+    Assert.assertEquals(5, tsFileManager.getUnsequenceListByTimePartition(0).size());
+    Assert.assertTrue(tsFileManager.isAllowCompaction());
   }
 
   @Test
@@ -232,6 +238,15 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
     compactionLogger.logFiles(unseqResources, STR_UNSEQ_FILES);
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+    for (TsFileResource resource : seqResources) {
+      tsFileManager.getSequenceListByTimePartition(0).remove(resource);
+    }
+    for (TsFileResource resource : unseqResources) {
+      tsFileManager.getUnsequenceListByTimePartition(0).remove(resource);
+    }
+    for (TsFileResource resource : targetResources) {
+      tsFileManager.getSequenceListByTimePartition(0).keepOrderInsert(resource);
+    }
     seqResources.get(0).getTsFile().delete();
     compactionLogger.logStringInfo(MAGIC_STRING);
     compactionLogger.close();
@@ -270,6 +285,9 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
       Assert.assertTrue(
           new File(resource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
     }
+    Assert.assertEquals(4, tsFileManager.getSequenceListByTimePartition(0).size());
+    Assert.assertEquals(0, tsFileManager.getUnsequenceListByTimePartition(0).size());
+    Assert.assertTrue(tsFileManager.isAllowCompaction());
   }
 
   /**
@@ -321,6 +339,15 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
       CompactionFileGeneratorUtils.generateMods(deleteMap, unseqResources.get(i), false);
     }
     CompactionUtils.combineModsInCompaction(seqResources, unseqResources, targetResources);
+    for (TsFileResource resource : seqResources) {
+      tsFileManager.getSequenceListByTimePartition(0).remove(resource);
+    }
+    for (TsFileResource resource : unseqResources) {
+      tsFileManager.getUnsequenceListByTimePartition(0).remove(resource);
+    }
+    for (TsFileResource resource : targetResources) {
+      tsFileManager.getSequenceListByTimePartition(0).keepOrderInsert(resource);
+    }
     seqResources.get(0).remove();
 
     CrossSpaceCompactionExceptionHandler.handleException(
@@ -372,6 +399,8 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
     // compaction log file should not exist
     Assert.assertFalse(compactionLogFile.exists());
 
+    Assert.assertEquals(4, tsFileManager.getSequenceListByTimePartition(0).size());
+    Assert.assertEquals(0, tsFileManager.getUnsequenceListByTimePartition(0).size());
     Assert.assertTrue(tsFileManager.isAllowCompaction());
   }
 
@@ -490,6 +519,8 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
     // compaction log file should not exist
     Assert.assertFalse(compactionLogFile.exists());
 
+    Assert.assertEquals(4, tsFileManager.getSequenceListByTimePartition(0).size());
+    Assert.assertEquals(5, tsFileManager.getUnsequenceListByTimePartition(0).size());
     Assert.assertTrue(tsFileManager.isAllowCompaction());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -147,6 +147,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
     assertEquals(2, result.length);
+    assertEquals(5, result[0].size());
+    assertEquals(1, result[1].size());
     resource.clear();
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionRecoverTest.java
@@ -485,12 +485,12 @@ public class RewriteCrossSpaceCompactionRecoverTest extends AbstractCompactionTe
     for (TsFileResource resource : seqResources) {
       resource.resetModFile();
       Assert.assertTrue(resource.getModFile().exists());
-      Assert.assertEquals(2, resource.getModFile().getModifications().size());
+      Assert.assertEquals(1, resource.getModFile().getModifications().size());
     }
     for (TsFileResource resource : unseqResources) {
       resource.resetModFile();
       Assert.assertTrue(resource.getModFile().exists());
-      Assert.assertEquals(2, resource.getModFile().getModifications().size());
+      Assert.assertEquals(1, resource.getModFile().getModifications().size());
     }
 
     // compaction log file should not exist

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionTest.java
@@ -31,8 +31,6 @@ import org.apache.iotdb.tsfile.utils.Pair;
 import org.h2.store.fs.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -42,8 +40,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompactionTest {
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(InnerSpaceCompactionExceptionTest.class);
 
   /**
    * Test when all source files exist, and target file is not complete. System should delete target
@@ -53,7 +49,6 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
    */
   @Test
   public void testWhenAllSourceExistsAndTargetNotComplete() throws Exception {
-    LOGGER.error("Running testWhenAllSourceExistsAndTargetNotComplete");
     tsFileManager.addAll(seqResources, true);
     tsFileManager.addAll(unseqResources, false);
     TsFileResource targetResource =
@@ -101,7 +96,6 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
    */
   @Test
   public void testWhenAllSourceExistsAndTargetComplete() throws Exception {
-    LOGGER.error("Running testWhenAllSourceExistsAndTargetComplete");
     tsFileManager.addAll(seqResources, true);
     tsFileManager.addAll(unseqResources, false);
     TsFileResource targetResource =
@@ -145,7 +139,6 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
    */
   @Test
   public void testWhenSomeSourceLostAndTargetComplete() throws Exception {
-    LOGGER.error("Running testWhenSomeSourceLostAndTargetComplete");
     tsFileManager.addAll(seqResources, true);
     tsFileManager.addAll(unseqResources, false);
     TsFileResource targetResource =
@@ -162,6 +155,10 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
         SizeTieredCompactionLogger.TARGET_INFO, targetResource.getTsFile());
     InnerSpaceCompactionUtils.compact(targetResource, seqResources);
     InnerSpaceCompactionUtils.moveTargetFile(targetResource, COMPACTION_TEST_SG);
+    for (TsFileResource resource : seqResources) {
+      tsFileManager.getSequenceListByTimePartition(0).remove(resource);
+    }
+    tsFileManager.getSequenceListByTimePartition(0).keepOrderInsert(targetResource);
     FileUtils.delete(seqResources.get(0).getTsFile().getPath());
     seqResources.get(0).remove();
     compactionLogger.close();
@@ -196,7 +193,6 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
    */
   @Test
   public void testWhenSomeSourceLostAndTargetNotComplete() throws Exception {
-    LOGGER.error("Running testWhenSomeSourceLostAndTargetNotComplete");
     tsFileManager.addAll(seqResources, true);
     tsFileManager.addAll(unseqResources, false);
     TsFileResource targetResource =
@@ -249,7 +245,6 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
    */
   @Test
   public void testHandleWithCompactionMods() throws Exception {
-    LOGGER.error("Running testHandleWithCompactionMods");
     tsFileManager.addAll(seqResources, true);
     tsFileManager.addAll(unseqResources, false);
     TsFileResource targetResource =
@@ -315,7 +310,6 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
    */
   @Test
   public void testHandleWithNormalMods() throws Exception {
-    LOGGER.error("Running testHandleWithNormalMods");
     tsFileManager.addAll(seqResources, true);
     tsFileManager.addAll(unseqResources, false);
     TsFileResource targetResource =
@@ -374,7 +368,6 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
    */
   @Test
   public void testHandleWithCompactionModsAndNormalMods() throws Exception {
-    LOGGER.error("Running testHandleWithCompactionModsAndNormalMods");
     tsFileManager.addAll(seqResources, true);
     tsFileManager.addAll(unseqResources, false);
     TsFileResource targetResource =

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionTest.java
@@ -397,6 +397,7 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
           deviceIds[0] + "." + measurementSchemas[0].getMeasurementId(),
           new Pair<>(i * ptNum + 10, i * ptNum + 15));
       CompactionFileGeneratorUtils.generateMods(deleteMap, seqResources.get(i), true);
+      CompactionFileGeneratorUtils.generateMods(deleteMap, seqResources.get(i), false);
     }
     compactionLogger.close();
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
@@ -524,7 +524,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     for (int i = 0; i < seqResources.size(); i++) {
       seqResources.get(i).resetModFile();
       Assert.assertTrue(seqResources.get(i).getModFile().exists());
-      Assert.assertEquals(2, seqResources.get(i).getModFile().getModifications().size());
+      Assert.assertEquals(1, seqResources.get(i).getModFile().getModifications().size());
     }
 
     // mods file of the target file should not exist

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
@@ -638,7 +638,7 @@ public class StorageGroupProcessorTest {
           TriggerExecutionException {
     int originCandidateFileNum =
         IoTDBDescriptor.getInstance().getConfig().getMaxCompactionCandidateFileNum();
-    IoTDBDescriptor.getInstance().getConfig().setMaxCompactionCandidateFileNum(10);
+    IoTDBDescriptor.getInstance().getConfig().setMaxCompactionCandidateFileNum(9);
     boolean originEnableSeqSpaceCompaction =
         IoTDBDescriptor.getInstance().getConfig().isEnableSeqSpaceCompaction();
     boolean originEnableUnseqSpaceCompaction =
@@ -687,7 +687,7 @@ public class StorageGroupProcessorTest {
             context,
             null,
             null);
-    Assert.assertEquals(1, queryDataSource.getSeqResources().size());
+    Assert.assertEquals(2, queryDataSource.getSeqResources().size());
     for (TsFileResource resource : queryDataSource.getSeqResources()) {
       Assert.assertTrue(resource.isClosed());
     }


### PR DESCRIPTION
After compaction, we have some operations as following:
(1) move tmp target files to final target files
(2) update memory, make it atomic.
(3) delete source files and its corresponding files 