### PR TITLE
Rename thrift endpoint

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/coordinator/Coordinator.java
@@ -38,7 +38,7 @@ import org.apache.iotdb.cluster.server.member.MetaGroupMember;
 import org.apache.iotdb.cluster.server.monitor.Timer;
 import org.apache.iotdb.cluster.utils.PartitionUtils;
 import org.apache.iotdb.cluster.utils.StatusUtils;
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.utils.TestOnly;
@@ -512,7 +512,7 @@ public class Coordinator {
     List<String> errorCodePartitionGroups = new ArrayList<>();
     TSStatus tmpStatus;
     boolean allRedirect = true;
-    EndPoint endPoint = null;
+    TEndPoint endPoint = null;
     for (Map.Entry<PhysicalPlan, PartitionGroup> entry : planGroupMap.entrySet()) {
       tmpStatus = forwardToSingleGroup(entry);
       if (tmpStatus.isSetRedirectNode()) {
@@ -767,7 +767,7 @@ public class Coordinator {
       }
       if (!StatusUtils.TIME_OUT.equals(status)) {
         if (!status.isSetRedirectNode()) {
-          status.setRedirectNode(new EndPoint(node.getClientIp(), node.getClientPort()));
+          status.setRedirectNode(new TEndPoint(node.getClientIp(), node.getClientPort()));
         }
         return status;
       } else {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
@@ -71,7 +71,7 @@ import org.apache.iotdb.cluster.server.monitor.Timer;
 import org.apache.iotdb.cluster.server.monitor.Timer.Statistic;
 import org.apache.iotdb.cluster.utils.IOUtils;
 import org.apache.iotdb.cluster.utils.StatusUtils;
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
@@ -90,7 +90,12 @@ import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.qp.executor.PlanExecutor;
 import org.apache.iotdb.db.qp.physical.BatchPlan;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
-import org.apache.iotdb.db.qp.physical.crud.*;
+import org.apache.iotdb.db.qp.physical.crud.InsertMultiTabletsPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertRowsOfOneDevicePlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertRowsPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertTabletPlan;
 import org.apache.iotdb.db.qp.physical.sys.FlushPlan;
 import org.apache.iotdb.db.qp.physical.sys.LogPlan;
 import org.apache.iotdb.db.service.IoTDB;
@@ -837,7 +842,7 @@ public class DataGroupMember extends RaftMember implements DataGroupMemberMBean 
       Timer.Statistic.DATA_GROUP_MEMBER_FORWARD_PLAN.calOperationCostTimeFromStart(startTime);
       if (!StatusUtils.NO_LEADER.equals(result)) {
         result.setRedirectNode(
-            new EndPoint(leader.get().getClientIp(), leader.get().getClientPort()));
+            new TEndPoint(leader.get().getClientIp(), leader.get().getClientPort()));
         return result;
       }
     }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -74,7 +74,7 @@ import org.apache.iotdb.cluster.utils.ClusterUtils;
 import org.apache.iotdb.cluster.utils.PartitionUtils;
 import org.apache.iotdb.cluster.utils.StatusUtils;
 import org.apache.iotdb.cluster.utils.nodetool.function.Status;
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.service.IService;
@@ -1382,7 +1382,7 @@ public class MetaGroupMember extends RaftMember implements IService, MetaGroupMe
       if (!StatusUtils.NO_LEADER.equals(result)) {
         result =
             StatusUtils.getStatus(
-                result, new EndPoint(leader.get().getInternalIp(), leader.get().getClientPort()));
+                result, new TEndPoint(leader.get().getInternalIp(), leader.get().getClientPort()));
         return result;
       }
     }
@@ -1398,7 +1398,7 @@ public class MetaGroupMember extends RaftMember implements IService, MetaGroupMe
     TSStatus result = forwardPlan(plan, leader.get(), null);
     if (!StatusUtils.NO_LEADER.equals(result)) {
       result.setRedirectNode(
-          new EndPoint(leader.get().getClientIp(), leader.get().getClientPort()));
+          new TEndPoint(leader.get().getClientIp(), leader.get().getClientPort()));
     }
     return result;
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/service/BaseAsyncService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/service/BaseAsyncService.java
@@ -35,7 +35,7 @@ import org.apache.iotdb.cluster.server.NodeCharacter;
 import org.apache.iotdb.cluster.server.member.RaftMember;
 import org.apache.iotdb.cluster.utils.IOUtils;
 import org.apache.iotdb.cluster.utils.StatusUtils;
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 
 import org.apache.thrift.TException;
