### PR TITLE
[IOTDB-2855] Fix DeletionFileNodeTest error

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -269,7 +269,7 @@ public class EnvironmentUtils {
     MetricConfigDescriptor.getInstance().getMetricConfig().setEnableMetric(false);
     IoTDBDescriptor.getInstance().getConfig().setAvgSeriesPointNumberThreshold(Integer.MAX_VALUE);
     // the default wal buffer size may cause ci failed
-    IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(1024 * 1024);
+    IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(4 * 1024 * 1024);
     if (daemon == null) {
       daemon = new IoTDB();
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -268,6 +268,8 @@ public class EnvironmentUtils {
     // we do not start 9091 port in test.
     MetricConfigDescriptor.getInstance().getMetricConfig().setEnableMetric(false);
     IoTDBDescriptor.getInstance().getConfig().setAvgSeriesPointNumberThreshold(Integer.MAX_VALUE);
+    // the default wal buffer size may cause ci failed
+    IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(1024 * 1024);
     if (daemon == null) {
       daemon = new IoTDB();
     }

--- a/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionFileNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionFileNodeTest.java
@@ -28,7 +28,6 @@ import org.apache.iotdb.db.engine.querycontext.ReadOnlyMemChunk;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.VirtualStorageGroupProcessor;
 import org.apache.iotdb.db.exception.StorageEngineException;
-import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -124,14 +123,16 @@ public class DeletionFileNodeTest {
 
   @Test
   public void testDeleteWithTimePartitionFilter()
-      throws IllegalPathException, StorageEngineException, QueryProcessException, IOException {
+      throws StorageEngineException, QueryProcessException, IOException {
     boolean prevEnablePartition = StorageEngine.isEnablePartition();
     long prevPartitionInterval = StorageEngine.getTimePartitionInterval();
     int prevConcurrentTimePartition =
         IoTDBDescriptor.getInstance().getConfig().getConcurrentWritingTimePartition();
+    int prevWalBufferSize = IoTDBDescriptor.getInstance().getConfig().getWalBufferSize();
     try {
       StorageEngine.setEnablePartition(true);
       IoTDBDescriptor.getInstance().getConfig().setConcurrentWritingTimePartition(10);
+      IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(16 * 1024);
       long newPartitionInterval = 100;
       StorageEngine.setTimePartitionInterval(newPartitionInterval);
       // generate 10 time partitions
@@ -157,6 +158,7 @@ public class DeletionFileNodeTest {
       IoTDBDescriptor.getInstance()
           .getConfig()
           .setConcurrentWritingTimePartition(prevConcurrentTimePartition);
+      IoTDBDescriptor.getInstance().getConfig().setWalBufferSize(prevWalBufferSize);
     }
   }
 


### PR DESCRIPTION
## Description

https://github.com/apache/iotdb/runs/5852474920?check_suite_focus=true

The default wal buffer size `16MB` is too large in CI env, and may cause OOM error. Therefore change the size to `4MB` to fix it.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
