### PR TITLE
[To rel/0.12][IOTDB-2640]Fix cross compaction recover bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.engine.merge.recover;
 import org.apache.iotdb.db.engine.merge.manage.MergeResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
@@ -155,6 +155,16 @@ public class MergeLogAnalyzer {
         }
       }
       if (!currentFileFound) {
+        mergeUnseqFiles.add(
+            new TsFileResource(
+                new File(
+                    resource
+                        .getSeqFiles()
+                        .get(0)
+                        .getTsFile()
+                        .getParent()
+                        .replace("unsequence", "sequence"),
+                    MergeFileInfo.getFileInfoFromString(currLine).filename)));
         allSourceFileExists = false;
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.db.engine.merge.recover;
 import org.apache.iotdb.db.engine.merge.manage.MergeResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -155,6 +154,16 @@ public class MergeLogAnalyzer {
         }
       }
       if (!currentFileFound) {
+        mergeUnseqFiles.add(
+            new TsFileResource(
+                new File(
+                    resource
+                        .getSeqFiles()
+                        .get(0)
+                        .getTsFile()
+                        .getParent()
+                        .replace("sequence", "unsequence"),
+                    MergeFileInfo.getFileInfoFromString(currLine).filename)));
         allSourceFileExists = false;
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
@@ -155,16 +155,6 @@ public class MergeLogAnalyzer {
         }
       }
       if (!currentFileFound) {
-        mergeUnseqFiles.add(
-            new TsFileResource(
-                new File(
-                    resource
-                        .getSeqFiles()
-                        .get(0)
-                        .getTsFile()
-                        .getParent()
-                        .replace("unsequence", "sequence"),
-                    MergeFileInfo.getFileInfoFromString(currLine).filename)));
         allSourceFileExists = false;
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeLogAnalyzer.java
@@ -110,6 +110,11 @@ public class MergeLogAnalyzer {
         }
       }
       if (!currentFileFound) {
+        mergeSeqFiles.add(
+            new TsFileResource(
+                new File(
+                    resource.getSeqFiles().get(0).getTsFile().getParent(),
+                    MergeFileInfo.getFileInfoFromString(currLine).filename)));
         allSourceFileExists = false;
       }
     }

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
@@ -138,6 +138,13 @@ public class MergeRecoverTest extends MergeTest {
     }
     Assert.assertFalse(mergingModsFile.exists());
     Assert.assertFalse(logFile.exists());
