### PR TITLE
[IOTDB-2858] Construct SinkHandle in LocalExecutionPlanner and remove the IOExecption in Operator

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/operator/Operator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/operator/Operator.java
@@ -41,10 +41,10 @@ public interface Operator extends AutoCloseable {
   }
 
   /** Gets next tsBlock from this operator. If no data is currently available, return null. */
-  TsBlock next() throws IOException;
+  TsBlock next();
 
   /** @return true if the operator has more data, otherwise false */
-  boolean hasNext() throws IOException;
+  boolean hasNext();
 
   /** This method will always be called before releasing the Operator reference. */
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/operator/process/LimitOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/operator/process/LimitOperator.java
@@ -53,7 +53,7 @@ public class LimitOperator implements ProcessOperator {
   }
 
   @Override
-  public TsBlock next() throws IOException {
+  public TsBlock next() {
     TsBlock block = child.next();
     TsBlock res = block;
     if (block.getPositionCount() <= remainingLimit) {
@@ -66,7 +66,7 @@ public class LimitOperator implements ProcessOperator {
   }
 
   @Override
-  public boolean hasNext() throws IOException {
+  public boolean hasNext() {
     return remainingLimit > 0 && child.hasNext();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/operator/process/TimeJoinOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/operator/process/TimeJoinOperator.java
@@ -32,7 +32,6 @@ import org.apache.iotdb.tsfile.read.common.block.column.TimeColumnBuilder;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-import java.io.IOException;
 import java.util.List;
 
 public class TimeJoinOperator implements ProcessOperator {
@@ -96,7 +95,7 @@ public class TimeJoinOperator implements ProcessOperator {
   }
 
   @Override
-  public TsBlock next() throws IOException {
+  public TsBlock next() {
     // end time for returned TsBlock this time, it's the min end time among all the children
     // TsBlocks
     long currentEndTime = 0;
@@ -154,7 +153,7 @@ public class TimeJoinOperator implements ProcessOperator {
   }
 
   @Override
-  public boolean hasNext() throws IOException {
+  public boolean hasNext() {
     if (finished) {
       return false;
     }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/operator/LimitOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/operator/LimitOperatorTest.java
@@ -162,7 +162,7 @@ public class LimitOperatorTest {
         count++;
       }
       assertEquals(13, count);
-    } catch (IOException | IllegalPathException e) {
+    } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();
     }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/operator/SeriesScanOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/operator/SeriesScanOperatorTest.java
@@ -118,7 +118,7 @@ public class SeriesScanOperatorTest {
         count++;
       }
       assertEquals(25, count);
-    } catch (IOException | IllegalPathException e) {
+    } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();
     }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/operator/TimeJoinOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/operator/TimeJoinOperatorTest.java
@@ -148,7 +148,7 @@ public class TimeJoinOperatorTest {
         count++;
       }
       assertEquals(25, count);
-    } catch (IOException | IllegalPathException e) {
+    } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();
     }


### PR DESCRIPTION
1. Construct SinkHandle in LocalExecutionPlanner
2. Remove the IOExecption in next and hasNext method of Operator