### PR TITLE
[IOTDB-2775] Fix throwing exception when query non-exist device in TsFileSequenceReader

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -142,14 +142,13 @@ public class TimeSeriesMetadataCache {
     return TimeSeriesMetadataCache.TimeSeriesMetadataCacheHolder.INSTANCE;
   }
 
-  public TimeseriesMetadata get(TimeSeriesMetadataCacheKey key, Set<String> allSensors)
-      throws IOException {
-    return get(key, allSensors, false);
-  }
-
   @SuppressWarnings("squid:S1860") // Suppress synchronize warning
   public TimeseriesMetadata get(
-      TimeSeriesMetadataCacheKey key, Set<String> allSensors, boolean debug) throws IOException {
+      TimeSeriesMetadataCacheKey key,
+      Set<String> allSensors,
+      boolean ignoreNotExists,
+      boolean debug)
+      throws IOException {
     if (!CACHE_ENABLE) {
       // bloom filter part
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
@@ -159,7 +158,7 @@ public class TimeSeriesMetadataCache {
         return null;
       }
       TimeseriesMetadata timeseriesMetadata =
-          reader.readTimeseriesMetadata(new Path(key.device, key.measurement), false);
+          reader.readTimeseriesMetadata(new Path(key.device, key.measurement), ignoreNotExists);
       return (timeseriesMetadata == null || timeseriesMetadata.getStatistics().getCount() == 0)
           ? null
           : timeseriesMetadata;

--- a/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
@@ -99,6 +99,8 @@ public class FileLoaderUtils {
     TimeseriesMetadata timeSeriesMetadata;
     // If the tsfile is closed, we need to load from tsfile
     if (resource.isClosed()) {
+      // when resource.getTimeIndexType() == 1, TsFileResource.timeIndexType is deviceTimeIndex
+      // we should not ignore the non-exist of device in TsFileMetadata
       timeSeriesMetadata =
           TimeSeriesMetadataCache.getInstance()
               .get(
@@ -107,6 +109,7 @@ public class FileLoaderUtils {
                       seriesPath.getDevice(),
                       seriesPath.getMeasurement()),
                   allSensors,
+                  resource.getTimeIndexType() != 1,
                   context.isDebug());
       if (timeSeriesMetadata != null) {
         timeSeriesMetadata.setChunkMetadataLoader(
@@ -164,8 +167,15 @@ public class FileLoaderUtils {
       boolean isDebug = context.isDebug();
       String filePath = resource.getTsFilePath();
       String deviceId = vectorPath.getDevice();
+
+      // when resource.getTimeIndexType() == 1, TsFileResource.timeIndexType is deviceTimeIndex
+      // we should not ignore the non-exist of device in TsFileMetadata
       TimeseriesMetadata timeColumn =
-          cache.get(new TimeSeriesMetadataCacheKey(filePath, deviceId, ""), allSensors, isDebug);
+          cache.get(
+              new TimeSeriesMetadataCacheKey(filePath, deviceId, ""),
+              allSensors,
+              resource.getTimeIndexType() != 1,
+              isDebug);
       if (timeColumn != null) {
         List<TimeseriesMetadata> valueTimeSeriesMetadataList =
             new ArrayList<>(valueMeasurementList.size());
@@ -176,6 +186,7 @@ public class FileLoaderUtils {
               cache.get(
                   new TimeSeriesMetadataCacheKey(filePath, deviceId, valueMeasurement),
                   allSensors,
+                  resource.getTimeIndexType() != 1,
                   isDebug);
           exist = (exist || (valueColumn != null));
           valueTimeSeriesMetadataList.add(valueColumn);


### PR DESCRIPTION
After introducing FileTimeIndex, it does not filter for device. Therefore, when querying a non-exist device in TsFileSequenceReader, it should not throw exception that the device does not exist.