### PR TITLE
[IOTDB-2511]Change import-csv-tool  feedback from synchronous to asynchronous

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
@@ -37,6 +37,8 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -65,6 +67,8 @@ import static org.apache.iotdb.tsfile.file.metadata.enums.TSDataType.INT64;
 import static org.apache.iotdb.tsfile.file.metadata.enums.TSDataType.TEXT;
 
 public class ImportCsv extends AbstractCsvTool {
+
+  private static Logger logger = LoggerFactory.getLogger(ImportCsv.class);
 
   private static final String FILE_ARGS = "f";
   private static final String FILE_NAME = "file or folder";
@@ -360,9 +364,15 @@ public class ImportCsv extends AbstractCsvTool {
                   if (type != null) {
                     headerTypeMap.put(header, type);
                   } else {
-                    System.out.printf(
-                        "Line '%s', column '%s': '%s' unknown type%n",
-                        record.getRecordNumber(), header, value);
+                    logger.error(
+                        new StringBuilder("Line '")
+                            .append(record.getRecordNumber())
+                            .append("', column '")
+                            .append(header)
+                            .append("': '")
+                            .append(value)
+                            .append("' unknown type")
+                            .toString());
                     isFail = true;
                   }
                 }
@@ -371,9 +381,16 @@ public class ImportCsv extends AbstractCsvTool {
                   Object valueTrans = typeTrans(value, type);
                   if (valueTrans == null) {
                     isFail = true;
-                    System.out.printf(
-                        "Line '%s', column '%s': '%s' can't convert to '%s'%n",
-                        record.getRecordNumber(), header, value, type);
+                    logger.error(
+                        new StringBuilder("Line '")
+                            .append(record.getRecordNumber())
+                            .append("', column '")
+                            .append(header)
+                            .append("': '")
+                            .append(value)
+                            .append("' can't convert to '")
+                            .append(type)
+                            .toString());
                   } else {
                     measurements.add(headerNameMap.get(header).replace(deviceId + '.', ""));
                     types.add(type);
@@ -489,9 +506,15 @@ public class ImportCsv extends AbstractCsvTool {
                   if (type != null) {
                     headerTypeMap.put(measurement, type);
                   } else {
-                    System.out.printf(
-                        "Line '%s', column '%s': '%s' unknown type%n",
-                        record.getRecordNumber(), measurement, value);
+                    logger.error(
+                        new StringBuilder("Line '")
+                            .append(record.getRecordNumber())
+                            .append("', column '")
+                            .append(measurement)
+                            .append("': '")
+                            .append(value)
+                            .append("' unknown type")
+                            .toString());
                     isFail.set(true);
                   }
                 }
@@ -501,9 +524,17 @@ public class ImportCsv extends AbstractCsvTool {
                 Object valueTrans = typeTrans(value, type);
                 if (valueTrans == null) {
                   isFail.set(true);
-                  System.out.printf(
-                      "Line '%s', column '%s': '%s' can't convert to '%s'%n",
-                      record.getRecordNumber(), headerNameMap.get(measurement), value, type);
+                  logger.error(
+                      new StringBuilder("Line '")
+                          .append(record.getRecordNumber())
+                          .append("', column '")
+                          .append(headerNameMap.get(measurement))
+                          .append("': '")
+                          .append(value)
+                          .append("' can't convert to '")
+                          .append(type)
+                          .append("'")
+                          .toString());
                 } else {
                   values.add(valueTrans);
                   measurements.add(headerNameMap.get(measurement));

--- a/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/ImportCsv.java
@@ -365,14 +365,10 @@ public class ImportCsv extends AbstractCsvTool {
                     headerTypeMap.put(header, type);
                   } else {
                     logger.error(
-                        new StringBuilder("Line '")
-                            .append(record.getRecordNumber())
-                            .append("', column '")
-                            .append(header)
-                            .append("': '")
-                            .append(value)
-                            .append("' unknown type")
-                            .toString());
+                        "Line {}, column {}: {} unknown type",
+                        record.getRecordNumber(),
+                        header,
+                        value);
                     isFail = true;
                   }
                 }
@@ -382,15 +378,11 @@ public class ImportCsv extends AbstractCsvTool {
                   if (valueTrans == null) {
                     isFail = true;
                     logger.error(
-                        new StringBuilder("Line '")
-                            .append(record.getRecordNumber())
-                            .append("', column '")
-                            .append(header)
-                            .append("': '")
-                            .append(value)
-                            .append("' can't convert to '")
-                            .append(type)
-                            .toString());
+                        "Line {}, column {}: {} can't convert to {}",
+                        record.getRecordNumber(),
+                        header,
+                        value,
+                        type);
                   } else {
                     measurements.add(headerNameMap.get(header).replace(deviceId + '.', ""));
                     types.add(type);
@@ -507,14 +499,10 @@ public class ImportCsv extends AbstractCsvTool {
                     headerTypeMap.put(measurement, type);
                   } else {
                     logger.error(
-                        new StringBuilder("Line '")
-                            .append(record.getRecordNumber())
-                            .append("', column '")
-                            .append(measurement)
-                            .append("': '")
-                            .append(value)
-                            .append("' unknown type")
-                            .toString());
+                        "Line {}, column {}: {} unknown type",
+                        record.getRecordNumber(),
+                        measurement,
+                        value);
                     isFail.set(true);
                   }
                 }
@@ -525,16 +513,11 @@ public class ImportCsv extends AbstractCsvTool {
                 if (valueTrans == null) {
                   isFail.set(true);
                   logger.error(
-                      new StringBuilder("Line '")
-                          .append(record.getRecordNumber())
-                          .append("', column '")
-                          .append(headerNameMap.get(measurement))
-                          .append("': '")
-                          .append(value)
-                          .append("' can't convert to '")
-                          .append(type)
-                          .append("'")
-                          .toString());
+                      "Line {}, column {}: {} can't convert to {}",
+                      record.getRecordNumber(),
+                      headerNameMap.get(measurement),
+                      value,
+                      type);
                 } else {
                   values.add(valueTrans);
                   measurements.add(headerNameMap.get(measurement));


### PR DESCRIPTION
When importing massive data, synchronous feedback will have a great impact on processing time, so I changed the feedback that impacts on performance to asynchronous way. Based on the principle of minimum modification, there is no change of feedback that has little impact on performance.