### PR TITLE
[To rel/0.12][IOTDB-2603]Fix compaction recover

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -451,11 +451,6 @@ timestamp_precision=ms
 # If you are feeling the rebooting is too slow, set this to false, false by default
 # continue_merge_after_reboot=false
 
-# When set to true, all unseq merges becomes full merge (the whole SeqFiles are re-written despite how
-# much they are overflowed). This may increase merge overhead depending on how much the SeqFiles
-# are overflowed.
-# force_full_merge=true
-
 # How many threads will be set up to perform compaction, 10 by default.
 # Set to 1 when less than or equal to 0.
 # compaction_thread_num=10

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1463,10 +1463,6 @@ public class IoTDBConfig {
     return forceFullMerge;
   }
 
-  void setForceFullMerge(boolean forceFullMerge) {
-    this.forceFullMerge = forceFullMerge;
-  }
-
   public int getCompactionThreadNum() {
     return compactionThreadNum;
   }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -511,10 +511,6 @@ public class IoTDBDescriptor {
           Long.parseLong(
               properties.getProperty(
                   "compaction_interval", Long.toString(conf.getCompactionInterval()))));
-      conf.setForceFullMerge(
-          Boolean.parseBoolean(
-              properties.getProperty(
-                  "force_full_merge", Boolean.toString(conf.isForceFullMerge()))));
       conf.setCompactionThreadNum(
           Integer.parseInt(
               properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -82,8 +82,6 @@ public abstract class TsFileManagement {
   protected boolean isMergeExecutedInCurrentTask = false;
 
   protected boolean isForceFullMerge = IoTDBDescriptor.getInstance().getConfig().isForceFullMerge();
-  private final int maxOpenFileNumInEachUnseqCompaction =
-      IoTDBDescriptor.getInstance().getConfig().getMaxSelectUnseqFileNumInEachUnseqCompaction();
 
   protected ReentrantLock compactionSelectionLock = new ReentrantLock();
 
@@ -387,7 +385,7 @@ public abstract class TsFileManagement {
     }
   }
 
-  private void removeMergingModification() {
+  public void removeMergingModification() {
     try {
       if (mergingModification != null) {
         mergingModification.remove();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -334,6 +334,19 @@ public abstract class TsFileManagement {
     seqFile.writeUnlock();
   }
 
+  public void replace(
+      List<TsFileResource> seqResources,
+      List<TsFileResource> unseqResources,
+      List<TsFileResource> targetResources,
+      boolean isTargetSeq)
+      throws IOException {
+    writeLock();
+    removeAll(seqResources, true);
+    removeAll(unseqResources, false);
+    addAll(targetResources, isTargetSeq);
+    writeUnlock();
+  }
+
   private void removeUnseqFiles(List<TsFileResource> unseqFiles) {
     writeLock();
     try {
@@ -358,7 +371,7 @@ public abstract class TsFileManagement {
   }
 
   @SuppressWarnings("squid:S1141")
-  private void updateMergeModification(TsFileResource seqFile) {
+  public void updateMergeModification(TsFileResource seqFile) {
     try {
       // remove old modifications and write modifications generated during merge
       seqFile.removeModFile();

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.db.engine.merge.recover;
 import org.apache.iotdb.db.engine.merge.manage.MergeResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,8 +74,8 @@ public class MergeLogAnalyzer {
     try (BufferedReader bufferedReader = new BufferedReader(new FileReader(logFile))) {
       currLine = bufferedReader.readLine();
       if (currLine != null) {
+        status = Status.All_SOURCE_FILES_EXIST;
         analyzeSeqFiles(bufferedReader);
-
         analyzeUnseqFiles(bufferedReader);
       }
     }
@@ -119,7 +118,7 @@ public class MergeLogAnalyzer {
           (System.currentTimeMillis() - startTime));
     }
     if (!allSourceFileExists) {
-      status = Status.MERGE_END;
+      status = Status.SOME_SOURCE_FILES_LOST;
     }
     resource.setSeqFiles(mergeSeqFiles);
   }
@@ -128,7 +127,6 @@ public class MergeLogAnalyzer {
     if (!STR_UNSEQ_FILES.equals(currLine)) {
       return;
     }
-    status = Status.MERGE_START;
     long startTime = System.currentTimeMillis();
     List<TsFileResource> mergeUnseqFiles = new ArrayList<>();
     boolean allSourceFileExists = true;
@@ -158,7 +156,7 @@ public class MergeLogAnalyzer {
           (System.currentTimeMillis() - startTime));
     }
     if (!allSourceFileExists) {
-      status = Status.MERGE_END;
+      status = Status.SOME_SOURCE_FILES_LOST;
     }
     resource.setUnseqFiles(mergeUnseqFiles);
   }
@@ -166,9 +164,9 @@ public class MergeLogAnalyzer {
   public enum Status {
     // almost nothing has been done
     NONE,
-    // at least the files and timeseries to be merged are known
-    MERGE_START,
-    // all the merge files are merged with the origin files and the task is almost done
-    MERGE_END
+    // all source files exist
+    All_SOURCE_FILES_EXIST,
+    // some source files lost
+    SOME_SOURCE_FILES_LOST
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.engine.merge.recover;
 import org.apache.iotdb.db.engine.merge.manage.MergeResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +103,9 @@ public class MergeLogAnalyzer {
           mergeSeqFiles.add(seqFile);
           // remove to speed-up next iteration
           iterator.remove();
-          currentFileFound = true;
+          if (seqFile.getTsFile().exists()) {
+            currentFileFound = true;
+          }
           break;
         }
       }
@@ -140,7 +143,9 @@ public class MergeLogAnalyzer {
           mergeUnseqFiles.add(unseqFile);
           // remove to speed-up next iteration
           iterator.remove();
-          currentFileFound = true;
+          if (unseqFile.getTsFile().exists()) {
+            currentFileFound = true;
+          }
           break;
         }
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/CompactionMergeRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/CompactionMergeRecoverTask.java
@@ -21,14 +21,12 @@ package org.apache.iotdb.db.engine.merge.task;
 
 import org.apache.iotdb.db.engine.compaction.TsFileManagement;
 import org.apache.iotdb.db.engine.storagegroup.StorageGroupProcessor;
-import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.List;
 
 public class CompactionMergeRecoverTask implements Runnable {
 
@@ -41,8 +39,6 @@ public class CompactionMergeRecoverTask implements Runnable {
 
   public CompactionMergeRecoverTask(
       TsFileManagement tsFileManagement,
-      List<TsFileResource> seqFiles,
-      List<TsFileResource> unseqFiles,
       String storageGroupSysDir,
       MergeCallback callback,
       String taskName,
@@ -54,13 +50,7 @@ public class CompactionMergeRecoverTask implements Runnable {
     this.closeCompactionMergeCallBack = closeCompactionMergeCallBack;
     this.recoverMergeTask =
         new RecoverMergeTask(
-            seqFiles,
-            unseqFiles,
-            storageGroupSysDir,
-            callback,
-            taskName,
-            fullMerge,
-            storageGroupName);
+            tsFileManagement, storageGroupSysDir, callback, taskName, fullMerge, storageGroupName);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/RecoverMergeTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/RecoverMergeTask.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.db.engine.merge.recover.MergeLogAnalyzer;
 import org.apache.iotdb.db.engine.merge.recover.MergeLogAnalyzer.Status;
 import org.apache.iotdb.db.engine.merge.recover.MergeLogger;
 import org.apache.iotdb.db.engine.modification.Modification;
-import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
@@ -36,7 +35,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import static org.apache.iotdb.db.engine.storagegroup.StorageGroupProcessor.MERGING_MODIFICATION_FILE_NAME;
 import static org.apache.iotdb.db.engine.storagegroup.TsFileResource.modifyTsFileNameUnseqMergCnt;
 
 /**
@@ -66,14 +64,6 @@ public class RecoverMergeTask extends MergeTask {
         fullMerge,
         storageGroupName);
     this.tsFileManagement = tsfileManagement;
-    ModificationFile mergingModsFile =
-        new ModificationFile(
-            resource.getSeqFiles().get(0).getTsFile().getParent()
-                + File.separator
-                + MERGING_MODIFICATION_FILE_NAME);
-    if (mergingModsFile.exists()) {
-      tsfileManagement.mergingModification = mergingModsFile;
-    }
   }
 
   public void recoverMerge() throws IOException, MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.engine.storagegroup;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.concurrent.ThreadName;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -80,6 +79,8 @@ import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
+
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.engine.storagegroup;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.concurrent.ThreadName;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -79,8 +80,6 @@ import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
-
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -517,8 +517,6 @@ public class StorageGroupProcessor {
       CompactionMergeRecoverTask recoverTask =
           new CompactionMergeRecoverTask(
               tsFileManagement,
-              new ArrayList<>(tsFileManagement.getTsFileList(true)),
-              tsFileManagement.getTsFileList(false),
               storageGroupSysDir.getPath(),
               tsFileManagement::mergeEndAction,
               taskName,

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.engine.merge;
+
+import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.constant.TestConstant;
+import org.apache.iotdb.db.engine.cache.ChunkCache;
+import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
+import org.apache.iotdb.db.engine.compaction.TsFileManagement;
+import org.apache.iotdb.db.engine.merge.manage.MergeManager;
+import org.apache.iotdb.db.engine.merge.manage.MergeResource;
+import org.apache.iotdb.db.engine.merge.recover.MergeLogger;
+import org.apache.iotdb.db.engine.merge.task.MergeTask;
+import org.apache.iotdb.db.engine.merge.task.RecoverMergeTask;
+import org.apache.iotdb.db.engine.modification.Deletion;
+import org.apache.iotdb.db.engine.modification.ModificationFile;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.exception.metadata.IllegalPathException;
+import org.apache.iotdb.db.exception.metadata.MetadataException;
+import org.apache.iotdb.db.metadata.PartialPath;
+import org.apache.iotdb.db.service.IoTDB;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.iotdb.db.engine.storagegroup.StorageGroupProcessor.MERGING_MODIFICATION_FILE_NAME;
+import static org.apache.iotdb.db.engine.storagegroup.TsFileResource.modifyTsFileNameUnseqMergCnt;
+
+public class MergeRecoverTest {
+  private List<TsFileResource> sourceSeqFiles = new ArrayList<>();
+  private List<TsFileResource> sourceUnseqFiles = new ArrayList<>();
+  private List<TsFileResource> tmpSourceSeqFiles = new ArrayList<>();
+  private List<TsFileResource> tmpSourceUnseqFiles = new ArrayList<>();
+  private File logFile = new File(TestConstant.SEQUENCE_DATA_DIR, MergeLogger.MERGE_LOG_NAME);
+  private final int seqFileNum = 10;
+  private final int unseqFileNum = 5;
+  private final File seqDataDir = new File(TestConstant.SEQUENCE_DATA_DIR);
+  private final File unseqDataDir = new File(TestConstant.UNSEQUENCE_DATA_DIR);
+  private final ModificationFile mergingModsFile =
+      new ModificationFile(
+          TestConstant.SEQUENCE_DATA_DIR + File.separator + MERGING_MODIFICATION_FILE_NAME);
+  private TsFileManagement tsFileManagement =
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .getCompactionStrategy()
+          .getTsFileManagement("root.sg1", "0", TestConstant.SEQUENCE_DATA_DIR);
+
+  @Before
+  public void setUp() throws IOException, IllegalPathException {
+    Assert.assertTrue(seqDataDir.mkdirs());
+    Assert.assertTrue(unseqDataDir.mkdirs());
+    createFiles();
+    tsFileManagement.addAll(sourceSeqFiles, true);
+    tsFileManagement.addAll(sourceUnseqFiles, false);
+    IoTDB.metaManager.init();
+    MergeManager.getINSTANCE().start();
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    ChunkCache.getInstance().clear();
+    TimeSeriesMetadataCache.getInstance().clear();
+    IoTDB.metaManager.clear();
+    EnvironmentUtils.cleanAllDir();
+    MergeManager.getINSTANCE().stop();
+    deleteFiles();
+  }
+
+  /**
+   * source seq file index: 1~10<br>
+   * source unseq file index: 11~15<br>
+   * deleted file: 1.tsfile <br>
+   * no target file exist
+   */
+  @Test
+  public void testRecoverWithSomeSourceFilesLost() throws IOException, MetadataException {
+    sourceSeqFiles.get(0).getTsFile().delete();
+    RecoverMergeTask recoverMergeTask =
+        new RecoverMergeTask(
+            tsFileManagement,
+            TestConstant.SEQUENCE_DATA_DIR,
+            tsFileManagement::mergeEndAction,
+            "recoverTest",
+            true,
+            "root.sg1");
+    recoverMergeTask.recoverMerge();
+    for (TsFileResource seqResource : tmpSourceSeqFiles) {
+      Assert.assertFalse(seqResource.getTsFile().exists());
+      Assert.assertFalse(
+          new File(seqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(new File(seqResource.getTsFilePath() + MergeTask.MERGE_SUFFIX).exists());
+      Assert.assertFalse(seqResource.getModFile().exists());
+      File targetFile = modifyTsFileNameUnseqMergCnt(seqResource.getTsFile());
+      Assert.assertTrue(targetFile.exists());
+      Assert.assertTrue(new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      ModificationFile targetModsFile =
+          new ModificationFile(targetFile.getPath() + ModificationFile.FILE_SUFFIX);
+      Assert.assertTrue(targetModsFile.exists());
+      Assert.assertEquals(2, targetModsFile.getModifications().size());
+    }
+    for (TsFileResource unseqResource : tmpSourceUnseqFiles) {
+      Assert.assertFalse(unseqResource.getTsFile().exists());
+      Assert.assertFalse(
+          new File(unseqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(unseqResource.getModFile().exists());
+    }
+    Assert.assertFalse(mergingModsFile.exists());
+    Assert.assertFalse(logFile.exists());
+  }
+
+  /**
+   * source seq file index: 1~10 <br>
+   * source unseq file index: 11~15 <br>
+   * deleted file: 1.tsfile, 1.tsfile.resource, 2.tsfile existed target file: 1.tsfile,
+   * 1.tsfile.resource, 2.tsfile
+   */
+  @Test
+  public void testRecoverWithSomeSourceFilesLostAndSomeTargetFilesExist()
+      throws IOException, MetadataException {
+    sourceSeqFiles.get(0).getTsFile().delete();
+    File targetFile = modifyTsFileNameUnseqMergCnt(sourceSeqFiles.get(0).getTsFile());
+    Assert.assertTrue(targetFile.createNewFile());
+    FSFactoryProducer.getFSFactory()
+        .moveFile(
+            new File(sourceSeqFiles.get(0).getTsFilePath() + TsFileResource.RESOURCE_SUFFIX),
+            new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX));
+    sourceSeqFiles.get(1).getTsFile().delete();
+    targetFile = modifyTsFileNameUnseqMergCnt(sourceSeqFiles.get(1).getTsFile());
+    Assert.assertTrue(targetFile.createNewFile());
+    RecoverMergeTask recoverMergeTask =
+        new RecoverMergeTask(
+            tsFileManagement,
+            TestConstant.SEQUENCE_DATA_DIR,
+            tsFileManagement::mergeEndAction,
+            "recoverTest",
+            true,
+            "root.sg1");
+    recoverMergeTask.recoverMerge();
+    for (TsFileResource seqResource : tmpSourceSeqFiles) {
+      Assert.assertFalse(seqResource.getTsFile().exists());
+      Assert.assertFalse(
+          new File(seqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(new File(seqResource.getTsFilePath() + MergeTask.MERGE_SUFFIX).exists());
+      targetFile = modifyTsFileNameUnseqMergCnt(seqResource.getTsFile());
+      Assert.assertTrue(targetFile.exists());
+      Assert.assertTrue(new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(seqResource.getModFile().exists());
+      ModificationFile targetModsFile =
+          new ModificationFile(targetFile.getPath() + ModificationFile.FILE_SUFFIX);
+      Assert.assertTrue(targetModsFile.exists());
+      Assert.assertEquals(2, targetModsFile.getModifications().size());
+    }
+    for (TsFileResource unseqResource : tmpSourceUnseqFiles) {
+      Assert.assertFalse(unseqResource.getTsFile().exists());
+      Assert.assertFalse(
+          new File(unseqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(unseqResource.getModFile().exists());
+    }
+    Assert.assertFalse(mergingModsFile.exists());
+    Assert.assertFalse(logFile.exists());
+  }
+
+  @Test
+  public void testRecoverWithAllSeqSourceFilesLost() throws IOException, MetadataException {
+    for (TsFileResource resource : sourceSeqFiles) {
+      File targetFile = modifyTsFileNameUnseqMergCnt(resource.getTsFile());
+      FSFactoryProducer.getFSFactory()
+          .moveFile(new File(resource.getTsFilePath() + MergeTask.MERGE_SUFFIX), targetFile);
+      FSFactoryProducer.getFSFactory()
+          .moveFile(
+              new File(resource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX),
+              new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX));
+      resource.remove();
+    }
+    RecoverMergeTask recoverMergeTask =
+        new RecoverMergeTask(
+            tsFileManagement,
+            TestConstant.SEQUENCE_DATA_DIR,
+            tsFileManagement::mergeEndAction,
+            "recoverTest",
+            true,
+            "root.sg1");
+    recoverMergeTask.recoverMerge();
+    for (TsFileResource seqResource : tmpSourceSeqFiles) {
+      Assert.assertFalse(seqResource.getTsFile().exists());
+      Assert.assertFalse(
+          new File(seqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(new File(seqResource.getTsFilePath() + MergeTask.MERGE_SUFFIX).exists());
+      File targetFile = modifyTsFileNameUnseqMergCnt(seqResource.getTsFile());
+      Assert.assertTrue(targetFile.exists());
+      Assert.assertTrue(new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(seqResource.getModFile().exists());
+      ModificationFile targetModsFile =
+          new ModificationFile(targetFile.getPath() + ModificationFile.FILE_SUFFIX);
+      Assert.assertTrue(targetModsFile.exists());
+      Assert.assertEquals(2, targetModsFile.getModifications().size());
+    }
+    for (TsFileResource unseqResource : tmpSourceUnseqFiles) {
+      Assert.assertFalse(unseqResource.getTsFile().exists());
+      Assert.assertFalse(
+          new File(unseqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(unseqResource.getModFile().exists());
+    }
+    Assert.assertFalse(mergingModsFile.exists());
+    Assert.assertFalse(logFile.exists());
+  }
+
+  @Test
+  public void testRecoverWithAllSourceFilesLost() throws IOException, MetadataException {
+    for (TsFileResource resource : sourceSeqFiles) {
+      File targetFile = modifyTsFileNameUnseqMergCnt(resource.getTsFile());
+      FSFactoryProducer.getFSFactory()
+          .moveFile(new File(resource.getTsFilePath() + MergeTask.MERGE_SUFFIX), targetFile);
+      FSFactoryProducer.getFSFactory()
+          .moveFile(
+              new File(resource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX),
+              new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX));
+      resource.remove();
+    }
+    for (TsFileResource resource : sourceUnseqFiles) {
+      resource.remove();
+    }
+    RecoverMergeTask recoverMergeTask =
+        new RecoverMergeTask(
+            tsFileManagement,
+            TestConstant.SEQUENCE_DATA_DIR,
+            tsFileManagement::mergeEndAction,
+            "recoverTest",
+            true,
+            "root.sg1");
+    recoverMergeTask.recoverMerge();
+    for (TsFileResource seqResource : tmpSourceSeqFiles) {
+      Assert.assertFalse(seqResource.getTsFile().exists());
+      Assert.assertFalse(
+          new File(seqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(new File(seqResource.getTsFilePath() + MergeTask.MERGE_SUFFIX).exists());
+      File targetFile = modifyTsFileNameUnseqMergCnt(seqResource.getTsFile());
+      Assert.assertTrue(targetFile.exists());
+      Assert.assertTrue(new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(seqResource.getModFile().exists());
+      ModificationFile targetModsFile =
+          new ModificationFile(targetFile.getPath() + ModificationFile.FILE_SUFFIX);
+      Assert.assertTrue(targetModsFile.exists());
+      Assert.assertEquals(2, targetModsFile.getModifications().size());
+    }
+    for (TsFileResource unseqResource : tmpSourceUnseqFiles) {
+      Assert.assertFalse(unseqResource.getTsFile().exists());
+      Assert.assertFalse(
+          new File(unseqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(unseqResource.getModFile().exists());
+    }
+    Assert.assertFalse(mergingModsFile.exists());
+    Assert.assertFalse(logFile.exists());
+  }
+
+  @Test
+  public void testRecoverWithAllSourceFilesExist() throws IOException, MetadataException {
+    RecoverMergeTask recoverMergeTask =
+        new RecoverMergeTask(
+            tsFileManagement,
+            TestConstant.SEQUENCE_DATA_DIR,
+            tsFileManagement::mergeEndAction,
+            "recoverTest",
+            true,
+            "root.sg1");
+    recoverMergeTask.recoverMerge();
+    for (TsFileResource seqResource : tmpSourceSeqFiles) {
+      Assert.assertTrue(seqResource.getTsFile().exists());
+      Assert.assertTrue(
+          new File(seqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertFalse(new File(seqResource.getTsFilePath() + MergeTask.MERGE_SUFFIX).exists());
+      Assert.assertTrue(seqResource.getModFile().exists());
+      Assert.assertEquals(4, seqResource.getModFile().getModifications().size());
+      File targetFile = modifyTsFileNameUnseqMergCnt(seqResource.getTsFile());
+      Assert.assertFalse(targetFile.exists());
+      Assert.assertFalse(new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      ModificationFile targetModsFile =
+          new ModificationFile(targetFile.getPath() + ModificationFile.FILE_SUFFIX);
+      Assert.assertFalse(targetModsFile.exists());
+    }
+    for (TsFileResource unseqResource : tmpSourceUnseqFiles) {
+      Assert.assertTrue(unseqResource.getTsFile().exists());
+      Assert.assertTrue(
+          new File(unseqResource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).exists());
+      Assert.assertTrue(unseqResource.getModFile().exists());
+    }
+    Assert.assertFalse(mergingModsFile.exists());
+    Assert.assertFalse(logFile.exists());
+  }
+
+  private void createFiles() throws IOException, IllegalPathException {
+    // create source seq files
+    for (int i = 0; i < seqFileNum; i++) {
+      File file =
+          new File(
+              TestConstant.SEQUENCE_DATA_DIR.concat(
+                  i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      Assert.assertTrue(file.createNewFile());
+      TsFileResource tsFileResource = new TsFileResource(file);
+      tsFileResource.setClosed(true);
+      tsFileResource.setMinPlanIndex(i);
+      tsFileResource.setMaxPlanIndex(i);
+      tsFileResource.setVersion(i);
+      tsFileResource.serialize();
+      sourceSeqFiles.add(tsFileResource);
+      tmpSourceSeqFiles.add(new TsFileResource(file));
+      // create mods file
+      Deletion deletion = new Deletion(new PartialPath("root.sg1.d1", "s0"), 1, 0, 100);
+      tsFileResource.getModFile().write(deletion);
+      deletion = new Deletion(new PartialPath("root.sg1.d1", "s0"), 1, 200, 300);
+      tsFileResource.getModFile().write(deletion);
+      tsFileResource.getModFile().close();
+    }
+
+    // create source unseq files
+    for (int i = seqFileNum; i < seqFileNum + unseqFileNum; i++) {
+      File file =
+          new File(
+              TestConstant.UNSEQUENCE_DATA_DIR.concat(
+                  i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"));
+      Assert.assertTrue(file.createNewFile());
+      TsFileResource tsFileResource = new TsFileResource(file);
+      tsFileResource.setClosed(true);
+      tsFileResource.setMinPlanIndex(i);
+      tsFileResource.setMaxPlanIndex(i);
+      tsFileResource.setVersion(i);
+      tsFileResource.serialize();
+      sourceUnseqFiles.add(tsFileResource);
+      tmpSourceUnseqFiles.add(new TsFileResource(file));
+      // create mods file
+      Deletion deletion = new Deletion(new PartialPath("root.sg1.d1", "s0"), 1, 0, 100);
+      tsFileResource.getModFile().write(deletion);
+      deletion = new Deletion(new PartialPath("root.sg1.d1", "s0"), 1, 200, 300);
+      tsFileResource.getModFile().write(deletion);
+      tsFileResource.getModFile().close();
+    }
+
+    // create .merge files
+    for (int i = 0; i < seqFileNum; i++) {
+      File file =
+          new File(
+              TestConstant.SEQUENCE_DATA_DIR.concat(
+                  i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + i
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + IoTDBConstant.FILE_NAME_SEPARATOR
+                      + 0
+                      + ".tsfile"
+                      + MergeTask.MERGE_SUFFIX));
+      Assert.assertTrue(file.createNewFile());
+    }
+
+    // create merging mods file
+    Deletion deletion = new Deletion(new PartialPath("root.sg1.d1", "s1"), 1, 0, 100);
+    mergingModsFile.write(deletion);
+    deletion = new Deletion(new PartialPath("root.sg1.d1", "s1"), 1, 200, 30000);
+    mergingModsFile.write(deletion);
+    mergingModsFile.close();
+
+    // create log
+    MergeLogger mergeLogger = new MergeLogger(TestConstant.SEQUENCE_DATA_DIR);
+    MergeResource mergeResource = new MergeResource(sourceSeqFiles, sourceUnseqFiles);
+    mergeLogger.logFiles(mergeResource);
+    mergeLogger.close();
+  }
+
+  private void deleteFiles() {
+    for (TsFileResource seqResource : sourceSeqFiles) {
+      seqResource.remove();
+      File mergeFile = new File(seqResource.getTsFilePath() + MergeTask.MERGE_SUFFIX);
+      if (mergeFile.exists()) {
+        mergeFile.delete();
+      }
+    }
+    for (TsFileResource seqResource : sourceSeqFiles) {
+      seqResource.remove();
+    }
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
@@ -78,6 +78,7 @@ public class MergeRecoverTest {
     createFiles();
     tsFileManagement.addAll(sourceSeqFiles, true);
     tsFileManagement.addAll(sourceUnseqFiles, false);
+    tsFileManagement.mergingModification = mergingModsFile;
     IoTDB.metaManager.init();
     MergeManager.getINSTANCE().start();
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTest.java
@@ -100,7 +100,7 @@ abstract class MergeTest {
     MergeManager.getINSTANCE().stop();
   }
 
-  private void prepareSeries() throws MetadataException {
+  protected void prepareSeries() throws MetadataException {
     measurementSchemas = new MeasurementSchema[measurementNum];
     for (int i = 0; i < measurementNum; i++) {
       measurementSchemas[i] =


### PR DESCRIPTION
Fix 2 problems:
1. There may be more data after iotdb restart. The reason is that cross space compaction recovery did not consisder one case, which is when some source files lost.
2. If there is deletion during cross space compaction process, if the iOTDB is stopped then and all the source files are not deleted, then the deleted data will be queried during the next restart.