### PR TITLE
 Fix NoClassDefFound CI error

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/mpp/operator/LimitOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/operator/LimitOperatorTest.java
@@ -133,7 +133,6 @@ public class LimitOperatorTest {
           new LimitOperator(
               fragmentInstanceContext.getOperatorContexts().get(3), 250, timeJoinOperator);
       int count = 0;
-      System.out.println("Time\tsensor0\tsensor1");
       while (limitOperator.hasNext()) {
         TsBlock tsBlock = limitOperator.next();
         assertEquals(2, tsBlock.getValueColumnCount());
@@ -146,12 +145,6 @@ public class LimitOperatorTest {
         }
         for (int i = 0; i < tsBlock.getPositionCount(); i++) {
           long expectedTime = i + 20L * count;
-          System.out.println(
-              expectedTime
-                  + " \t "
-                  + tsBlock.getColumn(0).getInt(i)
-                  + " \t "
-                  + tsBlock.getColumn(1).getInt(i));
           assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
           if (expectedTime < 200) {
             assertEquals(20000 + expectedTime, tsBlock.getColumn(0).getInt(i));

--- a/server/src/test/java/org/apache/iotdb/db/mpp/operator/LimitOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/operator/LimitOperatorTest.java
@@ -133,6 +133,7 @@ public class LimitOperatorTest {
           new LimitOperator(
               fragmentInstanceContext.getOperatorContexts().get(3), 250, timeJoinOperator);
       int count = 0;
+      System.out.println("Time\tsensor0\tsensor1");
       while (limitOperator.hasNext()) {
         TsBlock tsBlock = limitOperator.next();
         assertEquals(2, tsBlock.getValueColumnCount());
@@ -145,6 +146,12 @@ public class LimitOperatorTest {
         }
         for (int i = 0; i < tsBlock.getPositionCount(); i++) {
           long expectedTime = i + 20L * count;
+          System.out.println(
+              expectedTime
+                  + " \t "
+                  + tsBlock.getColumn(0).getInt(i)
+                  + " \t "
+                  + tsBlock.getColumn(1).getInt(i));
           assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
           if (expectedTime < 200) {
             assertEquals(20000 + expectedTime, tsBlock.getColumn(0).getInt(i));

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnBuilderStatus.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnBuilderStatus.java
@@ -24,6 +24,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -59,6 +60,8 @@ public class ColumnBuilderStatus {
    * Computes the size of an instance of this class assuming that all reference fields are non-null
    */
   private static int deepInstanceSize(Class<?> clazz) {
+    System.out.println("class name: " + clazz.getSimpleName());
+    System.out.println("class fields: " + Arrays.toString(clazz.getDeclaredFields()));
     if (clazz.isArray()) {
       throw new IllegalArgumentException(
           format(

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnBuilderStatus.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnBuilderStatus.java
@@ -24,7 +24,6 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -60,8 +59,6 @@ public class ColumnBuilderStatus {
    * Computes the size of an instance of this class assuming that all reference fields are non-null
    */
   private static int deepInstanceSize(Class<?> clazz) {
-    System.out.println("class name: " + clazz.getSimpleName());
-    System.out.println("class fields: " + Arrays.toString(clazz.getDeclaredFields()));
     if (clazz.isArray()) {
       throw new IllegalArgumentException(
           format(
@@ -82,7 +79,10 @@ public class ColumnBuilderStatus {
 
     int size = ClassLayout.parseClass(clazz).instanceSize();
     for (Field field : clazz.getDeclaredFields()) {
-      if (!field.getType().isPrimitive()) {
+      // if the field is not static and is a reference field and it's not synthetic
+      if (!Modifier.isStatic(field.getModifiers())
+          && !field.getType().isPrimitive()
+          && !field.isSynthetic()) {
         size += deepInstanceSize(field.getType());
       }
     }


### PR DESCRIPTION
`jacoco` in `maven` which is used to calculate code coverage will add some synthetic fields in class, you can see in the following picture:
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/16079446/160585884-2d605d6c-a4c0-4041-8d2c-c56830d19f0d.png">
the last two fields: boolean[] and `$jacocoData` is not defined in my class, so when I iterate the fields in this class using `Class<?>.getDeclaredFields()` method, we will get this unexpected one.