### PR TITLE
Fix class path in SchemaFileSketcher.sh and mLogParser.sh

### DIFF
--- a/server/src/assembly/resources/tools/schema/SchemaFileSketcher.sh
+++ b/server/src/assembly/resources/tools/schema/SchemaFileSketcher.sh
@@ -42,7 +42,7 @@ for f in ${IOTDB_HOME}/lib/*.jar; do
   CLASSPATH=${CLASSPATH}":"$f
 done
 
-MAIN_CLASS=org.apache.iotdb.db.tools.mlog.SchemaFileSketchTool
+MAIN_CLASS=org.apache.iotdb.db.tools.schema.SchemaFileSketchTool
 
 "$JAVA" -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
 exit $?

--- a/server/src/assembly/resources/tools/schema/mLogParser.sh
+++ b/server/src/assembly/resources/tools/schema/mLogParser.sh
@@ -42,7 +42,7 @@ for f in ${IOTDB_HOME}/lib/*.jar; do
   CLASSPATH=${CLASSPATH}":"$f
 done
 
-MAIN_CLASS=org.apache.iotdb.db.tools.mlog.MLogParser
+MAIN_CLASS=org.apache.iotdb.db.tools.schema.MLogParser
 
 "$JAVA" -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
 exit $?


### PR DESCRIPTION
## Description

Since the path of the class to sketch SchemaFile and MLog has been changed to org.apache.iotdb.db.tools.schema from org.apache.iotdb.db.tools.mlog, corresponding script should modify the classpath parameter as well.