### PR TITLE
Change assertion to prevent SchemaBuilderTest from failing due to indeterminate ordering

### DIFF
--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
@@ -30,8 +30,8 @@ import org.apache.iotdb.tsfile.write.schema.Schema;
 
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
@@ -30,12 +30,13 @@ import org.apache.iotdb.tsfile.write.schema.Schema;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SchemaBuilderTest {
 
@@ -65,10 +66,15 @@ public class SchemaBuilderTest {
     String[] tsDesStrings = {
       "[s4,DOUBLE,RLE,{max_point_number=3},SNAPPY]", "[s5,INT32,TS_2DIFF,,UNCOMPRESSED]"
     };
-    int i = 0;
+    List<String> expected = Arrays.asList(tsDesStrings);
+    List<String> actual = new ArrayList<String>();
     for (IMeasurementSchema desc : timeseries) {
-      assertEquals(tsDesStrings[i++], desc.toString());
+      actual.add(desc.toString());
     }
+    assertTrue(
+        actual.size() == expected.size()
+            && actual.containsAll(expected)
+            && expected.containsAll(actual));
   }
 
   @Test
@@ -101,10 +107,15 @@ public class SchemaBuilderTest {
     String[] tsDesStrings = {
       "[s4,DOUBLE,RLE,{max_point_number=3},SNAPPY]", "[s5,INT32,TS_2DIFF,,UNCOMPRESSED]"
     };
-    int i = 0;
+    List<String> expected = Arrays.asList(tsDesStrings);
+    List<String> actual = new ArrayList<String>();
     for (IMeasurementSchema desc : timeseries) {
-      assertEquals(tsDesStrings[i++], desc.toString());
+      actual.add(desc.toString());
     }
+    assertTrue(
+        actual.size() == expected.size()
+            && actual.containsAll(expected)
+            && expected.containsAll(actual));
   }
 
   @Test
@@ -145,9 +156,14 @@ public class SchemaBuilderTest {
       "[s5,INT32,TS_2DIFF,,UNCOMPRESSED]",
       "[s6,INT64,RLE,{max_point_number=3},SNAPPY]"
     };
-    int i = 0;
+    List<String> expected = Arrays.asList(tsDesStrings);
+    List<String> actual = new ArrayList<String>();
     for (IMeasurementSchema desc : timeseries) {
-      assertEquals(tsDesStrings[i++], desc.toString());
+      actual.add(desc.toString());
     }
+    assertTrue(
+        actual.size() == expected.size()
+            && actual.containsAll(expected)
+            && expected.containsAll(actual));
   }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
@@ -38,6 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
+
 public class SchemaBuilderTest {
 
   @Test

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
@@ -33,10 +33,10 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertTrue;
+import java.util.Set;
 
 public class SchemaBuilderTest {
 
@@ -66,15 +66,13 @@ public class SchemaBuilderTest {
     String[] tsDesStrings = {
       "[s4,DOUBLE,RLE,{max_point_number=3},SNAPPY]", "[s5,INT32,TS_2DIFF,,UNCOMPRESSED]"
     };
-    List<String> expected = Arrays.asList(tsDesStrings);
+    Set<String> expected = new HashSet<String>(Arrays.asList(tsDesStrings));
     List<String> actual = new ArrayList<String>();
     for (IMeasurementSchema desc : timeseries) {
       actual.add(desc.toString());
     }
-    assertTrue(
-        actual.size() == expected.size()
-            && actual.containsAll(expected)
-            && expected.containsAll(actual));
+    assertEquals(expected.size(), actual.size());
+    assertEquals(expected, new HashSet<String>(actual));
   }
 
   @Test
@@ -107,15 +105,13 @@ public class SchemaBuilderTest {
     String[] tsDesStrings = {
       "[s4,DOUBLE,RLE,{max_point_number=3},SNAPPY]", "[s5,INT32,TS_2DIFF,,UNCOMPRESSED]"
     };
-    List<String> expected = Arrays.asList(tsDesStrings);
+    Set<String> expected = new HashSet<String>(Arrays.asList(tsDesStrings));
     List<String> actual = new ArrayList<String>();
     for (IMeasurementSchema desc : timeseries) {
       actual.add(desc.toString());
     }
-    assertTrue(
-        actual.size() == expected.size()
-            && actual.containsAll(expected)
-            && expected.containsAll(actual));
+    assertEquals(expected.size(), actual.size());
+    assertEquals(expected, new HashSet<String>(actual));
   }
 
   @Test
@@ -156,14 +152,12 @@ public class SchemaBuilderTest {
       "[s5,INT32,TS_2DIFF,,UNCOMPRESSED]",
       "[s6,INT64,RLE,{max_point_number=3},SNAPPY]"
     };
-    List<String> expected = Arrays.asList(tsDesStrings);
+    Set<String> expected = new HashSet<String>(Arrays.asList(tsDesStrings));
     List<String> actual = new ArrayList<String>();
     for (IMeasurementSchema desc : timeseries) {
       actual.add(desc.toString());
     }
-    assertTrue(
-        actual.size() == expected.size()
-            && actual.containsAll(expected)
-            && expected.containsAll(actual));
+    assertEquals(expected.size(), actual.size());
+    assertEquals(expected, new HashSet<String>(actual));
   }
 }


### PR DESCRIPTION
## Description
All tests in the class `org.apache.iotdb.tsfile.write.schema.converter.SchemaBuilderTest` can fail based on the order of iteration in `HashMap`.

I found the issue using [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn test-compile -pl tsfile -am
mvn -pl tsfile edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.iotdb.tsfile.write.schema.converter.SchemaBuilderTest
```
The test can fail because it assumes that the order in `timeseries` is determinate, and can be fixed it by ignoring the order.