### PR TITLE
[IOTDB-2828] Update iotdb_version after upgrading finished

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
@@ -267,6 +267,7 @@ public class IoTDBConfigCheck {
               properties.setProperty(k, v);
             }
           });
+      properties.setProperty(IOTDB_VERSION_STRING, IoTDBConstant.VERSION);
       properties.store(tmpFOS, SYSTEM_PROPERTIES_STRING);
 
       // upgrade finished, delete old system.properties file
@@ -295,7 +296,7 @@ public class IoTDBConfigCheck {
               properties.setProperty(k, v);
             }
           });
-
+      properties.setProperty(IOTDB_VERSION_STRING, IoTDBConstant.VERSION);
       properties.store(tmpFOS, SYSTEM_PROPERTIES_STRING);
       // upgrade finished, delete old system.properties file
       if (propertiesFile.exists()) {


### PR DESCRIPTION
Currently after upgrading from 0.12 or 0.13 to newest version, the system.properties file is updated, but the `iotdb_version` still remains the same. It may cause the future upgrading incorrectly.