### PR TITLE
Decouple the circular dependency between FragmentSinkNode and ExchangeNode

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/DistributionPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/DistributionPlanner.java
@@ -299,7 +299,7 @@ public class DistributionPlanner {
         ExchangeNode exchangeNode = (ExchangeNode) root;
         FragmentSinkNode sinkNode = new FragmentSinkNode(PlanNodeIdAllocator.generateId());
         sinkNode.setChild(exchangeNode.getChild());
-        sinkNode.setDownStreamNode(exchangeNode);
+        sinkNode.setDownStreamPlanNodeId(exchangeNode.getId());
         // Record the source node info in the ExchangeNode so that we can keep the connection of
         // these nodes/fragments
         exchangeNode.setRemoteSourceNode(sinkNode);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/FragmentInstance.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/FragmentInstance.java
@@ -85,7 +85,7 @@ public class FragmentInstance implements IConsensusRequest {
       FragmentSinkNode sink = (FragmentSinkNode) root;
       return String.format(
           "(%s, %s, %s)",
-          sink.getDownStreamEndpoint(), sink.getDownStreamInstanceId(), sink.getDownStreamNode());
+          sink.getDownStreamEndpoint(), sink.getDownStreamInstanceId(), sink.getDownStreamPlanNodeId());
     }
     return "<No downstream>";
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/SimpleFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/SimpleFragmentParallelPlanner.java
@@ -98,7 +98,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
       if (rootNode instanceof FragmentSinkNode) {
         // Set target Endpoint for FragmentSinkNode
         FragmentSinkNode sinkNode = (FragmentSinkNode) rootNode;
-        PlanNodeId downStreamNodeId = sinkNode.getDownStreamNode().getId();
+        PlanNodeId downStreamNodeId = sinkNode.getDownStreamPlanNodeId();
         FragmentInstance downStreamInstance = findDownStreamInstance(downStreamNodeId);
         sinkNode.setDownStream(
             downStreamInstance.getHostEndpoint(), downStreamInstance.getId(), downStreamNodeId);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/ExchangeNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/process/ExchangeNode.java
@@ -65,7 +65,7 @@ public class ExchangeNode extends PlanNode {
     ExchangeNode node = new ExchangeNode(getId());
     if (remoteSourceNode != null) {
       FragmentSinkNode remoteSourceNodeClone = (FragmentSinkNode) remoteSourceNode.clone();
-      remoteSourceNodeClone.setDownStreamNode(node);
+      remoteSourceNodeClone.setDownStreamPlanNodeId(node.getId());
       node.setRemoteSourceNode(remoteSourceNode);
     }
     return node;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/sink/FragmentSinkNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/sink/FragmentSinkNode.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.commons.cluster.Endpoint;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
-import org.apache.iotdb.db.mpp.sql.planner.plan.node.process.ExchangeNode;
 
 import com.google.common.collect.ImmutableList;
 
@@ -31,7 +30,6 @@ import java.util.List;
 
 public class FragmentSinkNode extends SinkNode {
   private PlanNode child;
-  private ExchangeNode downStreamNode;
 
   private Endpoint downStreamEndpoint;
   private FragmentInstanceId downStreamInstanceId;
@@ -55,7 +53,6 @@ public class FragmentSinkNode extends SinkNode {
   public PlanNode clone() {
     FragmentSinkNode sinkNode = new FragmentSinkNode(getId());
     sinkNode.setDownStream(downStreamEndpoint, downStreamInstanceId, downStreamPlanNodeId);
-    sinkNode.setDownStreamNode(downStreamNode);
     return sinkNode;
   }
 
@@ -103,18 +100,14 @@ public class FragmentSinkNode extends SinkNode {
         getDownStreamEndpoint().getIp(), getDownStreamInstanceId(), getDownStreamPlanNodeId());
   }
 
-  public ExchangeNode getDownStreamNode() {
-    return downStreamNode;
-  }
-
-  public void setDownStreamNode(ExchangeNode downStreamNode) {
-    this.downStreamNode = downStreamNode;
-  }
-
   public void setDownStream(Endpoint endPoint, FragmentInstanceId instanceId, PlanNodeId nodeId) {
     this.downStreamEndpoint = endPoint;
     this.downStreamInstanceId = instanceId;
     this.downStreamPlanNodeId = nodeId;
+  }
+
+  public void setDownStreamPlanNodeId(PlanNodeId downStreamPlanNodeId) {
+    this.downStreamPlanNodeId = downStreamPlanNodeId;
   }
 
   public Endpoint getDownStreamEndpoint() {


### PR DESCRIPTION
## Description
Decouple the circular dependency between FragmentSinkNode and ExchanageNode, which makes the PlanNode serialization easier.