### PR TITLE
[IOTDB-2745]Fix compaction priority param incorrect bug

### DIFF
--- a/docs/UserGuide/Reference/Config-Manual.md
+++ b/docs/UserGuide/Reference/Config-Manual.md
@@ -791,9 +791,9 @@ The permission definitions are in ${IOTDB\_CONF}/conf/jmx.access.
 
 |Name| compaction\_priority |
 |:---:|:---|
-|Description| Priority of compaction task. When it is balance, system executes all types of compaction equally; when it is inner_cross, system takes precedence over executing inner space compaction task; when it is cross_inner, system takes precedence over executing cross space compaction task |
+|Description| Priority of compaction task. When it is BALANCE, system executes all types of compaction equally; when it is INNER_CROSS, system takes precedence over executing inner space compaction task; when it is CROSS_INNER, system takes precedence over executing cross space compaction task |
 |Type| String |
-|Default| balance|
+|Default| BALANCE|
 |Effective|After restart system|
 
 * target\_compaction\_file\_size

--- a/docs/zh/UserGuide/Reference/Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/Config-Manual.md
@@ -832,7 +832,7 @@ Server，客户端的使用方式详见 [SQL 命令行终端（CLI）](https://i
 |:---:|:---|
 |描述| 合并时的优先级，BALANCE 各种合并平等，INNER_CROSS 优先进行顺序文件和顺序文件或乱序文件和乱序文件的合并，CROSS_INNER 优先将乱序文件合并到顺序文件中 |
 |类型| String |
-|默认值| balance |
+|默认值| BALANCE |
 |改后生效方式|重启服务生效|
 
 * target\_compaction\_file\_size

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -432,10 +432,10 @@ timestamp_precision=ms
 # inner_compaction_strategy=size_tiered_compaction
 
 # The priority of compaction execution
-# inner_cross: prioritize inner space compaction, reduce the number of files first
-# cross_inner: prioritize cross space compaction, eliminate the unsequence files first
-# balance: alternate two compaction types
-# compaction_priority=balance
+# INNER_CROSS: prioritize inner space compaction, reduce the number of files first
+# CROSS_INNER: prioritize cross space compaction, eliminate the unsequence files first
+# BALANCE: alternate two compaction types
+# compaction_priority=BALANCE
 
 # The target tsfile size in compaction
 # Datatype: long, Unit: byte


### PR DESCRIPTION
The argument "compaction_priority" in iotdb-engine.properties file should be uppercase.