### PR TITLE
[To rel/0.13][IOTDB-2750] Enhance check statement before writing mlog

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -934,7 +934,7 @@ public class MManager {
         }
       }
       node = mtree.getDeviceNodeWithAutoCreating(path, sgLevel);
-      if (!(node.isStorageGroup())) {
+      if (!(node.isStorageGroup()) && !isRecovering) {
         logWriter.autoCreateDeviceMNode(new AutoCreateDeviceMNodePlan(node.getPartialPath()));
       }
       return node;
@@ -946,7 +946,7 @@ public class MManager {
       }
       // ignore set storage group concurrently
       node = mtree.getDeviceNodeWithAutoCreating(path, sgLevel);
-      if (!(node.isStorageGroup())) {
+      if (!(node.isStorageGroup()) && !isRecovering) {
         logWriter.autoCreateDeviceMNode(new AutoCreateDeviceMNodePlan(node.getPartialPath()));
       }
       return node;


### PR DESCRIPTION
Reason of the ISSUE:

During recovery from mlog.bin, MManager::MLogWrite is not initialized since there is no need to write a new entry into mlog, which directly causes the NPE of this issue. This may be caused by nonstandard usage of Templates or originate from disharmonious implementation between MManager and TemplateManager. We will make a thorough refactor to these modules soon.

To fix this issue, we enhanced the check statement before writing entry into mlog.