### PR TITLE
[To rel/0.12][IOTDB-2584]Fix cross space compaction selector

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -228,14 +228,6 @@ public abstract class TsFileManagement {
         return false;
       }
 
-      if (unSeqMergeList.size() > maxOpenFileNumInEachUnseqCompaction) {
-        logger.info(
-            "{} too much unseq files to be merged, reduce it to {}",
-            storageGroupName,
-            maxOpenFileNumInEachUnseqCompaction);
-        unSeqMergeList = unSeqMergeList.subList(0, maxOpenFileNumInEachUnseqCompaction);
-      }
-
       long budget = IoTDBDescriptor.getInstance().getConfig().getMergeMemoryBudget();
       long timeLowerBound = System.currentTimeMillis() - dataTTL;
       MergeResource mergeResource = new MergeResource(seqMergeList, unSeqMergeList, timeLowerBound);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -603,9 +603,12 @@ public class TsFileResource {
     isMerging = merging;
   }
 
-  /** check if any of the device lives over the given time bound */
+  /**
+   * check if any of the device lives over the given time bound. If the file is not closed, then
+   * return true.
+   */
   public boolean stillLives(long timeLowerBound) {
-    return timeIndex.stillLives(timeLowerBound);
+    return !isClosed() || timeIndex.stillLives(timeLowerBound);
   }
 
   public boolean isSatisfied(

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
@@ -311,6 +311,12 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
     }
   }
 
+  /**
+   * 5 source seq files: [11,11] [12,12] [13,13] [14,14] [15,15]<br>
+   * 10 source unseq files: [0,0] [1,1] ... [9,9]<br>
+   * selected seq file index: 1<br>
+   * selected unseq file index: 1 ~ 10
+   */
   @Test
   public void testUnseqFilesOverlappedWithOneSeqFile()
       throws IOException, WriteProcessException, MergeException {
@@ -368,6 +374,12 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
     Assert.assertEquals(10, result[1].size());
   }
 
+  /**
+   * 5 source seq files: [11,11] [12,12] [13,13] [14,14] [15,15]<br>
+   * 1 source unseq files: [0 ~ 9]<br>
+   * selected seq file index: 1<br>
+   * selected unseq file index: 1
+   */
   @Test
   public void testOneUnseqFileOverlappedWithOneSeqFile()
       throws IOException, WriteProcessException, MergeException {
@@ -425,6 +437,12 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
     Assert.assertEquals(1, result[1].size());
   }
 
+  /**
+   * 5 source seq files: [11,11] [12,12] [13,13] [14,14] [15,15]<br>
+   * 2 source unseq files: [7~9] [10~13]<br>
+   * selected seq file index: 1 2 3 <br>
+   * selected unseq file index: 1 2
+   */
   @Test
   public void testUnseqFilesOverlapped() throws IOException, WriteProcessException, MergeException {
     List<TsFileResource> seqList = new ArrayList<>();
@@ -482,6 +500,12 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
     Assert.assertEquals(2, result[1].size());
   }
 
+  /**
+   * 5 source seq files: [11,11] [12,12] [13,13] [14,14] [15,15]<br>
+   * 4 source unseq files: [7~9] [10~13] [14~16] [17~18]<br>
+   * selected seq file index: 1 2 3 4 5<br>
+   * selected unseq file index: 1 2 3 4
+   */
   @Test
   public void testAllUnseqFilesOverlapped()
       throws IOException, WriteProcessException, MergeException {

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.engine.storagegroup.timeindex.ITimeIndex;
 import org.apache.iotdb.db.exception.MergeException;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
@@ -308,5 +309,236 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
     } finally {
       removeFiles(seqList, unseqList);
     }
