### PR TITLE
[To rel/0.12] [IOTDB-2773] Fix overlapped data should be consumed first bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReader.java
@@ -526,35 +526,36 @@ public class SeriesReader {
     if (CONFIG.isEnablePerformanceTracing()) {
       addTotalPageNumInTracing(pageReaderList.size());
     }
-    pageReaderList.forEach(
-        pageReader -> {
-          if (chunkMetaData.isSeq()) {
-            // addLast for asc; addFirst for desc
-            if (orderUtils.getAscending()) {
-              seqPageReaders.add(
+    if (chunkMetaData.isSeq()) {
+      if (orderUtils.getAscending()) {
+        for (IPageReader iPageReader : pageReaderList) {
+          seqPageReaders.add(
+              new VersionPageReader(
+                  chunkMetaData.getVersion(),
+                  chunkMetaData.getOffsetOfChunkHeader(),
+                  iPageReader,
+                  true));
+        }
+      } else {
+        for (int i = pageReaderList.size() - 1; i >= 0; i--) {
+          seqPageReaders.add(
+              new VersionPageReader(
+                  chunkMetaData.getVersion(),
+                  chunkMetaData.getOffsetOfChunkHeader(),
+                  pageReaderList.get(i),
+                  true));
+        }
+      }
+    } else {
+      pageReaderList.forEach(
+          pageReader ->
+              unSeqPageReaders.add(
                   new VersionPageReader(
                       chunkMetaData.getVersion(),
                       chunkMetaData.getOffsetOfChunkHeader(),
                       pageReader,
-                      true));
-            } else {
-              seqPageReaders.add(
-                  0,
-                  new VersionPageReader(
-                      chunkMetaData.getVersion(),
-                      chunkMetaData.getOffsetOfChunkHeader(),
-                      pageReader,
-                      true));
-            }
-          } else {
-            unSeqPageReaders.add(
-                new VersionPageReader(
-                    chunkMetaData.getVersion(),
-                    chunkMetaData.getOffsetOfChunkHeader(),
-                    pageReader,
-                    false));
-          }
-        });
+                      false)));
+    }
   }
 
   private void addTotalPageNumInTracing(int pageNum) {


### PR DESCRIPTION
`max_time` aggregation query will use desc read order to accelerate. But there exist a bug in SeriesReader while using desc order. In `unpackOneChunkMetaData` function of `SeriesReader`, we iterate all page readers of this chunk in asc order and add them into `seqPageReaders`'s tail while in asc order reader, however, we will also iterate page readers of this chunk in asc order and add them into `seqPageReaders`'s head while in desc order reader which is incorrect. 

For example, if we have chunkA which contains two pages(pageA-1 which has two time point [1, 2], pageA-2 which has two time point[3, 4]) and another chunkB which contains two pages(pageB-1 which has two time point [5, 6], pageA-2 which has two time point[7, 8]), if in desc order reader, we want them in `seqPageReaders` in this order([7, 8], [5, 6], [3, 4], [1, 2]), but now they are in that order([3, 4], [1, 2], [7, 8], [5, 6]).

The correct thing we need to do is to iterate page readers of this chunk in desc order and add them into `seqPageReaders`'s tail while in desc order reader.