### PR TITLE
[IOTDB-2922] Fix NPE when compacting with files that contains zero device

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -94,7 +94,10 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
   public boolean hasNextDevice() {
     boolean hasNext = false;
     for (TsFileDeviceIterator iterator : deviceIteratorMap.values()) {
-      hasNext = hasNext || iterator.hasNext() || !iterator.current().equals(currentDevice);
+      hasNext =
+          hasNext
+              || iterator.hasNext()
+              || (iterator.current() != null && !iterator.current().equals(currentDevice));
     }
     return hasNext;
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigNode.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
@@ -179,7 +178,6 @@ public class LocalConfigNode {
     }
 
     try {
-      CompactionTaskManager.getInstance().stop();
       SchemaResourceManager.clearSchemaResource();
 
       if (timedForceMLogThread != null) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigNode.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
@@ -178,6 +179,7 @@ public class LocalConfigNode {
     }
 
     try {
+      CompactionTaskManager.getInstance().stop();
       SchemaResourceManager.clearSchemaResource();
 
       if (timedForceMLogThread != null) {

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.service;
 
+import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.utils.MemUtils;
 
 import org.slf4j.Logger;
@@ -29,6 +30,7 @@ public class IoTDBShutdownHook extends Thread {
 
   @Override
   public void run() {
+    CompactionTaskManager.getInstance().stop();
     // close rocksdb if possible to avoid lose data
     IoTDB.configManager.clear();
     if (logger.isInfoEnabled()) {


### PR DESCRIPTION
See [IOTDB-2922](https://issues.apache.org/jira/browse/IOTDB-2922).
The reason for this bug is that, when compacting with files that contains zero device, the variable `currentDevice` in `TsFileDeviceIterator` is initialized as null, and if we visit it, NPE will occurs.