### PR TITLE
[ISSUE-5030]optimize the tsfile configuration loading

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
@@ -149,7 +149,9 @@ public class TSFileDescriptor {
     }
     String tsFileHome = System.getProperty(TsFileConstant.TSFILE_HOME);
     if (tsFileHome != null) {
-      return Paths.get(tsFileHome, "conf", TSFileConfig.CONFIG_FILE_NAME).toAbsolutePath().toString();
+      return Paths.get(tsFileHome, "conf", TSFileConfig.CONFIG_FILE_NAME)
+          .toAbsolutePath()
+          .toString();
     }
 
     return detectPropertiesFromClassPath();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
@@ -149,7 +149,7 @@ public class TSFileDescriptor {
     }
     String tsFileHome = System.getProperty(TsFileConstant.TSFILE_HOME);
     if (tsFileHome != null) {
-      return Paths.get(tsFileHome, TSFileConfig.CONFIG_FILE_NAME).toAbsolutePath().toString();
+      return Paths.get(tsFileHome, "conf", TSFileConfig.CONFIG_FILE_NAME).toAbsolutePath().toString();
     }
 
     return detectPropertiesFromClassPath();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
@@ -25,23 +25,25 @@ import org.apache.iotdb.tsfile.utils.Loader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /** TSFileDescriptor is used to load TSFileConfig and provide configure information. */
 public class TSFileDescriptor {
 
   private static final Logger logger = LoggerFactory.getLogger(TSFileDescriptor.class);
-  private TSFileConfig conf = new TSFileConfig();
+  private final TSFileConfig conf = new TSFileConfig();
 
-  private TSFileDescriptor() {
-    loadProps();
+  /** The constructor just visible for test */
+  /* private */ TSFileDescriptor() {
+    init();
   }
 
   public static TSFileDescriptor getInstance() {
@@ -50,6 +52,122 @@ public class TSFileDescriptor {
 
   public TSFileConfig getConfig() {
     return conf;
+  }
+
+  private void init() {
+    Properties properties = loadProperties();
+    if (properties != null) {
+      overwriteConfigByCustomSettings(this.conf, properties);
+    }
+  }
+
+  private void overwriteConfigByCustomSettings(TSFileConfig conf, Properties properties) {
+    PropertiesOverWriter writer = new PropertiesOverWriter(properties);
+
+    writer.setInt(conf::setGroupSizeInByte, "group_size_in_byte");
+    writer.setInt(conf::setPageSizeInByte, "page_size_in_byte");
+    if (conf.getPageSizeInByte() > conf.getGroupSizeInByte()) {
+      int groupSizeInByte = conf.getGroupSizeInByte();
+      logger.warn(
+          "page_size is greater than group size, will set it as the same with group size {}",
+          groupSizeInByte);
+      conf.setPageSizeInByte(groupSizeInByte);
+    }
+    writer.setInt(conf::setMaxNumberOfPointsInPage, "max_number_of_points_in_page");
+    writer.setInt(conf::setMaxDegreeOfIndexNode, "max_degree_of_index_node");
+    writer.setInt(conf::setMaxStringLength, "max_string_length");
+    writer.setInt(conf::setFloatPrecision, "float_precision");
+    writer.setString(conf::setTimeEncoder, "time_encoder");
+    writer.setString(conf::setValueEncoder, "value_encoder");
+    writer.setString(conf::setCompressor, "compressor");
+    writer.setInt(conf::setBatchSize, "batch_size");
+  }
+
+  private class PropertiesOverWriter {
+
+    private final Properties properties;
+
+    public PropertiesOverWriter(Properties properties) {
+      if (properties == null) {
+        throw new NullPointerException("properties should not be null");
+      }
+      this.properties = properties;
+    }
+
+    public void setInt(Consumer<Integer> setter, String propertyKey) {
+      set(setter, propertyKey, Integer::parseInt);
+    }
+
+    public void setString(Consumer<String> setter, String propertyKey) {
+      set(setter, propertyKey, Function.identity());
+    }
+
+    private <T> void set(
+        Consumer<T> setter, String propertyKey, Function<String, T> propertyValueConverter) {
+      String value = this.properties.getProperty(propertyKey);
+
+      if (value != null) {
+        try {
+          T v = propertyValueConverter.apply(value);
+          setter.accept(v);
+        } catch (Exception e) {
+          logger.warn("invalid value for {}, use the default value", propertyKey);
+        }
+      }
+    }
+  }
+
+  private Properties loadProperties() {
+    String file = detectPropertiesFile();
+    if (file != null) {
+      logger.info("try loading {} from {}", TSFileConfig.CONFIG_FILE_NAME, file);
+      return loadPropertiesFromFile(file);
+    } else {
+      logger.warn("not found {}, use the default configs.", TSFileConfig.CONFIG_FILE_NAME);
+      return null;
+    }
+  }
+
+  private Properties loadPropertiesFromFile(String filePath) {
+    try (FileInputStream fileInputStream = new FileInputStream(filePath)) {
+      Properties properties = new Properties();
+      properties.load(fileInputStream);
+      return properties;
+    } catch (FileNotFoundException e) {
+      logger.warn("Fail to find config file {}", filePath);
+      return null;
+    } catch (IOException e) {
+      logger.warn("read file ({}) failure, please check the access permissions.", filePath);
+      return null;
+    }
+  }
+
+  private String detectPropertiesFile() {
+    String confDirectory = System.getProperty(TsFileConstant.TSFILE_CONF);
+    if (confDirectory != null) {
+      return Paths.get(confDirectory, TSFileConfig.CONFIG_FILE_NAME).toAbsolutePath().toString();
+    }
+    String tsFileHome = System.getProperty(TsFileConstant.TSFILE_HOME);
+    if (tsFileHome != null) {
+      return Paths.get(tsFileHome, TSFileConfig.CONFIG_FILE_NAME).toAbsolutePath().toString();
+    }
+
+    return detectPropertiesFromClassPath();
+  }
+
+  private static URL getResource(String filename, ClassLoader classLoader) {
+    return Loader.getResource(filename, classLoader);
+  }
+
+  private String detectPropertiesFromClassPath() {
+    ClassLoader classLoader = Loader.getClassLoaderOfObject(this);
+    URL u = getResource(TSFileConfig.CONFIG_FILE_NAME, classLoader);
+    if (u == null) {
+      return null;
+    } else {
+      multiplicityWarning(TSFileConfig.CONFIG_FILE_NAME, classLoader);
+      return u.getFile();
+    }
   }
 
   private void multiplicityWarning(String resource, ClassLoader classLoader) {
@@ -63,94 +181,6 @@ public class TSFileDescriptor {
       }
     } catch (IOException e) {
       logger.error("Failed to get url list for {}", resource);
-    }
-  }
-
-  private static URL getResource(String filename, ClassLoader classLoader) {
-    return Loader.getResource(filename, classLoader);
-  }
-
-  /** load an .properties file and set TSFileConfig variables */
-  private void loadProps() {
-    InputStream inputStream;
-    String url = System.getProperty(TsFileConstant.TSFILE_CONF, null);
-    if (url == null) {
-      url = System.getProperty(TsFileConstant.TSFILE_HOME, null);
-      if (url != null) {
-        url = url + File.separator + "conf" + File.separator + TSFileConfig.CONFIG_FILE_NAME;
-      } else {
-        ClassLoader classLoader = Loader.getClassLoaderOfObject(this);
-        URL u = getResource(TSFileConfig.CONFIG_FILE_NAME, classLoader);
-        if (u == null) {
-          logger.warn(
-              "Failed to find config file {} at classpath, use default configuration",
-              TSFileConfig.CONFIG_FILE_NAME);
-          return;
-        } else {
-          multiplicityWarning(TSFileConfig.CONFIG_FILE_NAME, classLoader);
-          url = u.getFile();
-        }
-      }
-    } else {
-      url += (File.separatorChar + TSFileConfig.CONFIG_FILE_NAME);
-    }
-    try {
-      inputStream = new FileInputStream(new File(url));
-    } catch (FileNotFoundException e) {
-      logger.warn("Fail to find config file {}", url);
-      return;
-    }
-
-    logger.info("Start to read config file {}", url);
-    Properties properties = new Properties();
-    try {
-      properties.load(inputStream);
-      conf.setGroupSizeInByte(
-          Integer.parseInt(
-              properties.getProperty(
-                  "group_size_in_byte", Integer.toString(conf.getGroupSizeInByte()))));
-      conf.setPageSizeInByte(
-          Integer.parseInt(
-              properties.getProperty(
-                  "page_size_in_byte", Integer.toString(conf.getPageSizeInByte()))));
-      if (conf.getPageSizeInByte() > conf.getGroupSizeInByte()) {
-        logger.warn(
-            "page_size is greater than group size, will set it as the same with group size");
-        conf.setPageSizeInByte(conf.getGroupSizeInByte());
-      }
-      conf.setMaxNumberOfPointsInPage(
-          Integer.parseInt(
-              properties.getProperty(
-                  "max_number_of_points_in_page",
-                  Integer.toString(conf.getMaxNumberOfPointsInPage()))));
-      conf.setMaxDegreeOfIndexNode(
-          Integer.parseInt(
-              properties.getProperty(
-                  "max_degree_of_index_node", Integer.toString(conf.getMaxDegreeOfIndexNode()))));
-      conf.setMaxStringLength(
-          Integer.parseInt(
-              properties.getProperty(
-                  "max_string_length", Integer.toString(conf.getMaxStringLength()))));
-      conf.setFloatPrecision(
-          Integer.parseInt(
-              properties.getProperty(
-                  "float_precision", Integer.toString(conf.getFloatPrecision()))));
-      conf.setTimeEncoder(properties.getProperty("time_encoder", conf.getTimeEncoder()));
-      conf.setValueEncoder(properties.getProperty("value_encoder", conf.getValueEncoder()));
-      conf.setCompressor(properties.getProperty("compressor", conf.getCompressor().toString()));
-      conf.setBatchSize(
-          Integer.parseInt(
-              properties.getProperty("batch_size", Integer.toString(conf.getBatchSize()))));
-    } catch (IOException e) {
-      logger.warn("Cannot load config file, use default configuration", e);
-    } catch (Exception e) {
-      logger.error("Loading settings {} failed", url, e);
-    } finally {
-      try {
-        inputStream.close();
-      } catch (IOException e) {
-        logger.error("Failed to close stream for loading config", e);
-      }
     }
   }
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.tsfile.common.conf;
+
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class TSFileDescriptorTest {
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private TSFileConfig tsFileConfig1;
+  private TSFileConfig tsFileConfig2;
+
+  @BeforeClass
+  public static void setUpClass() {
+    // System.setProperty(TsFileConstant.TSFILE_CONF, configDirectory); in the setUp method may
+    // cause the other tests getting a polluted TSFileDescriptor instance in a concurrent
+    // environment.
+    TSFileDescriptor.getInstance();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    File file = tempFolder.newFile(TSFileConfig.CONFIG_FILE_NAME);
+    try (FileWriter writer = new FileWriter(file)) {
+      writer.write("page_size_in_byte=1234\n");
+      writer.write("max_string_length=bad\n");
+      writer.write("float_precision=4\n");
+      writer.write("batch_size=100\n");
+    }
+    String configDirectory = tempFolder.getRoot().getAbsolutePath();
+
+    String originalProperty =  System.getProperty(TsFileConstant.TSFILE_CONF);
+    System.setProperty(TsFileConstant.TSFILE_CONF, configDirectory);
+    this.tsFileConfig1 = new TSFileConfig();
+    this.tsFileConfig2 = new TSFileDescriptor().getConfig();
+    if (originalProperty == null) {
+      System.clearProperty(TsFileConstant.TSFILE_CONF);
+    } else {
+      System.setProperty(TsFileConstant.TSFILE_CONF, originalProperty);
+    }
+  }
+
+  @Test
+  public void testGetInstanceOverWriteFromFile() {
+
+    Assert.assertEquals(65536, tsFileConfig1.getPageSizeInByte());
+    Assert.assertEquals(1234, tsFileConfig2.getPageSizeInByte());
+
+    Assert.assertEquals(2, tsFileConfig1.getFloatPrecision());
+    Assert.assertEquals(4, tsFileConfig2.getFloatPrecision());
+
+    Assert.assertEquals(1000, tsFileConfig1.getBatchSize());
+    Assert.assertEquals(100, tsFileConfig2.getBatchSize());
+
+    Assert.assertEquals(tsFileConfig1.getMaxStringLength(), tsFileConfig2.getMaxStringLength());
+  }
+}

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptorTest.java
@@ -57,7 +57,7 @@ public class TSFileDescriptorTest {
     }
     String configDirectory = tempFolder.getRoot().getAbsolutePath();
 
-    String originalProperty =  System.getProperty(TsFileConstant.TSFILE_CONF);
+    String originalProperty = System.getProperty(TsFileConstant.TSFILE_CONF);
     System.setProperty(TsFileConstant.TSFILE_CONF, configDirectory);
     this.tsFileConfig1 = new TSFileConfig();
     this.tsFileConfig2 = new TSFileDescriptor().getConfig();


### PR DESCRIPTION
## Description
Skip the corrupted custom property when loading TSFileConfig from the properties file.
#5030  

1. Refactoring the code, disassembling the big method.
2. Handling the corrupted properties file in a more intuitive approach.



<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
`org.apache.iotdb.tsfile.common.conf.TSFileDescriptor`