+    Assert.assertEquals(10, tsFileManagement.getTsFileList(true).size());
+    Assert.assertEquals(0, tsFileManagement.getTsFileList(false).size());
+    for (int i = 0; i < tsFileManagement.getTsFileList(true).size(); i++) {
+      Assert.assertEquals(
+          tsFileManagement.getTsFileList(true).get(i).getTsFilePath(),
+          modifyTsFileNameUnseqMergCnt(tmpSourceSeqFiles.get(i).getTsFile()).getPath());
+    }
   }
 
   /**
@@ -199,6 +206,13 @@ public class MergeRecoverTest extends MergeTest {
     }
     Assert.assertFalse(mergingModsFile.exists());
     Assert.assertFalse(logFile.exists());
+    Assert.assertEquals(10, tsFileManagement.getTsFileList(true).size());
+    Assert.assertEquals(0, tsFileManagement.getTsFileList(false).size());
+    for (int i = 0; i < tsFileManagement.getTsFileList(true).size(); i++) {
+      Assert.assertEquals(
+          tsFileManagement.getTsFileList(true).get(i).getTsFilePath(),
+          modifyTsFileNameUnseqMergCnt(tmpSourceSeqFiles.get(i).getTsFile()).getPath());
+    }
   }
 
   @Test
@@ -247,6 +261,13 @@ public class MergeRecoverTest extends MergeTest {
     }
     Assert.assertFalse(mergingModsFile.exists());
     Assert.assertFalse(logFile.exists());
+    Assert.assertEquals(10, tsFileManagement.getTsFileList(true).size());
+    Assert.assertEquals(0, tsFileManagement.getTsFileList(false).size());
+    for (int i = 0; i < tsFileManagement.getTsFileList(true).size(); i++) {
+      Assert.assertEquals(
+          tsFileManagement.getTsFileList(true).get(i).getTsFilePath(),
+          modifyTsFileNameUnseqMergCnt(tmpSourceSeqFiles.get(i).getTsFile()).getPath());
+    }
   }
 
   @Test
@@ -300,6 +321,13 @@ public class MergeRecoverTest extends MergeTest {
     }
     Assert.assertFalse(mergingModsFile.exists());
     Assert.assertFalse(logFile.exists());
+    Assert.assertEquals(10, tsFileManagement.getTsFileList(true).size());
+    Assert.assertEquals(0, tsFileManagement.getTsFileList(false).size());
+    for (int i = 0; i < tsFileManagement.getTsFileList(true).size(); i++) {
+      Assert.assertEquals(
+          tsFileManagement.getTsFileList(true).get(i).getTsFilePath(),
+          modifyTsFileNameUnseqMergCnt(tmpSourceSeqFiles.get(i).getTsFile()).getPath());
+    }
   }
 
   @Test
@@ -351,6 +379,13 @@ public class MergeRecoverTest extends MergeTest {
     }
     Assert.assertFalse(mergingModsFile.exists());
     Assert.assertFalse(logFile.exists());
+    Assert.assertEquals(10, tsFileManagement.getTsFileList(true).size());
+    Assert.assertEquals(0, tsFileManagement.getTsFileList(false).size());
+    for (int i = 0; i < tsFileManagement.getTsFileList(true).size(); i++) {
+      Assert.assertEquals(
+          tsFileManagement.getTsFileList(true).get(i).getTsFilePath(),
+          modifyTsFileNameUnseqMergCnt(tmpSourceSeqFiles.get(i).getTsFile()).getPath());
+    }
   }
 
   @Test
@@ -385,6 +420,18 @@ public class MergeRecoverTest extends MergeTest {
     }
     Assert.assertFalse(mergingModsFile.exists());
     Assert.assertFalse(logFile.exists());
+    Assert.assertEquals(10, tsFileManagement.getTsFileList(true).size());
+    Assert.assertEquals(5, tsFileManagement.getTsFileList(false).size());
+    for (int i = 0; i < tsFileManagement.getTsFileList(true).size(); i++) {
+      Assert.assertEquals(
+          tsFileManagement.getTsFileList(true).get(i).getTsFilePath(),
+          tmpSourceSeqFiles.get(i).getTsFilePath());
+    }
+    for (int i = 0; i < tsFileManagement.getTsFileList(false).size(); i++) {
+      Assert.assertEquals(
+          tsFileManagement.getTsFileList(false).get(i).getTsFilePath(),
+          tmpSourceUnseqFiles.get(i).getTsFilePath());
+    }
   }
 
   private void createFiles() throws IOException, IllegalPathException, WriteProcessException {

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
@@ -106,6 +106,7 @@ public class MergeRecoverTest extends MergeTest {
   @Test
   public void testRecoverWithSomeSourceFilesLost() throws IOException, MetadataException {
     sourceSeqFiles.get(0).getTsFile().delete();
+    tsFileManagement.remove(sourceSeqFiles.get(0), true);
     RecoverMergeTask recoverMergeTask =
         new RecoverMergeTask(
             tsFileManagement,
@@ -154,6 +155,8 @@ public class MergeRecoverTest extends MergeTest {
         .moveFile(
             new File(sourceSeqFiles.get(0).getTsFilePath() + TsFileResource.RESOURCE_SUFFIX),
             new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX));
+    tsFileManagement.remove(sourceSeqFiles.get(0), true);
+    tsFileManagement.add(new TsFileResource(targetFile), true);
     targetFile = modifyTsFileNameUnseqMergCnt(sourceSeqFiles.get(1).getTsFile());
     FSFactoryProducer.getFSFactory().moveFile(sourceSeqFiles.get(1).getTsFile(), targetFile);
     // sg recover will serialize resouce file
@@ -162,6 +165,8 @@ public class MergeRecoverTest extends MergeTest {
       FileLoaderUtils.updateTsFileResource(reader, targetTsFileResouce);
     }
     targetTsFileResouce.serialize();
+    tsFileManagement.remove(sourceSeqFiles.get(1), true);
+    tsFileManagement.add(targetTsFileResouce, true);
 
     RecoverMergeTask recoverMergeTask =
         new RecoverMergeTask(
@@ -207,7 +212,10 @@ public class MergeRecoverTest extends MergeTest {
               new File(resource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX),
               new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX));
       resource.remove();
+      tsFileManagement.remove(resource, true);
+      tsFileManagement.add(new TsFileResource(targetFile), true);
     }
+
     RecoverMergeTask recoverMergeTask =
         new RecoverMergeTask(
             tsFileManagement,
@@ -252,9 +260,12 @@ public class MergeRecoverTest extends MergeTest {
               new File(resource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX),
               new File(targetFile.getPath() + TsFileResource.RESOURCE_SUFFIX));
       resource.remove();
+      tsFileManagement.remove(resource, true);
+      tsFileManagement.add(new TsFileResource(targetFile), true);
     }
     for (TsFileResource resource : sourceUnseqFiles) {
       resource.remove();
+      tsFileManagement.remove(resource, false);
     }
     RecoverMergeTask recoverMergeTask =
         new RecoverMergeTask(

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeRecoverTest.java
@@ -339,6 +339,7 @@ public class MergeRecoverTest extends MergeTest {
                       + ".tsfile"));
       Assert.assertTrue(file.createNewFile());
       TsFileResource tsFileResource = new TsFileResource(file);
+      prepareFile(tsFileResource, i * 10, 10, i * 10);
       tsFileResource.setClosed(true);
       tsFileResource.setMinPlanIndex(i);
       tsFileResource.setMaxPlanIndex(i);
@@ -352,8 +353,6 @@ public class MergeRecoverTest extends MergeTest {
       deletion = new Deletion(new PartialPath("root.sg1.d1", "s0"), 1, 200, 300);
       tsFileResource.getModFile().write(deletion);
       tsFileResource.getModFile().close();
-
-      prepareFile(tsFileResource, i * 10, 10, i * 10);
     }
 
     // create source unseq files
@@ -371,6 +370,7 @@ public class MergeRecoverTest extends MergeTest {
                       + ".tsfile"));
       Assert.assertTrue(file.createNewFile());
       TsFileResource tsFileResource = new TsFileResource(file);
+      prepareFile(tsFileResource, i * 10, 5, i * 10);
       tsFileResource.setClosed(true);
       tsFileResource.setMinPlanIndex(i);
       tsFileResource.setMaxPlanIndex(i);
@@ -384,8 +384,6 @@ public class MergeRecoverTest extends MergeTest {
       deletion = new Deletion(new PartialPath("root.sg1.d1", "s0"), 1, 200, 300);
       tsFileResource.getModFile().write(deletion);
       tsFileResource.getModFile().close();
-
-      prepareFile(tsFileResource, i * 10, 5, i * 10);
     }
 
     // create .merge files


### PR DESCRIPTION
Query less data after compaction recovery. When handling recover, add the source tsfiles which have been deleted at the last cross space compaction.