### PR TITLE
[To rel/0.13] [IOTDB-2734] Correct result type name in ResultMetadata

### DIFF
--- a/.github/workflows/influxdb-protocol.yml
+++ b/.github/workflows/influxdb-protocol.yml
@@ -16,17 +16,11 @@ on:
   push:
     branches:
       - influxdb-*
-    branches-ignore:
-      - master
-      - 'rel/*'
     paths-ignore:
       - 'docs/**'
   pull_request:
     branches:
       - influxdb-*
-    branches-ignore:
-      - master
-      - 'rel/*'
     paths-ignore:
       - 'docs/**'
   # allow manually run the action:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,6 +52,7 @@
 * [IOTDB-1986] Support select UDF as alisa clauses 
 * [IOTDB-1989] Spark-IoTDB-connector support inserting data
 * [IOTDB-2131] Support previous, linear, constant value fill funtion New fill
+* [IOTDB-2593] Support using IoTDB with JDK17
 * [ISSUE-3811] Provide a data type column for the last query dataset
 * add rabbitmq example
 
@@ -146,6 +147,10 @@
 * [IOTDB-2267] UDF: Error code 500 caused by user logic
 * [IOTDB-2282] fix tag recovery bug after tag upsert
 * [IOTDB-2290] Fix Incorrect query result in C++ client 
+* [IOTDB-2520] Fix `list user privilege root` returns empty 
+* [IOTDB-2544] Fix tag info sync error during metadata sync
+* [IOTDB-2550] Avoid show timeseries error after alter tag on sync sender
+* [IOTDB-2654] Fix Alias doesn't show when using group by level
 * Fix CPP client could not be successfully built on windows
 * Fix dead lock in setDataTTL method
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -154,6 +154,61 @@
 * Fix CPP client could not be successfully built on windows
 * Fix dead lock in setDataTTL method
 
+# Apache IoTDB 0.12.5
+
+## New Features
+* [IOTDB-2078] Split large TsFile tool
+* [IOTDB-2192] Support extreme function
+
+## Improvements
+* [IOTDB-1297] Refactor the memory control when enabling time partitions
+* [IOTDB-2195] Control the concurrent query execution thread
+* [IOTDB-2475] Remove sg not ready log in batch process
+* [IOTDB-2502] Add query sql in error log if encountering exception
+* [IOTDB-2506] Refine the lock granularity of the aggregation query
+* [IOTDB-2534] add character support while using double quote
+* [IOTDB-2562] Change default value of sync mlog period parameter
+* Avoid too many warning logs being printed, when opening too many file handlers
+
+
+## Bug Fixes
+* [IOTDB-1960] Fix count timeseries bug in cluster mode
+* [IOTDB-2174] Fix Regexp filter serializing and deserializing error
+* [IoTDB-2185] fix get an exception bug when parsing the header of CSV
+* [IOTDB-2194] Fix SHOW TIMESERIES will only display 2000 timeseries in cluster mode
+* [IOTDB-2197] Fix datatype conversion exception in Spark Connector
+* [IOTDB-2209] Fix logback CVE-2021-42550 issue
+* [IOTDB-2219] Fix query in-memory data is incorrect in cluster mode
+* [IOTDB-2222] Fix OOM and data was written in incorrectly bugs of Spark Connector
+* [IOTDB-2251] [IOTDB-2252] Fix Query deadlock
+* [IOTDB-2282] fix tag recover bug after tag update
+* [IOTDB-2320] MemoryLeak cause by wal Scheduled trim task thread
+* [IOTDB-2381] Fix deadlock caused by incorrect buffer pool size counter
+* [IOTDB-2400] Fix series reader bug
+* [IOTDB-2426] WAL deadlock caused by too many open files
+* [IOTDB-2445] Fix overlapped data should be consumed first bug
+* [IOTDB-2499] Fix division by zero error when recovering merge
+* [IOTDB-2507] Fix NPE when merge recover
+* [IOTDB-2528] Fix MLog corruption and recovery bug after killing system
+* [IOTDB-2532] Fix query with align by device can't get value after clear cache
+* [IOTDB-2533] Fix change max_deduplicated_path_num does not take effect
+* [IOTDB-2544] Fix tag info sync error during metadata sync
+* [IOTDB-2550] Avoid show timeseries error after alter tag on sync sender
+* [IOTDB-2567]  Fix thread and ByteBuffer leak after service stopped
+* [IOTDB-2568] "show query processlist" is blocked
+* [IOTDB-2580] Fix DirectByteBuffer and thread leak when deleting storage group
+* [IOTDB-2584] Fix cross space compaction selector
+* [IOTDB-2603] Fix compaction recover
+* [IOTDB-2604] Fix batch size is invalid in import-csv tool
+* [IOTDB-2620] Unrecognizable operator type (SHOW) for AuthorityChecker
+* [IOTDB-2624] Fix "overlapped data should be consumed first" occurs when executing query
+* [IOTDB-2640] Fix cross compaction recover bug
+* [IOTDB-2641] Fix time range of TsFile resource overlaps after unseq compaction
+* [IOTDB-2642] Fix the new file has a higher compact priority than the old file in unseq compaction
+* Fix a logical bug in processPlanLocally in cluster mode
+* Throw Exception while using last query with align by device
+* Add a judgement to determine raft log size can fit into buffer before log appending in cluster mode
+* Fix grafana can't be used bug
 
 # Apache IoTDB 0.12.4
 

