### PR TITLE
[IOTDB-2896] Fix warning of illegal cross compaction strategy

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -475,7 +475,7 @@ timestamp_precision=ms
 
 # the performer of inner unsequence space compaction task
 # Options: read_point
-# inner_seq_performer=read_point
+# inner_unseq_performer=read_point
 
 # The priority of compaction execution
 # INNER_CROSS: prioritize inner space compaction, reduce the number of files first

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -364,17 +364,17 @@ public class IoTDBDescriptor {
                   Boolean.toString(conf.isEnableUnseqSpaceCompaction()))));
 
       conf.setCrossCompactionSelector(
-          CrossCompactionSelector.getCrossCompactionStrategy(
+          CrossCompactionSelector.getCrossCompactionSelector(
               properties.getProperty(
                   "cross_selector", conf.getCrossCompactionSelector().toString())));
 
       conf.setInnerSequenceCompactionSelector(
-          InnerSequenceCompactionSelector.getInnerSequenceCompactionStrategy(
+          InnerSequenceCompactionSelector.getInnerSequenceCompactionSelector(
               properties.getProperty(
                   "inner_seq_selector", conf.getInnerSequenceCompactionSelector().toString())));
 
       conf.setInnerUnsequenceCompactionSelector(
-          InnerUnsequenceCompactionSelector.getInnerUnsequenceCompactionStrategy(
+          InnerUnsequenceCompactionSelector.getInnerUnsequenceCompactionSelector(
               properties.getProperty(
                   "inner_unseq_selector", conf.getInnerUnsequenceCompactionSelector().toString())));
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionScheduler.java
@@ -96,14 +96,12 @@ public class CompactionScheduler {
       innerSpaceCompactionSelector =
           config
               .getInnerSequenceCompactionSelector()
-              .getCompactionSelector(
-                  logicalStorageGroupName, dataRegionId, timePartition, tsFileManager);
+              .createInstance(logicalStorageGroupName, dataRegionId, timePartition, tsFileManager);
     } else {
       innerSpaceCompactionSelector =
           config
               .getInnerUnsequenceCompactionSelector()
-              .getCompactionSelector(
-                  logicalStorageGroupName, dataRegionId, timePartition, tsFileManager);
+              .createInstance(logicalStorageGroupName, dataRegionId, timePartition, tsFileManager);
     }
     List<List<TsFileResource>> taskList =
         innerSpaceCompactionSelector.selectInnerSpaceTask(
@@ -116,11 +114,11 @@ public class CompactionScheduler {
               ? IoTDBDescriptor.getInstance()
                   .getConfig()
                   .getInnerSeqCompactionPerformer()
-                  .getCompactionPerformer()
+                  .createInstance()
               : IoTDBDescriptor.getInstance()
                   .getConfig()
                   .getInnerUnseqCompactionPerformer()
-                  .getCompactionPerformer();
+                  .createInstance();
       CompactionTaskManager.getInstance()
           .addTaskToWaitingQueue(
               new InnerSpaceCompactionTask(
@@ -146,8 +144,7 @@ public class CompactionScheduler {
     ICrossSpaceSelector crossSpaceCompactionSelector =
         config
             .getCrossCompactionSelector()
-            .getCompactionSelector(
-                logicalStorageGroupName, dataRegionId, timePartition, tsFileManager);
+            .createInstance(logicalStorageGroupName, dataRegionId, timePartition, tsFileManager);
     List<Pair<List<TsFileResource>, List<TsFileResource>>> taskList =
         crossSpaceCompactionSelector.selectCrossSpaceTask(
             tsFileManager.getSequenceListByTimePartition(timePartition),
@@ -163,7 +160,7 @@ public class CompactionScheduler {
                   IoTDBDescriptor.getInstance()
                       .getConfig()
                       .getCrossCompactionPerformer()
-                      .getCompactionPerformer(),
+                      .createInstance(),
                   CompactionTaskManager.currentTaskNum));
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionScheduler.java
@@ -59,7 +59,6 @@ public class CompactionScheduler {
       tryToSubmitCrossSpaceCompactionTask(
           tsFileManager.getStorageGroupName(),
           tsFileManager.getDataRegion(),
-          tsFileManager.getStorageGroupDir(),
           timePartition,
           tsFileManager);
       tryToSubmitInnerSpaceCompactionTask(
@@ -76,6 +75,7 @@ public class CompactionScheduler {
           false);
     } catch (InterruptedException e) {
       LOGGER.error("Exception occurs when selecting compaction tasks", e);
+      Thread.currentThread().interrupt();
     }
   }
 
@@ -134,7 +134,6 @@ public class CompactionScheduler {
   private static void tryToSubmitCrossSpaceCompactionTask(
       String logicalStorageGroupName,
       String dataRegionId,
-      String storageGroupDir,
       long timePartition,
       TsFileManager tsFileManager)
       throws InterruptedException {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CrossCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CrossCompactionPerformer.java
@@ -31,7 +31,7 @@ public enum CrossCompactionPerformer {
     throw new RuntimeException("Illegal compaction performer for cross compaction " + name);
   }
 
-  public ICrossCompactionPerformer getCompactionPerformer() {
+  public ICrossCompactionPerformer createInstance() {
     switch (this) {
       case READ_POINT:
       default:

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CrossCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CrossCompactionSelector.java
@@ -18,15 +18,9 @@
  */
 package org.apache.iotdb.db.engine.compaction.constant;
 
-import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
-import org.apache.iotdb.db.engine.compaction.cross.CrossSpaceCompactionTask;
 import org.apache.iotdb.db.engine.compaction.cross.ICrossSpaceSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.RewriteCrossSpaceCompactionSelector;
-import org.apache.iotdb.db.engine.compaction.performer.impl.ReadPointCompactionPerformer;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
-import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
-
-import java.util.List;
 
 public enum CrossCompactionSelector {
   REWRITE;
@@ -35,28 +29,10 @@ public enum CrossCompactionSelector {
     if (REWRITE.toString().equalsIgnoreCase(name)) {
       return REWRITE;
     }
-    throw new RuntimeException("Illegal Cross Compaction Strategy " + name);
+    throw new RuntimeException("Illegal Cross Compaction Selector " + name);
   }
 
-  public CrossSpaceCompactionTask getCompactionTask(
-      long timePartitionId,
-      TsFileManager tsFileManager,
-      List<TsFileResource> selectedSeqTsFileResourceList,
-      List<TsFileResource> selectedUnSeqTsFileResourceList) {
-    switch (this) {
-      case REWRITE:
-      default:
-        return new CrossSpaceCompactionTask(
-            timePartitionId,
-            tsFileManager,
-            selectedSeqTsFileResourceList,
-            selectedUnSeqTsFileResourceList,
-            new ReadPointCompactionPerformer(),
-            CompactionTaskManager.currentTaskNum);
-    }
-  }
-
-  public ICrossSpaceSelector getCompactionSelector(
+  public ICrossSpaceSelector createInstance(
       String logicalStorageGroupName,
       String virtualGroupId,
       long timePartition,

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CrossCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CrossCompactionSelector.java
@@ -31,8 +31,8 @@ import java.util.List;
 public enum CrossCompactionSelector {
   REWRITE;
 
-  public static CrossCompactionSelector getCrossCompactionStrategy(String name) {
-    if ("REWRITE_COMPACTION".equalsIgnoreCase(name)) {
+  public static CrossCompactionSelector getCrossCompactionSelector(String name) {
+    if (REWRITE.toString().equalsIgnoreCase(name)) {
       return REWRITE;
     }
     throw new RuntimeException("Illegal Cross Compaction Strategy " + name);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerSeqCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerSeqCompactionPerformer.java
@@ -31,7 +31,7 @@ public enum InnerSeqCompactionPerformer {
     throw new RuntimeException("Illegal compaction performer for seq inner compaction " + name);
   }
 
-  public ISeqCompactionPerformer getCompactionPerformer() {
+  public ISeqCompactionPerformer createInstance() {
     switch (this) {
       case READ_CHUNK:
       default:

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerSequenceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerSequenceCompactionSelector.java
@@ -30,10 +30,10 @@ public enum InnerSequenceCompactionSelector {
     if (SIZE_TIERED.toString().equalsIgnoreCase(name)) {
       return SIZE_TIERED;
     }
-    throw new RuntimeException("Illegal Compaction Strategy " + name);
+    throw new RuntimeException("Illegal Compaction Selector " + name);
   }
 
-  public IInnerSeqSpaceSelector getCompactionSelector(
+  public IInnerSeqSpaceSelector createInstance(
       String logicalStorageGroupName,
       String virtualStorageGroupName,
       long timePartition,

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerSequenceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerSequenceCompactionSelector.java
@@ -26,8 +26,8 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 public enum InnerSequenceCompactionSelector {
   SIZE_TIERED;
 
-  public static InnerSequenceCompactionSelector getInnerSequenceCompactionStrategy(String name) {
-    if ("SIZE_TIERED_COMPACTION".equalsIgnoreCase(name)) {
+  public static InnerSequenceCompactionSelector getInnerSequenceCompactionSelector(String name) {
+    if (SIZE_TIERED.toString().equalsIgnoreCase(name)) {
       return SIZE_TIERED;
     }
     throw new RuntimeException("Illegal Compaction Strategy " + name);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerUnseqCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerUnseqCompactionPerformer.java
@@ -31,7 +31,7 @@ public enum InnerUnseqCompactionPerformer {
     throw new RuntimeException("Illegal compaction performer for unseq inner compaction " + name);
   }
 
-  public IUnseqCompactionPerformer getCompactionPerformer() {
+  public IUnseqCompactionPerformer createInstance() {
     switch (this) {
       case READ_POINT:
       default:

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerUnsequenceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerUnsequenceCompactionSelector.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 public enum InnerUnsequenceCompactionSelector {
   SIZE_TIERED;
 
-  public static InnerUnsequenceCompactionSelector getInnerUnsequenceCompactionStrategy(
+  public static InnerUnsequenceCompactionSelector getInnerUnsequenceCompactionSelector(
       String name) {
     if (SIZE_TIERED.toString().equalsIgnoreCase(name)) {
       return SIZE_TIERED;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerUnsequenceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/InnerUnsequenceCompactionSelector.java
@@ -30,10 +30,10 @@ public enum InnerUnsequenceCompactionSelector {
     if (SIZE_TIERED.toString().equalsIgnoreCase(name)) {
       return SIZE_TIERED;
     }
-    throw new RuntimeException("Illegal Compaction Strategy " + name);
+    throw new RuntimeException("Illegal Compaction Selector " + name);
   }
 
-  public IInnerUnseqSpaceSelector getCompactionSelector(
+  public IInnerUnseqSpaceSelector createInstance(
       String logicalStorageGroupName,
       String virtualStorageGroupName,
       long timePartition,

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
@@ -226,6 +226,15 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
   }
 
   @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof CrossSpaceCompactionTask)) {
+      return false;
+    }
+
+    return equalsOtherTask((CrossSpaceCompactionTask) other);
+  }
+
+  @Override
   public void resetCompactionCandidateStatusForAllSourceFiles() {
     selectedSequenceFiles.forEach(x -> x.setStatus(TsFileResourceStatus.CLOSED));
     selectedUnsequenceFiles.forEach(x -> x.setStatus(TsFileResourceStatus.CLOSED));

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
@@ -197,7 +197,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       LOGGER.error(
           "{} [Compaction] Throwable is caught during execution of SizeTieredCompaction, {}",
           fullStorageGroupName,
-          throwable);
+          throwable.getMessage());
       LOGGER.warn("{} [Compaction] Start to handle exception", fullStorageGroupName);
       if (compactionLogger != null) {
         compactionLogger.close();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
@@ -199,6 +199,9 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           fullStorageGroupName,
           throwable.getMessage());
       LOGGER.warn("{} [Compaction] Start to handle exception", fullStorageGroupName);
+      if (throwable instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       if (compactionLogger != null) {
         compactionLogger.close();
       }
@@ -316,6 +319,14 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
   @Override
   public int hashCode() {
     return toString().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof InnerSpaceCompactionTask)) {
+      return false;
+    }
+    return equalsOtherTask((InnerSpaceCompactionTask) other);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/log/TsFileIdentifier.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/log/TsFileIdentifier.java
@@ -170,6 +170,11 @@ public class TsFileIdentifier {
         && otherInfo.filename.equals(this.filename);
   }
 
+  @Override
+  public int hashCode() {
+    return this.toString().hashCode();
+  }
+
   /**
    * This method find the File object of current file by searching it in every data directory. If
    * the file is not found, it will return null.

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadChunkCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadChunkCompactionPerformer.java
@@ -116,7 +116,7 @@ public class ReadChunkCompactionPerformer implements ISeqCompactionPerformer {
   }
 
   private void checkThreadInterrupted() throws InterruptedException {
-    if (Thread.currentThread().isInterrupted()) {
+    if (Thread.interrupted()) {
       throw new InterruptedException(
           String.format(
               "[Compaction] compaction for target file %s abort", targetResource.toString()));

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
@@ -231,7 +231,7 @@ public class ReadPointCompactionPerformer
         futures.get(i).get();
       } catch (InterruptedException | ExecutionException e) {
         LOGGER.error("SubCompactionTask meet errors ", e);
-        Thread.interrupted();
+        Thread.currentThread().interrupt();
         throw new InterruptedException();
       }
     }
@@ -340,7 +340,7 @@ public class ReadPointCompactionPerformer
   }
 
   private void checkThreadInterrupted() throws InterruptedException {
-    if (Thread.currentThread().isInterrupted()) {
+    if (Thread.interrupted()) {
       throw new InterruptedException(
           String.format(
               "[Compaction] compaction for target file %s abort", targetFiles.toString()));

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
@@ -72,6 +72,7 @@ public abstract class AbstractCompactionTask implements Callable<Void> {
       doCompaction();
     } catch (InterruptedException e) {
       LOGGER.warn("Current task is interrupted");
+      Thread.interrupted();
     } catch (Exception e) {
       LOGGER.error(e.getMessage(), e);
     } finally {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
@@ -70,6 +70,8 @@ public abstract class AbstractCompactionTask implements Callable<Void> {
     currentTaskNum.incrementAndGet();
     try {
       doCompaction();
+    } catch (InterruptedException e) {
+      LOGGER.error("Current task is interrupted");
     } catch (Exception e) {
       LOGGER.error(e.getMessage(), e);
     } finally {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
@@ -71,7 +71,7 @@ public abstract class AbstractCompactionTask implements Callable<Void> {
     try {
       doCompaction();
     } catch (InterruptedException e) {
-      LOGGER.error("Current task is interrupted");
+      LOGGER.warn("Current task is interrupted");
     } catch (Exception e) {
       LOGGER.error(e.getMessage(), e);
     } finally {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
@@ -62,6 +62,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.fail;
 
@@ -429,17 +430,19 @@ public class CrossSpaceCompactionTest {
           index++;
           if (mergeFiles.length > 0) {
             AbstractCompactionTask compactionTask =
-                IoTDBDescriptor.getInstance()
-                    .getConfig()
-                    .getCrossCompactionSelector()
-                    .getCompactionTask(
-                        0,
-                        new TsFileManager(
-                            "root.compactionTest",
-                            "0",
-                            "target\\data\\sequence\\test\\root.compactionTest\\0\\0\\"),
-                        mergeResource.getSeqFiles(),
-                        mergeResource.getUnseqFiles());
+                new CrossSpaceCompactionTask(
+                    0,
+                    new TsFileManager(
+                        "root.compactionTest",
+                        "0",
+                        "target\\data\\sequence\\test\\root.compactionTest\\0\\0\\"),
+                    mergeResource.getSeqFiles(),
+                    mergeResource.getUnseqFiles(),
+                    IoTDBDescriptor.getInstance()
+                        .getConfig()
+                        .getCrossCompactionPerformer()
+                        .createInstance(),
+                    new AtomicInteger(0));
             compactionTask.call();
             List<TsFileResource> targetTsfileResourceList = new ArrayList<>();
             for (TsFileResource seqResource : seqResources) {
@@ -732,17 +735,19 @@ public class CrossSpaceCompactionTest {
           mergeResource.clear();
           if (mergeFiles.length > 0) {
             AbstractCompactionTask compactionTask =
-                IoTDBDescriptor.getInstance()
-                    .getConfig()
-                    .getCrossCompactionSelector()
-                    .getCompactionTask(
-                        0,
-                        new TsFileManager(
-                            "root.compactionTest",
-                            "0",
-                            "target\\data\\sequence\\test\\root.compactionTest\\0\\0\\"),
-                        mergeResource.getSeqFiles(),
-                        mergeResource.getUnseqFiles());
+                new CrossSpaceCompactionTask(
+                    0,
+                    new TsFileManager(
+                        "root.compactionTest",
+                        "0",
+                        "target\\data\\sequence\\test\\root.compactionTest\\0\\0\\"),
+                    mergeResource.getSeqFiles(),
+                    mergeResource.getUnseqFiles(),
+                    IoTDBDescriptor.getInstance()
+                        .getConfig()
+                        .getCrossCompactionPerformer()
+                        .createInstance(),
+                    new AtomicInteger(0));
             compactionTask.call();
             List<TsFileResource> targetTsfileResourceList = new ArrayList<>();
             for (TsFileResource seqResource : seqResources.subList(1, 4)) {
@@ -1034,17 +1039,19 @@ public class CrossSpaceCompactionTest {
           mergeResource.clear();
           if (mergeFiles.length > 0) {
             AbstractCompactionTask compactionTask =
-                IoTDBDescriptor.getInstance()
-                    .getConfig()
-                    .getCrossCompactionSelector()
-                    .getCompactionTask(
-                        0,
-                        new TsFileManager(
-                            "root.compactionTest",
-                            "0",
-                            "target\\data\\sequence\\test\\root.compactionTest\\0\\0\\"),
-                        mergeResource.getSeqFiles(),
-                        mergeResource.getUnseqFiles());
+                new CrossSpaceCompactionTask(
+                    0,
+                    new TsFileManager(
+                        "root.compactionTest",
+                        "0",
+                        "target\\data\\sequence\\test\\root.compactionTest\\0\\0\\"),
+                    mergeResource.getSeqFiles(),
+                    mergeResource.getUnseqFiles(),
+                    IoTDBDescriptor.getInstance()
+                        .getConfig()
+                        .getCrossCompactionPerformer()
+                        .createInstance(),
+                    new AtomicInteger(0));
             compactionTask.call();
             List<TsFileResource> targetTsfileResourceList = new ArrayList<>();
             for (TsFileResource seqResource : seqResources.subList(1, 4)) {


### PR DESCRIPTION
See [IOTDB-2896](https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-2896?filter=myopenissues).
The reason for this bug is as following, in [pr-5437](https://github.com/apache/iotdb/pull/5437) we refactor the compaction frame work, and separate the compaction configuration _inner_space_compaction_strategy_ and _cross_space_compaction_strategy_ into multiple configuration items, which enables us to configurate compaction more flexiblely. But in `CrossSpaceCompactionSelector` and `InnerSequenceCompactionSelector`, we forgot to modify the code that checks the configuration items, thus causing errors during configuration checks.