### PR TITLE
[IOTDB-2878] Add getLeader interface to IConsensus

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -58,4 +58,6 @@ public interface IConsensus {
   ConsensusGenericResponse triggerSnapshot(ConsensusGroupId groupId);
 
   boolean isLeader(ConsensusGroupId groupId);
+
+  Peer getLeader(ConsensusGroupId groupId);
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -452,7 +452,7 @@ class RatisConsensus implements IConsensus {
   @Override
   public Peer getLeader(ConsensusGroupId groupId) {
     if (isLeader(groupId)) {
-      return new Peer(groupId,  Utils.parseFromRatisId(myself.getId().toString()));
+      return new Peer(groupId, Utils.parseFromRatisId(myself.getId().toString()));
     }
 
     RaftGroupId raftGroupId = Utils.toRatisGroupId(groupId);

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -450,6 +450,17 @@ class RatisConsensus implements IConsensus {
   }
 
   @Override
+  public Peer getLeader(ConsensusGroupId groupId) {
+    RaftGroupId raftGroupId = Utils.toRatisGroupId(groupId);
+    RaftClient client = clientMap.getOrDefault(raftGroupId, null);
+    if (client == null) {
+      return null;
+    }
+    Endpoint leaderEndpoint =  Utils.parseFromRatisId(client.getLeaderId().toString());
+    return new Peer(groupId, leaderEndpoint);
+  }
+
+  @Override
   public ConsensusGenericResponse triggerSnapshot(ConsensusGroupId groupId) {
     return ConsensusGenericResponse.newBuilder().setSuccess(false).build();
   }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -451,6 +451,10 @@ class RatisConsensus implements IConsensus {
 
   @Override
   public Peer getLeader(ConsensusGroupId groupId) {
+    if (isLeader(groupId)) {
+      return new Peer(groupId,  Utils.parseFromRatisId(myself.getId().toString()));
+    }
+
     RaftGroupId raftGroupId = Utils.toRatisGroupId(groupId);
     RaftClient client = clientMap.getOrDefault(raftGroupId, null);
     if (client == null) {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -456,7 +456,7 @@ class RatisConsensus implements IConsensus {
     if (client == null) {
       return null;
     }
-    Endpoint leaderEndpoint =  Utils.parseFromRatisId(client.getLeaderId().toString());
+    Endpoint leaderEndpoint = Utils.parseFromRatisId(client.getLeaderId().toString());
     return new Peer(groupId, leaderEndpoint);
   }
 

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
@@ -71,11 +71,19 @@ public class Utils {
     return String.format("%s-%d", groupTypeAbbr, consensusGroupId.getId());
   }
 
+  public static String RatisPeerId(Endpoint endpoint) {
+    return String.format("%s-%d", endpoint.getIp(), endpoint.getPort());
+  }
+
+  public static Endpoint parseFromRatisId(String ratisId) {
+    String[] items = ratisId.split("-");
+    return new Endpoint(items[0], Integer.parseInt(items[1]));
+  }
+
   // priority is used as ordinal of leader election
   public static RaftPeer toRaftPeer(Endpoint endpoint, int priority) {
-    String Id = String.format("%s-%d", endpoint.getIp(), endpoint.getPort());
     return RaftPeer.newBuilder()
-        .setId(Id)
+        .setId(RatisPeerId(endpoint))
         .setAddress(IPAddress(endpoint))
         .setPriority(priority)
         .build();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
@@ -183,4 +183,12 @@ class StandAloneConsensus implements IConsensus {
   public boolean isLeader(ConsensusGroupId groupId) {
     return true;
   }
+
+  @Override
+  public Peer getLeader(ConsensusGroupId groupId) {
+    if (!stateMachineMap.containsKey(groupId)) {
+      return null;
+    }
+    return new Peer(groupId, thisNode);
+  }
 }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -183,6 +183,7 @@ public class RatisConsensusTest {
     // then use removeConsensusGroup to clean up removed Consensus-Peer's states
     servers.get(0).removeConsensusGroup(gid);
     servers.get(2).removeConsensusGroup(gid);
+    Assert.assertEquals(servers.get(1).getLeader(gid), peers.get(1));
 
     // 7. try consensus again with one peer
     doConsensus(servers.get(1), gid, 10, 20);


### PR DESCRIPTION
## Description
Currently `IConsensus::isLeader` is not enough for application scenarios. In this PR I add getLeader interface, which can return the POSSIBLE leader peer of a ConsensusGroup.