### PR TITLE
[To rel/0.12][IOTDB-2624] Fix "overlapped data should be consumed first" occurs when executing query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
@@ -240,7 +240,7 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
       boolean noMoreOverlap = false;
       for (int i = 0; i < resource.getSeqFiles().size() && !noMoreOverlap; i++) {
         TsFileResource seqFile = resource.getSeqFiles().get(i);
-        if (!seqFile.getDevices().contains(deviceId)) {
+        if (tmpSelectedSeqFiles.contains(i) || !seqFile.getDevices().contains(deviceId)) {
           continue;
         }
 
@@ -257,22 +257,16 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
         } else if (!seqFile.isClosed()) {
           // we cannot make sure whether unclosed file has overlap or not, so we just add it.
           tmpSelectedSeqFiles.add(i);
-          tmpSelectedNum++;
         } else if (unseqEndTime <= seqEndTime) {
           // if time range in unseq file is 10-20, seq file is 15-25, then select this seq file and
           // there is no more overlap later.
           tmpSelectedSeqFiles.add(i);
-          tmpSelectedNum++;
           noMoreOverlap = true;
         } else if (unseqStartTime <= seqEndTime) {
           // if time range in unseq file is 10-20, seq file is 0-15, then select this seq file and
           // there may be overlap later.
           tmpSelectedSeqFiles.add(i);
-          tmpSelectedNum++;
         }
-      }
-      if (tmpSelectedNum + seqSelectedNum == resource.getSeqFiles().size()) {
-        break;
       }
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
@@ -29,6 +29,11 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.timeindex.ITimeIndex;
 import org.apache.iotdb.db.exception.MergeException;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.write.TsFileWriter;
+import org.apache.iotdb.tsfile.write.record.TSRecord;
+import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -631,6 +636,229 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
     List[] result = mergeFileSelector.select();
     Assert.assertEquals(2, result.length);
     Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+  }
