### PR TITLE
[IOTDB-2580] Fix DirectByteBuffer and thread leak when deleting storage group

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -861,6 +861,7 @@ public class StorageEngine implements IService {
     StorageGroupManager storageGroupManager = processorMap.remove(storageGroupPath);
     storageGroupManager.deleteStorageGroupSystemFolder(
         systemDir + File.pathSeparator + storageGroupPath);
+    storageGroupManager.stopSchedulerPool();
   }
 
   public void loadNewTsFileForSync(TsFileResource newTsFileResource)


### PR DESCRIPTION
stop scheduler pool when deleting storage group.