### PR TITLE
[To rel/0.13][IOTDB-2742] Hide IDTable configurations

### DIFF
--- a/docs/UserGuide/Reference/Config-Manual.md
+++ b/docs/UserGuide/Reference/Config-Manual.md
@@ -1007,6 +1007,7 @@ The permission definitions are in ${IOTDB\_CONF}/conf/jmx.access.
 |Default| 1 |
 |Effective|Only allowed to be modified in first start up|
 
+<!--
 * enable\_id\_table
 
 |Name| enable\_id\_table |
@@ -1033,6 +1034,8 @@ The permission definitions are in ${IOTDB\_CONF}/conf/jmx.access.
 |Type| bool |
 |Default| false |
 |Effective|After restarting system|
+
+-->
 
 ### UDF
 

--- a/docs/zh/UserGuide/Reference/Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/Config-Manual.md
@@ -1569,6 +1569,7 @@ Server，客户端的使用方式详见 [SQL 命令行终端（CLI）](https://i
 |默认值| 1 |
 |改后生效方式|仅允许在第一次启动服务前修改|
 
+<!--
 * enable\_id\_table
 
 |名字| enable\_id\_table |
@@ -1595,6 +1596,8 @@ Server，客户端的使用方式详见 [SQL 命令行终端（CLI）](https://i
 |类型| bool |
 |默认值| false |
 |改后生效方式|重启服务生效|
+
+-->
 
 * concurrent\_writing\_time\_partition
 

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -505,19 +505,6 @@ timestamp_precision=ms
 # Datatype: int
 # query_timeout_threshold=60000
 
-# the method to transform device path to device id, can be 'Plain' or 'SHA256'
-# Datatype: string
-# device_id_transformation_method=Plain
-
-# whether to use id table. ATTENTION: id table is not compatible with alias
-# Datatype: boolean
-# enable_id_table=false
-
-
-# whether create mapping file of id table. This file can map device id in tsfile to device path
-# Datatype: boolean
-# enable_id_table_log_file=false
-
 ####################
 ### Metadata Cache Configuration
 ####################

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -704,18 +704,20 @@ public class IoTDBDescriptor {
       }
 
       // id table related configuration
-      conf.setDeviceIDTransformationMethod(
-          properties.getProperty(
-              "device_id_transformation_method", conf.getDeviceIDTransformationMethod()));
+      //      conf.setDeviceIDTransformationMethod(
+      //          properties.getProperty(
+      //              "device_id_transformation_method", conf.getDeviceIDTransformationMethod()));
 
-      conf.setEnableIDTable(
-          Boolean.parseBoolean(
-              properties.getProperty("enable_id_table", String.valueOf(conf.isEnableIDTable()))));
+      //      conf.setEnableIDTable(
+      //          Boolean.parseBoolean(
+      //              properties.getProperty("enable_id_table",
+      // String.valueOf(conf.isEnableIDTable()))));
 
-      conf.setEnableIDTableLogFile(
-          Boolean.parseBoolean(
-              properties.getProperty(
-                  "enable_id_table_log_file", String.valueOf(conf.isEnableIDTableLogFile()))));
+      //      conf.setEnableIDTableLogFile(
+      //          Boolean.parseBoolean(
+      //              properties.getProperty(
+      //                  "enable_id_table_log_file",
+      // String.valueOf(conf.isEnableIDTableLogFile()))));
 
       // mqtt
       if (properties.getProperty(IoTDBConstant.MQTT_HOST_NAME) != null) {


### PR DESCRIPTION
## Description

Since IDTable is not formal feature of 0.13, we need to hide the configuration and not allow users to open it.