### PR TITLE
[IOTDB-2600] Ban inserting duplicated columns in one row

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
@@ -154,4 +154,15 @@ public class IOTDBInsertIT {
     Statement st1 = connection.createStatement();
     st1.execute("insert into root.t1.wf01.wt01(status, temperature) values(true, 20.1, false)");
   }
+
+  @Test
+  public void testInsertWithDuplicatedMeasurements() {
+    try (Statement st1 = connection.createStatement()) {
+      st1.execute(
+          "insert into root.t1.wf01.wt01(time, s3, status, status) values(100, true, 20.1, 20.2)");
+      Assert.fail();
+    } catch (SQLException e) {
+      Assert.assertEquals("411: Insertion contains duplicated measurement: status", e.getMessage());
+    }
+  }
 }

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IOTDBInsertAlignedValuesIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IOTDBInsertAlignedValuesIT.java
@@ -358,4 +358,15 @@ public class IOTDBInsertAlignedValuesIT {
     Assert.assertEquals(true, rs.getBoolean(2));
     st1.close();
   }
+
+  @Test
+  public void testInsertWithDuplicatedMeasurements() {
+    try (Statement st1 = connection.createStatement()) {
+      st1.execute(
+          "insert into root.t1.wf01.wt01(time, s3, status, status) aligned values(100, true, 20.1, 20.2)");
+      Assert.fail();
+    } catch (SQLException e) {
+      Assert.assertEquals("411: Insertion contains duplicated measurement: status", e.getMessage());
+    }
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
@@ -29,7 +29,9 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public abstract class InsertPlan extends PhysicalPlan {
 
@@ -197,10 +199,17 @@ public abstract class InsertPlan extends PhysicalPlan {
     if (measurements == null) {
       throw new QueryProcessException("Measurements are null");
     }
+    Set<String> deduplicatedMeasurements = new HashSet<>();
     for (String measurement : measurements) {
       if (measurement == null || measurement.isEmpty()) {
         throw new QueryProcessException(
             "Measurement contains null or empty string: " + Arrays.toString(measurements));
+      }
+      if (deduplicatedMeasurements.contains(measurement)) {
+        throw new QueryProcessException(
+            "Insertion contains duplicated measurement: " + measurement);
+      } else {
+        deduplicatedMeasurements.add(measurement);
       }
     }
   }


### PR DESCRIPTION
## Description

Currently, if we insert multiple same measurements in one row, it'll succeed for non-aligned timeseries but not for aligned timeseries. 

```
IoTDB> insert into root.sg.d1(time,s1,s1) values(1,2,3)
insert into root.sg.d1(time,s1,s1) values(1,2,3)
Msg: The statement is executed successfully.
IoTDB> select ** from root
select ** from root
+-----------------------------+-------------+
|                         Time|root.sg.d1.s1|
+-----------------------------+-------------+
|1970-01-01T08:00:00.001+08:00|          3.0|
+-----------------------------+-------------+
Total line number = 1
It costs 0.058s
IoTDB> insert into root.sg.d2(time,s1,s1) aligned values(1,2,3)
insert into root.sg.d2(time,s1,s1) aligned values(1,2,3)
Msg: 500: [INTERNAL_SERVER_ERROR(500)] Exception occurred: executeNonQueryPlan failed. Index 1 out of bounds for length 1
```
We need to ban this kind of behavior to unify them.