### PR TITLE
Add block cancel when GetBlockTask throws exception

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/SourceHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/SourceHandle.java
@@ -356,6 +356,12 @@ public class SourceHandle implements ISourceHandle {
               localMemoryManager
                   .getQueryPool()
                   .free(localFragmentInstanceId.getQueryId(), reservedBytes);
+              // That GetDataBlocksTask throws exception means some TsBlock cannot be
+              // fetched permanently. Someone maybe waiting the SourceHandle to be
+              // unblocked after fetching data. So the blocked should be released.
+              if (blocked != null && !blocked.isDone()) {
+                blocked.cancel(true);
+              }
             }
           }
         }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryExecution.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -210,7 +211,7 @@ public class QueryExecution implements IQueryExecution {
       }
       return resultHandle.receive();
 
-    } catch (ExecutionException | IOException e) {
+    } catch (ExecutionException | IOException | CancellationException e) {
       stateMachine.transitionToFailed(e);
       throwIfUnchecked(e.getCause());
       throw new RuntimeException(e.getCause());


### PR DESCRIPTION
## Motivation
A scenario will lead to the invoker wait permanently when using SourceHandle. That is, the SourceHandle's EOS has been received while the GetDataBlockTask is still in progress. And then, the GetDataBlockTask throws exception. If the invoker is waiting the `blocked` future it will be blocked permanently here.

## Solution
Cancel the `blocked` if the GetDataBlockTask threw exception