### PR TITLE
[IoTDB-2519] Avoid logging stack trace when SQL errors occur

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
@@ -80,7 +80,8 @@ public class ErrorHandlingUtils {
     if (status != null) {
       // ignore logging sg not ready exception
       if (status.getCode() != TSStatusCode.STORAGE_GROUP_NOT_READY.getStatusCode()) {
-        LOGGER.error("Status code: {}, Query Statement: {} failed", status.getCode(), operation, e);
+        LOGGER.error("Status code: {}, Query Statement: {} failed", status.getCode(), operation);
+        LOGGER.error(e.toString());
       }
       return status;
     } else {


### PR DESCRIPTION
To make the logs concise, this PR tries to prevent printing stack traces when SQL errors occur. Please refer to IOTDB-2519 for specific details.

I am expecting advice to optimize the solution. Thanks for your attention and help!