### PR TITLE
[IOTDB-2524] Aligned Timeseries support tags and attributes

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -683,11 +683,13 @@ public class MManager {
       List<String> measurements,
       List<TSDataType> dataTypes,
       List<TSEncoding> encodings,
-      List<CompressionType> compressors)
+      List<CompressionType> compressors,
+      List<Map<String, String>> tags,
+      List<Map<String, String>> attributes)
       throws MetadataException {
     createAlignedTimeSeries(
         new CreateAlignedTimeSeriesPlan(
-            prefixPath, measurements, dataTypes, encodings, compressors, null));
+            prefixPath, measurements, dataTypes, encodings, compressors, null, tags, attributes));
   }
 
   /**
@@ -706,6 +708,8 @@ public class MManager {
       List<String> measurements = plan.getMeasurements();
       List<TSDataType> dataTypes = plan.getDataTypes();
       List<TSEncoding> encodings = plan.getEncodings();
+      List<Map<String, String>> tagsList = plan.getTagsList();
+      List<Map<String, String>> attributesList = plan.getAttributesList();
 
       for (int i = 0; i < measurements.size(); i++) {
         SchemaUtils.checkDataTypeWithEncoding(dataTypes.get(i), encodings.get(i));
@@ -714,15 +718,25 @@ public class MManager {
       ensureStorageGroup(prefixPath);
 
       // create time series in MTree
-      mtree.createAlignedTimeseries(
-          prefixPath,
-          measurements,
-          plan.getDataTypes(),
-          plan.getEncodings(),
-          plan.getCompressors());
+      List<IMeasurementMNode> measurementMNodeList =
+          mtree.createAlignedTimeseries(
+              prefixPath,
+              measurements,
+              plan.getDataTypes(),
+              plan.getEncodings(),
+              plan.getCompressors());
 
       // the cached mNode may be replaced by new entityMNode in mtree
       mNodeCache.invalidate(prefixPath);
+
+      for (int i = 0; i < measurements.size(); i++) {
+        if (!plan.getTagOffsets().isEmpty() && isRecovering) {
+          tagManager.recoverIndex(plan.getTagOffsets().get(i), measurementMNodeList.get(i));
+        } else if (plan.getTagsList() != null && !plan.getTagsList().isEmpty()) {
+          // tag key, tag value
+          tagManager.addIndex(plan.getTagsList().get(i), measurementMNodeList.get(i));
+        }
+      }
 
       // update statistics and schemaDataTypeNumMap
       totalSeriesNumber.addAndGet(measurements.size());
@@ -730,9 +744,25 @@ public class MManager {
         logger.warn("Current series number {} is too large...", totalSeriesNumber);
         allowToCreateNewSeries = false;
       }
+
       // write log
+      List<Long> tagOffsets = new ArrayList<>();
       if (!isRecovering) {
+        if ((plan.getTagsList() != null && !plan.getTagsList().isEmpty())
+            || (plan.getAttributesList() != null && !plan.getAttributesList().isEmpty())) {
+          for (int i = 0; i < measurements.size(); i++) {
+            tagOffsets.add(tagManager.writeTagFile(tagsList.get(i), attributesList.get(i)));
+          }
+        } else {
+          for (int i = 0; i < measurements.size(); i++) {
+            tagOffsets.add(Long.parseLong("-1"));
+          }
+        }
+        plan.setTagOffsets(tagOffsets);
         logWriter.createAlignedTimeseries(plan);
+      }
+      for (int i = 0; i < measurements.size(); i++) {
+        measurementMNodeList.get(i).setOffset(tagOffsets.get(i));
       }
     } catch (IOException e) {
       throw new MetadataException(e);
@@ -2171,7 +2201,8 @@ public class MManager {
       encodings.add(getDefaultEncoding(dataType));
       compressors.add(TSFileDescriptor.getInstance().getConfig().getCompressor());
     }
-    createAlignedTimeSeries(prefixPath, measurements, dataTypes, encodings, compressors);
+    createAlignedTimeSeries(
+        prefixPath, measurements, dataTypes, encodings, compressors, null, null);
   }
 
   // endregion

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
@@ -434,13 +434,14 @@ public class MTree implements Serializable {
    * @param encodings encodings list
    * @param compressors compressor
    */
