### PR TITLE
[IOTDB-2532] Fix group by fill logic

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/GroupByTimeFillPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/GroupByTimeFillPlan.java
@@ -55,8 +55,16 @@ public class GroupByTimeFillPlan extends GroupByTimePlan {
     this.fillTypes = fillTypes;
   }
 
+  public void setQueryStartTime(long queryStartTime) {
+    this.queryStartTime = queryStartTime;
+  }
+
   public long getQueryStartTime() {
     return queryStartTime;
+  }
+
+  public void setQueryEndTime(long queryEndTime) {
+    this.queryEndTime = queryEndTime;
   }
 
   public long getQueryEndTime() {

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/QueryRouter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/QueryRouter.java
@@ -222,9 +222,11 @@ public class QueryRouter implements IQueryRouter {
       throws StorageEngineException, QueryProcessException {
 
     GroupByFillDataSet dataSet = new GroupByFillDataSet(context, groupByFillPlan);
-    groupByFillPlan.initFillRange();
 
     GroupByEngineDataSet engineDataSet;
+    // reset queryStartTime and queryEndTime for init GroupByEngineDataSet
+    groupByFillPlan.setQueryStartTime(groupByFillPlan.getStartTime());
+    groupByFillPlan.setQueryEndTime(groupByFillPlan.getEndTime());
     if (groupByFillPlan.getExpression().getType() == ExpressionType.GLOBAL_TIME) {
       engineDataSet = getGroupByWithoutValueFilterDataSet(context, groupByFillPlan);
       ((GroupByWithoutValueFilterDataSet) engineDataSet).initGroupBy(context, groupByFillPlan);


### PR DESCRIPTION
After #5045 , initFillRange() is invoked twice, which may bring some risk. The things we only need to do is reset the query startTime and Endtime.