@@ -167,7 +167,7 @@ public abstract class BaseAsyncService implements RaftService.AsyncIface {
       resultHandler.onComplete(
           StatusUtils.getStatus(
               status,
-              new EndPoint(
+              new TEndPoint(
                   member.getThisNode().getClientIp(), member.getThisNode().getClientPort())));
     } catch (Exception e) {
       resultHandler.onError(e);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/utils/StatusUtils.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/utils/StatusUtils.java
@@ -19,7 +19,7 @@
 
 package org.apache.iotdb.cluster.utils;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.TSStatusCode;
 
@@ -208,7 +208,7 @@ public class StatusUtils {
     return status;
   }
 
-  public static TSStatus getStatus(TSStatusCode statusCode, EndPoint redirectedNode) {
+  public static TSStatus getStatus(TSStatusCode statusCode, TEndPoint redirectedNode) {
     TSStatus status = getStatus(statusCode);
     status.setRedirectNode(redirectedNode);
     return status;
@@ -220,7 +220,7 @@ public class StatusUtils {
     return newStatus;
   }
 
-  public static TSStatus getStatus(TSStatus status, EndPoint redirectedNode) {
+  public static TSStatus getStatus(TSStatus status, TEndPoint redirectedNode) {
     TSStatus newStatus = status.deepCopy();
     newStatus.setRedirectNode(redirectedNode);
     return newStatus;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/DataNodesInfoDataSet.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/DataNodesInfoDataSet.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.confignode.consensus.response;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.cluster.DataNodeLocation;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeMessage;
@@ -64,7 +64,7 @@ public class DataNodesInfoDataSet implements DataSet {
             info.getDataNodeId(),
             new TDataNodeMessage(
                 info.getDataNodeId(),
-                new EndPoint(info.getEndPoint().getIp(), info.getEndPoint().getPort())));
+                new TEndPoint(info.getEndPoint().getIp(), info.getEndPoint().getPort())));
         resp.setDataNodeMessageMap(msgMap);
       }
     }

--- a/confignode/src/test/java/org/apache/iotdb/confignode/consensus/RatisConsensusDemo.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/consensus/RatisConsensusDemo.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.confignode.consensus;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.confignode.rpc.thrift.ConfigIService;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeMessageResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterReq;
@@ -90,7 +90,7 @@ public class RatisConsensusDemo {
   private void registerDataNodes() throws TException, InterruptedException {
     // DataNodes can connect to any ConfigNode and send write requests
     for (int i = 0; i < 10; i++) {
-      EndPoint endPoint = new EndPoint("0.0.0.0", 6667 + i);
+      TEndPoint endPoint = new TEndPoint("0.0.0.0", 6667 + i);
       TDataNodeRegisterReq req = new TDataNodeRegisterReq(endPoint);
       TDataNodeRegisterResp resp = clients[0].registerDataNode(req);
       Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), resp.getStatus().getCode());
@@ -142,7 +142,7 @@ public class RatisConsensusDemo {
 
   private void registerDataNodeOnLeader() throws TException {
     for (int i = 0; i < 3; i++) {
-      EndPoint endPoint = new EndPoint("0.0.0.0", 6667);
+      TEndPoint endPoint = new TEndPoint("0.0.0.0", 6667);
       TDataNodeRegisterReq req = new TDataNodeRegisterReq(endPoint);
       TDataNodeRegisterResp resp = clients[i].registerDataNode(req);
       System.out.println(resp);

--- a/confignode/src/test/java/org/apache/iotdb/confignode/manager/ConfigManagerManualTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/manager/ConfigManagerManualTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.confignode.manager;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.confignode.rpc.thrift.ConfigIService;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeMessage;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterReq;
@@ -74,7 +74,7 @@ public class ConfigManagerManualTest {
 
   private void registerDataNodes() throws TException {
     for (int i = 0; i < 3; i++) {
-      TDataNodeRegisterReq req = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6667 + i));
+      TDataNodeRegisterReq req = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6667 + i));
       TDataNodeRegisterResp resp = clients[0].registerDataNode(req);
       Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), resp.getStatus().getCode());
       Assert.assertEquals(i, resp.getDataNodeID());
@@ -114,7 +114,7 @@ public class ConfigManagerManualTest {
     }
 
     TDataNodeRegisterResp resp =
-        clients[1].registerDataNode(new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6670)));
+        clients[1].registerDataNode(new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6670)));
     Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), resp.getStatus().getCode());
     Assert.assertEquals(3, resp.getDataNodeID());
 

--- a/confignode/src/test/java/org/apache/iotdb/confignode/service/thrift/server/ConfigNodeRPCServerProcessorTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/service/thrift/server/ConfigNodeRPCServerProcessorTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.confignode.service.thrift.server;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
@@ -107,9 +107,9 @@ public class ConfigNodeRPCServerProcessorTest {
   @Test
   public void registerAndQueryDataNodeTest() throws TException {
     TDataNodeRegisterResp resp;
-    TDataNodeRegisterReq registerReq0 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6667));
-    TDataNodeRegisterReq registerReq1 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6668));
-    TDataNodeRegisterReq registerReq2 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6669));
+    TDataNodeRegisterReq registerReq0 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6667));
+    TDataNodeRegisterReq registerReq1 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6668));
+    TDataNodeRegisterReq registerReq2 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6669));
 
     // test success register
     resp = processor.registerDataNode(registerReq0);
