### PR TITLE
Remove mpp_mode property in iotdb-engine.properties

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -27,9 +27,6 @@ rpc_address=0.0.0.0
 # Datatype: int
 rpc_port=6667
 
-# whether start data node in mpp mode
-# mpp_mode=false
-
 ####################
 ### Shuffle Configuration
 ####################

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -167,10 +167,6 @@ public class IoTDBDescriptor {
           Integer.parseInt(
               properties.getProperty("rpc_port", Integer.toString(conf.getRpcPort()))));
 
-      conf.setMppMode(
-          Boolean.parseBoolean(
-              properties.getProperty("mpp_mode", Boolean.toString(conf.isMppMode()))));
-
       conf.setEnableInfluxDBRpcService(
           Boolean.parseBoolean(
               properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -157,6 +157,8 @@ public class DataNode implements DataNodeMBean {
   }
 
   public void active() throws StartupException {
+    // set the mpp mode to true
+    IoTDBDescriptor.getInstance().getConfig().setMppMode(true);
     // start iotdb server first
     IoTDB.getInstance().active();
 


### PR DESCRIPTION
We don't mpp_mode property because if we start from `DataNode` Class, it must be mpp mode.