### PR TITLE
Add Concurrency Control On CI

### DIFF
--- a/.github/workflows/client-go.yml
+++ b/.github/workflows/client-go.yml
@@ -20,6 +20,10 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -19,6 +19,10 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 

--- a/.github/workflows/cluster.yml
+++ b/.github/workflows/cluster.yml
@@ -14,6 +14,10 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,10 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 

--- a/.github/workflows/grafana-plugin.yml
+++ b/.github/workflows/grafana-plugin.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - master
       - "new_*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,6 +2,10 @@ name: Greetings
 
 on: [issues, pull_request_target]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   greeting:
     runs-on: ubuntu-latest

--- a/.github/workflows/influxdb-protocol.yml
+++ b/.github/workflows/influxdb-protocol.yml
@@ -26,6 +26,10 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 

--- a/.github/workflows/main-unix.yml
+++ b/.github/workflows/main-unix.yml
@@ -21,6 +21,10 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 

--- a/.github/workflows/main-win.yml
+++ b/.github/workflows/main-win.yml
@@ -21,6 +21,10 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -28,6 +28,10 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
## Description

Currently, each push of our pr will trigger a batch of CI actions, which takes too much resource. 

We refer to https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency and add the concurrency config to our CI.

With provided configs, only the actions triggered by our latest push on our pr will be executed and the actions triggered before will be cancelled. 


This has been tested on my own repository, illustrated in the following picture. The actions of different PR won't affect each other. Only the actions of latest push will cancel the previous actions of the same pr.
![image](https://user-images.githubusercontent.com/38524330/158613289-5a9de454-2d25-4c09-9133-e227221a2b06.png)

![image](https://user-images.githubusercontent.com/38524330/158613825-c6237f0d-53ea-4780-b738-070f235497eb.png)
