### PR TITLE
[To rel/0.13][IOTDB-2826]Unmark storage group among templates when deleted

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -869,6 +869,11 @@ public class MManager {
           removeFromTagInvertedIndex(leafMNode);
         }
 
+        // unmark all storage group from related templates
+        for (Template template : templateManager.getTemplateMap().values()) {
+          template.unmarkStorageGroups(storageGroups);
+        }
+
         // drop triggers with no exceptions
         TriggerEngine.drop(leafMNodes);
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
@@ -421,6 +421,10 @@ public class Template {
     return relatedStorageGroup.removeAll(getSGPaths(unsetNode));
   }
 
+  public boolean unmarkStorageGroups(Collection<PartialPath> sgPaths) {
+    return relatedStorageGroup.removeAll(sgPaths);
+  }
+
   // endregion
 
   // region inner utils

--- a/server/src/test/java/org/apache/iotdb/db/metadata/TemplateTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/TemplateTest.java
@@ -417,6 +417,24 @@ public class TemplateTest {
   }
 
   @Test
+  public void testDropTemplateWithStorageGroupDeleted() throws MetadataException {
+    MManager mManager = IoTDB.metaManager;
+    mManager.createSchemaTemplate(getTreeTemplatePlan());
+    mManager.setSchemaTemplate(new SetTemplatePlan("treeTemplate", "root.sg1.d1"));
+    try {
+      mManager.dropSchemaTemplate(new DropTemplatePlan("treeTemplate"));
+      fail();
+    } catch (MetadataException e) {
+      assertEquals(
+          "Template [treeTemplate] has been set on MTree, cannot be dropped now.", e.getMessage());
+    }
+
+    mManager.deleteStorageGroups(Arrays.asList(new PartialPath("root.sg1")));
+    mManager.dropSchemaTemplate(new DropTemplatePlan("treeTemplate"));
+    assertEquals(0, mManager.getAllTemplates().size());
+  }
+
+  @Test
   public void testTemplateAlignment() throws MetadataException {
     MManager manager = IoTDB.metaManager;
     manager.createTimeseries(

--- a/server/src/test/java/org/apache/iotdb/db/metadata/TemplateTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/TemplateTest.java
@@ -418,20 +418,20 @@ public class TemplateTest {
 
   @Test
   public void testDropTemplateWithStorageGroupDeleted() throws MetadataException {
-    MManager mManager = IoTDB.metaManager;
-    mManager.createSchemaTemplate(getTreeTemplatePlan());
-    mManager.setSchemaTemplate(new SetTemplatePlan("treeTemplate", "root.sg1.d1"));
+    MManager manager = IoTDB.metaManager;
+    manager.createSchemaTemplate(getTreeTemplatePlan());
+    manager.setSchemaTemplate(new SetTemplatePlan("treeTemplate", "root.sg1.d1"));
     try {
-      mManager.dropSchemaTemplate(new DropTemplatePlan("treeTemplate"));
+      manager.dropSchemaTemplate(new DropTemplatePlan("treeTemplate"));
       fail();
     } catch (MetadataException e) {
       assertEquals(
           "Template [treeTemplate] has been set on MTree, cannot be dropped now.", e.getMessage());
     }
 
-    mManager.deleteStorageGroups(Arrays.asList(new PartialPath("root.sg1")));
-    mManager.dropSchemaTemplate(new DropTemplatePlan("treeTemplate"));
-    assertEquals(0, mManager.getAllTemplates().size());
+    manager.deleteStorageGroups(Arrays.asList(new PartialPath("root.sg1")));
+    manager.dropSchemaTemplate(new DropTemplatePlan("treeTemplate"));
+    assertEquals(0, manager.getAllTemplates().size());
   }
 
   @Test


### PR DESCRIPTION
In Template, we mark which storage group this template is set, this is act as a cache to accelerate related traverse.
When a storage group is deleted, we need to discard this cache in related templates.