### PR TITLE
Modify the jdbc query time column to be empty

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.integration.env.ConfigFactory;
 import org.apache.iotdb.integration.env.EnvFactory;
 import org.apache.iotdb.itbase.category.ClusterTest;
 import org.apache.iotdb.itbase.category.LocalStandaloneTest;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -33,10 +32,8 @@ import org.junit.experimental.categories.Category;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Types;
 import java.util.Locale;
 
 import static org.apache.iotdb.db.constant.TestConstant.avg;
@@ -1028,32 +1025,6 @@ public class IoTDBAggregationIT {
       }
     } catch (Exception e) {
       e.printStackTrace();
-    }
-  }
-
-  @Test
-  public void timeWasNullTest() throws Exception {
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      boolean hasResultSet =
-          statement.execute(
-              "select max_value(temperature),count(status) from root.ln.wf01.wt01 group by ([0, 600), 100ms);");
-      Assert.assertTrue(hasResultSet);
-      ResultSet resultSet = statement.getResultSet();
-      ResultSetMetaData metaData = resultSet.getMetaData();
-      int columnCount = metaData.getColumnCount();
-      while (resultSet.next()) {
-        for (int i = 1; i <= columnCount; i++) {
-          int ct = metaData.getColumnType(i);
-          if (ct == Types.TIMESTAMP) {
-            if (resultSet.wasNull()) {
-              Assert.assertTrue(false);
-            } else {
-              Assert.assertTrue(true);
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aggregation/IoTDBAggregationIT.java
@@ -33,8 +33,10 @@ import org.junit.experimental.categories.Category;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Locale;
 
 import static org.apache.iotdb.db.constant.TestConstant.avg;
@@ -1026,6 +1028,32 @@ public class IoTDBAggregationIT {
       }
     } catch (Exception e) {
       e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void timeWasNullTest() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      boolean hasResultSet =
+          statement.execute(
+              "select max_value(temperature),count(status) from root.ln.wf01.wt01 group by ([0, 600), 100ms);");
+      Assert.assertTrue(hasResultSet);
+      ResultSet resultSet = statement.getResultSet();
+      ResultSetMetaData metaData = resultSet.getMetaData();
+      int columnCount = metaData.getColumnCount();
+      while (resultSet.next()) {
+        for (int i = 1; i <= columnCount; i++) {
+          int ct = metaData.getColumnType(i);
+          if (ct == Types.TIMESTAMP) {
+            if (resultSet.wasNull()) {
+              Assert.assertTrue(false);
+            } else {
+              Assert.assertTrue(true);
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -200,6 +200,7 @@ public class IoTDBRpcDataSet {
 
   public boolean next() throws StatementExecutionException, IoTDBConnectionException {
     if (hasCachedResults()) {
+      lastReadWasNull = false;
       constructOneRow();
       return true;
     }
@@ -252,7 +253,6 @@ public class IoTDBRpcDataSet {
   }
 
   public void constructOneRow() {
-    lastReadWasNull = false;
     tsQueryDataSet.time.get(time);
     for (int i = 0; i < tsQueryDataSet.bitmapList.size(); i++) {
       ByteBuffer bitmapBuffer = tsQueryDataSet.bitmapList.get(i);

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -252,6 +252,7 @@ public class IoTDBRpcDataSet {
   }
 
   public void constructOneRow() {
+    lastReadWasNull = false;
     tsQueryDataSet.time.get(time);
     for (int i = 0; i < tsQueryDataSet.bitmapList.size(); i++) {
       ByteBuffer bitmapBuffer = tsQueryDataSet.bitmapList.get(i);


### PR DESCRIPTION
When the query statement is executed with jdbc, when the last column of the previous row is empty, the next row last Read Was Null will still be true, resulting in the Timestamp column not displaying time information