+
+  @Test
+  public void testMultiFileOverlapWithOneFile()
+      throws IOException, WriteProcessException, MergeException {
+    List<TsFileResource> seqList = new ArrayList<>();
+    List<TsFileResource> unseqList = new ArrayList<>();
+    // first file [0, 10]
+    // first device [0, 5]
+    // second device [0, 10]
+    File firstFile =
+        new File(
+            TestConstant.OUTPUT_DATA_DIR.concat(
+                1
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 1
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource firstTsFileResource = new TsFileResource(firstFile);
+    firstTsFileResource.setClosed(true);
+    firstTsFileResource.setMinPlanIndex(1);
+    firstTsFileResource.setMaxPlanIndex(1);
+    firstTsFileResource.setVersion(1);
+    seqList.add(firstTsFileResource);
+    if (!firstFile.getParentFile().exists()) {
+      Assert.assertTrue(firstFile.getParentFile().mkdirs());
+    }
+
+    TsFileWriter fileWriter = new TsFileWriter(firstFile);
+    for (String deviceId : deviceIds) {
+      for (MeasurementSchema measurementSchema : measurementSchemas) {
+        fileWriter.registerTimeseries(
+            new Path(deviceId, measurementSchema.getMeasurementId()), measurementSchema);
+      }
+    }
+    for (long i = 0; i < 10; ++i) {
+      for (int j = 0; j < deviceNum; j++) {
+        if (j == 3 && i > 5) {
+          continue;
+        }
+        TSRecord record = new TSRecord(i, deviceIds[j]);
+        for (int k = 0; k < measurementNum; ++k) {
+          record.addTuple(
+              DataPoint.getDataPoint(
+                  measurementSchemas[k].getType(),
+                  measurementSchemas[k].getMeasurementId(),
+                  String.valueOf(i)));
+        }
+        fileWriter.write(record);
+        firstTsFileResource.updateStartTime(deviceIds[j], i);
+        firstTsFileResource.updateEndTime(deviceIds[j], i);
+      }
+    }
+
+    fileWriter.flushAllChunkGroups();
+    fileWriter.close();
+
+    // second file time range: [11, 20]
+    // first measurement: [11, 20]
+    // second measurement: [11, 20]
+    File secondFile =
+        new File(
+            TestConstant.OUTPUT_DATA_DIR.concat(
+                2
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 2
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource secondTsFileResource = new TsFileResource(secondFile);
+    secondTsFileResource.setClosed(true);
+    secondTsFileResource.setMinPlanIndex(2);
+    secondTsFileResource.setMaxPlanIndex(2);
+    secondTsFileResource.setVersion(2);
+    seqList.add(secondTsFileResource);
+
+    if (!secondFile.getParentFile().exists()) {
+      Assert.assertTrue(secondFile.getParentFile().mkdirs());
+    }
+    fileWriter = new TsFileWriter(secondFile);
+    for (String deviceId : deviceIds) {
+      for (MeasurementSchema measurementSchema : measurementSchemas) {
+        fileWriter.registerTimeseries(
+            new Path(deviceId, measurementSchema.getMeasurementId()), measurementSchema);
+      }
+    }
+    for (long i = 11; i < 21; ++i) {
+      for (int j = 0; j < deviceNum; j++) {
+        TSRecord record = new TSRecord(i, deviceIds[j]);
+        for (int k = 0; k < measurementNum; k++) {
+          record.addTuple(
+              DataPoint.getDataPoint(
+                  measurementSchemas[k].getType(),
+                  measurementSchemas[k].getMeasurementId(),
+                  String.valueOf(i)));
+        }
+        fileWriter.write(record);
+        secondTsFileResource.updateStartTime(deviceIds[j], i);
+        secondTsFileResource.updateEndTime(deviceIds[j], i);
+      }
+    }
+    fileWriter.flushAllChunkGroups();
+    fileWriter.close();
+
+    // unseq file: [0, 1]
+    File thirdFile =
+        new File(
+            TestConstant.OUTPUT_DATA_DIR.concat(
+                3
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 3
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource thirdTsFileResource = new TsFileResource(thirdFile);
+    thirdTsFileResource.setClosed(true);
+    thirdTsFileResource.setMinPlanIndex(3);
+    thirdTsFileResource.setMaxPlanIndex(3);
+    thirdTsFileResource.setVersion(3);
+    unseqList.add(thirdTsFileResource);
+
+    if (!secondFile.getParentFile().exists()) {
+      Assert.assertTrue(thirdFile.getParentFile().mkdirs());
+    }
+    fileWriter = new TsFileWriter(thirdFile);
+    for (String deviceId : deviceIds) {
+      for (MeasurementSchema measurementSchema : measurementSchemas) {
+        fileWriter.registerTimeseries(
+            new Path(deviceId, measurementSchema.getMeasurementId()), measurementSchema);
+      }
+    }
+    for (long i = 0; i < 2; ++i) {
+      for (int j = 0; j < deviceNum; j++) {
+        TSRecord record = new TSRecord(i, deviceIds[j]);
+        for (int k = 0; k < measurementNum; k++) {
+          record.addTuple(
+              DataPoint.getDataPoint(
+                  measurementSchemas[k].getType(),
+                  measurementSchemas[k].getMeasurementId(),
+                  String.valueOf(i)));
+        }
+        fileWriter.write(record);
+        thirdTsFileResource.updateStartTime(deviceIds[j], i);
+        thirdTsFileResource.updateEndTime(deviceIds[j], i);
+      }
+    }
+    fileWriter.flushAllChunkGroups();
+    fileWriter.close();
+
+    // unseq file: [6, 8]
+    File fourthFile =
+        new File(
+            TestConstant.OUTPUT_DATA_DIR.concat(
+                4
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 4
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource fourthTsFileResource = new TsFileResource(fourthFile);
+    fourthTsFileResource.setClosed(true);
+    fourthTsFileResource.setMinPlanIndex(4);
+    fourthTsFileResource.setMaxPlanIndex(4);
+    fourthTsFileResource.setVersion(4);
+    unseqList.add(fourthTsFileResource);
+
+    if (!fourthFile.getParentFile().exists()) {
+      Assert.assertTrue(fourthFile.getParentFile().mkdirs());
+    }
+    fileWriter = new TsFileWriter(fourthFile);
+    for (String deviceId : deviceIds) {
+      for (MeasurementSchema measurementSchema : measurementSchemas) {
+        fileWriter.registerTimeseries(
+            new Path(deviceId, measurementSchema.getMeasurementId()), measurementSchema);
+      }
+    }
+    for (long i = 6; i < 15; ++i) {
+      for (int j = 0; j < deviceNum; j++) {
+        if (j == 3) {
+          continue;
+        }
+        TSRecord record = new TSRecord(i, deviceIds[j]);
+        for (int k = 0; k < measurementNum; k++) {
+          record.addTuple(
+              DataPoint.getDataPoint(
+                  measurementSchemas[k].getType(),
+                  measurementSchemas[k].getMeasurementId(),
+                  String.valueOf(i)));
+        }
+        fileWriter.write(record);
+        fourthTsFileResource.updateStartTime(deviceIds[j], i);
+        fourthTsFileResource.updateEndTime(deviceIds[j], i);
+      }
+    }
+    TSRecord record = new TSRecord(1, deviceIds[3]);
+    for (int k = 0; k < measurementNum; k++) {
+      record.addTuple(
+          DataPoint.getDataPoint(
+              measurementSchemas[k].getType(),
+              measurementSchemas[k].getMeasurementId(),
+              String.valueOf(1)));
+    }
+    fileWriter.write(record);
+    fourthTsFileResource.updateStartTime(deviceIds[3], 1);
+    fourthTsFileResource.updateEndTime(deviceIds[3], 1);
+    fileWriter.flushAllChunkGroups();
+    fileWriter.close();
+
+    MergeResource resource = new MergeResource(seqList, unseqList);
+    IMergeFileSelector mergeFileSelector =
+        new MaxFileMergeFileSelector(resource, 500 * 1024 * 1024);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result[0].size());
     Assert.assertEquals(2, result[1].size());
   }
 }


### PR DESCRIPTION
see [IOTDB-2624](https://issues.apache.org/jira/browse/IOTDB-2624)