### PR TITLE
[IOTDB-2723] Fix sequence inner space compaction lose data

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/SingleSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/SingleSeriesCompactionExecutor.java
@@ -209,7 +209,14 @@ public class SingleSeriesCompactionExecutor {
   }
 
   private void writeCachedChunkIntoChunkWriter() throws IOException {
-    cachedChunk.getData().flip();
+    if (cachedChunk.getData().position() != 0) {
+      // If the position of cache chunk data buffer is 0,
+      // it means that the cache chunk is the first chunk cached,
+      // and it hasn't merged with any chunk yet.
+      // If we flip it, both the position and limit in the buffer will be 0,
+      // which leads to the lost of data.
+      cachedChunk.getData().flip();
+    }
     writeChunkIntoChunkWriter(cachedChunk);
     cachedChunk = null;
     cachedChunkMetadata = null;

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionUtilsNoAlignedTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionUtilsNoAlignedTest.java
@@ -758,7 +758,7 @@ public class InnerSpaceCompactionUtilsNoAlignedTest {
   }
 
   @Test
-  public void testMixCompact() throws Exception {
+  public void testMixCompact1() throws Exception {
     long testTargetChunkPointNum = 2000L;
     long testChunkSizeLowerBound = 1024L;
     long testChunkPointNumLowerBound = 100L;
@@ -814,6 +814,87 @@ public class InnerSpaceCompactionUtilsNoAlignedTest {
       for (String path : fullPathSet) {
         CompactionCheckerUtils.putOnePageChunk(chunkPagePointsNumMerged, path, 2750);
         CompactionCheckerUtils.putOnePageChunk(chunkPagePointsNumMerged, path, 2950);
+        CompactionCheckerUtils.putOnePageChunk(chunkPagePointsNumMerged, path, 2500);
+        CompactionCheckerUtils.putChunk(
+            chunkPagePointsNumMerged, path, new long[] {1000, 500, 500});
+      }
+      Map<PartialPath, List<TimeValuePair>> compactedData =
+          CompactionCheckerUtils.getDataByQuery(
+              paths, schemaList, Collections.singletonList(targetResource), new ArrayList<>());
+      CompactionCheckerUtils.validDataByValueList(originData, compactedData);
+      CompactionCheckerUtils.checkChunkAndPage(chunkPagePointsNumMerged, targetResource);
+    } finally {
+      IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(originTargetChunkSize);
+      IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(originTargetChunkPointNum);
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setChunkSizeLowerBoundInCompaction(originChunkSizeLowerBound);
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setChunkPointNumLowerBoundInCompaction(originChunkPointNumLowerBound);
+    }
+  }
+
+  @Test
+  public void testMixCompact2() throws Exception {
+    long testTargetChunkPointNum = 2000L;
+    long testChunkSizeLowerBound = 1024L;
+    long testChunkPointNumLowerBound = 100L;
+    long originTargetChunkSize = IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
+    long originTargetChunkPointNum =
+        IoTDBDescriptor.getInstance().getConfig().getTargetChunkPointNum();
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(1024 * 1024);
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(testTargetChunkPointNum);
+    long originChunkSizeLowerBound =
+        IoTDBDescriptor.getInstance().getConfig().getChunkSizeLowerBoundInCompaction();
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setChunkSizeLowerBoundInCompaction(testChunkSizeLowerBound);
+    long originChunkPointNumLowerBound =
+        IoTDBDescriptor.getInstance().getConfig().getChunkPointNumLowerBoundInCompaction();
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setChunkPointNumLowerBoundInCompaction(testChunkPointNumLowerBound);
+    try {
+      List<TsFileResource> sourceFiles = new ArrayList();
+      int fileNum = 12;
+      long pointStep = 10L;
+      long[] points = new long[] {1960, 50, 1960, 50, 2100, 50, 1960, 2300, 2500, 1000, 500, 500};
+      for (int i = 0; i < fileNum; ++i) {
+        List<List<Long>> chunkPagePointsNum = new ArrayList<>();
+        List<Long> pagePointsNum = new ArrayList<>();
+        pagePointsNum.add(points[i]);
+        chunkPagePointsNum.add(pagePointsNum);
+        TsFileResource resource =
+            new TsFileResource(new File(SEQ_DIRS, String.format("%d-%d-0-0.tsfile", i + 1, i + 1)));
+        sourceFiles.add(resource);
+        CompactionFileGeneratorUtils.writeTsFile(
+            fullPathSet, chunkPagePointsNum, i * 2500L, resource);
+      }
+
+      Map<PartialPath, List<TimeValuePair>> originData =
+          CompactionCheckerUtils.getDataByQuery(paths, schemaList, sourceFiles, new ArrayList<>());
+      TsFileNameGenerator.TsFileName tsFileName =
+          TsFileNameGenerator.getTsFileName(sourceFiles.get(0).getTsFile().getName());
+      TsFileResource targetResource =
+          new TsFileResource(
+              new File(
+                  SEQ_DIRS,
+                  String.format(
+                      "%d-%d-%d-%d.tsfile",
+                      tsFileName.getTime(),
+                      tsFileName.getVersion(),
+                      tsFileName.getInnerCompactionCnt() + 1,
+                      tsFileName.getCrossCompactionCnt())));
+      InnerSpaceCompactionUtils.compact(targetResource, sourceFiles);
+      Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
+      // outer list is a chunk, inner list is point num in each page
+      for (String path : fullPathSet) {
+        CompactionCheckerUtils.putOnePageChunk(chunkPagePointsNumMerged, path, 2010);
+        CompactionCheckerUtils.putOnePageChunk(chunkPagePointsNumMerged, path, 2010);
+        CompactionCheckerUtils.putOnePageChunk(chunkPagePointsNumMerged, path, 2100);
+        CompactionCheckerUtils.putOnePageChunk(chunkPagePointsNumMerged, path, 2010);
+        CompactionCheckerUtils.putOnePageChunk(chunkPagePointsNumMerged, path, 2300);
         CompactionCheckerUtils.putOnePageChunk(chunkPagePointsNumMerged, path, 2500);
         CompactionCheckerUtils.putChunk(
             chunkPagePointsNumMerged, path, new long[] {1000, 500, 500});


### PR DESCRIPTION
When executing inner space compaction for sequence files, the chunks of a series are read into memory one by one, and the program uses three ways to determine how to process a chunk:
1. If the chunk is small or part of data in the chunk is deleted, the chunk will be deserialized into points and rewritten into chunk writer. The following chunk will be written into chunk writer util the size of chunk writer is large enough to flush.
2. If the chunk is too large, the program just flush it to the disk.
3. If the chunk is neither too small nor too large, the program just caches it in memory and merges it with the chunk following. The cached chunk will not be flush util its size is large enough.

Of course, these are rough descriptions. When the program reads a chunk that satisfies the condition of deserialization, if there is already a cached chunk in memory, the program will deserialize the cached chunk into chunk writer first, after which the freshly read chunk will be deserialized. Before the program deserializes the cached chunk, it will call the `flip` function of the cached chunk to make sure the chunk reader can read it correctly. However, in some cases, the cached chunk is the first cached chunk, which means it is a chunk directly read from TsFile using `readMemChunk` function in `TsFileSequenceReader`, and hasn't merged with any chunk yet. **The chunk read by `readMemChunk` has already called `flip` function, while the chunk generated by `mergeChunk` hasn't. The program only needs to call the `flip` function for the later. So if the program call the `flip` function for the former, the `flip` function is called twice actually, which accounts for the error of variable `position` and `limit` in the data buffer of the chunk.** Consequently, the chunk reader cannot read the data in the cached chunk correctly and the data is lost.

This bug actually has nothing to do with deletion