### PR TITLE
[To rel/0.13][IOTDB-2903] Fix last value fetch failure during show timesereis

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
@@ -623,4 +623,42 @@ public class IoTDBMetadataFetchIT {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  @Category({LocalStandaloneTest.class, ClusterTest.class, RemoteTest.class})
+  public void showLatestTimeseriesTest() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("insert into root.ln.wf01.wt01(time, status) values(1, 1)");
+      statement.execute("insert into root.ln.wf01.wt01(time, temperature) values(2, 1)");
+      String sql = "show latest timeseries root.ln.wf01.wt01.*";
+      Set<String> standard =
+          new HashSet<>(
+              Arrays.asList(
+                  "root.ln.wf01.wt01.temperature,null,root.ln.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,",
+                  "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,"));
+      try {
+        boolean hasResultSet = statement.execute(sql);
+        if (hasResultSet) {
+          try (ResultSet resultSet = statement.getResultSet()) {
+            ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+            while (resultSet.next()) {
+              StringBuilder builder = new StringBuilder();
+              for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+                builder.append(resultSet.getString(i)).append(",");
+              }
+              String string = builder.toString();
+              Assert.assertTrue(standard.contains(string));
+              standard.remove(string);
+            }
+            assertEquals(0, standard.size());
+          }
+        }
+      } catch (SQLException e) {
+        logger.error("showTimeseriesTest() failed", e);
+        fail(e.getMessage());
+      }
+    }
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
@@ -224,12 +224,12 @@ public class LastCacheManager {
         // because LastPointReader will do itself sort logic instead of depending on fillOrderIndex.
         QueryDataSource dataSource =
             QueryResourceManager.getInstance()
-                .getQueryDataSource(node.getPartialPath(), queryContext, null, false);
+                .getQueryDataSource(node.getMeasurementPath(), queryContext, null, false);
         Set<String> measurementSet = new HashSet<>();
-        measurementSet.add(node.getPartialPath().getFullPath());
+        measurementSet.add(node.getMeasurementPath().getFullPath());
         LastPointReader lastReader =
             new LastPointReader(
-                node.getPartialPath(),
+                node.getMeasurementPath(),
                 node.getSchema().getType(),
                 measurementSet,
                 queryContext,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
@@ -226,7 +226,7 @@ public class LastCacheManager {
             QueryResourceManager.getInstance()
                 .getQueryDataSource(node.getMeasurementPath(), queryContext, null, false);
         Set<String> measurementSet = new HashSet<>();
-        measurementSet.add(node.getMeasurementPath().getFullPath());
+        measurementSet.add(node.getName());
         LastPointReader lastReader =
             new LastPointReader(
                 node.getMeasurementPath(),


### PR DESCRIPTION
## Description


### Cause
When trying to get last value during show timeseries, ```PartialPath``` rather than ```MeasurementPath``` was passed, which results in the failure of query.


### Solution
Replace ```node.getPartialPath``` with ```node.getMeasurementPath```.

