### PR TITLE
[IOTDB-2712]Remove reading merge.mods in inner compaction recover

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTask.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.engine.compaction.inner.sizetiered;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.CompactionUtils;
@@ -31,6 +30,8 @@ import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
+
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/TsFileIdentifierUT.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/TsFileIdentifierUT.java
@@ -90,7 +90,7 @@ public class TsFileIdentifierUT {
 
   @Test
   public void testGetInfoFromInfoString() {
-    String[] firstInfoArray = new String[] {"root.test.sg", "0", "0", "true", "1-1-0-0.tsfile"};
+    String[] firstInfoArray = new String[] {"sequence", "root.test.sg", "0", "0", "1-1-0-0.tsfile"};
     String firstInfoString = String.join(INFO_SEPARATOR, firstInfoArray);
     TsFileIdentifier firstInfo = TsFileIdentifier.getFileIdentifierFromInfoString(firstInfoString);
     Assert.assertEquals(firstInfo.getFilename(), "1-1-0-0.tsfile");
@@ -100,7 +100,7 @@ public class TsFileIdentifierUT {
     Assert.assertTrue(firstInfo.isSequence());
 
     String[] secondInfoArray =
-        new String[] {"root.test.sg", "0", "425", "false", "666-888-222-131.tsfile"};
+        new String[] {"unsequence", "root.test.sg", "0", "425", "666-888-222-131.tsfile"};
     String secondInfoString = String.join(INFO_SEPARATOR, secondInfoArray);
     TsFileIdentifier secondInfo =
         TsFileIdentifier.getFileIdentifierFromInfoString(secondInfoString);
@@ -110,7 +110,7 @@ public class TsFileIdentifierUT {
     Assert.assertEquals(secondInfo.getLogicalStorageGroupName(), "root.test.sg");
     Assert.assertFalse(secondInfo.isSequence());
 
-    String[] illegalInfoArray = new String[] {"0", "425", "false", "666-888-222-131.tsfile"};
+    String[] illegalInfoArray = new String[] {"unsequence", "0", "425", "666-888-222-131.tsfile"};
     String illegalInfoString = String.join(INFO_SEPARATOR, illegalInfoArray);
 
     try {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverCompatibleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverCompatibleTest.java
@@ -31,7 +31,6 @@ import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
 import org.apache.iotdb.tsfile.utils.Pair;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -188,8 +187,6 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
 
     Assert.assertTrue(targetResource.getTsFile().exists());
     Assert.assertTrue(targetResource.resourceFileExists());
-    Assert.assertTrue(targetResource.getModFile().exists());
-    Assert.assertEquals(6, targetResource.getModFile().getModifications().size());
     Assert.assertFalse(logFile.exists());
   }
 
@@ -291,8 +288,6 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
 
     Assert.assertTrue(targetResource.getTsFile().exists());
     Assert.assertTrue(targetResource.resourceFileExists());
-    Assert.assertTrue(targetResource.getModFile().exists());
-    Assert.assertEquals(6, targetResource.getModFile().getModifications().size());
     Assert.assertFalse(logFile.exists());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverCompatibleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverCompatibleTest.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
 import org.apache.iotdb.tsfile.utils.Pair;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverCompatibleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverCompatibleTest.java
@@ -22,12 +22,15 @@ package org.apache.iotdb.db.engine.compaction.recover;
 import org.apache.iotdb.db.engine.compaction.AbstractCompactionTest;
 import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUtils;
+import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
+import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -39,7 +42,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
 
 /** This test is used to test the compatibility of compaction recovery with 0.12. */
 public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactionTest {
@@ -56,7 +63,7 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
   }
 
   @Test
-  public void testCompatibleWithFilePath() throws Exception {
+  public void testCompatibleWithAllSourceFilesExistWithFilePath() throws Exception {
     createFiles(6, 2, 3, 100, 0, 0, 50, 50, false, true);
     registerTimeseriesInMManger(2, 3, false);
     TsFileResource targetResource =
@@ -67,8 +74,18 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
     targetFile.getChannel().truncate(fileLength - 20);
     targetFile.close();
 
+    for (int i = 0; i < seqResources.size(); i++) {
+      Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+      deleteMap.put(
+          COMPACTION_TEST_SG + PATH_SEPARATOR + "d0" + PATH_SEPARATOR + "s0",
+          new Pair(i * 10L, i * 10L + 10));
+      CompactionFileGeneratorUtils.generateMods(deleteMap, seqResources.get(i), false);
+    }
+
     File logFile =
-        new File(targetResource.getTsFile().getParent(), "root.compactionTest" + ".compaction.log");
+        new File(
+            targetResource.getTsFile().getParent(),
+            "root.compactionTest" + CompactionLogger.INNER_COMPACTION_LOG_NAME_SUFFIX_FROM_OLD);
     BufferedWriter logWriter = new BufferedWriter(new FileWriter(logFile));
     for (TsFileResource tsFileResource : seqResources) {
       logWriter.write(
@@ -100,14 +117,84 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
 
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
+      Assert.assertTrue(resource.resourceFileExists());
+      Assert.assertTrue(resource.getModFile().exists());
     }
 
     Assert.assertFalse(targetResource.getTsFile().exists());
+    Assert.assertFalse(targetResource.resourceFileExists());
+    Assert.assertFalse(targetResource.getModFile().exists());
     Assert.assertFalse(logFile.exists());
   }
 
   @Test
-  public void testCompatibleWithFileInfo() throws Exception {
+  public void testCompatibleWithSomeSourceFilesLostWithFilePath() throws Exception {
+    createFiles(6, 2, 3, 100, 0, 0, 50, 50, false, true);
+    registerTimeseriesInMManger(2, 3, false);
+    TsFileResource targetResource =
+        TsFileNameGenerator.getInnerCompactionTargetFileResource(seqResources, true);
+    InnerSpaceCompactionUtils.compact(targetResource, seqResources);
+    InnerSpaceCompactionUtils.moveTargetFile(targetResource, "root.compactionTest");
+
+    // first source file does not exist
+    seqResources.get(0).delete();
+
+    for (int i = 0; i < seqResources.size(); i++) {
+      Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+      deleteMap.put(
+          COMPACTION_TEST_SG + PATH_SEPARATOR + "d0" + PATH_SEPARATOR + "s0",
+          new Pair(i * 10L, i * 10L + 10));
+      CompactionFileGeneratorUtils.generateMods(deleteMap, seqResources.get(i), false);
+    }
+
+    File logFile =
+        new File(
+            targetResource.getTsFile().getParent(),
+            "root.compactionTest" + CompactionLogger.INNER_COMPACTION_LOG_NAME_SUFFIX_FROM_OLD);
+    BufferedWriter logWriter = new BufferedWriter(new FileWriter(logFile));
+    for (TsFileResource tsFileResource : seqResources) {
+      logWriter.write(
+          String.format(
+              "info-source\nroot.compactionTest 0 0 %s sequence\n",
+              tsFileResource.getTsFile().getName()));
+    }
+    logWriter.write("sequence\n");
+    logWriter.write(
+        String.format(
+            "info-target\nroot.compactionTest 0 0 %s sequence\n",
+            targetResource.getTsFile().getName()));
+    logWriter.close();
+
+    TsFileManager tsFileManager =
+        new TsFileManager("root.compactionTest", "0", targetResource.getTsFile().getParent());
+    tsFileManager.addAll(seqResources, true);
+    SizeTieredCompactionRecoverTask recoverTask =
+        new SizeTieredCompactionRecoverTask(
+            "root.compactionTest",
+            "0",
+            0,
+            logFile,
+            targetResource.getTsFile().getParent(),
+            true,
+            new AtomicInteger(0),
+            tsFileManager);
+    recoverTask.call();
+
+    for (TsFileResource resource : seqResources) {
+      Assert.assertFalse(resource.getTsFile().exists());
+      Assert.assertFalse(resource.resourceFileExists());
+      Assert.assertFalse(resource.getModFile().exists());
+    }
+
+    Assert.assertTrue(targetResource.getTsFile().exists());
+    Assert.assertTrue(targetResource.resourceFileExists());
+    Assert.assertTrue(targetResource.getModFile().exists());
+    Assert.assertEquals(6, targetResource.getModFile().getModifications().size());
+    Assert.assertFalse(logFile.exists());
+  }
+
+  @Test
+  public void testCompatibleWithAllSourceFilesExistWithFileInfo() throws Exception {
     createFiles(6, 2, 3, 100, 0, 0, 50, 50, false, true);
     registerTimeseriesInMManger(2, 3, false);
     TsFileResource targetResource =
@@ -148,6 +235,64 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
     }
 
     Assert.assertFalse(targetResource.getTsFile().exists());
+    Assert.assertFalse(logFile.exists());
+  }
+
+  @Test
+  public void testCompatibleWithSomeSourceFilesLostWithFileInfo() throws Exception {
+    createFiles(6, 2, 3, 100, 0, 0, 50, 50, false, false);
+    registerTimeseriesInMManger(2, 3, false);
+    TsFileResource targetResource =
+        TsFileNameGenerator.getInnerCompactionTargetFileResource(unseqResources, true);
+    InnerSpaceCompactionUtils.compact(targetResource, unseqResources);
+    InnerSpaceCompactionUtils.moveTargetFile(targetResource, "root.compactionTest");
+
+    // first source file does not exist
+    unseqResources.get(0).delete();
+
+    for (int i = 0; i < unseqResources.size(); i++) {
+      Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+      deleteMap.put(
+          COMPACTION_TEST_SG + PATH_SEPARATOR + "d0" + PATH_SEPARATOR + "s0",
+          new Pair(i * 10L, i * 10L + 10));
+      CompactionFileGeneratorUtils.generateMods(deleteMap, unseqResources.get(i), false);
+    }
+
+    File logFile =
+        new File(targetResource.getTsFile().getParent(), "root.compactionTest" + ".compaction.log");
+    BufferedWriter logWriter = new BufferedWriter(new FileWriter(logFile));
+    for (TsFileResource tsFileResource : unseqResources) {
+      logWriter.write(String.format("source\n%s\n", tsFileResource.getTsFile().getAbsolutePath()));
+    }
+    logWriter.write("sequence\n");
+    logWriter.write(String.format("target\n%s\n", targetResource.getTsFile().getAbsolutePath()));
+    logWriter.close();
+
+    TsFileManager tsFileManager =
+        new TsFileManager("root.compactionTest", "0", targetResource.getTsFile().getParent());
+    tsFileManager.addAll(unseqResources, false);
+    SizeTieredCompactionRecoverTask recoverTask =
+        new SizeTieredCompactionRecoverTask(
+            "root.compactionTest",
+            "0",
+            0,
+            logFile,
+            targetResource.getTsFile().getParent(),
+            true,
+            new AtomicInteger(0),
+            tsFileManager);
+    recoverTask.call();
+
+    for (TsFileResource resource : unseqResources) {
+      Assert.assertFalse(resource.getTsFile().exists());
+      Assert.assertFalse(resource.resourceFileExists());
+      Assert.assertFalse(resource.getModFile().exists());
+    }
+
+    Assert.assertTrue(targetResource.getTsFile().exists());
+    Assert.assertTrue(targetResource.resourceFileExists());
+    Assert.assertTrue(targetResource.getModFile().exists());
+    Assert.assertEquals(6, targetResource.getModFile().getModifications().size());
     Assert.assertFalse(logFile.exists());
   }
 }


### PR DESCRIPTION
Merge.mods file is produced by cross compaction in 0.12, and we do not need to read it in inner cocmpaction recovery at 0.13.