@@ -168,9 +168,9 @@ public class ConfigNodeRPCServerProcessorTest {
     Assert.assertEquals("DataNode is not enough, please register more.", status.getMessage());
 
     // register DataNodes
-    TDataNodeRegisterReq registerReq0 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6667));
-    TDataNodeRegisterReq registerReq1 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6668));
-    TDataNodeRegisterReq registerReq2 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6669));
+    TDataNodeRegisterReq registerReq0 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6667));
+    TDataNodeRegisterReq registerReq1 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6668));
+    TDataNodeRegisterReq registerReq2 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6669));
     status = processor.registerDataNode(registerReq0).getStatus();
     Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
     status = processor.registerDataNode(registerReq1).getStatus();
@@ -234,9 +234,9 @@ public class ConfigNodeRPCServerProcessorTest {
     Map<String, Map<TSeriesPartitionSlot, TRegionReplicaSet>> schemaPartitionMap;
 
     // register DataNodes
-    TDataNodeRegisterReq registerReq0 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6667));
-    TDataNodeRegisterReq registerReq1 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6668));
-    TDataNodeRegisterReq registerReq2 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6669));
+    TDataNodeRegisterReq registerReq0 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6667));
+    TDataNodeRegisterReq registerReq1 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6668));
+    TDataNodeRegisterReq registerReq2 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6669));
     status = processor.registerDataNode(registerReq0).getStatus();
     Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
     status = processor.registerDataNode(registerReq1).getStatus();
@@ -441,9 +441,9 @@ public class ConfigNodeRPCServerProcessorTest {
     TDataPartitionResp dataPartitionResp;
 
     // register DataNodes
-    TDataNodeRegisterReq registerReq0 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6667));
-    TDataNodeRegisterReq registerReq1 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6668));
-    TDataNodeRegisterReq registerReq2 = new TDataNodeRegisterReq(new EndPoint("0.0.0.0", 6669));
+    TDataNodeRegisterReq registerReq0 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6667));
+    TDataNodeRegisterReq registerReq1 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6668));
+    TDataNodeRegisterReq registerReq2 = new TDataNodeRegisterReq(new TEndPoint("0.0.0.0", 6669));
     status = processor.registerDataNode(registerReq0).getStatus();
     Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
     status = processor.registerDataNode(registerReq1).getStatus();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -19,7 +19,7 @@
 
 package org.apache.iotdb.consensus.ratis;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.cluster.Endpoint;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
