### PR TITLE
[IOTDB-2743] ttl cannot be set if storage group is not exist

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTtlIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTtlIT.java
@@ -60,12 +60,12 @@ public class IoTDBTtlIT {
       try {
         statement.execute("SET TTL TO root.TTL_SG1 1000");
       } catch (SQLException e) {
-        assertEquals(TSStatusCode.TIMESERIES_NOT_EXIST.getStatusCode(), e.getErrorCode());
+        assertEquals(TSStatusCode.STORAGE_GROUP_NOT_EXIST.getStatusCode(), e.getErrorCode());
       }
       try {
         statement.execute("UNSET TTL TO root.TTL_SG1");
       } catch (SQLException e) {
-        assertEquals(TSStatusCode.TIMESERIES_NOT_EXIST.getStatusCode(), e.getErrorCode());
+        assertEquals(TSStatusCode.STORAGE_GROUP_NOT_EXIST.getStatusCode(), e.getErrorCode());
       }
 
       statement.execute("SET STORAGE GROUP TO root.TTL_SG1");

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1630,15 +1630,21 @@ public class PlanExecutor implements IPlanExecutor {
     }
   }
 
-  private void operateTTL(SetTTLPlan plan) throws QueryProcessException {
+  private void operateTTL(SetTTLPlan plan)
+      throws QueryProcessException, StorageGroupNotSetException {
     try {
       List<PartialPath> storageGroupPaths =
           IoTDB.schemaProcessor.getMatchedStorageGroups(
               plan.getStorageGroup(), plan.isPrefixMatch());
+      if (storageGroupPaths.isEmpty()) {
+        throw new StorageGroupNotSetException(plan.getStorageGroup().getFullPath());
+      }
       for (PartialPath storagePath : storageGroupPaths) {
         IoTDB.schemaProcessor.setTTL(storagePath, plan.getDataTTL());
         StorageEngine.getInstance().setTTL(storagePath, plan.getDataTTL());
       }
+    } catch (StorageGroupNotSetException e) {
+      throw e;
     } catch (MetadataException e) {
       throw new QueryProcessException(e);
     } catch (IOException e) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.exception.TriggerExecutionException;
 import org.apache.iotdb.db.exception.WriteProcessException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
+import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.exception.query.OutOfTTLException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
@@ -80,6 +81,7 @@ public class TTLTest {
 
   private String sg1 = "root.TTL_SG1";
   private String sg2 = "root.TTL_SG2";
+  private String storageGroupNotExist = "root.test.notExist";
   private long ttl = 12345;
   private DataRegion dataRegion;
   private String s1 = "s1";
@@ -139,6 +141,22 @@ public class TTLTest {
     // default ttl
     mNode = IoTDB.schemaProcessor.getStorageGroupNodeByPath(new PartialPath(sg2));
     assertEquals(Long.MAX_VALUE, mNode.getDataTTL());
+  }
+
+  @Test
+  public void testExecuteTtlPlan() throws QueryProcessException, StorageEngineException {
+    Planner planner = new Planner();
+    SetTTLPlan plan =
+        (SetTTLPlan)
+            planner.parseSQLToPhysicalPlan("SET TTL TO " + storageGroupNotExist + " 10000");
+    PlanExecutor executor = new PlanExecutor();
+    boolean result = false;
+    try {
+      executor.processNonQuery(plan);
+    } catch (StorageGroupNotSetException e) {
+      result = true;
+    }
+    assertTrue(result);
   }
 
   @Test


### PR DESCRIPTION
<img width="267" alt="1647317336" src="https://user-images.githubusercontent.com/44458757/158304597-ad0079f6-f3ff-41bf-b8e1-955f0d3284fc.png">

We should tell the user that they are using the wrong storage group,then let them troubleshoot the problem.