### PR TITLE
[IOTDB-2910] Fix Count aggregate is not right after delete sg bug

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBDeleteStorageGroupIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBDeleteStorageGroupIT.java
@@ -157,4 +157,27 @@ public class IoTDBDeleteStorageGroupIT {
       assertEquals(0, result.size());
     }
   }
+
+  @Test
+  public void testDeleteStorageGroupAndThenQuery() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("insert into root.sg1.d1(time,s1) values(1,1);");
+      statement.execute("flush");
+      statement.execute("select count(*) from root.**;");
+      statement.execute("delete storage group root.sg1");
+      statement.execute("insert into root.sg1.sdhkajhd(time,s1) values(1,1);");
+      statement.execute("flush");
+      boolean hasResult = statement.execute("select count(*) from root.**");
+      assertTrue(hasResult);
+      int count = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          count++;
+          assertEquals(1, resultSet.getLong("count(root.sg1.sdhkajhd.s1)"));
+        }
+      }
+      assertEquals(1, count);
+    }
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -27,8 +27,6 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
 import org.apache.iotdb.db.engine.StorageEngine;
-import org.apache.iotdb.db.engine.cache.ChunkCache;
-import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.CompactionRecoverManager;
 import org.apache.iotdb.db.engine.compaction.CompactionScheduler;
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
@@ -130,6 +128,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
 import static org.apache.iotdb.db.engine.storagegroup.TsFileResource.TEMP_SUFFIX;
+import static org.apache.iotdb.db.qp.executor.PlanExecutor.operateClearCache;
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 
 /**
@@ -2323,9 +2322,8 @@ public class DataRegion {
             .recoverSettleFileMap
             .remove(oldTsFileResource.getTsFile().getAbsolutePath());
       }
-      // clear Cache , including chunk cache and timeseriesMetadata cache
-      ChunkCache.getInstance().clear();
-      TimeSeriesMetadataCache.getInstance().clear();
+      // clear Cache , including chunk cache, timeseriesMetadata cache and bloom filter cache
+      operateClearCache();
 
       // if old tsfile is being deleted in the process due to its all data's being deleted.
       if (!oldTsFileResource.getTsFile().exists()) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.auth.entity.Role;
 import org.apache.iotdb.db.auth.entity.User;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
+import org.apache.iotdb.db.engine.cache.BloomFilterCache;
 import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.cq.ContinuousQueryService;
@@ -546,9 +547,10 @@ public class PlanExecutor implements IPlanExecutor {
     StorageEngine.getInstance().mergeAll();
   }
 
-  private void operateClearCache() {
+  public static void operateClearCache() {
     ChunkCache.getInstance().clear();
     TimeSeriesMetadataCache.getInstance().clear();
+    BloomFilterCache.getInstance().clear();
   }
 
   private void operateKillQuery(KillQueryPlan killQueryPlan) throws QueryIdNotExsitException {


### PR DESCRIPTION
In 0.13 and master, we add BloomFilterCache, but we forgot to add clear cache for it in `operateClearCache`.