### PR TITLE
[To rel/0.13] [IOTDB-2734] Correct result type name in ResultMetadata

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBResultMetadataIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBResultMetadataIT.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.integration.env.EnvFactory;
+import org.apache.iotdb.itbase.category.ClusterTest;
+import org.apache.iotdb.itbase.category.LocalStandaloneTest;
+
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+
+import java.sql.*;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Notice that, all test begins with "IoTDB" is integration test. All test which will start the
+ * IoTDB server should be defined as integration test.
+ */
+@Category({LocalStandaloneTest.class, ClusterTest.class})
+public class IoTDBResultMetadataIT {
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvironmentUtils.envSetUp();
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("create timeseries root.sg.dev.status with datatype=text,encoding=PLAIN;");
+      statement.execute("insert into root.sg.dev(time,status) values(1,3.14);");
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void columnTypeTest() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      long lastTimestamp;
+      try (ResultSet resultSet = statement.executeQuery("select status from root.sg.dev")) {
+        Assert.assertTrue(resultSet.next());
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        assertEquals(2, metaData.getColumnCount());
+        assertEquals("Time", metaData.getColumnName(1));
+        assertEquals(Types.TIMESTAMP, metaData.getColumnType(1));
+        assertEquals("TIME", metaData.getColumnTypeName(1));
+        assertEquals("root.sg.dev.status", metaData.getColumnName(2));
+        assertEquals(Types.VARCHAR, metaData.getColumnType(2));
+        assertEquals("TEXT", metaData.getColumnTypeName(2));
+      }
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+}

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
@@ -209,12 +209,7 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
     if (column == 1 && !ignoreTimestamp) {
       return "TIME";
     }
-    String columnType;
-    if (!ignoreTimestamp) {
-      columnType = columnTypeList.get(column - 2);
-    } else {
-      columnType = columnTypeList.get(column - 1);
-    }
+    String columnType = columnTypeList.get(column - 1);
     String typeString = columnType.toUpperCase();
     if ("BOOLEAN".equals(typeString)
         || "INT32".equals(typeString)
@@ -233,12 +228,7 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
     if (column == 1 && !ignoreTimestamp) {
       return 13;
     }
-    String columnType;
-    if (!ignoreTimestamp) {
-      columnType = columnTypeList.get(column - 2);
-    } else {
-      columnType = columnTypeList.get(column - 1);
-    }
+    String columnType = columnTypeList.get(column - 1);
     switch (columnType.toUpperCase()) {
       case "BOOLEAN":
         return 1;
@@ -264,12 +254,7 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
     if (column == 1 && !ignoreTimestamp) {
       return 0;
     }
-    String columnType;
-    if (!ignoreTimestamp) {
-      columnType = columnTypeList.get(column - 2);
-    } else {
-      columnType = columnTypeList.get(column - 1);
-    }
+    String columnType = columnTypeList.get(column - 1);
     switch (columnType.toUpperCase()) {
       case "BOOLEAN":
       case "INT32":
@@ -299,13 +284,7 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
       return "TIME";
     }
     // Temporarily use column names as table names
-    String columName;
-    if (!ignoreTimestamp) {
-      columName = columnInfoList.get(column - 2);
-    } else {
-      columName = columnInfoList.get(column - 1);
-    }
-    return columName;
+    return columnInfoList.get(column - 1);
   }
 
   @Override


### PR DESCRIPTION
You can see details in [JIRA](https://issues.apache.org/jira/browse/IOTDB-2734).

The reason that cause this bug is that we shouldn't minus 2 while calculating column index even if `ignoreTimestamp` is `false` because we already have time column in both `columnInfoList` and `columnTypeList`.