-  public void createAlignedTimeseries(
+  public List<IMeasurementMNode> createAlignedTimeseries(
       PartialPath devicePath,
       List<String> measurements,
       List<TSDataType> dataTypes,
       List<TSEncoding> encodings,
       List<CompressionType> compressors)
       throws MetadataException {
+    List<IMeasurementMNode> measurementMNodeList = new ArrayList<>();
     MetaFormatUtils.checkSchemaMeasurementNames(measurements);
     Pair<IMNode, Template> pair = checkAndAutoCreateInternalPath(devicePath);
     IMNode cur = pair.left;
@@ -482,8 +483,10 @@ public class MTree implements Serializable {
                     measurements.get(i), dataTypes.get(i), encodings.get(i), compressors.get(i)),
                 null);
         entityMNode.addChild(measurements.get(i), measurementMNode);
+        measurementMNodeList.add(measurementMNode);
       }
     }
+    return measurementMNodeList;
   }
 
   private Pair<IMNode, Template> checkAndAutoCreateInternalPath(PartialPath devicePath)

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.auth.AuthorityChecker;
 import org.apache.iotdb.db.auth.authorizer.BasicAuthorizer;
 import org.apache.iotdb.db.auth.authorizer.IAuthorizer;
 import org.apache.iotdb.db.auth.entity.PathPrivilege;
+import org.apache.iotdb.db.auth.entity.PrivilegeType;
 import org.apache.iotdb.db.auth.entity.Role;
 import org.apache.iotdb.db.auth.entity.User;
 import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
@@ -2182,34 +2183,30 @@ public class PlanExecutor implements IPlanExecutor {
     }
     List<PartialPath> headerList = new ArrayList<>();
     List<TSDataType> typeList = new ArrayList<>();
-    headerList.add(new PartialPath(COLUMN_ROLE, false));
-    headerList.add(new PartialPath(COLUMN_PRIVILEGE, false));
-    typeList.add(TSDataType.TEXT);
-    typeList.add(TSDataType.TEXT);
-    ListDataSet dataSet = new ListDataSet(headerList, typeList);
     int index = 0;
