### PR TITLE
[IOTDB-2653] Fix "overlapped data should be consumed first" occurs when executing query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
@@ -24,7 +24,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.cross.AbstractCrossSpaceCompactionSelector;
 import org.apache.iotdb.db.engine.compaction.cross.CrossSpaceCompactionTaskFactory;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceMergeResource;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
 import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUtils;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
@@ -90,8 +90,8 @@ public class RewriteCrossSpaceCompactionSelector extends AbstractCrossSpaceCompa
     }
     long budget = config.getCrossCompactionMemoryBudget();
     long timeLowerBound = System.currentTimeMillis() - Long.MAX_VALUE;
-    CrossSpaceMergeResource mergeResource =
-        new CrossSpaceMergeResource(seqFileList, unSeqFileList, timeLowerBound);
+    CrossSpaceCompactionResource mergeResource =
+        new CrossSpaceCompactionResource(seqFileList, unSeqFileList, timeLowerBound);
 
     ICrossSpaceMergeFileSelector fileSelector =
         InnerSpaceCompactionUtils.getCrossSpaceFileSelector(budget, mergeResource);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/manage/CrossSpaceCompactionResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/manage/CrossSpaceCompactionResource.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
  * CrossSpaceMergeResource manages files and caches of readers, writers, MeasurementSchemas and
  * modifications to avoid unnecessary object creations and file openings.
  */
