### PR TITLE
[IOTDB-2954] fix influxdb protocol bug found in benchmark test of verificationQueryMode

### DIFF
--- a/influxdb-protocol/src/main/java/org/apache/iotdb/influxdb/session/InfluxDBSession.java
+++ b/influxdb-protocol/src/main/java/org/apache/iotdb/influxdb/session/InfluxDBSession.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.influxdb.session;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.protocol.influxdb.util.JacksonUtils;
 import org.apache.iotdb.protocol.influxdb.rpc.thrift.InfluxCloseSessionReq;
 import org.apache.iotdb.protocol.influxdb.rpc.thrift.InfluxCreateDatabaseReq;
 import org.apache.iotdb.protocol.influxdb.rpc.thrift.InfluxDBService;
@@ -35,7 +36,6 @@ import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.Config;
 
-import com.google.gson.Gson;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
@@ -182,7 +182,7 @@ public class InfluxDBSession {
     try {
       InfluxQueryResultRsp tsQueryResultRsp = client.query(request);
       RpcUtils.verifySuccess(tsQueryResultRsp.status);
-      return new Gson().fromJson(tsQueryResultRsp.resultJsonString, QueryResult.class);
+      return JacksonUtils.json2Bean(tsQueryResultRsp.resultJsonString, QueryResult.class);
     } catch (TException e) {
       e.printStackTrace();
       logger.error(e.getMessage());
@@ -191,7 +191,7 @@ public class InfluxDBSession {
           request.setSessionId(sessionId);
           InfluxQueryResultRsp tsQueryResultRsp = client.query(request);
           RpcUtils.verifySuccess(tsQueryResultRsp.status);
-          return new Gson().fromJson(tsQueryResultRsp.resultJsonString, QueryResult.class);
+          return JacksonUtils.json2Bean(tsQueryResultRsp.resultJsonString, QueryResult.class);
         } catch (TException e1) {
           throw new IoTDBConnectionException(e1);
         }

--- a/influxdb-protocol/src/test/java/org/apache/iotdb/influxdb/integration/IoTDBInfluxDBIT.java
+++ b/influxdb-protocol/src/test/java/org/apache/iotdb/influxdb/integration/IoTDBInfluxDBIT.java
@@ -178,7 +178,7 @@ public class IoTDBInfluxDBIT {
     QueryResult result = influxDB.query(query);
     QueryResult.Series series = result.getResults().get(0).getSeries().get(0);
 
-    Object[] retArray = new Object[] {0.0, 99.0, 87.0, 186.0, 2.0, 12.0, 93.0, 87.0, 99.0};
+    Object[] retArray = new Object[] {0, 99.0, 87.0, 186.0, 2, 12.0, 93.0, 87, 99};
     for (int i = 0; i < series.getColumns().size(); i++) {
       assertEquals(retArray[i], series.getValues().get(0).get(i));
     }
@@ -194,7 +194,7 @@ public class IoTDBInfluxDBIT {
     QueryResult.Series series = result.getResults().get(0).getSeries().get(0);
 
     Object[] retArray =
-        new Object[] {0.0, 2.0, 87.0, "china", 99.0, 93.0, 93.0, 87.0, 87.0, 12.0, 6.0, 186.0};
+        new Object[] {0, 1, 87, "china", 87.0, 87.0, 87.0, 87.0, 87, 0.0, 0.0, 87.0};
     for (int i = 0; i < series.getColumns().size(); i++) {
       assertEquals(retArray[i], series.getValues().get(0).get(i));
     }

--- a/influxdb-protocol/src/test/java/org/apache/iotdb/influxdb/integration/IoTDBInfluxDBIT.java
+++ b/influxdb-protocol/src/test/java/org/apache/iotdb/influxdb/integration/IoTDBInfluxDBIT.java
@@ -194,7 +194,7 @@ public class IoTDBInfluxDBIT {
     QueryResult.Series series = result.getResults().get(0).getSeries().get(0);
 
     Object[] retArray =
-        new Object[] {0, 1, 87, "china", 87.0, 87.0, 87.0, 87.0, 87, 0.0, 0.0, 87.0};
+        new Object[] {0, 2, 87, "china", 99.0, 93.0, 93.0, 87.0, 87, 12.0, 6.0, 186.0};
     for (int i = 0; i < series.getColumns().size(); i++) {
       assertEquals(retArray[i], series.getValues().get(0).get(i));
     }

--- a/server/src/main/java/org/apache/iotdb/db/protocol/influxdb/handler/QueryHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/protocol/influxdb/handler/QueryHandler.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.db.protocol.influxdb.operator.InfluxQueryOperator;
 import org.apache.iotdb.db.protocol.influxdb.operator.InfluxSelectComponent;
 import org.apache.iotdb.db.protocol.influxdb.util.FieldUtils;
 import org.apache.iotdb.db.protocol.influxdb.util.FilterUtils;
+import org.apache.iotdb.db.protocol.influxdb.util.JacksonUtils;
 import org.apache.iotdb.db.protocol.influxdb.util.QueryResultUtils;
 import org.apache.iotdb.db.protocol.influxdb.util.StringUtils;
 import org.apache.iotdb.db.qp.constant.FilterConstant;
@@ -61,7 +62,6 @@ import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.SingleSeriesExpression;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 
-import com.google.gson.Gson;
 import org.apache.thrift.TException;
 import org.influxdb.InfluxDBException;
 import org.influxdb.dto.QueryResult;
@@ -112,7 +112,7 @@ public class QueryHandler {
                 queryOperator.getSelectComponent(), database, measurement, serviceProvider);
       }
       return tsQueryResultRsp
-          .setResultJsonString(new Gson().toJson(queryResult))
+          .setResultJsonString(JacksonUtils.bean2Json(queryResult))
           .setStatus(RpcUtils.getInfluxDBStatus(TSStatusCode.SUCCESS_STATUS));
     } catch (AuthException e) {
       return tsQueryResultRsp.setStatus(

--- a/server/src/main/java/org/apache/iotdb/db/protocol/influxdb/util/JacksonUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/protocol/influxdb/util/JacksonUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.protocol.influxdb.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class JacksonUtils {
+  private static final ObjectMapper mapper = new ObjectMapper();
+
+  public static String bean2Json(Object obj) {
+    try {
+      return mapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      return null;
+    }
+  }
+
+  public static <T> T json2Bean(String jsonStr, Class<T> objClass) {
+    try {
+      return mapper.readValue(jsonStr, objClass);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/protocol/influxdb/util/StringUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/protocol/influxdb/util/StringUtils.java
@@ -32,7 +32,8 @@ public class StringUtils {
    * @return string after processing
    */
   public static String removeQuotation(String str) {
-    if (str.charAt(0) == '"' && str.charAt(str.length() - 1) == '"') {
+    if ((str.charAt(0) == '"' && str.charAt(str.length() - 1) == '"')
+        || str.charAt(0) == '\'' && str.charAt(str.length() - 1) == '\'') {
       return str.substring(1, str.length() - 1);
     }
     return str;


### PR DESCRIPTION
see : https://issues.apache.org/jira/browse/IOTDB-2954

## Bug Fixes
- Use Jackson instead of Gosn, because Gosn will convert all number type in the object into double type
- Fixed a problem where the value of a single quote could not be resolved
