### PR TITLE
[IOTDB-2357] Support create timeseries interface with tags in python client

### DIFF
--- a/client-py/SessionExample.py
+++ b/client-py/SessionExample.py
@@ -48,6 +48,16 @@ session.create_time_series(
 session.create_time_series(
     "root.sg_test_01.d_01.s_03", TSDataType.INT64, TSEncoding.PLAIN, Compressor.SNAPPY
 )
+session.create_time_series(
+    "root.sg_test_01.d_02.s_01",
+    TSDataType.INT64,
+    TSEncoding.PLAIN,
+    Compressor.SNAPPY,
+    None,
+    {"tag1": "v1"},
+    {"description": "v1"},
+    "temperature"
+)
 
 # setting multiple time series once.
 ts_path_lst_ = [
@@ -72,6 +82,30 @@ session.create_multi_time_series(
     ts_path_lst_, data_type_lst_, encoding_lst_, compressor_lst_
 )
 
+ts_path_lst_ = [
+    "root.sg_test_01.d_02.s_04",
+    "root.sg_test_01.d_02.s_05",
+    "root.sg_test_01.d_02.s_06",
+    "root.sg_test_01.d_02.s_07",
+    "root.sg_test_01.d_02.s_08",
+    "root.sg_test_01.d_02.s_09",
+]
+data_type_lst_ = [
+    TSDataType.FLOAT,
+    TSDataType.DOUBLE,
+    TSDataType.TEXT,
+    TSDataType.FLOAT,
+    TSDataType.DOUBLE,
+    TSDataType.TEXT,
+]
+encoding_lst_ = [TSEncoding.PLAIN for _ in range(len(data_type_lst_))]
+compressor_lst_ = [Compressor.SNAPPY for _ in range(len(data_type_lst_))]
+tags_lst_ = [{"tag2": "v2"} for _ in range(len(data_type_lst_))]
+attributes_lst_ = [{"description": "v2"} for _ in range(len(data_type_lst_))]
+session.create_multi_time_series(
+    ts_path_lst_, data_type_lst_, encoding_lst_, compressor_lst_, None, tags_lst_, attributes_lst_, None
+)
+
 # delete time series
 session.delete_time_series(
     [
@@ -89,6 +123,14 @@ print(
 print(
     "s_03 expecting True, checking result: ",
     session.check_time_series_exists("root.sg_test_01.d_01.s_03"),
+)
+print(
+    "d_02.s_01 expecting True, checking result: ",
+    session.check_time_series_exists("root.sg_test_01.d_02.s_01"),
+)
+print(
+    "d_02.s_06 expecting True, checking result: ",
+    session.check_time_series_exists("root.sg_test_01.d_02.s_06"),
 )
 
 # insert one record into the database.

--- a/client-py/SessionTest.py
+++ b/client-py/SessionTest.py
@@ -75,6 +75,16 @@ session.create_time_series(
 session.create_time_series(
     "root.sg_test_01.d_01.s_03", TSDataType.INT64, TSEncoding.PLAIN, Compressor.SNAPPY
 )
+session.create_time_series(
+    "root.sg_test_01.d_02.s_01",
+    TSDataType.INT64,
+    TSEncoding.PLAIN,
+    Compressor.SNAPPY,
+    None,
+    {"tag1": "v1"},
+    {"description": "v1"},
+    "temperature"
+)
 
 # setting multiple time series once.
 ts_path_lst_ = [
@@ -97,6 +107,29 @@ encoding_lst_ = [TSEncoding.PLAIN for _ in range(len(data_type_lst_))]
 compressor_lst_ = [Compressor.SNAPPY for _ in range(len(data_type_lst_))]
 session.create_multi_time_series(
     ts_path_lst_, data_type_lst_, encoding_lst_, compressor_lst_
+)
+ts_path_lst_ = [
+    "root.sg_test_01.d_02.s_04",
+    "root.sg_test_01.d_02.s_05",
+    "root.sg_test_01.d_02.s_06",
+    "root.sg_test_01.d_02.s_07",
+    "root.sg_test_01.d_02.s_08",
+    "root.sg_test_01.d_02.s_09",
+]
+data_type_lst_ = [
+    TSDataType.FLOAT,
+    TSDataType.DOUBLE,
+    TSDataType.TEXT,
+    TSDataType.FLOAT,
+    TSDataType.DOUBLE,
+    TSDataType.TEXT,
+]
+encoding_lst_ = [TSEncoding.PLAIN for _ in range(len(data_type_lst_))]
+compressor_lst_ = [Compressor.SNAPPY for _ in range(len(data_type_lst_))]
+tags_lst_ = [{"tag2": "v2"} for _ in range(len(data_type_lst_))]
+attributes_lst_ = [{"description": "v2"} for _ in range(len(data_type_lst_))]
+session.create_multi_time_series(
+    ts_path_lst_, data_type_lst_, encoding_lst_, compressor_lst_, None, tags_lst_, attributes_lst_, None
 )
 
 # delete time series
@@ -123,6 +156,14 @@ if session.check_time_series_exists("root.sg_test_01.d_01.s_07"):
 if not session.check_time_series_exists("root.sg_test_01.d_01.s_03"):
     test_fail()
     print_message("root.sg_test_01.d_01.s_03 should exist")
+# d_02.s_01 expecting True
+if not session.check_time_series_exists("root.sg_test_01.d_02.s_01"):
+    test_fail()
+    print_message("root.sg_test_01.d_02.s_01 should exist")
+# d_02.s_06 expecting True
+if not session.check_time_series_exists("root.sg_test_01.d_02.s_06"):
+    test_fail()
+    print_message("root.sg_test_01.d_02.s_06 should exist")
 
 # insert one record into the database.
 measurements_ = ["s_01", "s_02", "s_03", "s_04", "s_05", "s_06"]

--- a/client-py/iotdb/Session.py
+++ b/client-py/iotdb/Session.py
@@ -34,6 +34,7 @@ from .thrift.rpc.TSIService import (
     TSExecuteStatementReq,
     TSOpenSessionReq,
     TSCreateMultiTimeseriesReq,
+    TSCreateSchemaTemplateReq,
     TSCloseSessionReq,
     TSInsertTabletsReq,
     TSInsertRecordsReq,
@@ -192,19 +193,24 @@ class Session(object):
 
         return Session.verify_success(status)
 
-    def create_time_series(self, ts_path, data_type, encoding, compressor):
+    def create_time_series(self, ts_path, data_type, encoding, compressor,
+                           props=None, tags=None, attributes=None, alias=None):
         """
         create single time series
         :param ts_path: String, complete time series path (starts from root)
         :param data_type: TSDataType, data type for this time series
         :param encoding: TSEncoding, encoding for this time series
         :param compressor: Compressor, compressing type for this time series
+        :param props: Dictionary, properties for time series
+        :param tags: Dictionary, tag map for time series
+        :param attributes: Dictionary, attribute map for time series
+        :param alias: String, measurement alias for time series
         """
         data_type = data_type.value
         encoding = encoding.value
         compressor = compressor.value
         request = TSCreateTimeseriesReq(
-            self.__session_id, ts_path, data_type, encoding, compressor
+            self.__session_id, ts_path, data_type, encoding, compressor, props, tags, attributes, alias
         )
         status = self.__client.createTimeseries(request)
         logger.debug(
@@ -241,7 +247,8 @@ class Session(object):
         return Session.verify_success(status)
 
     def create_multi_time_series(
-        self, ts_path_lst, data_type_lst, encoding_lst, compressor_lst
+            self, ts_path_lst, data_type_lst, encoding_lst, compressor_lst,
+            props_lst=None, tags_lst=None, attributes_lst=None, alias_lst=None
     ):
         """
         create multiple time series
@@ -249,13 +256,18 @@ class Session(object):
         :param data_type_lst: List of TSDataType, data types for time series
         :param encoding_lst: List of TSEncoding, encodings for time series
         :param compressor_lst: List of Compressor, compressing types for time series
+        :param props_lst: List of Props Dictionary, properties for time series
+        :param tags_lst: List of tag Dictionary, tag maps for time series
+        :param attributes_lst: List of attribute Dictionary, attribute maps for time series
+        :param alias_lst: List of alias, measurement alias for time series
         """
         data_type_lst = [data_type.value for data_type in data_type_lst]
         encoding_lst = [encoding.value for encoding in encoding_lst]
         compressor_lst = [compressor.value for compressor in compressor_lst]
 
         request = TSCreateMultiTimeseriesReq(
-            self.__session_id, ts_path_lst, data_type_lst, encoding_lst, compressor_lst
+            self.__session_id, ts_path_lst, data_type_lst, encoding_lst, compressor_lst, props_lst, tags_lst,
+            attributes_lst, alias_lst
         )
         status = self.__client.createMultiTimeseries(request)
         logger.debug(


### PR DESCRIPTION
## Description

Support the following usage:
```python
session.create_time_series(
    "root.sg_test_01.d_02.s_01",
    TSDataType.INT64,
    TSEncoding.PLAIN,
    Compressor.SNAPPY,
    None,
    {"tag1": "v1"},
    {"description": "v1"},
    "temperature"
)
```
The result after execute the tests:
```
IoTDB> show timeseries
+-------------------------+-----------+---------------+--------+--------+-----------+-------------+--------------------+
|               timeseries|      alias|  storage group|dataType|encoding|compression|         tags|          attributes|
+-------------------------+-----------+---------------+--------+--------+-----------+-------------+--------------------+
|root.sg_test_01.d_01.s_05|       null|root.sg_test_01|  DOUBLE|   PLAIN|     SNAPPY|         null|                null|
|root.sg_test_01.d_01.s_04|       null|root.sg_test_01|   FLOAT|   PLAIN|     SNAPPY|         null|                null|
|root.sg_test_01.d_01.s_06|       null|root.sg_test_01|    TEXT|   PLAIN|     SNAPPY|         null|                null|
|root.sg_test_01.d_01.s_01|       null|root.sg_test_01| BOOLEAN|   PLAIN|     SNAPPY|         null|                null|
|root.sg_test_01.d_01.s_03|       null|root.sg_test_01|   INT64|   PLAIN|     SNAPPY|         null|                null|
|root.sg_test_01.d_01.s_02|       null|root.sg_test_01|   INT32|   PLAIN|     SNAPPY|         null|                null|
|root.sg_test_01.d_02.s_09|       null|root.sg_test_01|    TEXT|   PLAIN|     SNAPPY|{"tag2":"v2"}|{"description":"v2"}|
|root.sg_test_01.d_02.s_08|       null|root.sg_test_01|  DOUBLE|   PLAIN|     SNAPPY|{"tag2":"v2"}|{"description":"v2"}|
|root.sg_test_01.d_02.s_05|       null|root.sg_test_01|  DOUBLE|   PLAIN|     SNAPPY|{"tag2":"v2"}|{"description":"v2"}|
|root.sg_test_01.d_02.s_04|       null|root.sg_test_01|   FLOAT|   PLAIN|     SNAPPY|{"tag2":"v2"}|{"description":"v2"}|
|root.sg_test_01.d_02.s_07|       null|root.sg_test_01|   FLOAT|   PLAIN|     SNAPPY|{"tag2":"v2"}|{"description":"v2"}|
|root.sg_test_01.d_02.s_06|       null|root.sg_test_01|    TEXT|   PLAIN|     SNAPPY|{"tag2":"v2"}|{"description":"v2"}|
|root.sg_test_01.d_02.s_01|temperature|root.sg_test_01|   INT64|   PLAIN|     SNAPPY|{"tag1":"v1"}|{"description":"v1"}|
+-------------------------+-----------+---------------+--------+--------+-----------+-------------+--------------------+
Total line number = 13
It costs 0.130s
```