### PR TITLE
[IOTDB-2544] Fix tag info sync error during metadata sync

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -606,8 +606,9 @@ public class MManager {
 
       // update tag index
 
-      if (offset != -1) {
-        // offset != -1 means the timeseries has already been created and now system is recovering
+      if (offset != -1 && isRecovering) {
+        // the timeseries has already been created and now system is recovering, using the tag info
+        // in tagFile to recover index directly
         tagManager.recoverIndex(offset, leafMNode);
       } else if (plan.getTags() != null) {
         // tag key, tag value

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -2389,4 +2389,37 @@ public class MManagerBasicTest {
     resultTag = results.get(0).getTag();
     assertEquals("newValue", resultTag.get("description"));
   }
+
+  @Test
+  public void testTagCreationViaMLogPlanDuringMetadataSync() throws Exception {
+    MManager manager = IoTDB.metaManager;
+
+    PartialPath path = new PartialPath("root.sg.d.s");
+    Map<String, String> tags = new HashMap<>();
+    tags.put("type", "test");
+    CreateTimeSeriesPlan plan =
+        new CreateTimeSeriesPlan(
+            path,
+            TSDataType.valueOf("INT32"),
+            TSEncoding.valueOf("RLE"),
+            compressionType,
+            null,
+            tags,
+            null,
+            null);
+    // mock that the plan has already been executed on sender and receiver will redo this plan
+    plan.setTagOffset(10);
+
+    manager.operation(plan);
+
+    ShowTimeSeriesPlan showTimeSeriesPlan =
+        new ShowTimeSeriesPlan(new PartialPath("root.sg.d.s"), true, "type", "test", 0, 0, false);
+    List<ShowTimeSeriesResult> results =
+        manager.showTimeseries(showTimeSeriesPlan, new QueryContext());
+    assertEquals(1, results.size());
+    Map<String, String> resultTag = results.get(0).getTag();
+    assertEquals("test", resultTag.get("type"));
+
+    assertEquals(0, manager.getMeasurementMNode(path).getOffset());
+  }
 }


### PR DESCRIPTION
## Description

### Problem
The createTimeseriesPlan received from sender may contains tagOffset, which results in MManager mistaken this plan as recovering plan. 

### Solution
Add isRecover check before processing the tag info in the plan

