### PR TITLE
[IOTDB-2601] fix default max_thrift_frame_size from 64M to 512M

### DIFF
--- a/docs/UserGuide/Reference/Config-Manual.md
+++ b/docs/UserGuide/Reference/Config-Manual.md
@@ -697,7 +697,7 @@ The permission definitions are in ${IOTDB\_CONF}/conf/jmx.access.
 |:---:|:---|
 |Description| the max bytes in a RPC request/response|
 |Type| long |
-|Default| 67108864 (should >= 8 * 1024 * 1024) |
+|Default| 536870912 (should >= 512 * 1024 * 1024) |
 |Effective|After restarting system|
 
 ### InfluxDB-Protocol Adaptor

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -751,7 +751,7 @@ public class IoTDBConfig {
   private long startUpNanosecond = System.nanoTime();
 
   /** Unit: byte */
-  private int thriftMaxFrameSize = 67108864;
+  private int thriftMaxFrameSize = 536870912;
 
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;
 


### PR DESCRIPTION
Keep Consistent between IoTDBConfig and iotdb-engine.properties