-public class CrossSpaceMergeResource {
+public class CrossSpaceCompactionResource {
 
   private List<TsFileResource> seqFiles;
   private List<TsFileResource> unseqFiles = new ArrayList<>();
@@ -63,7 +63,7 @@ public class CrossSpaceMergeResource {
 
   private boolean cacheDeviceMeta = false;
 
-  public CrossSpaceMergeResource(List<TsFileResource> seqFiles, List<TsFileResource> unseqFiles) {
+  public CrossSpaceCompactionResource(List<TsFileResource> seqFiles, List<TsFileResource> unseqFiles) {
     this.seqFiles = seqFiles.stream().filter(this::filterSeqResource).collect(Collectors.toList());
     filterUnseqResource(unseqFiles);
   }
@@ -89,7 +89,7 @@ public class CrossSpaceMergeResource {
     }
   }
 
-  public CrossSpaceMergeResource(
+  public CrossSpaceCompactionResource(
       Collection<TsFileResource> seqFiles, List<TsFileResource> unseqFiles, long ttlLowerBound) {
     this.ttlLowerBound = ttlLowerBound;
     this.seqFiles = seqFiles.stream().filter(this::filterSeqResource).collect(Collectors.toList());

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/manage/CrossSpaceCompactionResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/manage/CrossSpaceCompactionResource.java
@@ -63,7 +63,8 @@ public class CrossSpaceCompactionResource {
 
   private boolean cacheDeviceMeta = false;
 
-  public CrossSpaceCompactionResource(List<TsFileResource> seqFiles, List<TsFileResource> unseqFiles) {
+  public CrossSpaceCompactionResource(
+      List<TsFileResource> seqFiles, List<TsFileResource> unseqFiles) {
     this.seqFiles = seqFiles.stream().filter(this::filterSeqResource).collect(Collectors.toList());
     filterUnseqResource(unseqFiles);
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/recover/RewriteCrossSpaceCompactionLogger.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/recover/RewriteCrossSpaceCompactionLogger.java
@@ -20,7 +20,7 @@
 package org.apache.iotdb.db.engine.compaction.cross.rewrite.recover;
 
 import org.apache.iotdb.db.engine.compaction.TsFileIdentifier;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceMergeResource;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 
 import java.io.BufferedWriter;
@@ -58,7 +58,7 @@ public class RewriteCrossSpaceCompactionLogger implements AutoCloseable {
     logStream.flush();
   }
 
-  public void logFiles(CrossSpaceMergeResource resource) throws IOException {
+  public void logFiles(CrossSpaceCompactionResource resource) throws IOException {
     logFiles(resource.getSeqFiles(), STR_SEQ_FILES);
     logFiles(resource.getUnseqFiles(), STR_UNSEQ_FILES);
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/InnerSpaceCompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/InnerSpaceCompactionUtils.java
@@ -22,7 +22,7 @@ package org.apache.iotdb.db.engine.compaction.inner.utils;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.cross.CrossCompactionStrategy;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceMergeResource;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.modification.Modification;
@@ -230,7 +230,7 @@ public class InnerSpaceCompactionUtils {
   }
 
   public static ICrossSpaceMergeFileSelector getCrossSpaceFileSelector(
-      long budget, CrossSpaceMergeResource resource) {
+      long budget, CrossSpaceCompactionResource resource) {
     CrossCompactionStrategy strategy =
         IoTDBDescriptor.getInstance().getConfig().getCrossCompactionStrategy();
     switch (strategy) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.db.engine.compaction.cross;
 
 import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceMergeResource;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
@@ -414,8 +414,8 @@ public class CrossSpaceCompactionTest {
           TsFileResourceList unseqTsFileResourceList = new TsFileResourceList();
           unseqTsFileResourceList.addAll(unseqResources);
           long timeLowerBound = System.currentTimeMillis() - Long.MAX_VALUE;
-          CrossSpaceMergeResource mergeResource =
-              new CrossSpaceMergeResource(
+          CrossSpaceCompactionResource mergeResource =
+              new CrossSpaceCompactionResource(
                   seqTsFileResourceList, unseqTsFileResourceList, timeLowerBound);
           ICrossSpaceMergeFileSelector fileSelector =
               new RewriteCompactionFileSelector(mergeResource, Long.MAX_VALUE);
@@ -718,8 +718,8 @@ public class CrossSpaceCompactionTest {
           TsFileResourceList unseqTsFileResourceList = new TsFileResourceList();
           unseqTsFileResourceList.addAll(unseqResources);
           long timeLowerBound = System.currentTimeMillis() - Long.MAX_VALUE;
-          CrossSpaceMergeResource mergeResource =
-              new CrossSpaceMergeResource(
+          CrossSpaceCompactionResource mergeResource =
+              new CrossSpaceCompactionResource(
                   seqTsFileResourceList, unseqTsFileResourceList, timeLowerBound);
           ICrossSpaceMergeFileSelector fileSelector =
               new RewriteCompactionFileSelector(mergeResource, Long.MAX_VALUE);
@@ -1020,8 +1020,8 @@ public class CrossSpaceCompactionTest {
           TsFileResourceList unseqTsFileResourceList = new TsFileResourceList();
           unseqTsFileResourceList.addAll(unseqResources);
           long timeLowerBound = System.currentTimeMillis() - Long.MAX_VALUE;
-          CrossSpaceMergeResource mergeResource =
-              new CrossSpaceMergeResource(
+          CrossSpaceCompactionResource mergeResource =
+              new CrossSpaceCompactionResource(
                   seqTsFileResourceList, unseqTsFileResourceList, timeLowerBound);
           ICrossSpaceMergeFileSelector fileSelector =
               new RewriteCompactionFileSelector(mergeResource, Long.MAX_VALUE);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeUpgradeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeUpgradeTest.java
@@ -79,7 +79,8 @@ public class MergeUpgradeTest {
 
   @Test
   public void testMergeUpgradeSelect() throws MergeException {
-    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
     RewriteCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeUpgradeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeUpgradeTest.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.db.engine.compaction.cross;
 
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.constant.TestConstant;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceMergeResource;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionConfigRestorer;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
@@ -79,7 +79,7 @@ public class MergeUpgradeTest {
 
   @Test
   public void testMergeUpgradeSelect() throws MergeException {
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
     RewriteCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -801,7 +801,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     fileWriter.flushAllChunkGroups();
     fileWriter.close();
 
-    // unseq file: [6, 8]
+    // unseq file: [6, 14]
     File fourthFile =
         new File(
             TestConstant.OUTPUT_DATA_DIR.concat(

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -51,7 +51,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
   @Test
   public void testFullSelection() throws MergeException, IOException {
-    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
@@ -82,7 +83,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
   @Test
   public void testNonSelection() throws MergeException, IOException {
-    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector = new RewriteCompactionFileSelector(resource, 1);
     List[] result = mergeFileSelector.select();
     assertEquals(0, result.length);
@@ -91,7 +93,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
   @Test
   public void testRestrictedSelection() throws MergeException, IOException {
-    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, 400000);
     List[] result = mergeFileSelector.select();
@@ -148,7 +151,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
     List<TsFileResource> newUnseqResources = new ArrayList<>();
     newUnseqResources.add(largeUnseqTsFileResource);
-    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, newUnseqResources);
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, newUnseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
@@ -239,7 +243,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     unseqResources.clear();
     unseqResources.add(largeUnseqTsFileResource);
 
-    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
@@ -676,8 +681,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     TsFileWriter fileWriter = new TsFileWriter(firstFile);
     for (String deviceId : deviceIds) {
       for (MeasurementSchema measurementSchema : measurementSchemas) {
-        fileWriter.registerTimeseries(
-            new Path(deviceId), measurementSchema);
+        fileWriter.registerTimeseries(new Path(deviceId), measurementSchema);
       }
     }
 
@@ -730,8 +734,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     fileWriter = new TsFileWriter(secondFile);
     for (String deviceId : deviceIds) {
       for (MeasurementSchema measurementSchema : measurementSchemas) {
-        fileWriter.registerTimeseries(
-            new Path(deviceId), measurementSchema);
+        fileWriter.registerTimeseries(new Path(deviceId), measurementSchema);
       }
     }
     for (long i = 11; i < 21; ++i) {
@@ -777,8 +780,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     fileWriter = new TsFileWriter(thirdFile);
     for (String deviceId : deviceIds) {
       for (MeasurementSchema measurementSchema : measurementSchemas) {
-        fileWriter.registerTimeseries(
-            new Path(deviceId), measurementSchema);
+        fileWriter.registerTimeseries(new Path(deviceId), measurementSchema);
       }
     }
     for (long i = 0; i < 2; ++i) {
@@ -824,8 +826,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     fileWriter = new TsFileWriter(fourthFile);
     for (String deviceId : deviceIds) {
       for (MeasurementSchema measurementSchema : measurementSchemas) {
-        fileWriter.registerTimeseries(
-            new Path(deviceId), measurementSchema);
+        fileWriter.registerTimeseries(new Path(deviceId), measurementSchema);
       }
     }
     for (long i = 6; i < 15; ++i) {
@@ -860,8 +861,10 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     fileWriter.flushAllChunkGroups();
     fileWriter.close();
 
-    CrossSpaceCompactionResource compactionResource = new CrossSpaceCompactionResource(seqList, unseqList);
-    RewriteCompactionFileSelector selector = new RewriteCompactionFileSelector(compactionResource, 500 * 1024 * 1024);
+    CrossSpaceCompactionResource compactionResource =
+        new CrossSpaceCompactionResource(seqList, unseqList);
+    RewriteCompactionFileSelector selector =
+        new RewriteCompactionFileSelector(compactionResource, 500 * 1024 * 1024);
     List[] result = selector.select();
     Assert.assertEquals(2, result[0].size());
     Assert.assertEquals(2, result[1].size());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -22,13 +22,18 @@ package org.apache.iotdb.db.engine.compaction.cross;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.constant.TestConstant;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceMergeResource;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.timeindex.ITimeIndex;
 import org.apache.iotdb.db.exception.MergeException;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.write.TsFileWriter;
+import org.apache.iotdb.tsfile.write.record.TSRecord;
+import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,7 +51,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
   @Test
   public void testFullSelection() throws MergeException, IOException {
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
@@ -56,7 +61,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     assertEquals(unseqResources, unseqSelected);
     resource.clear();
 
-    resource = new CrossSpaceMergeResource(seqResources.subList(0, 1), unseqResources);
+    resource = new CrossSpaceCompactionResource(seqResources.subList(0, 1), unseqResources);
     mergeFileSelector = new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     result = mergeFileSelector.select();
     seqSelected = result[0];
@@ -65,7 +70,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     assertEquals(unseqResources, unseqSelected);
     resource.clear();
 
-    resource = new CrossSpaceMergeResource(seqResources, unseqResources.subList(0, 1));
+    resource = new CrossSpaceCompactionResource(seqResources, unseqResources.subList(0, 1));
     mergeFileSelector = new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     result = mergeFileSelector.select();
     seqSelected = result[0];
@@ -77,7 +82,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
   @Test
   public void testNonSelection() throws MergeException, IOException {
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector = new RewriteCompactionFileSelector(resource, 1);
     List[] result = mergeFileSelector.select();
     assertEquals(0, result.length);
@@ -86,7 +91,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
   @Test
   public void testRestrictedSelection() throws MergeException, IOException {
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, 400000);
     List[] result = mergeFileSelector.select();
@@ -143,7 +148,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
     List<TsFileResource> newUnseqResources = new ArrayList<>();
     newUnseqResources.add(largeUnseqTsFileResource);
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqResources, newUnseqResources);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, newUnseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
@@ -197,8 +202,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     newUnseqResources.add(largeUnseqTsFileResource);
 
     long ttlLowerBound = System.currentTimeMillis() - Long.MAX_VALUE;
-    CrossSpaceMergeResource mergeResource =
-        new CrossSpaceMergeResource(seqResources, newUnseqResources, ttlLowerBound);
+    CrossSpaceCompactionResource mergeResource =
+        new CrossSpaceCompactionResource(seqResources, newUnseqResources, ttlLowerBound);
     assertEquals(5, mergeResource.getSeqFiles().size());
     assertEquals(1, mergeResource.getUnseqFiles().size());
     mergeResource.clear();
@@ -234,7 +239,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     unseqResources.clear();
     unseqResources.add(largeUnseqTsFileResource);
 
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqResources, unseqResources);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
     ICrossSpaceMergeFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
@@ -291,7 +296,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
       prepareFile(unseqList.get(1), 0, 100, 20);
       prepareFile(unseqList.get(2), 99, 1, 30);
 
-      CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqList, unseqList);
+      CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
       // the budget is enough to select unseq0 and unseq2, but not unseq1
       // the first selection should only contain seq0 and unseq0
       ICrossSpaceMergeFileSelector mergeFileSelector =
@@ -304,7 +309,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
       resource.clear();
 
       resource =
-          new CrossSpaceMergeResource(
+          new CrossSpaceCompactionResource(
               seqList.subList(1, seqList.size()), unseqList.subList(1, unseqList.size()));
       // the second selection should be empty
       mergeFileSelector = new RewriteCompactionFileSelector(resource, 29000);
@@ -368,7 +373,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
       unseqList.add(fileResource);
     }
 
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqList, unseqList);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(10, resource.getUnseqFiles().size());
     ICrossSpaceMergeFileSelector mergeFileSelector =
@@ -431,7 +436,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
       unseqList.add(fileResource);
     }
 
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqList, unseqList);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(1, resource.getUnseqFiles().size());
     ICrossSpaceMergeFileSelector mergeFileSelector =
@@ -494,7 +499,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     prepareFile(unseqList.get(0), 7, 3, 7);
     prepareFile(unseqList.get(1), 10, 4, 10);
 
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqList, unseqList);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(2, resource.getUnseqFiles().size());
     ICrossSpaceMergeFileSelector mergeFileSelector =
@@ -560,7 +565,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     prepareFile(unseqList.get(2), 14, 3, 14);
     prepareFile(unseqList.get(3), 17, 2, 17);
 
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqList, unseqList);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(4, resource.getUnseqFiles().size());
     ICrossSpaceMergeFileSelector mergeFileSelector =
@@ -628,7 +633,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     prepareFile(unseqList.get(2), 14, 3, 14);
     prepareFile(unseqList.get(3), 17, 2, 17);
 
-    CrossSpaceMergeResource resource = new CrossSpaceMergeResource(seqList, unseqList);
+    CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(4, resource.getUnseqFiles().size());
     ICrossSpaceMergeFileSelector mergeFileSelector =
@@ -636,6 +641,229 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     List[] result = mergeFileSelector.select();
     Assert.assertEquals(2, result.length);
     Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+  }
+
+  @Test
+  public void testMultiFileOverlapWithOneFile()
+      throws IOException, WriteProcessException, MergeException {
+    List<TsFileResource> seqList = new ArrayList<>();
+    List<TsFileResource> unseqList = new ArrayList<>();
+    // first file [0, 10]
+    // first device [0, 5]
+    // second device [0, 10]
+    File firstFile =
+        new File(
+            TestConstant.OUTPUT_DATA_DIR.concat(
+                1
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 1
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource firstTsFileResource = new TsFileResource(firstFile);
+    firstTsFileResource.setClosed(true);
+    firstTsFileResource.setMinPlanIndex(1);
+    firstTsFileResource.setMaxPlanIndex(1);
+    firstTsFileResource.setVersion(1);
+    seqList.add(firstTsFileResource);
+    if (!firstFile.getParentFile().exists()) {
+      Assert.assertTrue(firstFile.getParentFile().mkdirs());
+    }
+
+    TsFileWriter fileWriter = new TsFileWriter(firstFile);
+    for (String deviceId : deviceIds) {
+      for (MeasurementSchema measurementSchema : measurementSchemas) {
+        fileWriter.registerTimeseries(
+            new Path(deviceId), measurementSchema);
+      }
+    }
+
+    for (long i = 0; i < 10; ++i) {
+      for (int j = 0; j < deviceNum; j++) {
+        if (j == 3 && i > 5) {
+          continue;
+        }
+        TSRecord record = new TSRecord(i, deviceIds[j]);
+        for (int k = 0; k < measurementNum; ++k) {
+          record.addTuple(
+              DataPoint.getDataPoint(
+                  measurementSchemas[k].getType(),
+                  measurementSchemas[k].getMeasurementId(),
+                  String.valueOf(i)));
+        }
+        fileWriter.write(record);
+        firstTsFileResource.updateStartTime(deviceIds[j], i);
+        firstTsFileResource.updateEndTime(deviceIds[j], i);
+      }
+    }
+
+    fileWriter.flushAllChunkGroups();
+    fileWriter.close();
+
+    // second file time range: [11, 20]
+    // first measurement: [11, 20]
+    // second measurement: [11, 20]
+    File secondFile =
+        new File(
+            TestConstant.OUTPUT_DATA_DIR.concat(
+                2
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 2
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource secondTsFileResource = new TsFileResource(secondFile);
+    secondTsFileResource.setClosed(true);
+    secondTsFileResource.setMinPlanIndex(2);
+    secondTsFileResource.setMaxPlanIndex(2);
+    secondTsFileResource.setVersion(2);
+    seqList.add(secondTsFileResource);
+
+    if (!secondFile.getParentFile().exists()) {
+      Assert.assertTrue(secondFile.getParentFile().mkdirs());
+    }
+    fileWriter = new TsFileWriter(secondFile);
+    for (String deviceId : deviceIds) {
+      for (MeasurementSchema measurementSchema : measurementSchemas) {
+        fileWriter.registerTimeseries(
+            new Path(deviceId), measurementSchema);
+      }
+    }
+    for (long i = 11; i < 21; ++i) {
+      for (int j = 0; j < deviceNum; j++) {
+        TSRecord record = new TSRecord(i, deviceIds[j]);
+        for (int k = 0; k < measurementNum; k++) {
+          record.addTuple(
+              DataPoint.getDataPoint(
+                  measurementSchemas[k].getType(),
+                  measurementSchemas[k].getMeasurementId(),
+                  String.valueOf(i)));
+        }
+        fileWriter.write(record);
+        secondTsFileResource.updateStartTime(deviceIds[j], i);
+        secondTsFileResource.updateEndTime(deviceIds[j], i);
+      }
+    }
+    fileWriter.flushAllChunkGroups();
+    fileWriter.close();
+
+    // unseq file: [0, 1]
+    File thirdFile =
+        new File(
+            TestConstant.OUTPUT_DATA_DIR.concat(
+                3
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 3
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource thirdTsFileResource = new TsFileResource(thirdFile);
+    thirdTsFileResource.setClosed(true);
+    thirdTsFileResource.setMinPlanIndex(3);
+    thirdTsFileResource.setMaxPlanIndex(3);
+    thirdTsFileResource.setVersion(3);
+    unseqList.add(thirdTsFileResource);
+
+    if (!secondFile.getParentFile().exists()) {
+      Assert.assertTrue(thirdFile.getParentFile().mkdirs());
+    }
+    fileWriter = new TsFileWriter(thirdFile);
+    for (String deviceId : deviceIds) {
+      for (MeasurementSchema measurementSchema : measurementSchemas) {
+        fileWriter.registerTimeseries(
+            new Path(deviceId), measurementSchema);
+      }
+    }
+    for (long i = 0; i < 2; ++i) {
+      for (int j = 0; j < deviceNum; j++) {
+        TSRecord record = new TSRecord(i, deviceIds[j]);
+        for (int k = 0; k < measurementNum; k++) {
+          record.addTuple(
+              DataPoint.getDataPoint(
+                  measurementSchemas[k].getType(),
+                  measurementSchemas[k].getMeasurementId(),
+                  String.valueOf(i)));
+        }
+        fileWriter.write(record);
+        thirdTsFileResource.updateStartTime(deviceIds[j], i);
+        thirdTsFileResource.updateEndTime(deviceIds[j], i);
+      }
+    }
+    fileWriter.flushAllChunkGroups();
+    fileWriter.close();
+
+    // unseq file: [6, 8]
+    File fourthFile =
+        new File(
+            TestConstant.OUTPUT_DATA_DIR.concat(
+                4
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 4
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + IoTDBConstant.FILE_NAME_SEPARATOR
+                    + 0
+                    + ".tsfile"));
+    TsFileResource fourthTsFileResource = new TsFileResource(fourthFile);
+    fourthTsFileResource.setClosed(true);
+    fourthTsFileResource.setMinPlanIndex(4);
+    fourthTsFileResource.setMaxPlanIndex(4);
+    fourthTsFileResource.setVersion(4);
+    unseqList.add(fourthTsFileResource);
+
+    if (!fourthFile.getParentFile().exists()) {
+      Assert.assertTrue(fourthFile.getParentFile().mkdirs());
+    }
+    fileWriter = new TsFileWriter(fourthFile);
+    for (String deviceId : deviceIds) {
+      for (MeasurementSchema measurementSchema : measurementSchemas) {
+        fileWriter.registerTimeseries(
+            new Path(deviceId), measurementSchema);
+      }
+    }
+    for (long i = 6; i < 15; ++i) {
+      for (int j = 0; j < deviceNum; j++) {
+        if (j == 3) {
+          continue;
+        }
+        TSRecord record = new TSRecord(i, deviceIds[j]);
+        for (int k = 0; k < measurementNum; k++) {
+          record.addTuple(
+              DataPoint.getDataPoint(
+                  measurementSchemas[k].getType(),
+                  measurementSchemas[k].getMeasurementId(),
+                  String.valueOf(i)));
+        }
+        fileWriter.write(record);
+        fourthTsFileResource.updateStartTime(deviceIds[j], i);
+        fourthTsFileResource.updateEndTime(deviceIds[j], i);
+      }
+    }
+    TSRecord record = new TSRecord(1, deviceIds[3]);
+    for (int k = 0; k < measurementNum; k++) {
+      record.addTuple(
+          DataPoint.getDataPoint(
+              measurementSchemas[k].getType(),
+              measurementSchemas[k].getMeasurementId(),
+              String.valueOf(1)));
+    }
+    fileWriter.write(record);
+    fourthTsFileResource.updateStartTime(deviceIds[3], 1);
+    fourthTsFileResource.updateEndTime(deviceIds[3], 1);
+    fileWriter.flushAllChunkGroups();
+    fileWriter.close();
+
+    CrossSpaceCompactionResource compactionResource = new CrossSpaceCompactionResource(seqList, unseqList);
+    RewriteCompactionFileSelector selector = new RewriteCompactionFileSelector(compactionResource, 500 * 1024 * 1024);
+    List[] result = selector.select();
+    Assert.assertEquals(2, result[0].size());
     Assert.assertEquals(2, result[1].size());
   }
 }


### PR DESCRIPTION
see [IOTDB-2653](https://issues.apache.org/jira/browse/IOTDB-2653)