### PR TITLE
Change the result of ConfigExecution from Void to TsBlock

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/config/AuthorizerConfigTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/config/AuthorizerConfigTask.java
@@ -48,8 +48,8 @@ public class AuthorizerConfigTask implements IConfigTask {
   }
 
   @Override
-  public ListenableFuture<Void> execute() {
-    SettableFuture<Void> future = SettableFuture.create();
+  public ListenableFuture<ConfigTaskResult> execute() {
+    SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     ConfigNodeClient configNodeClient = null;
     try {
       // Construct request using statement
@@ -75,7 +75,7 @@ public class AuthorizerConfigTask implements IConfigTask {
             tsStatus);
         future.setException(new StatementExecutionException(tsStatus));
       } else {
-        future.set(null);
+        future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
       }
     } catch (IoTDBConnectionException | BadNodeUrlException e) {
       LOGGER.error("Failed to connect to config node.");

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/config/ConfigTaskResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/config/ConfigTaskResult.java
@@ -19,29 +19,35 @@
 
 package org.apache.iotdb.db.mpp.execution.config;
 
-import org.apache.iotdb.db.mpp.sql.statement.Statement;
+import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
+public class ConfigTaskResult {
+  private TSStatusCode statusCode;
+  private TsBlock resultSet;
 
-public class SampleConfigTask implements IConfigTask {
-
-  private Statement statement;
-
-  public SampleConfigTask(Statement statement) {
-    this.statement = statement;
+  public ConfigTaskResult(TSStatusCode statusCode) {
+    this.statusCode = statusCode;
   }
 
-  @Override
-  public ListenableFuture<Void> execute() {
-    // Construct request using statement
+  public ConfigTaskResult(TSStatusCode statusCode, TsBlock resultSet) {
+    this.statusCode = statusCode;
+    this.resultSet = resultSet;
+  }
 
-    // Send request to some API server
+  public TSStatusCode getStatusCode() {
+    return statusCode;
+  }
 
-    // Get response or throw exception
+  public void setStatusCode(TSStatusCode statusCode) {
+    this.statusCode = statusCode;
+  }
 
-    // If the action is executed successfully, return the Future.
-    // If your operation is async, you can return the corresponding future directly.
-    return Futures.immediateVoidFuture();
+  public TsBlock getResultSet() {
+    return resultSet;
+  }
+
+  public void setResultSet(TsBlock resultSet) {
+    this.resultSet = resultSet;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/config/IConfigTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/config/IConfigTask.java
@@ -22,5 +22,5 @@ package org.apache.iotdb.db.mpp.execution.config;
 import com.google.common.util.concurrent.ListenableFuture;
 
 public interface IConfigTask {
-  ListenableFuture<Void> execute() throws InterruptedException;
+  ListenableFuture<ConfigTaskResult> execute() throws InterruptedException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/config/SetStorageGroupTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/config/SetStorageGroupTask.java
@@ -42,8 +42,8 @@ public class SetStorageGroupTask implements IConfigTask {
   }
 
   @Override
-  public ListenableFuture<Void> execute() {
-    SettableFuture<Void> future = SettableFuture.create();
+  public ListenableFuture<ConfigTaskResult> execute() {
+    SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     // Construct request using statement
     TSetStorageGroupReq req =
         new TSetStorageGroupReq(setStorageGroupStatement.getStorageGroupPath().getFullPath());
@@ -61,7 +61,7 @@ public class SetStorageGroupTask implements IConfigTask {
             tsStatus);
         future.setException(new StatementExecutionException(tsStatus));
       } else {
-        future.set(null);
+        future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
       }
     } catch (IoTDBConnectionException | BadNodeUrlException e) {
       LOGGER.error("Failed to connect to config node.");


### PR DESCRIPTION
## Motivation

Some execution which need to be run in ConfigNode will have resultSet such as `show storage group`. We need to make the ConfigExecution has the ability of returning result set after executing.

## Changes
Change the body of `Future` of IConfigTask from `Void` to `ConfigTaskResult`. And `ConfigTaskResult` will contains two params: 1. the status code; 2. the result set if it has.