--- a/docker/src/main/Dockerfile-0.12.3-cluster
+++ b/docker/src/main/Dockerfile-0.12.3-cluster
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.3/apache-iotdb-0.12.3-cluster-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.3/apache-iotdb-0.12.3-cluster-bin.zip \
+  && unzip apache-iotdb-0.12.3-cluster-bin.zip \
+  && rm apache-iotdb-0.12.3-cluster-bin.zip \
+  && mv apache-iotdb-0.12.3-cluster-bin /iotdb \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y \
+  # modify the seeds in configuration file
+  && sed -i '/^seed_nodes/cseed_nodes=127.0.0.1:9003' /iotdb/conf/iotdb-cluster.properties \
+  && sed -i '/^default_replica_num/cdefault_replica_num=1' /iotdb/conf/iotdb-cluster.properties
+
+# rpc port
+EXPOSE 6667
+# JMX port
+EXPOSE 31999
+# sync port
+EXPOSE 5555
+# monitor port
+EXPOSE 8181
+# internal meta port
+EXPOSE 9003
+# internal data port
+EXPOSE 40010
+VOLUME /iotdb/data
+VOLUME /iotdb/logs
+ENV PATH="/iotdb/sbin/:/iotdb/tools/:${PATH}"
+ENTRYPOINT ["/iotdb/sbin/start-node.sh"]

--- a/docker/src/main/Dockerfile-0.12.3-grafana
+++ b/docker/src/main/Dockerfile-0.12.3-grafana
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.3/apache-iotdb-0.12.3-grafana-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.3/apache-iotdb-0.12.3-grafana-bin.zip \
+  && unzip apache-iotdb-0.12.3-grafana-bin.zip \
+  && rm apache-iotdb-0.12.3-grafana-bin.zip \
+  && mv apache-iotdb-0.12.3-grafana-bin /iotdb-grafana \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y
+# rpc port
+EXPOSE 8888
+VOLUME /iotdb-grafana/config
+RUN echo "#!/bin/bash" > /iotdb-grafana/runboot.sh
+RUN echo "java -Djava.security.egd=file:/dev/./urandom -jar /iotdb-grafana/iotdb-grafana.war" >> /iotdb-grafana/runboot.sh
+RUN chmod a+x /iotdb-grafana/runboot.sh
+WORKDIR /iotdb-grafana
+ENTRYPOINT ["./runboot.sh"]

--- a/docker/src/main/Dockerfile-0.12.3-node
+++ b/docker/src/main/Dockerfile-0.12.3-node
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.3/apache-iotdb-0.12.3-server-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.3/apache-iotdb-0.12.3-server-bin.zip \
+  && unzip apache-iotdb-0.12.3-server-bin.zip \
+  && rm apache-iotdb-0.12.3-server-bin.zip \
+  && mv apache-iotdb-0.12.3-server-bin /iotdb \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y
+# rpc port
+EXPOSE 6667
+# JMX port
+EXPOSE 31999
+# sync port
+EXPOSE 5555
+# monitor port
+EXPOSE 8181
+VOLUME /iotdb/data
+VOLUME /iotdb/logs
+ENV PATH="/iotdb/sbin/:/iotdb/tools/:${PATH}"
+ENTRYPOINT ["/iotdb/sbin/start-server.sh"]

