### PR TITLE
[IOTDB-2906] Commit pipe data serial number error, Can not find tsfile

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/snapshot/FileSnapshot.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/snapshot/FileSnapshot.java
@@ -410,7 +410,7 @@ public class FileSnapshot extends Snapshot implements TimeseriesSchemaSnapshot {
           new PartialPath(
               FilePathUtils.getLogicalStorageGroupName(resource.getTsFile().getAbsolutePath()));
       try {
-        StorageEngine.getInstance().getProcessor(storageGroupName).loadNewTsFile(resource);
+        StorageEngine.getInstance().getProcessor(storageGroupName).loadNewTsFile(resource, true);
         if (resource.isPlanRangeUnique()) {
           // only when a file has a unique range can we remove other files that over lap with it,
           // otherwise we may remove data that is not contained in the file

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/snapshot/FileSnapshotTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/snapshot/FileSnapshotTest.java
@@ -285,7 +285,7 @@ public class FileSnapshotTest extends DataSnapshotTest {
       resource.getTsFile().renameTo(fileWithoutHardlinkSuffix);
       resource.setFile(fileWithoutHardlinkSuffix);
       resource.serialize();
-      processor.loadNewTsFile(resource);
+      processor.loadNewTsFile(resource, true);
     }
     snapshot.setTimeseriesSchemas(timeseriesSchemas);
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -882,7 +882,7 @@ public class StorageEngine implements IService {
     manager.abortCompaction();
   }
 
-  public void loadNewTsFile(TsFileResource newTsFileResource)
+  public void loadNewTsFile(TsFileResource newTsFileResource, boolean deleteOriginFile)
       throws LoadFileException, StorageEngineException, MetadataException {
     Set<String> deviceSet = newTsFileResource.getDevices();
     if (deviceSet == null || deviceSet.isEmpty()) {
@@ -891,7 +891,7 @@ public class StorageEngine implements IService {
     String device = deviceSet.iterator().next();
     PartialPath devicePath = new PartialPath(device);
     PartialPath storageGroupPath = IoTDB.schemaProcessor.getBelongedStorageGroup(devicePath);
-    getProcessorDirectly(storageGroupPath).loadNewTsFile(newTsFileResource);
+    getProcessorDirectly(storageGroupPath).loadNewTsFile(newTsFileResource, deleteOriginFile);
   }
 
   public boolean deleteTsfile(File deletedTsfile)

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -2422,8 +2422,10 @@ public class DataRegion {
    * <p>Finally, update the latestTimeForEachDevice and partitionLatestFlushedTimeForEachDevice.
    *
    * @param newTsFileResource tsfile resource @UsedBy load external tsfile module
+   * @param deleteOriginFile whether to delete origin tsfile
    */
-  public void loadNewTsFile(TsFileResource newTsFileResource) throws LoadFileException {
+  public void loadNewTsFile(TsFileResource newTsFileResource, boolean deleteOriginFile)
+      throws LoadFileException {
     File tsfileToBeInserted = newTsFileResource.getTsFile();
     long newFilePartitionId = newTsFileResource.getTimePartitionWithCheck();
     writeLock("loadNewTsFile");
@@ -2450,7 +2452,12 @@ public class DataRegion {
             fsFactory.getFile(tsfileToBeInserted.getParentFile(), newFileName));
       }
       loadTsFileByType(
-          tsFileType, tsfileToBeInserted, newTsFileResource, newFilePartitionId, insertPos);
+          tsFileType,
+          tsfileToBeInserted,
+          newTsFileResource,
+          newFilePartitionId,
+          insertPos,
+          deleteOriginFile);
       resetLastCacheWhenLoadingTsfile(newTsFileResource);
 
       // update latest time map
@@ -2737,6 +2744,7 @@ public class DataRegion {
    * @param type load type
    * @param tsFileResource tsfile resource to be loaded
    * @param filePartitionId the partition id of the new file
+   * @param deleteOriginFile whether to delete the original file
    * @return load the file successfully @UsedBy sync module, load external tsfile module.
    */
   private boolean loadTsFileByType(
@@ -2744,7 +2752,8 @@ public class DataRegion {
       File tsFileToLoad,
       TsFileResource tsFileResource,
       long filePartitionId,
-      int insertPos)
+      int insertPos,
+      boolean deleteOriginFile)
       throws LoadFileException, DiskSpaceInsufficientException {
     File targetFile;
     switch (type) {
@@ -2805,7 +2814,11 @@ public class DataRegion {
       targetFile.getParentFile().mkdirs();
     }
     try {
-      FileUtils.moveFile(tsFileToLoad, targetFile);
+      if (deleteOriginFile) {
+        FileUtils.moveFile(tsFileToLoad, targetFile);
+      } else {
+        Files.createLink(targetFile.toPath(), tsFileToLoad.toPath());
+      }
     } catch (IOException e) {
       logger.error(
           "File renaming failed when loading tsfile. Origin: {}, Target: {}",
@@ -2823,7 +2836,11 @@ public class DataRegion {
     File targetResourceFile =
         fsFactory.getFile(targetFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX);
     try {
-      FileUtils.moveFile(resourceFileToLoad, targetResourceFile);
+      if (deleteOriginFile) {
+        FileUtils.moveFile(resourceFileToLoad, targetResourceFile);
+      } else {
+        Files.createLink(targetResourceFile.toPath(), resourceFileToLoad.toPath());
+      }
     } catch (IOException e) {
       logger.error(
           "File renaming failed when loading .resource file. Origin: {}, Target: {}",
@@ -2851,7 +2868,11 @@ public class DataRegion {
         logger.warn("Cannot delete localModFile {}", targetModFile, e);
       }
       try {
-        FileUtils.moveFile(modFileToLoad, targetModFile);
+        if (deleteOriginFile) {
+          FileUtils.moveFile(modFileToLoad, targetModFile);
+        } else {
+          Files.createLink(targetModFile.toPath(), modFileToLoad.toPath());
+        }
       } catch (IOException e) {
         logger.error(
             "File renaming failed when loading .mod file. Origin: {}, Target: {}",

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1439,7 +1439,7 @@ public class PlanExecutor implements IPlanExecutor {
       }
 
       for (TsFileResource resource : splitResources) {
-        StorageEngine.getInstance().loadNewTsFile(resource);
+        StorageEngine.getInstance().loadNewTsFile(resource, true);
       }
     } catch (Exception e) {
       logger.error("fail to load file {}", file.getName(), e);

--- a/server/src/main/java/org/apache/iotdb/db/sync/receiver/load/TsFileLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/receiver/load/TsFileLoader.java
@@ -58,7 +58,7 @@ public class TsFileLoader implements ILoader {
       }
 
       for (TsFileResource resource : splitResources) {
-        StorageEngine.getInstance().loadNewTsFile(resource);
+        StorageEngine.getInstance().loadNewTsFile(resource, false);
       }
     } catch (Exception e) {
       throw new PipeDataLoadUnbearableException(e.getMessage());


### PR DESCRIPTION
The reason for this error message is that the system deletes the file when it is loaded successfully. So `commit()` function in PipeDataQueue can not find tsfile that has been loaded to system.

I add a parameters to config whether to delete file after loading.
* If true, use move
* If false, create hardlink