### PR TITLE
[To rel/0.12][ISSUE-4399] When non-root user returns a null value, return no permission error message

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/SFWOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/SFWOperator.java
@@ -84,6 +84,16 @@ public abstract class SFWOperator extends RootOperator {
     return selectOperator != null ? selectOperator.getSuffixPaths() : null;
   }
 
+  /**
+   * get information from FromOperator in case if getSelectedPaths are null and need to do path
+   * verification.
+   *
+   * @return - a list of seriesPath
+   */
+  public List<PartialPath> getFromPaths() {
+    return fromOperator != null ? fromOperator.getPrefixPaths() : null;
+  }
+
   public boolean hasAggregation() {
     return hasAggregation;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -110,6 +110,10 @@ public abstract class PhysicalPlan {
 
   public abstract List<PartialPath> getPaths();
 
+  public List<PartialPath> getFromPaths() {
+    return Collections.emptyList();
+  }
+
   public void setPaths(List<PartialPath> paths) {}
 
   public boolean isQuery() {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
@@ -32,6 +32,7 @@ import java.util.Map;
 public abstract class QueryPlan extends PhysicalPlan {
 
   protected List<PartialPath> paths = null;
+  protected List<PartialPath> fromPaths = null;
   protected List<TSDataType> dataTypes = null;
   private boolean alignByTime = true; // for disable align sql
 
@@ -67,6 +68,15 @@ public abstract class QueryPlan extends PhysicalPlan {
   @Override
   public void setPaths(List<PartialPath> paths) {
     this.paths = paths;
+  }
+
+  @Override
+  public List<PartialPath> getFromPaths() {
+    return fromPaths;
+  }
+
+  public void setFromPaths(List<PartialPath> fromPaths) {
+    this.fromPaths = fromPaths;
   }
 
   public List<TSDataType> getDataTypes() {

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -562,6 +562,7 @@ public class PhysicalGenerator {
       queryPlan = getAlignQueryPlan(queryOperator, fetchSize, queryPlan);
     } else {
       queryPlan.setPaths(queryOperator.getSelectedPaths());
+      queryPlan.setFromPaths(queryOperator.getFromPaths());
       // Last query result set will not be affected by alignment
       if (queryPlan instanceof LastQueryPlan && !queryOperator.isAlignByTime()) {
         throw new QueryProcessException("Disable align cannot be applied to LAST query.");

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -130,8 +130,8 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 
-import com.nimbusds.oauth2.sdk.util.CollectionUtils;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -130,6 +130,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 
+import com.nimbusds.oauth2.sdk.util.CollectionUtils;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -875,7 +876,8 @@ public class TSServiceImpl implements TSIService.Iface {
     List<String> columnsTypes = new ArrayList<>();
 
     // check permissions
-    if ((physicalPlan.getAuthPaths().isEmpty() && !physicalPlan.getFromPaths().isEmpty())
+    if ((physicalPlan.getAuthPaths().isEmpty()
+            && !CollectionUtils.isEmpty(physicalPlan.getFromPaths()))
         || !physicalPlan.getAuthPaths().isEmpty()) {
       List<PartialPath> checkPaths =
           physicalPlan.getAuthPaths().isEmpty()

--- a/server/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
@@ -1171,4 +1171,5 @@ public class IoTDBAuthorizationIT {
       }
     }
   }
+
 }

--- a/server/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
@@ -1171,5 +1171,4 @@ public class IoTDBAuthorizationIT {
       }
     }
   }
-
 }

--- a/server/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/auth/IoTDBAuthorizationIT.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the
@@ -1150,11 +1151,17 @@ public class IoTDBAuthorizationIT {
       resultSet = userStatement.executeQuery("select sin(s8) from root.sg1.d1;");
       resultSetMetaData = resultSet.getMetaData();
       assertEquals(1, resultSetMetaData.getColumnCount());
+      while (resultSet.next()) {
+        fail();
+      }
 
       // Case 3:
       resultSet = userStatement.executeQuery("select s8 from root.sg1.d1;");
       resultSetMetaData = resultSet.getMetaData();
       assertEquals(1, resultSetMetaData.getColumnCount());
+      while (resultSet.next()) {
+        fail();
+      }
 
       // Case 4:
       try {


### PR DESCRIPTION
## Description
[ISSUE-4399](https://github.com/apache/iotdb/issues/4399)
TO reproduce:
user admin user:
SET STORAGE GROUP TO root.sg1;
CREATE TIMESERIES root.sg1.d1.s1 WITH DATATYPE=INT32, ENCODING=PLAIN;
CREATE TIMESERIES root.sg1.d1.s2 WITH DATATYPE=INT32, ENCODING=PLAIN;
INSERT INTO root.sg1.d1(timestamp, s1, s2) VALUES (0, -1, 1);
INSERT INTO root.sg1.d1(timestamp, s1, s2) VALUES (1, -2, 2);
INSERT INTO root.sg1.d1(timestamp, s1, s2) VALUES (2, -3, 3);

CREATE FUNCTION example AS "org.apache.iotdb.udf.UDTFExample";

SET STORAGE GROUP TO root.sg2;
CREATE TIMESERIES root.sg2.d1.s1 WITH DATATYPE=INT32, ENCODING=PLAIN;
CREATE TIMESERIES root.sg2.d1.s2 WITH DATATYPE=INT32, ENCODING=PLAIN;
INSERT INTO root.sg2.d1(timestamp, s1, s2) VALUES (0, -1, 1);
INSERT INTO root.sg2.d1(timestamp, s1, s2) VALUES (1, -2, 2);
INSERT INTO root.sg2.d1(timestamp, s1, s2) VALUES (2, -3, 3);

user a user A with only root.sg1 read permission:
pervious version:
![image](https://user-images.githubusercontent.com/17932988/156698450-39216f1a-a856-4155-802b-aad863e31ae0.png)

after fixed it:
![image](https://user-images.githubusercontent.com/17932988/156698609-70ce0169-51f0-45e3-93f5-0df937046e44.png)


### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