--- a/docker/src/main/Dockerfile-0.12.4-cluster
+++ b/docker/src/main/Dockerfile-0.12.4-cluster
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.4/apache-iotdb-0.12.4-cluster-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.4/apache-iotdb-0.12.4-cluster-bin.zip \
+  && unzip apache-iotdb-0.12.4-cluster-bin.zip \
+  && rm apache-iotdb-0.12.4-cluster-bin.zip \
+  && mv apache-iotdb-0.12.4-cluster-bin /iotdb \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y \
+  # modify the seeds in configuration file
+  && sed -i '/^seed_nodes/cseed_nodes=127.0.0.1:9003' /iotdb/conf/iotdb-cluster.properties \
+  && sed -i '/^default_replica_num/cdefault_replica_num=1' /iotdb/conf/iotdb-cluster.properties
+
+# rpc port
+EXPOSE 6667
+# JMX port
+EXPOSE 31999
+# sync port
+EXPOSE 5555
+# monitor port
+EXPOSE 8181
+# internal meta port
+EXPOSE 9003
+# internal data port
+EXPOSE 40010
+VOLUME /iotdb/data
+VOLUME /iotdb/logs
+ENV PATH="/iotdb/sbin/:/iotdb/tools/:${PATH}"
+ENTRYPOINT ["/iotdb/sbin/start-node.sh"]

--- a/docker/src/main/Dockerfile-0.12.4-grafana
+++ b/docker/src/main/Dockerfile-0.12.4-grafana
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.4/apache-iotdb-0.12.4-grafana-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.4/apache-iotdb-0.12.4-grafana-bin.zip \
+  && unzip apache-iotdb-0.12.4-grafana-bin.zip \
+  && rm apache-iotdb-0.12.4-grafana-bin.zip \
+  && mv apache-iotdb-0.12.4-grafana-bin /iotdb-grafana \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y
+# rpc port
+EXPOSE 8888
+VOLUME /iotdb-grafana/config
+RUN echo "#!/bin/bash" > /iotdb-grafana/runboot.sh
+RUN echo "java -Djava.security.egd=file:/dev/./urandom -jar /iotdb-grafana/iotdb-grafana.war" >> /iotdb-grafana/runboot.sh
+RUN chmod a+x /iotdb-grafana/runboot.sh
+WORKDIR /iotdb-grafana
+ENTRYPOINT ["./runboot.sh"]

--- a/docker/src/main/Dockerfile-0.12.4-node
+++ b/docker/src/main/Dockerfile-0.12.4-node
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.4/apache-iotdb-0.12.4-server-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.4/apache-iotdb-0.12.4-server-bin.zip \
+  && unzip apache-iotdb-0.12.4-server-bin.zip \
+  && rm apache-iotdb-0.12.4-server-bin.zip \
+  && mv apache-iotdb-0.12.4-server-bin /iotdb \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y
+# rpc port
+EXPOSE 6667
+# JMX port
+EXPOSE 31999
+# sync port
+EXPOSE 5555
+# monitor port
+EXPOSE 8181
+VOLUME /iotdb/data
+VOLUME /iotdb/logs
+ENV PATH="/iotdb/sbin/:/iotdb/tools/:${PATH}"
+ENTRYPOINT ["/iotdb/sbin/start-server.sh"]

--- a/docker/src/main/Dockerfile-0.12.5-cluster
+++ b/docker/src/main/Dockerfile-0.12.5-cluster
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.5/apache-iotdb-0.12.5-cluster-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.5/apache-iotdb-0.12.5-cluster-bin.zip \
+  && unzip apache-iotdb-0.12.5-cluster-bin.zip \
+  && rm apache-iotdb-0.12.5-cluster-bin.zip \
+  && mv apache-iotdb-0.12.5-cluster-bin /iotdb \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y \
+  # modify the seeds in configuration file
+  && sed -i '/^seed_nodes/cseed_nodes=127.0.0.1:9003' /iotdb/conf/iotdb-cluster.properties \
+  && sed -i '/^default_replica_num/cdefault_replica_num=1' /iotdb/conf/iotdb-cluster.properties
+
+# rpc port
+EXPOSE 6667
+# JMX port
+EXPOSE 31999
+# sync port
+EXPOSE 5555
+# monitor port
+EXPOSE 8181
+# internal meta port
+EXPOSE 9003
+# internal data port
+EXPOSE 40010
+VOLUME /iotdb/data
+VOLUME /iotdb/logs
+ENV PATH="/iotdb/sbin/:/iotdb/tools/:${PATH}"
+ENTRYPOINT ["/iotdb/sbin/start-node.sh"]