-    for (PathPrivilege pathPrivilege : user.getPrivilegeList()) {
-      if (path == null || AuthUtils.pathBelongsTo(path.getFullPath(), pathPrivilege.getPath())) {
+    if (IoTDBDescriptor.getInstance().getConfig().getAdminName().equals(userName)) {
+      headerList.add(new PartialPath(COLUMN_PRIVILEGE, false));
+      typeList.add(TSDataType.TEXT);
+      ListDataSet dataSet = new ListDataSet(headerList, typeList);
+      for (PrivilegeType privilegeType : PrivilegeType.values()) {
         RowRecord record = new RowRecord(index++);
-        Field roleF = new Field(TSDataType.TEXT);
-        roleF.setBinaryV(new Binary(""));
-        record.addField(roleF);
         Field privilegeF = new Field(TSDataType.TEXT);
-        privilegeF.setBinaryV(new Binary(pathPrivilege.toString()));
+        privilegeF.setBinaryV(new Binary(privilegeType.toString()));
         record.addField(privilegeF);
         dataSet.putRecord(record);
       }
-    }
-    for (String roleN : user.getRoleList()) {
-      Role role = authorizer.getRole(roleN);
-      if (role == null) {
-        continue;
-      }
-      for (PathPrivilege pathPrivilege : role.getPrivilegeList()) {
+      return dataSet;
+    } else {
+      headerList.add(new PartialPath(COLUMN_ROLE, false));
+      headerList.add(new PartialPath(COLUMN_PRIVILEGE, false));
+      typeList.add(TSDataType.TEXT);
+      typeList.add(TSDataType.TEXT);
+      ListDataSet dataSet = new ListDataSet(headerList, typeList);
+      for (PathPrivilege pathPrivilege : user.getPrivilegeList()) {
         if (path == null || AuthUtils.pathBelongsTo(path.getFullPath(), pathPrivilege.getPath())) {
           RowRecord record = new RowRecord(index++);
           Field roleF = new Field(TSDataType.TEXT);
-          roleF.setBinaryV(new Binary(roleN));
+          roleF.setBinaryV(new Binary(""));
           record.addField(roleF);
           Field privilegeF = new Field(TSDataType.TEXT);
           privilegeF.setBinaryV(new Binary(pathPrivilege.toString()));
@@ -2217,8 +2214,27 @@ public class PlanExecutor implements IPlanExecutor {
           dataSet.putRecord(record);
         }
       }
+      for (String roleN : user.getRoleList()) {
+        Role role = authorizer.getRole(roleN);
+        if (role == null) {
+          continue;
+        }
+        for (PathPrivilege pathPrivilege : role.getPrivilegeList()) {
+          if (path == null
+              || AuthUtils.pathBelongsTo(path.getFullPath(), pathPrivilege.getPath())) {
+            RowRecord record = new RowRecord(index++);
+            Field roleF = new Field(TSDataType.TEXT);
+            roleF.setBinaryV(new Binary(roleN));
+            record.addField(roleF);
+            Field privilegeF = new Field(TSDataType.TEXT);
+            privilegeF.setBinaryV(new Binary(pathPrivilege.toString()));
+            record.addField(privilegeF);
+            dataSet.putRecord(record);
+          }
+        }
+      }
+      return dataSet;
     }
-    return dataSet;
   }
 
   @SuppressWarnings("unused") // for the distributed version

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1449,7 +1449,7 @@ public class PlanExecutor implements IPlanExecutor {
         }
 
         IoTDB.metaManager.createAlignedTimeSeries(
-            devicePath, measurements, dataTypes, encodings, compressors);
+            devicePath, measurements, dataTypes, encodings, compressors, null, null);
       } else {
         for (int i = 0; i < size; i++) {
           IMeasurementSchema schema = needRegisterSchema.get(i);

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/CreateAlignedTimeSeriesOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/CreateAlignedTimeSeriesOperator.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class CreateAlignedTimeSeriesOperator extends Operator {
@@ -42,6 +43,9 @@ public class CreateAlignedTimeSeriesOperator extends Operator {
   private List<TSEncoding> encodings = new ArrayList<>();
   private List<CompressionType> compressors = new ArrayList<>();
   private List<String> aliasList = null;
+  private List<Map<String, String>> tagsList = new ArrayList<>();
+  private List<Map<String, String>> attributesList = new ArrayList<>();
+  private List<Long> tagOffsets = null;
 
   public CreateAlignedTimeSeriesOperator(int tokenIntType) {
     super(tokenIntType);
@@ -116,6 +120,48 @@ public class CreateAlignedTimeSeriesOperator extends Operator {
     this.aliasList.add(alias);
   }
 
+  public List<Map<String, String>> getTagsList() {
+    return tagsList;
+  }
+
+  public void setTagsList(List<Map<String, String>> tagsList) {
+    this.tagsList = tagsList;
+  }
+
+  public void addTagsList(Map<String, String> tags) {
+    this.tagsList.add(tags);
+  }
+
+  public List<Map<String, String>> getAttributesList() {
+    return attributesList;
+  }
+
+  public void setAttributesList(List<Map<String, String>> attributesList) {
+    this.attributesList = attributesList;
+  }
+
+  public void addAttributesList(Map<String, String> attributes) {
+    this.attributesList.add(attributes);
+  }
+
+  public List<Long> getTagOffsets() {
+    if (tagOffsets == null) {
+      tagOffsets = new ArrayList<>();
+      for (int i = 0; i < measurements.size(); i++) {
+        tagOffsets.add(Long.parseLong("-1"));
+      }
+    }
+    return tagOffsets;
+  }
+
+  public void setTagOffsets(List<Long> tagOffsets) {
+    this.tagOffsets = tagOffsets;
+  }
+
+  public void addTagOffsets(Long tagsOffset) {
+    this.tagOffsets.add(tagsOffset);
+  }
+
   @Override
   public PhysicalPlan generatePhysicalPlan(PhysicalGenerator generator)
       throws QueryProcessException {
@@ -126,6 +172,13 @@ public class CreateAlignedTimeSeriesOperator extends Operator {
     }
 
     return new CreateAlignedTimeSeriesPlan(
-        prefixPath, measurements, dataTypes, encodings, compressors, aliasList);
+        prefixPath,
+        measurements,
+        dataTypes,
+        encodings,
+        compressors,
+        aliasList,
+        tagsList,
+        attributesList);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateAlignedTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateAlignedTimeSeriesPlan.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
@@ -48,6 +49,9 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
   private List<TSEncoding> encodings;
   private List<CompressionType> compressors;
   private List<String> aliasList;
+  private List<Map<String, String>> tagsList;
+  private List<Map<String, String>> attributesList;
+  private List<Long> tagOffsets = null;
 
   public CreateAlignedTimeSeriesPlan() {
     super(Operator.OperatorType.CREATE_ALIGNED_TIMESERIES);
@@ -60,7 +64,9 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
       List<TSDataType> dataTypes,
       List<TSEncoding> encodings,
       List<CompressionType> compressors,
-      List<String> aliasList) {
+      List<String> aliasList,
+      List<Map<String, String>> tagsList,
+      List<Map<String, String>> attributesList) {
     super(Operator.OperatorType.CREATE_ALIGNED_TIMESERIES);
     this.prefixPath = prefixPath;
     this.measurements = measurements;
@@ -69,6 +75,8 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
     this.compressors = compressors;
     this.aliasList = aliasList;
     this.canBeSplit = false;
+    this.tagsList = tagsList;
+    this.attributesList = attributesList;
   }
 
   public PartialPath getPrefixPath() {
@@ -119,11 +127,41 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
     this.aliasList = aliasList;
   }
 
+  public List<Map<String, String>> getTagsList() {
+    return tagsList;
+  }
+
+  public void setTagsList(List<Map<String, String>> tagsList) {
+    this.tagsList = tagsList;
+  }
+
+  public List<Map<String, String>> getAttributesList() {
+    return attributesList;
+  }
+
+  public void setAttributesList(List<Map<String, String>> attributesList) {
+    this.attributesList = attributesList;
+  }
+
+  public List<Long> getTagOffsets() {
+    if (tagOffsets == null) {
+      tagOffsets = new ArrayList<>();
+      for (int i = 0; i < measurements.size(); i++) {
+        tagOffsets.add(Long.parseLong("-1"));
+      }
+    }
+    return tagOffsets;
+  }
+
+  public void setTagOffsets(List<Long> tagOffsets) {
+    this.tagOffsets = tagOffsets;
+  }
+
   @Override
   public String toString() {
     return String.format(
         "devicePath: %s, measurements: %s, dataTypes: %s, encodings: %s, compressions: %s",
-        prefixPath, measurements, dataTypes, encodings, compressors);
+        "tagOffsets: %s", prefixPath, measurements, dataTypes, encodings, compressors, tagOffsets);
   }
 
   @Override
@@ -159,12 +197,35 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
     for (CompressionType compressor : compressors) {
       stream.write(compressor.ordinal());
     }
+    for (Long tagOffset : tagOffsets) {
+      stream.writeLong(tagOffset);
+    }
 
     // alias
-    if (aliasList != null) {
+    if (aliasList != null && !aliasList.isEmpty()) {
       stream.write(1);
       for (String alias : aliasList) {
         ReadWriteIOUtils.write(alias, stream);
+      }
+    } else {
+      stream.write(0);
+    }
+
+    // tags
+    if (tagsList != null && !tagsList.isEmpty()) {
+      stream.write(1);
+      for (Map<String, String> tags : tagsList) {
+        ReadWriteIOUtils.write(tags, stream);
+      }
+    } else {
+      stream.write(0);
+    }
+
+    // attributes
+    if (attributesList != null && !attributesList.isEmpty()) {
+      stream.write(1);
+      for (Map<String, String> attributes : attributesList) {
+        ReadWriteIOUtils.write(attributes, stream);
       }
     } else {
       stream.write(0);
@@ -192,9 +253,12 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
     for (CompressionType compressor : compressors) {
       buffer.put((byte) compressor.ordinal());
     }
+    for (Long tagOffset : tagOffsets) {
+      buffer.putLong(tagOffset);
+    }
 
     // alias
-    if (aliasList != null) {
+    if (aliasList != null && !aliasList.isEmpty()) {
       buffer.put((byte) 1);
       for (String alias : aliasList) {
         ReadWriteIOUtils.write(alias, buffer);
@@ -203,6 +267,25 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
       buffer.put((byte) 0);
     }
 
+    // tags
+    if (tagsList != null && !tagsList.isEmpty()) {
+      buffer.put((byte) 1);
+      for (Map<String, String> tags : tagsList) {
+        ReadWriteIOUtils.write(tags, buffer);
+      }
+    } else {
+      buffer.put((byte) 0);
+    }
+
+    // attributes
+    if (attributesList != null && !attributesList.isEmpty()) {
+      buffer.put((byte) 1);
+      for (Map<String, String> attributes : attributesList) {
+        ReadWriteIOUtils.write(attributes, buffer);
+      }
+    } else {
+      buffer.put((byte) 0);
+    }
     buffer.putLong(index);
   }
 
@@ -230,12 +313,32 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
     for (int i = 0; i < size; i++) {
       compressors.add(CompressionType.values()[buffer.get()]);
     }
+    tagOffsets = new ArrayList<>();
+    for (int i = 0; i < size; i++) {
+      tagOffsets.add(buffer.getLong());
+    }
 
     // alias
     if (buffer.get() == 1) {
       aliasList = new ArrayList<>();
       for (int i = 0; i < size; i++) {
         aliasList.add(ReadWriteIOUtils.readString(buffer));
+      }
+    }
+
+    // tags
+    if (buffer.get() == 1) {
+      tagsList = new ArrayList<>();
+      for (int i = 0; i < size; i++) {
+        tagsList.add(ReadWriteIOUtils.readMap(buffer));
+      }
+    }
+
+    // attributes
+    if (buffer.get() == 1) {
+      attributesList = new ArrayList<>();
+      for (int i = 0; i < size; i++) {
+        attributesList.add(ReadWriteIOUtils.readMap(buffer));
       }
     }
 
@@ -256,11 +359,12 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
         && Objects.equals(measurements, that.measurements)
         && Objects.equals(dataTypes, that.dataTypes)
         && Objects.equals(encodings, that.encodings)
-        && Objects.equals(compressors, that.compressors);
+        && Objects.equals(compressors, that.compressors)
+        && Objects.equals(tagOffsets, that.tagOffsets);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(prefixPath, measurements, dataTypes, encodings, compressors);
+    return Objects.hash(prefixPath, measurements, dataTypes, encodings, compressors, tagOffsets);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/sql/IoTDBSqlVisitor.java
@@ -292,16 +292,15 @@ public class IoTDBSqlVisitor extends IoTDBSqlParserBaseVisitor<Operator> {
     }
     createAlignedTimeSeriesOperator.addCompressor(compressor);
 
+    if (ctx.tagClause() != null) {
+      parseTagClause(ctx.tagClause(), createAlignedTimeSeriesOperator);
+    }
+    if (ctx.attributeClause() != null) {
+      parseAttributeClause(ctx.attributeClause(), createAlignedTimeSeriesOperator);
+    }
+
     if (ctx.propertyClause(0) != null) {
       throw new SQLParserException("create aligned timeseries: property is not supported yet.");
-    }
-
-    if (ctx.tagClause() != null) {
-      throw new SQLParserException("create aligned timeseries: tag is not supported yet.");
-    }
-
-    if (ctx.attributeClause() != null) {
-      throw new SQLParserException("create aligned timeseries: attribute is not supported yet.");
     }
   }
 
@@ -2680,6 +2679,8 @@ public class IoTDBSqlVisitor extends IoTDBSqlParserBaseVisitor<Operator> {
     Map<String, String> tags = extractMap(ctx.propertyClause(), ctx.propertyClause(0));
     if (operator instanceof CreateTimeSeriesOperator) {
       ((CreateTimeSeriesOperator) operator).setTags(tags);
+    } else if (operator instanceof CreateAlignedTimeSeriesOperator) {
+      ((CreateAlignedTimeSeriesOperator) operator).addTagsList(tags);
     } else if (operator instanceof AlterTimeSeriesOperator) {
       ((AlterTimeSeriesOperator) operator).setTagsMap(tags);
     }
@@ -2689,6 +2690,8 @@ public class IoTDBSqlVisitor extends IoTDBSqlParserBaseVisitor<Operator> {
     Map<String, String> attributes = extractMap(ctx.propertyClause(), ctx.propertyClause(0));
     if (operator instanceof CreateTimeSeriesOperator) {
       ((CreateTimeSeriesOperator) operator).setAttributes(attributes);
+    } else if (operator instanceof CreateAlignedTimeSeriesOperator) {
+      ((CreateAlignedTimeSeriesOperator) operator).addAttributesList(attributes);
     } else if (operator instanceof AlterTimeSeriesOperator) {
       ((AlterTimeSeriesOperator) operator).setAttributesMap(attributes);
     }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -1762,7 +1762,9 @@ public class TSServiceImpl implements TSIService.Iface {
               dataTypes,
               encodings,
               compressors,
-              req.measurementAlias);
+              req.measurementAlias,
+              req.tagsList,
+              req.attributesList);
       TSStatus status = serviceProvider.checkAuthority(plan, req.getSessionId());
       return status != null ? status : executeNonQueryPlan(plan);
     } catch (IoTDBException e) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -238,7 +238,9 @@ public class AbstractCompactionTest {
             measurements,
             dataTypes,
             encodings,
-            compressionTypes);
+            compressionTypes,
+            null,
+            null);
       } else {
         for (int j = 0; j < measurementNum; j++) {
           IoTDB.metaManager.createTimeseries(

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/TestUtilsForAlignedSeries.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/TestUtilsForAlignedSeries.java
@@ -71,7 +71,9 @@ public class TestUtilsForAlignedSeries {
             Arrays.asList(measurements),
             Arrays.asList(dataTypes),
             Arrays.asList(encodings),
-            Arrays.asList(compressionTypes));
+            Arrays.asList(compressionTypes),
+            null,
+            null);
       }
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -301,7 +301,9 @@ public class MManagerBasicTest {
               TSDataType.valueOf("INT32")),
           Arrays.asList(
               TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
-          Arrays.asList(compressionType, compressionType, compressionType));
+          Arrays.asList(compressionType, compressionType, compressionType),
+          null,
+          null);
     } catch (MetadataException e) {
       e.printStackTrace();
       fail(e.getMessage());
@@ -342,7 +344,9 @@ public class MManagerBasicTest {
               TSDataType.valueOf("INT32")),
           Arrays.asList(
               TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
-          Arrays.asList(compressionType, compressionType, compressionType));
+          Arrays.asList(compressionType, compressionType, compressionType),
+          null,
+          null);
     } catch (MetadataException e) {
       e.printStackTrace();
       fail(e.getMessage());
@@ -1932,7 +1936,9 @@ public class MManagerBasicTest {
               TSDataType.valueOf("INT32")),
           Arrays.asList(
               TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
-          Arrays.asList(compressionType, compressionType, compressionType));
+          Arrays.asList(compressionType, compressionType, compressionType),
+          null,
+          null);
 
       // construct an insertRowPlan with mismatched data type
       long time = 1L;
@@ -1979,7 +1985,9 @@ public class MManagerBasicTest {
               TSDataType.valueOf("INT32")),
           Arrays.asList(
               TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
-          Arrays.asList(compressionType, compressionType, compressionType));
+          Arrays.asList(compressionType, compressionType, compressionType),
+          null,
+          null);
     } catch (Exception e) {
       fail();
     }
@@ -2102,7 +2110,9 @@ public class MManagerBasicTest {
               TSDataType.valueOf("INT32")),
           Arrays.asList(
               TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
-          Arrays.asList(compressionType, compressionType, compressionType));
+          Arrays.asList(compressionType, compressionType, compressionType),
+          null,
+          null);
       fail();
     } catch (Exception e) {
       Assert.assertEquals(
@@ -2158,7 +2168,9 @@ public class MManagerBasicTest {
                 TSDataType.valueOf("INT32")),
             Arrays.asList(
                 TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
-            Arrays.asList(compressionType, compressionType, compressionType));
+            Arrays.asList(compressionType, compressionType, compressionType),
+            null,
+            null);
         fail();
       } catch (Exception e) {
         Assert.assertEquals(
@@ -2181,7 +2193,9 @@ public class MManagerBasicTest {
                 TSDataType.valueOf("INT32")),
             Arrays.asList(
                 TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
-            Arrays.asList(compressionType, compressionType, compressionType));
+            Arrays.asList(compressionType, compressionType, compressionType),
+            null,
+            null);
         fail();
       } catch (Exception e) {
         Assert.assertEquals(String.format("%s is an illegal name.", measurementId), e.getMessage());

--- a/server/src/test/java/org/apache/iotdb/db/metadata/idtable/IDTableTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/idtable/IDTableTest.java
@@ -109,6 +109,8 @@ public class IDTableTest {
               Arrays.asList(
                   TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
               Arrays.asList(compressionType, compressionType, compressionType),
+              null,
+              null,
               null);
 
       manager.createAlignedTimeSeries(plan);
@@ -188,6 +190,8 @@ public class IDTableTest {
               Arrays.asList(
                   TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE"), TSEncoding.valueOf("RLE")),
               Arrays.asList(compressionType, compressionType, compressionType),
+              null,
+              null,
               null);
 
       manager.createAlignedTimeSeries(plan);

--- a/server/src/test/java/org/apache/iotdb/db/qp/PlannerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/PlannerTest.java
@@ -18,12 +18,16 @@
  */
 package org.apache.iotdb.db.qp;
 
+import org.apache.iotdb.db.auth.entity.PrivilegeType;
 import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
+import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.runtime.SQLParserException;
 import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.qp.executor.PlanExecutor;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
@@ -32,15 +36,18 @@ import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.service.rpc.thrift.TSLastDataQueryReq;
 import org.apache.iotdb.service.rpc.thrift.TSRawDataQueryReq;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.exception.filter.QueryFilterOptimizationException;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -272,5 +279,20 @@ public class PlannerTest {
             tsLastDataQueryReq, ZoneId.of("Asia/Shanghai"), IoTDBConstant.ClientVersion.V_0_13);
     assertEquals(OperatorType.LAST, physicalPlan.getOperatorType());
     assertEquals(paths.get(0), physicalPlan.getPaths().get(0).getFullPath());
+  }
+
+  @Test
+  public void testRootPrivilege()
+      throws QueryProcessException, StorageEngineException, IOException, InterruptedException,
+          QueryFilterOptimizationException, MetadataException {
+    String listRootPrivilegeStatement = "list user privileges root";
+    PhysicalPlan physicalPlan = processor.parseSQLToPhysicalPlan(listRootPrivilegeStatement);
+    PlanExecutor executor = new PlanExecutor();
+    QueryDataSet queryDataSet = executor.processQuery(physicalPlan, null);
+    for (PrivilegeType privilegeType : PrivilegeType.values()) {
+      if (queryDataSet.hasNext()) {
+        assertEquals(String.valueOf(queryDataSet.next().getFields()), "[" + privilegeType + "]");
+      }
+    }
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanSerializeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanSerializeTest.java
@@ -199,6 +199,8 @@ public class PhysicalPlanSerializeTest {
             Arrays.asList(TSDataType.DOUBLE, TSDataType.INT32),
             Arrays.asList(TSEncoding.RLE, TSEncoding.RLE),
             Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY),
+            null,
+            null,
             null);
 
     PhysicalPlan result = testTwoSerializeMethodAndDeserialize(createAlignedTimeSeriesPlan);

--- a/thrift/src/main/thrift/rpc.thrift
+++ b/thrift/src/main/thrift/rpc.thrift
@@ -314,6 +314,8 @@ struct TSCreateAlignedTimeseriesReq {
   5: required list<i32> encodings
   6: required list<i32> compressors
   7: optional list<string> measurementAlias
+  8: optional list<map<string, string>> tagsList
+  9: optional list<map<string, string>> attributesList
 }
 
 struct TSRawDataQueryReq {


### PR DESCRIPTION
IoTDB> create aligned timeseries root.sg1.d1(s1 INT32 tags(tag1=v1, tag2=v2) attributes(attr1=v1, attr2=v2), s2 DOUBLE tags(tag3=v3, tag4=v4) attributes(attr3=v3, attr4=v4))

IoTDB> show timeseries
+--------------+-----+-------------+--------+--------+-----------+-------------------------+---------------------------+
|    timeseries|alias|storage group|dataType|encoding|compression|                     tags|                 attributes|
+--------------+-----+-------------+--------+--------+-----------+-------------------------+---------------------------+
|root.sg1.d1.s1| null|     root.sg1|   INT32|     RLE|     SNAPPY|{"tag1":"v1","tag2":"v2"}|{"attr2":"v2","attr1":"v1"}|
|root.sg1.d1.s2| null|     root.sg1|  DOUBLE| GORILLA|     SNAPPY|{"tag4":"v4","tag3":"v3"}|{"attr4":"v4","attr3":"v3"}|
+--------------+-----+-------------+--------+--------+-----------+-------------------------+---------------------------+
