### PR TITLE
[IOTDB-2825] Fix count node by level

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/versionadaption/IoTDBDDLVersionAdaptionIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/versionadaption/IoTDBDDLVersionAdaptionIT.java
@@ -275,7 +275,7 @@ public class IoTDBDDLVersionAdaptionIT {
           "COUNT NODES root.ln.wf01 level=1",
           "COUNT NODES root.ln.wf01 level=2",
           "COUNT NODES root.ln.wf01 level=3",
-          "COUNT NODES root.ln.wf01 level=4"
+          "COUNT NODES root.ln.wf01.wt01 level=4"
         };
     Set<String>[] standards =
         new Set[] {
@@ -285,7 +285,7 @@ public class IoTDBDDLVersionAdaptionIT {
           new HashSet<>(Collections.singletonList("1,")),
           new HashSet<>(Collections.singletonList("1,")),
           new HashSet<>(Collections.singletonList("2,")),
-          new HashSet<>(Collections.singletonList("4,"))
+          new HashSet<>(Collections.singletonList("2,"))
         };
     executeAndCheckResult(sqls, standards);
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigManager.java
@@ -424,25 +424,24 @@ public class LocalConfigManager {
   }
 
   /**
-   * To calculate the count of nodes in the given level for given path pattern. If using prefix
-   * match, the path pattern is used to match prefix path. All nodes start with the matched prefix
-   * path will be counted. This method only count in nodes above storage group. Nodes below storage
-   * group, including storage group node will be counted by certain Storage Group. The involved
-   * storage groups will be collected to count nodes below storage group.
+   * To collect nodes in the given level for given path pattern. If using prefix match, the path
+   * pattern is used to match prefix path. All nodes start with the matched prefix path will be
+   * collected. This method only count in nodes above storage group. Nodes below storage group,
+   * including storage group node will be collected by certain SchemaRegion. The involved storage
+   * groups will be collected to fetch schemaRegion.
    *
    * @param pathPattern a path pattern or a full path
-   * @param level the level should match the level of the path
+   * @param nodeLevel the level should match the level of the path
    * @param isPrefixMatch if true, the path pattern is used to match prefix path
    */
-  public Pair<Integer, Set<PartialPath>> getNodesCountInGivenLevel(
-      PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
-    return storageGroupSchemaManager.getNodesCountInGivenLevel(pathPattern, level, isPrefixMatch);
-  }
-
   public Pair<List<PartialPath>, Set<PartialPath>> getNodesListInGivenLevel(
-      PartialPath pathPattern, int nodeLevel, LocalSchemaProcessor.StorageGroupFilter filter)
+      PartialPath pathPattern,
+      int nodeLevel,
+      boolean isPrefixMatch,
+      LocalSchemaProcessor.StorageGroupFilter filter)
       throws MetadataException {
-    return storageGroupSchemaManager.getNodesListInGivenLevel(pathPattern, nodeLevel, filter);
+    return storageGroupSchemaManager.getNodesListInGivenLevel(
+        pathPattern, nodeLevel, isPrefixMatch, filter);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaProcessor.java
@@ -73,6 +73,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -496,15 +497,7 @@ public class LocalSchemaProcessor {
    */
   public int getNodesCountInGivenLevel(PartialPath pathPattern, int level, boolean isPrefixMatch)
       throws MetadataException {
-    Pair<Integer, Set<PartialPath>> pair =
-        configManager.getNodesCountInGivenLevel(pathPattern, level, isPrefixMatch);
-    int count = pair.left;
-    for (PartialPath storageGroup : pair.right) {
-      for (SchemaRegion schemaRegion : getInvolvedSchemaRegions(storageGroup, isPrefixMatch)) {
-        count += schemaRegion.getNodesCountInGivenLevel(pathPattern, level, isPrefixMatch);
-      }
-    }
-    return count;
+    return getNodesListInGivenLevel(pathPattern, level, isPrefixMatch).size();
   }
 
   /**
@@ -555,15 +548,27 @@ public class LocalSchemaProcessor {
 
   public List<PartialPath> getNodesListInGivenLevel(
       PartialPath pathPattern, int nodeLevel, StorageGroupFilter filter) throws MetadataException {
+    return getNodesListInGivenLevel(pathPattern, nodeLevel, false, filter);
+  }
+
+  private List<PartialPath> getNodesListInGivenLevel(
+      PartialPath pathPattern, int nodeLevel, boolean isPrefixMatch) throws MetadataException {
+    return getNodesListInGivenLevel(pathPattern, nodeLevel, isPrefixMatch, null);
+  }
+
+  private List<PartialPath> getNodesListInGivenLevel(
+      PartialPath pathPattern, int nodeLevel, boolean isPrefixMatch, StorageGroupFilter filter)
+      throws MetadataException {
     Pair<List<PartialPath>, Set<PartialPath>> pair =
-        configManager.getNodesListInGivenLevel(pathPattern, nodeLevel, filter);
-    List<PartialPath> result = pair.left;
+        configManager.getNodesListInGivenLevel(pathPattern, nodeLevel, isPrefixMatch, filter);
+    Set<PartialPath> result = new TreeSet<>(pair.left);
     for (PartialPath storageGroup : pair.right) {
       for (SchemaRegion schemaRegion : getSchemaRegionsByStorageGroup(storageGroup)) {
-        result.addAll(schemaRegion.getNodesListInGivenLevel(pathPattern, nodeLevel, filter));
+        result.addAll(
+            schemaRegion.getNodesListInGivenLevel(pathPattern, nodeLevel, isPrefixMatch, filter));
       }
     }
-    return result;
+    return new ArrayList<>(result);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
@@ -36,7 +36,6 @@ import org.apache.iotdb.db.metadata.mnode.StorageGroupMNode;
 import org.apache.iotdb.db.metadata.mtree.traverser.collector.MNodeAboveSGCollector;
 import org.apache.iotdb.db.metadata.mtree.traverser.collector.StorageGroupCollector;
 import org.apache.iotdb.db.metadata.mtree.traverser.counter.CounterTraverser;
-import org.apache.iotdb.db.metadata.mtree.traverser.counter.MNodeAboveSGLevelCounter;
 import org.apache.iotdb.db.metadata.mtree.traverser.counter.StorageGroupCounter;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.metadata.template.Template;
@@ -412,21 +411,14 @@ public class MTreeAboveSG {
   }
 
   /**
-   * Get the count of nodes in the given level matching the given path. If using prefix match, the
-   * path pattern is used to match prefix path. All timeseries start with the matched prefix path
-   * will be counted.
+   * Get all paths of nodes in the given level matching the given path. If using prefix match, the
+   * path pattern is used to match prefix path.
    */
-  public Pair<Integer, Set<PartialPath>> getNodesCountInGivenLevel(
-      PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
-    MNodeAboveSGLevelCounter counter = new MNodeAboveSGLevelCounter(root, pathPattern, level);
-    counter.setPrefixMatch(isPrefixMatch);
-    counter.traverse();
-    return new Pair<>(counter.getCount(), counter.getInvolvedStorageGroupMNodes());
-  }
-
-  /** Get all paths from root to the given level */
   public Pair<List<PartialPath>, Set<PartialPath>> getNodesListInGivenLevel(
-      PartialPath pathPattern, int nodeLevel, LocalSchemaProcessor.StorageGroupFilter filter)
+      PartialPath pathPattern,
+      int nodeLevel,
+      boolean isPrefixMatch,
+      LocalSchemaProcessor.StorageGroupFilter filter)
       throws MetadataException {
     MNodeAboveSGCollector<List<PartialPath>> collector =
         new MNodeAboveSGCollector<List<PartialPath>>(root, pathPattern) {
@@ -437,6 +429,7 @@ public class MTreeAboveSG {
         };
     collector.setResultSet(new LinkedList<>());
     collector.setTargetLevel(nodeLevel);
+    collector.setPrefixMatch(isPrefixMatch);
     collector.setStorageGroupFilter(filter);
     collector.traverse();
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSG.java
@@ -747,7 +747,8 @@ public class MTreeBelowSG implements Serializable {
 
   /** Get all paths from root to the given level */
   public List<PartialPath> getNodesListInGivenLevel(
-      PartialPath pathPattern, int nodeLevel, StorageGroupFilter filter) throws MetadataException {
+      PartialPath pathPattern, int nodeLevel, boolean isPrefixMatch, StorageGroupFilter filter)
+      throws MetadataException {
     MNodeCollector<List<PartialPath>> collector =
         new MNodeCollector<List<PartialPath>>(storageGroupMNode, pathPattern) {
           @Override
@@ -757,6 +758,7 @@ public class MTreeBelowSG implements Serializable {
         };
     collector.setResultSet(new LinkedList<>());
     collector.setTargetLevel(nodeLevel);
+    collector.setPrefixMatch(isPrefixMatch);
     collector.setStorageGroupFilter(filter);
     collector.traverse();
     return collector.getResult();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -78,8 +78,8 @@ public abstract class Traverser {
     }
     this.startNode = startNode;
     this.nodes = nodes;
-    initStartIndexAndLevel(path);
     this.traverseContext = new ArrayDeque<>();
+    initStartIndexAndLevel(path);
   }
 
   /**
@@ -94,6 +94,8 @@ public abstract class Traverser {
     startLevel = 0;
     while (parent != null) {
       startLevel++;
+      traverseContext.addLast(parent);
+
       ancestors.push(parent);
       parent = parent.getParent();
     }
@@ -335,11 +337,7 @@ public abstract class Traverser {
       nodeNames.add(nodes.next().getName());
     }
 
-    if (nodeNames.isEmpty()) {
-      nodeNames.addAll(Arrays.asList(currentNode.getPartialPath().getNodes()));
-    } else {
-      nodeNames.add(currentNode.getName());
-    }
+    nodeNames.add(currentNode.getName());
 
     return nodeNames.toArray(new String[0]);
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MNodeLevelCounter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MNodeLevelCounter.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 //
@@ -47,7 +48,7 @@ public class MNodeLevelCounter extends CounterTraverser {
 
   @Override
   protected boolean processInternalMatchedMNode(IMNode node, int idx, int level) {
-    return processLevelMatchedMNode(node, level);
+    return false;
   }
 
   @Override
@@ -61,10 +62,21 @@ public class MNodeLevelCounter extends CounterTraverser {
       return false;
     }
     // record processed node so they will not be processed twice
-    if (!processedNodes.contains(node)) {
-      processedNodes.add(node);
+    IMNode levelMatchedAncestor = getLevelMatchedAncestor(node, level);
+    if (!processedNodes.contains(levelMatchedAncestor)) {
+      processedNodes.add(levelMatchedAncestor);
       count++;
     }
     return true;
+  }
+
+  private IMNode getLevelMatchedAncestor(IMNode node, int level) {
+    Iterator<IMNode> iterator = traverseContext.iterator();
+    while (level > targetLevel && iterator.hasNext()) {
+      node = iterator.next();
+      level--;
+    }
+
+    return node;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegion.java
@@ -824,9 +824,12 @@ public class SchemaRegion {
 
   // region Interfaces for level Node info Query
   public List<PartialPath> getNodesListInGivenLevel(
-      PartialPath pathPattern, int nodeLevel, LocalSchemaProcessor.StorageGroupFilter filter)
+      PartialPath pathPattern,
+      int nodeLevel,
+      boolean isPrefixMatch,
+      LocalSchemaProcessor.StorageGroupFilter filter)
       throws MetadataException {
-    return mtree.getNodesListInGivenLevel(pathPattern, nodeLevel, filter);
+    return mtree.getNodesListInGivenLevel(pathPattern, nodeLevel, isPrefixMatch, filter);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
@@ -159,21 +159,21 @@ public interface IStorageGroupSchemaManager {
   boolean isStorageGroupAlreadySet(PartialPath path);
 
   /**
-   * To calculate the count of nodes in the given level for given path pattern. If using prefix
-   * match, the path pattern is used to match prefix path. All nodes start with the matched prefix
-   * path will be counted. This method only count in nodes above storage group. Nodes below storage
-   * group, including storage group node will be counted by certain Storage Group. The involved
-   * storage groups will be collected to count nodes below storage group.
+   * To collect nodes in the given level for given path pattern. If using prefix match, the path
+   * pattern is used to match prefix path. All nodes start with the matched prefix path will be
+   * collected. This method only count in nodes above storage group. Nodes below storage group,
+   * including storage group node will be collected by certain SchemaRegion. The involved storage
+   * groups will be collected to fetch schemaRegion.
    *
    * @param pathPattern a path pattern or a full path
-   * @param level the level should match the level of the path
+   * @param nodeLevel the level should match the level of the path
    * @param isPrefixMatch if true, the path pattern is used to match prefix path
    */
-  Pair<Integer, Set<PartialPath>> getNodesCountInGivenLevel(
-      PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException;
-
   Pair<List<PartialPath>, Set<PartialPath>> getNodesListInGivenLevel(
-      PartialPath pathPattern, int nodeLevel, LocalSchemaProcessor.StorageGroupFilter filter)
+      PartialPath pathPattern,
+      int nodeLevel,
+      boolean isPrefixMatch,
+      LocalSchemaProcessor.StorageGroupFilter filter)
       throws MetadataException;
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
@@ -240,16 +240,13 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
   }
 
   @Override
-  public Pair<Integer, Set<PartialPath>> getNodesCountInGivenLevel(
-      PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
-    return mtree.getNodesCountInGivenLevel(pathPattern, level, isPrefixMatch);
-  }
-
-  @Override
   public Pair<List<PartialPath>, Set<PartialPath>> getNodesListInGivenLevel(
-      PartialPath pathPattern, int nodeLevel, LocalSchemaProcessor.StorageGroupFilter filter)
+      PartialPath pathPattern,
+      int nodeLevel,
+      boolean isPrefixMatch,
+      LocalSchemaProcessor.StorageGroupFilter filter)
       throws MetadataException {
-    return mtree.getNodesListInGivenLevel(pathPattern, nodeLevel, filter);
+    return mtree.getNodesListInGivenLevel(pathPattern, nodeLevel, isPrefixMatch, filter);
   }
 
   @Override

--- a/server/src/test/java/org/apache/iotdb/db/metadata/SchemaBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/SchemaBasicTest.java
@@ -2649,4 +2649,48 @@ public class SchemaBasicTest {
 
     assertEquals(0, schemaProcessor.getMeasurementMNode(path).getOffset());
   }
+
+  @Test
+  public void testCountNodesWithLevel() throws Exception {
+    LocalSchemaProcessor schemaProcessor = IoTDB.schemaProcessor;
+    schemaProcessor.createTimeseries(
+        new PartialPath("root.sgcc.wf03.wt01.temperature"),
+        TSDataType.valueOf("INT32"),
+        TSEncoding.valueOf("RLE"),
+        compressionType,
+        Collections.emptyMap());
+    schemaProcessor.createTimeseries(
+        new PartialPath("root.sgcc.wf03.t01.status"),
+        TSDataType.valueOf("INT32"),
+        TSEncoding.valueOf("RLE"),
+        compressionType,
+        Collections.emptyMap());
+    schemaProcessor.createTimeseries(
+        new PartialPath("root.ln.wf01.wt01.temperature"),
+        TSDataType.valueOf("INT32"),
+        TSEncoding.valueOf("RLE"),
+        compressionType,
+        Collections.emptyMap());
+    schemaProcessor.createTimeseries(
+        new PartialPath("root.ln.wf01.wt01.status"),
+        TSDataType.valueOf("INT32"),
+        TSEncoding.valueOf("RLE"),
+        compressionType,
+        Collections.emptyMap());
+    schemaProcessor.createTimeseries(
+        new PartialPath("root.ln.wf02.wt02.status"),
+        TSDataType.valueOf("INT32"),
+        TSEncoding.valueOf("RLE"),
+        compressionType,
+        Collections.emptyMap());
+    schemaProcessor.createTimeseries(
+        new PartialPath("root.ln.wf02.wt02.hardware"),
+        TSDataType.valueOf("INT32"),
+        TSEncoding.valueOf("RLE"),
+        compressionType,
+        Collections.emptyMap());
+
+    Assert.assertEquals(
+        2, schemaProcessor.getNodesCountInGivenLevel(new PartialPath("root.**.temperature"), 3));
+  }
 }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSGTest.java
@@ -269,23 +269,23 @@ public class MTreeAboveSGTest {
         storageGroup -> storageGroup.equals("root.sg1");
 
     Pair<List<PartialPath>, Set<PartialPath>> result =
-        root.getNodesListInGivenLevel(new PartialPath("root.**"), 3, null);
+        root.getNodesListInGivenLevel(new PartialPath("root.**"), 3, false, null);
     Assert.assertEquals(0, result.left.size());
     Assert.assertEquals(2, result.right.size());
 
-    result = root.getNodesListInGivenLevel(new PartialPath("root.*.*"), 2, null);
+    result = root.getNodesListInGivenLevel(new PartialPath("root.*.*"), 2, false, null);
     Assert.assertEquals(0, result.left.size());
     Assert.assertEquals(2, result.right.size());
 
-    result = root.getNodesListInGivenLevel(new PartialPath("root.*.*"), 1, null);
+    result = root.getNodesListInGivenLevel(new PartialPath("root.*.*"), 1, false, null);
     Assert.assertEquals(0, result.left.size());
     Assert.assertEquals(2, result.right.size());
 
-    result = root.getNodesListInGivenLevel(new PartialPath("root.**"), 3, filter);
+    result = root.getNodesListInGivenLevel(new PartialPath("root.**"), 3, false, filter);
     Assert.assertEquals(0, result.left.size());
     Assert.assertEquals(1, result.right.size());
 
-    result = root.getNodesListInGivenLevel(new PartialPath("root.*.**"), 2, filter);
+    result = root.getNodesListInGivenLevel(new PartialPath("root.*.**"), 2, false, filter);
     Assert.assertEquals(0, result.left.size());
     Assert.assertEquals(1, result.right.size());
   }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
@@ -637,19 +637,29 @@ public class MTreeBelowSGTest {
         null);
 
     Assert.assertEquals(
-        2, storageGroup.getNodesListInGivenLevel(new PartialPath("root.**"), 3, null).size());
+        2,
+        storageGroup.getNodesListInGivenLevel(new PartialPath("root.**"), 3, false, null).size());
 
     Assert.assertEquals(
-        1, storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*"), 2, null).size());
+        1,
+        storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*"), 2, false, null).size());
     Assert.assertEquals(
-        1, storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*"), 1, null).size());
+        1,
+        storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*"), 1, false, null).size());
     Assert.assertEquals(
-        1, storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*.s1"), 2, null).size());
+        1,
+        storageGroup
+            .getNodesListInGivenLevel(new PartialPath("root.*.*.s1"), 2, false, null)
+            .size());
 
     Assert.assertEquals(
-        2, storageGroup.getNodesListInGivenLevel(new PartialPath("root.**"), 3, filter).size());
+        2,
+        storageGroup.getNodesListInGivenLevel(new PartialPath("root.**"), 3, false, filter).size());
     Assert.assertEquals(
-        1, storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.**"), 2, filter).size());
+        1,
+        storageGroup
+            .getNodesListInGivenLevel(new PartialPath("root.*.**"), 2, false, filter)
+            .size());
 
     storageGroup = getStorageGroup(new PartialPath("root.sg2"));
     storageGroup.createTimeseries(
@@ -668,19 +678,29 @@ public class MTreeBelowSGTest {
         null);
 
     Assert.assertEquals(
-        2, storageGroup.getNodesListInGivenLevel(new PartialPath("root.**"), 3, null).size());
+        2,
+        storageGroup.getNodesListInGivenLevel(new PartialPath("root.**"), 3, false, null).size());
 
     Assert.assertEquals(
-        2, storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*"), 2, null).size());
+        2,
+        storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*"), 2, false, null).size());
     Assert.assertEquals(
-        1, storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*"), 1, null).size());
+        1,
+        storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*"), 1, false, null).size());
     Assert.assertEquals(
-        2, storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.*.s1"), 2, null).size());
+        2,
+        storageGroup
+            .getNodesListInGivenLevel(new PartialPath("root.*.*.s1"), 2, false, null)
+            .size());
 
     Assert.assertEquals(
-        0, storageGroup.getNodesListInGivenLevel(new PartialPath("root.**"), 3, filter).size());
+        0,
+        storageGroup.getNodesListInGivenLevel(new PartialPath("root.**"), 3, false, filter).size());
     Assert.assertEquals(
-        0, storageGroup.getNodesListInGivenLevel(new PartialPath("root.*.**"), 2, filter).size());
+        0,
+        storageGroup
+            .getNodesListInGivenLevel(new PartialPath("root.*.**"), 2, false, filter)
+            .size());
   }
 
   @Test


### PR DESCRIPTION
## Description


### Cause
When counting nodes above sg, the node cannot be counted correctly because the existing method in MTreeBelowSG won't check the node above sg and also mistaken the level comparision.

### Solution
Enable MTreeBelowSG to check the node above sg, remove duplicated nodes in SchemaProcessor and finally return the num of matched nodes.
