### PR TITLE
[IOTDB-2540] Hide password encrypt configuration until more encryption added

### DIFF
--- a/docs/UserGuide/Administration-Management/Administration.md
+++ b/docs/UserGuide/Administration-Management/Administration.md
@@ -318,8 +318,6 @@ IoTDB specifies that the character length of a username should not be less than 
 ### Password Restrictions
 
 IoTDB specifies that the character length of a password should have no less than 4 character length, and no spaces. The password is encrypted with MD5.
-Users can adapt different encryption algorithms according to their own scenarios. They need to implement the AsymmetricEncrypt interface and add it to the configuration item iotdb_ server_ encrypt_ decrypt_ In the provider.
-If this encryption algorithm requires parameters, this parameter needs to be added to iotdb_ server_ encrypt_ decrypt_ provider_ Parameter configuration item, and then initialize in this implementation class.
 ### Role Name Restrictions
 
 IoTDB specifies that the character length of a role name should have no less than 4 character length, and no spaces.

--- a/docs/UserGuide/Reference/Config-Manual.md
+++ b/docs/UserGuide/Reference/Config-Manual.md
@@ -1122,27 +1122,3 @@ sbin\start-server.bat printgc
 
 GC log is stored at `IOTDB_HOME/logs/gc.log`.
 There will be at most 10 gc.log.* files and each one can reach to 10MB.
-
-## Adaptive cipher encryption algorithm
-
-The user password is encrypted and stored locally. If the encryption algorithm level is not high, it may be cracked.
-
-Therefore, users can implement the asymmetricencrypt interface and use their own encryption algorithm according to their own scenarios.
-
-- iotdb_server_encrypt_decrypt_provider
-
-|     Name     | iotdb_server_encrypt_decrypt_provider |
-| :----------: | :---------------------------------    |
-|  Description | encrypt provider class                |
-|     Type     | String                                |
-|    Default   | org.apache.iotdb.db.security.encrypt.MessageDigestEncrypt|
-|   Effective  | After restarting system               |
-
-- iotdb_server_encrypt_decrypt_provider_parameter
-
-|     Name     | continuous_query_min_every_interval |
-| :----------: | :---------------------------------- |
-| Description  | encrypt provider class parameter    |
-|     Type     | String                              |
-|    Default   | null                                |
-|  Effective   | After restarting system             |

--- a/docs/zh/UserGuide/Administration-Management/Administration.md
+++ b/docs/zh/UserGuide/Administration-Management/Administration.md
@@ -323,9 +323,7 @@ IoTDB 规定用户名的字符长度不小于 4，其中用户名不能包含空
 
 ### 密码限制
 
-IoTDB 规定密码的字符长度不小于 4，其中密码不能包含空格，密码采用 MD5 进行加密。
-用户根据自己的场景，适配不同的加密算法，需要实现AsymmetricEncrypt接口，并增加到配置项iotdb_server_encrypt_decrypt_provider中。
-如果此加密算法需要参数，需要将此参数加入到iotdb_server_encrypt_decrypt_provider_parameter配置项中，然后在此实现类中初始化。
+IoTDB 规定密码的字符长度不小于 4，其中密码不能包含空格，密码默认采用 MD5 进行加密。
 
 ### 角色名限制
 

--- a/docs/zh/UserGuide/Reference/Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/Config-Manual.md
@@ -1681,26 +1681,3 @@ sbin\start-server.bat printgc
 ```
 
 GC 日志会被存储在`IOTDB_HOME/logs/gc.log`. 至多会存储 10 个 gc.log 文件，每个文件最多 10MB。
-
-## 适配密码加密算法
-
-用户密码加密后存储在本地，如果加密算法级别不高，那么就有可能会被破解。
-因此用户可以根据自己的场景，实现AsymmetricEncrypt接口，使用自己的加密算法。
-
-- iotdb_server_encrypt_decrypt_provider
-
-|     名字     | iotdb_server_encrypt_decrypt_provider |
-| :----------: | :--------------------------------- |
-|     描述     | 密码加密提供类                         |
-|     类型     | String                              |
-|    默认值    | org.apache.iotdb.db.security.encrypt.MessageDigestEncrypt   |
-| 改后生效方式  | 重启服务生效                          |
-
-- iotdb_server_encrypt_decrypt_provider_parameter
-
-|     名字     | continuous_query_min_every_interval |
-| :----------: | :---------------------------------- |
-|     描述     | 密码加密提供类参数                      |
-|     类型     | String                              |
-|    默认值    | 空                                  |
-| 改后生效方式 | 重启服务生效                           |

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -924,9 +924,3 @@ timestamp_precision=ms
 ####################
 # Datatype: float
 # group_by_fill_cache_size_in_mb=1.0
-
-####################
-### password encrypt Configuration
-####################
-# iotdb_server_encrypt_decrypt_provider=org.apache.iotdb.db.security.encrypt.MessageDigestEncrypt
-# iotdb_server_encrypt_decrypt_provider_parameter=


### PR DESCRIPTION
## Description

#5001 added the configuration of changing password encrypt algorithm. However we have still only one encrypt algorithm MD5 in IoTDB currently. These configs are meaningless for normal users. Therefore, I think we should hide them until more encryption methods added.