### PR TITLE
[IOTDB-2861]Fix Cross compaction selector bug

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/RemoteTsFileResource.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/RemoteTsFileResource.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.utils.NodeSerializeUtils;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.utils.SerializeUtils;
 
 import java.io.DataOutputStream;
@@ -46,14 +47,14 @@ public class RemoteTsFileResource extends TsFileResource {
   private boolean isPlanRangeUnique = false;
 
   public RemoteTsFileResource() {
-    setClosed(true);
+    setStatus(TsFileResourceStatus.CLOSED);
     this.timeIndex = IoTDBDescriptor.getInstance().getConfig().getTimeIndexLevel().getTimeIndex();
   }
 
   private RemoteTsFileResource(TsFileResource other) throws IOException {
     super(other);
     withModification = new File(getModFile().getFilePath()).exists();
-    setClosed(true);
+    setStatus(TsFileResourceStatus.CLOSED);
   }
 
   public RemoteTsFileResource(TsFileResource other, Node source) throws IOException {

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -505,6 +505,12 @@ timestamp_precision=ms
 # Datatype: int
 # query_timeout_threshold=60000
 
+# The number of sub compaction threads to be set up to perform compaction.
+# Currently only works for nonAligned data in cross space compaction and unseq inner space compaction.
+# Set to 1 when less than or equal to 0.
+# Datatype: int
+# sub_compaction_thread_num=4
+
 ####################
 ### Metadata Cache Configuration
 ####################

--- a/server/src/main/java/org/apache/iotdb/db/concurrent/ThreadName.java
+++ b/server/src/main/java/org/apache/iotdb/db/concurrent/ThreadName.java
@@ -37,6 +37,7 @@ public enum ThreadName {
   FLUSH_SERVICE("Flush"),
   FLUSH_SUB_TASK_SERVICE("Flush-SubTask"),
   COMPACTION_SERVICE("Compaction"),
+  COMPACTION_SUB_SERVICE("Sub-Compaction"),
   COMPACTION_SCHEDULE("Compaction_Schedule"),
   WAL_DAEMON("WAL-Sync"),
   WAL_FORCE_DAEMON("WAL-Force"),

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -426,6 +426,12 @@ public class IoTDBConfig {
   /** The interval of compaction task submission from queue in CompactionTaskMananger */
   private long compactionSubmissionIntervalInMs = 60_000L;
 
+  /**
+   * The number of sub compaction threads to be set up to perform compaction. Currently only works
+   * for nonAligned data in cross space compaction and unseq inner space compaction.
+   */
+  private int subCompactionTaskNum = 4;
+
   /** whether to cache meta data(ChunkMetaData and TsFileMetaData) or not. */
   private boolean metaDataCacheEnable = true;
 
@@ -2510,6 +2516,14 @@ public class IoTDBConfig {
 
   public void setCompactionSubmissionIntervalInMs(long interval) {
     compactionSubmissionIntervalInMs = interval;
+  }
+
+  public int getSubCompactionTaskNum() {
+    return subCompactionTaskNum;
+  }
+
+  public void setSubCompactionTaskNum(int subCompactionTaskNum) {
+    this.subCompactionTaskNum = subCompactionTaskNum;
   }
 
   public String getDeviceIDTransformationMethod() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -361,6 +361,13 @@ public class IoTDBDescriptor {
               properties.getProperty(
                   "compaction_priority", conf.getCompactionPriority().toString())));
 
+      int subtaskNum =
+          Integer.parseInt(
+              properties.getProperty(
+                  "sub_compaction_thread_num", Integer.toString(conf.getSubCompactionTaskNum())));
+      subtaskNum = subtaskNum <= 0 ? 1 : subtaskNum;
+      conf.setSubCompactionTaskNum(subtaskNum);
+
       conf.setQueryTimeoutThreshold(
           Integer.parseInt(
               properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -66,8 +65,6 @@ public class CompactionTaskManager implements IService {
   // <logicalStorageGroupName,futureSet>, it is used to terminate all compaction tasks under the
   // logicalStorageGroup
   private Map<String, Set<Future<Void>>> storageGroupTasks = new ConcurrentHashMap<>();
-  private Map<String, Map<Long, Set<Future<Void>>>> compactionTaskFutures =
-      new ConcurrentHashMap<>();
   private List<AbstractCompactionTask> runningCompactionTaskList = new ArrayList<>();
 
   // The thread pool that periodically fetches and executes the compaction task from
@@ -243,7 +240,7 @@ public class CompactionTaskManager implements IService {
             task, CompactionTaskStatus.POLL_FROM_QUEUE, candidateCompactionTaskQueue.size());
 
         if (task != null && task.checkValidAndSetMerging()) {
-          submitTask(task.getFullStorageGroupName(), task.getTimePartition(), task);
+          submitTask(task);
           runningCompactionTaskList.add(task);
           CompactionMetricsManager.recordTaskInfo(
               task, CompactionTaskStatus.READY_TO_EXECUTE, runningCompactionTaskList.size());
@@ -293,15 +290,10 @@ public class CompactionTaskManager implements IService {
    *
    * @throws RejectedExecutionException
    */
-  public synchronized void submitTask(
-      String fullStorageGroupName, long timePartition, Callable<Void> compactionMergeTask)
+  public synchronized void submitTask(Callable<Void> compactionMergeTask)
       throws RejectedExecutionException {
     if (taskExecutionPool != null && !taskExecutionPool.isTerminated()) {
-      Future<Void> future = taskExecutionPool.submit(compactionMergeTask);
-      compactionTaskFutures
-          .computeIfAbsent(fullStorageGroupName, k -> new ConcurrentHashMap<>())
-          .computeIfAbsent(timePartition, k -> new HashSet<>())
-          .add(future);
+      taskExecutionPool.submit(compactionMergeTask);
       return;
     }
     logger.warn(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
@@ -59,6 +59,10 @@ public class CompactionTaskManager implements IService {
   // The thread pool that executes the compaction task. The default number of threads for this pool
   // is 10.
   private WrappedScheduledExecutorService taskExecutionPool;
+
+  // The thread pool that executes the sub compaction task.
+  private ScheduledExecutorService subCompactionTaskExecutionPool;
+
   public static volatile AtomicInteger currentTaskNum = new AtomicInteger(0);
   private FixedPriorityBlockingQueue<AbstractCompactionTask> candidateCompactionTaskQueue =
       new FixedPriorityBlockingQueue<>(1024, new CompactionTaskComparator());
@@ -90,6 +94,11 @@ public class CompactionTaskManager implements IService {
               IoTDBThreadPoolFactory.newScheduledThreadPool(
                   IoTDBDescriptor.getInstance().getConfig().getConcurrentCompactionThread(),
                   ThreadName.COMPACTION_SERVICE.getName());
+      this.subCompactionTaskExecutionPool =
+          IoTDBThreadPoolFactory.newScheduledThreadPool(
+              IoTDBDescriptor.getInstance().getConfig().getConcurrentCompactionThread()
+                  * IoTDBDescriptor.getInstance().getConfig().getSubCompactionTaskNum(),
+              ThreadName.COMPACTION_SUB_SERVICE.getName());
       currentTaskNum = new AtomicInteger(0);
       compactionTaskSubmissionThreadPool =
           IoTDBThreadPoolFactory.newScheduledThreadPool(1, ThreadName.COMPACTION_SERVICE.getName());
@@ -301,6 +310,14 @@ public class CompactionTaskManager implements IService {
         taskExecutionPool == null
             ? "taskExecutionPool is null"
             : "taskExecutionPool is terminated");
+  }
+
+  public synchronized Future<Void> submitSubTask(Callable<Void> subCompactionTask) {
+    if (subCompactionTaskExecutionPool != null && !subCompactionTaskExecutionPool.isTerminated()) {
+      Future<Void> future = subCompactionTaskExecutionPool.submit(subCompactionTask);
+      return future;
+    }
+    return null;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/AbstractCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/AbstractCrossSpaceCompactionTask.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.engine.compaction.cross;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,8 +45,9 @@ public abstract class AbstractCrossSpaceCompactionTask extends AbstractCompactio
 
   @Override
   public void setSourceFilesToCompactionCandidate() {
-    this.selectedSequenceFiles.forEach(x -> x.setCompactionCandidate(true));
-    this.selectedUnsequenceFiles.forEach(x -> x.setCompactionCandidate(true));
+    this.selectedSequenceFiles.forEach(x -> x.setStatus(TsFileResourceStatus.COMPACTION_CANDIDATE));
+    this.selectedUnsequenceFiles.forEach(
+        x -> x.setStatus(TsFileResourceStatus.COMPACTION_CANDIDATE));
   }
 
   public List<TsFileResource> getSelectedSequenceFiles() {
@@ -71,13 +73,11 @@ public abstract class AbstractCrossSpaceCompactionTask extends AbstractCompactio
     }
 
     for (TsFileResource resource : selectedSequenceFiles) {
-      resource.setCompacting(true);
-      resource.setCompactionCandidate(false);
+      resource.setStatus(TsFileResourceStatus.COMPACTING);
     }
 
     for (TsFileResource resource : selectedUnsequenceFiles) {
-      resource.setCompacting(true);
-      resource.setCompactionCandidate(false);
+      resource.setStatus(TsFileResourceStatus.COMPACTING);
     }
 
     return true;
@@ -98,7 +98,7 @@ public abstract class AbstractCrossSpaceCompactionTask extends AbstractCompactio
 
   @Override
   public void resetCompactionCandidateStatusForAllSourceFiles() {
-    selectedSequenceFiles.forEach(x -> x.setCompactionCandidate(false));
-    selectedUnsequenceFiles.forEach(x -> x.setCompactionCandidate(false));
+    selectedSequenceFiles.forEach(x -> x.setStatus(TsFileResourceStatus.CLOSED));
+    selectedUnsequenceFiles.forEach(x -> x.setStatus(TsFileResourceStatus.CLOSED));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/AbstractCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/AbstractCrossSpaceCompactionTask.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.engine.compaction.cross;
 
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
+import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 
 import java.util.List;
@@ -34,17 +35,11 @@ public abstract class AbstractCrossSpaceCompactionTask extends AbstractCompactio
       long timePartition,
       AtomicInteger currentTaskNum,
       List<TsFileResource> selectedSequenceFiles,
-      List<TsFileResource> selectedUnsequenceFiles) {
-    super(fullStorageGroupName, timePartition, currentTaskNum);
+      List<TsFileResource> selectedUnsequenceFiles,
+      TsFileManager tsFileManager) {
+    super(fullStorageGroupName, timePartition, tsFileManager, currentTaskNum);
     this.selectedSequenceFiles = selectedSequenceFiles;
     this.selectedUnsequenceFiles = selectedUnsequenceFiles;
-  }
-
-  public AbstractCrossSpaceCompactionTask(
-      String fullStorageGroupName, long timePartition, AtomicInteger currentTaskNum) {
-    super(fullStorageGroupName, timePartition, currentTaskNum);
-    this.selectedSequenceFiles = null;
-    this.selectedUnsequenceFiles = null;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossCompactionStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossCompactionStrategy.java
@@ -20,12 +20,10 @@ package org.apache.iotdb.db.engine.compaction.cross;
 
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.RewriteCrossSpaceCompactionSelector;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.task.RewriteCrossCompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.task.RewriteCrossSpaceCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 
-import java.io.File;
 import java.util.List;
 
 public enum CrossCompactionStrategy {
@@ -56,25 +54,6 @@ public enum CrossCompactionStrategy {
             selectedSeqTsFileResourceList,
             selectedUnSeqTsFileResourceList,
             CompactionTaskManager.currentTaskNum);
-    }
-  }
-
-  public AbstractCrossSpaceCompactionTask getCompactionRecoverTask(
-      String logicalStorageGroupName,
-      String virtualStorageGroupName,
-      long timePartitionId,
-      File logFile,
-      TsFileManager tsFileManager) {
-    switch (this) {
-      case REWRITE_COMPACTION:
-      default:
-        return new RewriteCrossCompactionRecoverTask(
-            logicalStorageGroupName,
-            virtualStorageGroupName,
-            timePartitionId,
-            logFile,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -103,7 +103,7 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
   public List[] select() throws MergeException {
     long startTime = System.currentTimeMillis();
     try {
-      logger.info(
+      logger.debug(
           "Selecting merge candidates from {} seqFile, {} unseqFiles",
           resource.getSeqFiles().size(),
           resource.getUnseqFiles().size());
@@ -115,7 +115,7 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
       resource.setUnseqFiles(selectedUnseqFiles);
       resource.removeOutdatedSeqReaders();
       if (selectedUnseqFiles.isEmpty()) {
-        logger.info("No merge candidates are found");
+        logger.debug("No merge candidates are found");
         return new List[0];
       }
     } catch (IOException e) {
@@ -226,8 +226,8 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
   /**
    * To avoid redundant data in seq files, cross space compaction should select all the seq files
    * which have overlap with unseq files whether they are compacting or not. Therefore, before
-   * adding task into the queue, cross space compaction task should be check whether source seq
-   * files are being compacted or not to speed up compaction.
+   * adding task into the queue, cross space compaction task should check whether source seq files
+   * are being compacted or not to speed up compaction.
    */
   private boolean checkIsSeqFilesValid() {
     for (Integer seqIdx : tmpSelectedSeqFiles) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -198,9 +198,10 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
   }
 
   private boolean updateSelectedFiles(long newCost, TsFileResource unseqFile) {
-    if (seqSelectedNum + selectedUnseqFiles.size() + 1 + tmpSelectedSeqFiles.size()
-            <= maxCrossCompactionFileNum
-        && totalCost + newCost < memoryBudget) {
+    if (selectedUnseqFiles.size() == 0
+        || (seqSelectedNum + selectedUnseqFiles.size() + 1 + tmpSelectedSeqFiles.size()
+                <= maxCrossCompactionFileNum
+            && totalCost + newCost < memoryBudget)) {
       selectedUnseqFiles.add(unseqFile);
       maxSeqFileCost = tempMaxSeqFileCost;
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossCompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossCompactionRecoverTask.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.utils.FileLoaderUtils;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
@@ -221,7 +222,9 @@ public class RewriteCrossCompactionRecoverTask extends RewriteCrossSpaceCompacti
     for (TsFileIdentifier sourceFileIdentifier : sourceFileIdentifiers) {
       File sourceFile = sourceFileIdentifier.getFileFromDataDirs();
       if (sourceFile != null) {
-        remainSourceTsFileResources.add(new TsFileResource(sourceFile));
+        TsFileResource resource = new TsFileResource(sourceFile);
+        resource.setStatus(TsFileResourceStatus.CLOSED);
+        remainSourceTsFileResources.add(resource);
       } else {
         // if source file does not exist, its resource file may still exist, so delete it.
         File resourceFile =

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
@@ -21,8 +21,8 @@ package org.apache.iotdb.db.engine.compaction.cross.rewrite.task;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.engine.compaction.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.cross.AbstractCrossSpaceCompactionTask;
-import org.apache.iotdb.db.engine.compaction.cross.CrossSpaceCompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
+import org.apache.iotdb.db.engine.compaction.task.CompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
@@ -53,7 +53,6 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
   protected List<TsFileResource> selectedUnSeqTsFileResourceList;
   protected TsFileResourceList seqTsFileResourceList;
   protected TsFileResourceList unseqTsFileResourceList;
-  protected TsFileManager tsFileManager;
   private File logFile;
 
   private List<TsFileResource> targetTsfileResourceList;
@@ -73,12 +72,12 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
         timePartitionId,
         currentTaskNum,
         selectedSeqTsFileResourceList,
-        selectedUnSeqTsFileResourceList);
+        selectedUnSeqTsFileResourceList,
+        tsFileManager);
     this.selectedSeqTsFileResourceList = selectedSeqTsFileResourceList;
     this.selectedUnSeqTsFileResourceList = selectedUnSeqTsFileResourceList;
     this.seqTsFileResourceList = tsFileManager.getSequenceListByTimePartition(timePartition);
     this.unseqTsFileResourceList = tsFileManager.getUnsequenceListByTimePartition(timePartition);
-    this.tsFileManager = tsFileManager;
   }
 
   @Override
@@ -88,14 +87,16 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
     } catch (Throwable throwable) {
       // catch throwable instead of exception to handle OOM errors
       logger.error("Meet errors in cross space compaction, {}", throwable.getMessage());
-      CrossSpaceCompactionExceptionHandler.handleException(
+      CompactionExceptionHandler.handleException(
           fullStorageGroupName,
           logFile,
           targetTsfileResourceList,
           selectedSeqTsFileResourceList,
           selectedUnSeqTsFileResourceList,
           tsFileManager,
-          timePartition);
+          timePartition,
+          false,
+          true);
       throw throwable;
     } finally {
       releaseAllLock();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.query.control.FileReaderManager;
@@ -187,7 +188,7 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
         releaseAllLock();
         return false;
       }
-      tsFileResource.setCompacting(true);
+      tsFileResource.setStatus(TsFileResourceStatus.COMPACTING);
     }
     return true;
   }
@@ -208,15 +209,15 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
   }
 
   private void releaseAllLock() {
-    selectedSeqTsFileResourceList.forEach(x -> x.setCompactionCandidate(false));
-    selectedUnSeqTsFileResourceList.forEach(x -> x.setCompactionCandidate(false));
+    selectedSeqTsFileResourceList.forEach(x -> x.setStatus(TsFileResourceStatus.CLOSED));
+    selectedUnSeqTsFileResourceList.forEach(x -> x.setStatus(TsFileResourceStatus.CLOSED));
     for (TsFileResource tsFileResource : holdReadLockList) {
       tsFileResource.readUnlock();
-      tsFileResource.setCompacting(false);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     }
     for (TsFileResource tsFileResource : holdWriteLockList) {
       tsFileResource.writeUnlock();
-      tsFileResource.setCompacting(false);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     }
     holdReadLockList.clear();
     holdWriteLockList.clear();
@@ -225,7 +226,7 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
   private void deleteOldFiles(List<TsFileResource> tsFileResourceList) throws IOException {
     for (TsFileResource tsFileResource : tsFileResourceList) {
       FileReaderManager.getInstance().closeFileAndRemoveReader(tsFileResource.getTsFilePath());
-      tsFileResource.setDeleted(true);
+      tsFileResource.setStatus(TsFileResourceStatus.DELETED);
       tsFileResource.remove();
       logger.info(
           "[CrossSpaceCompaction] Delete TsFile :{}.",

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/SubCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/SubCompactionTask.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.engine.compaction.cross.rewrite.task;
+
+import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.engine.compaction.CompactionUtils;
+import org.apache.iotdb.db.engine.compaction.writer.AbstractCompactionWriter;
+import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
+import org.apache.iotdb.db.exception.metadata.PathNotExistException;
+import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.query.context.QueryContext;
+import org.apache.iotdb.db.service.IoTDB;
+import org.apache.iotdb.tsfile.read.reader.IBatchReader;
+import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/**
+ * This class is used to implement reading the measurements and writing to the target files in
+ * parallel in the compaction. Currently, it only works for nonAligned data in cross space
+ * compaction and unseq inner space compaction.
+ */
+public class SubCompactionTask implements Callable<Void> {
+  private static final Logger logger =
+      LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
+  private final String device;
+  private final Set<String> measurementList;
+  private final QueryContext queryContext;
+  private final QueryDataSource queryDataSource;
+  private final AbstractCompactionWriter compactionWriter;
+  private final int taskId;
+
+  public SubCompactionTask(
+      String device,
+      Set<String> measurementList,
+      QueryContext queryContext,
+      QueryDataSource queryDataSource,
+      AbstractCompactionWriter compactionWriter,
+      int taskId) {
+    this.device = device;
+    this.measurementList = measurementList;
+    this.queryContext = queryContext;
+    this.queryDataSource = queryDataSource;
+    this.compactionWriter = compactionWriter;
+    this.taskId = taskId;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    for (String measurement : measurementList) {
+      List<IMeasurementSchema> measurementSchemas = new ArrayList<>();
+      try {
+        measurementSchemas.add(
+            IoTDB.metaManager.getSeriesSchema(new PartialPath(device, measurement)));
+      } catch (PathNotExistException e) {
+        logger.info("A deleted path is skipped: {}", e.getMessage());
+        continue;
+      }
+
+      IBatchReader dataBatchReader =
+          CompactionUtils.constructReader(
+              device,
+              Collections.singletonList(measurement),
+              measurementSchemas,
+              measurementList,
+              queryContext,
+              queryDataSource,
+              false);
+
+      if (dataBatchReader.hasNextBatch()) {
+        compactionWriter.startMeasurement(measurementSchemas, taskId);
+        CompactionUtils.writeWithReader(compactionWriter, dataBatchReader, taskId);
+        compactionWriter.endMeasurement(taskId);
+      }
+    }
+    return null;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/AbstractInnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/AbstractInnerSpaceCompactionTask.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.engine.compaction.inner;
 
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
+import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 
@@ -47,8 +48,9 @@ public abstract class AbstractInnerSpaceCompactionTask extends AbstractCompactio
       long timePartition,
       AtomicInteger currentTaskNum,
       boolean sequence,
-      List<TsFileResource> selectedTsFileResourceList) {
-    super(storageGroupName, timePartition, currentTaskNum);
+      List<TsFileResource> selectedTsFileResourceList,
+      TsFileManager tsFileManager) {
+    super(storageGroupName, timePartition, tsFileManager, currentTaskNum);
     this.selectedTsFileResourceList = selectedTsFileResourceList;
     this.sequence = sequence;
     collectSelectedFilesInfo();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/AbstractInnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/AbstractInnerSpaceCompactionTask.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +59,14 @@ public abstract class AbstractInnerSpaceCompactionTask extends AbstractCompactio
 
   @Override
   public void setSourceFilesToCompactionCandidate() {
-    this.selectedTsFileResourceList.forEach(x -> x.setCompactionCandidate(true));
+    this.selectedTsFileResourceList.forEach(
+        tsFileResource -> {
+          try {
+            tsFileResource.setStatus(TsFileResourceStatus.COMPACTION_CANDIDATE);
+          } catch (Exception e) {
+            LOGGER.error("Exception occurs when setting compaction candidate", e);
+          }
+        });
   }
 
   private void collectSelectedFilesInfo() {
@@ -116,8 +124,7 @@ public abstract class AbstractInnerSpaceCompactionTask extends AbstractCompactio
     }
 
     for (TsFileResource resource : selectedTsFileResourceList) {
-      resource.setCompacting(true);
-      resource.setCompactionCandidate(false);
+      resource.setStatus(TsFileResourceStatus.COMPACTING);
     }
     return true;
   }
@@ -139,6 +146,6 @@ public abstract class AbstractInnerSpaceCompactionTask extends AbstractCompactio
 
   @Override
   public void resetCompactionCandidateStatusForAllSourceFiles() {
-    selectedTsFileResourceList.forEach(x -> x.setCompactionCandidate(false));
+    selectedTsFileResourceList.forEach(x -> x.setStatus(TsFileResourceStatus.CLOSED));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionStrategy.java
@@ -20,13 +20,11 @@
 package org.apache.iotdb.db.engine.compaction.inner;
 
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
-import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompactionSelector;
 import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 
-import java.io.File;
 import java.util.List;
 
 public enum InnerCompactionStrategy {
@@ -57,29 +55,6 @@ public enum InnerCompactionStrategy {
             selectedTsFileResourceList,
             sequence,
             CompactionTaskManager.currentTaskNum);
-    }
-  }
-
-  public AbstractInnerSpaceCompactionTask getCompactionRecoverTask(
-      String logicalStorageGroupName,
-      String virtualStorageGroup,
-      long timePartition,
-      File compactionLogFile,
-      String dataDir,
-      boolean sequence,
-      TsFileManager tsFileManager) {
-    switch (this) {
-      case SIZE_TIERED_COMPACTION:
-      default:
-        return new SizeTieredCompactionRecoverTask(
-            logicalStorageGroupName,
-            virtualStorageGroup,
-            timePartition,
-            compactionLogFile,
-            dataDir,
-            sequence,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTask.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogAnalyzer;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 
 import org.apache.commons.io.FileUtils;
@@ -228,7 +229,9 @@ public class SizeTieredCompactionRecoverTask extends SizeTieredCompactionTask {
     for (TsFileIdentifier sourceFileIdentifier : sourceFileIdentifiers) {
       File sourceFile = sourceFileIdentifier.getFileFromDataDirs();
       if (sourceFile != null) {
-        remainSourceTsFileResources.add(new TsFileResource(sourceFile));
+        TsFileResource resource = new TsFileResource(sourceFile);
+        resource.setStatus(TsFileResourceStatus.CLOSED);
+        remainSourceTsFileResources.add(resource);
       } else {
         // if source file does not exist, its resource file may still exist, so delete it.
         File resourceFile =

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionSelector.java
@@ -123,7 +123,9 @@ public class SizeTieredCompactionSelector extends AbstractInnerSpaceCompactionSe
     for (TsFileResource currentFile : tsFileResources) {
       TsFileNameGenerator.TsFileName currentName =
           TsFileNameGenerator.getTsFileName(currentFile.getTsFile().getName());
-      if (currentName.getInnerCompactionCnt() != level || currentFile.isCompactionCandidate()) {
+      if (currentName.getInnerCompactionCnt() != level
+          || currentFile.isCompactionCandidate()
+          || currentFile.isCompacting()) {
         selectedFileList.clear();
         selectedFileSize = 0L;
         continue;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTask.java
@@ -21,9 +21,9 @@ package org.apache.iotdb.db.engine.compaction.inner.sizetiered;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.engine.compaction.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.inner.AbstractInnerSpaceCompactionTask;
-import org.apache.iotdb.db.engine.compaction.inner.InnerSpaceCompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUtils;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
+import org.apache.iotdb.db.engine.compaction.task.CompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
@@ -48,7 +48,6 @@ public class SizeTieredCompactionTask extends AbstractInnerSpaceCompactionTask {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
   protected TsFileResourceList tsFileResourceList;
-  protected TsFileManager tsFileManager;
   protected boolean[] isHoldingReadLock;
   protected boolean[] isHoldingWriteLock;
 
@@ -65,8 +64,8 @@ public class SizeTieredCompactionTask extends AbstractInnerSpaceCompactionTask {
         timePartition,
         currentTaskNum,
         sequence,
-        selectedTsFileResourceList);
-    this.tsFileManager = tsFileManager;
+        selectedTsFileResourceList,
+        tsFileManager);
     isHoldingReadLock = new boolean[selectedTsFileResourceList.size()];
     isHoldingWriteLock = new boolean[selectedTsFileResourceList.size()];
     for (int i = 0; i < selectedTsFileResourceList.size(); ++i) {
@@ -201,13 +200,29 @@ public class SizeTieredCompactionTask extends AbstractInnerSpaceCompactionTask {
       if (sizeTieredCompactionLogger != null) {
         sizeTieredCompactionLogger.close();
       }
-      InnerSpaceCompactionExceptionHandler.handleException(
-          fullStorageGroupName,
-          logFile,
-          targetTsFileResource,
-          selectedTsFileResourceList,
-          tsFileManager,
-          tsFileResourceList);
+      if (isSequence()) {
+        CompactionExceptionHandler.handleException(
+            fullStorageGroupName,
+            logFile,
+            Collections.singletonList(targetTsFileResource),
+            selectedTsFileResourceList,
+            Collections.emptyList(),
+            tsFileManager,
+            timePartition,
+            true,
+            isSequence());
+      } else {
+        CompactionExceptionHandler.handleException(
+            fullStorageGroupName,
+            logFile,
+            Collections.singletonList(targetTsFileResource),
+            Collections.emptyList(),
+            selectedTsFileResourceList,
+            tsFileManager,
+            timePartition,
+            true,
+            isSequence());
+      }
     } finally {
       releaseFileLocksAndResetMergingStatus(true);
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/InnerSpaceCompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/InnerSpaceCompactionUtils.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.db.engine.compaction.cross.CrossCompactionStrategy;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
-import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
@@ -253,16 +252,6 @@ public class InnerSpaceCompactionUtils {
         return new RewriteCompactionFileSelector(resource, budget);
       default:
         throw new UnsupportedOperationException("Unknown CrossSpaceFileStrategy " + strategy);
-    }
-  }
-
-  public static File[] findInnerSpaceCompactionLogs(String directory) {
-    File timePartitionDir = new File(directory);
-    if (timePartitionDir.exists()) {
-      return timePartitionDir.listFiles(
-          (dir, name) -> name.endsWith(CompactionLogger.INNER_COMPACTION_LOG_NAME_SUFFIX));
-    } else {
-      return new File[0];
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/InnerSpaceCompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/InnerSpaceCompactionUtils.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -234,7 +235,7 @@ public class InnerSpaceCompactionUtils {
   public static boolean deleteTsFile(TsFileResource seqFile) {
     try {
       FileReaderManager.getInstance().closeFileAndRemoveReader(seqFile.getTsFilePath());
-      seqFile.setDeleted(true);
+      seqFile.setStatus(TsFileResourceStatus.DELETED);
       seqFile.delete();
     } catch (IOException e) {
       logger.error(e.getMessage(), e);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
@@ -21,8 +21,7 @@ package org.apache.iotdb.db.engine.compaction.task;
 
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.task.RewriteCrossCompactionRecoverTask;
-import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompactionRecoverTask;
+import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,12 +41,17 @@ public abstract class AbstractCompactionTask implements Callable<Void> {
   protected String fullStorageGroupName;
   protected long timePartition;
   protected final AtomicInteger currentTaskNum;
+  protected final TsFileManager tsFileManager;
   protected long timeCost = 0L;
 
   public AbstractCompactionTask(
-      String fullStorageGroupName, long timePartition, AtomicInteger currentTaskNum) {
+      String fullStorageGroupName,
+      long timePartition,
+      TsFileManager tsFileManager,
+      AtomicInteger currentTaskNum) {
     this.fullStorageGroupName = fullStorageGroupName;
     this.timePartition = timePartition;
+    this.tsFileManager = tsFileManager;
     this.currentTaskNum = currentTaskNum;
   }
 
@@ -64,11 +68,8 @@ public abstract class AbstractCompactionTask implements Callable<Void> {
     } catch (Exception e) {
       LOGGER.error(e.getMessage(), e);
     } finally {
+      CompactionTaskManager.getInstance().removeRunningTaskFromList(this);
       timeCost = System.currentTimeMillis() - startTime;
-      if (!(this instanceof RewriteCrossCompactionRecoverTask)
-          && !(this instanceof SizeTieredCompactionRecoverTask)) {
-        CompactionTaskManager.getInstance().removeRunningTaskFromList(this);
-      }
       this.currentTaskNum.decrementAndGet();
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionExceptionHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionExceptionHandler.java
@@ -19,8 +19,7 @@
 
 package org.apache.iotdb.db.engine.compaction.task;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.CompactionUtils;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
@@ -29,6 +28,8 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.rescon.TsFileResourceManager;
 import org.apache.iotdb.tsfile.utils.TsFileUtils;
+
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionExceptionHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionExceptionHandler.java
@@ -17,17 +17,17 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.engine.compaction.cross;
+package org.apache.iotdb.db.engine.compaction.task;
 
-import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.commons.io.FileUtils;
+import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.CompactionUtils;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
 import org.apache.iotdb.db.rescon.TsFileResourceManager;
 import org.apache.iotdb.tsfile.utils.TsFileUtils;
-
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,18 +36,21 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CrossSpaceCompactionExceptionHandler {
+public class CompactionExceptionHandler {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
 
   public static void handleException(
-      String storageGroup,
+      String fullStorageGroupName,
       File logFile,
       List<TsFileResource> targetResourceList,
       List<TsFileResource> seqResourceList,
       List<TsFileResource> unseqResourceList,
       TsFileManager tsFileManager,
-      long timePartition) {
+      long timePartition,
+      boolean isInnerSpace,
+      boolean isTargetSequence) {
+    String compactionType = isInnerSpace ? "inner" : "cross";
     try {
       if (logFile == null || !logFile.exists()) {
         // the log file is null or the log file does not exists
@@ -56,42 +59,45 @@ public class CrossSpaceCompactionExceptionHandler {
         return;
       }
       LOGGER.info(
-          "[Compaction][ExceptionHandler] Cross space compaction start handling exception, source seqFiles is "
-              + seqResourceList
-              + ", source unseqFiles is "
-              + unseqResourceList);
+          "{} [Compaction][ExceptionHandler] {} space compaction start handling exception, source seqFiles is {}, source unseqFiles is {}.",
+          fullStorageGroupName,
+          compactionType,
+          seqResourceList,
+          unseqResourceList);
 
       boolean handleSuccess = true;
 
       List<TsFileResource> lostSourceFiles = new ArrayList<>();
 
-      boolean allSeqFilesExist = checkAllSourceFileExists(seqResourceList, lostSourceFiles);
-      boolean allUnseqFilesExist = checkAllSourceFileExists(unseqResourceList, lostSourceFiles);
+      boolean allSourceSeqFilesExist = checkAllSourceFileExists(seqResourceList, lostSourceFiles);
+      boolean allSourceUnseqFilesExist =
+          checkAllSourceFileExists(unseqResourceList, lostSourceFiles);
 
-      if (allSeqFilesExist && allUnseqFilesExist) {
-        // all source files exists, remove target file and recover memory
+      if (allSourceSeqFilesExist && allSourceUnseqFilesExist) {
         handleSuccess =
             handleWhenAllSourceFilesExist(
-                storageGroup,
                 targetResourceList,
                 seqResourceList,
                 unseqResourceList,
                 tsFileManager,
-                timePartition);
+                timePartition,
+                isTargetSequence,
+                fullStorageGroupName);
       } else {
         handleSuccess =
             handleWhenSomeSourceFilesLost(
-                storageGroup,
+                targetResourceList,
                 seqResourceList,
                 unseqResourceList,
-                targetResourceList,
-                lostSourceFiles);
+                lostSourceFiles,
+                fullStorageGroupName);
       }
 
       if (!handleSuccess) {
         LOGGER.error(
-            "[Compaction][ExceptionHandler] failed to handle exception, set allowCompaction to false in {}",
-            storageGroup);
+            "[Compaction][ExceptionHandler] Fail to handle {} space compaction exception, set allowCompaction to false in {}",
+            compactionType,
+            fullStorageGroupName);
         tsFileManager.setAllowCompaction(false);
       } else {
         FileUtils.delete(logFile);
@@ -100,9 +106,9 @@ public class CrossSpaceCompactionExceptionHandler {
       // catch throwable when handling exception
       // set the allowCompaction to false
       LOGGER.error(
-          "[Compaction][ExceptionHandler] exception occurs when handling exception in cross space compaction."
-              + " Set allowCompaction to false in {}",
-          storageGroup,
+          "[Compaction][ExceptionHandler] exception occurs when handling exception in {} space compaction. Set allowCompaction to false in {}",
+          compactionType,
+          fullStorageGroupName,
           throwable);
       tsFileManager.setAllowCompaction(false);
     }
@@ -124,12 +130,13 @@ public class CrossSpaceCompactionExceptionHandler {
    * under OOM errors, we do not check whether the target files are complete.
    */
   private static boolean handleWhenAllSourceFilesExist(
-      String storageGroup,
-      List<TsFileResource> targetTsFiles,
-      List<TsFileResource> seqFileList,
-      List<TsFileResource> unseqFileList,
+      List<TsFileResource> targetResourceList,
+      List<TsFileResource> sourceSeqResourceList,
+      List<TsFileResource> sourceUnseqResourceList,
       TsFileManager tsFileManager,
-      long timePartition)
+      long timePartition,
+      boolean isTargetSequence,
+      String fullStorageGroupName)
       throws IOException {
     TsFileResourceList unseqTsFileResourceList =
         tsFileManager.getUnsequenceListByTimePartition(timePartition);
@@ -137,18 +144,18 @@ public class CrossSpaceCompactionExceptionHandler {
         tsFileManager.getSequenceListByTimePartition(timePartition);
 
     // delete compaction mods files
-    CompactionUtils.deleteCompactionModsFile(seqFileList, unseqFileList);
+    CompactionUtils.deleteCompactionModsFile(sourceSeqResourceList, sourceUnseqResourceList);
 
     boolean removeAllTargetFile = true;
-    tsFileManager.writeLock("CrossSpaceCompactionExceptionHandler");
+    tsFileManager.writeLock("CompactionExceptionHandler");
     try {
-      for (TsFileResource targetTsFile : targetTsFiles) {
-        // delete target files
+      for (TsFileResource targetTsFile : targetResourceList) {
+        // delete target file
         targetTsFile.writeLock();
         if (!targetTsFile.remove()) {
           LOGGER.error(
-              "{} [Compaction][Exception] failed to delete target tsfile {} when handling exception",
-              storageGroup,
+              "{} [Compaction][Exception] fail to delete target tsfile {} when handling exception",
+              fullStorageGroupName,
               targetTsFile);
           removeAllTargetFile = false;
         }
@@ -156,19 +163,23 @@ public class CrossSpaceCompactionExceptionHandler {
 
         // remove target tsfile resource in memory
         if (targetTsFile.isFileInList()) {
-          seqTsFileResourceList.remove(targetTsFile);
+          if (isTargetSequence) {
+            seqTsFileResourceList.remove(targetTsFile);
+          } else {
+            unseqTsFileResourceList.remove(targetTsFile);
+          }
           TsFileResourceManager.getInstance().removeTsFileResource(targetTsFile);
         }
       }
 
       // recover source tsfile resource in memory
-      for (TsFileResource tsFileResource : seqFileList) {
+      for (TsFileResource tsFileResource : sourceSeqResourceList) {
         if (!tsFileResource.isFileInList()) {
           seqTsFileResourceList.keepOrderInsert(tsFileResource);
           TsFileResourceManager.getInstance().registerSealedTsFileResource(tsFileResource);
         }
       }
-      for (TsFileResource tsFileResource : unseqFileList) {
+      for (TsFileResource tsFileResource : sourceUnseqResourceList) {
         if (!tsFileResource.isFileInList()) {
           unseqTsFileResourceList.keepOrderInsert(tsFileResource);
           TsFileResourceManager.getInstance().registerSealedTsFileResource(tsFileResource);
@@ -181,38 +192,40 @@ public class CrossSpaceCompactionExceptionHandler {
   }
 
   /**
-   * Some source files are lost, check if the compaction has finished. If the compaction has
-   * finished, delete the remaining source files and compaction mods files. If the compaction has
-   * not finished, set the allowCompaction in tsFileManager to false and print some error logs.
+   * Some source files are lost, check if all target files are complete. If all target files are
+   * complete, delete the remaining source files and compaction mods files. If some target files are
+   * not complete, set the allowCompaction in tsFileManager to false and print some error logs.
    */
-  public static boolean handleWhenSomeSourceFilesLost(
-      String storageGroup,
-      List<TsFileResource> seqFileList,
-      List<TsFileResource> unseqFileList,
-      List<TsFileResource> targetFileList,
-      List<TsFileResource> lostSourceFiles)
+  private static boolean handleWhenSomeSourceFilesLost(
+      List<TsFileResource> targetResourceList,
+      List<TsFileResource> sourceSeqResourceList,
+      List<TsFileResource> sourceUnseqResourceList,
+      List<TsFileResource> lostSourceResourceList,
+      String fullStorageGroupName)
       throws IOException {
-    if (!checkIsTargetFilesComplete(targetFileList, lostSourceFiles, storageGroup)) {
+    // check whether is all target files complete
+    if (!checkIsTargetFilesComplete(
+        targetResourceList, lostSourceResourceList, fullStorageGroupName)) {
       return false;
     }
 
     // delete source files
-    for (TsFileResource unseqFile : unseqFileList) {
-      unseqFile.remove();
-      unseqFile.setDeleted(true);
+    for (TsFileResource resource : sourceSeqResourceList) {
+      resource.setStatus(TsFileResourceStatus.DELETED);
+      resource.remove();
     }
-    for (TsFileResource seqFile : seqFileList) {
-      seqFile.remove();
-      seqFile.setDeleted(true);
+    for (TsFileResource resource : sourceUnseqResourceList) {
+      resource.setStatus(TsFileResourceStatus.DELETED);
+      resource.remove();
     }
 
     // delete compaction mods files
-    CompactionUtils.deleteCompactionModsFile(seqFileList, unseqFileList);
+    CompactionUtils.deleteCompactionModsFile(sourceSeqResourceList, sourceUnseqResourceList);
 
     return true;
   }
 
-  public static boolean checkIsTargetFilesComplete(
+  private static boolean checkIsTargetFilesComplete(
       List<TsFileResource> targetResources,
       List<TsFileResource> lostSourceResources,
       String fullStorageGroupName)
@@ -224,6 +237,7 @@ public class CrossSpaceCompactionExceptionHandler {
             fullStorageGroupName,
             targetResource,
             lostSourceResources);
+        IoTDBDescriptor.getInstance().getConfig().setReadOnly(true);
         return false;
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionExceptionHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionExceptionHandler.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.engine.compaction.CompactionUtils;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.rescon.TsFileResourceManager;
 import org.apache.iotdb.tsfile.utils.TsFileUtils;
 import org.slf4j.Logger;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverManager.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.db.engine.compaction.task;
 
-import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverManager.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.engine.compaction.task;
+
+import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.directories.DirectoryManager;
+import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
+import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
+import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger.CROSS_COMPACTION_LOG_NAME_FROM_OLD;
+import static org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger.INNER_COMPACTION_LOG_NAME_SUFFIX_FROM_OLD;
+
+/**
+ * CompactionRecoverManager searches compaction log and call {@link CompactionRecoverTask} to
+ * execute the recover process for all compaction task sequentially, including InnerCompactionTask
+ * in sequence/unsequence space, CrossSpaceCompaction.
+ */
+public class CompactionRecoverManager {
+  private static final Logger logger =
+      LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
+  private final TsFileManager tsFileManager;
+  private final String logicalStorageGroupName;
+  private final String virtualStorageGroupId;
+
+  public CompactionRecoverManager(
+      TsFileManager tsFileManager, String logicalStorageGroupName, String virtualStorageGroupId) {
+    this.tsFileManager = tsFileManager;
+    this.logicalStorageGroupName = logicalStorageGroupName;
+    this.virtualStorageGroupId = virtualStorageGroupId;
+  }
+
+  public void recoverInnerSpaceCompaction(boolean isSequence) {
+    logger.info("recovering inner compaction");
+    recoverCompactionBefore013(true);
+    recoverCompaction(true, isSequence);
+  }
+
+  public void recoverCrossSpaceCompaction() {
+    logger.info("recovering cross compaction");
+    recoverCompactionBefore013(false);
+    recoverCompaction(false, true);
+  }
+
+  private void recoverCompaction(boolean isInnerSpace, boolean isLogSequence) {
+    List<String> dirs;
+    if (isLogSequence) {
+      dirs = DirectoryManager.getInstance().getAllSequenceFileFolders();
+    } else {
+      dirs = DirectoryManager.getInstance().getAllUnSequenceFileFolders();
+    }
+    for (String dir : dirs) {
+      File storageGroupDir =
+          new File(
+              dir
+                  + File.separator
+                  + logicalStorageGroupName
+                  + File.separator
+                  + virtualStorageGroupId);
+      if (!storageGroupDir.exists()) {
+        return;
+      }
+      File[] timePartitionDirs = storageGroupDir.listFiles();
+      if (timePartitionDirs == null) {
+        return;
+      }
+      for (File timePartitionDir : timePartitionDirs) {
+        if (!timePartitionDir.isDirectory()
+            || !Pattern.compile("[0-9]*").matcher(timePartitionDir.getName()).matches()) {
+          continue;
+        }
+        File[] compactionLogs =
+            CompactionLogger.findCompactionLogs(isInnerSpace, timePartitionDir.getPath());
+        for (File compactionLog : compactionLogs) {
+          logger.info("Calling compaction recover task.");
+          new CompactionRecoverTask(
+                  logicalStorageGroupName,
+                  virtualStorageGroupId,
+                  tsFileManager,
+                  compactionLog,
+                  isInnerSpace)
+              .doCompaction();
+        }
+      }
+    }
+  }
+
+  /** Check whether there is old compaction log from previous version (<0.13) and recover it. */
+  private void recoverCompactionBefore013(boolean isInnerSpace) {
+    String oldLogName =
+        isInnerSpace
+            ? logicalStorageGroupName + INNER_COMPACTION_LOG_NAME_SUFFIX_FROM_OLD
+            : CROSS_COMPACTION_LOG_NAME_FROM_OLD;
+    File logFileFromOld =
+        FSFactoryProducer.getFSFactory().getFile(tsFileManager.getStorageGroupDir(), oldLogName);
+
+    if (logFileFromOld.exists()) {
+      logger.info("Calling compaction task to recover from previous version.");
+      new CompactionRecoverTask(
+              logicalStorageGroupName,
+              virtualStorageGroupId,
+              tsFileManager,
+              logFileFromOld,
+              isInnerSpace)
+          .doCompaction();
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverTask.java
@@ -20,102 +20,479 @@ package org.apache.iotdb.db.engine.compaction.task;
 
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.conf.directories.DirectoryManager;
+import org.apache.iotdb.db.engine.compaction.CompactionUtils;
+import org.apache.iotdb.db.engine.compaction.TsFileIdentifier;
+import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogAnalyzer;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
+import org.apache.iotdb.db.engine.modification.Modification;
+import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
+import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.utils.FileLoaderUtils;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
+import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
+import org.apache.iotdb.tsfile.utils.TsFileUtils;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
 
-/**
- * CompactionRecoverTask execute the recover process for all compaction task sequentially, including
- * InnerCompactionTask in sequence/unsequence space, CrossSpaceCompaction.
- */
+/** CompactionRecoverTask executes the recover process for all compaction tasks. */
 public class CompactionRecoverTask {
-  private static final Logger logger =
-      LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
-  private TsFileManager tsFileManager;
-  private String logicalStorageGroupName;
-  private String virtualStorageGroupId;
+  private final Logger LOGGER = LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
+  private final File compactionLogFile;
+  private final boolean isInnerSpace;
+  private final String fullStorageGroupName;
+  private final TsFileManager tsFileManager;
 
   public CompactionRecoverTask(
-      TsFileManager tsFileManager, String logicalStorageGroupName, String virtualStorageGroupId) {
+      String logicalStorageGroupName,
+      String virtualStorageGroupName,
+      TsFileManager tsFileManager,
+      File logFile,
+      boolean isInnerSpace) {
+    this.compactionLogFile = logFile;
+    this.isInnerSpace = isInnerSpace;
+    this.fullStorageGroupName = logicalStorageGroupName + "-" + virtualStorageGroupName;
     this.tsFileManager = tsFileManager;
-    this.logicalStorageGroupName = logicalStorageGroupName;
-    this.virtualStorageGroupId = virtualStorageGroupId;
   }
 
-  public void recoverCrossSpaceCompaction() throws Exception {
-    logger.info("recovering cross compaction");
-    recoverCrossCompactionFromOldVersion();
-    recoverCrossCompaction();
-    logger.info("try to synchronize CompactionScheduler");
-  }
-
-  private void recoverCrossCompaction() throws Exception {
-    List<String> sequenceDirs = DirectoryManager.getInstance().getAllSequenceFileFolders();
-    for (String dir : sequenceDirs) {
-      File storageGroupDir =
-          new File(
-              dir
-                  + File.separator
-                  + logicalStorageGroupName
-                  + File.separator
-                  + virtualStorageGroupId);
-      if (!storageGroupDir.exists()) {
-        return;
-      }
-      File[] timePartitionDirs = storageGroupDir.listFiles();
-      if (timePartitionDirs == null) {
-        return;
-      }
-      for (File timePartitionDir : timePartitionDirs) {
-        if (!timePartitionDir.isDirectory()
-            || !Pattern.compile("[0-9]*").matcher(timePartitionDir.getName()).matches()) {
-          continue;
+  public void doCompaction() {
+    boolean recoverSuccess = true;
+    LOGGER.info(
+        "{} [Compaction][Recover] compaction log is {}", fullStorageGroupName, compactionLogFile);
+    try {
+      if (compactionLogFile.exists()) {
+        LOGGER.info(
+            "{} [Compaction][Recover] compaction log file {} exists, start to recover it",
+            fullStorageGroupName,
+            compactionLogFile);
+        CompactionLogAnalyzer logAnalyzer = new CompactionLogAnalyzer(compactionLogFile);
+        CompactionRecoverFromOld compactionRecoverFromOld = new CompactionRecoverFromOld();
+        if (isInnerSpace && compactionRecoverFromOld.isInnerCompactionLogBefore013()) {
+          // inner compaction log from previous version (<0.13)
+          logAnalyzer.analyzeOldInnerCompactionLog();
+        } else if (!isInnerSpace && compactionRecoverFromOld.isCrossCompactionLogBefore013()) {
+          // cross compaction log from previous version (<0.13)
+          logAnalyzer.analyzeOldCrossCompactionLog();
+        } else {
+          logAnalyzer.analyze();
         }
-        File[] compactionLogs =
-            CompactionLogger.findCrossSpaceCompactionLogs(timePartitionDir.getPath());
-        for (File compactionLog : compactionLogs) {
-          logger.info("calling cross compaction task");
-          IoTDBDescriptor.getInstance()
-              .getConfig()
-              .getCrossCompactionStrategy()
-              .getCompactionRecoverTask(
-                  logicalStorageGroupName,
-                  virtualStorageGroupId,
-                  Long.parseLong(timePartitionDir.getName()),
-                  compactionLog,
-                  tsFileManager)
-              .call();
+        List<TsFileIdentifier> sourceFileIdentifiers = logAnalyzer.getSourceFileInfos();
+        List<TsFileIdentifier> targetFileIdentifiers = logAnalyzer.getTargetFileInfos();
+
+        // compaction log file is incomplete
+        if (targetFileIdentifiers.isEmpty() || sourceFileIdentifiers.isEmpty()) {
+          LOGGER.info(
+              "{} [Compaction][Recover] incomplete log file, abort recover", fullStorageGroupName);
+          return;
+        }
+
+        // check is all source files existed
+        boolean isAllSourcesFileExisted = true;
+        for (TsFileIdentifier sourceFileIdentifier : sourceFileIdentifiers) {
+          File sourceFile = sourceFileIdentifier.getFileFromDataDirs();
+          if (sourceFile == null) {
+            isAllSourcesFileExisted = false;
+            break;
+          }
+        }
+
+        if (isAllSourcesFileExisted) {
+          if (!isInnerSpace && logAnalyzer.isLogFromOld()) {
+            recoverSuccess =
+                compactionRecoverFromOld.handleCrossCompactionWithAllSourceFilesExistBefore013(
+                    targetFileIdentifiers);
+          } else {
+            recoverSuccess =
+                handleWithAllSourceFilesExist(targetFileIdentifiers, sourceFileIdentifiers);
+          }
+        } else {
+          if (!isInnerSpace && logAnalyzer.isLogFromOld()) {
+            recoverSuccess =
+                compactionRecoverFromOld.handleCrossCompactionWithSomeSourceFilesLostBefore013(
+                    targetFileIdentifiers, sourceFileIdentifiers);
+          } else {
+            recoverSuccess =
+                handleWithSomeSourceFilesLost(targetFileIdentifiers, sourceFileIdentifiers);
+          }
+        }
+      }
+    } catch (IOException e) {
+      LOGGER.error("Recover compaction error", e);
+    } finally {
+      if (!recoverSuccess) {
+        LOGGER.error(
+            "{} [Compaction][Recover] Failed to recover compaction, set allowCompaction to false",
+            fullStorageGroupName);
+        tsFileManager.setAllowCompaction(false);
+      } else {
+        if (compactionLogFile.exists()) {
+          try {
+            LOGGER.info(
+                "{} [Compaction][Recover] Recover compaction successfully, delete log file {}",
+                fullStorageGroupName,
+                compactionLogFile);
+            FileUtils.delete(compactionLogFile);
+          } catch (IOException e) {
+            LOGGER.error(
+                "{} [Compaction][Recover] Exception occurs while deleting log file {}, set allowCompaction to false",
+                fullStorageGroupName,
+                compactionLogFile,
+                e);
+            tsFileManager.setAllowCompaction(false);
+          }
         }
       }
     }
   }
 
-  private void recoverCrossCompactionFromOldVersion() throws Exception {
-    // check whether there is old compaction log from previous version (<0.13)
-    File mergeLogFromOldVersion =
-        new File(
-            tsFileManager.getStorageGroupDir()
-                + File.separator
-                + CompactionLogger.CROSS_COMPACTION_LOG_NAME_FROM_OLD);
-    if (mergeLogFromOldVersion.exists()) {
-      logger.info("calling cross compaction task to recover from previous version.");
-      IoTDBDescriptor.getInstance()
-          .getConfig()
-          .getCrossCompactionStrategy()
-          .getCompactionRecoverTask(
-              logicalStorageGroupName,
-              virtualStorageGroupId,
-              0L,
-              mergeLogFromOldVersion,
-              tsFileManager)
-          .call();
+  /**
+   * All source files exist: (1) delete all the target files and tmp target files (2) delete
+   * compaction mods files.
+   */
+  private boolean handleWithAllSourceFilesExist(
+      List<TsFileIdentifier> targetFileIdentifiers, List<TsFileIdentifier> sourceFileIdentifiers) {
+    LOGGER.info(
+        "{} [Compaction][Recover] all source files exists, delete all target files.",
+        fullStorageGroupName);
+
+    // remove tmp target files and target files
+    for (TsFileIdentifier targetFileIdentifier : targetFileIdentifiers) {
+      // xxx.inner or xxx.cross
+      File tmpTargetFile = targetFileIdentifier.getFileFromDataDirs();
+      // xxx.tsfile
+      File targetFile =
+          getFileFromDataDirs(
+              targetFileIdentifier
+                  .getFilePath()
+                  .replace(
+                      isInnerSpace
+                          ? IoTDBConstant.INNER_COMPACTION_TMP_FILE_SUFFIX
+                          : IoTDBConstant.CROSS_COMPACTION_TMP_FILE_SUFFIX,
+                      TsFileConstant.TSFILE_SUFFIX));
+      TsFileResource targetResource = null;
+      if (tmpTargetFile != null) {
+        targetResource = new TsFileResource(tmpTargetFile);
+      } else if (targetFile != null) {
+        targetResource = new TsFileResource(targetFile);
+      }
+
+      if (targetResource != null && !targetResource.remove()) {
+        // failed to remove tmp target tsfile
+        // system should not carry out the subsequent compaction in case of data redundant
+        LOGGER.error(
+            "{} [Compaction][Recover] failed to remove target file {}",
+            fullStorageGroupName,
+            targetResource);
+        return false;
+      }
+    }
+
+    // delete compaction mods files
+    List<TsFileResource> sourceTsFileResourceList = new ArrayList<>();
+    for (TsFileIdentifier sourceFileIdentifier : sourceFileIdentifiers) {
+      sourceTsFileResourceList.add(new TsFileResource(sourceFileIdentifier.getFileFromDataDirs()));
+    }
+    try {
+      CompactionUtils.deleteCompactionModsFile(sourceTsFileResourceList, Collections.emptyList());
+    } catch (Throwable e) {
+      LOGGER.error(
+          "{} [Compaction][Recover] Exception occurs while deleting compaction mods file, set allowCompaction to false",
+          fullStorageGroupName,
+          e);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Some source files lost: delete remaining source files, including: tsfile, resource file, mods
+   * file and compaction mods file.
+   */
+  private boolean handleWithSomeSourceFilesLost(
+      List<TsFileIdentifier> targetFileIdentifiers, List<TsFileIdentifier> sourceFileIdentifiers)
+      throws IOException {
+    // some source files have been deleted, while target file must exist and complete.
+    if (!checkIsTargetFilesComplete(targetFileIdentifiers)) {
+      return false;
+    }
+
+    boolean handleSuccess = true;
+    for (TsFileIdentifier sourceFileIdentifier : sourceFileIdentifiers) {
+      File sourceFile = sourceFileIdentifier.getFileFromDataDirs();
+      if (sourceFile != null) {
+        // delete source tsfile, resource file and mods file
+        if (!new TsFileResource(sourceFile).remove()) {
+          LOGGER.error(
+              "{} [Compaction][Recover] fail to delete remaining source file {}.",
+              fullStorageGroupName,
+              sourceFile);
+          handleSuccess = false;
+        }
+      } else {
+        // if source file does not exist, its resource file may still exist, so delete it.
+        File resourceFile =
+            getFileFromDataDirs(
+                sourceFileIdentifier.getFilePath() + TsFileResource.RESOURCE_SUFFIX);
+
+        if (!checkAndDeleteFile(resourceFile)) {
+          handleSuccess = false;
+        }
+
+        // delete .mods file of source tsfile
+        File modFile =
+            getFileFromDataDirs(sourceFileIdentifier.getFilePath() + ModificationFile.FILE_SUFFIX);
+        if (!checkAndDeleteFile(modFile)) {
+          handleSuccess = false;
+        }
+      }
+
+      // delete .compaction.mods file of all source files
+      File compactionModFile =
+          getFileFromDataDirs(
+              sourceFileIdentifier.getFilePath() + ModificationFile.COMPACTION_FILE_SUFFIX);
+      if (!checkAndDeleteFile(compactionModFile)) {
+        handleSuccess = false;
+      }
+    }
+    return handleSuccess;
+  }
+
+  /**
+   * This method find the File object of given filePath by searching it in every data directory. If
+   * the file is not found, it will return null.
+   */
+  private File getFileFromDataDirs(String filePath) {
+    String[] dataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();
+    for (String dataDir : dataDirs) {
+      File f = new File(dataDir, filePath);
+      if (f.exists()) {
+        return f;
+      }
+    }
+    return null;
+  }
+
+  private boolean checkIsTargetFilesComplete(List<TsFileIdentifier> targetFileIdentifiers)
+      throws IOException {
+    for (TsFileIdentifier targetFileIdentifier : targetFileIdentifiers) {
+      // xxx.tsfile
+      File targetFile =
+          getFileFromDataDirs(
+              targetFileIdentifier
+                  .getFilePath()
+                  .replace(
+                      isInnerSpace
+                          ? IoTDBConstant.INNER_COMPACTION_TMP_FILE_SUFFIX
+                          : IoTDBConstant.CROSS_COMPACTION_TMP_FILE_SUFFIX,
+                      TsFileConstant.TSFILE_SUFFIX));
+      if (targetFile == null
+          || !TsFileUtils.isTsFileComplete(new TsFileResource(targetFile).getTsFile())) {
+        LOGGER.error(
+            "{} [Compaction][ExceptionHandler] target file {} is not complete, and some source files is lost, do nothing. Set allowCompaction to false",
+            fullStorageGroupName,
+            targetFileIdentifier.getFilePath());
+        IoTDBDescriptor.getInstance().getConfig().setReadOnly(true);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Return true if the file is not existed or if the file is existed and has been deleted
+   * correctly. Otherwise, return false.
+   */
+  private boolean checkAndDeleteFile(File file) {
+    if ((file != null && file.exists()) && !file.delete()) {
+      LOGGER.error("{} [Compaction][Recover] failed to remove file {}", fullStorageGroupName, file);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Used to check whether it is recoverd from last version (<0.13) and perform corresponding
+   * process.
+   */
+  private class CompactionRecoverFromOld {
+
+    /** Return whether cross compaction log file is from previous version (<0.13). */
+    private boolean isCrossCompactionLogBefore013() {
+      return compactionLogFile
+          .getName()
+          .equals(CompactionLogger.CROSS_COMPACTION_LOG_NAME_FROM_OLD);
+    }
+
+    /** Return whether inner compaction log file is from previous version (<0.13). */
+    private boolean isInnerCompactionLogBefore013() {
+      return compactionLogFile.getName().startsWith(tsFileManager.getStorageGroupName());
+    }
+
+    /** Delete tmp target file and compaction mods file. */
+    private boolean handleCrossCompactionWithAllSourceFilesExistBefore013(
+        List<TsFileIdentifier> targetFileIdentifiers) {
+      // delete tmp target file
+      for (TsFileIdentifier targetFileIdentifier : targetFileIdentifiers) {
+        // xxx.tsfile.merge
+        File tmpTargetFile = targetFileIdentifier.getFileFromDataDirs();
+        if (tmpTargetFile != null) {
+          tmpTargetFile.delete();
+        }
+      }
+
+      // delete compaction mods file
+      File compactionModsFileFromOld =
+          new File(
+              tsFileManager.getStorageGroupDir()
+                  + File.separator
+                  + IoTDBConstant.COMPACTION_MODIFICATION_FILE_NAME_FROM_OLD);
+      if (!checkAndDeleteFile(compactionModsFileFromOld)) {
+        return false;
+      }
+      return true;
+    }
+
+    /**
+     * 1. If target file does not exist, then move .merge file to target file <br>
+     * 2. If target resource file does not exist, then serialize it. <br>
+     * 3. Append merging modification to target mods file and delete merging mods file. <br>
+     * 4. Delete source files and .merge file. <br>
+     */
+    private boolean handleCrossCompactionWithSomeSourceFilesLostBefore013(
+        List<TsFileIdentifier> targetFileIdentifiers,
+        List<TsFileIdentifier> sourceFileIdentifiers) {
+      try {
+        File compactionModsFileFromOld =
+            new File(
+                tsFileManager.getStorageGroupDir()
+                    + File.separator
+                    + IoTDBConstant.COMPACTION_MODIFICATION_FILE_NAME_FROM_OLD);
+        List<TsFileResource> targetFileResources = new ArrayList<>();
+        for (int i = 0; i < sourceFileIdentifiers.size(); i++) {
+          TsFileIdentifier sourceFileIdentifier = sourceFileIdentifiers.get(i);
+          if (sourceFileIdentifier.isSequence()) {
+            File tmpTargetFile = targetFileIdentifiers.get(i).getFileFromDataDirs();
+            File targetFile = null;
+
+            // move tmp target file to target file if not exist
+            if (tmpTargetFile != null) {
+              // move tmp target file to target file
+              String sourceFilePath =
+                  tmpTargetFile
+                      .getPath()
+                      .replace(
+                          TsFileConstant.TSFILE_SUFFIX
+                              + IoTDBConstant.CROSS_COMPACTION_TMP_FILE_SUFFIX_FROM_OLD,
+                          TsFileConstant.TSFILE_SUFFIX);
+              targetFile = TsFileNameGenerator.increaseCrossCompactionCnt(new File(sourceFilePath));
+              FSFactoryProducer.getFSFactory().moveFile(tmpTargetFile, targetFile);
+            } else {
+              // target file must exist
+              File file =
+                  TsFileNameGenerator.increaseCrossCompactionCnt(
+                      new File(
+                          targetFileIdentifiers
+                              .get(i)
+                              .getFilePath()
+                              .replace(
+                                  TsFileConstant.TSFILE_SUFFIX
+                                      + IoTDBConstant.CROSS_COMPACTION_TMP_FILE_SUFFIX_FROM_OLD,
+                                  TsFileConstant.TSFILE_SUFFIX)));
+
+              targetFile = getFileFromDataDirs(file.getPath());
+            }
+            if (targetFile == null) {
+              LOGGER.error(
+                  "{} [Compaction][Recover] target file of source seq file {} does not exist (<0.13).",
+                  fullStorageGroupName,
+                  sourceFileIdentifier.getFilePath());
+              return false;
+            }
+
+            // serialize target resource file if not exist
+            TsFileResource targetResource = new TsFileResource(targetFile);
+            if (!targetResource.resourceFileExists()) {
+              try (TsFileSequenceReader reader =
+                  new TsFileSequenceReader(targetFile.getAbsolutePath())) {
+                FileLoaderUtils.updateTsFileResource(reader, targetResource);
+              }
+              targetResource.serialize();
+            }
+
+            targetFileResources.add(targetResource);
+
+            // append compaction modifications to target mods file and delete compaction mods file
+            if (compactionModsFileFromOld.exists()) {
+              ModificationFile compactionModsFile =
+                  new ModificationFile(compactionModsFileFromOld.getPath());
+              appendCompactionModificationsBefore013(targetResource, compactionModsFile);
+            }
+
+            // delete tmp target file
+            if (!checkAndDeleteFile(tmpTargetFile)) {
+              return false;
+            }
+          }
+
+          // delete source tsfile
+          File sourceFile = sourceFileIdentifier.getFileFromDataDirs();
+          if (!checkAndDeleteFile(sourceFile)) {
+            return false;
+          }
+
+          // delete source resource file
+          sourceFile =
+              getFileFromDataDirs(
+                  sourceFileIdentifier.getFilePath() + TsFileResource.RESOURCE_SUFFIX);
+          if (!checkAndDeleteFile(sourceFile)) {
+            return false;
+          }
+
+          // delete source mods file
+          sourceFile =
+              getFileFromDataDirs(
+                  sourceFileIdentifier.getFilePath() + ModificationFile.FILE_SUFFIX);
+          if (!checkAndDeleteFile(sourceFile)) {
+            return false;
+          }
+        }
+
+        // delete compaction mods file
+        if (!checkAndDeleteFile(compactionModsFileFromOld)) {
+          return false;
+        }
+      } catch (Throwable e) {
+        LOGGER.error(
+            "{} [Compaction][Recover] fail to handle with some source files lost from old version.",
+            fullStorageGroupName,
+            e);
+        return false;
+      }
+
+      return true;
+    }
+
+    private void appendCompactionModificationsBefore013(
+        TsFileResource resource, ModificationFile compactionModsFile) throws IOException {
+      if (compactionModsFile != null) {
+        for (Modification modification : compactionModsFile.getModifications()) {
+          // we have to set modification offset to MAX_VALUE, as the offset of source chunk may
+          // change after compaction
+          modification.setFileOffset(Long.MAX_VALUE);
+          resource.getModFile().write(modification);
+        }
+        resource.getModFile().close();
+      }
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/log/CompactionLogger.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/utils/log/CompactionLogger.java
@@ -71,11 +71,12 @@ public class CompactionLogger implements AutoCloseable {
     logStream.flush();
   }
 
-  public static File[] findCrossSpaceCompactionLogs(String directory) {
+  public static File[] findCompactionLogs(boolean isInnerSpace, String directory) {
+    String compactionLogSuffix =
+        isInnerSpace ? INNER_COMPACTION_LOG_NAME_SUFFIX : CROSS_COMPACTION_LOG_NAME_SUFFIX;
     File timePartitionDir = new File(directory);
     if (timePartitionDir.exists()) {
-      return timePartitionDir.listFiles(
-          (dir, name) -> name.endsWith(CROSS_COMPACTION_LOG_NAME_SUFFIX));
+      return timePartitionDir.listFiles((dir, name) -> name.endsWith(compactionLogSuffix));
     } else {
       return new File[0];
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.engine.compaction.writer;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
-import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 
 import java.io.IOException;
@@ -36,68 +35,73 @@ public class CrossSpaceCompactionWriter extends AbstractCompactionWriter {
   // source tsfiles
   private List<TsFileResource> seqTsFileResources;
 
-  private int seqFileIndex;
+  // Each sub task has its corresponding seq file index.
+  // The index of the array corresponds to subTaskId.
+  private int[] seqFileIndexArray = new int[subTaskNum];
 
+  // device end time in each source seq file
   private final long[] currentDeviceEndTime;
 
+  // whether each target file is empty or not
   private final boolean[] isEmptyFile;
 
-  private final boolean[] hasTargetFileStartChunkGroup;
+  // whether each target file has device data or not
+  private final boolean[] isDeviceExistedInTargetFiles;
 
-  private final List<TsFileResource> targetTsFileResources;
+  // current chunk group header size
+  private int chunkGroupHeaderSize;
 
   public CrossSpaceCompactionWriter(
       List<TsFileResource> targetResources, List<TsFileResource> seqFileResources)
       throws IOException {
     currentDeviceEndTime = new long[seqFileResources.size()];
     isEmptyFile = new boolean[seqFileResources.size()];
-    hasTargetFileStartChunkGroup = new boolean[seqFileResources.size()];
+    isDeviceExistedInTargetFiles = new boolean[targetResources.size()];
     for (int i = 0; i < targetResources.size(); i++) {
-      this.fileWriterList.add(new RestorableTsFileIOWriter(targetResources.get(i).getTsFile()));
+      this.fileWriterList.add(new TsFileIOWriter(targetResources.get(i).getTsFile()));
       isEmptyFile[i] = true;
     }
     this.seqTsFileResources = seqFileResources;
-    this.targetTsFileResources = targetResources;
-    seqFileIndex = 0;
   }
 
   @Override
   public void startChunkGroup(String deviceId, boolean isAlign) throws IOException {
     this.deviceId = deviceId;
     this.isAlign = isAlign;
-    this.seqFileIndex = 0;
+    this.seqFileIndexArray = new int[subTaskNum];
     checkIsDeviceExistAndGetDeviceEndTime();
-    for (int i = 0; i < seqTsFileResources.size(); i++) {
-      hasTargetFileStartChunkGroup[i] = false;
+    for (int i = 0; i < fileWriterList.size(); i++) {
+      chunkGroupHeaderSize = fileWriterList.get(i).startChunkGroup(deviceId);
     }
   }
 
   @Override
   public void endChunkGroup() throws IOException {
     for (int i = 0; i < seqTsFileResources.size(); i++) {
-      if (hasTargetFileStartChunkGroup[i]) {
-        fileWriterList.get(i).endChunkGroup();
+      TsFileIOWriter targetFileWriter = fileWriterList.get(i);
+      if (isDeviceExistedInTargetFiles[i]) {
+        targetFileWriter.endChunkGroup();
+      } else {
+        targetFileWriter.truncate(targetFileWriter.getPos() - chunkGroupHeaderSize);
       }
+      isDeviceExistedInTargetFiles[i] = false;
     }
     deviceId = null;
   }
 
   @Override
-  public void endMeasurement() throws IOException {
-    writeRateLimit(chunkWriter.estimateMaxSeriesMemSize());
-    chunkWriter.writeToFileWriter(fileWriterList.get(seqFileIndex));
-    chunkWriter = null;
-    seqFileIndex = 0;
+  public void endMeasurement(int subTaskId) throws IOException {
+    flushChunkToFileWriter(fileWriterList.get(seqFileIndexArray[subTaskId]), subTaskId);
+    seqFileIndexArray[subTaskId] = 0;
   }
 
   @Override
-  public void write(long timestamp, Object value) throws IOException {
-    checkTimeAndMayFlushChunkToCurrentFile(timestamp);
-    checkAndMayStartChunkGroup();
-    writeDataPoint(timestamp, value);
-    updateDeviceStartAndEndTime(targetTsFileResources.get(seqFileIndex), timestamp);
-    checkChunkSizeAndMayOpenANewChunk(fileWriterList.get(seqFileIndex));
-    isEmptyFile[seqFileIndex] = false;
+  public void write(long timestamp, Object value, int subTaskId) throws IOException {
+    checkTimeAndMayFlushChunkToCurrentFile(timestamp, subTaskId);
+    writeDataPoint(timestamp, value, subTaskId);
+    checkChunkSizeAndMayOpenANewChunk(fileWriterList.get(seqFileIndexArray[subTaskId]), subTaskId);
+    isDeviceExistedInTargetFiles[seqFileIndexArray[subTaskId]] = true;
+    isEmptyFile[seqFileIndexArray[subTaskId]] = false;
   }
 
   @Override
@@ -123,16 +127,21 @@ public class CrossSpaceCompactionWriter extends AbstractCompactionWriter {
     }
     fileWriterList = null;
     seqTsFileResources = null;
-    chunkWriter = null;
   }
 
-  private void checkTimeAndMayFlushChunkToCurrentFile(long timestamp) throws IOException {
+  @Override
+  public List<TsFileIOWriter> getFileIOWriter() {
+    return fileWriterList;
+  }
+
+  private void checkTimeAndMayFlushChunkToCurrentFile(long timestamp, int subTaskId)
+      throws IOException {
+    int fileIndex = seqFileIndexArray[subTaskId];
     // if timestamp is later than the current source seq tsfile, than flush chunk writer
-    while (timestamp > currentDeviceEndTime[seqFileIndex]) {
-      if (seqFileIndex != seqTsFileResources.size() - 1) {
-        writeRateLimit(chunkWriter.estimateMaxSeriesMemSize());
-        chunkWriter.writeToFileWriter(fileWriterList.get(seqFileIndex));
-        seqFileIndex++;
+    while (timestamp > currentDeviceEndTime[fileIndex]) {
+      if (fileIndex != seqTsFileResources.size() - 1) {
+        flushChunkToFileWriter(fileWriterList.get(fileIndex), subTaskId);
+        seqFileIndexArray[subTaskId] = ++fileIndex;
       } else {
         // If the seq file is deleted for various reasons, the following two situations may occur
         // when selecting the source files: (1) unseq files may have some devices or measurements
@@ -166,13 +175,6 @@ public class CrossSpaceCompactionWriter extends AbstractCompactionWriter {
       }
 
       fileIndex++;
-    }
-  }
-
-  private void checkAndMayStartChunkGroup() throws IOException {
-    if (!hasTargetFileStartChunkGroup[seqFileIndex]) {
-      fileWriterList.get(seqFileIndex).startChunkGroup(deviceId);
-      hasTargetFileStartChunkGroup[seqFileIndex] = true;
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -99,10 +99,7 @@ public class TsFileResource {
 
   private ModificationFile compactionModFile;
 
-  protected volatile boolean closed = false;
-  private volatile boolean deleted = false;
-  volatile boolean isCompacting = false;
-  volatile boolean compactionCandidate = false;
+  protected volatile TsFileResourceStatus status = TsFileResourceStatus.UNCLOSED;
 
   private TsFileLock tsFileLock = new TsFileLock();
 
@@ -164,9 +161,7 @@ public class TsFileResource {
     this.timeIndex = other.timeIndex;
     this.timeIndexType = other.timeIndexType;
     this.modFile = other.modFile;
-    this.closed = other.closed;
-    this.deleted = other.deleted;
-    this.isCompacting = other.isCompacting;
+    this.status = other.status;
     this.pathToChunkMetadataListMap = other.pathToChunkMetadataListMap;
     this.pathToReadOnlyMemChunkMap = other.pathToReadOnlyMemChunkMap;
     this.pathToTimeSeriesMetadataMap = other.pathToTimeSeriesMetadataMap;
@@ -383,7 +378,7 @@ public class TsFileResource {
   }
 
   public long getTsFileSize() {
-    if (closed) {
+    if (isClosed()) {
       if (tsFileSize == -1) {
         synchronized (this) {
           if (tsFileSize == -1) {
@@ -432,11 +427,11 @@ public class TsFileResource {
   }
 
   public boolean isClosed() {
-    return closed;
+    return this.status != TsFileResourceStatus.UNCLOSED;
   }
 
   public void close() throws IOException {
-    closed = true;
+    this.setStatus(TsFileResourceStatus.CLOSED);
     if (modFile != null) {
       modFile.close();
       modFile = null;
@@ -555,9 +550,7 @@ public class TsFileResource {
 
   @Override
   public String toString() {
-    return String.format(
-        "file is %s, compactionCandidate: %s, compacting: %s",
-        file.toString(), compactionCandidate, isCompacting);
+    return String.format("file is %s, status: ", file.toString(), status);
   }
 
   @Override
@@ -577,32 +570,60 @@ public class TsFileResource {
     return Objects.hash(file);
   }
 
-  public void setClosed(boolean closed) {
-    this.closed = closed;
-  }
-
   public boolean isDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(boolean deleted) {
-    this.deleted = deleted;
+    return this.status == TsFileResourceStatus.DELETED;
   }
 
   public boolean isCompacting() {
-    return isCompacting;
-  }
-
-  public void setCompacting(boolean compacting) {
-    isCompacting = compacting;
+    return this.status == TsFileResourceStatus.COMPACTING;
   }
 
   public boolean isCompactionCandidate() {
-    return compactionCandidate;
+    return this.status == TsFileResourceStatus.COMPACTION_CANDIDATE;
   }
 
-  public void setCompactionCandidate(boolean compactionCandidate) {
-    this.compactionCandidate = compactionCandidate;
+  public void setStatus(TsFileResourceStatus status) {
+    switch (status) {
+      case CLOSED:
+        if (this.status != TsFileResourceStatus.DELETED) {
+          this.status = TsFileResourceStatus.CLOSED;
+        }
+        break;
+      case UNCLOSED:
+        // Print a stack trace in a warn statement.
+        RuntimeException e = new RuntimeException();
+        LOGGER.error("Setting the status of a TsFileResource to UNCLOSED", e);
+        this.status = TsFileResourceStatus.UNCLOSED;
+        break;
+      case DELETED:
+        if (this.status != TsFileResourceStatus.UNCLOSED) {
+          this.status = TsFileResourceStatus.DELETED;
+        } else {
+          throw new RuntimeException(
+              "Cannot set the status of an unclosed TsFileResource to DELETED");
+        }
+        break;
+      case COMPACTING:
+        if (this.status == TsFileResourceStatus.COMPACTION_CANDIDATE) {
+          this.status = TsFileResourceStatus.COMPACTING;
+        } else {
+          throw new RuntimeException(
+              "Cannot set the status of TsFileResource to COMPACTING while its status is "
+                  + this.status);
+        }
+        break;
+      case COMPACTION_CANDIDATE:
+        if (this.status == TsFileResourceStatus.CLOSED) {
+          this.status = TsFileResourceStatus.COMPACTION_CANDIDATE;
+        } else {
+          throw new RuntimeException(
+              "Cannot set the status of TsFileResource to COMPACTION_CANDIDATE while its status is "
+                  + this.status);
+        }
+        break;
+      default:
+        break;
+    }
   }
 
   /**
@@ -633,7 +654,7 @@ public class TsFileResource {
     }
 
     long startTime = getStartTime(deviceId);
-    long endTime = closed || !isSeq ? getEndTime(deviceId) : Long.MAX_VALUE;
+    long endTime = isClosed() || !isSeq ? getEndTime(deviceId) : Long.MAX_VALUE;
 
     if (!isAlive(endTime, ttl)) {
       if (debug) {
@@ -656,7 +677,7 @@ public class TsFileResource {
   /** @return true if the TsFile lives beyond TTL */
   private boolean isSatisfied(Filter timeFilter, boolean isSeq, long ttl, boolean debug) {
     long startTime = getFileStartTime();
-    long endTime = closed || !isSeq ? getFileEndTime() : Long.MAX_VALUE;
+    long endTime = isClosed() || !isSeq ? getFileEndTime() : Long.MAX_VALUE;
 
     if (!isAlive(endTime, ttl)) {
       if (debug) {
@@ -695,7 +716,7 @@ public class TsFileResource {
     }
 
     long startTime = getStartTime(deviceId);
-    long endTime = closed || !isSeq ? getEndTime(deviceId) : Long.MAX_VALUE;
+    long endTime = isClosed() || !isSeq ? getEndTime(deviceId) : Long.MAX_VALUE;
 
     if (timeFilter != null) {
       boolean res = timeFilter.satisfyStartEndTime(startTime, endTime);
@@ -853,7 +874,7 @@ public class TsFileResource {
     }
     maxPlanIndex = Math.max(maxPlanIndex, planIndex);
     minPlanIndex = Math.min(minPlanIndex, planIndex);
-    if (closed) {
+    if (isClosed()) {
       try {
         serialize();
       } catch (IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResourceStatus.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResourceStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.engine.storagegroup;
+
+public enum TsFileResourceStatus {
+  UNCLOSED,
+  CLOSED,
+  COMPACTION_CANDIDATE,
+  COMPACTING,
+  DELETED
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.engine.storagegroup;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.concurrent.ThreadName;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -29,8 +30,7 @@ import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.CompactionScheduler;
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
-import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUtils;
-import org.apache.iotdb.db.engine.compaction.task.CompactionRecoverTask;
+import org.apache.iotdb.db.engine.compaction.task.CompactionRecoverManager;
 import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
 import org.apache.iotdb.db.engine.flush.CloseFileListener;
 import org.apache.iotdb.db.engine.flush.FlushListener;
@@ -90,8 +90,6 @@ import org.apache.iotdb.tsfile.fileSystem.fsFactory.FSFactory;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
-
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,10 +117,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.regex.Pattern;
 
-import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
-import static org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger.INNER_COMPACTION_LOG_NAME_SUFFIX_FROM_OLD;
+import static org.apache.iotdb.commons.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
 import static org.apache.iotdb.db.engine.storagegroup.TsFileResource.TEMP_SUFFIX;
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 
@@ -496,9 +492,7 @@ public class VirtualStorageGroupProcessor {
   /** recover from file */
   private void recover() throws StorageGroupProcessorException {
     try {
-      recoverInnerSpaceCompaction(true);
-      recoverInnerSpaceCompaction(false);
-      recoverCrossSpaceCompaction();
+      recoverCompaction();
     } catch (Exception e) {
       throw new StorageGroupProcessorException(e);
     }
@@ -592,83 +586,12 @@ public class VirtualStorageGroupProcessor {
         TimeUnit.MILLISECONDS);
   }
 
-  /** recover crossSpaceCompaction */
-  private void recoverCrossSpaceCompaction() throws Exception {
-    CompactionRecoverTask compactionRecoverTask =
-        new CompactionRecoverTask(tsFileManager, logicalStorageGroupName, virtualStorageGroupId);
-    compactionRecoverTask.recoverCrossSpaceCompaction();
-  }
-
-  private void recoverInnerSpaceCompaction(boolean isSequence) throws Exception {
-    // search compaction log for SizeTieredCompaction
-    List<String> dirs;
-    if (isSequence) {
-      dirs = DirectoryManager.getInstance().getAllSequenceFileFolders();
-    } else {
-      dirs = DirectoryManager.getInstance().getAllUnSequenceFileFolders();
-    }
-    for (String dir : dirs) {
-      File storageGroupDir =
-          new File(
-              dir
-                  + File.separator
-                  + logicalStorageGroupName
-                  + File.separator
-                  + virtualStorageGroupId);
-      if (!storageGroupDir.exists()) {
-        return;
-      }
-      File[] timePartitionDirs = storageGroupDir.listFiles();
-      if (timePartitionDirs == null) {
-        return;
-      }
-      for (File timePartitionDir : timePartitionDirs) {
-        if (!timePartitionDir.isDirectory()
-            || !Pattern.compile("[0-9]*").matcher(timePartitionDir.getName()).matches()) {
-          continue;
-        }
-        File[] compactionLogs =
-            InnerSpaceCompactionUtils.findInnerSpaceCompactionLogs(timePartitionDir.getPath());
-        for (File compactionLog : compactionLogs) {
-          IoTDBDescriptor.getInstance()
-              .getConfig()
-              .getInnerCompactionStrategy()
-              .getCompactionRecoverTask(
-                  tsFileManager.getStorageGroupName(),
-                  tsFileManager.getVirtualStorageGroup(),
-                  Long.parseLong(
-                      timePartitionDir
-                          .getPath()
-                          .substring(timePartitionDir.getPath().lastIndexOf(File.separator) + 1)),
-                  compactionLog,
-                  timePartitionDir.getPath(),
-                  isSequence,
-                  tsFileManager)
-              .call();
-        }
-      }
-    }
-
-    // search compaction log for old LevelCompaction
-    File logFile =
-        FSFactoryProducer.getFSFactory()
-            .getFile(
-                storageGroupSysDir.getAbsolutePath(),
-                logicalStorageGroupName + INNER_COMPACTION_LOG_NAME_SUFFIX_FROM_OLD);
-    if (logFile.exists()) {
-      IoTDBDescriptor.getInstance()
-          .getConfig()
-          .getInnerCompactionStrategy()
-          .getCompactionRecoverTask(
-              tsFileManager.getStorageGroupName(),
-              tsFileManager.getVirtualStorageGroup(),
-              -1,
-              logFile,
-              logFile.getParent(),
-              isSequence,
-              tsFileManager)
-          .call();
-    }
+  private void recoverCompaction() throws Exception {
+    CompactionRecoverManager compactionRecoverManager =
+        new CompactionRecoverManager(tsFileManager, logicalStorageGroupName, virtualStorageGroupId);
+    compactionRecoverManager.recoverInnerSpaceCompaction(true);
+    compactionRecoverManager.recoverInnerSpaceCompaction(false);
+    compactionRecoverManager.recoverCrossSpaceCompaction();
   }
 
   private void updatePartitionFileVersion(long partitionNum, long fileVersion) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
@@ -700,7 +700,8 @@ public class VirtualStorageGroupProcessor {
     List<TsFileResource> upgradeRet = new ArrayList<>();
     for (File f : upgradeFiles) {
       TsFileResource fileResource = new TsFileResource(f);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
+      ;
       // make sure the flush command is called before IoTDB is down.
       fileResource.deserializeFromOldFile();
       upgradeRet.add(fileResource);
@@ -769,7 +770,7 @@ public class VirtualStorageGroupProcessor {
           if (writer != null && writer.hasCrashed()) {
             tsFileManager.addForRecover(tsFileResource, isSeq);
           } else {
-            tsFileResource.setClosed(true);
+            tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
             tsFileManager.add(tsFileResource, isSeq);
             tsFileResourceManager.registerSealedTsFileResource(tsFileResource);
           }
@@ -1496,7 +1497,7 @@ public class VirtualStorageGroupProcessor {
     }
 
     // prevent new merges and queries from choosing this file
-    resource.setDeleted(true);
+    resource.setStatus(TsFileResourceStatus.DELETED);
 
     // ensure that the file is not used by any queries
     if (resource.tryWriteLock()) {
@@ -1959,7 +1960,7 @@ public class VirtualStorageGroupProcessor {
         continue;
       }
 
-      if (tsFileResource.isCompacting) {
+      if (tsFileResource.isCompacting()) {
         // we have to set modification offset to MAX_VALUE, as the offset of source chunk may
         // change after compaction
         deletion.setFileOffset(Long.MAX_VALUE);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.engine.storagegroup;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.concurrent.ThreadName;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -90,6 +89,8 @@ import org.apache.iotdb.tsfile.fileSystem.fsFactory.FSFactory;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
+
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,7 +119,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.apache.iotdb.commons.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
+import static org.apache.iotdb.db.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
 import static org.apache.iotdb.db.engine.storagegroup.TsFileResource.TEMP_SUFFIX;
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.cq.ContinuousQueryService;
 import org.apache.iotdb.db.engine.flush.pool.FlushTaskPoolManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.engine.storagegroup.VirtualStorageGroupProcessor.TimePartitionFilter;
 import org.apache.iotdb.db.engine.trigger.service.TriggerRegistrationService;
 import org.apache.iotdb.db.exception.BatchProcessException;
@@ -1269,7 +1270,7 @@ public class PlanExecutor implements IPlanExecutor {
       return;
     }
     TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     try {
       // check file
       RestorableTsFileIOWriter restorableTsFileIOWriter = new RestorableTsFileIOWriter(file);

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileRewriteTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileRewriteTool.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.engine.modification.Deletion;
 import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
@@ -503,7 +504,7 @@ public class TsFileRewriteTool implements AutoCloseable {
     }
     tsFileResource.setMinPlanIndex(minPlanIndex);
     tsFileResource.setMaxPlanIndex(maxPlanIndex);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.serialize();
     return tsFileResource;
   }

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSplitTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSplitTool.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.encoding.decoder.Decoder;
@@ -278,7 +279,7 @@ public class TsFileSplitTool {
     }
     tsFileResource.setMinPlanIndex(minPlanIndex);
     tsFileResource.setMaxPlanIndex(maxPlanIndex);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.serialize();
 
     return tsFileResource;

--- a/server/src/main/java/org/apache/iotdb/db/tools/settle/TsFileAndModSettleTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/settle/TsFileAndModSettleTool.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.tools.settle;
 import org.apache.iotdb.db.engine.settle.SettleLog;
 import org.apache.iotdb.db.engine.settle.SettleLog.SettleCheckStatus;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.tools.TsFileRewriteTool;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
@@ -66,7 +67,7 @@ public class TsFileAndModSettleTool {
     for (Map.Entry<String, Integer> entry : getInstance().recoverSettleFileMap.entrySet()) {
       String path = entry.getKey();
       TsFileResource resource = new TsFileResource(new File(path));
-      resource.setClosed(true);
+      resource.setStatus(TsFileResourceStatus.CLOSED);
       oldTsFileResources.put(resource.getTsFile().getName(), resource);
     }
     List<File> tsFiles = checkArgs(args);
@@ -74,7 +75,7 @@ public class TsFileAndModSettleTool {
       if (!oldTsFileResources.containsKey(file.getName())) {
         if (new File(file + TsFileResource.RESOURCE_SUFFIX).exists()) {
           TsFileResource resource = new TsFileResource(file);
-          resource.setClosed(true);
+          resource.setStatus(TsFileResourceStatus.CLOSED);
           oldTsFileResources.put(file.getName(), resource);
         }
       }
@@ -215,7 +216,7 @@ public class TsFileAndModSettleTool {
       tsFileRewriteTool.parseAndRewriteFile(settledResources);
     }
     if (settledResources.size() == 0) {
-      resourceToBeSettled.setDeleted(true);
+      resourceToBeSettled.setStatus(TsFileResourceStatus.DELETED);
     }
   }
 
@@ -336,7 +337,7 @@ public class TsFileAndModSettleTool {
 
         // move .resource File
         newTsFileResource.setFile(fsFactory.getFile(oldTsFile.getParent(), newTsFile.getName()));
-        newTsFileResource.setClosed(true);
+        newTsFileResource.setStatus(TsFileResourceStatus.CLOSED);
         try {
           newTsFileResource.serialize();
         } catch (IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache.TimeSeriesMetadataCacheKey;
 import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.metadata.path.AlignedPath;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.query.context.QueryContext;
@@ -62,7 +63,7 @@ public class FileLoaderUtils {
     } else {
       tsFileResource.deserialize();
     }
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
   }
 
   public static void updateTsFileResource(

--- a/server/src/main/java/org/apache/iotdb/db/utils/UpgradeUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/UpgradeUtils.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.utils;
 
 import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.engine.upgrade.UpgradeCheckStatus;
 import org.apache.iotdb.db.engine.upgrade.UpgradeLog;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
@@ -118,7 +119,7 @@ public class UpgradeUtils {
       if (fsFactory.getFile(partitionDir, newModsFile.getName()).exists()) {
         upgradedResource.getModFile();
       }
-      upgradedResource.setClosed(true);
+      upgradedResource.setStatus(TsFileResourceStatus.CLOSED);
       upgradedResource.serialize();
       // delete generated temp resource file
       Files.delete(tempResourceFile.toPath());

--- a/server/src/test/java/org/apache/iotdb/db/engine/cache/ChunkCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/cache/ChunkCacheTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.engine.cache;
 
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -166,7 +167,7 @@ public class ChunkCacheTest {
         Assert.assertTrue(file.getParentFile().mkdirs());
       }
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes(i);
       seqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum, 0);
@@ -177,7 +178,7 @@ public class ChunkCacheTest {
         Assert.assertTrue(file.getParentFile().mkdirs());
       }
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes(i + seqFileNum);
       unseqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum * (i + 1) / unseqFileNum, 10000);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionConfigRestorer;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -203,7 +204,7 @@ public class AbstractCompactionTest {
       }
     }
     resource.updatePlanIndexes(fileVersion);
-    resource.setClosed(true);
+    resource.setStatus(TsFileResourceStatus.CLOSED);
     // resource.setTimeIndexType((byte) 0);
     resource.serialize();
     if (isSeq) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManagerTest.java
@@ -184,6 +184,7 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
       Thread.sleep(10);
     }
     seqResources.get(0).readLock();
+
     // an invalid task can be submitted to waiting queue, but should not be submitted to thread pool
     Assert.assertTrue(manager.addTaskToWaitingQueue(task2));
     manager.submitTaskFromTaskQueue();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionUtilsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionUtilsTest.java
@@ -30,9 +30,14 @@ import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.db.query.reader.series.SeriesRawDataBatchReader;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.MetaMarker;
+import org.apache.iotdb.tsfile.file.header.ChunkGroupHeader;
+import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.BatchData;
 import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 import org.apache.iotdb.tsfile.utils.Pair;
@@ -202,6 +207,20 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
         CompactionFileGeneratorUtils.getInnerCompactionTargetTsFileResources(seqResources, true);
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     CompactionUtils.moveTargetFile(targetResources, true, COMPACTION_TEST_SG);
+    assertEquals(
+        0, targetResources.get(0).getStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+    assertEquals(
+        0, targetResources.get(0).getStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+    assertEquals(
+        250, targetResources.get(0).getStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+    assertEquals(
+        600, targetResources.get(0).getStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+    assertEquals(
+        600, targetResources.get(0).getStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d4"));
+    for (int i = 0; i < 5; i++) {
+      assertEquals(
+          749, targetResources.get(0).getEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i));
+    }
 
     for (int i = 0; i < 5; i++) {
       for (int j = 0; j < 5; j++) {
@@ -1752,7 +1771,7 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
   }
 
   /**
-   * Total 5 seq files and 5 unseq files, each file has different nonAligned timeseries.
+   * Total 4 seq files and 5 unseq files, each file has different nonAligned timeseries.
    *
    * <p>Seq files<br>
    * first and second file has d0 ~ d1 and s0 ~ s2, time range is 0 ~ 299 and 350 ~ 649, value range
@@ -1836,6 +1855,34 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
+    List<String> deviceIdList = new ArrayList<>();
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1");
+    for (int i = 0; i < 2; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+    for (int i = 2; i < 4; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+
     Map<String, Long> measurementMaxTime = new HashMap<>();
 
     for (int i = 0; i < 4; i++) {
@@ -1905,7 +1952,7 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
   }
 
   /**
-   * Total 5 seq files and 5 unseq files, each file has different nonAligned timeseries.
+   * Total 4 seq files and 5 unseq files, each file has different nonAligned timeseries.
    *
    * <p>Seq files<br>
    * first and second file has d0 ~ d1 and s0 ~ s2, time range is 0 ~ 299 and 350 ~ 649, value range
@@ -2002,6 +2049,34 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
+    List<String> deviceIdList = new ArrayList<>();
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1");
+    for (int i = 0; i < 2; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+    for (int i = 2; i < 4; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+
     Map<String, Long> measurementMaxTime = new HashMap<>();
     for (int i = 0; i < 4; i++) {
       for (int j = 0; j < 5; j++) {
@@ -2072,7 +2147,7 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
   }
 
   /**
-   * Total 5 seq files and 5 unseq files, each file has different nonAligned timeseries.
+   * Total 4 seq files and 5 unseq files, each file has different nonAligned timeseries.
    *
    * <p>Seq files<br>
    * first and second file has d0 ~ d1 and s0 ~ s2, time range is 0 ~ 299 and 350 ~ 649, value range
@@ -2165,6 +2240,32 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
+    List<String> deviceIdList = new ArrayList<>();
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1");
+    for (int i = 0; i < 2; i++) {
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+    for (int i = 2; i < 4; i++) {
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+
     Map<String, Long> measurementMaxTime = new HashMap<>();
     for (int i = 0; i < 4; i++) {
       for (int j = 0; j < 5; j++) {
@@ -2231,7 +2332,7 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
   }
 
   /**
-   * Total 5 seq files and 5 unseq files, each file has different nonAligned timeseries.
+   * Total 4 seq files and 5 unseq files, each file has different nonAligned timeseries.
    *
    * <p>Seq files<br>
    * first and second file has d0 ~ d1 and s0 ~ s2, time range is 0 ~ 299 and 350 ~ 649, value range
@@ -2245,8 +2346,8 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
    * forth and fifth file has d0 and s0 ~ s4, time range is 450 ~ 549 and 550 ~ 649, value range is
    * 20450 ~ 20549 and 20550 ~ 20649.
    *
-   * <p>The data of d0, d1 and d2 is deleted in each file. Data in the first target file is all
-   * deleted.
+   * <p>The data of d0, d1 and d2 is deleted in each file. Data in the first and second target file
+   * is all deleted.
    */
   @Test
   public void testCrossSpaceCompactionWithAllDataDeletedInOneTargetFile()
@@ -2320,6 +2421,21 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
+    Assert.assertEquals(2, targetResources.size());
+    List<String> deviceIdList = new ArrayList<>();
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+    for (int i = 0; i < 2; i++) {
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+
     Map<String, Long> measurementMaxTime = new HashMap<>();
     for (int i = 0; i < 4; i++) {
       for (int j = 0; j < 5; j++) {
@@ -2380,7 +2496,7 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
   }
 
   /**
-   * Total 5 seq files and 5 unseq files, each file has different nonAligned timeseries.
+   * Total 4 seq files and 5 unseq files, each file has different nonAligned timeseries.
    *
    * <p>Seq files<br>
    * first and second file has d0 ~ d1 and s0 ~ s2, time range is 0 ~ 299 and 350 ~ 649, value range
@@ -2476,6 +2592,48 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+
+    Assert.assertEquals(4, targetResources.size());
+    List<String> deviceIdList = new ArrayList<>();
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1");
+    for (int i = 0; i < 2; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+    for (int i = 2; i < 3; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+    deviceIdList.clear();
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+    for (int i = 3; i < 4; i++) {
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
 
     Map<String, Long> measurementMaxTime = new HashMap<>();
     for (int i = 0; i < 4; i++) {
@@ -2932,6 +3090,35 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+
+    Assert.assertEquals(4, targetResources.size());
+    List<String> deviceIdList = new ArrayList<>();
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10000");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10001");
+    for (int i = 0; i < 2; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10000"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10001"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10002"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10003"));
+      check(targetResources.get(i), deviceIdList);
+    }
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10002");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10003");
+    for (int i = 2; i < 4; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10000"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10001"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10002"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d10003"));
+      check(targetResources.get(i), deviceIdList);
+    }
 
     for (int i = TsFileGeneratorUtils.getAlignDeviceOffset();
         i < TsFileGeneratorUtils.getAlignDeviceOffset() + 4;
@@ -3433,6 +3620,54 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
           CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
       CompactionUtils.compact(seqResources, unseqResources, targetResources);
       CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+
+      Assert.assertEquals(4, targetResources.size());
+      List<String> deviceIdList = new ArrayList<>();
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0");
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1");
+      for (int i = 0; i < 2; i++) {
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+        Assert.assertFalse(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+        Assert.assertFalse(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+        check(targetResources.get(i), deviceIdList);
+      }
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2");
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+      for (int i = 2; i < 3; i++) {
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+        check(targetResources.get(i), deviceIdList);
+      }
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2");
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d4");
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d5");
+      for (int i = 3; i < 4; i++) {
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d4"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d5"));
+        check(targetResources.get(i), deviceIdList);
+      }
     } catch (MetadataException
         | IOException
         | WriteProcessException
@@ -3455,6 +3690,35 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
           CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
       CompactionUtils.compact(seqResources, unseqResources, targetResources);
       CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+
+      Assert.assertEquals(2, targetResources.size());
+      List<String> deviceIdList = new ArrayList<>();
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0");
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1");
+      for (int i = 0; i < 1; i++) {
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+        Assert.assertFalse(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+        Assert.assertFalse(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+        check(targetResources.get(i), deviceIdList);
+      }
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2");
+      deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+      for (int i = 1; i < 2; i++) {
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+        Assert.assertTrue(
+            targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+        check(targetResources.get(i), deviceIdList);
+      }
 
       for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 4; j++) {
@@ -3513,6 +3777,49 @@ public class CompactionUtilsTest extends AbstractCompactionTest {
         deleteMap.put(path, new Pair<>(startValue, endValue));
       }
       CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+  }
+
+  /**
+   * Check whether target file contain empty chunk group or not. Assert fail if it contains empty
+   * chunk group whose deviceID is not in the deviceIdList.
+   */
+  public void check(TsFileResource targetResource, List<String> deviceIdList) throws IOException {
+    byte marker;
+    try (TsFileSequenceReader reader =
+        new TsFileSequenceReader(targetResource.getTsFile().getAbsolutePath())) {
+      reader.position((long) TSFileConfig.MAGIC_STRING.getBytes().length + 1);
+      while ((marker = reader.readMarker()) != MetaMarker.SEPARATOR) {
+        switch (marker) {
+          case MetaMarker.CHUNK_HEADER:
+          case MetaMarker.TIME_CHUNK_HEADER:
+          case MetaMarker.VALUE_CHUNK_HEADER:
+          case MetaMarker.ONLY_ONE_PAGE_CHUNK_HEADER:
+          case MetaMarker.ONLY_ONE_PAGE_TIME_CHUNK_HEADER:
+          case MetaMarker.ONLY_ONE_PAGE_VALUE_CHUNK_HEADER:
+            ChunkHeader header = reader.readChunkHeader(marker);
+            int dataSize = header.getDataSize();
+            reader.position(reader.position() + dataSize);
+            break;
+          case MetaMarker.CHUNK_GROUP_HEADER:
+            ChunkGroupHeader chunkGroupHeader = reader.readChunkGroupHeader();
+            String deviceID = chunkGroupHeader.getDeviceID();
+            if (!deviceIdList.contains(deviceID)) {
+              Assert.fail(
+                  "Target file "
+                      + targetResource.getTsFile().getPath()
+                      + " contains empty chunk group "
+                      + deviceID);
+            }
+            break;
+          case MetaMarker.OPERATION_INDEX_RANGE:
+            reader.readPlanIndex();
+            break;
+          default:
+            // the disk file is corrupted, using this file may be dangerous
+            throw new IOException("Unexpected marker " + marker);
+        }
+      }
     }
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionExceptionTest.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.AbstractCompactionTest;
 import org.apache.iotdb.db.engine.compaction.CompactionUtils;
+import org.apache.iotdb.db.engine.compaction.task.CompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionConfigRestorer;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
@@ -91,14 +92,16 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
     compactionLogger.logFiles(unseqResources, STR_SOURCE_FILES);
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     compactionLogger.close();
-    CrossSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         compactionLogFile,
         targetResources,
         seqResources,
         unseqResources,
         tsFileManager,
-        0L);
+        0,
+        false,
+        true);
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -161,14 +164,16 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     compactionLogger.close();
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
-    CrossSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         compactionLogFile,
         targetResources,
         seqResources,
         unseqResources,
         tsFileManager,
-        0L);
+        0,
+        false,
+        true);
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -241,14 +246,16 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
     }
     seqResources.get(0).getTsFile().delete();
     compactionLogger.close();
-    CrossSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         compactionLogFile,
         targetResources,
         seqResources,
         unseqResources,
         tsFileManager,
-        0L);
+        0,
+        false,
+        true);
     // all source file should not exist
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.getTsFile().exists());
@@ -339,14 +346,16 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
     }
     seqResources.get(0).remove();
 
-    CrossSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         compactionLogFile,
         targetResources,
         seqResources,
         unseqResources,
         tsFileManager,
-        0L);
+        0,
+        false,
+        true);
     // All source file should not exist. All compaction mods file and old mods file of each source
     // file should not exist
     for (TsFileResource resource : seqResources) {
@@ -441,14 +450,16 @@ public class CrossSpaceCompactionExceptionTest extends AbstractCompactionTest {
     }
     CompactionUtils.combineModsInCompaction(seqResources, unseqResources, targetResources);
 
-    CrossSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         compactionLogFile,
         targetResources,
         seqResources,
         unseqResources,
         tsFileManager,
-        0L);
+        0,
+        false,
+        true);
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -442,7 +443,7 @@ public class CrossSpaceCompactionTest {
                   new TsFileResource(
                       TsFileNameGenerator.increaseCrossCompactionCnt(seqResource).getTsFile());
               targetResource.deserialize();
-              targetResource.setClosed(true);
+              targetResource.setStatus(TsFileResourceStatus.CLOSED);
               targetTsfileResourceList.add(targetResource);
             }
             CompactionCheckerUtils.checkDataAndResource(sourceData, targetTsfileResourceList);
@@ -745,7 +746,7 @@ public class CrossSpaceCompactionTest {
                   new TsFileResource(
                       TsFileNameGenerator.increaseCrossCompactionCnt(seqResource).getTsFile());
               targetResource.deserialize();
-              targetResource.setClosed(true);
+              targetResource.setStatus(TsFileResourceStatus.CLOSED);
               targetTsfileResourceList.add(targetResource);
             }
             CompactionCheckerUtils.checkDataAndResource(sourceData, targetTsfileResourceList);
@@ -1047,7 +1048,7 @@ public class CrossSpaceCompactionTest {
                   new TsFileResource(
                       TsFileNameGenerator.increaseCrossCompactionCnt(seqResource).getTsFile());
               targetResource.deserialize();
-              targetResource.setClosed(true);
+              targetResource.setStatus(TsFileResourceStatus.CLOSED);
               targetTsfileResourceList.add(targetResource);
             }
             CompactionCheckerUtils.checkDataAndResource(sourceData, targetTsfileResourceList);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.engine.compaction.cross;
 
 import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
+import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
@@ -108,6 +109,7 @@ public class CrossSpaceCompactionTest {
           TSFileDescriptor.getInstance().getConfig().getCompressor(),
           Collections.emptyMap());
     }
+    CompactionTaskManager.getInstance().start();
     Thread.currentThread().setName("pool-1-IoTDB-Compaction-1");
   }
 
@@ -118,6 +120,7 @@ public class CrossSpaceCompactionTest {
     ChunkCache.getInstance().clear();
     TimeSeriesMetadataCache.getInstance().clear();
     IoTDB.metaManager.clear();
+    CompactionTaskManager.getInstance().stop();
     EnvironmentUtils.cleanAllDir();
     Thread.currentThread().setName(oldThreadName);
     new CompactionConfigRestorer().restoreCompactionConfig();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeTest.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionConfigRestorer;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -120,7 +121,7 @@ abstract class MergeTest {
       File file = new File(TestConstant.getTestTsFilePath("root.sg1", 0, 0, i));
       mkdirs(file);
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.setMinPlanIndex(i);
       tsFileResource.setMaxPlanIndex(i);
       tsFileResource.setVersion(i);
@@ -131,7 +132,7 @@ abstract class MergeTest {
       File file = new File(TestConstant.getTestTsFilePath("root.sg1", 0, 0, i + seqFileNum));
       mkdirs(file);
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.setMinPlanIndex(i + seqFileNum);
       tsFileResource.setMaxPlanIndex(i + seqFileNum);
       tsFileResource.setVersion(i + seqFileNum);
@@ -143,7 +144,7 @@ abstract class MergeTest {
         new File(TestConstant.getTestTsFilePath("root.sg1", 0, 0, seqFileNum + unseqFileNum));
     mkdirs(file);
     TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.setMinPlanIndex(seqFileNum + unseqFileNum);
     tsFileResource.setMaxPlanIndex(seqFileNum + unseqFileNum);
     tsFileResource.setVersion(seqFileNum + unseqFileNum);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceComp
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.engine.storagegroup.timeindex.ITimeIndex;
 import org.apache.iotdb.db.exception.MergeException;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
@@ -128,7 +129,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                     + ".tsfile"));
     TsFileResource largeUnseqTsFileResource = new TsFileResource(file);
     unseqResources.add(largeUnseqTsFileResource);
-    largeUnseqTsFileResource.setClosed(true);
+    largeUnseqTsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     largeUnseqTsFileResource.setMinPlanIndex(10);
     largeUnseqTsFileResource.setMaxPlanIndex(10);
     largeUnseqTsFileResource.setVersion(10);
@@ -136,7 +137,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
     // update the second file's status to open
     TsFileResource secondTsFileResource = seqResources.get(1);
-    secondTsFileResource.setClosed(false);
+    secondTsFileResource.setStatus(TsFileResourceStatus.UNCLOSED);
     Set<String> devices = secondTsFileResource.getDevices();
     // update the end time of the file to Long.MIN_VALUE, so we can simulate a real open file
     Field timeIndexField = TsFileResource.class.getDeclaredField("timeIndex");
@@ -182,7 +183,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                     + ".tsfile"));
     TsFileResource largeUnseqTsFileResource = new TsFileResource(file);
     unseqResources.add(largeUnseqTsFileResource);
-    largeUnseqTsFileResource.setClosed(true);
+    largeUnseqTsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     largeUnseqTsFileResource.setMinPlanIndex(10);
     largeUnseqTsFileResource.setMaxPlanIndex(10);
     largeUnseqTsFileResource.setVersion(10);
@@ -190,7 +191,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
     // update the second file's status to open
     TsFileResource secondTsFileResource = seqResources.get(1);
-    secondTsFileResource.setClosed(false);
+    secondTsFileResource.setStatus(TsFileResourceStatus.UNCLOSED);
     Set<String> devices = secondTsFileResource.getDevices();
     // update the end time of the file to Long.MIN_VALUE, so we can simulate a real open file
     Field timeIndexField = TsFileResource.class.getDeclaredField("timeIndex");
@@ -234,7 +235,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                     + 0
                     + ".tsfile"));
     TsFileResource largeUnseqTsFileResource = new TsFileResource(file);
-    largeUnseqTsFileResource.setClosed(true);
+    largeUnseqTsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     largeUnseqTsFileResource.setMinPlanIndex(10);
     largeUnseqTsFileResource.setMaxPlanIndex(10);
     largeUnseqTsFileResource.setVersion(10);
@@ -274,7 +275,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                         + 0
                         + ".tsfile"));
         TsFileResource fileResource = new TsFileResource(file);
-        fileResource.setClosed(true);
+        fileResource.setStatus(TsFileResourceStatus.CLOSED);
         prepareFile(fileResource, i, 1, 0);
         seqList.add(fileResource);
       }
@@ -294,7 +295,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                         + 0
                         + ".tsfile"));
         TsFileResource fileResource = new TsFileResource(file);
-        fileResource.setClosed(true);
+        fileResource.setStatus(TsFileResourceStatus.CLOSED);
         unseqList.add(fileResource);
       }
       prepareFile(unseqList.get(0), 0, 1, 10);
@@ -353,7 +354,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
       prepareFile(fileResource, i, 1, i);
       seqList.add(fileResource);
     }
@@ -373,7 +374,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
       prepareFile(fileResource, i, 1, i);
       unseqList.add(fileResource);
     }
@@ -416,7 +417,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
       prepareFile(fileResource, i, 1, i);
       seqList.add(fileResource);
     }
@@ -436,7 +437,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
       prepareFile(fileResource, i, 10, i);
       unseqList.add(fileResource);
     }
@@ -478,7 +479,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
       prepareFile(fileResource, i, 1, i);
       seqList.add(fileResource);
     }
@@ -498,7 +499,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
       unseqList.add(fileResource);
     }
     prepareFile(unseqList.get(0), 7, 3, 7);
@@ -542,7 +543,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
       prepareFile(fileResource, i, 1, i);
       seqList.add(fileResource);
     }
@@ -562,7 +563,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
       unseqList.add(fileResource);
     }
     prepareFile(unseqList.get(0), 7, 3, 7);
@@ -609,11 +610,12 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      if (i - 11 != 3) {
+        fileResource.setStatus(TsFileResourceStatus.CLOSED);
+      }
       prepareFile(fileResource, i, 1, i);
       seqList.add(fileResource);
     }
-    seqList.get(3).setClosed(false);
     int unseqFileNum = 4;
     // 4 unseq files [7~9] [10~13] [14~16] [17~18]
     for (int i = 0; i < unseqFileNum; i++) {
@@ -630,7 +632,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                       + 0
                       + ".tsfile"));
       TsFileResource fileResource = new TsFileResource(file);
-      fileResource.setClosed(true);
+      fileResource.setStatus(TsFileResourceStatus.CLOSED);
       unseqList.add(fileResource);
     }
     prepareFile(unseqList.get(0), 7, 3, 7);
@@ -669,7 +671,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                     + 0
                     + ".tsfile"));
     TsFileResource firstTsFileResource = new TsFileResource(firstFile);
-    firstTsFileResource.setClosed(true);
+    firstTsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     firstTsFileResource.setMinPlanIndex(1);
     firstTsFileResource.setMaxPlanIndex(1);
     firstTsFileResource.setVersion(1);
@@ -722,7 +724,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                     + 0
                     + ".tsfile"));
     TsFileResource secondTsFileResource = new TsFileResource(secondFile);
-    secondTsFileResource.setClosed(true);
+    secondTsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     secondTsFileResource.setMinPlanIndex(2);
     secondTsFileResource.setMaxPlanIndex(2);
     secondTsFileResource.setVersion(2);
@@ -768,7 +770,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                     + 0
                     + ".tsfile"));
     TsFileResource thirdTsFileResource = new TsFileResource(thirdFile);
-    thirdTsFileResource.setClosed(true);
+    thirdTsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     thirdTsFileResource.setMinPlanIndex(3);
     thirdTsFileResource.setMaxPlanIndex(3);
     thirdTsFileResource.setVersion(3);
@@ -814,7 +816,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                     + 0
                     + ".tsfile"));
     TsFileResource fourthTsFileResource = new TsFileResource(fourthFile);
-    fourthTsFileResource.setClosed(true);
+    fourthTsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     fourthTsFileResource.setMinPlanIndex(4);
     fourthTsFileResource.setMaxPlanIndex(4);
     fourthTsFileResource.setVersion(4);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -892,4 +892,25 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
         .getConfig()
         .setMaxCrossCompactionCandidateFileNum(oldMaxCrossCompactionCandidateFileNum);
   }
+
+  @Test
+  public void testAtLeastOneUnseqFileBeenSelected() throws IOException, MergeException {
+    int maxCrossFilesNum =
+        IoTDBDescriptor.getInstance().getConfig().getMaxCrossCompactionCandidateFileNum();
+    IoTDBDescriptor.getInstance().getConfig().setMaxCrossCompactionCandidateFileNum(1);
+
+    RewriteCrossSpaceCompactionResource resource =
+        new RewriteCrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceMergeFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    List<TsFileResource> seqSelected = result[0];
+    List<TsFileResource> unseqSelected = result[1];
+    assertEquals(1, seqSelected.size());
+    assertEquals(1, unseqSelected.size());
+    resource.clear();
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setMaxCrossCompactionCandidateFileNum(maxCrossFilesNum);
+  }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionRecoverTest.java
@@ -21,9 +21,8 @@ package org.apache.iotdb.db.engine.compaction.cross;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.AbstractCompactionTest;
-import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.CompactionUtils;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.task.RewriteCrossCompactionRecoverTask;
+import org.apache.iotdb.db.engine.compaction.task.CompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
@@ -46,7 +45,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger.INNER_COMPACTION_LOG_NAME_SUFFIX;
 import static org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger.STR_SOURCE_FILES;
 import static org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger.STR_TARGET_FILES;
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
@@ -91,14 +89,8 @@ public class RewriteCrossSpaceCompactionRecoverTest extends AbstractCompactionTe
     compactionLogger.logFiles(unseqResources, STR_SOURCE_FILES);
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     compactionLogger.close();
-    new RewriteCrossCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, false)
+        .doCompaction();
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -165,14 +157,8 @@ public class RewriteCrossSpaceCompactionRecoverTest extends AbstractCompactionTe
       }
     }
     compactionLogger.close();
-    new RewriteCrossCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, false)
+        .doCompaction();
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -232,14 +218,8 @@ public class RewriteCrossSpaceCompactionRecoverTest extends AbstractCompactionTe
     CompactionUtils.compact(seqResources, unseqResources, targetResources);
     compactionLogger.close();
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
-    new RewriteCrossCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, false)
+        .doCompaction();
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -300,14 +280,8 @@ public class RewriteCrossSpaceCompactionRecoverTest extends AbstractCompactionTe
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
     seqResources.get(0).getTsFile().delete();
     compactionLogger.close();
-    new RewriteCrossCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, false)
+        .doCompaction();
     // all source file should not exist
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.getTsFile().exists());
@@ -386,14 +360,8 @@ public class RewriteCrossSpaceCompactionRecoverTest extends AbstractCompactionTe
     CompactionUtils.combineModsInCompaction(seqResources, unseqResources, targetResources);
     seqResources.get(0).remove();
 
-    new RewriteCrossCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, false)
+        .doCompaction();
     // All source file should not exist. All compaction mods file and old mods file of each source
     // file should not exist
     for (TsFileResource resource : seqResources) {
@@ -486,14 +454,8 @@ public class RewriteCrossSpaceCompactionRecoverTest extends AbstractCompactionTe
     }
     CompactionUtils.combineModsInCompaction(seqResources, unseqResources, targetResources);
 
-    new RewriteCrossCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, false)
+        .doCompaction();
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -605,14 +567,8 @@ public class RewriteCrossSpaceCompactionRecoverTest extends AbstractCompactionTe
       CompactionFileGeneratorUtils.generateMods(deleteMap, unseqResources.get(i), false);
     }
 
-    new RewriteCrossCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, false)
+        .doCompaction();
     // all source file should still exist
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionTest.java
@@ -612,6 +612,7 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
             seqResources,
             unseqResources,
             new AtomicInteger(0));
+    rewriteCrossSpaceCompactionTask.setSourceFilesToCompactionCandidate();
     rewriteCrossSpaceCompactionTask.checkValidAndSetMerging();
     // delete data in source file during compaction
     vsgp.delete(
@@ -721,6 +722,7 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
             seqResources,
             unseqResources,
             new AtomicInteger(0));
+    rewriteCrossSpaceCompactionTask.setSourceFilesToCompactionCandidate();
     rewriteCrossSpaceCompactionTask.checkValidAndSetMerging();
     // delete data in source file during compaction
     vsgp.delete(

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/AbstractInnerSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/AbstractInnerSpaceCompactionTest.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompacti
 import org.apache.iotdb.db.engine.compaction.utils.CompactionConfigRestorer;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -175,7 +176,7 @@ public abstract class AbstractInnerSpaceCompactionTest {
                           + 0
                           + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes((long) i);
       seqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum, 0);
@@ -194,7 +195,7 @@ public abstract class AbstractInnerSpaceCompactionTest {
                           + 0
                           + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes(i + seqFileNum);
       unseqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * 2 * ptNum, ptNum * (i + 1) / unseqFileNum, 10000);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionMoreDataTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionMoreDataTest.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.engine.compaction.CompactionScheduler;
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.MeasurementPath;
@@ -108,7 +109,7 @@ public class InnerCompactionMoreDataTest extends InnerCompactionTest {
                           + 0
                           + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes((long) i);
       seqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum, 0);
@@ -127,7 +128,7 @@ public class InnerCompactionMoreDataTest extends InnerCompactionTest {
                           + 0
                           + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes((long) (i + seqFileNum));
       unseqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum * (i + 1) / unseqFileNum, 10000);
@@ -146,7 +147,7 @@ public class InnerCompactionMoreDataTest extends InnerCompactionTest {
                         + 0
                         + ".tsfile"));
     TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.updatePlanIndexes(seqFileNum + unseqFileNum);
     unseqResources.add(tsFileResource);
     prepareFile(tsFileResource, 0, ptNum * unseqFileNum, 20000);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionSchedulerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionSchedulerTest.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.task.FakedInnerSpaceCompactionTaskFactory;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
@@ -110,7 +111,8 @@ public class InnerCompactionSchedulerTest extends AbstractCompactionTest {
     TsFileResourceList tsFileResources = new TsFileResourceList();
     createFiles(2, 2, 3, 100, 0, 0, 50, 50, false, true);
     createFiles(2, 3, 5, 50, 250, 250, 50, 50, false, true);
-    seqResources.get(0).setCompacting(true);
+    seqResources.get(0).setStatus(TsFileResourceStatus.COMPACTION_CANDIDATE);
+    seqResources.get(0).setStatus(TsFileResourceStatus.COMPACTING);
     TsFileManager tsFileManager = new TsFileManager("testSG", "0", "tmp");
     tsFileManager.addAll(seqResources, true);
     CompactionScheduler.tryToSubmitInnerSpaceCompactionTask(

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionTest.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionConfigRestorer;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -135,7 +136,7 @@ public abstract class InnerCompactionTest {
                           + 0
                           + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes((long) i);
       seqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum, 0);
@@ -154,7 +155,7 @@ public abstract class InnerCompactionTest {
                           + 0
                           + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes(i + seqFileNum);
       unseqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum * (i + 1) / unseqFileNum, 10000);
@@ -173,7 +174,7 @@ public abstract class InnerCompactionTest {
                         + 0
                         + ".tsfile"));
     TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.updatePlanIndexes(seqFileNum + unseqFileNum);
     unseqResources.add(tsFileResource);
     prepareFile(tsFileResource, 0, ptNum * unseqFileNum, 20000);
@@ -247,7 +248,7 @@ public abstract class InnerCompactionTest {
                         + 0
                         + ".tsfile"));
     TsFileResource tsFileResource1 = new TsFileResource(file1);
-    tsFileResource1.setClosed(true);
+    tsFileResource1.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource1.updatePlanIndexes((long) 0);
     TsFileWriter fileWriter1 = new TsFileWriter(tsFileResource1.getTsFile());
     fileWriter1.registerTimeseries(new Path(deviceIds[0]), measurementSchemas[0]);
@@ -273,7 +274,7 @@ public abstract class InnerCompactionTest {
                         + 0
                         + ".tsfile"));
     TsFileResource tsFileResource2 = new TsFileResource(file2);
-    tsFileResource2.setClosed(true);
+    tsFileResource2.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource2.updatePlanIndexes((long) 1);
     TsFileWriter fileWriter2 = new TsFileWriter(tsFileResource2.getTsFile());
     fileWriter2.registerTimeseries(new Path(deviceIds[0]), measurementSchemas[1]);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionTest.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.engine.compaction.inner;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUtils;
+import org.apache.iotdb.db.engine.compaction.task.CompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.modification.Modification;
@@ -69,13 +70,16 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
       channel.truncate(targetResource.getTsFileSize() - 10);
     }
     compactionLogger.close();
-    InnerSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         logFile,
-        targetResource,
+        Collections.singletonList(targetResource),
         seqResources,
+        Collections.emptyList(),
         tsFileManager,
-        tsFileManager.getSequenceListByTimePartition(0));
+        0,
+        true,
+        true);
     Assert.assertFalse(targetResource.getTsFile().exists());
     Assert.assertFalse(targetResource.resourceFileExists());
 
@@ -110,13 +114,16 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
     InnerSpaceCompactionUtils.compact(targetResource, seqResources);
     InnerSpaceCompactionUtils.moveTargetFile(targetResource, COMPACTION_TEST_SG);
     compactionLogger.close();
-    InnerSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         logFile,
-        targetResource,
+        Collections.singletonList(targetResource),
         seqResources,
+        Collections.emptyList(),
         tsFileManager,
-        tsFileManager.getSequenceListByTimePartition(0));
+        0,
+        true,
+        true);
     Assert.assertFalse(targetResource.getTsFile().exists());
     Assert.assertFalse(targetResource.resourceFileExists());
 
@@ -159,13 +166,16 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
     compactionLogger.close();
     Assert.assertTrue(targetResource.getTsFile().exists());
     Assert.assertTrue(targetResource.resourceFileExists());
-    InnerSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         logFile,
-        targetResource,
+        Collections.singletonList(targetResource),
         seqResources,
+        Collections.emptyList(),
         tsFileManager,
-        tsFileManager.getSequenceListByTimePartition(0));
+        0,
+        true,
+        true);
     Assert.assertTrue(targetResource.getTsFile().exists());
     Assert.assertTrue(targetResource.resourceFileExists());
 
@@ -209,13 +219,16 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
     }
     compactionLogger.close();
     Assert.assertTrue(targetResource.getTsFile().exists());
-    InnerSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         logFile,
-        targetResource,
+        Collections.singletonList(targetResource),
         seqResources,
+        Collections.emptyList(),
         tsFileManager,
-        tsFileManager.getSequenceListByTimePartition(0));
+        0,
+        true,
+        true);
     Assert.assertTrue(targetResource.getTsFile().exists());
     Assert.assertTrue(targetResource.resourceFileExists());
 
@@ -265,13 +278,16 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
     compactionLogger.close();
 
     Assert.assertTrue(targetResource.getTsFile().exists());
-    InnerSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         logFile,
-        targetResource,
+        Collections.singletonList(targetResource),
         seqResources,
+        Collections.emptyList(),
         tsFileManager,
-        tsFileManager.getSequenceListByTimePartition(0));
+        0,
+        true,
+        true);
     Assert.assertTrue(targetResource.getTsFile().exists());
     Assert.assertTrue(targetResource.resourceFileExists());
     Assert.assertTrue(targetResource.getModFile().exists());
@@ -327,13 +343,16 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
     compactionLogger.close();
 
     Assert.assertTrue(targetResource.getTsFile().exists());
-    InnerSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         logFile,
-        targetResource,
+        Collections.singletonList(targetResource),
         seqResources,
+        Collections.emptyList(),
         tsFileManager,
-        tsFileManager.getSequenceListByTimePartition(0));
+        0,
+        true,
+        true);
     Assert.assertTrue(targetResource.getTsFile().exists());
     Assert.assertTrue(targetResource.resourceFileExists());
     Assert.assertFalse(targetResource.getModFile().exists());
@@ -388,13 +407,16 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
     }
     compactionLogger.close();
 
-    InnerSpaceCompactionExceptionHandler.handleException(
+    CompactionExceptionHandler.handleException(
         COMPACTION_TEST_SG,
         logFile,
-        targetResource,
+        Collections.singletonList(targetResource),
         seqResources,
+        Collections.emptyList(),
         tsFileManager,
-        tsFileManager.getSequenceListByTimePartition(0));
+        0,
+        true,
+        true);
     Assert.assertFalse(targetResource.getTsFile().exists());
     Assert.assertFalse(targetResource.resourceFileExists());
     Assert.assertFalse(targetResource.getModFile().exists());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
@@ -22,9 +22,9 @@ package org.apache.iotdb.db.engine.compaction.inner.sizetiered;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
-import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.inner.AbstractInnerSpaceCompactionTest;
 import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUtils;
+import org.apache.iotdb.db.engine.compaction.task.CompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionConfigRestorer;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
@@ -173,16 +173,8 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     out.close();
 
     tsFileManager.addForRecover(targetTsFileResource, true);
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, true)
+        .doCompaction();
     path =
         SchemaTestUtils.getMeasurementPath(
             deviceIds[0]
@@ -274,16 +266,8 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     InnerSpaceCompactionUtils.compact(
         targetTsFileResource, new ArrayList<>(seqResources.subList(0, 3)));
     compactionLogger.close();
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, true)
+        .doCompaction();
     // all source file should still exist
     Assert.assertTrue(seqResources.get(0).getTsFile().exists());
     Assert.assertTrue(seqResources.get(1).getTsFile().exists());
@@ -306,7 +290,6 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
             deviceIds[0]
                 + TsFileConstant.PATH_SEPARATOR
                 + measurementSchemas[0].getMeasurementId());
-    System.out.println(tsFileManager.getTsFileList(true));
     tsFilesReader =
         new SeriesRawDataBatchReader(
             path,
@@ -395,16 +378,8 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     // target file may not exist
     targetTsFileResource.remove();
     compactionLogger.close();
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, true)
+        .doCompaction();
     // all source file should still exist
     Assert.assertTrue(seqResources.get(0).getTsFile().exists());
     Assert.assertTrue(seqResources.get(1).getTsFile().exists());
@@ -427,7 +402,6 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
             deviceIds[0]
                 + TsFileConstant.PATH_SEPARATOR
                 + measurementSchemas[0].getMeasurementId());
-    System.out.println(tsFileManager.getTsFileList(true));
     tsFilesReader =
         new SeriesRawDataBatchReader(
             path,
@@ -517,16 +491,8 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     // delete one source file
     seqResources.get(0).remove();
     compactionLogger.close();
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, true)
+        .doCompaction();
     // all source files should be deleted
     Assert.assertFalse(seqResources.get(0).getTsFile().exists());
     Assert.assertFalse(seqResources.get(1).getTsFile().exists());
@@ -605,16 +571,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     InnerSpaceCompactionUtils.combineModsInCompaction(seqResources, targetResource);
     compactionLogger.close();
 
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            logFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, logFile, true).doCompaction();
     // all source file should exist
     for (int i = 0; i < seqResources.size(); i++) {
       Assert.assertTrue(seqResources.get(i).getTsFile().exists());
@@ -682,16 +639,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     }
     compactionLogger.close();
 
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            logFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, logFile, true).doCompaction();
     // all source file should exist
     for (int i = 0; i < seqResources.size(); i++) {
       Assert.assertTrue(seqResources.get(i).getTsFile().exists());
@@ -763,16 +711,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     seqResources.get(0).remove();
     compactionLogger.close();
 
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            logFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, logFile, true).doCompaction();
     // all source files should not exist
     for (int i = 0; i < seqResources.size(); i++) {
       Assert.assertFalse(seqResources.get(i).getTsFile().exists());
@@ -874,16 +813,8 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     compactionLogger.close();
     InnerSpaceCompactionUtils.moveTargetFile(targetTsFileResource, COMPACTION_TEST_SG);
     tsFileManager.add(targetTsFileResource, true);
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, true)
+        .doCompaction();
     path =
         SchemaTestUtils.getMeasurementPath(
             deviceIds[0]
@@ -983,16 +914,8 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
       tsFileManager.remove(resource, true);
     }
     tsFileManager.add(targetTsFileResource, true);
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, true)
+        .doCompaction();
     path =
         SchemaTestUtils.getMeasurementPath(
             deviceIds[0]
@@ -1092,16 +1015,8 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
       deleteFileIfExists(resource.getTsFile());
     }
     tsFileManager.add(targetTsFileResource, true);
-    new SizeTieredCompactionRecoverTask(
-            INNER_COMPACTION_LOG_NAME_SUFFIX,
-            "0",
-            0,
-            compactionLogFile,
-            tempSGDir.getAbsolutePath(),
-            true,
-            CompactionTaskManager.currentTaskNum,
-            tsFileManager)
-        .call();
+    new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, true)
+        .doCompaction();
     path =
         SchemaTestUtils.getMeasurementPath(
             deviceIds[0]

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTest.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionConfigRestorer;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
@@ -130,7 +131,7 @@ public class SizeTieredCompactionTest {
                           + 0
                           + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes((long) i);
       seqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum, 0);
@@ -149,7 +150,7 @@ public class SizeTieredCompactionTest {
                           + 0
                           + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes(i + seqFileNum);
       unseqResources.add(tsFileResource);
       prepareFile(tsFileResource, i * ptNum, ptNum * (i + 1) / unseqFileNum, 10000);
@@ -168,7 +169,7 @@ public class SizeTieredCompactionTest {
                         + 0
                         + ".tsfile"));
     TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.updatePlanIndexes(seqFileNum + unseqFileNum);
     unseqResources.add(tsFileResource);
     prepareFile(tsFileResource, 0, ptNum * unseqFileNum, 20000);
@@ -243,7 +244,7 @@ public class SizeTieredCompactionTest {
                         + 0
                         + ".tsfile"));
     TsFileResource tsFileResource1 = new TsFileResource(file1);
-    tsFileResource1.setClosed(true);
+    tsFileResource1.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource1.updatePlanIndexes((long) 0);
     TsFileWriter fileWriter1 = new TsFileWriter(tsFileResource1.getTsFile());
     fileWriter1.registerTimeseries(
@@ -270,7 +271,7 @@ public class SizeTieredCompactionTest {
                         + 0
                         + ".tsfile"));
     TsFileResource tsFileResource2 = new TsFileResource(file2);
-    tsFileResource2.setClosed(true);
+    tsFileResource2.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource2.updatePlanIndexes((long) 1);
     TsFileWriter fileWriter2 = new TsFileWriter(tsFileResource2.getTsFile());
     fileWriter2.registerTimeseries(

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/RewriteCrossSpaceCompactionRecoverCompatibleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/RewriteCrossSpaceCompactionRecoverCompatibleTest.java
@@ -20,8 +20,7 @@ package org.apache.iotdb.db.engine.compaction.recover;
 
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.engine.compaction.AbstractCompactionTest;
-import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.task.RewriteCrossCompactionRecoverTask;
+import org.apache.iotdb.db.engine.compaction.task.CompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.modification.Deletion;
@@ -120,9 +119,7 @@ public class RewriteCrossSpaceCompactionRecoverCompatibleTest extends AbstractCo
     mergeMods.close();
 
     TsFileManager tsFileManager = new TsFileManager(TEST_SG, "0", SEQ_DIRS.getPath());
-    new RewriteCrossCompactionRecoverTask(
-            TEST_SG, "0", 0, logFile, CompactionTaskManager.currentTaskNum, tsFileManager)
-        .call();
+    new CompactionRecoverTask(TEST_SG, "0", tsFileManager, logFile, false).doCompaction();
 
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -201,9 +198,7 @@ public class RewriteCrossSpaceCompactionRecoverCompatibleTest extends AbstractCo
     mergeMods.close();
 
     TsFileManager tsFileManager = new TsFileManager(TEST_SG, "0", SEQ_DIRS.getPath());
-    new RewriteCrossCompactionRecoverTask(
-            TEST_SG, "0", 0, logFile, CompactionTaskManager.currentTaskNum, tsFileManager)
-        .call();
+    new CompactionRecoverTask(TEST_SG, "0", tsFileManager, logFile, false).doCompaction();
 
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.getTsFile().exists());
@@ -291,9 +286,7 @@ public class RewriteCrossSpaceCompactionRecoverCompatibleTest extends AbstractCo
     mergeMods.close();
 
     TsFileManager tsFileManager = new TsFileManager(TEST_SG, "0", SEQ_DIRS.getPath());
-    new RewriteCrossCompactionRecoverTask(
-            TEST_SG, "0", 0, logFile, CompactionTaskManager.currentTaskNum, tsFileManager)
-        .call();
+    new CompactionRecoverTask(TEST_SG, "0", tsFileManager, logFile, false).doCompaction();
 
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -375,9 +368,7 @@ public class RewriteCrossSpaceCompactionRecoverCompatibleTest extends AbstractCo
     mergeMods.close();
 
     TsFileManager tsFileManager = new TsFileManager(TEST_SG, "0", SEQ_DIRS.getPath());
-    new RewriteCrossCompactionRecoverTask(
-            TEST_SG, "0", 0, logFile, CompactionTaskManager.currentTaskNum, tsFileManager)
-        .call();
+    new CompactionRecoverTask(TEST_SG, "0", tsFileManager, logFile, false).doCompaction();
 
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.getTsFile().exists());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverCompatibleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverCompatibleTest.java
@@ -20,8 +20,8 @@
 package org.apache.iotdb.db.engine.compaction.recover;
 
 import org.apache.iotdb.db.engine.compaction.AbstractCompactionTest;
-import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUtils;
+import org.apache.iotdb.db.engine.compaction.task.CompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
@@ -44,7 +44,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
 
@@ -103,17 +102,9 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
     TsFileManager tsFileManager =
         new TsFileManager("root.compactionTest", "0", targetResource.getTsFile().getParent());
     tsFileManager.addAll(seqResources, true);
-    SizeTieredCompactionRecoverTask recoverTask =
-        new SizeTieredCompactionRecoverTask(
-            "root.compactionTest",
-            "0",
-            0,
-            logFile,
-            targetResource.getTsFile().getParent(),
-            true,
-            new AtomicInteger(0),
-            tsFileManager);
-    recoverTask.call();
+    CompactionRecoverTask recoverTask =
+        new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, logFile, true);
+    recoverTask.doCompaction();
 
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -168,17 +159,9 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
     TsFileManager tsFileManager =
         new TsFileManager("root.compactionTest", "0", targetResource.getTsFile().getParent());
     tsFileManager.addAll(seqResources, true);
-    SizeTieredCompactionRecoverTask recoverTask =
-        new SizeTieredCompactionRecoverTask(
-            "root.compactionTest",
-            "0",
-            0,
-            logFile,
-            targetResource.getTsFile().getParent(),
-            true,
-            new AtomicInteger(0),
-            tsFileManager);
-    recoverTask.call();
+    CompactionRecoverTask recoverTask =
+        new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, logFile, true);
+    recoverTask.doCompaction();
 
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.getTsFile().exists());
@@ -216,17 +199,9 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
     TsFileManager tsFileManager =
         new TsFileManager("root.compactionTest", "0", targetResource.getTsFile().getParent());
     tsFileManager.addAll(seqResources, true);
-    SizeTieredCompactionRecoverTask recoverTask =
-        new SizeTieredCompactionRecoverTask(
-            "root.compactionTest",
-            "0",
-            0,
-            logFile,
-            targetResource.getTsFile().getParent(),
-            true,
-            new AtomicInteger(0),
-            tsFileManager);
-    recoverTask.call();
+    CompactionRecoverTask recoverTask =
+        new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, logFile, true);
+    recoverTask.doCompaction();
 
     for (TsFileResource resource : seqResources) {
       Assert.assertTrue(resource.getTsFile().exists());
@@ -269,17 +244,9 @@ public class SizeTieredCompactionRecoverCompatibleTest extends AbstractCompactio
     TsFileManager tsFileManager =
         new TsFileManager("root.compactionTest", "0", targetResource.getTsFile().getParent());
     tsFileManager.addAll(unseqResources, false);
-    SizeTieredCompactionRecoverTask recoverTask =
-        new SizeTieredCompactionRecoverTask(
-            "root.compactionTest",
-            "0",
-            0,
-            logFile,
-            targetResource.getTsFile().getParent(),
-            true,
-            new AtomicInteger(0),
-            tsFileManager);
-    recoverTask.call();
+    CompactionRecoverTask recoverTask =
+        new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, logFile, true);
+    recoverTask.doCompaction();
 
     for (TsFileResource resource : unseqResources) {
       Assert.assertFalse(resource.getTsFile().exists());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.engine.compaction.recover;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -42,8 +43,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
-
-import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -783,13 +782,4 @@ public class SizeTieredCompactionRecoverTest {
       FileUtils.deleteDirectory(new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"));
     }
   }
-<<<<<<< HEAD
-
-  public static class TestMetaManager extends MManager {
-    public IMeasurementSchema getSeriesSchema(PartialPath path) {
-      return new MeasurementSchema(path.getMeasurement(), TSDataType.INT64);
-    }
-  }
-=======
->>>>>>> d53f4fa42 ([IOTDB-2561]Compaction code refactoring for restart recovery and exception handling (#5316))
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.engine.compaction.recover;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -43,6 +42,8 @@ import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
@@ -22,8 +22,8 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.constant.TestConstant;
-import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUtils;
+import org.apache.iotdb.db.engine.compaction.task.CompactionRecoverTask;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionConfigRestorer;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger;
@@ -34,7 +34,6 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.VirtualStorageGroupProcessor;
 import org.apache.iotdb.db.exception.StorageGroupProcessorException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
-import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
@@ -42,7 +41,6 @@ import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
-import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.apache.commons.io.FileUtils;
@@ -62,7 +60,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger.STR_SOURCE_FILES;
 import static org.apache.iotdb.db.engine.compaction.utils.log.CompactionLogger.STR_TARGET_FILES;
@@ -94,7 +91,7 @@ public class SizeTieredCompactionRecoverTest {
           + "0"
           + File.separator
           + "0";
-  static final TsFileManager tsileManager =
+  static final TsFileManager tsFileManager =
       new TsFileManager(COMPACTION_TEST_SG, "0", TestConstant.BASE_OUTPUT_PATH);
   static final String[] fullPaths =
       new String[] {
@@ -239,16 +236,9 @@ public class SizeTieredCompactionRecoverTest {
     compactionLogger.close();
     InnerSpaceCompactionUtils.compact(targetResource, sourceFiles);
     InnerSpaceCompactionUtils.moveTargetFile(targetResource, COMPACTION_TEST_SG);
-    SizeTieredCompactionRecoverTask recoverTask =
-        new SizeTieredCompactionRecoverTask(
-            COMPACTION_TEST_SG,
-            "0",
-            0,
-            new File(logFilePath),
-            "",
-            true,
-            new AtomicInteger(0),
-            tsileManager);
+    CompactionRecoverTask recoverTask =
+        new CompactionRecoverTask(
+            COMPACTION_TEST_SG, "0", tsFileManager, new File(logFilePath), true);
     recoverTask.doCompaction();
     // all the source file should still exist
     for (TsFileResource resource : sourceFiles) {
@@ -300,16 +290,9 @@ public class SizeTieredCompactionRecoverTest {
     FileChannel channel = targetStream.getChannel();
     channel.truncate(targetResource.getTsFile().length() - 100);
     channel.close();
-    SizeTieredCompactionRecoverTask recoverTask =
-        new SizeTieredCompactionRecoverTask(
-            COMPACTION_TEST_SG,
-            "0",
-            0,
-            new File(logFilePath),
-            "",
-            true,
-            new AtomicInteger(0),
-            tsileManager);
+    CompactionRecoverTask recoverTask =
+        new CompactionRecoverTask(
+            COMPACTION_TEST_SG, "0", tsFileManager, new File(logFilePath), true);
     recoverTask.doCompaction();
     // all the source file should be deleted
     for (TsFileResource resource : sourceFiles) {
@@ -358,16 +341,9 @@ public class SizeTieredCompactionRecoverTest {
     logger.close();
     InnerSpaceCompactionUtils.compact(targetResource, sourceFiles);
     InnerSpaceCompactionUtils.moveTargetFile(targetResource, COMPACTION_TEST_SG);
-    SizeTieredCompactionRecoverTask recoverTask =
-        new SizeTieredCompactionRecoverTask(
-            COMPACTION_TEST_SG,
-            "0",
-            0,
-            new File(logFilePath),
-            "",
-            true,
-            new AtomicInteger(0),
-            tsileManager);
+    CompactionRecoverTask recoverTask =
+        new CompactionRecoverTask(
+            COMPACTION_TEST_SG, "0", tsFileManager, new File(logFilePath), true);
     recoverTask.doCompaction();
     // all the source file should still exist
     for (TsFileResource resource : sourceFiles) {
@@ -419,16 +395,9 @@ public class SizeTieredCompactionRecoverTest {
     FileChannel channel = targetStream.getChannel();
     channel.truncate(targetResource.getTsFile().length() - 100);
     channel.close();
-    SizeTieredCompactionRecoverTask recoverTask =
-        new SizeTieredCompactionRecoverTask(
-            COMPACTION_TEST_SG,
-            "0",
-            0,
-            new File(logFilePath),
-            "",
-            true,
-            new AtomicInteger(0),
-            tsileManager);
+    CompactionRecoverTask recoverTask =
+        new CompactionRecoverTask(
+            COMPACTION_TEST_SG, "0", tsFileManager, new File(logFilePath), true);
     recoverTask.doCompaction();
     // all the source file should be deleted
     for (TsFileResource resource : sourceFiles) {
@@ -485,16 +454,9 @@ public class SizeTieredCompactionRecoverTest {
           new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data"),
           new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"));
       setDataDirs(new String[] {TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"});
-      SizeTieredCompactionRecoverTask recoverTask =
-          new SizeTieredCompactionRecoverTask(
-              COMPACTION_TEST_SG,
-              "0",
-              0,
-              new File(logFilePath),
-              "",
-              true,
-              new AtomicInteger(0),
-              tsileManager);
+      CompactionRecoverTask recoverTask =
+          new CompactionRecoverTask(
+              COMPACTION_TEST_SG, "0", tsFileManager, new File(logFilePath), true);
       recoverTask.doCompaction();
       // all the source files should exist
       for (String sourceFileName : sourceFileNames) {
@@ -591,16 +553,9 @@ public class SizeTieredCompactionRecoverTest {
           new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data"),
           new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"));
       setDataDirs(new String[] {TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"});
-      SizeTieredCompactionRecoverTask recoverTask =
-          new SizeTieredCompactionRecoverTask(
-              COMPACTION_TEST_SG,
-              "0",
-              0,
-              new File(logFilePath),
-              "",
-              true,
-              new AtomicInteger(0),
-              tsileManager);
+      CompactionRecoverTask recoverTask =
+          new CompactionRecoverTask(
+              COMPACTION_TEST_SG, "0", tsFileManager, new File(logFilePath), true);
       recoverTask.doCompaction();
       // all the source file should be deleted
       for (String sourceFileName : sourceFileNames) {
@@ -688,16 +643,9 @@ public class SizeTieredCompactionRecoverTest {
           new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data"),
           new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"));
       setDataDirs(new String[] {TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"});
-      SizeTieredCompactionRecoverTask recoverTask =
-          new SizeTieredCompactionRecoverTask(
-              COMPACTION_TEST_SG,
-              "0",
-              0,
-              new File(logFilePath),
-              "",
-              true,
-              new AtomicInteger(0),
-              tsileManager);
+      CompactionRecoverTask recoverTask =
+          new CompactionRecoverTask(
+              COMPACTION_TEST_SG, "0", tsFileManager, new File(logFilePath), true);
       recoverTask.doCompaction();
       // all the source files should exist
       for (String sourceFileName : sourceFileNames) {
@@ -794,16 +742,9 @@ public class SizeTieredCompactionRecoverTest {
           new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data"),
           new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"));
       setDataDirs(new String[] {TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"});
-      SizeTieredCompactionRecoverTask recoverTask =
-          new SizeTieredCompactionRecoverTask(
-              COMPACTION_TEST_SG,
-              "0",
-              0,
-              new File(logFilePath),
-              "",
-              true,
-              new AtomicInteger(0),
-              tsileManager);
+      CompactionRecoverTask recoverTask =
+          new CompactionRecoverTask(
+              COMPACTION_TEST_SG, "0", tsFileManager, new File(logFilePath), true);
       recoverTask.doCompaction();
       // all the source file should be deleted
       for (String sourceFileName : sourceFileNames) {
@@ -842,10 +783,13 @@ public class SizeTieredCompactionRecoverTest {
       FileUtils.deleteDirectory(new File(TestConstant.BASE_OUTPUT_PATH + File.separator + "data1"));
     }
   }
+<<<<<<< HEAD
 
   public static class TestMetaManager extends MManager {
     public IMeasurementSchema getSeriesSchema(PartialPath path) {
       return new MeasurementSchema(path.getMeasurement(), TSDataType.INT64);
     }
   }
+=======
+>>>>>>> d53f4fa42 ([IOTDB-2561]Compaction code refactoring for restart recovery and exception handling (#5316))
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/FakedTsFileResource.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/FakedTsFileResource.java
@@ -33,23 +33,8 @@ public class FakedTsFileResource extends TsFileResource {
   public FakedTsFileResource(long tsFileSize, String name) {
     this.timeIndex = new FileTimeIndex();
     this.tsFileSize = tsFileSize;
-    super.closed = true;
-    super.isCompacting = false;
+    super.status = TsFileResourceStatus.CLOSED;
     fakeTsfileName = name;
-  }
-
-  public FakedTsFileResource(long tsFileSize, boolean isClosed, boolean isMerging, String name) {
-    this.tsFileSize = tsFileSize;
-    super.closed = isClosed;
-    super.isCompacting = isMerging;
-    fakeTsfileName = name;
-  }
-
-  public FakedTsFileResource(long tsFileSize, long startTime, long endTime) {
-    this.timeIndex = new FileTimeIndex();
-    timeIndex.putStartTime("", startTime);
-    timeIndex.putEndTime("", endTime);
-    this.tsFileSize = tsFileSize;
   }
 
   public void setTsFileSize(long tsFileSize) {
@@ -65,8 +50,7 @@ public class FakedTsFileResource extends TsFileResource {
   public String toString() {
     StringBuilder builder = new StringBuilder();
     builder.append(tsFileSize).append(",");
-    builder.append(closed).append(",");
-    builder.append(isCompacting);
+    builder.append(status);
     return builder.toString();
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/query/reader/series/SeriesReaderTestUtil.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/reader/series/SeriesReaderTestUtil.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.query.control.FileReaderManager;
@@ -90,7 +91,7 @@ public class SeriesReaderTestUtil {
     for (int i = 0; i < seqFileNum; i++) {
       File file = new File(TestConstant.getTestTsFilePath(SERIES_READER_TEST_SG, 0, 0, i));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.setMinPlanIndex(i);
       tsFileResource.setMaxPlanIndex(i);
       tsFileResource.setVersion(i);
@@ -101,7 +102,7 @@ public class SeriesReaderTestUtil {
       File file =
           new File(TestConstant.getTestTsFilePath(SERIES_READER_TEST_SG, 0, 0, i + seqFileNum));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.setMinPlanIndex(i + seqFileNum);
       tsFileResource.setMaxPlanIndex(i + seqFileNum);
       tsFileResource.setVersion(i + seqFileNum);
@@ -119,7 +120,7 @@ public class SeriesReaderTestUtil {
         new File(
             TestConstant.getTestTsFilePath(SERIES_READER_TEST_SG, 0, 0, seqFileNum + unseqFileNum));
     TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.setMinPlanIndex(seqFileNum + unseqFileNum);
     tsFileResource.setMaxPlanIndex(seqFileNum + unseqFileNum);
     tsFileResource.setVersion(seqFileNum + unseqFileNum);

--- a/server/src/test/java/org/apache/iotdb/db/rescon/ResourceManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/rescon/ResourceManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.engine.storagegroup.timeindex.TimeIndexLevel;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
@@ -194,7 +195,7 @@ public class ResourceManagerTest {
                     + 0
                     + ".tsfile"));
     TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.updatePlanIndexes((long) 0);
     prepareFile(tsFileResource, 0, ptNum, 0);
     long previousRamSize = tsFileResource.calculateRamSize();
@@ -221,7 +222,7 @@ public class ResourceManagerTest {
                     + 0
                     + ".tsfile"));
     TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.updatePlanIndexes((long) 0);
     prepareFile(tsFileResource, 0, ptNum, 0);
     assertEquals(
@@ -248,7 +249,7 @@ public class ResourceManagerTest {
                     + 0
                     + ".tsfile"));
     TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource.updatePlanIndexes((long) 0);
     prepareFile(tsFileResource, 0, ptNum, 0);
     assertEquals(
@@ -278,7 +279,7 @@ public class ResourceManagerTest {
                     + 0
                     + ".tsfile"));
     TsFileResource tsFileResource1 = new TsFileResource(file1);
-    tsFileResource1.setClosed(true);
+    tsFileResource1.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource1.updatePlanIndexes((long) 0);
     prepareFile(tsFileResource1, 0, ptNum, 0);
     assertEquals(
@@ -302,7 +303,7 @@ public class ResourceManagerTest {
                     + 0
                     + ".tsfile"));
     TsFileResource tsFileResource2 = new TsFileResource(file2);
-    tsFileResource2.setClosed(true);
+    tsFileResource2.setStatus(TsFileResourceStatus.CLOSED);
     tsFileResource2.updatePlanIndexes((long) 1);
     prepareFile(tsFileResource2, ptNum, ptNum, 0);
     assertEquals(
@@ -333,7 +334,7 @@ public class ResourceManagerTest {
                       + 0
                       + ".tsfile"));
       TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
+      tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
       tsFileResource.updatePlanIndexes((long) i);
       assertEquals(
           TimeIndexLevel.DEVICE_TIME_INDEX,
@@ -376,7 +377,7 @@ public class ResourceManagerTest {
                         + 0
                         + ".tsfile"));
         TsFileResource tsFileResource = new TsFileResource(file);
-        tsFileResource.setClosed(true);
+        tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
         tsFileResource.updatePlanIndexes((long) i);
         seqResources.add(tsFileResource);
         assertEquals(

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -142,14 +142,14 @@ public class TsFileIOWriter implements AutoCloseable {
     out.write(VERSION_NUMBER_BYTE);
   }
 
-  public void startChunkGroup(String deviceId) throws IOException {
+  public int startChunkGroup(String deviceId) throws IOException {
     this.currentChunkGroupDeviceId = deviceId;
     if (logger.isDebugEnabled()) {
       logger.debug("start chunk group:{}, file position {}", deviceId, out.getPosition());
     }
     chunkMetadataList = new ArrayList<>();
     ChunkGroupHeader chunkGroupHeader = new ChunkGroupHeader(currentChunkGroupDeviceId);
-    chunkGroupHeader.serializeTo(out.wrapAsStream());
+    return chunkGroupHeader.serializeTo(out.wrapAsStream());
   }
 
   /**
@@ -456,6 +456,10 @@ public class TsFileIOWriter implements AutoCloseable {
     ReadWriteIOUtils.write(minPlanIndex, out.wrapAsStream());
     ReadWriteIOUtils.write(maxPlanIndex, out.wrapAsStream());
     out.flush();
+  }
+
+  public void truncate(long offset) throws IOException {
+    out.truncate(offset);
   }
 
   /**


### PR DESCRIPTION
When the total number of selected files exceeds the parameter `maxCrossCompactionCandidateFileNum`, no files will be selected, resulting in cross-space compaction never selecting files. At least one batch of files should be selected for compacting.