### PR TITLE
Add isLeaderOf to Consensus

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -56,4 +56,6 @@ public interface IConsensus {
   ConsensusGenericResponse transferLeader(ConsensusGroupId groupId, Peer newLeader);
 
   ConsensusGenericResponse triggerSnapshot(ConsensusGroupId groupId);
+
+  boolean isLeaderOf(ConsensusGroupId groupId);
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -57,5 +57,5 @@ public interface IConsensus {
 
   ConsensusGenericResponse triggerSnapshot(ConsensusGroupId groupId);
 
-  boolean isLeaderOf(ConsensusGroupId groupId);
+  boolean isLeader(ConsensusGroupId groupId);
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -440,7 +440,7 @@ public class RatisConsensus implements IConsensus {
   }
 
   @Override
-  public boolean isLeaderOf(ConsensusGroupId groupId) {
+  public boolean isLeader(ConsensusGroupId groupId) {
     RaftGroupId raftGroupId = Utils.toRatisGroupId(groupId);
 
     boolean isLeader;
@@ -448,6 +448,7 @@ public class RatisConsensus implements IConsensus {
       isLeader = server.getDivision(raftGroupId).getInfo().isLeader();
     } catch (IOException exception) {
       // if the query fails, simply return not leader
+      logger.warn("isLeader request failed with exception: ", exception);
       isLeader = false;
     }
     return isLeader;
@@ -525,7 +526,7 @@ public class RatisConsensus implements IConsensus {
     this.localFakeCallId = new AtomicLong(0);
 
     // create a RaftPeer as endpoint of comm
-    String address = Utils.IP_PORT(endpoint);
+    String address = Utils.IPAddress(endpoint);
     myself = Utils.toRaftPeer(endpoint, DEFAULT_PRIORITY);
 
     RaftProperties properties = new RaftProperties();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
@@ -42,7 +42,7 @@ public class Utils {
   private static final String SchemaRegionAbbr = "SR";
   private static final String PartitionRegionAbbr = "PR";
 
-  public static String IP_PORT(Endpoint endpoint) {
+  public static String IPAddress(Endpoint endpoint) {
     return String.format("%s:%d", endpoint.getIp(), endpoint.getPort());
   }
 
@@ -74,7 +74,7 @@ public class Utils {
     String Id = String.format("%s-%d", endpoint.getIp(), endpoint.getPort());
     return RaftPeer.newBuilder()
         .setId(Id)
-        .setAddress(IP_PORT(endpoint))
+        .setAddress(IPAddress(endpoint))
         .setPriority(priority)
         .build();
   }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
@@ -69,13 +69,18 @@ public class Utils {
     return String.format("%s-%d", groupTypeAbbr, consensusGroupId.getId());
   }
 
-  public static RaftPeer toRaftPeer(Endpoint endpoint) {
+  // priority is used as ordinal of leader election
+  public static RaftPeer toRaftPeer(Endpoint endpoint, int priority) {
     String Id = String.format("%s-%d", endpoint.getIp(), endpoint.getPort());
-    return RaftPeer.newBuilder().setId(Id).setAddress(IP_PORT(endpoint)).build();
+    return RaftPeer.newBuilder()
+        .setId(Id)
+        .setAddress(IP_PORT(endpoint))
+        .setPriority(priority)
+        .build();
   }
 
-  public static RaftPeer toRaftPeer(Peer peer) {
-    return toRaftPeer(peer.getEndpoint());
+  public static RaftPeer toRaftPeer(Peer peer, int priority) {
+    return toRaftPeer(peer.getEndpoint(), priority);
   }
 
   public static Endpoint getEndPoint(RaftPeer raftPeer) {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
@@ -168,4 +168,9 @@ public class StandAloneConsensus implements IConsensus {
   public ConsensusGenericResponse triggerSnapshot(ConsensusGroupId groupId) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }
+
+  @Override
+  public boolean isLeaderOf(ConsensusGroupId groupId) {
+    return false;
+  }
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
@@ -170,7 +170,7 @@ public class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public boolean isLeaderOf(ConsensusGroupId groupId) {
-    return false;
+  public boolean isLeader(ConsensusGroupId groupId) {
+    return true;
   }
 }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -165,7 +165,9 @@ public class RatisConsensusTest {
     doConsensus(servers.get(0), group.getGroupId(), 10, 10);
 
     // 6. Remove two Peers from Group (peer 0 and peer 2)
+    // transfer the leader to peer1
     servers.get(0).transferLeader(gid, peer1);
+    Assert.assertTrue(servers.get(1).isLeaderOf(gid));
     // first use removePeer to inform the group leader of configuration change
     servers.get(1).removePeer(gid, peer0);
     servers.get(1).removePeer(gid, peer2);

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -167,7 +167,7 @@ public class RatisConsensusTest {
     // 6. Remove two Peers from Group (peer 0 and peer 2)
     // transfer the leader to peer1
     servers.get(0).transferLeader(gid, peer1);
-    Assert.assertTrue(servers.get(1).isLeaderOf(gid));
+    Assert.assertTrue(servers.get(1).isLeader(gid));
     // first use removePeer to inform the group leader of configuration change
     servers.get(1).removePeer(gid, peer0);
     servers.get(1).removePeer(gid, peer2);


### PR DESCRIPTION
## Description
In this PR, I add a new interface method `isLeaderOf` to IConsensus to determine whether current peer is the leader of a given consensus group.
Also, I fixed a bug related to previous transferLeader method

## Details
Ratis assign every peer a default priority 0. When transferring leadership, it won't allow any peer with (peer.priority <= currentLeader.priority) to become the new leader. Thus before call transferLeader, we should first upgrade newLeader's priority and degrade every others.