@@ -181,7 +181,7 @@ class RatisConsensus implements IConsensus {
 
     if (suggestedLeader != null) {
       Endpoint leaderEndPoint = Utils.getEndpoint(suggestedLeader);
-      writeResult.setRedirectNode(new EndPoint(leaderEndPoint.getIp(), leaderEndPoint.getPort()));
+      writeResult.setRedirectNode(new TEndPoint(leaderEndPoint.getIp(), leaderEndPoint.getPort()));
     }
 
     return ConsensusWriteResponse.newBuilder().setStatus(writeResult).build();

--- a/influxdb-protocol/src/main/java/org/apache/iotdb/influxdb/protocol/dto/SessionPoint.java
+++ b/influxdb-protocol/src/main/java/org/apache/iotdb/influxdb/protocol/dto/SessionPoint.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.influxdb.protocol.dto;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.session.Session;
 
 public class SessionPoint {
@@ -45,10 +45,10 @@ public class SessionPoint {
         if (reflectField
                 .getType()
                 .getName()
-                .equalsIgnoreCase("org.apache.iotdb.common.rpc.thrift.EndPoint")
+                .equalsIgnoreCase("org.apache.iotdb.common.rpc.thrift.TEndPoint")
             && reflectField.getName().equalsIgnoreCase("defaultEndPoint")) {
-          this.rpcPort = ((EndPoint) reflectField.get(session)).port;
-          this.host = ((EndPoint) reflectField.get(session)).ip;
+          this.rpcPort = ((TEndPoint) reflectField.get(session)).port;
+          this.host = ((TEndPoint) reflectField.get(session)).ip;
         }
         if (reflectField.getType().getName().equalsIgnoreCase("java.lang.String")
             && reflectField.getName().equalsIgnoreCase("username")) {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/RegionReplicaSet.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/RegionReplicaSet.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.commons.partition;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.cluster.DataNodeLocation;
 import org.apache.iotdb.commons.cluster.Endpoint;
@@ -79,11 +79,11 @@ public class RegionReplicaSet {
     tRegionReplicaSet.setRegionId(buffer);
 
     // Convert EndPoints
-    List<EndPoint> endPointList = new ArrayList<>();
+    List<TEndPoint> endPointList = new ArrayList<>();
     dataNodeList.forEach(
         dataNodeLocation ->
             endPointList.add(
-                new EndPoint(
+                new TEndPoint(
                     dataNodeLocation.getEndPoint().getIp(),
                     dataNodeLocation.getEndPoint().getPort())));
     tRegionReplicaSet.setEndpoint(endPointList);

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
@@ -225,8 +225,8 @@ public class AlignByDeviceDataSet extends QueryDataSet {
       }
 
       if (currentDataSet.getEndPoint() != null) {
-        org.apache.iotdb.common.rpc.thrift.EndPoint endPoint =
-            new org.apache.iotdb.common.rpc.thrift.EndPoint();
+        org.apache.iotdb.common.rpc.thrift.TEndPoint endPoint =
+            new org.apache.iotdb.common.rpc.thrift.TEndPoint();
         endPoint.setIp(currentDataSet.getEndPoint().getIp());
         endPoint.setPort(currentDataSet.getEndPoint().getPort());
         throw new RedirectException(endPoint);

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.db.service;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.cluster.Endpoint;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.BadNodeUrlException;
@@ -125,7 +125,7 @@ public class DataNode implements DataNodeMBean {
       try {
         TDataNodeRegisterResp dataNodeRegisterResp =
             configNodeClient.registerDataNode(
-                new TDataNodeRegisterReq(new EndPoint(thisNode.getIp(), thisNode.getPort())));
+                new TDataNodeRegisterReq(new TEndPoint(thisNode.getIp(), thisNode.getPort())));
         if (dataNodeRegisterResp.getStatus().getCode()
                 == TSStatusCode.SUCCESS_STATUS.getStatusCode()
             || dataNodeRegisterResp.getStatus().getCode()

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/InternalServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/InternalServiceImpl.java
@@ -19,7 +19,7 @@
 
 package org.apache.iotdb.db.service.thrift.impl;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.cluster.Endpoint;
@@ -152,7 +152,7 @@ public class InternalServiceImpl implements InternalService.Iface {
       LOGGER.info("SchemaRegionId: " + schemaRegionId.getId());
       schemaEngine.createSchemaRegion(storageGroupPartitionPath, schemaRegionId);
       List<Peer> peers = new ArrayList<>();
-      for (EndPoint endPoint : regionReplicaSet.getEndpoint()) {
+      for (TEndPoint endPoint : regionReplicaSet.getEndpoint()) {
         Endpoint endpoint = new Endpoint(endPoint.getIp(), endPoint.getPort());
         // TODO: Expend Peer and RegisterDataNodeReq
         endpoint.setPort(endpoint.getPort() + 31007);
@@ -192,7 +192,7 @@ public class InternalServiceImpl implements InternalService.Iface {
       LOGGER.info("DataRegionId: " + dataRegionId.getId());
       storageEngine.createDataRegion(dataRegionId, req.storageGroup, req.ttl);
       List<Peer> peers = new ArrayList<>();
-      for (EndPoint endPoint : regionReplicaSet.getEndpoint()) {
+      for (TEndPoint endPoint : regionReplicaSet.getEndpoint()) {
         Endpoint endpoint = new Endpoint(endPoint.getIp(), endPoint.getPort());
         // TODO: Expend Peer and RegisterDataNodeReq
         endpoint.setPort(endpoint.getPort() + 31007);

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.db.service.thrift.impl;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IoTDBException;
@@ -80,7 +80,46 @@ import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.rpc.RedirectException;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
-import org.apache.iotdb.service.rpc.thrift.*;
+import org.apache.iotdb.service.rpc.thrift.ServerProperties;
+import org.apache.iotdb.service.rpc.thrift.TSAppendSchemaTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TSCancelOperationReq;
+import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
+import org.apache.iotdb.service.rpc.thrift.TSCloseSessionReq;
+import org.apache.iotdb.service.rpc.thrift.TSCreateAlignedTimeseriesReq;
+import org.apache.iotdb.service.rpc.thrift.TSCreateMultiTimeseriesReq;
+import org.apache.iotdb.service.rpc.thrift.TSCreateSchemaTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TSCreateTimeseriesReq;
+import org.apache.iotdb.service.rpc.thrift.TSDeleteDataReq;
+import org.apache.iotdb.service.rpc.thrift.TSDropSchemaTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TSExecuteBatchStatementReq;
+import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementReq;
+import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
+import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataReq;
+import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataResp;
+import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
+import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
+import org.apache.iotdb.service.rpc.thrift.TSGetTimeZoneResp;
+import org.apache.iotdb.service.rpc.thrift.TSInsertRecordReq;
+import org.apache.iotdb.service.rpc.thrift.TSInsertRecordsOfOneDeviceReq;
+import org.apache.iotdb.service.rpc.thrift.TSInsertRecordsReq;
+import org.apache.iotdb.service.rpc.thrift.TSInsertStringRecordReq;
+import org.apache.iotdb.service.rpc.thrift.TSInsertStringRecordsOfOneDeviceReq;
+import org.apache.iotdb.service.rpc.thrift.TSInsertStringRecordsReq;
+import org.apache.iotdb.service.rpc.thrift.TSInsertTabletReq;
+import org.apache.iotdb.service.rpc.thrift.TSInsertTabletsReq;
+import org.apache.iotdb.service.rpc.thrift.TSLastDataQueryReq;
+import org.apache.iotdb.service.rpc.thrift.TSOpenSessionReq;
+import org.apache.iotdb.service.rpc.thrift.TSOpenSessionResp;
+import org.apache.iotdb.service.rpc.thrift.TSPruneSchemaTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
+import org.apache.iotdb.service.rpc.thrift.TSQueryNonAlignDataSet;
+import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateResp;
+import org.apache.iotdb.service.rpc.thrift.TSRawDataQueryReq;
+import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
+import org.apache.iotdb.service.rpc.thrift.TSTracingInfo;
+import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
 import org.apache.iotdb.tsfile.exception.filter.QueryFilterOptimizationException;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -804,7 +843,7 @@ public class TSServiceImpl implements TSIEventHandler {
         resp.setQueryDataSet(tsQueryDataSet);
       } catch (RedirectException e) {
         if (plan.isEnableRedirect()) {
-          EndPoint endPoint = e.getEndPoint();
+          TEndPoint endPoint = e.getEndPoint();
           return redirectQueryToAnotherNode(resp, context, endPoint.ip, endPoint.port);
         } else {
           LOGGER.error(
@@ -864,7 +903,7 @@ public class TSServiceImpl implements TSIEventHandler {
         ip,
         port);
     TSStatus status = new TSStatus();
-    status.setRedirectNode(new EndPoint(ip, port));
+    status.setRedirectNode(new TEndPoint(ip, port));
     status.setCode(TSStatusCode.NEED_REDIRECTION.getStatusCode());
     resp.setStatus(status);
     resp.setQueryId(context.getQueryId());

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RedirectException.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RedirectException.java
@@ -19,34 +19,34 @@
 
 package org.apache.iotdb.rpc;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 
 import java.io.IOException;
 import java.util.Map;
 
 public class RedirectException extends IOException {
 
-  private final EndPoint endPoint;
+  private final TEndPoint endPoint;
 
-  private final Map<String, EndPoint> deviceEndPointMap;
+  private final Map<String, TEndPoint> deviceEndPointMap;
 
-  public RedirectException(EndPoint endPoint) {
+  public RedirectException(TEndPoint endPoint) {
     super("later request in same group will be redirected to " + endPoint.toString());
     this.endPoint = endPoint;
     this.deviceEndPointMap = null;
   }
 
-  public RedirectException(Map<String, EndPoint> deviceEndPointMap) {
+  public RedirectException(Map<String, TEndPoint> deviceEndPointMap) {
     super("later request in same group will be redirected to " + deviceEndPointMap);
     this.endPoint = null;
     this.deviceEndPointMap = deviceEndPointMap;
   }
 
-  public EndPoint getEndPoint() {
+  public TEndPoint getEndPoint() {
     return this.endPoint;
   }
 
-  public Map<String, EndPoint> getDeviceEndPointMap() {
+  public Map<String, TEndPoint> getDeviceEndPointMap() {
     return deviceEndPointMap;
   }
 }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.rpc;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.protocol.influxdb.rpc.thrift.InfluxDBService;
 import org.apache.iotdb.protocol.influxdb.rpc.thrift.InfluxTSStatus;
@@ -123,7 +123,7 @@ public class RpcUtils {
     verifySuccess(status);
     if (status.getCode() == TSStatusCode.MULTIPLE_ERROR.getStatusCode()
         || status.getCode() == TSStatusCode.NEED_REDIRECTION.getStatusCode()) {
-      Map<String, EndPoint> deviceEndPointMap = new HashMap<>();
+      Map<String, TEndPoint> deviceEndPointMap = new HashMap<>();
       List<TSStatus> statusSubStatus = status.getSubStatus();
       for (int i = 0; i < statusSubStatus.size(); i++) {
         TSStatus subStatus = statusSubStatus.get(i);

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.session;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.rpc.BatchExecutionException;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.RedirectException;
@@ -121,15 +121,15 @@ public class Session {
   protected int thriftDefaultBufferSize;
   protected int thriftMaxFrameSize;
 
-  protected EndPoint defaultEndPoint;
+  protected TEndPoint defaultEndPoint;
   protected SessionConnection defaultSessionConnection;
   private boolean isClosed = true;
 
   // Cluster version cache
   protected boolean enableCacheLeader;
   protected SessionConnection metaSessionConnection;
-  protected volatile Map<String, EndPoint> deviceIdToEndpoint;
-  protected volatile Map<EndPoint, SessionConnection> endPointToSessionConnection;
+  protected volatile Map<String, TEndPoint> deviceIdToEndpoint;
+  protected volatile Map<TEndPoint, SessionConnection> endPointToSessionConnection;
 
   protected boolean enableQueryRedirection = false;
 
@@ -275,7 +275,7 @@ public class Session {
       int thriftMaxFrameSize,
       boolean enableCacheLeader,
       Version version) {
-    this.defaultEndPoint = new EndPoint(host, rpcPort);
+    this.defaultEndPoint = new TEndPoint(host, rpcPort);
     this.username = username;
     this.password = password;
     this.fetchSize = fetchSize;
@@ -412,7 +412,7 @@ public class Session {
   }
 
   public SessionConnection constructSessionConnection(
-      Session session, EndPoint endpoint, ZoneId zoneId) throws IoTDBConnectionException {
+      Session session, TEndPoint endpoint, ZoneId zoneId) throws IoTDBConnectionException {
     if (endpoint == null) {
       return new SessionConnection(session, zoneId);
     }
@@ -817,7 +817,7 @@ public class Session {
   }
 
   private SessionConnection getSessionConnection(String deviceId) {
-    EndPoint endPoint;
+    TEndPoint endPoint;
     if (enableCacheLeader
         && !deviceIdToEndpoint.isEmpty()
         && (endPoint = deviceIdToEndpoint.get(deviceId)) != null) {
@@ -835,11 +835,11 @@ public class Session {
   private void removeBrokenSessionConnection(SessionConnection sessionConnection) {
     // remove the cached broken leader session
     if (enableCacheLeader) {
-      EndPoint endPoint = null;
-      for (Iterator<Entry<EndPoint, SessionConnection>> it =
+      TEndPoint endPoint = null;
+      for (Iterator<Entry<TEndPoint, SessionConnection>> it =
               endPointToSessionConnection.entrySet().iterator();
           it.hasNext(); ) {
-        Map.Entry<EndPoint, SessionConnection> entry = it.next();
+        Map.Entry<TEndPoint, SessionConnection> entry = it.next();
         if (entry.getValue().equals(sessionConnection)) {
           endPoint = entry.getKey();
           it.remove();
@@ -847,9 +847,9 @@ public class Session {
         }
       }
 
-      for (Iterator<Entry<String, EndPoint>> it = deviceIdToEndpoint.entrySet().iterator();
+      for (Iterator<Entry<String, TEndPoint>> it = deviceIdToEndpoint.entrySet().iterator();
           it.hasNext(); ) {
-        Map.Entry<String, EndPoint> entry = it.next();
+        Map.Entry<String, TEndPoint> entry = it.next();
         if (entry.getValue().equals(endPoint)) {
           it.remove();
         }
@@ -880,7 +880,7 @@ public class Session {
     }
   }
 
-  private void handleRedirection(String deviceId, EndPoint endpoint)
+  private void handleRedirection(String deviceId, TEndPoint endpoint)
       throws IoTDBConnectionException {
     if (enableCacheLeader) {
       AtomicReference<IoTDBConnectionException> exceptionReference = new AtomicReference<>();
@@ -903,7 +903,7 @@ public class Session {
     }
   }
 
-  private void handleQueryRedirection(EndPoint endPoint) throws IoTDBConnectionException {
+  private void handleQueryRedirection(TEndPoint endPoint) throws IoTDBConnectionException {
     if (enableQueryRedirection) {
       AtomicReference<IoTDBConnectionException> exceptionReference = new AtomicReference<>();
       SessionConnection connection =
@@ -1057,8 +1057,8 @@ public class Session {
       try {
         defaultSessionConnection.insertRecords(request);
       } catch (RedirectException e) {
-        Map<String, EndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
-        for (Map.Entry<String, EndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
+        Map<String, TEndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
+        for (Map.Entry<String, TEndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
           handleRedirection(deviceEndPointEntry.getKey(), deviceEndPointEntry.getValue());
         }
       }
@@ -1094,8 +1094,8 @@ public class Session {
       try {
         defaultSessionConnection.insertRecords(request);
       } catch (RedirectException e) {
-        Map<String, EndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
-        for (Map.Entry<String, EndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
+        Map<String, TEndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
+        for (Map.Entry<String, TEndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
           handleRedirection(deviceEndPointEntry.getKey(), deviceEndPointEntry.getValue());
         }
       }
@@ -1180,8 +1180,8 @@ public class Session {
       try {
         defaultSessionConnection.insertRecords(request);
       } catch (RedirectException e) {
-        Map<String, EndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
-        for (Map.Entry<String, EndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
+        Map<String, TEndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
+        for (Map.Entry<String, TEndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
           handleRedirection(deviceEndPointEntry.getKey(), deviceEndPointEntry.getValue());
         }
       }
@@ -1218,8 +1218,8 @@ public class Session {
       try {
         defaultSessionConnection.insertRecords(request);
       } catch (RedirectException e) {
-        Map<String, EndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
-        for (Map.Entry<String, EndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
+        Map<String, TEndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
+        for (Map.Entry<String, TEndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
           handleRedirection(deviceEndPointEntry.getKey(), deviceEndPointEntry.getValue());
         }
       }
@@ -1704,8 +1704,8 @@ public class Session {
       try {
         defaultSessionConnection.insertTablets(request);
       } catch (RedirectException e) {
-        Map<String, EndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
-        for (Map.Entry<String, EndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
+        Map<String, TEndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
+        for (Map.Entry<String, TEndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
           handleRedirection(deviceEndPointEntry.getKey(), deviceEndPointEntry.getValue());
         }
       }
@@ -1742,8 +1742,8 @@ public class Session {
       try {
         defaultSessionConnection.insertTablets(request);
       } catch (RedirectException e) {
-        Map<String, EndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
-        for (Map.Entry<String, EndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
+        Map<String, TEndPoint> deviceEndPointMap = e.getDeviceEndPointMap();
+        for (Map.Entry<String, TEndPoint> deviceEndPointEntry : deviceEndPointMap.entrySet()) {
           handleRedirection(deviceEndPointEntry.getKey(), deviceEndPointEntry.getValue());
         }
       }

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -19,7 +19,7 @@
 
 package org.apache.iotdb.session;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.RedirectException;
@@ -81,14 +81,14 @@ public class SessionConnection {
   private long sessionId;
   private long statementId;
   private ZoneId zoneId;
-  private EndPoint endPoint;
-  private List<EndPoint> endPointList = new ArrayList<>();
+  private TEndPoint endPoint;
+  private List<TEndPoint> endPointList = new ArrayList<>();
   private boolean enableRedirect = false;
 
   // TestOnly
   public SessionConnection() {}
 
-  public SessionConnection(Session session, EndPoint endPoint, ZoneId zoneId)
+  public SessionConnection(Session session, TEndPoint endPoint, ZoneId zoneId)
       throws IoTDBConnectionException {
     this.session = session;
     this.endPoint = endPoint;
@@ -104,7 +104,7 @@ public class SessionConnection {
     initClusterConn();
   }
 
-  private void init(EndPoint endPoint) throws IoTDBConnectionException {
+  private void init(TEndPoint endPoint) throws IoTDBConnectionException {
     RpcTransportFactory.setDefaultBufferCapacity(session.thriftDefaultBufferSize);
     RpcTransportFactory.setThriftMaxFrameSize(session.thriftMaxFrameSize);
     try {
@@ -160,7 +160,7 @@ public class SessionConnection {
   }
 
   private void initClusterConn() throws IoTDBConnectionException {
-    for (EndPoint endPoint : endPointList) {
+    for (TEndPoint endPoint : endPointList) {
       try {
         session.defaultEndPoint = endPoint;
         init(endPoint);
@@ -950,11 +950,11 @@ public class SessionConnection {
     this.enableRedirect = enableRedirect;
   }
 
-  public EndPoint getEndPoint() {
+  public TEndPoint getEndPoint() {
     return endPoint;
   }
 
-  public void setEndPoint(EndPoint endPoint) {
+  public void setEndPoint(TEndPoint endPoint) {
     this.endPoint = endPoint;
   }
 

--- a/session/src/main/java/org/apache/iotdb/session/util/SessionUtils.java
+++ b/session/src/main/java/org/apache/iotdb/session/util/SessionUtils.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.session.util;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
@@ -237,20 +237,20 @@ public class SessionUtils {
     }
   }
 
-  public static List<EndPoint> parseSeedNodeUrls(List<String> nodeUrls) {
+  public static List<TEndPoint> parseSeedNodeUrls(List<String> nodeUrls) {
     if (nodeUrls == null) {
       throw new NumberFormatException("nodeUrls is null");
     }
-    List<EndPoint> endPointsList = new ArrayList<>();
+    List<TEndPoint> endPointsList = new ArrayList<>();
     for (String nodeUrl : nodeUrls) {
-      EndPoint endPoint = parseNodeUrl(nodeUrl);
+      TEndPoint endPoint = parseNodeUrl(nodeUrl);
       endPointsList.add(endPoint);
     }
     return endPointsList;
   }
 
-  private static EndPoint parseNodeUrl(String nodeUrl) {
-    EndPoint endPoint = new EndPoint();
+  private static TEndPoint parseNodeUrl(String nodeUrl) {
+    TEndPoint endPoint = new TEndPoint();
     String[] split = nodeUrl.split(":");
     if (split.length != 2) {
       throw new NumberFormatException("NodeUrl Incorrect format");

--- a/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
+++ b/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderUT.java
@@ -19,7 +19,7 @@
 
 package org.apache.iotdb.session;
 
-import org.apache.iotdb.common.rpc.thrift.EndPoint;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.RedirectException;
 import org.apache.iotdb.rpc.StatementExecutionException;
@@ -51,20 +51,20 @@ import static org.junit.Assert.fail;
 
 public class SessionCacheLeaderUT {
 
-  private static final List<EndPoint> endpoints =
-      new ArrayList<EndPoint>() {
+  private static final List<TEndPoint> endpoints =
+      new ArrayList<TEndPoint>() {
         {
-          add(new EndPoint("127.0.0.1", 55560)); // default endpoint
-          add(new EndPoint("127.0.0.1", 55561)); // meta leader endpoint
-          add(new EndPoint("127.0.0.1", 55562));
-          add(new EndPoint("127.0.0.1", 55563));
+          add(new TEndPoint("127.0.0.1", 55560)); // default endpoint
+          add(new TEndPoint("127.0.0.1", 55561)); // meta leader endpoint
+          add(new TEndPoint("127.0.0.1", 55562));
+          add(new TEndPoint("127.0.0.1", 55563));
         }
       };
 
   private Session session;
 
   // just for simulation
-  public static EndPoint getDeviceIdBelongedEndpoint(String deviceId) {
+  public static TEndPoint getDeviceIdBelongedEndpoint(String deviceId) {
     if (deviceId.startsWith("root.sg1")) {
       return endpoints.get(0);
     } else if (deviceId.startsWith("root.sg2")) {
@@ -849,7 +849,7 @@ public class SessionCacheLeaderUT {
     }
     assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
     assertEquals(3, session.deviceIdToEndpoint.size());
-    for (Map.Entry<String, EndPoint> endPointMap : session.deviceIdToEndpoint.entrySet()) {
+    for (Map.Entry<String, TEndPoint> endPointMap : session.deviceIdToEndpoint.entrySet()) {
       assertEquals(getDeviceIdBelongedEndpoint(endPointMap.getKey()), endPointMap.getValue());
     }
     assertEquals(3, session.endPointToSessionConnection.size());
@@ -1032,7 +1032,7 @@ public class SessionCacheLeaderUT {
 
     assertEquals(session.metaSessionConnection, session.defaultSessionConnection);
     assertEquals(2, session.deviceIdToEndpoint.size());
-    for (Map.Entry<String, EndPoint> endPointEntry : session.deviceIdToEndpoint.entrySet()) {
+    for (Map.Entry<String, TEndPoint> endPointEntry : session.deviceIdToEndpoint.entrySet()) {
       assertEquals(getDeviceIdBelongedEndpoint(endPointEntry.getKey()), endPointEntry.getValue());
     }
     assertEquals(3, session.endPointToSessionConnection.size());
@@ -1090,7 +1090,7 @@ public class SessionCacheLeaderUT {
 
     @Override
     public SessionConnection constructSessionConnection(
-        Session session, EndPoint endpoint, ZoneId zoneId) {
+        Session session, TEndPoint endpoint, ZoneId zoneId) {
       lastConstructedSessionConnection = new MockSessionConnection(session, endpoint, zoneId);
       return lastConstructedSessionConnection;
     }
@@ -1102,11 +1102,11 @@ public class SessionCacheLeaderUT {
 
   static class MockSessionConnection extends SessionConnection {
 
-    private EndPoint endPoint;
+    private TEndPoint endPoint;
     private boolean connectionBroken;
     private IoTDBConnectionException ioTDBConnectionException;
 
-    public MockSessionConnection(Session session, EndPoint endPoint, ZoneId zoneId) {
+    public MockSessionConnection(Session session, TEndPoint endPoint, ZoneId zoneId) {
       super();
       this.endPoint = endPoint;
       ioTDBConnectionException =
@@ -1199,7 +1199,7 @@ public class SessionCacheLeaderUT {
     }
 
     private RedirectException getRedirectException(List<String> deviceIds) {
-      Map<String, EndPoint> deviceEndPointMap = new HashMap<>();
+      Map<String, TEndPoint> deviceEndPointMap = new HashMap<>();
       for (String deviceId : deviceIds) {
         deviceEndPointMap.put(deviceId, getDeviceIdBelongedEndpoint(deviceId));
       }

--- a/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/thrift-confignode/src/main/thrift/confignode.thrift
@@ -23,7 +23,7 @@ namespace py iotdb.thrift.confignode
 
 // DataNode
 struct TDataNodeRegisterReq {
-  1: required common.EndPoint endPoint
+  1: required common.TEndPoint endPoint
   // Map<StorageGroupName, TStorageGroupSchema>
   // DataNode can use statusMap to report its status to the ConfigNode when restart
   2: optional map<string, TStorageGroupSchema> statusMap
@@ -50,7 +50,7 @@ struct TDataNodeMessageResp {
 
 struct TDataNodeMessage {
   1: required i32 dataNodeId
-  2: required common.EndPoint endPoint
+  2: required common.TEndPoint endPoint
 }
 
 // StorageGroup

--- a/thrift/src/main/thrift/common.thrift
+++ b/thrift/src/main/thrift/common.thrift
@@ -20,7 +20,7 @@
 namespace java org.apache.iotdb.common.rpc.thrift
 namespace py iotdb.thrift.common
 
-struct EndPoint {
+struct TEndPoint {
   1: required string ip
   2: required i32 port
 }
@@ -30,12 +30,12 @@ struct TSStatus {
   1: required i32 code
   2: optional string message
   3: optional list<TSStatus> subStatus
-  4: optional EndPoint redirectNode
+  4: optional TEndPoint redirectNode
 }
 
 struct TRegionReplicaSet {
   1: required binary regionId
-  2: required list<EndPoint> endpoint
+  2: required list<TEndPoint> endpoint
 }
 
 struct TSeriesPartitionSlot {


### PR DESCRIPTION
It is quite confusing when there are 2 classes named "EndPoint". They are org.apache.iotdb.commons.cluster.EndPoint and org.apache.iotdb.common.rpc.thrift.EndPoint.

By convention, the name of thrift generated classes should start with "T", so I renamed the org.apache.iotdb.common.rpc.thrift.EndPoint to org.apache.iotdb.common.rpc.thrift.TEndPoint.