### PR TITLE
[IOTDB-2732] Reject inserting an invalid infinity float value

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
@@ -165,4 +165,30 @@ public class IOTDBInsertIT {
       Assert.assertEquals("411: Insertion contains duplicated measurement: status", e.getMessage());
     }
   }
+
+  @Test
+  public void testInsertInfinityFloatValue() {
+    try (Statement st1 = connection.createStatement()) {
+      st1.execute("CREATE TIMESERIES root.t1.wf01.wt01.f1 WITH DATATYPE=FLOAT, ENCODING=PLAIN");
+      st1.execute("insert into root.t1.wf01.wt01(time, f1) values(100, 3.4028235E300)");
+      Assert.fail();
+    } catch (SQLException e) {
+      Assert.assertEquals(
+          "313: failed to insert measurements [f1] caused by The input float value is Infinity",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testInsertInfinityDoubleValue() {
+    try (Statement st1 = connection.createStatement()) {
+      st1.execute("CREATE TIMESERIES root.t1.wf01.wt01.d1 WITH DATATYPE=DOUBLE, ENCODING=PLAIN");
+      st1.execute("insert into root.t1.wf01.wt01(time, d1) values(100, 3.4028235E6000)");
+      Assert.fail();
+    } catch (SQLException e) {
+      Assert.assertEquals(
+          "313: failed to insert measurements [d1] caused by The input double value is Infinity",
+          e.getMessage());
+    }
+  }
 }

--- a/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
@@ -77,6 +77,8 @@ public class IOTDBInsertIT {
     sqls.add("SET STORAGE GROUP TO root.t1");
     sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN");
     sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.temperature WITH DATATYPE=FLOAT, ENCODING=RLE");
+    sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.f1 WITH DATATYPE=FLOAT, ENCODING=PLAIN");
+    sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.d1 WITH DATATYPE=DOUBLE, ENCODING=PLAIN");
   }
 
   private static void insertData() throws SQLException {
@@ -169,7 +171,6 @@ public class IOTDBInsertIT {
   @Test
   public void testInsertInfinityFloatValue() {
     try (Statement st1 = connection.createStatement()) {
-      st1.execute("CREATE TIMESERIES root.t1.wf01.wt01.f1 WITH DATATYPE=FLOAT, ENCODING=PLAIN");
       st1.execute("insert into root.t1.wf01.wt01(time, f1) values(100, 3.4028235E300)");
       Assert.fail();
     } catch (SQLException e) {
@@ -182,7 +183,6 @@ public class IOTDBInsertIT {
   @Test
   public void testInsertInfinityDoubleValue() {
     try (Statement st1 = connection.createStatement()) {
-      st1.execute("CREATE TIMESERIES root.t1.wf01.wt01.d1 WITH DATATYPE=DOUBLE, ENCODING=PLAIN");
       st1.execute("insert into root.t1.wf01.wt01(time, d1) values(100, 3.4028235E6000)");
       Assert.fail();
     } catch (SQLException e) {

--- a/server/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
@@ -104,9 +104,17 @@ public class CommonUtils {
         case INT64:
           return Long.parseLong(StringUtils.trim(value));
         case FLOAT:
-          return Float.parseFloat(value);
+          float f = Float.parseFloat(value);
+          if (Float.isInfinite(f)) {
+            throw new NumberFormatException("The input float value is Infinity");
+          }
+          return f;
         case DOUBLE:
-          return Double.parseDouble(value);
+          double d = Double.parseDouble(value);
+          if (Double.isInfinite(d)) {
+            throw new NumberFormatException("The input double value is Infinity");
+          }
+          return d;
         case TEXT:
           if ((value.startsWith(SQLConstant.QUOTE) && value.endsWith(SQLConstant.QUOTE))
               || (value.startsWith(SQLConstant.DQUOTE) && value.endsWith(SQLConstant.DQUOTE))) {


### PR DESCRIPTION
## Description

See IOTDB-2732.

Repetition steps:

1. create timeseries root.wt04.PLAIN1 WITH DATATYPE=FLOAT,ENCODING=PLAIN,COMPRESSOR=UNCOMPRESSED
2. insert into root.wt04(timestamp,PLAIN1) values(5,3.4028235E300)
3. select PLAIN1 from root.wt04

```
Time     |root.wt04.PLAIN1    |
5        |Infinity            |
```

The reason of this problem is 3.4028235E300 is too large for float type but not for double type.
When parse String `3.4028235E300` to float value, JVM will not throw an exception but parse it to a special value `Infinity`.
Therefore, I added a check for it.