### PR TITLE
enable workflow for branchs start with `new_`

### DIFF
--- a/.github/workflows/client-go.yml
+++ b/.github/workflows/client-go.yml
@@ -7,12 +7,14 @@ on:
     branches:
       - master
       - 'rel/*'
+      - "new_*"
     paths-ignore:
       - 'docs/**'
   pull_request:
     branches:
       - master
       - 'rel/*'
+      - "new_*"
     paths-ignore:
       - 'docs/**'
   # allow manually run the action:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -10,10 +10,12 @@ on:
     branches:
       - master
       - "rel/*"
+      - "new_*"
   pull_request:
     branches:
       - master
       - "rel/*"
+      - "new_*"
   # allow manually run the action:
   workflow_dispatch:
 

--- a/.github/workflows/grafana-plugin.yml
+++ b/.github/workflows/grafana-plugin.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - "new_*"
   pull_request:
     branches:
       - master
+      - "new_*"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-unix.yml
+++ b/.github/workflows/main-unix.yml
@@ -8,15 +8,14 @@ on:
     branches:
       - master
       - 'rel/*'
-      - Vector
+      - "new_*"
     paths-ignore:
       - 'docs/**'
   pull_request:
     branches:
       - master
       - 'rel/*'
-      - cluster_new
-      - Vector
+      - "new_*"
     paths-ignore:
       - 'docs/**'
   # allow manually run the action:

--- a/.github/workflows/main-win.yml
+++ b/.github/workflows/main-win.yml
@@ -8,13 +8,14 @@ on:
     branches:
       - master
       - 'rel/*'
+      - "new_*"
     paths-ignore:
       - 'docs/**'
   pull_request:
     branches:
       - master
       - 'rel/*'
-      - cluster_new
+      - "new_*"
     paths-ignore:
       - 'docs/**'
   # allow manually run the action:

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -8,20 +8,21 @@ on:
     branches:
       - master
       - "rel/*"
+      - "new_*"
     paths-ignore:
       - "docs/**"
   pull_request:
     branches:
       - master
       - "rel/*"
-      - cluster_new
+      - "new_*"
     paths-ignore:
       - "docs/**"
   pull_request_target:
     branches:
       - master
       - "rel/*"
-      - cluster_new
+      - "new_*"
     paths-ignore:
       - "docs/**"
   # allow manually run the action:


### PR DESCRIPTION
## Description

We can enable github actions workflow for all important new features branches.  For example, `new_sync`, `new_cluster`, `new_wal`, etc.