--- a/docker/src/main/Dockerfile-0.12.5-grafana
+++ b/docker/src/main/Dockerfile-0.12.5-grafana
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.5/apache-iotdb-0.12.5-grafana-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.5/apache-iotdb-0.12.5-grafana-bin.zip \
+  && unzip apache-iotdb-0.12.5-grafana-bin.zip \
+  && rm apache-iotdb-0.12.5-grafana-bin.zip \
+  && mv apache-iotdb-0.12.5-grafana-bin /iotdb-grafana \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y
+# rpc port
+EXPOSE 8888
+VOLUME /iotdb-grafana/config
+RUN echo "#!/bin/bash" > /iotdb-grafana/runboot.sh
+RUN echo "java -Djava.security.egd=file:/dev/./urandom -jar /iotdb-grafana/iotdb-grafana.war" >> /iotdb-grafana/runboot.sh
+RUN chmod a+x /iotdb-grafana/runboot.sh
+WORKDIR /iotdb-grafana
+ENTRYPOINT ["./runboot.sh"]

--- a/docker/src/main/Dockerfile-0.12.5-node
+++ b/docker/src/main/Dockerfile-0.12.5-node
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:11-jre-slim
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.12.5/apache-iotdb-0.12.5-server-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.12.5/apache-iotdb-0.12.5-server-bin.zip \
+  && unzip apache-iotdb-0.12.5-server-bin.zip \
+  && rm apache-iotdb-0.12.5-server-bin.zip \
+  && mv apache-iotdb-0.12.5-server-bin /iotdb \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y
+# rpc port
+EXPOSE 6667
+# JMX port
+EXPOSE 31999
+# sync port
+EXPOSE 5555
+# monitor port
+EXPOSE 8181
+VOLUME /iotdb/data
+VOLUME /iotdb/logs
+ENV PATH="/iotdb/sbin/:/iotdb/tools/:${PATH}"
+ENTRYPOINT ["/iotdb/sbin/start-server.sh"]

