### PR TITLE
[To rel/0.12][IOTDB-2624] "overlapped data should be consumed first" occurs when executing query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -153,7 +153,7 @@ public class IoTDBConfig {
   private int flushWalThreshold = 10000;
 
   /** this variable set timestamp precision as millisecond, microsecond or nanosecond */
-  private String timestampPrecision = "ms";
+  private String timestampPrecision = "ns";
 
   /**
    * The cycle when write ahead log is periodically forced to be written to disk(in milliseconds) If
@@ -715,7 +715,7 @@ public class IoTDBConfig {
   private int ioTaskQueueSizeForFlushing = 10;
 
   /** the number of virtual storage groups per user-defined storage group */
-  private int virtualStorageGroupNum = 1;
+  private int virtualStorageGroupNum = 8;
 
   private String adminName = "root";
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/TsFileManagement.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.MergeException;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -363,7 +364,20 @@ public abstract class TsFileManagement {
     for (TsFileResource unseqFile : unseqFiles) {
       unseqFile.writeLock();
       try {
+        FileUtils.moveFile(
+            unseqFile.getTsFile(),
+            new File(
+                unseqFile.getTsFile().getAbsolutePath().replace(".tsfile", ".merge-old-file")));
+        FileUtils.moveFile(
+            new File(unseqFile.getTsFilePath() + ".resource"),
+            new File(
+                unseqFile
+                    .getTsFile()
+                    .getAbsolutePath()
+                    .replace(".tsfile", ".merge-old-file.resource")));
         unseqFile.remove();
+      } catch (IOException e) {
+        logger.error("exception occurs ", e);
       } finally {
         unseqFile.writeUnlock();
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/level/LevelCompactionTsFileManagement.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.db.utils.TestOnly;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,7 +155,17 @@ public class LevelCompactionTsFileManagement extends TsFileManagement {
       TimeSeriesMetadataCache.getInstance().clear();
       FileReaderManager.getInstance().closeFileAndRemoveReader(seqFile.getTsFilePath());
       seqFile.setDeleted(true);
-      seqFile.delete();
+      FileUtils.moveFile(
+          seqFile.getTsFile(),
+          new File(
+              seqFile.getTsFile().getAbsolutePath().replace(".tsfile", ".compaction-old-file")));
+      FileUtils.moveFile(
+          new File(seqFile.getTsFile().getAbsolutePath() + ".resource"),
+          new File(
+              seqFile
+                  .getTsFile()
+                  .getAbsolutePath()
+                  .replace(".tsfile", ".compaction-old-file.resource")));
     } catch (IOException e) {
       logger.error(e.getMessage(), e);
     } finally {

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
@@ -249,6 +249,20 @@ public class MergeResource {
   }
 
   public List<TsFileResource> getSeqFiles() {
+    List<TsFileResource> resources = new ArrayList<>(seqFiles);
+    resources.sort(
+        (o1, o2) -> {
+          try {
+            TsFileResource.TsFileName o1Name =
+                TsFileResource.getTsFileName(o1.getTsFile().getName());
+            TsFileResource.TsFileName o2Name =
+                TsFileResource.getTsFileName(o2.getTsFile().getName());
+            return (int) (o1Name.getTime() - o2Name.getTime());
+          } catch (IOException e) {
+            e.printStackTrace();
+            return 0;
+          }
+        });
     return seqFiles;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxSeriesMergeFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxSeriesMergeFileSelector.java
@@ -57,6 +57,12 @@ public class MaxSeriesMergeFileSelector extends MaxFileMergeFileSelector {
           resource.getUnseqFiles().size());
 
       searchMaxSeriesNum();
+      logger.error(
+          "selected seq files is {}, selected unseq files is {}, total seq files is {}, total unseq files is {}",
+          selectedSeqFiles,
+          selectedUnseqFiles,
+          resource.getSeqFiles(),
+          resource.getUnseqFiles());
       resource.setSeqFiles(selectedSeqFiles);
       resource.setUnseqFiles(selectedUnseqFiles);
       resource.removeOutdatedSeqReaders();

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeFileTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeFileTask.java
@@ -166,12 +166,12 @@ public class MergeFileTask {
 
         if (devicesTimeRangeMap.containsKey(device)
             && devicesTimeRangeMap.get(device) > minStartTimeForThisFile) {
-          //          logger.error(
-          //              "merge error occurs. seq file is {}, unseq file is {}, device is {}",
-          //              resource.getSeqFiles(),
-          //              resource.getUnseqFiles(),
-          //              device);
-          //          System.exit(-1);
+          logger.error(
+              "merge error occurs. seq file is {}, unseq file is {}, device is {}",
+              resource.getSeqFiles(),
+              resource.getUnseqFiles(),
+              device);
+          System.exit(-1);
         }
         devicesTimeRangeMap.put(device, maxEndTimeForThisFile);
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
@@ -509,7 +509,7 @@ public class MergeMultiChunkTask {
               chunk,
               chunkWriter,
               unseqReader,
-              isLastChunk ? currMeta.getEndTime() : resourceEndTime,
+              isLastChunk ? resourceEndTime : currMeta.getEndTime(),
               pathIdx);
       mergedChunkNum.incrementAndGet();
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/task/MergeMultiChunkTask.java
@@ -315,6 +315,7 @@ public class MergeMultiChunkTask {
     mergeFileWriter.startChunkGroup(deviceId);
     boolean dataWritten =
         mergeChunks(
+            deviceId,
             seqChunkMeta,
             isLastFile,
             fileSequenceReader,
@@ -343,6 +344,7 @@ public class MergeMultiChunkTask {
 
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   private boolean mergeChunks(
+      String deviceId,
       List<ChunkMetadata>[] seqChunkMeta,
       boolean isLastFile,
       TsFileSequenceReader reader,
@@ -396,6 +398,7 @@ public class MergeMultiChunkTask {
                       unseqReaders,
                       currFile,
                       isLastFile,
+                      currFile.getEndTime(deviceId),
                       i)));
 
       if (Thread.interrupted()) {
@@ -451,6 +454,8 @@ public class MergeMultiChunkTask {
       ChunkMetadata currMeta,
       boolean chunkOverflowed,
       boolean chunkTooSmall,
+      boolean isLastChunk,
+      long resourceEndTime,
       Chunk chunk,
       int lastUnclosedChunkPoint,
       int pathIdx,
@@ -500,7 +505,12 @@ public class MergeMultiChunkTask {
     } else {
       // 3.2 SK is overflowed, uncompress sequence chunk and merge with unseq chunk, then write
       unclosedChunkPoint +=
-          writeChunkWithUnseq(chunk, chunkWriter, unseqReader, currMeta.getEndTime(), pathIdx);
+          writeChunkWithUnseq(
+              chunk,
+              chunkWriter,
+              unseqReader,
+              isLastChunk ? currMeta.getEndTime() : resourceEndTime,
+              pathIdx);
       mergedChunkNum.incrementAndGet();
     }
 
@@ -589,6 +599,7 @@ public class MergeMultiChunkTask {
     private TsFileResource currFile;
     private boolean isLastFile;
     private int taskNum;
+    private long resourceEndTime;
 
     private int totalSeriesNum;
 
@@ -601,6 +612,7 @@ public class MergeMultiChunkTask {
         IPointReader[] unseqReaders,
         TsFileResource currFile,
         boolean isLastFile,
+        long resourceEndTime,
         int taskNum) {
       this.chunkIdxHeap = chunkIdxHeap;
       this.metaListEntries = metaListEntries;
@@ -612,6 +624,7 @@ public class MergeMultiChunkTask {
       this.isLastFile = isLastFile;
       this.taskNum = taskNum;
       this.totalSeriesNum = chunkIdxHeap.size();
+      this.resourceEndTime = resourceEndTime;
     }
 
     @Override
@@ -651,6 +664,8 @@ public class MergeMultiChunkTask {
                   currMeta,
                   chunkOverflowed,
                   chunkTooSmall,
+                  isLastChunk,
+                  resourceEndTime,
                   chunk,
                   ptWrittens[pathIdx],
                   pathIdx,

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileResourcePrinter.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileResourcePrinter.java
@@ -38,7 +38,8 @@ public class TsFileResourcePrinter {
   @SuppressWarnings("squid:S106")
   public static void main(String[] args) throws IOException {
 
-    String folder = "data/data/sequence/root.group_1/0";
+    String folder =
+        "D:\\Workspace\\iotdb\\data\\data\\sequence\\root.Baoshan\\4\\0\\1645862192442-4-0-1.tsfile.resource";
     if (args.length >= 1) {
       folder = args[0];
     }
@@ -78,9 +79,9 @@ public class TsFileResourcePrinter {
           "device %s, start time %d (%s), end time %d (%s)%n",
           device,
           resource.getStartTime(device),
-          DatetimeUtils.convertMillsecondToZonedDateTime(resource.getStartTime(device)),
+          DatetimeUtils.convertMillsecondToZonedDateTime(resource.getStartTime(device) / 1000000),
           resource.getEndTime(device),
-          DatetimeUtils.convertMillsecondToZonedDateTime(resource.getEndTime(device)));
+          DatetimeUtils.convertMillsecondToZonedDateTime(resource.getEndTime(device) / 1000000));
     }
     System.out.println();
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeManagerTest.java
@@ -144,7 +144,17 @@ public class MergeManagerTest extends MergeTest {
       private String progress = "0";
 
       public FakedSubMergeTask(int serialNum) {
-        super(new PriorityQueue<>(), null, null, null, null, null, null, false, serialNum);
+        super(
+            new PriorityQueue<>(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            Long.MAX_VALUE,
+            serialNum);
         this.serialNum = serialNum;
       }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeManagerTest.java
@@ -145,6 +145,7 @@ public class MergeManagerTest extends MergeTest {
 
       public FakedSubMergeTask(int serialNum) {
         super(
+            null,
             new PriorityQueue<>(),
             null,
             null,


### PR DESCRIPTION
see [IOTDB-2624](https://issues.apache.org/jira/browse/IOTDB-2624)