### PR TITLE
[IOTDB-2943] Fix cannot use stop-server.sh to stop IoTDB

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
@@ -175,7 +175,7 @@ public class CompactionTaskManager implements IService {
     while (!taskExecutionPool.isTerminated()) {
       int timeMillis = 0;
       try {
-        Thread.sleep(200);
+        this.wait(200);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
@@ -177,10 +177,6 @@ public class CompactionTaskManager implements IService {
       try {
         Thread.sleep(200);
       } catch (InterruptedException e) {
-        logger.error(
-            "CompactionMergeTaskPoolManager {} shutdown",
-            ThreadName.COMPACTION_SERVICE.getName(),
-            e);
         Thread.currentThread().interrupt();
       }
       timeMillis += 200;


### PR DESCRIPTION
See [IOTDB-2943](https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-2943?filter=allopenissues).
The reason for this bug is that, the `awaitTerminate` function in `CompactionTaskManager` is synchronized, which cause a deadlock with `removeRunningTaskFuture`.