### PR TITLE
[IOTDB-2896] Fix warning of illegal seq compaction performer

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -381,7 +381,7 @@ public class IoTDBDescriptor {
       conf.setInnerSeqCompactionPerformer(
           InnerSeqCompactionPerformer.getInnerSeqCompactionPerformer(
               properties.getProperty(
-                  "inner_seq_performer", conf.getInnerUnseqCompactionPerformer().toString())));
+                  "inner_seq_performer", conf.getInnerSeqCompactionPerformer().toString())));
 
       conf.setInnerUnseqCompactionPerformer(
           InnerUnseqCompactionPerformer.getInnerUnseqCompactionPerformer(


### PR DESCRIPTION
The reason is same as [pr-5503](https://github.com/apache/iotdb/pull/5503)