### PR TITLE
[IOTDB-2864] Fix Read-only occurred when insert Text values to aligned timeseries

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBInsertAlignedValuesIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBInsertAlignedValuesIT.java
@@ -40,7 +40,7 @@ import java.sql.Statement;
 import java.util.Objects;
 
 @Category({LocalStandaloneTest.class})
-public class IOTDBInsertAlignedValuesIT {
+public class IoTDBInsertAlignedValuesIT {
   private static Connection connection;
   private static final int oldTsFileGroupSizeInByte =
       TSFileDescriptor.getInstance().getConfig().getGroupSizeInByte();
@@ -368,5 +368,24 @@ public class IOTDBInsertAlignedValuesIT {
     } catch (SQLException e) {
       Assert.assertEquals("411: Insertion contains duplicated measurement: status", e.getMessage());
     }
+  }
+
+  @Test
+  public void testExtendTextColumn() {
+    int primitiveArraySize = IoTDBDescriptor.getInstance().getConfig().getPrimitiveArraySize();
+    IoTDBDescriptor.getInstance().getConfig().setPrimitiveArraySize(2);
+    try (Statement st1 = connection.createStatement()) {
+      st1.execute("insert into root.sg.d1(time,s1,s2) aligned values(1,'test','test')");
+      st1.execute("insert into root.sg.d1(time,s1,s2) aligned values(2,'test','test')");
+      st1.execute("insert into root.sg.d1(time,s1,s2) aligned values(3,'test','test')");
+      st1.execute("insert into root.sg.d1(time,s1,s2) aligned values(4,'test','test')");
+      st1.execute("insert into root.sg.d1(time,s1,s3) aligned values(5,'test','test')");
+      st1.execute("insert into root.sg.d1(time,s1,s2) aligned values(6,'test','test')");
+      st1.execute("flush");
+      st1.execute("insert into root.sg.d1(time,s1,s3) aligned values(7,'test','test')");
+    } catch (SQLException e) {
+      Assert.fail();
+    }
+    IoTDBDescriptor.getInstance().getConfig().setPrimitiveArraySize(primitiveArraySize);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -298,8 +298,9 @@ public class AlignedTVList extends TVList {
           break;
       }
       BitMap bitMap = new BitMap(ARRAY_SIZE);
-      // last bitmap should be marked to the tslist size's position
-      if (i == timestamps.size() - 1) {
+      // last bitmap should be marked to the tvlist size's position
+      // if rowCount % ARRAY_SIZE != 0, last bitmap should mark all
+      if (i == timestamps.size() - 1 && rowCount % ARRAY_SIZE != 0) {
         for (int j = 0; j < rowCount % ARRAY_SIZE; j++) {
           bitMap.mark(j);
         }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -298,8 +298,15 @@ public class AlignedTVList extends TVList {
           break;
       }
       BitMap bitMap = new BitMap(ARRAY_SIZE);
-      // last bitmap should be marked to the tvlist size's position
-      // if rowCount % ARRAY_SIZE != 0, last bitmap should mark all
+      // The following code is for these 2 kinds of scenarios.
+
+      // Eg1: If rowCount=5 and ARRAY_SIZE=2, we need to supply 3 bitmaps for the extending column.
+      // The first 2 bitmaps should mark all bits to represent 4 nulls and the 3rd bitmap should
+      // mark
+      // the 1st bit to represent 1 null value.
+
+      // Eg2: If rowCount=4 and ARRAY_SIZE=2, we need to supply 2 bitmaps for the extending column.
+      // These 2 bitmaps should mark all bits to represent 4 nulls.
       if (i == timestamps.size() - 1 && rowCount % ARRAY_SIZE != 0) {
         for (int j = 0; j < rowCount % ARRAY_SIZE; j++) {
           bitMap.mark(j);


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/25913899/162470614-b4048ae8-cb85-45d8-8ca7-7d8cf9f9e6b6.png)

When extending column in AlignedTVList, we need to supply bitmaps for the extending column. There is a bug causes the last supplying bitmap doesn't be marked, which will cause NPE when the extending column is TEXT dataType and execute flushing. Finally the server will turn to read-only because of it.