### PR TITLE
Ratis Consensus Impl Bug Fix

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RequestMessage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RequestMessage.java
@@ -27,7 +27,7 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 public class RequestMessage implements Message {
 
   private final IConsensusRequest actualRequest;
-  private ByteString serializedContent;
+  private volatile ByteString serializedContent;
 
   public RequestMessage(IConsensusRequest request) {
     this.actualRequest = request;
@@ -41,10 +41,14 @@ public class RequestMessage implements Message {
   @Override
   public ByteString getContent() {
     if (serializedContent == null) {
-      assert actualRequest instanceof ByteBufferConsensusRequest;
-      ByteBufferConsensusRequest req = (ByteBufferConsensusRequest) actualRequest;
-      serializedContent = ByteString.copyFrom(req.getContent());
-      req.getContent().flip(); // so that it can be read from other sources
+      synchronized (this) {
+        if (serializedContent == null) {
+           assert actualRequest instanceof ByteBufferConsensusRequest;
+          ByteBufferConsensusRequest req = (ByteBufferConsensusRequest) actualRequest;
+          serializedContent = ByteString.copyFrom(req.getContent());
+          req.getContent().flip(); // so that it can be read from other sources
+        }
+      }
     }
     return serializedContent;
   }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RequestMessage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RequestMessage.java
@@ -43,7 +43,7 @@ public class RequestMessage implements Message {
     if (serializedContent == null) {
       synchronized (this) {
         if (serializedContent == null) {
-           assert actualRequest instanceof ByteBufferConsensusRequest;
+          assert actualRequest instanceof ByteBufferConsensusRequest;
           ByteBufferConsensusRequest req = (ByteBufferConsensusRequest) actualRequest;
           serializedContent = ByteString.copyFrom(req.getContent());
           req.getContent().flip(); // so that it can be read from other sources

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ResponseMessage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ResponseMessage.java
@@ -51,7 +51,7 @@ public class ResponseMessage implements Message {
     if (serializedData == null) {
       synchronized (this) {
         if (serializedData == null) {
-           assert contentHolder instanceof TSStatus;
+          assert contentHolder instanceof TSStatus;
           TSStatus status = (TSStatus) contentHolder;
           try {
             serializedData = ByteString.copyFrom(Utils.serializeTSStatus(status));

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ResponseMessage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ResponseMessage.java
@@ -34,7 +34,7 @@ public class ResponseMessage implements Message {
    */
   private final Object contentHolder;
 
-  private ByteString serializedData;
+  private volatile ByteString serializedData;
   private final Logger logger = LoggerFactory.getLogger(ResponseMessage.class);
 
   public ResponseMessage(Object content) {
@@ -49,12 +49,16 @@ public class ResponseMessage implements Message {
   @Override
   public ByteString getContent() {
     if (serializedData == null) {
-      assert contentHolder instanceof TSStatus;
-      TSStatus status = (TSStatus) contentHolder;
-      try {
-        serializedData = ByteString.copyFrom(Utils.serializeTSStatus(status));
-      } catch (TException e) {
-        logger.warn("serialize TSStatus failed {}", status);
+      synchronized (this) {
+        if (serializedData == null) {
+           assert contentHolder instanceof TSStatus;
+          TSStatus status = (TSStatus) contentHolder;
+          try {
+            serializedData = ByteString.copyFrom(Utils.serializeTSStatus(status));
+          } catch (TException e) {
+            logger.warn("serialize TSStatus failed {}", status);
+          }
+        }
       }
     }
     return serializedData;

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
@@ -50,9 +50,21 @@ public class Utils {
     // use abbreviations to prevent overflow
     String groupTypeAbbr = null;
     switch (consensusGroupId.getType()) {
-      case DataRegion: {groupTypeAbbr = DataRegionAbbr; break;}
-      case SchemaRegion: {groupTypeAbbr = SchemaRegionAbbr; break;}
-      case PartitionRegion: {groupTypeAbbr = PartitionRegionAbbr; break;}
+      case DataRegion:
+        {
+          groupTypeAbbr = DataRegionAbbr;
+          break;
+        }
+      case SchemaRegion:
+        {
+          groupTypeAbbr = SchemaRegionAbbr;
+          break;
+        }
+      case PartitionRegion:
+        {
+          groupTypeAbbr = PartitionRegionAbbr;
+          break;
+        }
     }
     return String.format("%s-%d", groupTypeAbbr, consensusGroupId.getId());
   }
@@ -95,9 +107,21 @@ public class Utils {
     String[] items = consensusGroupString.split("-");
     GroupType groupType = null;
     switch (items[0]) {
-      case DataRegionAbbr: {groupType = GroupType.DataRegion; break;}
-      case PartitionRegionAbbr: {groupType = GroupType.PartitionRegion; break;}
-      case SchemaRegionAbbr: {groupType = GroupType.SchemaRegion; break;}
+      case DataRegionAbbr:
+        {
+          groupType = GroupType.DataRegion;
+          break;
+        }
+      case PartitionRegionAbbr:
+        {
+          groupType = GroupType.PartitionRegion;
+          break;
+        }
+      case SchemaRegionAbbr:
+        {
+          groupType = GroupType.SchemaRegion;
+          break;
+        }
     }
     return new ConsensusGroupId(groupType, Long.parseLong(items[1]));
   }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/UtilsTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/UtilsTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class UtilsTest {
   @Test
   public void testEncryption() {
-    ConsensusGroupId raw = new ConsensusGroupId(GroupType.DataRegion, 1L);
+    ConsensusGroupId raw = new ConsensusGroupId(GroupType.PartitionRegion, 100L);
     RaftGroupId id = Utils.toRatisGroupId(raw);
     ConsensusGroupId cgid = Utils.toConsensusGroupId(id);
     Assert.assertEquals(raw, cgid);


### PR DESCRIPTION
## Description
In this PR, I fix two bugs:
1. Add volatile & synchronize to Response and Request to prevent parallel serialization race condition.
2. Use abbreviations to name Ratis Group, in case of the group-name length overflows
