### PR TITLE
[IOTDB-2851]ChunkReaderTest failed in CI

### DIFF
--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileReaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileReaderTest.java
@@ -71,6 +71,8 @@ public class TsFileReaderTest {
 
     TSFileConfig tsFileConfig = TSFileDescriptor.getInstance().getConfig();
     // make multi pages in one group
+    int oldPointNumInPage = tsFileConfig.getMaxNumberOfPointsInPage();
+    int oldGroupSizeInByte = tsFileConfig.getGroupSizeInByte();
     tsFileConfig.setMaxNumberOfPointsInPage(100);
     tsFileConfig.setGroupSizeInByte(100 * 1024 * 1024);
     TsFileWriter tsFileWriter = new TsFileWriter(file, new Schema(), tsFileConfig);
@@ -120,6 +122,8 @@ public class TsFileReaderTest {
 
     tsFileReader.close();
     file.delete();
+    tsFileConfig.setGroupSizeInByte(oldGroupSizeInByte);
+    tsFileConfig.setMaxNumberOfPointsInPage(oldPointNumInPage);
   }
 
   @Test

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/TsFileGeneratorForTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/TsFileGeneratorForTest.java
@@ -176,6 +176,9 @@ public class TsFileGeneratorForTest {
 
     Schema schema = generateTestSchema();
 
+    int oldGroupSizeInByte = TSFileDescriptor.getInstance().getConfig().getGroupSizeInByte();
+    int oldMaxPointNumInPage =
+        TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
     TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(chunkGroupSize);
     TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(pageSize);
 
@@ -190,6 +193,9 @@ public class TsFileGeneratorForTest {
       }
     } catch (WriteProcessException e) {
       e.printStackTrace();
+    } finally {
+      TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(oldMaxPointNumInPage);
+      TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(oldGroupSizeInByte);
     }
   }
 
@@ -281,6 +287,9 @@ public class TsFileGeneratorForTest {
       Assert.assertTrue(file.delete());
     }
     file.getParentFile().mkdirs();
+    int oldGroupSizeInByte = TSFileDescriptor.getInstance().getConfig().getGroupSizeInByte();
+    int oldMaxPointNumInPage =
+        TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
     TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(chunkGroupSize);
     TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(pageSize);
     try (TsFileWriter tsFileWriter = new TsFileWriter(file)) {
@@ -309,6 +318,9 @@ public class TsFileGeneratorForTest {
 
     } catch (IOException | WriteProcessException e) {
       e.printStackTrace();
+    } finally {
+      TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(oldMaxPointNumInPage);
+      TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(oldGroupSizeInByte);
     }
   }
 


### PR DESCRIPTION
Solution: setGroupSizeInByte(oldGroupSizeInByte) and setMaxNumberOfPointsInPage(oldPointNumInPage) after modifing it in test.