### PR TITLE
Fix the bug that FREQ does not support DOUBLE.

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
@@ -79,6 +79,7 @@ public class SchemaUtils {
     floatSet.add(TSEncoding.TS_2DIFF);
     floatSet.add(TSEncoding.GORILLA_V1);
     floatSet.add(TSEncoding.GORILLA);
+    floatSet.add(TSEncoding.FREQ);
     schemaChecker.put(TSDataType.FLOAT, floatSet);
     schemaChecker.put(TSDataType.DOUBLE, floatSet);
 


### PR DESCRIPTION
Due to the mistake of solving conflicts, the support is missed. This PR fixes the bug that encoding FREQ does not support data type FLOAT and DOUBLE.  