### PR TITLE
[To rel/0.12][IOTDB-2426] WAL deadlock caused by too many open files

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -38,7 +38,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.ExecutorService;
@@ -265,8 +264,8 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
       if (bufferedLogNum == 0) {
         return;
       }
-      switchBufferWorkingToFlushing();
       ILogWriter currWriter = getCurrentFileWriter();
+      switchBufferWorkingToFlushing();
       FLUSH_BUFFER_THREAD_POOL.submit(() -> flushBuffer(currWriter));
       bufferedLogNum = 0;
       logger.debug("Log node {} ends sync.", identifier);
@@ -283,19 +282,16 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
   private void flushBuffer(ILogWriter writer) {
     try {
       writer.write(logBufferFlushing);
-    } catch (ClosedChannelException e) {
-      // ignore
-    } catch (IOException e) {
-      logger.warn("Log node {} sync failed, change system mode to read-only", identifier, e);
+    } catch (Throwable e) {
+      logger.error("Log node {} sync failed, change system mode to read-only", identifier, e);
       IoTDBDescriptor.getInstance().getConfig().setReadOnly(true);
-      return;
-    }
-
-    // switch buffer flushing to idle and notify the sync thread
-    synchronized (switchBufferCondition) {
-      logBufferIdle = logBufferFlushing;
-      logBufferFlushing = null;
-      switchBufferCondition.notifyAll();
+    } finally {
+      // switch buffer flushing to idle and notify the sync thread
+      synchronized (switchBufferCondition) {
+        logBufferIdle = logBufferFlushing;
+        logBufferFlushing = null;
+        switchBufferCondition.notifyAll();
+      }
     }
   }
 


### PR DESCRIPTION
1. get new FileWriter before switchBufferWorkingToFlushing
2. set system to read-only when error occurs in flushBuffer method