### PR TITLE
[IOTDB-2826]Unmark storage group among templates when deleted

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigManager.java
@@ -243,6 +243,10 @@ public class LocalConfigManager {
     deleteSchemaRegionsInStorageGroup(
         storageGroup, partitionTable.deleteStorageGroup(storageGroup));
 
+    for (Template template : templateManager.getTemplateMap().values()) {
+      templateManager.unmarkStorageGroup(template, storageGroup.getFullPath());
+    }
+
     if (!config.isEnableMemControl()) {
       MemTableManager.getInstance().addOrDeleteStorageGroup(-1);
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
@@ -438,6 +438,10 @@ public class Template {
     }
   }
 
+  public void unmarkStorageGroup(String storageGroup) {
+    relatedSchemaRegion.remove(storageGroup);
+  }
+
   // endregion
 
   // region inner utils

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/TemplateManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/TemplateManager.java
@@ -330,6 +330,13 @@ public class TemplateManager {
     template.unmarkSchemaRegion(storageGroup, schemaRegionId);
   }
 
+  public void unmarkStorageGroup(Template template, String storageGroup) {
+    synchronized (templateUsageInStorageGroup) {
+      templateUsageInStorageGroup.remove(storageGroup);
+    }
+    template.unmarkStorageGroup(storageGroup);
+  }
+
   public void forceLog() {
     try {
       logWriter.force();

--- a/server/src/test/java/org/apache/iotdb/db/metadata/TemplateTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/TemplateTest.java
@@ -422,6 +422,24 @@ public class TemplateTest {
   }
 
   @Test
+  public void testDropTemplateWithStorageGroupDeleted() throws MetadataException {
+    LocalSchemaProcessor schemaProcessor = IoTDB.schemaProcessor;
+    schemaProcessor.createSchemaTemplate(getTreeTemplatePlan());
+    schemaProcessor.setSchemaTemplate(new SetTemplatePlan("treeTemplate", "root.sg1.d1"));
+    try {
+      schemaProcessor.dropSchemaTemplate(new DropTemplatePlan("treeTemplate"));
+      fail();
+    } catch (MetadataException e) {
+      assertEquals(
+          "Template [treeTemplate] has been set on MTree, cannot be dropped now.", e.getMessage());
+    }
+
+    schemaProcessor.deleteStorageGroups(Arrays.asList(new PartialPath("root.sg1")));
+    schemaProcessor.dropSchemaTemplate(new DropTemplatePlan("treeTemplate"));
+    assertEquals(0, schemaProcessor.getAllTemplates().size());
+  }
+
+  @Test
   public void testTemplateAlignment() throws MetadataException {
     LocalSchemaProcessor schemaProcessor = IoTDB.schemaProcessor;
     schemaProcessor.createTimeseries(


### PR DESCRIPTION
In Template, we mark which storage group this template is set, this is act as a cache to accelerate related traverse.
When a storage group is deleted, we need to discard this cache in related templates.