### PR TITLE
[IOTDB-2673] Implement the consensus layer basic framework

### DIFF
--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>iotdb-parent</artifactId>
+        <groupId>org.apache.iotdb</groupId>
+        <version>0.13.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>iotdb-consensus</artifactId>
+    <name>IoTDB Consensus</name>
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.apache.ratis/ratis-server -->
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-server</artifactId>
+            <version>2.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>iotdb-thrift</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+</project>

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -27,10 +27,11 @@ import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
 
 import java.util.List;
 
+/** Consensus module base class. Each method should be thread-safe */
 public interface IConsensus {
-  void start();
+  void Start();
 
-  void stop();
+  void Stop();
 
   // write API
   ConsensusWriteResponse Write(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest);
@@ -47,10 +48,10 @@ public interface IConsensus {
 
   ConsensusGenericResponse RemovePeer(ConsensusGroupId groupId, Peer peer);
 
-  ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> peers);
+  ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> newPeers);
 
   // management API
-  ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newPeer);
+  ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newLeader);
 
   ConsensusGenericResponse TriggerSnapshot(ConsensusGroupId groupId);
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -29,29 +29,29 @@ import java.util.List;
 
 /** Consensus module base class. Each method should be thread-safe */
 public interface IConsensus {
-  void Start();
+  void start();
 
-  void Stop();
+  void stop();
 
   // write API
-  ConsensusWriteResponse Write(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest);
+  ConsensusWriteResponse write(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest);
   // read API
-  ConsensusReadResponse Read(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest);
+  ConsensusReadResponse read(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest);
 
   // multi consensus group API
-  ConsensusGenericResponse AddConsensusGroup(ConsensusGroupId groupId, List<Peer> peers);
+  ConsensusGenericResponse addConsensusGroup(ConsensusGroupId groupId, List<Peer> peers);
 
-  ConsensusGenericResponse RemoveConsensusGroup(ConsensusGroupId groupId);
+  ConsensusGenericResponse removeConsensusGroup(ConsensusGroupId groupId);
 
   // single consensus group API
-  ConsensusGenericResponse AddPeer(ConsensusGroupId groupId, Peer peer);
+  ConsensusGenericResponse addPeer(ConsensusGroupId groupId, Peer peer);
 
-  ConsensusGenericResponse RemovePeer(ConsensusGroupId groupId, Peer peer);
+  ConsensusGenericResponse removePeer(ConsensusGroupId groupId, Peer peer);
 
-  ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> newPeers);
+  ConsensusGenericResponse changePeer(ConsensusGroupId groupId, List<Peer> newPeers);
 
   // management API
-  ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newLeader);
+  ConsensusGenericResponse transferLeader(ConsensusGroupId groupId, Peer newLeader);
 