+  }
+
+  @Test
+  public void testUnseqFilesOverlappedWithOneSeqFile()
+      throws IOException, WriteProcessException, MergeException {
+    List<TsFileResource> seqList = new ArrayList<>();
+    List<TsFileResource> unseqList = new ArrayList<>();
+    // 5 seq files [11,11] [12,12] [13,13] ... [15,15]
+    int seqFileNum = 5;
+    for (int i = 11; i < seqFileNum + 11; i++) {
+      File file =
+          new File(
+              TestConstant.OUTPUT_DATA_DIR.concat(
+                  10
+                      + "seq"
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 10
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      TsFileResource fileResource = new TsFileResource(file);
+      fileResource.setClosed(true);
+      prepareFile(fileResource, i, 1, i);
+      seqList.add(fileResource);
+    }
+    int unseqFileNum = 10;
+    // 10 unseq files [0,0] [1,1] ... [9,9]
+    for (int i = 0; i < unseqFileNum; i++) {
+      File file =
+          new File(
+              TestConstant.OUTPUT_DATA_DIR.concat(
+                  10
+                      + "unseq"
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 10
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      TsFileResource fileResource = new TsFileResource(file);
+      fileResource.setClosed(true);
+      prepareFile(fileResource, i, 1, i);
+      unseqList.add(fileResource);
+    }
+
+    MergeResource resource = new MergeResource(seqList, unseqList);
+    Assert.assertEquals(5, resource.getSeqFiles().size());
+    Assert.assertEquals(10, resource.getUnseqFiles().size());
+    IMergeFileSelector mergeFileSelector =
+        new MaxFileMergeFileSelector(resource, 500 * 1024 * 1024);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(1, result[0].size());
+    Assert.assertEquals(10, result[1].size());
+  }
+
+  @Test
+  public void testOneUnseqFileOverlappedWithOneSeqFile()
+      throws IOException, WriteProcessException, MergeException {
+    List<TsFileResource> seqList = new ArrayList<>();
+    List<TsFileResource> unseqList = new ArrayList<>();
+    // 5 seq files [11,11] [12,12] [13,13] ... [15,15]
+    int seqFileNum = 5;
+    for (int i = 11; i < seqFileNum + 11; i++) {
+      File file =
+          new File(
+              TestConstant.OUTPUT_DATA_DIR.concat(
+                  10
+                      + "seq"
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 10
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      TsFileResource fileResource = new TsFileResource(file);
+      fileResource.setClosed(true);
+      prepareFile(fileResource, i, 1, i);
+      seqList.add(fileResource);
+    }
+    int unseqFileNum = 1;
+    // 1 unseq files [0~9]
+    for (int i = 0; i < unseqFileNum; i++) {
+      File file =
+          new File(
+              TestConstant.OUTPUT_DATA_DIR.concat(
+                  10
+                      + "unseq"
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 10
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      TsFileResource fileResource = new TsFileResource(file);
+      fileResource.setClosed(true);
+      prepareFile(fileResource, i, 10, i);
+      unseqList.add(fileResource);
+    }
+
+    MergeResource resource = new MergeResource(seqList, unseqList);
+    Assert.assertEquals(5, resource.getSeqFiles().size());
+    Assert.assertEquals(1, resource.getUnseqFiles().size());
+    IMergeFileSelector mergeFileSelector =
+        new MaxFileMergeFileSelector(resource, 500 * 1024 * 1024);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(1, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+  }
+
+  @Test
+  public void testUnseqFilesOverlapped() throws IOException, WriteProcessException, MergeException {
+    List<TsFileResource> seqList = new ArrayList<>();
+    List<TsFileResource> unseqList = new ArrayList<>();
+    // 5 seq files [11,11] [12,12] [13,13] ... [15,15]
+    int seqFileNum = 5;
+    for (int i = 11; i < seqFileNum + 11; i++) {
+      File file =
+          new File(
+              TestConstant.OUTPUT_DATA_DIR.concat(
+                  10
+                      + "seq"
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 10
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      TsFileResource fileResource = new TsFileResource(file);
+      fileResource.setClosed(true);
+      prepareFile(fileResource, i, 1, i);
+      seqList.add(fileResource);
+    }
+    int unseqFileNum = 2;
+    // 2 unseq files [7~9] [10~13]
+    for (int i = 0; i < unseqFileNum; i++) {
+      File file =
+          new File(
+              TestConstant.OUTPUT_DATA_DIR.concat(
+                  10
+                      + "unseq"
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 10
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      TsFileResource fileResource = new TsFileResource(file);
+      fileResource.setClosed(true);
+      unseqList.add(fileResource);
+    }
+    prepareFile(unseqList.get(0), 7, 3, 7);
+    prepareFile(unseqList.get(1), 10, 4, 10);
+
+    MergeResource resource = new MergeResource(seqList, unseqList);
+    Assert.assertEquals(5, resource.getSeqFiles().size());
+    Assert.assertEquals(2, resource.getUnseqFiles().size());
+    IMergeFileSelector mergeFileSelector =
+        new MaxFileMergeFileSelector(resource, 500 * 1024 * 1024);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+  }
+
+  @Test
+  public void testAllUnseqFilesOverlapped()
+      throws IOException, WriteProcessException, MergeException {
+    List<TsFileResource> seqList = new ArrayList<>();
+    List<TsFileResource> unseqList = new ArrayList<>();
+    // 5 seq files [11,11] [12,12] [13,13] ... [15,15]
+    int seqFileNum = 5;
+    for (int i = 11; i < seqFileNum + 11; i++) {
+      File file =
+          new File(
+              TestConstant.OUTPUT_DATA_DIR.concat(
+                  10
+                      + "seq"
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 10
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      TsFileResource fileResource = new TsFileResource(file);
+      fileResource.setClosed(true);
+      prepareFile(fileResource, i, 1, i);
+      seqList.add(fileResource);
+    }
+    int unseqFileNum = 4;
+    // 4 unseq files [7~9] [10~13] [14~16] [17~18]
+    for (int i = 0; i < unseqFileNum; i++) {
+      File file =
+          new File(
+              TestConstant.OUTPUT_DATA_DIR.concat(
+                  10
+                      + "unseq"
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 10
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      TsFileResource fileResource = new TsFileResource(file);
+      fileResource.setClosed(true);
+      unseqList.add(fileResource);
+    }
+    prepareFile(unseqList.get(0), 7, 3, 7);
+    prepareFile(unseqList.get(1), 10, 4, 10);
+    prepareFile(unseqList.get(2), 14, 3, 14);
+    prepareFile(unseqList.get(3), 17, 2, 17);
+
+    MergeResource resource = new MergeResource(seqList, unseqList);
+    Assert.assertEquals(5, resource.getSeqFiles().size());
+    Assert.assertEquals(4, resource.getUnseqFiles().size());
+    IMergeFileSelector mergeFileSelector =
+        new MaxFileMergeFileSelector(resource, 500 * 1024 * 1024);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(5, result[0].size());
+    Assert.assertEquals(4, result[1].size());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
@@ -559,8 +559,8 @@ public class MergeTaskTest extends MergeTest {
   }
 
   /**
-   * merge 3 seqFile and 1 unseqFile seqFile1: d1.s1:0-100 d1.s2:0-100 seqFile2: d1.s1:100-200
-   * seqFile3: d2.s1:0-100 unseqFile1: d1.s3:0-100
+   * merge 3 seqFile and 1 unseqFile seqFile1: d0.s0:0-100 d0.s1:0-100 seqFile2: d0.s0:100-200
+   * seqFile3: d1.s0:0-100 unseqFile1: d0.s2:0-100
    */
   @Test
   public void testMergeWithSeqFileMissSomeSensorAndDevice() throws Exception {
@@ -583,6 +583,7 @@ public class MergeTaskTest extends MergeTest {
     seqTsFile1Data.put(new Pair<>(deviceIds[0], measurementSchemas[0]), new Pair<>(0L, 100L));
     seqTsFile1Data.put(new Pair<>(deviceIds[0], measurementSchemas[1]), new Pair<>(0L, 100L));
     prepareFileWithSensorAndTime(seqTsFile1, seqTsFile1Data);
+    seqTsFile1.setClosed(true);
     testSeqResources.add(seqTsFile1);
 
     file =
@@ -600,6 +601,7 @@ public class MergeTaskTest extends MergeTest {
     Map<Pair<String, MeasurementSchema>, Pair<Long, Long>> seqTsFileData2 = new HashMap<>();
     seqTsFileData2.put(new Pair<>(deviceIds[0], measurementSchemas[0]), new Pair<>(100L, 200L));
     prepareFileWithSensorAndTime(seqTsFile2, seqTsFileData2);
+    seqTsFile2.setClosed(true);
     testSeqResources.add(seqTsFile2);
 
     file =
@@ -617,6 +619,7 @@ public class MergeTaskTest extends MergeTest {
     Map<Pair<String, MeasurementSchema>, Pair<Long, Long>> seqTsFileData3 = new HashMap<>();
     seqTsFileData3.put(new Pair<>(deviceIds[1], measurementSchemas[0]), new Pair<>(0L, 100L));
     prepareFileWithSensorAndTime(seqTsFile3, seqTsFileData3);
+    seqTsFile3.setClosed(true);
     testSeqResources.add(seqTsFile3);
 
     file =
@@ -634,6 +637,7 @@ public class MergeTaskTest extends MergeTest {
     Map<Pair<String, MeasurementSchema>, Pair<Long, Long>> unseqTsFileData = new HashMap<>();
     unseqTsFileData.put(new Pair<>(deviceIds[0], measurementSchemas[2]), new Pair<>(0L, 100L));
     prepareFileWithSensorAndTime(unseqTsFile, unseqTsFileData);
+    unseqTsFile.setClosed(true);
     testUnseqResources.add(unseqTsFile);
 
     MergeTask mergeTask =


### PR DESCRIPTION
(1) Fix Cross space compaction selector bug, which can avoid unseq data exists in target files.

(2) Accelerate and optimize selecting files in cross space compaction. 