### PR TITLE
[To rel/0.12] Fix windows CI failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1014,7 +1014,7 @@
             </activation>
             <properties>
                 <os.classifier>windows-x86_64</os.classifier>
-                <thrift.download-url>http://artfiles.org/apache.org/thrift/${thrift.version}/thrift-${thrift.version}.exe</thrift.download-url>
+                <thrift.download-url>http://archive.apache.org/dist/thrift/${thrift.version}/thrift-${thrift.version}.exe</thrift.download-url>
                 <thrift.executable>thrift-${thrift.version}-win-x86_64.exe</thrift.executable>
                 <thrift.skip-making-executable>true</thrift.skip-making-executable>
                 <thrift.exec-cmd.executable>echo</thrift.exec-cmd.executable>


### PR DESCRIPTION
## Description

Change the Windows Thrift download url to http://archive.apache.org/dist/thrift/0.14.1/thrift-0.14.1.exe .