### PR TITLE
[IOTDB-2835]Fix empty page in selfcheck method of TsFileSequenceReader

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -141,6 +141,7 @@ import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.TsFileCheckStatus;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.Field;
 import org.apache.iotdb.tsfile.read.common.Path;
@@ -1258,7 +1259,12 @@ public class PlanExecutor implements IPlanExecutor {
 
       List<ChunkGroupMetadata> chunkGroupMetadataList = new ArrayList<>();
       try (TsFileSequenceReader reader = new TsFileSequenceReader(file.getAbsolutePath(), false)) {
-        reader.selfCheck(schemaMap, chunkGroupMetadataList, false);
+        if (reader.selfCheck(schemaMap, chunkGroupMetadataList, false)
+            != TsFileCheckStatus.COMPLETE_FILE) {
+          throw new QueryProcessException(
+              String.format(
+                  "Cannot load file %s because the file has crashed.", file.getAbsolutePath()));
+        }
         if (plan.getVerifyMetadata()) {
           loadNewTsFileVerifyMetadata(reader);
         }

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.TsFileMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.MetadataIndexNodeType;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.iotdb.tsfile.read.TsFileCheckStatus;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.Chunk;
 import org.apache.iotdb.tsfile.read.common.Path;
@@ -85,7 +86,10 @@ public class TsFileSketchTool {
       // get metadata information
       tsFileMetaData = reader.readFileMetadata();
       allChunkGroupMetadata = new ArrayList<>();
-      reader.selfCheck(null, allChunkGroupMetadata, false);
+      if (reader.selfCheck(null, allChunkGroupMetadata, false) != TsFileCheckStatus.COMPLETE_FILE) {
+        throw new IOException(
+            String.format("Cannot load file %s because the file has crashed.", filename));
+      }
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -1309,7 +1309,10 @@ public class TsFileSequenceReader implements AutoCloseable {
                 while (dataSize > 0) {
                   // a new Page
                   PageHeader pageHeader = this.readPageHeader(chunkHeader.getDataType(), true);
-                  chunkStatistics.mergeStatistics(pageHeader.getStatistics());
+                  if (pageHeader.getUncompressedSize() != 0) {
+                    // not empty page
+                    chunkStatistics.mergeStatistics(pageHeader.getStatistics());
+                  }
                   this.skipPageData(pageHeader);
                   dataSize -= pageHeader.getSerializedPageSize();
                   chunkHeader.increasePageNums(1);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -1481,11 +1481,12 @@ public class TsFileSequenceReader implements AutoCloseable {
       }
       truncatedSize = this.position() - 1;
     } catch (Exception e) {
-      logger.info(
+      logger.error(
           "TsFile {} self-check cannot proceed at position {} " + "recovered, because : {}",
           file,
           this.position(),
           e.getMessage());
+      throw new IOException();
     }
     // Despite the completeness of the data section, we will discard current FileMetadata
     // so that we can continue to write data into this tsfile.

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/TsFileWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/TsFileWriter.java
@@ -636,8 +636,4 @@ public class TsFileWriter implements AutoCloseable {
   public TsFileIOWriter getIOWriter() {
     return this.fileWriter;
   }
-
-  public void setIsUnseq(boolean unseq) {
-    this.isUnseq = unseq;
-  }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
@@ -20,19 +20,28 @@
 package org.apache.iotdb.tsfile.read;
 
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
 import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.header.ChunkGroupHeader;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.utils.FileGenerator;
 import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.utils.TsFileGeneratorUtils;
+import org.apache.iotdb.tsfile.write.TsFileWriter;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -124,5 +133,41 @@ public class TsFileSequenceReaderTest {
     // test for non-exist device "d3"
     Assert.assertTrue(reader.readChunkMetadataInDevice("d3").isEmpty());
     reader.close();
+  }
+
+  @Test
+  public void testReadEmptyPageInSelfCheck() throws IOException, WriteProcessException {
+    int oldMaxPagePointNum =
+        TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(10);
+    File testFile = new File(FILE_PATH);
+
+    // create tsfile with empty page
+    try (TsFileWriter tsFileWriter = new TsFileWriter(testFile)) {
+      // register aligned timeseries
+      List<MeasurementSchema> alignedMeasurementSchemas = new ArrayList<>();
+      alignedMeasurementSchemas.add(
+          new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.PLAIN));
+      alignedMeasurementSchemas.add(
+          new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.PLAIN));
+      tsFileWriter.registerAlignedTimeseries(new Path("d1"), alignedMeasurementSchemas);
+
+      List<MeasurementSchema> writeMeasurementScheams = new ArrayList<>();
+      // only write s1
+      writeMeasurementScheams.add(alignedMeasurementSchemas.get(0));
+      TsFileGeneratorUtils.writeWithTsRecord(
+          tsFileWriter, "d1", writeMeasurementScheams, 25, 0, 0, true);
+
+      // write s1 and s2, fill 2 empty pages for s2
+      writeMeasurementScheams.add(alignedMeasurementSchemas.get(1));
+      TsFileGeneratorUtils.writeWithTsRecord(
+          tsFileWriter, "d1", writeMeasurementScheams, 10, 25, 0, true);
+    } finally {
+      TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(oldMaxPagePointNum);
+    }
+
+    // read tsfile with selfCheck method
+    TsFileSequenceReader reader = new TsFileSequenceReader(FILE_PATH);
+    reader.selfCheck(new HashMap<>(), new ArrayList<>(), false);
   }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
@@ -168,6 +168,8 @@ public class TsFileSequenceReaderTest {
 
     // read tsfile with selfCheck method
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_PATH);
-    reader.selfCheck(new HashMap<>(), new ArrayList<>(), false);
+    Assert.assertEquals(
+        TsFileCheckStatus.COMPLETE_FILE,
+        reader.selfCheck(new HashMap<>(), new ArrayList<>(), false));
   }
 }


### PR DESCRIPTION
See details in [IOTDB-2835](https://issues.apache.org/jira/browse/IOTDB-2835).
Solution: skip empty page in aligned chunk in selfcheck method.