--- a/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
@@ -77,6 +77,8 @@ public class IOTDBInsertIT {
     sqls.add("SET STORAGE GROUP TO root.t1");
     sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN");
     sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.temperature WITH DATATYPE=FLOAT, ENCODING=RLE");
+    sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.f1 WITH DATATYPE=FLOAT, ENCODING=PLAIN");
+    sqls.add("CREATE TIMESERIES root.t1.wf01.wt01.d1 WITH DATATYPE=DOUBLE, ENCODING=PLAIN");
   }
 
   private static void insertData() throws SQLException {
@@ -163,6 +165,30 @@ public class IOTDBInsertIT {
       Assert.fail();
     } catch (SQLException e) {
       Assert.assertEquals("411: Insertion contains duplicated measurement: status", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testInsertInfinityFloatValue() {
+    try (Statement st1 = connection.createStatement()) {
+      st1.execute("insert into root.t1.wf01.wt01(time, f1) values(100, 3.4028235E300)");
+      Assert.fail();
+    } catch (SQLException e) {
+      Assert.assertEquals(
+          "313: failed to insert measurements [f1] caused by The input float value is Infinity",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testInsertInfinityDoubleValue() {
+    try (Statement st1 = connection.createStatement()) {
+      st1.execute("insert into root.t1.wf01.wt01(time, d1) values(100, 3.4028235E6000)");
+      Assert.fail();
+    } catch (SQLException e) {
+      Assert.assertEquals(
+          "313: failed to insert measurements [d1] caused by The input double value is Infinity",
+          e.getMessage());
     }
   }
 }

--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBResultMetadataIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBResultMetadataIT.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.integration.env.EnvFactory;
+import org.apache.iotdb.itbase.category.ClusterTest;
+import org.apache.iotdb.itbase.category.LocalStandaloneTest;
+
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+
+import java.sql.*;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Notice that, all test begins with "IoTDB" is integration test. All test which will start the
+ * IoTDB server should be defined as integration test.
+ */
+@Category({LocalStandaloneTest.class, ClusterTest.class})
+public class IoTDBResultMetadataIT {
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvironmentUtils.envSetUp();
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("create timeseries root.sg.dev.status with datatype=text,encoding=PLAIN;");
+      statement.execute("insert into root.sg.dev(time,status) values(1,3.14);");
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void columnTypeTest() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      long lastTimestamp;
+      try (ResultSet resultSet = statement.executeQuery("select status from root.sg.dev")) {
+        Assert.assertTrue(resultSet.next());
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        assertEquals(2, metaData.getColumnCount());
+        assertEquals("Time", metaData.getColumnName(1));
+        assertEquals(Types.TIMESTAMP, metaData.getColumnType(1));
+        assertEquals("TIME", metaData.getColumnTypeName(1));
+        assertEquals("root.sg.dev.status", metaData.getColumnName(2));
+        assertEquals(Types.VARCHAR, metaData.getColumnType(2));
+        assertEquals("TEXT", metaData.getColumnTypeName(2));
+      }
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+}

--- a/jdbc/src/main/feature/feature.xml
+++ b/jdbc/src/main/feature/feature.xml
@@ -18,7 +18,7 @@
 
 -->
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.5.0" name="driver-s7-feature">
-    <feature name="iotdb-feature" description="iotdb-feature" version="0.10.0.SNAPSHOT">
+    <feature name="iotdb-feature" description="iotdb-feature" version="0.13.0">
         <details>Feature to install required Bundle to use IoTDB inside Karaf container</details>
         <feature prerequisite="true">wrap</feature>
         <feature>scr</feature>

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
@@ -209,12 +209,7 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
     if (column == 1 && !ignoreTimestamp) {
       return "TIME";
     }
-    String columnType;
-    if (!ignoreTimestamp) {
-      columnType = columnTypeList.get(column - 2);
-    } else {
-      columnType = columnTypeList.get(column - 1);
-    }
+    String columnType = columnTypeList.get(column - 1);
     String typeString = columnType.toUpperCase();
     if ("BOOLEAN".equals(typeString)
         || "INT32".equals(typeString)
@@ -233,12 +228,7 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
     if (column == 1 && !ignoreTimestamp) {
       return 13;
     }
-    String columnType;
-    if (!ignoreTimestamp) {
-      columnType = columnTypeList.get(column - 2);
-    } else {
-      columnType = columnTypeList.get(column - 1);
-    }
+    String columnType = columnTypeList.get(column - 1);
     switch (columnType.toUpperCase()) {
       case "BOOLEAN":
         return 1;
@@ -264,12 +254,7 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
     if (column == 1 && !ignoreTimestamp) {
       return 0;
     }
-    String columnType;
-    if (!ignoreTimestamp) {
-      columnType = columnTypeList.get(column - 2);
-    } else {
-      columnType = columnTypeList.get(column - 1);
-    }
+    String columnType = columnTypeList.get(column - 1);
     switch (columnType.toUpperCase()) {
       case "BOOLEAN":
       case "INT32":
@@ -299,13 +284,7 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
       return "TIME";
     }
     // Temporarily use column names as table names
-    String columName;
-    if (!ignoreTimestamp) {
-      columName = columnInfoList.get(column - 2);
-    } else {
-      columName = columnInfoList.get(column - 1);
-    }
-    return columName;
+    return columnInfoList.get(column - 1);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
@@ -104,9 +104,17 @@ public class CommonUtils {
         case INT64:
           return Long.parseLong(StringUtils.trim(value));
         case FLOAT:
-          return Float.parseFloat(value);
+          float f = Float.parseFloat(value);
+          if (Float.isInfinite(f)) {
+            throw new NumberFormatException("The input float value is Infinity");
+          }
+          return f;
         case DOUBLE:
-          return Double.parseDouble(value);
+          double d = Double.parseDouble(value);
+          if (Double.isInfinite(d)) {
+            throw new NumberFormatException("The input double value is Infinity");
+          }
+          return d;
         case TEXT:
           if ((value.startsWith(SQLConstant.QUOTE) && value.endsWith(SQLConstant.QUOTE))
               || (value.startsWith(SQLConstant.DQUOTE) && value.endsWith(SQLConstant.DQUOTE))) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
@@ -93,13 +93,7 @@ public class Tablet {
 
     int indexInSchema = 0;
     for (MeasurementSchema schema : schemas) {
-      if (schema.getType() == TSDataType.VECTOR) {
-        for (String measurementId : schema.getSubMeasurementsList()) {
-          measurementIndex.put(measurementId, indexInSchema);
-        }
-      } else {
-        measurementIndex.put(schema.getMeasurementId(), indexInSchema);
-      }
+      measurementIndex.put(schema.getMeasurementId(), indexInSchema);
       indexInSchema++;
     }
 


### PR DESCRIPTION
You can see details in [JIRA](https://issues.apache.org/jira/browse/IOTDB-2734).

The reason that cause this bug is that we shouldn't minus 2 while calculating column index even if `ignoreTimestamp` is `false` because we already have time column in both `columnInfoList` and `columnTypeList`.