### PR TITLE
[IOTDB-2773] Fix overlapped data should be consumed first bug

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBMaxTimeQueryIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBMaxTimeQueryIT.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.*;
+
+import static org.junit.Assert.*;
+
+public class IoTDBMaxTimeQueryIT {
+
+  private static int numOfPointsPerPage;
+  private static boolean enableSeqSpaceCompaction;
+  private static boolean enableUnseqSpaceCompaction;
+  private static boolean enableCrossSpaceCompaction;
+
+  private static final String[] sqls =
+      new String[] {
+        "insert into root.sg1.d1(time, s1) values(1, 1.0)",
+        "insert into root.sg1.d1(time, s1) values(2, 2.0)",
+        "insert into root.sg1.d1(time, s1) values(6, 2.0)",
+        "insert into root.sg1.d1(time, s1) values(7, 2.0)",
+        "flush",
+        "insert into root.sg1.d1(time, s1) values(8, 8.0)",
+        "insert into root.sg1.d1(time, s1) values(9, 9.0)",
+        "insert into root.sg1.d1(time, s1) values(10, 10.0)",
+        "insert into root.sg1.d1(time, s1) values(11, 11.0)",
+        "flush",
+        "insert into root.sg1.d1(time, s1) values(13, 13.0)",
+        "flush",
+        "insert into root.sg1.d1(time, s1) values(4, 4.0)",
+        "insert into root.sg1.d1(time, s1) values(12, 12.0)",
+        "flush",
+      };
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvironmentUtils.envSetUp();
+    // TODO When the aligned time series support compaction, we need to set compaction to true
+    enableSeqSpaceCompaction =
+        IoTDBDescriptor.getInstance().getConfig().isEnableSeqSpaceCompaction();
+    enableUnseqSpaceCompaction =
+        IoTDBDescriptor.getInstance().getConfig().isEnableUnseqSpaceCompaction();
+    enableCrossSpaceCompaction =
+        IoTDBDescriptor.getInstance().getConfig().isEnableCrossSpaceCompaction();
+    numOfPointsPerPage = TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
+    IoTDBDescriptor.getInstance().getConfig().setEnableSeqSpaceCompaction(false);
+    IoTDBDescriptor.getInstance().getConfig().setEnableUnseqSpaceCompaction(false);
+    IoTDBDescriptor.getInstance().getConfig().setEnableCrossSpaceCompaction(false);
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(2);
+    insertData();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setEnableSeqSpaceCompaction(enableSeqSpaceCompaction);
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setEnableUnseqSpaceCompaction(enableUnseqSpaceCompaction);
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setEnableCrossSpaceCompaction(enableCrossSpaceCompaction);
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(numOfPointsPerPage);
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void maxTimeTest() throws ClassNotFoundException {
+    String[] retArray = new String[] {"12"};
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      boolean hasResultSet =
+          statement.execute("select max_time(s1) from root.sg1.d1 where time <= 12");
+      Assert.assertTrue(hasResultSet);
+      try (ResultSet resultSet = statement.getResultSet()) {
+        int cnt = 0;
+        while (resultSet.next()) {
+          assertEquals(retArray[cnt], resultSet.getString("max_time(root.sg1.d1.s1)"));
+          cnt++;
+        }
+        assertEquals(retArray.length, cnt);
+      }
+    } catch (SQLException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  private static void insertData() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      // create aligned and non-aligned time series
+      for (String sql : sqls) {
+        statement.execute(sql);
+      }
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
@@ -594,35 +594,36 @@ public class SeriesReader {
       addTotalPageNumInTracing(context.getQueryId(), pageReaderList.size());
     }
 
-    pageReaderList.forEach(
-        pageReader -> {
-          if (chunkMetaData.isSeq()) {
-            // addLast for asc; addFirst for desc
-            if (orderUtils.getAscending()) {
-              seqPageReaders.add(
+    if (chunkMetaData.isSeq()) {
+      if (orderUtils.getAscending()) {
+        for (IPageReader iPageReader : pageReaderList) {
+          seqPageReaders.add(
+              new VersionPageReader(
+                  chunkMetaData.getVersion(),
+                  chunkMetaData.getOffsetOfChunkHeader(),
+                  iPageReader,
+                  true));
+        }
+      } else {
+        for (int i = pageReaderList.size() - 1; i >= 0; i--) {
+          seqPageReaders.add(
+              new VersionPageReader(
+                  chunkMetaData.getVersion(),
+                  chunkMetaData.getOffsetOfChunkHeader(),
+                  pageReaderList.get(i),
+                  true));
+        }
+      }
+    } else {
+      pageReaderList.forEach(
+          pageReader ->
+              unSeqPageReaders.add(
                   new VersionPageReader(
                       chunkMetaData.getVersion(),
                       chunkMetaData.getOffsetOfChunkHeader(),
                       pageReader,
-                      true));
-            } else {
-              seqPageReaders.add(
-                  0,
-                  new VersionPageReader(
-                      chunkMetaData.getVersion(),
-                      chunkMetaData.getOffsetOfChunkHeader(),
-                      pageReader,
-                      true));
-            }
-          } else {
-            unSeqPageReaders.add(
-                new VersionPageReader(
-                    chunkMetaData.getVersion(),
-                    chunkMetaData.getOffsetOfChunkHeader(),
-                    pageReader,
-                    false));
-          }
-        });
+                      false)));
+    }
   }
 
   private void addTotalPageNumInTracing(long queryId, int pageNum) {


### PR DESCRIPTION
`max_time` aggregation query will use desc read order to accelerate. But there exist a bug in SeriesReader while using desc order. In `unpackOneChunkMetaData` function of `SeriesReader`, we iterate all page readers of this chunk in asc order and add them into `seqPageReaders`'s tail while in asc order reader, however, we will also iterate page readers of this chunk in asc order and add them into `seqPageReaders`'s head while in desc order reader which is incorrect. 

For example, if we have chunkA which contains two pages(pageA-1 which has two time point [1, 2], pageA-2 which has two time point[3, 4]) and another chunkB which contains two pages(pageB-1 which has two time point [5, 6], pageA-2 which has two time point[7, 8]), if in desc order reader, we want them in `seqPageReaders` in this order([7, 8], [5, 6], [3, 4], [1, 2]), but now they are in that order([3, 4], [1, 2], [7, 8], [5, 6]).

The correct thing we need to do is to iterate page readers of this chunk in desc order and add them into `seqPageReaders`'s tail while in desc order reader.