### PR TITLE
Change PhysicalPlan to FragmentInstance

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/BaseStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/BaseStateMachine.java
@@ -23,15 +23,12 @@ import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.consensus.common.request.ByteBufferConsensusRequest;
 import org.apache.iotdb.consensus.common.request.IConsensusRequest;
 import org.apache.iotdb.consensus.statemachine.IStateMachine;
-import org.apache.iotdb.db.exception.metadata.IllegalPathException;
-import org.apache.iotdb.db.qp.physical.PhysicalPlan;
+import org.apache.iotdb.db.mpp.sql.planner.plan.FragmentInstance;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 public abstract class BaseStateMachine implements IStateMachine {
 
@@ -39,36 +36,37 @@ public abstract class BaseStateMachine implements IStateMachine {
 
   @Override
   public TSStatus write(IConsensusRequest request) {
-    PhysicalPlan plan;
-    if (request instanceof ByteBufferConsensusRequest) {
-      try {
-        plan = PhysicalPlan.Factory.create(((ByteBufferConsensusRequest) request).getContent());
-      } catch (IOException | IllegalPathException e) {
-        logger.error("Deserialization error for write plan : {}", request);
-        return new TSStatus(TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode());
-      }
-    } else if (request instanceof PhysicalPlan) {
-      plan = (PhysicalPlan) request;
-    } else {
-      logger.error("Unexpected write plan : {}", request);
+    try {
+      return write(getFragmentInstance(request));
+    } catch (IllegalArgumentException e) {
       return new TSStatus(TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode());
     }
-    return write(plan);
   }
 
-  protected abstract TSStatus write(PhysicalPlan plan);
+  protected abstract TSStatus write(FragmentInstance fragmentInstance);
 
   @Override
   public DataSet read(IConsensusRequest request) {
-    PhysicalPlan plan;
-    if (request instanceof PhysicalPlan) {
-      plan = (PhysicalPlan) request;
-    } else {
-      logger.error("Unexpected read plan : {}", request);
+    try {
+      return read(getFragmentInstance(request));
+    } catch (IllegalArgumentException e) {
       return null;
     }
-    return read(plan);
   }
 
-  protected abstract DataSet read(PhysicalPlan plan);
+  protected abstract DataSet read(FragmentInstance fragmentInstance);
+
+  private FragmentInstance getFragmentInstance(IConsensusRequest request) {
+    FragmentInstance instance;
+    if (request instanceof ByteBufferConsensusRequest) {
+      instance =
+          FragmentInstance.deserializeFrom(((ByteBufferConsensusRequest) request).getContent());
+    } else if (request instanceof FragmentInstance) {
+      instance = (FragmentInstance) request;
+    } else {
+      logger.error("Unexpected IConsensusRequest : {}", request);
+      throw new IllegalArgumentException("Unexpected IConsensusRequest!");
+    }
+    return instance;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -20,7 +20,7 @@
 package org.apache.iotdb.db.consensus.statemachine;
 
 import org.apache.iotdb.consensus.common.DataSet;
-import org.apache.iotdb.db.qp.physical.PhysicalPlan;
+import org.apache.iotdb.db.mpp.sql.planner.plan.FragmentInstance;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 
@@ -38,14 +38,14 @@ public class DataRegionStateMachine extends BaseStateMachine {
   public void stop() {}
 
   @Override
-  protected TSStatus write(PhysicalPlan plan) {
-    logger.info("Execute write plan in DataRegionStateMachine : {}", plan);
+  protected TSStatus write(FragmentInstance fragmentInstance) {
+    logger.info("Execute write plan in DataRegionStateMachine : {}", fragmentInstance);
     return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
   }
 
   @Override
-  protected DataSet read(PhysicalPlan plan) {
-    logger.info("Execute read plan in DataRegionStateMachine: {}", plan);
+  protected DataSet read(FragmentInstance fragmentInstance) {
+    logger.info("Execute read plan in DataRegionStateMachine: {}", fragmentInstance);
     return null;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
@@ -20,7 +20,7 @@
 package org.apache.iotdb.db.consensus.statemachine;
 
 import org.apache.iotdb.consensus.common.DataSet;
-import org.apache.iotdb.db.qp.physical.PhysicalPlan;
+import org.apache.iotdb.db.mpp.sql.planner.plan.FragmentInstance;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 
@@ -38,14 +38,14 @@ public class SchemaRegionStateMachine extends BaseStateMachine {
   public void stop() {}
 
   @Override
-  protected TSStatus write(PhysicalPlan plan) {
-    logger.info("Execute write plan in SchemaRegionStateMachine : {}", plan);
+  protected TSStatus write(FragmentInstance fragmentInstance) {
+    logger.info("Execute write plan in SchemaRegionStateMachine : {}", fragmentInstance);
     return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
   }
 
   @Override
-  protected DataSet read(PhysicalPlan plan) {
-    logger.info("Execute read plan in SchemaRegionStateMachine: {}", plan);
+  protected DataSet read(FragmentInstance fragmentInstance) {
+    logger.info("Execute read plan in SchemaRegionStateMachine: {}", fragmentInstance);
     return null;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/PlanFragmentId.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/PlanFragmentId.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iotdb.db.mpp.common;
 
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -57,5 +60,10 @@ public class PlanFragmentId {
 
   public String toString() {
     return String.format("%s.%d", queryId, id);
+  }
+
+  public static PlanFragmentId deserialize(ByteBuffer byteBuffer) {
+    return new PlanFragmentId(
+        QueryId.deserialize(byteBuffer), ReadWriteIOUtils.readInt(byteBuffer));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/QueryId.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/QueryId.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iotdb.db.mpp.common;
 
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -109,5 +112,9 @@ public class QueryId {
     checkArgument(!id.isEmpty(), "id is empty");
     checkArgument(isValidId(id), "Invalid id %s", id);
     return id;
+  }
+
+  public static QueryId deserialize(ByteBuffer byteBuffer) {
+    return new QueryId(ReadWriteIOUtils.readString(byteBuffer));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/FragmentInstance.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/FragmentInstance.java
@@ -19,14 +19,19 @@
 package org.apache.iotdb.db.mpp.sql.planner.plan;
 
 import org.apache.iotdb.commons.partition.DataRegionReplicaSet;
+import org.apache.iotdb.consensus.common.request.IConsensusRequest;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeUtil;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.sink.FragmentSinkNode;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.write.InsertTabletNode;
 import org.apache.iotdb.service.rpc.thrift.EndPoint;
 
-public class FragmentInstance {
+import java.nio.ByteBuffer;
+
+public class FragmentInstance implements IConsensusRequest {
   private FragmentInstanceId id;
 
   // The reference of PlanFragment which this instance is generated from
@@ -92,5 +97,18 @@ public class FragmentInstance {
     ret.append(PlanNodeUtil.nodeToString(getFragment().getRoot()));
     ret.append("\n");
     return ret.toString();
+  }
+
+  /** TODO need to be implemented */
+  public static FragmentInstance deserializeFrom(ByteBuffer buffer) {
+    return new FragmentInstance(
+        new PlanFragment(
+            new PlanFragmentId("null", -1), new InsertTabletNode(new PlanNodeId("-1"))),
+        -1);
+  }
+
+  @Override
+  public void serializeRequest(ByteBuffer buffer) {
+    // TODO serialize itself to a ByteBuffer
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/PlanFragment.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/PlanFragment.java
@@ -22,10 +22,14 @@ import org.apache.iotdb.commons.partition.DataRegionReplicaSet;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeType;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.source.SourceNode;
+
+import java.nio.ByteBuffer;
 
 /** PlanFragment contains a sub-query of distributed query. */
 public class PlanFragment {
+  // TODO once you add field for this class you need to change the serialize and deserialize methods
   private PlanFragmentId id;
   private PlanNode root;
 
@@ -83,5 +87,19 @@ public class PlanFragment {
       }
     }
     return null;
+  }
+
+  public static PlanFragment deserialize(ByteBuffer byteBuffer) {
+    return new PlanFragment(PlanFragmentId.deserialize(byteBuffer), deserializeHelper(byteBuffer));
+  }
+
+  // deserialize the plan node recursively
+  private static PlanNode deserializeHelper(ByteBuffer byteBuffer) {
+    PlanNode root = PlanNodeType.deserialize(byteBuffer);
+    int childrenCount = byteBuffer.getInt();
+    for (int i = 0; i < childrenCount; i++) {
+      root.addChildren(deserializeHelper(byteBuffer));
+    }
+    return root;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/PlanNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/PlanNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.mpp.sql.planner.plan.node;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -39,6 +40,8 @@ public abstract class PlanNode {
 
   public abstract List<PlanNode> getChildren();
 
+  public abstract void addChildren(PlanNode child);
+
   public abstract PlanNode clone();
 
   public abstract PlanNode cloneWithChildren(List<PlanNode> children);
@@ -48,4 +51,6 @@ public abstract class PlanNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitPlan(this, context);
   }
+
+  public abstract void serialize(ByteBuffer byteBuffer);
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/PlanNodeType.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/PlanNodeType.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.mpp.sql.planner.plan.node;
+
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.metedata.read.ShowDevicesNode;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.metedata.write.CreateTimeSeriesNode;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.process.*;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.sink.FragmentSinkNode;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.source.SeriesAggregateScanNode;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.source.SeriesScanNode;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.write.*;
+
+import java.nio.ByteBuffer;
+
+public enum PlanNodeType {
+  AGGREGATE((short) 0),
+  DEVICE_MERGE((short) 1),
+  FILL((short) 2),
+  FILTER((short) 3),
+  FILTER_NULL((short) 4),
+  GROUP_BY_LEVEL((short) 5),
+  LIMIT((short) 6),
+  OFFSET((short) 7),
+  SORT((short) 8),
+  TIME_JOIN((short) 9),
+  FRAGMENT_SINK((short) 10),
+  SERIES_SCAN((short) 11),
+  SERIES_AGGREGATE_SCAN((short) 12),
+  INSERT_TABLET((short) 13),
+  INSERT_ROW((short) 14),
+  INSERT_ROWS((short) 15),
+  INSERT_ROWS_OF_ONE_DEVICE((short) 16),
+  INSERT_MULTI_TABLET((short) 17),
+  SHOW_DEVICES((short) 18),
+  CREATE_TIME_SERIES((short) 19),
+  EXCHANGE((short) 20);
+
+  private final short nodeType;
+
+  PlanNodeType(short nodeType) {
+    this.nodeType = nodeType;
+  }
+
+  public void serialize(ByteBuffer buffer) {
+    buffer.putShort(nodeType);
+  }
+
+  public static PlanNode deserialize(ByteBuffer buffer) {
+    short nodeType = buffer.getShort();
+    switch (nodeType) {
+      case 0:
+        return AggregateNode.deserialize(buffer);
+      case 1:
+        return DeviceMergeNode.deserialize(buffer);
+      case 2:
+        return FillNode.deserialize(buffer);
+      case 3:
+        return FilterNode.deserialize(buffer);
+      case 4:
+        return FilterNullNode.deserialize(buffer);
+      case 5:
+        return GroupByLevelNode.deserialize(buffer);
+      case 6:
+        return LimitNode.deserialize(buffer);
+      case 7:
+        return OffsetNode.deserialize(buffer);
+      case 8:
+        return SortNode.deserialize(buffer);
+      case 9:
+        return TimeJoinNode.deserialize(buffer);
+      case 10:
+        return FragmentSinkNode.deserialize(buffer);
+      case 11:
+        return SeriesScanNode.deserialize(buffer);
+      case 12:
+        return SeriesAggregateScanNode.deserialize(buffer);
+      case 13:
+        return InsertTabletNode.deserialize(buffer);
+      case 14:
+        return InsertRowNode.deserialize(buffer);
+      case 15:
+        return InsertRowsNode.deserialize(buffer);
+      case 16:
+        return InsertRowsOfOneDeviceNode.deserialize(buffer);
+      case 17:
+        return InsertMultiTabletNode.deserialize(buffer);
+      case 18:
+        return ShowDevicesNode.deserialize(buffer);
+      case 19:
+        return CreateTimeSeriesNode.deserialize(buffer);
+      case 20:
+        return ExchangeNode.deserialize(buffer);
+      default:
+        throw new IllegalArgumentException("Invalid node type: " + nodeType);
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/read/ShowDevicesNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/read/ShowDevicesNode.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.mpp.sql.planner.plan.node.metedata.read;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class ShowDevicesNode extends ShowNode {
@@ -33,6 +34,9 @@ public class ShowDevicesNode extends ShowNode {
   public List<PlanNode> getChildren() {
     return null;
   }
+
+  @Override
+  public void addChildren(PlanNode child) {}
 
   @Override
   public PlanNode clone() {
@@ -48,4 +52,11 @@ public class ShowDevicesNode extends ShowNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static ShowDevicesNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/read/ShowNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/read/ShowNode.java
@@ -21,9 +21,14 @@ package org.apache.iotdb.db.mpp.sql.planner.plan.node.metedata.read;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 
+import java.nio.ByteBuffer;
+
 public abstract class ShowNode extends PlanNode {
 
   protected ShowNode(PlanNodeId id) {
     super(id);
   }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/write/CreateTimeSeriesNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/write/CreateTimeSeriesNode.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -143,6 +144,9 @@ public class CreateTimeSeriesNode extends PlanNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -156,4 +160,11 @@ public class CreateTimeSeriesNode extends PlanNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static CreateTimeSeriesNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/AggregateNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/AggregateNode.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanVisitor;
 import org.apache.iotdb.db.query.expression.unary.FunctionExpression;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
@@ -63,6 +64,9 @@ public class AggregateNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -81,4 +85,11 @@ public class AggregateNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitRowBasedSeriesAggregate(this, context);
   }
+
+  public static AggregateNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/DeviceMergeNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/DeviceMergeNode.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanVisitor;
 import org.apache.iotdb.db.mpp.sql.statement.component.OrderBy;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
@@ -64,6 +65,9 @@ public class DeviceMergeNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -82,6 +86,13 @@ public class DeviceMergeNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitDeviceMerge(this, context);
   }
+
+  public static DeviceMergeNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public DeviceMergeNode(PlanNodeId id, Map<String, PlanNode> deviceNodeMap) {
     this(id);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/ExchangeNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/ExchangeNode.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.service.rpc.thrift.EndPoint;
 
 import com.google.common.collect.ImmutableList;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class ExchangeNode extends PlanNode {
@@ -51,6 +52,9 @@ public class ExchangeNode extends PlanNode {
     }
     return ImmutableList.of(child);
   }
+
+  @Override
+  public void addChildren(PlanNode child) {}
 
   @Override
   public PlanNode clone() {
@@ -80,6 +84,13 @@ public class ExchangeNode extends PlanNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static ExchangeNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public PlanNode getChild() {
     return child;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/FillNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/FillNode.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanVisitor;
 
 import com.google.common.collect.ImmutableList;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /** FillNode is used to fill the empty field in one row. */
@@ -45,6 +46,9 @@ public class FillNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -63,6 +67,13 @@ public class FillNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitFill(this, context);
   }
+
+  public static FillNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public FillNode(PlanNodeId id, FillPolicy fillPolicy) {
     this(id);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/FilterNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/FilterNode.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.qp.logical.crud.FilterOperator;
 
 import com.google.common.collect.ImmutableList;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /** The FilterNode is responsible to filter the RowRecord from TsBlock. */
@@ -47,6 +48,9 @@ public class FilterNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -65,6 +69,13 @@ public class FilterNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitFilter(this, context);
   }
+
+  public static FilterNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public FilterOperator getPredicate() {
     return predicate;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/FilterNullNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/FilterNullNode.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanVisitor;
 
 import com.google.common.collect.ImmutableList;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /** WithoutNode is used to discard specific rows from upstream node. */
@@ -54,6 +55,9 @@ public class FilterNullNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -72,6 +76,13 @@ public class FilterNullNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitFilterNull(this, context);
   }
+
+  public static FilterNullNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public void setFilterNullColumnNames(List<String> filterNullColumnNames) {
     this.filterNullColumnNames = filterNullColumnNames;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/GroupByLevelNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/GroupByLevelNode.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanVisitor;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
@@ -56,6 +57,9 @@ public class GroupByLevelNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -74,6 +78,13 @@ public class GroupByLevelNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitGroupByLevel(this, context);
   }
+
+  public static GroupByLevelNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public int[] getGroupByLevels() {
     return groupByLevels;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/LimitNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/LimitNode.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanVisitor;
 
 import com.google.common.collect.ImmutableList;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /** LimitNode is used to select top n result. It uses the default order of upstream nodes */
@@ -50,6 +51,9 @@ public class LimitNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return new LimitNode(PlanNodeIdAllocator.generateId(), this.limit);
   }
@@ -70,6 +74,13 @@ public class LimitNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitLimit(this, context);
   }
+
+  public static LimitNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public int getLimit() {
     return limit;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/OffsetNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/OffsetNode.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanVisitor;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
@@ -46,6 +47,9 @@ public class OffsetNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -64,6 +68,13 @@ public class OffsetNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitOffset(this, context);
   }
+
+  public static OffsetNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public PlanNode getChild() {
     return child;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/SortNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/SortNode.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.mpp.sql.statement.component.OrderBy;
 
 import com.google.common.collect.ImmutableList;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
@@ -52,6 +53,9 @@ public class SortNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -70,4 +74,11 @@ public class SortNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitSort(this, context);
   }
+
+  public static SortNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/TimeJoinNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/TimeJoinNode.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeIdAllocator;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanVisitor;
 import org.apache.iotdb.db.mpp.sql.statement.component.OrderBy;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -70,6 +71,9 @@ public class TimeJoinNode extends ProcessNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return new TimeJoinNode(
         PlanNodeIdAllocator.generateId(), this.mergeOrder, this.filterNullPolicy);
@@ -93,6 +97,13 @@ public class TimeJoinNode extends ProcessNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitTimeJoin(this, context);
   }
+
+  public static TimeJoinNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public void addChild(PlanNode child) {
     this.children.add(child);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/sink/CsvSinkNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/sink/CsvSinkNode.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.mpp.sql.planner.plan.node.sink;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class CsvSinkNode extends SinkNode {
@@ -32,6 +33,9 @@ public class CsvSinkNode extends SinkNode {
   public List<PlanNode> getChildren() {
     return null;
   }
+
+  @Override
+  public void addChildren(PlanNode child) {}
 
   @Override
   public PlanNode clone() {
@@ -47,6 +51,13 @@ public class CsvSinkNode extends SinkNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static CsvSinkNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   @Override
   public void close() throws Exception {}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/sink/FragmentSinkNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/sink/FragmentSinkNode.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.service.rpc.thrift.EndPoint;
 
 import com.google.common.collect.ImmutableList;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class FragmentSinkNode extends SinkNode {
@@ -46,6 +47,9 @@ public class FragmentSinkNode extends SinkNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -59,6 +63,13 @@ public class FragmentSinkNode extends SinkNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static FragmentSinkNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   @Override
   public void send() {}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/sink/ThriftSinkNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/sink/ThriftSinkNode.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.mpp.sql.planner.plan.node.sink;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /** not implemented in current IoTDB yet */
@@ -36,6 +37,9 @@ public class ThriftSinkNode extends SinkNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -49,6 +53,13 @@ public class ThriftSinkNode extends SinkNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static ThriftSinkNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   @Override
   public void close() throws Exception {}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/source/CsvSourceNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/source/CsvSourceNode.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.commons.partition.DataRegionReplicaSet;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /** Not implemented in current version. */
@@ -37,6 +38,9 @@ public class CsvSourceNode extends SourceNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -50,6 +54,13 @@ public class CsvSourceNode extends SourceNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static CsvSourceNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   @Override
   public void close() throws Exception {}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/source/SeriesAggregateScanNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/source/SeriesAggregateScanNode.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 
 import com.google.common.collect.ImmutableList;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
@@ -71,6 +72,9 @@ public class SeriesAggregateScanNode extends SourceNode {
   public List<PlanNode> getChildren() {
     return ImmutableList.of();
   }
+
+  @Override
+  public void addChildren(PlanNode child) {}
 
   @Override
   public PlanNode clone() {
@@ -118,6 +122,13 @@ public class SeriesAggregateScanNode extends SourceNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitSeriesAggregate(this, context);
   }
+
+  public static SeriesAggregateScanNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   // This method is used when do the PredicatePushDown.
   // The filter is not put in the constructor because the filter is only clear in the predicate

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/source/SeriesScanNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/source/SeriesScanNode.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 
 import com.google.common.collect.ImmutableList;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
@@ -116,6 +117,9 @@ public class SeriesScanNode extends SourceNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return new SeriesScanNode(getId(), getSeriesPath(), this.dataRegionReplicaSet);
   }
@@ -134,6 +138,13 @@ public class SeriesScanNode extends SourceNode {
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
     return visitor.visitSeriesScan(this, context);
   }
+
+  public static SeriesScanNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   public PartialPath getSeriesPath() {
     return seriesPath;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertMultiTabletNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertMultiTabletNode.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.mpp.sql.analyze.Analysis;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class InsertMultiTabletNode extends InsertNode {
@@ -41,6 +42,9 @@ public class InsertMultiTabletNode extends InsertNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -54,4 +58,11 @@ public class InsertMultiTabletNode extends InsertNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static InsertMultiTabletNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertNode.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public abstract class InsertNode extends PlanNode {
@@ -59,4 +60,7 @@ public abstract class InsertNode extends PlanNode {
   public boolean needSplit() {
     return true;
   }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertRowNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertRowNode.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.mpp.sql.analyze.Analysis;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class InsertRowNode extends InsertNode {
@@ -41,6 +42,9 @@ public class InsertRowNode extends InsertNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -54,6 +58,13 @@ public class InsertRowNode extends InsertNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static InsertRowNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   @Override
   public boolean needSplit() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertRowsNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertRowsNode.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.mpp.sql.analyze.Analysis;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class InsertRowsNode extends InsertNode {
@@ -34,6 +35,9 @@ public class InsertRowsNode extends InsertNode {
   public List<PlanNode> getChildren() {
     return null;
   }
+
+  @Override
+  public void addChildren(PlanNode child) {}
 
   @Override
   public PlanNode clone() {
@@ -49,6 +53,13 @@ public class InsertRowsNode extends InsertNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static InsertRowsNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   @Override
   public List<InsertNode> splitByPartition(Analysis analysis) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.mpp.sql.analyze.Analysis;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class InsertRowsOfOneDeviceNode extends InsertNode {
@@ -34,6 +35,9 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
   public List<PlanNode> getChildren() {
     return null;
   }
+
+  @Override
+  public void addChildren(PlanNode child) {}
 
   @Override
   public PlanNode clone() {
@@ -49,6 +53,13 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static InsertRowsOfOneDeviceNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   @Override
   public List<InsertNode> splitByPartition(Analysis analysis) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertTabletNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/write/InsertTabletNode.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.tsfile.utils.BitMap;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class InsertTabletNode extends InsertNode {
@@ -55,6 +56,9 @@ public class InsertTabletNode extends InsertNode {
   }
 
   @Override
+  public void addChildren(PlanNode child) {}
+
+  @Override
   public PlanNode clone() {
     return null;
   }
@@ -68,6 +72,13 @@ public class InsertTabletNode extends InsertNode {
   public List<String> getOutputColumnNames() {
     return null;
   }
+
+  public static InsertTabletNode deserialize(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  @Override
+  public void serialize(ByteBuffer byteBuffer) {}
 
   @Override
   public List<InsertNode> splitByPartition(Analysis analysis) {


### PR DESCRIPTION
1. Change `PhysicalPlan` to `FragmentInstance` in BaseStatementMachine and make `FragmentInstnace` implements `IConsensusRequest`
2. define serialize and deserialize methods in each PlanNode
3. define PlanNodeType to use a `short`to represent a PlanNode
4. implement a recursive DFS deserialize methods in PlanFragment.