### PR TITLE
[IOTDB-2588] Triggers support any tree level, such as storage groups, devices, measurements, and so on

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTriggerExecutionIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTriggerExecutionIT.java
@@ -73,7 +73,7 @@ public class IoTDBTriggerExecutionIT {
               ++count;
               statement.execute(
                   String.format(
-                      "insert into root.vehicle.d1(timestamp,s1,s2,s3,s4,s5,s6) values(%d,%d,%d,%d,%d,%s,'%d')",
+                      "insert into root.vehicle.a.b.c.d1(timestamp,s1,s2,s3,s4,s5,s6) values(%d,%d,%d,%d,%d,%s,'%d')",
                       count, count, count, count, count, count % 2 == 0 ? "true" : "false", count));
             } while (!isInterrupted());
           } catch (Exception e) {
@@ -102,37 +102,37 @@ public class IoTDBTriggerExecutionIT {
 
   private void createTimeseries() throws MetadataException {
     IoTDB.schemaProcessor.createTimeseries(
-        new PartialPath("root.vehicle.d1.s1"),
+        new PartialPath("root.vehicle.a.b.c.d1.s1"),
         TSDataType.INT32,
         TSEncoding.PLAIN,
         CompressionType.UNCOMPRESSED,
         null);
     IoTDB.schemaProcessor.createTimeseries(
-        new PartialPath("root.vehicle.d1.s2"),
+        new PartialPath("root.vehicle.a.b.c.d1.s2"),
         TSDataType.INT64,
         TSEncoding.PLAIN,
         CompressionType.UNCOMPRESSED,
         null);
     IoTDB.schemaProcessor.createTimeseries(
-        new PartialPath("root.vehicle.d1.s3"),
+        new PartialPath("root.vehicle.a.b.c.d1.s3"),
         TSDataType.FLOAT,
         TSEncoding.PLAIN,
         CompressionType.UNCOMPRESSED,
         null);
     IoTDB.schemaProcessor.createTimeseries(
-        new PartialPath("root.vehicle.d1.s4"),
+        new PartialPath("root.vehicle.a.b.c.d1.s4"),
         TSDataType.DOUBLE,
         TSEncoding.PLAIN,
         CompressionType.UNCOMPRESSED,
         null);
     IoTDB.schemaProcessor.createTimeseries(
-        new PartialPath("root.vehicle.d1.s5"),
+        new PartialPath("root.vehicle.a.b.c.d1.s5"),
         TSDataType.BOOLEAN,
         TSEncoding.PLAIN,
         CompressionType.UNCOMPRESSED,
         null);
     IoTDB.schemaProcessor.createTimeseries(
-        new PartialPath("root.vehicle.d1.s6"),
+        new PartialPath("root.vehicle.a.b.c.d1.s6"),
         TSDataType.TEXT,
         TSEncoding.PLAIN,
         CompressionType.UNCOMPRESSED,
@@ -158,17 +158,17 @@ public class IoTDBTriggerExecutionIT {
                 Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_4 after insert on root.vehicle.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_4 after insert on root.vehicle.a.b.c.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_5 before insert on root.vehicle.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_5 before insert on root.vehicle.a.b.c.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_6 after insert on root.vehicle.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_6 after insert on root.vehicle.a.b.c.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       int[] counters1 = getCounters(6);
       LOGGER.info(Arrays.toString(counters1));
@@ -209,11 +209,11 @@ public class IoTDBTriggerExecutionIT {
       waitCountIncreaseBy(500);
 
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       waitCountIncreaseBy(500);
 
@@ -230,11 +230,11 @@ public class IoTDBTriggerExecutionIT {
       waitCountIncreaseBy(500);
 
       statement.execute(
-          "create trigger trigger_4 after insert on root.vehicle.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_4 after insert on root.vehicle.a.b.c.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_5 before insert on root.vehicle.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_5 before insert on root.vehicle.a.b.c.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_6 after insert on root.vehicle.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_6 after insert on root.vehicle.a.b.c.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       // IOTDB-1825: if the background data generator's connection is closed, the following checks
       // will be meaningless, in which case we ignore the checks
@@ -264,11 +264,11 @@ public class IoTDBTriggerExecutionIT {
       waitCountIncreaseBy(500);
 
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       waitCountIncreaseBy(500);
 
@@ -289,22 +289,22 @@ public class IoTDBTriggerExecutionIT {
       statement.execute("drop trigger trigger_3");
       waitCountIncreaseBy(100);
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       waitCountIncreaseBy(100);
       statement.execute("drop trigger trigger_1");
       statement.execute("drop trigger trigger_2");
       statement.execute("drop trigger trigger_3");
       waitCountIncreaseBy(100);
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       waitCountIncreaseBy(500);
 
@@ -336,17 +336,17 @@ public class IoTDBTriggerExecutionIT {
       waitCountIncreaseBy(500);
 
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_4 after insert on root.vehicle.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_4 after insert on root.vehicle.a.b.c.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_5 before insert on root.vehicle.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_5 before insert on root.vehicle.a.b.c.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_6 after insert on root.vehicle.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_6 after insert on root.vehicle.a.b.c.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       waitCountIncreaseBy(500);
 
@@ -460,17 +460,17 @@ public class IoTDBTriggerExecutionIT {
       waitCountIncreaseBy(500);
 
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_4 after insert on root.vehicle.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_4 after insert on root.vehicle.a.b.c.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_5 before insert on root.vehicle.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_5 before insert on root.vehicle.a.b.c.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_6 after insert on root.vehicle.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_6 after insert on root.vehicle.a.b.c.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       waitCountIncreaseBy(500);
 
@@ -487,12 +487,12 @@ public class IoTDBTriggerExecutionIT {
 
       stopDataGenerator();
 
-      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.d1.s1"));
-      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.d1.s2"));
-      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.d1.s3"));
-      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.d1.s4"));
-      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.d1.s5"));
-      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.d1.s6"));
+      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.a.b.c.d1.s1"));
+      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.a.b.c.d1.s2"));
+      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.a.b.c.d1.s3"));
+      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.a.b.c.d1.s4"));
+      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.a.b.c.d1.s5"));
+      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath("root.vehicle.a.b.c.d1.s6"));
 
       for (int i = 0; i < 6; ++i) {
         try {
@@ -515,17 +515,17 @@ public class IoTDBTriggerExecutionIT {
       }
 
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_4 after insert on root.vehicle.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_4 after insert on root.vehicle.a.b.c.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_5 before insert on root.vehicle.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_5 before insert on root.vehicle.a.b.c.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_6 after insert on root.vehicle.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_6 after insert on root.vehicle.a.b.c.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       Thread.sleep(500);
 
@@ -550,17 +550,17 @@ public class IoTDBTriggerExecutionIT {
                 Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_4 after insert on root.vehicle.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_4 after insert on root.vehicle.a.b.c.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_5 before insert on root.vehicle.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_5 before insert on root.vehicle.a.b.c.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_6 after insert on root.vehicle.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_6 after insert on root.vehicle.a.b.c.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       waitCountIncreaseBy(500);
 
@@ -590,17 +590,17 @@ public class IoTDBTriggerExecutionIT {
       }
 
       statement.execute(
-          "create trigger trigger_1 before insert on root.vehicle.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_2 after insert on root.vehicle.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_2 after insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_3 before insert on root.vehicle.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_4 after insert on root.vehicle.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_4 after insert on root.vehicle.a.b.c.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_5 before insert on root.vehicle.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_5 before insert on root.vehicle.a.b.c.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
       statement.execute(
-          "create trigger trigger_6 after insert on root.vehicle.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+          "create trigger trigger_6 after insert on root.vehicle.a.b.c.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
 
       Thread.sleep(500);
 
@@ -610,6 +610,66 @@ public class IoTDBTriggerExecutionIT {
         assertEquals(Counter.BASE, counters1[2]);
       }
     } catch (SQLException | TriggerManagementException | MetadataException e) {
+      fail(e.getMessage());
+    } finally {
+      stopDataGenerator();
+    }
+  }
+
+  @Test
+  public void testCreateMultipleLevelTriggersMultipleTimesWhileInserting()
+      throws InterruptedException {
+
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          "create trigger trigger_1 before insert on root.vehicle.a.b.c.d1.s1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+      statement.execute(
+          "create trigger trigger_2 before insert on root.vehicle.a.b.c.d1.s2 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+      statement.execute(
+          "create trigger trigger_3 before insert on root.vehicle.a.b.c.d1.s3 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+      statement.execute(
+          "create trigger trigger_4 before insert on root.vehicle.a.b.c.d1.s4 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+      statement.execute(
+          "create trigger trigger_5 before insert on root.vehicle.a.b.c.d1.s5 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+      statement.execute(
+          "create trigger trigger_6 before insert on root.vehicle.a.b.c.d1.s6 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+
+      statement.execute(
+          "create trigger trigger_7 before insert on root.vehicle.a.b.c.d1 as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+      statement.execute(
+          "create trigger trigger_8 before insert on root.vehicle.a.b.c as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+      statement.execute(
+          "create trigger trigger_9 after insert on root.vehicle.a.b as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+      statement.execute(
+          "create trigger trigger_10 before insert on root.vehicle.a as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+      statement.execute(
+          "create trigger trigger_11 after insert on root.vehicle as 'org.apache.iotdb.db.engine.trigger.example.Counter'");
+
+      startDataGenerator();
+      waitCountIncreaseBy(500);
+      stopDataGenerator();
+      int[] counters = getCounters(11);
+      assertEquals(counters[0], counters[1]);
+      assertEquals(counters[3], counters[4]);
+      int sumCount =
+          counters[0]
+              + counters[1]
+              + counters[2]
+              + counters[3]
+              + counters[4]
+              + counters[5]
+              - 6 * Counter.BASE;
+      assertEquals(sumCount, (counters[6] - Counter.BASE));
+      assertEquals(sumCount, (counters[7] - Counter.BASE));
+      assertEquals(sumCount, (counters[8] - Counter.BASE));
+      assertEquals(sumCount, (counters[9] - Counter.BASE));
+      assertEquals(sumCount, (counters[10] - Counter.BASE));
+      LOGGER.info(Arrays.toString(counters));
+
+    } catch (SQLException | TriggerManagementException e) {
       fail(e.getMessage());
     } finally {
       stopDataGenerator();

--- a/server/src/main/java/org/apache/iotdb/db/engine/trigger/executor/TriggerEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/trigger/executor/TriggerEngine.java
@@ -53,7 +53,6 @@ public class TriggerEngine {
     Object[] values = insertRowPlan.getValues();
 
     for (int i = 0; i < size; ++i) {
-      long s = System.currentTimeMillis();
       IMeasurementMNode mNode = mNodes[i];
       if (mNode == null) {
         continue;

--- a/server/src/main/java/org/apache/iotdb/db/engine/trigger/executor/TriggerExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/trigger/executor/TriggerExecutor.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.db.engine.trigger.service.TriggerClassLoader;
 import org.apache.iotdb.db.engine.trigger.service.TriggerRegistrationInformation;
 import org.apache.iotdb.db.exception.TriggerExecutionException;
 import org.apache.iotdb.db.exception.TriggerManagementException;
-import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
+import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.Binary;
 
@@ -39,23 +39,21 @@ public class TriggerExecutor {
 
   private final TriggerClassLoader classLoader;
 
-  private final IMeasurementMNode measurementMNode;
-  private final TSDataType seriesDataType;
+  private final IMNode imNode;
 
   private final Trigger trigger;
 
   public TriggerExecutor(
       TriggerRegistrationInformation registrationInformation,
       TriggerClassLoader classLoader,
-      IMeasurementMNode measurementMNode)
+      IMNode imNode)
       throws TriggerManagementException {
     this.registrationInformation = registrationInformation;
     attributes = new TriggerAttributes(registrationInformation.getAttributes());
 
     this.classLoader = classLoader;
 
-    this.measurementMNode = measurementMNode;
-    seriesDataType = measurementMNode.getSchema().getType();
+    this.imNode = imNode;
 
     trigger = constructTriggerInstance();
   }
@@ -137,14 +135,16 @@ public class TriggerExecutor {
     }
   }
 
-  public void fireIfActivated(TriggerEvent event, long timestamp, Object value)
+  public void fireIfActivated(
+      TriggerEvent event, long timestamp, Object value, TSDataType seriesDataType)
       throws TriggerExecutionException {
     if (!registrationInformation.isStopped() && event.equals(registrationInformation.getEvent())) {
-      fire(timestamp, value);
+      fire(timestamp, value, seriesDataType);
     }
   }
 
-  private synchronized void fire(long timestamp, Object value) throws TriggerExecutionException {
+  private synchronized void fire(long timestamp, Object value, TSDataType seriesDataType)
+      throws TriggerExecutionException {
     Thread.currentThread().setContextClassLoader(classLoader);
 
     try {
@@ -177,14 +177,15 @@ public class TriggerExecutor {
     }
   }
 
-  public void fireIfActivated(TriggerEvent event, long[] timestamps, Object values)
+  public void fireIfActivated(
+      TriggerEvent event, long[] timestamps, Object values, TSDataType seriesDataType)
       throws TriggerExecutionException {
     if (!registrationInformation.isStopped() && event.equals(registrationInformation.getEvent())) {
-      fire(timestamps, values);
+      fire(timestamps, values, seriesDataType);
     }
   }
 
-  private synchronized void fire(long[] timestamps, Object values)
+  private synchronized void fire(long[] timestamps, Object values, TSDataType seriesDataType)
       throws TriggerExecutionException {
     Thread.currentThread().setContextClassLoader(classLoader);
 
@@ -231,8 +232,8 @@ public class TriggerExecutor {
     return registrationInformation;
   }
 
-  public IMeasurementMNode getMeasurementMNode() {
-    return measurementMNode;
+  public IMNode getIMNode() {
+    return imNode;
   }
 
   @TestOnly

--- a/server/src/main/java/org/apache/iotdb/db/engine/trigger/service/TriggerRegistrationService.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/trigger/service/TriggerRegistrationService.java
@@ -136,17 +136,12 @@ public class TriggerRegistrationService implements IService {
 
   private IMNode tryGetMNode(CreateTriggerPlan plan) throws TriggerManagementException {
     try {
-      IMNode sgPath = IoTDB.schemaProcessor.getNodeByPath(plan.getFullPath());
-      if (sgPath == null) {
+      IMNode imNode = IoTDB.schemaProcessor.getNodeByPath(plan.getFullPath());
+      if (imNode == null) {
         throw new TriggerManagementException(
             String.format("Path [%s] does not exist", plan.getFullPath().getFullPath()));
       }
-      if (plan.getFullPath().getFullPath().equals(sgPath.getFullPath())) {
-        return sgPath;
-      } else {
-        throw new TriggerManagementException(
-            String.format("Path [%s] does not exist", plan.getFullPath().getFullPath()));
-      }
+      return imNode;
     } catch (MetadataException e) {
       throw new TriggerManagementException(e.getMessage(), e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/trigger/service/TriggerRegistrationService.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/trigger/service/TriggerRegistrationService.java
@@ -33,6 +33,7 @@ import org.apache.iotdb.db.exception.TriggerManagementException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.idtable.IDTable;
 import org.apache.iotdb.db.metadata.idtable.IDTableManager;
+import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
@@ -95,15 +96,15 @@ public class TriggerRegistrationService implements IService {
 
   public synchronized void register(CreateTriggerPlan plan)
       throws TriggerManagementException, TriggerExecutionException {
-    IMeasurementMNode measurementMNode = tryGetMeasurementMNode(plan);
-    checkIfRegistered(plan, measurementMNode);
+    IMNode imNode = tryGetMNode(plan);
+    checkIfRegistered(plan, imNode);
     tryAppendRegistrationLog(plan);
-    doRegister(plan, measurementMNode);
+    doRegister(plan, imNode);
   }
 
-  private void checkIfRegistered(CreateTriggerPlan plan, IMeasurementMNode measurementMNode)
+  private void checkIfRegistered(CreateTriggerPlan plan, IMNode imNode)
       throws TriggerManagementException {
-    TriggerExecutor executor = measurementMNode.getTriggerExecutor();
+    TriggerExecutor executor = imNode.getTriggerExecutor();
     if (executor != null) {
       TriggerRegistrationInformation information = executor.getRegistrationInformation();
       throw new TriggerManagementException(
@@ -113,7 +114,7 @@ public class TriggerRegistrationService implements IService {
               plan.getClassName(),
               information.getTriggerName(),
               information.getClassName(),
-              measurementMNode.getFullPath()));
+              imNode.getFullPath()));
     }
 
     executor = executors.get(plan.getTriggerName());
@@ -133,10 +134,19 @@ public class TriggerRegistrationService implements IService {
     }
   }
 
-  private IMeasurementMNode tryGetMeasurementMNode(CreateTriggerPlan plan)
-      throws TriggerManagementException {
+  private IMNode tryGetMNode(CreateTriggerPlan plan) throws TriggerManagementException {
     try {
-      return IoTDB.schemaProcessor.getMeasurementMNode(plan.getFullPath());
+      IMNode sgPath = IoTDB.schemaProcessor.getNodeByPath(plan.getFullPath());
+      if (sgPath == null) {
+        throw new TriggerManagementException(
+            String.format("Path [%s] does not exist", plan.getFullPath().getFullPath()));
+      }
+      if (plan.getFullPath().getFullPath().equals(sgPath.getFullPath())) {
+        return sgPath;
+      } else {
+        throw new TriggerManagementException(
+            String.format("Path [%s] does not exist", plan.getFullPath().getFullPath()));
+      }
     } catch (MetadataException e) {
       throw new TriggerManagementException(e.getMessage(), e);
     }
@@ -153,7 +163,7 @@ public class TriggerRegistrationService implements IService {
     }
   }
 
-  private void doRegister(CreateTriggerPlan plan, IMeasurementMNode measurementMNode)
+  private void doRegister(CreateTriggerPlan plan, IMNode measurementMNode)
       throws TriggerManagementException, TriggerExecutionException {
     TriggerRegistrationInformation information = new TriggerRegistrationInformation(plan);
     TriggerClassLoader classLoader =
@@ -176,7 +186,9 @@ public class TriggerRegistrationService implements IService {
       try {
         IDTable idTable =
             IDTableManager.getInstance().getIDTable(plan.getFullPath().getDevicePath());
-        idTable.registerTrigger(plan.getFullPath(), measurementMNode);
+        if (executor.getIMNode().isMeasurement()) {
+          idTable.registerTrigger(plan.getFullPath(), (IMeasurementMNode) measurementMNode);
+        }
       } catch (MetadataException e) {
         throw new TriggerManagementException(e.getMessage(), e);
       }
@@ -214,7 +226,7 @@ public class TriggerRegistrationService implements IService {
 
   private void doDeregister(DropTriggerPlan plan) throws TriggerManagementException {
     TriggerExecutor executor = executors.remove(plan.getTriggerName());
-    executor.getMeasurementMNode().setTriggerExecutor(null);
+    executor.getIMNode().setTriggerExecutor(null);
 
     try {
       executor.onDrop();
@@ -228,9 +240,11 @@ public class TriggerRegistrationService implements IService {
     // update id table
     if (CONFIG.isEnableIDTable()) {
       try {
-        PartialPath fullPath = executor.getMeasurementMNode().getPartialPath();
+        PartialPath fullPath = executor.getIMNode().getPartialPath();
         IDTable idTable = IDTableManager.getInstance().getIDTable(fullPath.getDevicePath());
-        idTable.deregisterTrigger(fullPath, executor.getMeasurementMNode());
+        if (executor.getIMNode().isMeasurement()) {
+          idTable.deregisterTrigger(fullPath, (IMeasurementMNode) executor.getIMNode());
+        }
       } catch (MetadataException e) {
         throw new TriggerManagementException(e.getMessage(), e);
       }
@@ -367,7 +381,7 @@ public class TriggerRegistrationService implements IService {
   private void doRecoveryFromLogFile(File logFile) throws IOException, TriggerManagementException {
     for (CreateTriggerPlan createTriggerPlan : recoverCreateTriggerPlans(logFile)) {
       try {
-        doRegister(createTriggerPlan, tryGetMeasurementMNode(createTriggerPlan));
+        doRegister(createTriggerPlan, tryGetMNode(createTriggerPlan));
         if (createTriggerPlan.isStopped()) {
           executors.get(createTriggerPlan.getTriggerName()).onStop();
         }
@@ -469,6 +483,10 @@ public class TriggerRegistrationService implements IService {
   @Override
   public ServiceType getID() {
     return ServiceType.TRIGGER_REGISTRATION_SERVICE;
+  }
+
+  public int executorSize() {
+    return executors.size();
   }
 
   public static TriggerRegistrationService getInstance() {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaProcessor.java
@@ -938,6 +938,14 @@ public class LocalSchemaProcessor {
     }
   }
 
+  public IMNode getNodeByPath(PartialPath path) throws MetadataException {
+    try {
+      return getBelongedSchemaRegion(path).getNodeByPath(path);
+    } catch (StorageGroupNotSetException e) {
+      throw new PathNotExistException(path.getFullPath());
+    }
+  }
+
   /**
    * Invoked during insertPlan process. Get target MeasurementMNode from given EntityMNode. If the
    * result is not null and is not MeasurementMNode, it means a timeseries with same path cannot be

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/IMNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.metadata.mnode;
 
+import org.apache.iotdb.db.engine.trigger.executor.TriggerExecutor;
 import org.apache.iotdb.db.metadata.logfile.MLogWriter;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.metadata.template.Template;
@@ -89,6 +90,10 @@ public interface IMNode extends Serializable {
   IEntityMNode getAsEntityMNode();
 
   IMeasurementMNode getAsMeasurementMNode();
+
+  TriggerExecutor getTriggerExecutor();
+
+  void setTriggerExecutor(TriggerExecutor triggerExecutor);
 
   void serializeTo(MLogWriter logWriter) throws IOException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MNode.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.metadata.mnode;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.db.engine.trigger.executor.TriggerExecutor;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 
 import java.util.ArrayList;
@@ -34,6 +35,9 @@ public abstract class MNode implements IMNode {
 
   /** from root to this node, only be set when used once for InternalMNode */
   protected String fullPath;
+
+  /** registered trigger */
+  protected TriggerExecutor triggerExecutor;
 
   /** Constructor of MNode. */
   public MNode(IMNode parent, String name) {
@@ -161,6 +165,16 @@ public abstract class MNode implements IMNode {
     } else {
       throw new UnsupportedOperationException("Wrong MNode Type");
     }
+  }
+
+  @Override
+  public TriggerExecutor getTriggerExecutor() {
+    return triggerExecutor;
+  }
+
+  @Override
+  public void setTriggerExecutor(TriggerExecutor triggerExecutor) {
+    this.triggerExecutor = triggerExecutor;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MeasurementMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/MeasurementMNode.java
@@ -47,8 +47,6 @@ public class MeasurementMNode extends MNode implements IMeasurementMNode {
   private IMeasurementSchema schema;
   /** last value cache */
   private volatile ILastCacheContainer lastCacheContainer = null;
-  /** registered trigger */
-  private TriggerExecutor triggerExecutor = null;
 
   /**
    * MeasurementMNode factory method. The type of returned MeasurementMNode is according to the

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegion.java
@@ -1122,6 +1122,11 @@ public class SchemaRegion {
   // endregion
 
   // region Interfaces and methods for MNode query
+
+  public IMNode getNodeByPath(PartialPath path) throws MetadataException {
+    return mtree.getNodeByPath(path);
+  }
+
   public IMNode getDeviceNode(PartialPath path) throws MetadataException {
     IMNode node;
     try {


### PR DESCRIPTION
The current version of the trigger path comparison must be accurate to measurement.
Such as:
CREATE TRIGGER `alert-listener-sg1abcd1s1`
AFTER INSERT
ON root.sg1.a.b.c.d1.s1
AS 'org.apache.iotdb.db.engine.trigger.example.AlertListener'
WITH (
'lo' = '0',
'hi' = '100.0'
)

Expectation: Support to storage groups and any of the following levels

1. Storage group level
CREATE TRIGGER `alert-listener-sg1`
AFTER INSERT
ON root.sg1
AS 'org.apache.iotdb.db.engine.trigger.example.AlertListener'
WITH (
'lo' = '0',
'hi' = '100.0'
)

2. Business classification
CREATE TRIGGER `alert-listener-sg1ab`
AFTER INSERT
ON root.sg1.a.b
AS 'org.apache.iotdb.db.engine.trigger.example.AlertListener'
WITH (
'lo' = '0',
'hi' = '100.0'
)

3. equipment
CREATE TRIGGER `alert-listener-sg1abcd1`
AFTER INSERT
ON root.sg1.a.b.c.d1
AS 'org.apache.iotdb.db.engine.trigger.example.AlertListener'
WITH (
'lo' = '0',
'hi' = '100.0'
)

4. measurement
CREATE TRIGGER `alert-listener-sg1abcd1s1`
AFTER INSERT
ON root.sg1.a.b.c.d1.s1
AS 'org.apache.iotdb.db.engine.trigger.example.AlertListener'
WITH (
'lo' = '0',
'hi' = '100.0'
)
