### PR TITLE
Refactor schema region management and Improve DeleteStorageGroup procedure

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigManager.java
@@ -273,7 +273,6 @@ public class LocalConfigManager {
   }
 
   private void deleteStorageGroup(PartialPath storageGroup) throws MetadataException {
-    storageGroupSchemaManager.deleteStorageGroup(storageGroup);
     deleteSchemaRegionsInStorageGroup(
         storageGroup, partitionTable.deleteStorageGroup(storageGroup));
 
@@ -284,6 +283,7 @@ public class LocalConfigManager {
     if (!config.isEnableMemControl()) {
       MemTableManager.getInstance().addOrDeleteStorageGroup(-1);
     }
+    storageGroupSchemaManager.deleteStorageGroup(storageGroup);
   }
 
   private void deleteSchemaRegionsInStorageGroup(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaPartitionTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaPartitionTable.java
@@ -101,8 +101,8 @@ public class LocalSchemaPartitionTable {
     return result;
   }
 
-  public Set<SchemaRegionId> getSchemaRegionIdsByStorageGroup(PartialPath storageGroup) {
-    return table.get(storageGroup);
+  public List<SchemaRegionId> getSchemaRegionIdsByStorageGroup(PartialPath storageGroup) {
+    return new ArrayList<>(table.get(storageGroup));
   }
 
   public synchronized void setStorageGroup(PartialPath storageGroup) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.metadata.schemaregion;
 
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
-import org.apache.iotdb.db.exception.metadata.StorageGroupAlreadySetException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.metadata.storagegroup.IStorageGroupSchemaManager;
 import org.apache.iotdb.db.metadata.storagegroup.StorageGroupSchemaManager;
@@ -80,11 +79,7 @@ public class SchemaEngine {
     if (schemaRegion != null) {
       return;
     }
-    PartialPath checkedStorageGroup =
-        localStorageGroupSchemaManager.ensureStorageGroup(storageGroup);
-    if (!checkedStorageGroup.equals(storageGroup)) {
-      throw new StorageGroupAlreadySetException(checkedStorageGroup.getFullPath());
-    }
+    localStorageGroupSchemaManager.ensureStorageGroup(storageGroup);
     schemaRegion =
         new SchemaRegion(
             storageGroup,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
@@ -46,7 +46,9 @@ public interface IStorageGroupSchemaManager {
    */
   void setStorageGroup(PartialPath path) throws MetadataException;
 
-  PartialPath ensureStorageGroup(PartialPath path) throws MetadataException;
+  // different with LocalConfigManager.ensureStorageGroup, this method won't init storageGroup
+  // resources.
+  void ensureStorageGroup(PartialPath path) throws MetadataException;
 
   /**
    * Delete storage groups of given paths from MTree. Log format: "delete_storage_group,sg1,sg2,sg3"

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
@@ -46,6 +46,8 @@ public interface IStorageGroupSchemaManager {
    */
   void setStorageGroup(PartialPath path) throws MetadataException;
 
+  PartialPath ensureStorageGroup(PartialPath path) throws MetadataException;
+
   /**
    * Delete storage groups of given paths from MTree. Log format: "delete_storage_group,sg1,sg2,sg3"
    */

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
@@ -151,9 +151,9 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
   }
 
   @Override
-  public PartialPath ensureStorageGroup(PartialPath path) throws MetadataException {
+  public void ensureStorageGroup(PartialPath path) throws MetadataException {
     try {
-      return getBelongedStorageGroup(path);
+      getBelongedStorageGroup(path);
     } catch (StorageGroupNotSetException e) {
       if (!config.isAutoCreateSchemaEnabled()) {
         throw e;
@@ -162,7 +162,6 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
           MetaUtils.getStorageGroupPathByLevel(path, config.getDefaultStorageGroupLevel());
       try {
         setStorageGroup(storageGroupPath);
-        return storageGroupPath;
       } catch (StorageGroupAlreadySetException storageGroupAlreadySetException) {
         // do nothing
         // concurrent timeseries creation may result concurrent ensureStorageGroup
@@ -173,8 +172,6 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
           // Timeseries can't be created under a deviceNode without storageGroup.
           throw storageGroupAlreadySetException;
         }
-
-        return storageGroupPath;
       }
     }
   }


### PR DESCRIPTION
## Description

### Refactor schema region management
SchemaEngine  takes on all the responsibility of schema region management. Now the localConfigManager only manages the schemaRegionId and doesn't provide interfaces for schema region management.

### Improve DeleteStorageGroup procedure
Now only when all related schemaRegions are deleted, will the storageGroup be deleted.
