### PR TITLE
[To rel/0.13][IOTDB-2759]Complete result of show template using or set on template

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
@@ -1767,6 +1767,13 @@ public class MTree implements Serializable {
             : template.getRelatedStorageGroup();
     List<String> resSet = new ArrayList<>();
     for (PartialPath sgPath : initPath) {
+      // before Traverser refactored as 0.14, need check storage group alone
+      if (getNodeByPath(sgPath).getSchemaTemplate() != null) {
+        if (templateName.equals(ONE_LEVEL_PATH_WILDCARD)
+            || templateName.equals(getNodeByPath(sgPath).getSchemaTemplate().getName())) {
+          resSet.add(sgPath.getFullPath());
+        }
+      }
       CollectorTraverser<Set<String>> setTemplatePaths =
           new CollectorTraverser<Set<String>>(
               this.root, sgPath.concatNode(MULTI_LEVEL_PATH_WILDCARD)) {
@@ -1812,6 +1819,14 @@ public class MTree implements Serializable {
     List<String> result = new ArrayList<>();
 
     for (PartialPath sgPath : initPath) {
+      // before Traverser refactored as 0.14, need check storage group alone
+      if (getNodeByPath(sgPath).getSchemaTemplate() != null
+          && getNodeByPath(sgPath).isUseTemplate()) {
+        if (templateName.equals(ONE_LEVEL_PATH_WILDCARD)
+            || templateName.equals(getNodeByPath(sgPath).getSchemaTemplate().getName())) {
+          result.add(sgPath.getFullPath());
+        }
+      }
       CollectorTraverser<Set<String>> usingTemplatePaths =
           new CollectorTraverser<Set<String>>(
               this.root, sgPath.concatNode(MULTI_LEVEL_PATH_WILDCARD)) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -273,7 +273,8 @@ public abstract class Traverser {
    */
   protected PartialPath getCurrentPartialPath(IMNode currentNode) throws IllegalPathException {
     Iterator<IMNode> nodes = traverseContext.descendingIterator();
-    StringBuilder builder = new StringBuilder(nodes.next().getName());
+    StringBuilder builder =
+        nodes.hasNext() ? new StringBuilder(nodes.next().getName()) : new StringBuilder();
     while (nodes.hasNext()) {
       builder.append(TsFileConstant.PATH_SEPARATOR);
       builder.append(nodes.next().getName());

--- a/session/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
+++ b/session/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
@@ -151,6 +151,12 @@ public class TemplateUT {
         new HashSet<>(Arrays.asList("root.sg.v1", "root.sg.v2", "root.sg.v3")),
         new HashSet<>(session.showPathsTemplateSetOn("template1")));
 
+    session.setStorageGroup("root.test.sgt");
+    session.setSchemaTemplate("template1", "root.test.sgt");
+    assertEquals(
+        new HashSet<>(Arrays.asList("root.test.sgt", "root.sg.v1", "root.sg.v2", "root.sg.v3")),
+        new HashSet<>(session.showPathsTemplateSetOn("template1")));
+
     assertEquals(
         new HashSet<>(Arrays.asList()),
         new HashSet<>(session.showPathsTemplateUsingOn("template1")));
@@ -171,7 +177,8 @@ public class TemplateUT {
                 "root.sg.v3",
                 "root.sg.v4",
                 "root.sg.v5",
-                "root.sg.v6")),
+                "root.sg.v6",
+                "root.test.sgt")),
         new HashSet<>(session.showPathsTemplateSetOn("*")));
 
     session.insertRecord(
@@ -195,6 +202,21 @@ public class TemplateUT {
     assertEquals(
         new HashSet<>(Arrays.asList("root.sg.v1", "root.sg.v5")),
         new HashSet<>(session.showPathsTemplateUsingOn("*")));
+
+    session.insertRecord(
+        "root.test.sgt.GPS",
+        110L,
+        Arrays.asList("x"),
+        Arrays.asList(TSDataType.FLOAT),
+        Arrays.asList(1.0f));
+
+    assertEquals(
+        new HashSet<>(Arrays.asList("root.sg.v1", "root.sg.v5", "root.test.sgt")),
+        new HashSet<>(session.showPathsTemplateUsingOn("*")));
+
+    assertEquals(
+        new HashSet<>(Arrays.asList("root.test.sgt", "root.sg.v1")),
+        new HashSet<>(session.showPathsTemplateUsingOn("template1")));
   }
 
   @Test


### PR DESCRIPTION
This issue is fixed on 0.13 by a extra check on the related storage group of the target template.

On 0.14 or further version, this issue will be avoided by a refactored Traverser.