-  ConsensusGenericResponse TriggerSnapshot(ConsensusGroupId groupId);
+  ConsensusGenericResponse triggerSnapshot(ConsensusGroupId groupId);
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.consensus;
+
+import org.apache.iotdb.consensus.common.ConsensusGroupId;
+import org.apache.iotdb.consensus.common.Peer;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.consensus.common.response.ConsensusGenericResponse;
+import org.apache.iotdb.consensus.common.response.ConsensusReadResponse;
+import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
+
+import java.util.List;
+
+public interface IConsensus {
+  void start();
+
+  void stop();
+
+  // write API
+  ConsensusWriteResponse Write(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest);
+  // read API
+  ConsensusReadResponse Read(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest);
+
+  // multi consensus group API
+  ConsensusGenericResponse AddConsensusGroup(ConsensusGroupId groupId, List<Peer> peers);
+
+  ConsensusGenericResponse RemoveConsensusGroup(ConsensusGroupId groupId);
+
+  // single consensus group API
+  ConsensusGenericResponse AddPeer(ConsensusGroupId groupId, Peer peer);
+
+  ConsensusGenericResponse RemovePeer(ConsensusGroupId groupId, Peer peer);
+
+  ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> peers);
+
+  // management API
+  ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newPeer);
+
+  ConsensusGenericResponse TriggerSnapshot(ConsensusGroupId groupId);
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/ConsensusGroup.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/ConsensusGroup.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common;
+
+import java.util.List;
+import java.util.Objects;
+
+// TODO Use a mature IDL framework such as Protobuf to manage this structure
+public class ConsensusGroup {
+
+  private final ConsensusGroupId groupId;
+  private final List<Peer> peers;
+
+  public ConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
+    this.groupId = groupId;
+    this.peers = peers;
+  }
+
+  public ConsensusGroupId getGroupId() {
+    return groupId;
+  }
+
+  public List<Peer> getPeers() {
+    return peers;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ConsensusGroup that = (ConsensusGroup) o;
+    return Objects.equals(groupId, that.groupId) && Objects.equals(peers, that.peers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(groupId, peers);
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/ConsensusGroupId.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/ConsensusGroupId.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common;
+
+import java.util.Objects;
+
+// TODO Use a mature IDL framework such as Protobuf to manage this structure
+public class ConsensusGroupId {
+
+  private final GroupType type;
+  private final long id;
+
+  public ConsensusGroupId(GroupType type, long id) {
+    this.type = type;
+    this.id = id;
+  }
+
+  public GroupType getType() {
+    return type;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ConsensusGroupId that = (ConsensusGroupId) o;
+    return id == that.id && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, id);
+  }
+
+  @Override
+  public String toString() {
+    return "ConsensusGroupId{" + "type=" + type + ", id=" + id + '}';
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/DataSet.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/DataSet.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common;
+
+public interface DataSet {}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/Endpoint.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/Endpoint.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common;
+
+import java.util.Objects;
+
+// TODO Use a mature IDL framework such as Protobuf to manage this structure
+public class Endpoint {
+
+  private final String ip;
+  private final int port;
+
+  public Endpoint(String ip, int port) {
+    this.ip = ip;
+    this.port = port;
+  }
+
+  public String getIp() {
+    return ip;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Endpoint endpoint = (Endpoint) o;
+    return port == endpoint.port && Objects.equals(ip, endpoint.ip);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ip, port);
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/GroupType.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/GroupType.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common;
+
+// TODO Use a mature IDL framework such as Protobuf to manage this structure
+public enum GroupType {
+  Config,
+  DataRegion,
+  SchemaRegion
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/Peer.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/Peer.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common;
+
+import java.util.Objects;
+
+// TODO Use a mature IDL framework such as Protobuf to manage this structure
+public class Peer {
+
+  private final ConsensusGroupId groupId;
+  private final Endpoint endpoint;
+
+  public Peer(ConsensusGroupId groupId, Endpoint endpoint) {
+    this.groupId = groupId;
+    this.endpoint = endpoint;
+  }
+
+  public ConsensusGroupId getGroupId() {
+    return groupId;
+  }
+
+  public Endpoint getEndpoint() {
+    return endpoint;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Peer peer = (Peer) o;
+    return Objects.equals(groupId, peer.groupId) && Objects.equals(endpoint, peer.endpoint);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(groupId, endpoint);
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IConsensusRequest.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IConsensusRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common.request;
+
+import java.nio.ByteBuffer;
+
+public interface IConsensusRequest {
+
+  void serializeRequest(ByteBuffer buffer);
+
+  void deserializeRequest(ByteBuffer buffer) throws Exception;
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusGenericResponse.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusGenericResponse.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common.response;
+
+import org.apache.iotdb.consensus.exception.ConsensusException;
+
+public class ConsensusGenericResponse extends ConsensusResponse {
+
+  private final boolean success;
+
+  public ConsensusGenericResponse(ConsensusException exception, boolean success) {
+    super(exception);
+    this.success = success;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  @Override
+  public String toString() {
+    return "ConsensusGenericResponse{" + "success=" + success + "} " + super.toString();
+  }
+
+  public static ConsensusGenericResponse.Builder newBuilder() {
+    return new ConsensusGenericResponse.Builder();
+  }
+
+  public static class Builder {
+    private boolean success;
+    private ConsensusException exception;
+
+    public ConsensusGenericResponse build() {
+      return new ConsensusGenericResponse(exception, success);
+    }
+
+    public ConsensusGenericResponse.Builder setException(ConsensusException exception) {
+      this.exception = exception;
+      return this;
+    }
+
+    public ConsensusGenericResponse.Builder setSuccess(boolean success) {
+      this.success = success;
+      return this;
+    }
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusReadResponse.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusReadResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common.response;
+
+import org.apache.iotdb.consensus.common.DataSet;
+import org.apache.iotdb.consensus.exception.ConsensusException;
+
+public class ConsensusReadResponse extends ConsensusResponse {
+
+  private final DataSet dataset;
+
+  public ConsensusReadResponse(ConsensusException exception, DataSet dataset) {
+    super(exception);
+    this.dataset = dataset;
+  }
+
+  public DataSet getDataset() {
+    return dataset;
+  }
+
+  @Override
+  public String toString() {
+    return "ConsensusReadResponse{" + "dataset=" + dataset + "} " + super.toString();
+  }
+
+  public static ConsensusReadResponse.Builder newBuilder() {
+    return new ConsensusReadResponse.Builder();
+  }
+
+  public static class Builder {
+    private ConsensusException exception;
+    private DataSet dataset;
+
+    public ConsensusReadResponse build() {
+      return new ConsensusReadResponse(exception, dataset);
+    }
+
+    public ConsensusReadResponse.Builder setException(ConsensusException exception) {
+      this.exception = exception;
+      return this;
+    }
+
+    public ConsensusReadResponse.Builder setDataSet(DataSet dataset) {
+      this.dataset = dataset;
+      return this;
+    }
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusResponse.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common.response;
+
+import org.apache.iotdb.consensus.exception.ConsensusException;
+
+public abstract class ConsensusResponse {
+  private final ConsensusException exception;
+
+  public ConsensusResponse(ConsensusException exception) {
+    this.exception = exception;
+  }
+
+  public ConsensusException getException() {
+    return exception;
+  }
+
+  @Override
+  public String toString() {
+    return "exception=" + exception;
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusWriteResponse.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusWriteResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common.response;
+
+import org.apache.iotdb.consensus.exception.ConsensusException;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+public class ConsensusWriteResponse extends ConsensusResponse {
+
+  private final TSStatus status;
+
+  public ConsensusWriteResponse(ConsensusException exception, TSStatus status) {
+    super(exception);
+    this.status = status;
+  }
+
+  public TSStatus getStatus() {
+    return status;
+  }
+
+  @Override
+  public String toString() {
+    return "ConsensusWriteResponse{" + "status=" + status + "} " + super.toString();
+  }
+
+  public static ConsensusWriteResponse.Builder newBuilder() {
+    return new ConsensusWriteResponse.Builder();
+  }
+
+  public static class Builder {
+    private org.apache.iotdb.service.rpc.thrift.TSStatus status;
+    private ConsensusException exception;
+
+    public ConsensusWriteResponse build() {
+      return new ConsensusWriteResponse(exception, status);
+    }
+
+    public Builder setException(ConsensusException exception) {
+      this.exception = exception;
+      return this;
+    }
+
+    public Builder setStatus(org.apache.iotdb.service.rpc.thrift.TSStatus status) {
+      this.status = status;
+      return this;
+    }
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/exception/ConsensusException.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/exception/ConsensusException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.exception;
+
+public class ConsensusException extends Exception {
+
+  public ConsensusException(String message) {
+    super(message);
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/exception/ConsensusGroupAlreadyExistException.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/exception/ConsensusGroupAlreadyExistException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.exception;
+
+import org.apache.iotdb.consensus.common.ConsensusGroupId;
+
+public class ConsensusGroupAlreadyExistException extends ConsensusException {
+
+  private final ConsensusGroupId groupId;
+
+  public ConsensusGroupAlreadyExistException(ConsensusGroupId groupId) {
+    super(String.format("The consensus group %s already exists", groupId));
+    this.groupId = groupId;
+  }
+
+  public ConsensusGroupId getGroupId() {
+    return groupId;
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/exception/ConsensusGroupNotExistException.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/exception/ConsensusGroupNotExistException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.exception;
+
+import org.apache.iotdb.consensus.common.ConsensusGroupId;
+
+public class ConsensusGroupNotExistException extends ConsensusException {
+
+  private final ConsensusGroupId groupId;
+
+  public ConsensusGroupNotExistException(ConsensusGroupId groupId) {
+    super(String.format("The consensus group %s doesn't exist", groupId));
+    this.groupId = groupId;
+  }
+
+  public ConsensusGroupId getGroupId() {
+    return groupId;
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/exception/IllegalPeerNumException.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/exception/IllegalPeerNumException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.exception;
+
+public class IllegalPeerNumException extends ConsensusException {
+
+  public IllegalPeerNumException(int size) {
+    super(
+        String.format(
+            "Illegal Peer num %d, only support one peer in StandAloneConsensus Mode", size));
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.ratis;
+
+import org.apache.iotdb.consensus.IConsensus;
+import org.apache.iotdb.consensus.common.ConsensusGroupId;
+import org.apache.iotdb.consensus.common.Peer;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.consensus.common.response.ConsensusGenericResponse;
+import org.apache.iotdb.consensus.common.response.ConsensusReadResponse;
+import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
+
+import java.util.List;
+
+public class RatisConsensus implements IConsensus {
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+
+  @Override
+  public ConsensusWriteResponse Write(
+      ConsensusGroupId groupId, IConsensusRequest IConsensusRequest) {
+    return null;
+  }
+
+  @Override
+  public ConsensusReadResponse Read(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest) {
+    return null;
+  }
+
+  @Override
+  public ConsensusGenericResponse AddConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
+    return null;
+  }
+
+  @Override
+  public ConsensusGenericResponse RemoveConsensusGroup(ConsensusGroupId groupId) {
+    return null;
+  }
+
+  @Override
+  public ConsensusGenericResponse AddPeer(ConsensusGroupId groupId, Peer peer) {
+    return null;
+  }
+
+  @Override
+  public ConsensusGenericResponse RemovePeer(ConsensusGroupId groupId, Peer peer) {
+    return null;
+  }
+
+  @Override
+  public ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> peers) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newPeer) {
+    return null;
+  }
+
+  @Override
+  public ConsensusGenericResponse TriggerSnapshot(ConsensusGroupId groupId) {
+    return null;
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -29,57 +29,62 @@ import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
 
 import java.util.List;
 
+/**
+ * A multi-raft consensus implementation based on Ratis, currently still under development.
+ *
+ * <p>See jira [IOTDB-2674](https://issues.apache.org/jira/browse/IOTDB-2674) for more details.
+ */
 public class RatisConsensus implements IConsensus {
 
   @Override
-  public void start() {}
+  public void Start() {}
 
   @Override
-  public void stop() {}
+  public void Stop() {}
 
   @Override
   public ConsensusWriteResponse Write(
       ConsensusGroupId groupId, IConsensusRequest IConsensusRequest) {
-    return null;
+    return ConsensusWriteResponse.newBuilder().build();
   }
 
   @Override
   public ConsensusReadResponse Read(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest) {
-    return null;
+    return ConsensusReadResponse.newBuilder().build();
   }
 
   @Override
   public ConsensusGenericResponse AddConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
-    return null;
-  }
-
-  @Override
-  public ConsensusGenericResponse RemoveConsensusGroup(ConsensusGroupId groupId) {
-    return null;
-  }
-
-  @Override
-  public ConsensusGenericResponse AddPeer(ConsensusGroupId groupId, Peer peer) {
-    return null;
-  }
-
-  @Override
-  public ConsensusGenericResponse RemovePeer(ConsensusGroupId groupId, Peer peer) {
-    return null;
-  }
-
-  @Override
-  public ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> peers) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newPeer) {
-    return null;
+  public ConsensusGenericResponse RemoveConsensusGroup(ConsensusGroupId groupId) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse AddPeer(ConsensusGroupId groupId, Peer peer) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse RemovePeer(ConsensusGroupId groupId, Peer peer) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> newPeers) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newLeader) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
   public ConsensusGenericResponse TriggerSnapshot(ConsensusGroupId groupId) {
-    return null;
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -37,54 +37,54 @@ import java.util.List;
 public class RatisConsensus implements IConsensus {
 
   @Override
-  public void Start() {}
+  public void start() {}
 
   @Override
-  public void Stop() {}
+  public void stop() {}
 
   @Override
-  public ConsensusWriteResponse Write(
+  public ConsensusWriteResponse write(
       ConsensusGroupId groupId, IConsensusRequest IConsensusRequest) {
     return ConsensusWriteResponse.newBuilder().build();
   }
 
   @Override
-  public ConsensusReadResponse Read(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest) {
+  public ConsensusReadResponse read(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest) {
     return ConsensusReadResponse.newBuilder().build();
   }
 
   @Override
-  public ConsensusGenericResponse AddConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
+  public ConsensusGenericResponse addConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse RemoveConsensusGroup(ConsensusGroupId groupId) {
+  public ConsensusGenericResponse removeConsensusGroup(ConsensusGroupId groupId) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse AddPeer(ConsensusGroupId groupId, Peer peer) {
+  public ConsensusGenericResponse addPeer(ConsensusGroupId groupId, Peer peer) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse RemovePeer(ConsensusGroupId groupId, Peer peer) {
+  public ConsensusGenericResponse removePeer(ConsensusGroupId groupId, Peer peer) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> newPeers) {
+  public ConsensusGenericResponse changePeer(ConsensusGroupId groupId, List<Peer> newPeers) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newLeader) {
+  public ConsensusGenericResponse transferLeader(ConsensusGroupId groupId, Peer newLeader) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse TriggerSnapshot(ConsensusGroupId groupId) {
+  public ConsensusGenericResponse triggerSnapshot(ConsensusGroupId groupId) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.standalone;
+
+import org.apache.iotdb.consensus.IConsensus;
+import org.apache.iotdb.consensus.common.ConsensusGroupId;
+import org.apache.iotdb.consensus.common.DataSet;
+import org.apache.iotdb.consensus.common.Peer;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.consensus.common.response.ConsensusGenericResponse;
+import org.apache.iotdb.consensus.common.response.ConsensusReadResponse;
+import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
+import org.apache.iotdb.consensus.exception.ConsensusGroupAlreadyExistException;
+import org.apache.iotdb.consensus.exception.ConsensusGroupNotExistException;
+import org.apache.iotdb.consensus.exception.IllegalPeerNumException;
+import org.apache.iotdb.consensus.statemachine.IStateMachine;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class StandAloneConsensus implements IConsensus {
+
+  private final IStateMachine.Registry registry;
+  private final Map<ConsensusGroupId, StandAloneServerImpl> stateMachineMap;
+
+  public StandAloneConsensus(IStateMachine.Registry registry) {
+    this.registry = registry;
+    this.stateMachineMap = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+
+  @Override
+  public ConsensusWriteResponse Write(ConsensusGroupId groupId, IConsensusRequest request) {
+    AtomicReference<TSStatus> result = new AtomicReference<>();
+    stateMachineMap.computeIfPresent(
+        groupId,
+        (k, v) -> {
+          // TODO make Statemachine thread-safe to avoid thread-safe ways like this that may affect
+          // performance
+          result.set(v.Write(request));
+          return v;
+        });
+    if (result.get() == null) {
+      return ConsensusWriteResponse.newBuilder()
+          .setException(new ConsensusGroupNotExistException(groupId))
+          .build();
+    }
+    return ConsensusWriteResponse.newBuilder().setStatus(result.get()).build();
+  }
+
+  @Override
+  public ConsensusReadResponse Read(ConsensusGroupId groupId, IConsensusRequest request) {
+    AtomicReference<DataSet> result = new AtomicReference<>();
+    stateMachineMap.computeIfPresent(
+        groupId,
+        (k, v) -> {
+          // TODO make Statemachine thread-safe to avoid thread-safe ways like this that may affect
+          // performance
+          result.set(v.Read(request));
+          return v;
+        });
+    if (result.get() == null) {
+      return ConsensusReadResponse.newBuilder()
+          .setException(new ConsensusGroupNotExistException(groupId))
+          .build();
+    }
+    return ConsensusReadResponse.newBuilder().setDataSet(result.get()).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse AddConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
+    int consensusGroupSize = peers.size();
+    if (consensusGroupSize != 1) {
+      return ConsensusGenericResponse.newBuilder()
+          .setException(new IllegalPeerNumException(consensusGroupSize))
+          .build();
+    }
+    AtomicBoolean exist = new AtomicBoolean(true);
+    stateMachineMap.computeIfAbsent(
+        groupId,
+        (k) -> {
+          exist.set(false);
+          StandAloneServerImpl impl =
+              new StandAloneServerImpl(peers.get(0), registry.apply(groupId));
+          impl.start();
+          return impl;
+        });
+    if (exist.get()) {
+      return ConsensusGenericResponse.newBuilder()
+          .setException(new ConsensusGroupAlreadyExistException(groupId))
+          .build();
+    }
+    return ConsensusGenericResponse.newBuilder().setSuccess(true).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse RemoveConsensusGroup(ConsensusGroupId groupId) {
+    AtomicBoolean exist = new AtomicBoolean(false);
+    stateMachineMap.computeIfPresent(
+        groupId,
+        (k, v) -> {
+          exist.set(true);
+          v.stop();
+          return null;
+        });
+    if (!exist.get()) {
+      return ConsensusGenericResponse.newBuilder()
+          .setException(new ConsensusGroupNotExistException(groupId))
+          .build();
+    }
+    return ConsensusGenericResponse.newBuilder().setSuccess(true).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse AddPeer(ConsensusGroupId groupId, Peer peer) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse RemovePeer(ConsensusGroupId groupId, Peer peer) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> peers) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newPeer) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+
+  @Override
+  public ConsensusGenericResponse TriggerSnapshot(ConsensusGroupId groupId) {
+    return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
@@ -56,20 +56,20 @@ public class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public void Start() {}
+  public void start() {}
 
   @Override
-  public void Stop() {}
+  public void stop() {}
 
   @Override
-  public ConsensusWriteResponse Write(ConsensusGroupId groupId, IConsensusRequest request) {
+  public ConsensusWriteResponse write(ConsensusGroupId groupId, IConsensusRequest request) {
     AtomicReference<TSStatus> result = new AtomicReference<>();
     stateMachineMap.computeIfPresent(
         groupId,
         (k, v) -> {
           // TODO make Statemachine thread-safe to avoid thread-safe ways like this that may affect
           // performance
-          result.set(v.Write(request));
+          result.set(v.write(request));
           return v;
         });
     if (result.get() == null) {
@@ -81,14 +81,14 @@ public class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public ConsensusReadResponse Read(ConsensusGroupId groupId, IConsensusRequest request) {
+  public ConsensusReadResponse read(ConsensusGroupId groupId, IConsensusRequest request) {
     AtomicReference<DataSet> result = new AtomicReference<>();
     stateMachineMap.computeIfPresent(
         groupId,
         (k, v) -> {
           // TODO make Statemachine thread-safe to avoid thread-safe ways like this that may affect
           // performance
-          result.set(v.Read(request));
+          result.set(v.read(request));
           return v;
         });
     if (result.get() == null) {
@@ -100,7 +100,7 @@ public class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public ConsensusGenericResponse AddConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
+  public ConsensusGenericResponse addConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
     int consensusGroupSize = peers.size();
     if (consensusGroupSize != 1) {
       return ConsensusGenericResponse.newBuilder()
@@ -114,7 +114,7 @@ public class StandAloneConsensus implements IConsensus {
           exist.set(false);
           StandAloneServerImpl impl =
               new StandAloneServerImpl(peers.get(0), registry.apply(groupId));
-          impl.Start();
+          impl.start();
           return impl;
         });
     if (exist.get()) {
@@ -126,13 +126,13 @@ public class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public ConsensusGenericResponse RemoveConsensusGroup(ConsensusGroupId groupId) {
+  public ConsensusGenericResponse removeConsensusGroup(ConsensusGroupId groupId) {
     AtomicBoolean exist = new AtomicBoolean(false);
     stateMachineMap.computeIfPresent(
         groupId,
         (k, v) -> {
           exist.set(true);
-          v.Stop();
+          v.stop();
           return null;
         });
     if (!exist.get()) {
@@ -144,27 +144,27 @@ public class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public ConsensusGenericResponse AddPeer(ConsensusGroupId groupId, Peer peer) {
+  public ConsensusGenericResponse addPeer(ConsensusGroupId groupId, Peer peer) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse RemovePeer(ConsensusGroupId groupId, Peer peer) {
+  public ConsensusGenericResponse removePeer(ConsensusGroupId groupId, Peer peer) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> newPeers) {
+  public ConsensusGenericResponse changePeer(ConsensusGroupId groupId, List<Peer> newPeers) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newLeader) {
+  public ConsensusGenericResponse transferLeader(ConsensusGroupId groupId, Peer newLeader) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse TriggerSnapshot(ConsensusGroupId groupId) {
+  public ConsensusGenericResponse triggerSnapshot(ConsensusGroupId groupId) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
@@ -39,6 +39,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * A simple single replica consensus implementation.
+ *
+ * <p>any module can use `IConsensus consensusImpl = new StandAloneConsensus(id -> new
+ * EmptyStateMachine());` to perform an initialization implementation.
+ */
 public class StandAloneConsensus implements IConsensus {
 
   private final IStateMachine.Registry registry;
@@ -50,10 +56,10 @@ public class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public void start() {}
+  public void Start() {}
 
   @Override
-  public void stop() {}
+  public void Stop() {}
 
   @Override
   public ConsensusWriteResponse Write(ConsensusGroupId groupId, IConsensusRequest request) {
@@ -108,7 +114,7 @@ public class StandAloneConsensus implements IConsensus {
           exist.set(false);
           StandAloneServerImpl impl =
               new StandAloneServerImpl(peers.get(0), registry.apply(groupId));
-          impl.start();
+          impl.Start();
           return impl;
         });
     if (exist.get()) {
@@ -126,7 +132,7 @@ public class StandAloneConsensus implements IConsensus {
         groupId,
         (k, v) -> {
           exist.set(true);
-          v.stop();
+          v.Stop();
           return null;
         });
     if (!exist.get()) {
@@ -148,12 +154,12 @@ public class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> peers) {
+  public ConsensusGenericResponse ChangePeer(ConsensusGroupId groupId, List<Peer> newPeers) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 
   @Override
-  public ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newPeer) {
+  public ConsensusGenericResponse TransferLeader(ConsensusGroupId groupId, Peer newLeader) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
 

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneServerImpl.java
@@ -44,10 +44,10 @@ public class StandAloneServerImpl implements IStateMachine {
   }
 
   @Override
-  public void start() {}
+  public void Start() {}
 
   @Override
-  public void stop() {}
+  public void Stop() {}
 
   @Override
   public TSStatus Write(IConsensusRequest request) {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneServerImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.standalone;
+
+import org.apache.iotdb.consensus.common.DataSet;
+import org.apache.iotdb.consensus.common.Peer;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.consensus.statemachine.IStateMachine;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+public class StandAloneServerImpl implements IStateMachine {
+
+  private final Peer peer;
+  private final IStateMachine stateMachine;
+
+  public StandAloneServerImpl(Peer peer, IStateMachine stateMachine) {
+    this.peer = peer;
+    this.stateMachine = stateMachine;
+  }
+
+  public Peer getPeer() {
+    return peer;
+  }
+
+  public IStateMachine getStateMachine() {
+    return stateMachine;
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+
+  @Override
+  public TSStatus Write(IConsensusRequest request) {
+    return stateMachine.Write(request);
+  }
+
+  @Override
+  public DataSet Read(IConsensusRequest request) {
+    return stateMachine.Read(request);
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneServerImpl.java
@@ -44,18 +44,18 @@ public class StandAloneServerImpl implements IStateMachine {
   }
 
   @Override
-  public void Start() {}
+  public void start() {}
 
   @Override
-  public void Stop() {}
+  public void stop() {}
 
   @Override
-  public TSStatus Write(IConsensusRequest request) {
-    return stateMachine.Write(request);
+  public TSStatus write(IConsensusRequest request) {
+    return stateMachine.write(request);
   }
 
   @Override
-  public DataSet Read(IConsensusRequest request) {
-    return stateMachine.Read(request);
+  public DataSet read(IConsensusRequest request) {
+    return stateMachine.read(request);
   }
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/EmptyStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/EmptyStateMachine.java
@@ -26,10 +26,10 @@ import org.apache.iotdb.service.rpc.thrift.TSStatus;
 public class EmptyStateMachine implements IStateMachine {
 
   @Override
-  public void start() {}
+  public void Start() {}
 
   @Override
-  public void stop() {}
+  public void Stop() {}
 
   @Override
   public TSStatus Write(IConsensusRequest IConsensusRequest) {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/EmptyStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/EmptyStateMachine.java
@@ -26,18 +26,18 @@ import org.apache.iotdb.service.rpc.thrift.TSStatus;
 public class EmptyStateMachine implements IStateMachine {
 
   @Override
-  public void Start() {}
+  public void start() {}
 
   @Override
-  public void Stop() {}
+  public void stop() {}
 
   @Override
-  public TSStatus Write(IConsensusRequest IConsensusRequest) {
+  public TSStatus write(IConsensusRequest IConsensusRequest) {
     return new TSStatus();
   }
 
   @Override
-  public DataSet Read(IConsensusRequest IConsensusRequest) {
+  public DataSet read(IConsensusRequest IConsensusRequest) {
     return null;
   }
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/EmptyStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/EmptyStateMachine.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.statemachine;
+
+import org.apache.iotdb.consensus.common.DataSet;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+public class EmptyStateMachine implements IStateMachine {
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+
+  @Override
+  public TSStatus Write(IConsensusRequest IConsensusRequest) {
+    return new TSStatus();
+  }
+
+  @Override
+  public DataSet Read(IConsensusRequest IConsensusRequest) {
+    return null;
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/IStateMachine.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.statemachine;
+
+import org.apache.iotdb.consensus.common.ConsensusGroupId;
+import org.apache.iotdb.consensus.common.DataSet;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+import java.util.function.Function;
+
+public interface IStateMachine {
+
+  interface Registry extends Function<ConsensusGroupId, IStateMachine> {}
+
+  void start();
+
+  void stop();
+
+  TSStatus Write(IConsensusRequest IConsensusRequest);
+
+  DataSet Read(IConsensusRequest IConsensusRequest);
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/IStateMachine.java
@@ -30,11 +30,11 @@ public interface IStateMachine {
 
   interface Registry extends Function<ConsensusGroupId, IStateMachine> {}
 
-  void Start();
+  void start();
 
-  void Stop();
+  void stop();
 
-  TSStatus Write(IConsensusRequest IConsensusRequest);
+  TSStatus write(IConsensusRequest IConsensusRequest);
 
-  DataSet Read(IConsensusRequest IConsensusRequest);
+  DataSet read(IConsensusRequest IConsensusRequest);
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/statemachine/IStateMachine.java
@@ -30,9 +30,9 @@ public interface IStateMachine {
 
   interface Registry extends Function<ConsensusGroupId, IStateMachine> {}
 
-  void start();
+  void Start();
 
-  void stop();
+  void Stop();
 
   TSStatus Write(IConsensusRequest IConsensusRequest);
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.standalone;
+
+import org.apache.iotdb.consensus.IConsensus;
+import org.apache.iotdb.consensus.common.ConsensusGroupId;
+import org.apache.iotdb.consensus.common.DataSet;
+import org.apache.iotdb.consensus.common.Endpoint;
+import org.apache.iotdb.consensus.common.GroupType;
+import org.apache.iotdb.consensus.common.Peer;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.consensus.common.response.ConsensusGenericResponse;
+import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
+import org.apache.iotdb.consensus.exception.ConsensusGroupAlreadyExistException;
+import org.apache.iotdb.consensus.exception.ConsensusGroupNotExistException;
+import org.apache.iotdb.consensus.exception.IllegalPeerNumException;
+import org.apache.iotdb.consensus.statemachine.EmptyStateMachine;
+import org.apache.iotdb.consensus.statemachine.IStateMachine;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class StandAloneConsensusTest {
+
+  private IConsensus consensusImpl;
+  private final TestEntry entry = new TestEntry(0);
+  private final ConsensusGroupId dataRegionId = new ConsensusGroupId(GroupType.DataRegion, 0);
+  private final ConsensusGroupId schemaRegionId = new ConsensusGroupId(GroupType.SchemaRegion, 1);
+  private final ConsensusGroupId configId = new ConsensusGroupId(GroupType.Config, 2);
+
+  private static class TestEntry implements IConsensusRequest {
+
+    private int num;
+
+    public TestEntry(int num) {
+      this.num = num;
+    }
+
+    @Override
+    public void serializeRequest(ByteBuffer buffer) {
+      buffer.putInt(num);
+    }
+
+    @Override
+    public void deserializeRequest(ByteBuffer buffer) throws Exception {
+      num = buffer.getInt();
+    }
+  }
+
+  private static class TestStateMachine implements IStateMachine {
+
+    private final boolean direction;
+
+    public TestStateMachine(boolean direction) {
+      this.direction = direction;
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void stop() {}
+
+    @Override
+    public TSStatus Write(IConsensusRequest request) {
+      if (request instanceof TestEntry) {
+        return new TSStatus(
+            direction ? ((TestEntry) request).num + 1 : ((TestEntry) request).num - 1);
+      }
+      return new TSStatus();
+    }
+
+    @Override
+    public DataSet Read(IConsensusRequest request) {
+      return null;
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    consensusImpl =
+        new StandAloneConsensus(
+            gid -> {
+              switch (gid.getType()) {
+                case SchemaRegion:
+                  return new TestStateMachine(true);
+                case DataRegion:
+                  return new TestStateMachine(false);
+              }
+              return new EmptyStateMachine();
+            });
+    consensusImpl.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    consensusImpl.stop();
+  }
+
+  @Test
+  public void addConsensusGroup() {
+    ConsensusGenericResponse response1 =
+        consensusImpl.AddConsensusGroup(
+            dataRegionId,
+            Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
+    assertTrue(response1.isSuccess());
+    assertNull(response1.getException());
+
+    ConsensusGenericResponse response2 =
+        consensusImpl.AddConsensusGroup(
+            dataRegionId,
+            Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
+    assertFalse(response2.isSuccess());
+    assertTrue(response2.getException() instanceof ConsensusGroupAlreadyExistException);
+
+    ConsensusGenericResponse response3 =
+        consensusImpl.AddConsensusGroup(
+            dataRegionId,
+            Arrays.asList(
+                new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)),
+                new Peer(dataRegionId, new Endpoint("0.0.0.1", 6667))));
+    assertFalse(response3.isSuccess());
+    assertTrue(response3.getException() instanceof IllegalPeerNumException);
+
+    ConsensusGenericResponse response4 =
+        consensusImpl.AddConsensusGroup(
+            schemaRegionId,
+            Collections.singletonList(new Peer(schemaRegionId, new Endpoint("0.0.0.0", 6667))));
+    assertTrue(response4.isSuccess());
+    assertNull(response4.getException());
+  }
+
+  @Test
+  public void removeConsensusGroup() {
+    ConsensusGenericResponse response1 = consensusImpl.RemoveConsensusGroup(dataRegionId);
+    assertFalse(response1.isSuccess());
+    assertTrue(response1.getException() instanceof ConsensusGroupNotExistException);
+
+    ConsensusGenericResponse response2 =
+        consensusImpl.AddConsensusGroup(
+            dataRegionId,
+            Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
+    assertTrue(response2.isSuccess());
+    assertNull(response2.getException());
+
+    ConsensusGenericResponse response3 = consensusImpl.RemoveConsensusGroup(dataRegionId);
+    assertTrue(response3.isSuccess());
+    assertNull(response3.getException());
+  }
+
+  @Test
+  public void addPeer() {
+    ConsensusGenericResponse response =
+        consensusImpl.AddPeer(dataRegionId, new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)));
+    assertFalse(response.isSuccess());
+  }
+
+  @Test
+  public void removePeer() {
+    ConsensusGenericResponse response =
+        consensusImpl.RemovePeer(
+            dataRegionId, new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)));
+    assertFalse(response.isSuccess());
+  }
+
+  @Test
+  public void transferLeader() {
+    ConsensusGenericResponse response =
+        consensusImpl.TransferLeader(
+            dataRegionId, new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)));
+    assertFalse(response.isSuccess());
+  }
+
+  @Test
+  public void triggerSnapshot() {
+    ConsensusGenericResponse response = consensusImpl.TriggerSnapshot(dataRegionId);
+    assertFalse(response.isSuccess());
+  }
+
+  @Test
+  public void write() {
+    ConsensusGenericResponse response1 =
+        consensusImpl.AddConsensusGroup(
+            dataRegionId,
+            Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
+    assertTrue(response1.isSuccess());
+    assertNull(response1.getException());
+
+    ConsensusGenericResponse response2 =
+        consensusImpl.AddConsensusGroup(
+            schemaRegionId,
+            Collections.singletonList(new Peer(schemaRegionId, new Endpoint("0.0.0.0", 6667))));
+    assertTrue(response2.isSuccess());
+    assertNull(response2.getException());
+
+    ConsensusGenericResponse response3 =
+        consensusImpl.AddConsensusGroup(
+            configId, Collections.singletonList(new Peer(configId, new Endpoint("0.0.0.0", 6667))));
+    assertTrue(response3.isSuccess());
+    assertNull(response3.getException());
+
+    ConsensusWriteResponse response4 = consensusImpl.Write(dataRegionId, entry);
+    assertNull(response4.getException());
+    assertNotNull(response4.getStatus());
+    assertEquals(-1, response4.getStatus().getCode());
+
+    ConsensusWriteResponse response5 = consensusImpl.Write(schemaRegionId, entry);
+    assertNull(response5.getException());
+    assertNotNull(response5.getStatus());
+    assertEquals(1, response5.getStatus().getCode());
+
+    ConsensusWriteResponse response6 = consensusImpl.Write(configId, entry);
+    assertNull(response6.getException());
+    assertEquals(0, response6.getStatus().getCode());
+  }
+}

--- a/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
@@ -85,10 +85,10 @@ public class StandAloneConsensusTest {
     }
 
     @Override
-    public void start() {}
+    public void Start() {}
 
     @Override
-    public void stop() {}
+    public void Stop() {}
 
     @Override
     public TSStatus Write(IConsensusRequest request) {
@@ -118,12 +118,12 @@ public class StandAloneConsensusTest {
               }
               return new EmptyStateMachine();
             });
-    consensusImpl.start();
+    consensusImpl.Start();
   }
 
   @After
   public void tearDown() throws Exception {
-    consensusImpl.stop();
+    consensusImpl.Stop();
   }
 
   @Test
@@ -189,6 +189,15 @@ public class StandAloneConsensusTest {
     ConsensusGenericResponse response =
         consensusImpl.RemovePeer(
             dataRegionId, new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)));
+    assertFalse(response.isSuccess());
+  }
+
+  @Test
+  public void changePeer() {
+    ConsensusGenericResponse response =
+        consensusImpl.ChangePeer(
+            dataRegionId,
+            Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
     assertFalse(response.isSuccess());
   }
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
@@ -85,13 +85,13 @@ public class StandAloneConsensusTest {
     }
 
     @Override
-    public void Start() {}
+    public void start() {}
 
     @Override
-    public void Stop() {}
+    public void stop() {}
 
     @Override
-    public TSStatus Write(IConsensusRequest request) {
+    public TSStatus write(IConsensusRequest request) {
       if (request instanceof TestEntry) {
         return new TSStatus(
             direction ? ((TestEntry) request).num + 1 : ((TestEntry) request).num - 1);
@@ -100,7 +100,7 @@ public class StandAloneConsensusTest {
     }
 
     @Override
-    public DataSet Read(IConsensusRequest request) {
+    public DataSet read(IConsensusRequest request) {
       return null;
     }
   }
@@ -118,32 +118,32 @@ public class StandAloneConsensusTest {
               }
               return new EmptyStateMachine();
             });
-    consensusImpl.Start();
+    consensusImpl.start();
   }
 
   @After
   public void tearDown() throws Exception {
-    consensusImpl.Stop();
+    consensusImpl.stop();
   }
 
   @Test
   public void addConsensusGroup() {
     ConsensusGenericResponse response1 =
-        consensusImpl.AddConsensusGroup(
+        consensusImpl.addConsensusGroup(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
     assertTrue(response1.isSuccess());
     assertNull(response1.getException());
 
     ConsensusGenericResponse response2 =
-        consensusImpl.AddConsensusGroup(
+        consensusImpl.addConsensusGroup(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
     assertFalse(response2.isSuccess());
     assertTrue(response2.getException() instanceof ConsensusGroupAlreadyExistException);
 
     ConsensusGenericResponse response3 =
-        consensusImpl.AddConsensusGroup(
+        consensusImpl.addConsensusGroup(
             dataRegionId,
             Arrays.asList(
                 new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)),
@@ -152,7 +152,7 @@ public class StandAloneConsensusTest {
     assertTrue(response3.getException() instanceof IllegalPeerNumException);
 
     ConsensusGenericResponse response4 =
-        consensusImpl.AddConsensusGroup(
+        consensusImpl.addConsensusGroup(
             schemaRegionId,
             Collections.singletonList(new Peer(schemaRegionId, new Endpoint("0.0.0.0", 6667))));
     assertTrue(response4.isSuccess());
@@ -161,18 +161,18 @@ public class StandAloneConsensusTest {
 
   @Test
   public void removeConsensusGroup() {
-    ConsensusGenericResponse response1 = consensusImpl.RemoveConsensusGroup(dataRegionId);
+    ConsensusGenericResponse response1 = consensusImpl.removeConsensusGroup(dataRegionId);
     assertFalse(response1.isSuccess());
     assertTrue(response1.getException() instanceof ConsensusGroupNotExistException);
 
     ConsensusGenericResponse response2 =
-        consensusImpl.AddConsensusGroup(
+        consensusImpl.addConsensusGroup(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
     assertTrue(response2.isSuccess());
     assertNull(response2.getException());
 
-    ConsensusGenericResponse response3 = consensusImpl.RemoveConsensusGroup(dataRegionId);
+    ConsensusGenericResponse response3 = consensusImpl.removeConsensusGroup(dataRegionId);
     assertTrue(response3.isSuccess());
     assertNull(response3.getException());
   }
@@ -180,14 +180,14 @@ public class StandAloneConsensusTest {
   @Test
   public void addPeer() {
     ConsensusGenericResponse response =
-        consensusImpl.AddPeer(dataRegionId, new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)));
+        consensusImpl.addPeer(dataRegionId, new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)));
     assertFalse(response.isSuccess());
   }
 
   @Test
   public void removePeer() {
     ConsensusGenericResponse response =
-        consensusImpl.RemovePeer(
+        consensusImpl.removePeer(
             dataRegionId, new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)));
     assertFalse(response.isSuccess());
   }
@@ -195,7 +195,7 @@ public class StandAloneConsensusTest {
   @Test
   public void changePeer() {
     ConsensusGenericResponse response =
-        consensusImpl.ChangePeer(
+        consensusImpl.changePeer(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
     assertFalse(response.isSuccess());
@@ -204,50 +204,50 @@ public class StandAloneConsensusTest {
   @Test
   public void transferLeader() {
     ConsensusGenericResponse response =
-        consensusImpl.TransferLeader(
+        consensusImpl.transferLeader(
             dataRegionId, new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667)));
     assertFalse(response.isSuccess());
   }
 
   @Test
   public void triggerSnapshot() {
-    ConsensusGenericResponse response = consensusImpl.TriggerSnapshot(dataRegionId);
+    ConsensusGenericResponse response = consensusImpl.triggerSnapshot(dataRegionId);
     assertFalse(response.isSuccess());
   }
 
   @Test
   public void write() {
     ConsensusGenericResponse response1 =
-        consensusImpl.AddConsensusGroup(
+        consensusImpl.addConsensusGroup(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
     assertTrue(response1.isSuccess());
     assertNull(response1.getException());
 
     ConsensusGenericResponse response2 =
-        consensusImpl.AddConsensusGroup(
+        consensusImpl.addConsensusGroup(
             schemaRegionId,
             Collections.singletonList(new Peer(schemaRegionId, new Endpoint("0.0.0.0", 6667))));
     assertTrue(response2.isSuccess());
     assertNull(response2.getException());
 
     ConsensusGenericResponse response3 =
-        consensusImpl.AddConsensusGroup(
+        consensusImpl.addConsensusGroup(
             configId, Collections.singletonList(new Peer(configId, new Endpoint("0.0.0.0", 6667))));
     assertTrue(response3.isSuccess());
     assertNull(response3.getException());
 
-    ConsensusWriteResponse response4 = consensusImpl.Write(dataRegionId, entry);
+    ConsensusWriteResponse response4 = consensusImpl.write(dataRegionId, entry);
     assertNull(response4.getException());
     assertNotNull(response4.getStatus());
     assertEquals(-1, response4.getStatus().getCode());
 
-    ConsensusWriteResponse response5 = consensusImpl.Write(schemaRegionId, entry);
+    ConsensusWriteResponse response5 = consensusImpl.write(schemaRegionId, entry);
     assertNull(response5.getException());
     assertNotNull(response5.getStatus());
     assertEquals(1, response5.getStatus().getCode());
 
-    ConsensusWriteResponse response6 = consensusImpl.Write(configId, entry);
+    ConsensusWriteResponse response6 = consensusImpl.write(configId, entry);
     assertNull(response6.getException());
     assertEquals(0, response6.getStatus().getCode());
   }

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
         <module>client-cpp</module>
         <module>metrics</module>
         <module>integration</module>
+        <module>consensus</module>
         <!--        <module>library-udf</module>-->
     </modules>
     <!-- Properties Management -->

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -47,6 +47,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
+            <artifactId>iotdb-consensus</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
             <artifactId>tsfile</artifactId>
             <version>${project.version}</version>
             <exclusions>

--- a/server/src/main/java/org/apache/iotdb/db/consensus/ConsensusMain.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/ConsensusMain.java
@@ -50,19 +50,19 @@ public class ConsensusMain {
               }
               return new EmptyStateMachine();
             });
-    consensusImpl.Start();
+    consensusImpl.start();
     InsertRowPlan plan = getInsertRowPlan();
     ConsensusGroupId dataRegionId = new ConsensusGroupId(GroupType.DataRegion, 0);
     ConsensusGroupId schemaRegionId = new ConsensusGroupId(GroupType.SchemaRegion, 1);
-    consensusImpl.AddConsensusGroup(
+    consensusImpl.addConsensusGroup(
         dataRegionId,
         Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
-    consensusImpl.AddConsensusGroup(
+    consensusImpl.addConsensusGroup(
         schemaRegionId,
         Collections.singletonList(new Peer(schemaRegionId, new Endpoint("0.0.0.0", 6667))));
-    consensusImpl.Write(dataRegionId, plan);
-    consensusImpl.Write(schemaRegionId, plan);
-    consensusImpl.Stop();
+    consensusImpl.write(dataRegionId, plan);
+    consensusImpl.write(schemaRegionId, plan);
+    consensusImpl.stop();
   }
 
   private static InsertRowPlan getInsertRowPlan() throws IllegalPathException {

--- a/server/src/main/java/org/apache/iotdb/db/consensus/ConsensusMain.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/ConsensusMain.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.consensus;
+
+import org.apache.iotdb.consensus.IConsensus;
+import org.apache.iotdb.consensus.common.ConsensusGroupId;
+import org.apache.iotdb.consensus.common.Endpoint;
+import org.apache.iotdb.consensus.common.GroupType;
+import org.apache.iotdb.consensus.common.Peer;
+import org.apache.iotdb.consensus.standalone.StandAloneConsensus;
+import org.apache.iotdb.consensus.statemachine.EmptyStateMachine;
+import org.apache.iotdb.db.consensus.ratis.RatisDataRegionStateMachine;
+import org.apache.iotdb.db.consensus.ratis.RatisSchemaRegionStateMachine;
+import org.apache.iotdb.db.exception.metadata.IllegalPathException;
+import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import java.util.Collections;
+
+public class ConsensusMain {
+
+  public static void main(String[] args) throws IllegalPathException {
+
+    IConsensus consensusImpl =
+        new StandAloneConsensus(
+            id -> {
+              switch (id.getType()) {
+                case SchemaRegion:
+                  return new RatisSchemaRegionStateMachine();
+                case DataRegion:
+                  return new RatisDataRegionStateMachine();
+              }
+              return new EmptyStateMachine();
+            });
+    consensusImpl.start();
+    InsertRowPlan plan = getInsertRowPlan();
+    ConsensusGroupId dataRegionId = new ConsensusGroupId(GroupType.DataRegion, 0);
+    ConsensusGroupId schemaRegionId = new ConsensusGroupId(GroupType.SchemaRegion, 1);
+    consensusImpl.AddConsensusGroup(
+        dataRegionId,
+        Collections.singletonList(new Peer(dataRegionId, new Endpoint("0.0.0.0", 6667))));
+    consensusImpl.AddConsensusGroup(
+        schemaRegionId,
+        Collections.singletonList(new Peer(schemaRegionId, new Endpoint("0.0.0.0", 6667))));
+    consensusImpl.Write(dataRegionId, plan);
+    consensusImpl.Write(schemaRegionId, plan);
+    consensusImpl.stop();
+  }
+
+  private static InsertRowPlan getInsertRowPlan() throws IllegalPathException {
+    long time = 110L;
+    TSDataType[] dataTypes =
+        new TSDataType[] {
+          TSDataType.DOUBLE,
+          TSDataType.FLOAT,
+          TSDataType.INT64,
+          TSDataType.INT32,
+          TSDataType.BOOLEAN,
+          TSDataType.TEXT
+        };
+
+    String[] columns = new String[6];
+    columns[0] = 1.0 + "";
+    columns[1] = 2 + "";
+    columns[2] = 10000 + "";
+    columns[3] = 100 + "";
+    columns[4] = false + "";
+    columns[5] = "hh" + 0;
+
+    return new InsertRowPlan(
+        new PartialPath("root.isp.d1"),
+        time,
+        new String[] {"s1", "s2", "s3", "s4", "s5", "s6"},
+        dataTypes,
+        columns);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/consensus/ConsensusMain.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/ConsensusMain.java
@@ -50,7 +50,7 @@ public class ConsensusMain {
               }
               return new EmptyStateMachine();
             });
-    consensusImpl.start();
+    consensusImpl.Start();
     InsertRowPlan plan = getInsertRowPlan();
     ConsensusGroupId dataRegionId = new ConsensusGroupId(GroupType.DataRegion, 0);
     ConsensusGroupId schemaRegionId = new ConsensusGroupId(GroupType.SchemaRegion, 1);
@@ -62,7 +62,7 @@ public class ConsensusMain {
         Collections.singletonList(new Peer(schemaRegionId, new Endpoint("0.0.0.0", 6667))));
     consensusImpl.Write(dataRegionId, plan);
     consensusImpl.Write(schemaRegionId, plan);
-    consensusImpl.stop();
+    consensusImpl.Stop();
   }
 
   private static InsertRowPlan getInsertRowPlan() throws IllegalPathException {

--- a/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisDataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisDataRegionStateMachine.java
@@ -33,13 +33,13 @@ public class RatisDataRegionStateMachine implements IStateMachine {
   private static final Logger logger = LoggerFactory.getLogger(RatisDataRegionStateMachine.class);
 
   @Override
-  public void Start() {}
+  public void start() {}
 
   @Override
-  public void Stop() {}
+  public void stop() {}
 
   @Override
-  public TSStatus Write(IConsensusRequest request) {
+  public TSStatus write(IConsensusRequest request) {
     if (request instanceof InsertRowPlan) {
       logger.info("Execute write plan : {}", request);
     }
@@ -47,7 +47,7 @@ public class RatisDataRegionStateMachine implements IStateMachine {
   }
 
   @Override
-  public DataSet Read(IConsensusRequest request) {
+  public DataSet read(IConsensusRequest request) {
     logger.info("Execute read plan : {}", request);
     return null;
   }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisDataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisDataRegionStateMachine.java
@@ -33,10 +33,10 @@ public class RatisDataRegionStateMachine implements IStateMachine {
   private static final Logger logger = LoggerFactory.getLogger(RatisDataRegionStateMachine.class);
 
   @Override
-  public void start() {}
+  public void Start() {}
 
   @Override
-  public void stop() {}
+  public void Stop() {}
 
   @Override
   public TSStatus Write(IConsensusRequest request) {

--- a/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisDataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisDataRegionStateMachine.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.consensus.ratis;
+
+import org.apache.iotdb.consensus.common.DataSet;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.consensus.statemachine.IStateMachine;
+import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RatisDataRegionStateMachine implements IStateMachine {
+
+  private static final Logger logger = LoggerFactory.getLogger(RatisDataRegionStateMachine.class);
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+
+  @Override
+  public TSStatus Write(IConsensusRequest request) {
+    if (request instanceof InsertRowPlan) {
+      logger.info("Execute write plan : {}", request);
+    }
+    return new TSStatus(200);
+  }
+
+  @Override
+  public DataSet Read(IConsensusRequest request) {
+    logger.info("Execute read plan : {}", request);
+    return null;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisSchemaRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisSchemaRegionStateMachine.java
@@ -33,10 +33,10 @@ public class RatisSchemaRegionStateMachine implements IStateMachine {
   private static final Logger logger = LoggerFactory.getLogger(RatisSchemaRegionStateMachine.class);
 
   @Override
-  public void start() {}
+  public void Start() {}
 
   @Override
-  public void stop() {}
+  public void Stop() {}
 
   @Override
   public TSStatus Write(IConsensusRequest request) {

--- a/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisSchemaRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisSchemaRegionStateMachine.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.consensus.ratis;
+
+import org.apache.iotdb.consensus.common.DataSet;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.consensus.statemachine.IStateMachine;
+import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RatisSchemaRegionStateMachine implements IStateMachine {
+
+  private static final Logger logger = LoggerFactory.getLogger(RatisSchemaRegionStateMachine.class);
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+
+  @Override
+  public TSStatus Write(IConsensusRequest request) {
+    if (request instanceof InsertRowPlan) {
+      logger.info("Execute write plan : {}", request);
+    }
+    return new TSStatus(200);
+  }
+
+  @Override
+  public DataSet Read(IConsensusRequest request) {
+    logger.info("Execute read plan : {}", request);
+    return null;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisSchemaRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/ratis/RatisSchemaRegionStateMachine.java
@@ -33,13 +33,13 @@ public class RatisSchemaRegionStateMachine implements IStateMachine {
   private static final Logger logger = LoggerFactory.getLogger(RatisSchemaRegionStateMachine.class);
 
   @Override
-  public void Start() {}
+  public void start() {}
 
   @Override
-  public void Stop() {}
+  public void stop() {}
 
   @Override
-  public TSStatus Write(IConsensusRequest request) {
+  public TSStatus write(IConsensusRequest request) {
     if (request instanceof InsertRowPlan) {
       logger.info("Execute write plan : {}", request);
     }
@@ -47,7 +47,7 @@ public class RatisSchemaRegionStateMachine implements IStateMachine {
   }
 
   @Override
-  public DataSet Read(IConsensusRequest request) {
+  public DataSet read(IConsensusRequest request) {
     logger.info("Execute read plan : {}", request);
     return null;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.qp.physical;
 
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -87,12 +88,13 @@ import java.util.Collections;
 import java.util.List;
 
 /** This class is a abstract class for all type of PhysicalPlan. */
-public abstract class PhysicalPlan {
+public abstract class PhysicalPlan implements IConsensusRequest {
   private static final Logger logger = LoggerFactory.getLogger(PhysicalPlan.class);
 
   private static final String SERIALIZATION_UNIMPLEMENTED = "serialization unimplemented";
 
   private boolean isQuery = false;
+
   private Operator.OperatorType operatorType;
   private static final int NULL_VALUE_LEN = -1;
 
@@ -188,6 +190,20 @@ public abstract class PhysicalPlan {
    */
   public void serialize(DataOutputStream stream) throws IOException {
     throw new UnsupportedOperationException(SERIALIZATION_UNIMPLEMENTED);
+  }
+
+  @Override
+  public void serializeRequest(ByteBuffer buffer) {
+    serialize(buffer);
+  }
+
+  @Override
+  public void deserializeRequest(ByteBuffer buffer) throws Exception {
+    try {
+      deserialize(buffer);
+    } catch (IllegalPathException | IOException e) {
+      throw new Exception(e);
+    }
   }
 
   /**


### PR DESCRIPTION
- Create consensus Module
- Encapsulate the consensus layer interface implementation and implement the related class structure
- A consensus layer implementation `StandAloneConsensus` containing basic logic is implemented to facilitate the early use of other modules, any module can use`IConsensus consensusImpl = new StandAloneConsensus(id -> new EmptyStateMachine());` to perform an initialization implementation

see [doc](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=199536093) for class diagram