### PR TITLE
[To rel/0.12][IOTDB-2640]Fix cross compaction recover bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
@@ -110,6 +110,11 @@ public class MergeLogAnalyzer {
         }
       }
       if (!currentFileFound) {
+        mergeSeqFiles.add(
+            new TsFileResource(
+                new File(
+                    resource.getSeqFiles().get(0).getTsFile().getParent(),
+                    MergeFileInfo.getFileInfoFromString(currLine).filename)));
         allSourceFileExists = false;
       }
     }

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
@@ -339,6 +339,7 @@ public class MergeRecoverTest extends MergeTest {
                       + ".tsfile"));
       Assert.assertTrue(file.createNewFile());
       TsFileResource tsFileResource = new TsFileResource(file);
+      prepareFile(tsFileResource, i * 10, 10, i * 10);
       tsFileResource.setClosed(true);
       tsFileResource.setMinPlanIndex(i);
       tsFileResource.setMaxPlanIndex(i);
@@ -352,8 +353,6 @@ public class MergeRecoverTest extends MergeTest {
       deletion = new Deletion(new PartialPath("root.sg1.d1", "s0"), 1, 200, 300);
       tsFileResource.getModFile().write(deletion);
       tsFileResource.getModFile().close();
-
-      prepareFile(tsFileResource, i * 10, 10, i * 10);
     }
 
     // create source unseq files
@@ -371,6 +370,7 @@ public class MergeRecoverTest extends MergeTest {
                       + ".tsfile"));
       Assert.assertTrue(file.createNewFile());
       TsFileResource tsFileResource = new TsFileResource(file);
+      prepareFile(tsFileResource, i * 10, 5, i * 10);
       tsFileResource.setClosed(true);
       tsFileResource.setMinPlanIndex(i);
       tsFileResource.setMaxPlanIndex(i);
@@ -384,8 +384,6 @@ public class MergeRecoverTest extends MergeTest {
       deletion = new Deletion(new PartialPath("root.sg1.d1", "s0"), 1, 200, 300);
       tsFileResource.getModFile().write(deletion);
       tsFileResource.getModFile().close();
-
-      prepareFile(tsFileResource, i * 10, 5, i * 10);
     }
 
     // create .merge files


### PR DESCRIPTION
Query less data after compaction recovery. When handling recover, add the source tsfiles which have been deleted at the last cross space compaction.