### PR TITLE
[IOTDB-2914][IOTDB-2915]Fix npe of MLog force during killing system & Fix MLogTxtWriter while parsing CreateAlignedTimeseriesPlan

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogTxtWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogTxtWriter.java
@@ -58,6 +58,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 public class MLogTxtWriter implements AutoCloseable {
 
@@ -140,12 +141,14 @@ public class MLogTxtWriter implements AutoCloseable {
     buf.append(
         String.format(
             "%s,%s,%s,%s,%s,%s",
-            MetadataOperationType.CREATE_TIMESERIES,
+            MetadataOperationType.CREATE_ALIGNED_TIMESERIES,
             plan.getPrefixPath().getFullPath(),
             plan.getMeasurements(),
-            plan.getDataTypes().stream().map(TSDataType::serialize),
-            plan.getEncodings().stream().map(TSEncoding::serialize),
-            plan.getCompressors().stream().map(CompressionType::serialize)));
+            plan.getDataTypes().stream().map(TSDataType::serialize).collect(Collectors.toList()),
+            plan.getEncodings().stream().map(TSEncoding::serialize).collect(Collectors.toList()),
+            plan.getCompressors().stream()
+                .map(CompressionType::serialize)
+                .collect(Collectors.toList())));
 
     buf.append(",[");
     if (plan.getAliasList() != null) {

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iotdb.db.service;
 
-import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
-import org.apache.iotdb.db.metadata.schemaregion.SchemaEngine;
 import org.apache.iotdb.db.utils.MemUtils;
 
 import org.slf4j.Logger;
@@ -32,9 +30,7 @@ public class IoTDBShutdownHook extends Thread {
   @Override
   public void run() {
     // close rocksdb if possible to avoid lose data
-    for (ISchemaRegion schemaRegion : SchemaEngine.getInstance().getAllSchemaRegions()) {
-      schemaRegion.clear();
-    }
+    IoTDB.configManager.clear();
     if (logger.isInfoEnabled()) {
       logger.info(
           "IoTDB exits. Jvm memory usage: {}",


### PR DESCRIPTION
## Fix npe of MLog force during killing system

### Problem
![0d0dad006d396878918d85c2b4513a4](https://user-images.githubusercontent.com/38524330/163308405-e3817791-cbe4-40a1-a539-60c7b8d9cea4.png)
![6e48a1ecd133ef0fbc74f807264fe89](https://user-images.githubusercontent.com/38524330/163308412-37f65c92-5f7a-4091-bd90-55cd4b246a01.png)

### Cause
When kill system, the hook will be invoke before killing the mlog force thread and the npe was produced when the thread invoke a cleared schemaRegion

### Solution
Shutdown the thread in hook before region clear.

## Fix MLogTxtWriter while parsing CreateAlignedTimeseriesPlan
rename the plan name and fix the stream collect