### PR TITLE
[IOTDB-2578]Fix cross space compaction recover and log read compatible with 0.12

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -181,6 +181,12 @@ public class IoTDBConstant {
   // cross space compaction
   public static final String CROSS_COMPACTION_TMP_FILE_SUFFIX = ".cross";
 
+  // cross space compaction of previous version (<0.13)
+  public static final String CROSS_COMPACTION_TMP_FILE_SUFFIX_FROM_OLD = ".merge";
+
+  // compaction mods of previous version (<0.13)
+  public static final String COMPACTION_MODIFICATION_FILE_NAME_FROM_OLD = "merge.mods";
+
   // client version number
   public enum ClientVersion {
     V_0_12,

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileIdentifier.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileIdentifier.java
@@ -109,6 +109,28 @@ public class TsFileIdentifier {
         splittedFileInfo[FILE_NAME_OFFSET_IN_LOG]);
   }
 
+  /**
+   * This function generates an instance of CompactionFileIdentifier by parsing the old info string
+   * from previous version (<0.13) of a tsfile(usually recorded in a compaction.log), such as
+   * “root.test.sg 0 0 1-1-0-0.tsfile true"
+   */
+  public static TsFileIdentifier getFileIdentifierFromOldInfoString(String oldInfoString) {
+    String[] splittedFileInfo = oldInfoString.split(INFO_SEPARATOR);
+    int length = splittedFileInfo.length;
+    if (length != 5) {
+      throw new RuntimeException(
+          String.format(
+              "String %s is not a legal file info string from previous version (<0.13)",
+              oldInfoString));
+    }
+    return new TsFileIdentifier(
+        splittedFileInfo[LOGICAL_SG_OFFSET_IN_LOG],
+        splittedFileInfo[VIRTUAL_SG_OFFSET_IN_LOG],
+        splittedFileInfo[TIME_PARTITION_OFFSET_IN_LOG],
+        Boolean.parseBoolean(splittedFileInfo[FILE_NAME_OFFSET_IN_LOG]),
+        splittedFileInfo[SEQUENCE_OFFSET_IN_LOG]);
+  }
+
   @Override
   public String toString() {
     return String.format(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
@@ -97,6 +97,8 @@ public class RewriteCrossSpaceCompactionSelector extends AbstractCrossSpaceCompa
         InnerSpaceCompactionUtils.getCrossSpaceFileSelector(budget, mergeResource);
     try {
       List[] mergeFiles = fileSelector.select();
+      // avoid pending tasks holds the metadata and streams
+      mergeResource.clear();
       if (mergeFiles.length == 0) {
         if (mergeResource.getUnseqFiles().size() > 0) {
           // still have unseq files but cannot be selected
@@ -111,11 +113,6 @@ public class RewriteCrossSpaceCompactionSelector extends AbstractCrossSpaceCompa
           "select files for cross compaction, sequence files: {}, unsequence files {}",
           mergeFiles[0],
           mergeFiles[1]);
-      // avoid pending tasks holds the metadata and streams
-      mergeResource.clear();
-      // do not cache metadata until true candidates are chosen, or too much metadata will be
-      // cached during selection
-      mergeResource.setCacheDeviceMeta(true);
 
       if (mergeFiles[0].size() > 0 && mergeFiles[1].size() > 0) {
         mergeFiles[0].forEach(x -> ((TsFileResource) x).setCompactionCandidate(true));

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/recover/RewriteCrossSpaceCompactionLogger.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/recover/RewriteCrossSpaceCompactionLogger.java
@@ -78,17 +78,6 @@ public class RewriteCrossSpaceCompactionLogger implements AutoCloseable {
 
   public static File[] findCrossSpaceCompactionLogs(String directory) {
     File timePartitionDir = new File(directory);
-
-    // check whether there is old compaction log from previous version (<0.13)
-    File storageGroupDir = timePartitionDir.getParentFile();
-    if (storageGroupDir.exists()) {
-      File[] compactionLogsFromOld =
-          storageGroupDir.listFiles((dir, name) -> name.endsWith(COMPACTION_LOG_NAME_FEOM_OLD));
-      if (compactionLogsFromOld.length != 0) {
-        return compactionLogsFromOld;
-      }
-    }
-
     if (timePartitionDir.exists()) {
       return timePartitionDir.listFiles((dir, name) -> name.endsWith(COMPACTION_LOG_NAME));
     } else {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/recover/RewriteCrossSpaceCompactionLogger.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/recover/RewriteCrossSpaceCompactionLogger.java
@@ -33,6 +33,7 @@ import java.util.List;
 public class RewriteCrossSpaceCompactionLogger implements AutoCloseable {
 
   public static final String COMPACTION_LOG_NAME = "cross-compaction.log";
+  public static final String COMPACTION_LOG_NAME_FEOM_OLD = "merge.log";
 
   public static final String STR_SEQ_FILES = "seqFiles";
   public static final String STR_TARGET_FILES = "targetFiles";
@@ -77,6 +78,17 @@ public class RewriteCrossSpaceCompactionLogger implements AutoCloseable {
 
   public static File[] findCrossSpaceCompactionLogs(String directory) {
     File timePartitionDir = new File(directory);
+
+    // check whether there is old compaction log from previous version (<0.13)
+    File storageGroupDir = timePartitionDir.getParentFile();
+    if (storageGroupDir.exists()) {
+      File[] compactionLogsFromOld =
+          storageGroupDir.listFiles((dir, name) -> name.endsWith(COMPACTION_LOG_NAME_FEOM_OLD));
+      if (compactionLogsFromOld.length != 0) {
+        return compactionLogsFromOld;
+      }
+    }
+
     if (timePartitionDir.exists()) {
       return timePartitionDir.listFiles((dir, name) -> name.endsWith(COMPACTION_LOG_NAME));
     } else {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossCompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossCompactionRecoverTask.java
@@ -261,15 +261,11 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
       }
     }
     File compactionModsFileFromOld =
-        getFileFromDataDirs(
-            "sequence"
-                + File.separator
-                + tsFileManager.getStorageGroupName()
-                + File.separator
-                + tsFileManager.getVirtualStorageGroup()
+        new File(
+            tsFileManager.getStorageGroupDir()
                 + File.separator
                 + IoTDBConstant.COMPACTION_MODIFICATION_FILE_NAME_FROM_OLD);
-    if (compactionModsFileFromOld != null && !compactionModsFileFromOld.delete()) {
+    if (compactionModsFileFromOld.exists() && !compactionModsFileFromOld.delete()) {
       LOGGER.error(
           "{} [Compaction][Recover] fail to delete target file {}, this may cause data incorrectness",
           fullStorageGroupName,
@@ -289,12 +285,8 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
       List<TsFileIdentifier> targetFileIdentifiers, List<TsFileIdentifier> sourceFileIdentifiers) {
     try {
       File compactionModsFileFromOld =
-          getFileFromDataDirs(
-              "sequence"
-                  + File.separator
-                  + tsFileManager.getStorageGroupName()
-                  + File.separator
-                  + tsFileManager.getVirtualStorageGroup()
+          new File(
+              tsFileManager.getStorageGroupDir()
                   + File.separator
                   + IoTDBConstant.COMPACTION_MODIFICATION_FILE_NAME_FROM_OLD);
       List<TsFileResource> targetFileResources = new ArrayList<>();
@@ -352,7 +344,7 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
           targetFileResources.add(targetResource);
 
           // append compaction modifications to target mods file and delete compaction mods file
-          if (compactionModsFileFromOld != null) {
+          if (compactionModsFileFromOld.exists()) {
             ModificationFile compactionModsFile =
                 new ModificationFile(compactionModsFileFromOld.getPath());
             appendCompactionModificationsFromOld(targetResource, compactionModsFile);
@@ -387,7 +379,7 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
       }
 
       // delete compaction mods file
-      if (compactionModsFileFromOld != null && !compactionModsFileFromOld.delete()) {
+      if (compactionModsFileFromOld.exists() && !compactionModsFileFromOld.delete()) {
         LOGGER.error(
             "{} [Compaction][Recover] fail to delete target file {}, this may cause data incorrectness",
             fullStorageGroupName,

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossCompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossCompactionRecoverTask.java
@@ -25,10 +25,15 @@ import org.apache.iotdb.db.engine.compaction.TsFileIdentifier;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.recover.RewriteCrossSpaceCompactionLogAnalyzer;
 import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUtils;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
+import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
+import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.utils.FileLoaderUtils;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
+import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -42,9 +47,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompactionTask {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
+  private final Logger LOGGER = LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
   private File compactionLogFile;
 
   public RewriteCrossCompactionRecoverTask(
@@ -101,11 +104,20 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
           }
         }
         if (isAllSourcesFileExisted) {
-          handleSuccess =
-              handleWithAllSourceFilesExist(
-                  targetFileIdentifiers, sourceFileIdentifiers, fullStorageGroupName);
+          if (logAnalyzer.isLogFromOld()) {
+            handleSuccess = handleWithAllSourceFilesExistFromOld(targetFileIdentifiers);
+          } else {
+            handleSuccess =
+                handleWithAllSourceFilesExist(targetFileIdentifiers, sourceFileIdentifiers);
+          }
         } else {
-          handleSuccess = handleWithoutAllSourceFilesExist(sourceFileIdentifiers);
+          if (logAnalyzer.isLogFromOld()) {
+            handleSuccess =
+                handleWithoutAllSourceFilesExistFromOld(
+                    targetFileIdentifiers, sourceFileIdentifiers);
+          } else {
+            handleSuccess = handleWithoutAllSourceFilesExist(sourceFileIdentifiers);
+          }
         }
       }
     } catch (IOException e) {
@@ -142,15 +154,13 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
    * compaction mods files.
    */
   private boolean handleWithAllSourceFilesExist(
-      List<TsFileIdentifier> targetFileIdentifiers,
-      List<TsFileIdentifier> sourceFileIdentifiers,
-      String fullStorageGroupName) {
+      List<TsFileIdentifier> targetFileIdentifiers, List<TsFileIdentifier> sourceFileIdentifiers) {
     LOGGER.info(
         "{} [Compaction][Recover] all source files exists, delete all target files.",
         fullStorageGroupName);
 
     for (TsFileIdentifier targetFileIdentifier : targetFileIdentifiers) {
-      // xxx.merge
+      // xxx.cross
       File tmpTargetFile = targetFileIdentifier.getFileFromDataDirs();
       // xxx.tsfile
       File targetFile =
@@ -237,6 +247,176 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
       handleSuccess = false;
     }
     return handleSuccess;
+  }
+
+  /** Delete tmp target file and compaction mods file. */
+  private boolean handleWithAllSourceFilesExistFromOld(
+      List<TsFileIdentifier> targetFileIdentifiers) {
+    // delete tmp target file
+    for (TsFileIdentifier targetFileIdentifier : targetFileIdentifiers) {
+      // xxx.tsfile.merge
+      File tmpTargetFile = targetFileIdentifier.getFileFromDataDirs();
+      if (tmpTargetFile != null) {
+        tmpTargetFile.delete();
+      }
+    }
+    File compactionModsFileFromOld =
+        getFileFromDataDirs(
+            "sequence"
+                + File.separator
+                + tsFileManager.getStorageGroupName()
+                + File.separator
+                + tsFileManager.getVirtualStorageGroup()
+                + File.separator
+                + IoTDBConstant.COMPACTION_MODIFICATION_FILE_NAME_FROM_OLD);
+    if (compactionModsFileFromOld != null && !compactionModsFileFromOld.delete()) {
+      LOGGER.error(
+          "{} [Compaction][Recover] fail to delete target file {}, this may cause data incorrectness",
+          fullStorageGroupName,
+          compactionModsFileFromOld);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * 1. If target file does not exist, then move .merge file to target file <br>
+   * 2. If target resource file does not exist, then serialize it. <br>
+   * 3. Append merging modification to target mods file and delete merging mods file. <br>
+   * 4. Delete source files and .merge file. <br>
+   */
+  private boolean handleWithoutAllSourceFilesExistFromOld(
+      List<TsFileIdentifier> targetFileIdentifiers, List<TsFileIdentifier> sourceFileIdentifiers) {
+    try {
+      File compactionModsFileFromOld =
+          getFileFromDataDirs(
+              "sequence"
+                  + File.separator
+                  + tsFileManager.getStorageGroupName()
+                  + File.separator
+                  + tsFileManager.getVirtualStorageGroup()
+                  + File.separator
+                  + IoTDBConstant.COMPACTION_MODIFICATION_FILE_NAME_FROM_OLD);
+      List<TsFileResource> targetFileResources = new ArrayList<>();
+      for (int i = 0; i < sourceFileIdentifiers.size(); i++) {
+        TsFileIdentifier sourceFileIdentifier = sourceFileIdentifiers.get(i);
+        if (sourceFileIdentifier.isSequence()) {
+          File tmpTargetFile = targetFileIdentifiers.get(i).getFileFromDataDirs();
+          File targetFile = null;
+
+          // move tmp target file to target file if not exist
+          if (tmpTargetFile != null) {
+            // move tmp target file to target file
+            String sourceFilePath =
+                tmpTargetFile
+                    .getPath()
+                    .replace(
+                        TsFileConstant.TSFILE_SUFFIX
+                            + IoTDBConstant.CROSS_COMPACTION_TMP_FILE_SUFFIX_FROM_OLD,
+                        TsFileConstant.TSFILE_SUFFIX);
+            targetFile = TsFileNameGenerator.increaseCrossCompactionCnt(new File(sourceFilePath));
+            FSFactoryProducer.getFSFactory().moveFile(tmpTargetFile, targetFile);
+          } else {
+            // target file must exist
+            File file =
+                TsFileNameGenerator.increaseCrossCompactionCnt(
+                    new File(
+                        targetFileIdentifiers
+                            .get(i)
+                            .getFilePath()
+                            .replace(
+                                TsFileConstant.TSFILE_SUFFIX
+                                    + IoTDBConstant.CROSS_COMPACTION_TMP_FILE_SUFFIX_FROM_OLD,
+                                TsFileConstant.TSFILE_SUFFIX)));
+
+            targetFile = getFileFromDataDirs(file.getPath());
+          }
+          if (targetFile == null) {
+            LOGGER.error(
+                "{} [Compaction][Recover] target file of source seq file {} does not exist (<0.13).",
+                fullStorageGroupName,
+                sourceFileIdentifier.getFilePath());
+            return false;
+          }
+
+          // serialize target resource file if not exist
+          TsFileResource targetResource = new TsFileResource(targetFile);
+          if (!targetResource.resourceFileExists()) {
+            try (TsFileSequenceReader reader =
+                new TsFileSequenceReader(targetFile.getAbsolutePath())) {
+              FileLoaderUtils.updateTsFileResource(reader, targetResource);
+            }
+            targetResource.serialize();
+          }
+
+          targetFileResources.add(targetResource);
+
+          // append compaction modifications to target mods file and delete compaction mods file
+          if (compactionModsFileFromOld != null) {
+            ModificationFile compactionModsFile =
+                new ModificationFile(compactionModsFileFromOld.getPath());
+            appendCompactionModificationsFromOld(targetResource, compactionModsFile);
+          }
+
+          // delete tmp target file
+          if (tmpTargetFile != null) {
+            tmpTargetFile.delete();
+          }
+        }
+
+        // delete source tsfile
+        File sourceFile = sourceFileIdentifier.getFileFromDataDirs();
+        if (sourceFile != null) {
+          sourceFile.delete();
+        }
+
+        // delete source resource file
+        sourceFile =
+            getFileFromDataDirs(
+                sourceFileIdentifier.getFilePath() + TsFileResource.RESOURCE_SUFFIX);
+        if (sourceFile != null) {
+          sourceFile.delete();
+        }
+
+        // delete source mods file
+        sourceFile =
+            getFileFromDataDirs(sourceFileIdentifier.getFilePath() + ModificationFile.FILE_SUFFIX);
+        if (sourceFile != null) {
+          sourceFile.delete();
+        }
+      }
+
+      // delete compaction mods file
+      if (compactionModsFileFromOld != null && !compactionModsFileFromOld.delete()) {
+        LOGGER.error(
+            "{} [Compaction][Recover] fail to delete target file {}, this may cause data incorrectness",
+            fullStorageGroupName,
+            compactionModsFileFromOld);
+        return false;
+      }
+    } catch (Throwable e) {
+      LOGGER.error(
+          "{} [Compaction][Recover] fail to handle with some source files lost from old version.",
+          fullStorageGroupName,
+          e);
+      return false;
+    }
+
+    return true;
+  }
+
+  public void appendCompactionModificationsFromOld(
+      TsFileResource resource, ModificationFile compactionModsFile) throws IOException {
+
+    if (compactionModsFile != null) {
+      for (Modification modification : compactionModsFile.getModifications()) {
+        // we have to set modification offset to MAX_VALUE, as the offset of source chunk may
+        // change after compaction
+        modification.setFileOffset(Long.MAX_VALUE);
+        resource.getModFile().write(modification);
+      }
+      resource.getModFile().close();
+    }
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverTask.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.engine.compaction.task;
 
+import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.recover.RewriteCrossSpaceCompactionLogger;
@@ -35,7 +36,8 @@ import java.util.regex.Pattern;
  * InnerCompactionTask in sequence/unsequence space, CrossSpaceCompaction.
  */
 public class CompactionRecoverTask {
-  private static final Logger logger = LoggerFactory.getLogger(CompactionRecoverTask.class);
+  private static final Logger logger =
+      LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
   private TsFileManager tsFileManager;
   private String logicalStorageGroupName;
   private String virtualStorageGroupId;
@@ -49,6 +51,7 @@ public class CompactionRecoverTask {
 
   public void recoverCrossSpaceCompaction() throws Exception {
     logger.info("recovering cross compaction");
+    recoverCrossCompactionFromOldVersion();
     recoverCrossCompaction();
     logger.info("try to synchronize CompactionScheduler");
   }
@@ -92,6 +95,28 @@ public class CompactionRecoverTask {
               .call();
         }
       }
+    }
+  }
+
+  private void recoverCrossCompactionFromOldVersion() throws Exception {
+    // check whether there is old compaction log from previous version (<0.13)
+    File mergeLogFromOldVersion =
+        new File(
+            tsFileManager.getStorageGroupDir()
+                + File.separator
+                + RewriteCrossSpaceCompactionLogger.COMPACTION_LOG_NAME_FEOM_OLD);
+    if (mergeLogFromOldVersion.exists()) {
+      logger.info("calling cross compaction task to recover from previous version.");
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .getCrossCompactionStrategy()
+          .getCompactionRecoverTask(
+              logicalStorageGroupName,
+              virtualStorageGroupId,
+              0L,
+              mergeLogFromOldVersion,
+              tsFileManager)
+          .call();
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileNameGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileNameGenerator.java
@@ -163,7 +163,7 @@ public class TsFileNameGenerator {
    * own tmp target file.
    *
    * @param seqResources
-   * @return tmp target file list, which is xxx.merge
+   * @return tmp target file list, which is xxx.cross
    * @throws IOException
    */
   public static List<TsFileResource> getCrossCompactionTargetFileResources(


### PR DESCRIPTION
So far, the 0.13 compaction log parser cannot read the 0.12 compaction log. Therefore, we need to make compaction restart recovery and log reading forward compatible with 0.12.