### PR TITLE
[IOTDB-2887][IOTDB-2930][IOTDB-2932] Fix recover test error in CI & Fix NPE while concurrent createTimeseries & Add config check for schema engine mode

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
@@ -99,6 +99,9 @@ public class IoTDBConfigCheck {
   private static final String ENABLE_ID_TABLE_LOG_FILE = "enable_id_table_log_file";
   private static String enableIdTableLogFile = String.valueOf(config.isEnableIDTableLogFile());
 
+  private static final String SCHEMA_ENGINE_MODE = "schema_engine_mode";
+  private static String schemaEngineMode = String.valueOf(config.getSchemaEngineMode());
+
   private static final String TIME_ENCODER_KEY = "time_encoder";
   private static String timeEncoderValue =
       String.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
@@ -161,6 +164,7 @@ public class IoTDBConfigCheck {
     systemProperties.put(TIME_ENCODER_KEY, timeEncoderValue);
     systemProperties.put(ENABLE_ID_TABLE, enableIDTable);
     systemProperties.put(ENABLE_ID_TABLE_LOG_FILE, enableIdTableLogFile);
+    systemProperties.put(SCHEMA_ENGINE_MODE, schemaEngineMode);
   }
 
   /**
@@ -369,6 +373,10 @@ public class IoTDBConfigCheck {
 
     if (!(properties.getProperty(ENABLE_ID_TABLE_LOG_FILE).equals(enableIdTableLogFile))) {
       throwException(ENABLE_ID_TABLE_LOG_FILE, enableIdTableLogFile);
+    }
+
+    if (!(properties.getProperty(SCHEMA_ENGINE_MODE).equals(schemaEngineMode))) {
+      throwException(SCHEMA_ENGINE_MODE, schemaEngineMode);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalConfigNode.java
@@ -181,7 +181,7 @@ public class LocalConfigNode {
       SchemaResourceManager.clearSchemaResource();
 
       if (timedForceMLogThread != null) {
-        timedForceMLogThread.shutdownNow();
+        timedForceMLogThread.shutdown();
         timedForceMLogThread = null;
       }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaPartitionTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaPartitionTable.java
@@ -106,6 +106,9 @@ public class LocalSchemaPartitionTable {
   }
 
   public synchronized void setStorageGroup(PartialPath storageGroup) {
+    if (table.containsKey(storageGroup)) {
+      return;
+    }
     table.put(storageGroup, Collections.synchronizedSet(new HashSet<>()));
   }
 
@@ -116,6 +119,9 @@ public class LocalSchemaPartitionTable {
   // This method may be extended to implement multi schemaRegion for one storageGroup
   // todo keep consistent with the partition method of config node in new cluster
   private SchemaRegionId calculateSchemaRegionId(PartialPath storageGroup, PartialPath path) {
+    if (!table.containsKey(storageGroup)) {
+      setStorageGroup(storageGroup);
+    }
     return table.get(storageGroup).iterator().next();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/MTreeFlushTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/MTreeFlushTaskManager.java
@@ -54,7 +54,7 @@ public class MTreeFlushTaskManager {
 
   public void clear() {
     if (flushTaskExecutor != null) {
-      flushTaskExecutor.shutdownNow();
+      flushTaskExecutor.shutdown();
       while (!flushTaskExecutor.isTerminated()) ;
       flushTaskExecutor = null;
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/MTreeReleaseTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/MTreeReleaseTaskManager.java
@@ -53,7 +53,7 @@ public class MTreeReleaseTaskManager {
 
   public void clear() {
     if (releaseTaskExecutor != null) {
-      releaseTaskExecutor.shutdownNow();
+      releaseTaskExecutor.shutdown();
       while (!releaseTaskExecutor.isTerminated()) ;
       releaseTaskExecutor = null;
     }


### PR DESCRIPTION
## Description

### IOTDB-2887 Fix recover test error in CI
Sometimes schema recover test in CI may fail. 

The cause is that when the ```EnvironmentUtil.restartDameon()``` is invoked, ```LocalConfigNode.clear()``` is invoked and all the schema-related thread pool will be ```shutdownNow```, which means if a thread is waiting something, including the disk I/O, it will be interrupted and shutdown. Therefore, the file, for example, the mlog, may not store all the data in memory and will be different from what we expected.

Thus the ```threadPool.shutdownNow()``` is replaced by ```threadPool.shutdown()```, which guarantees that the thread task will finish and the data will be flushed to disk.

### IOTDB-2930 Add config check for schema engine mode
The schema engine mode should not be changed after initializing IoTDB for the first time, since the storage structures of different modes are not compatible with each other.

### IOTDB-2932 Fix NPE while concurrent createTimeseries
When set storage group, localPartitionTable should init a set for this storage group. The two steps are not grouped as synchronized operation, thus another thread may get the storage group while the partition table is not prepared well.

Thus a existence check and auto create mechanism is added to prevent npe.
