### PR TITLE
Fix the bug when matching pattern tree using multi-wildcard

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeVisitor.java
@@ -199,9 +199,11 @@ public class SchemaTreeVisitor implements Iterator<MeasurementPath> {
     SchemaNode child = node.getChild(childName);
     if (child != null) {
       stack.push(Collections.singletonList(child).iterator());
-      context.push(node);
-      indexStack.push(patternIndex);
+    } else {
+      stack.push(Collections.emptyIterator());
     }
+    context.push(node);
+    indexStack.push(patternIndex);
   }
 
   private boolean checkOneLevelWildcardMatch(String regex, SchemaNode node) {

--- a/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.mpp.common.schematree;
 
+import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.metadata.path.MeasurementPath;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -40,6 +41,19 @@ public class SchemaTreeTest {
     SchemaNode root = generateSchemaTree();
 
     testSchemaTree(root);
+  }
+
+  @Test
+  public void testMultiWildcard() throws IllegalPathException {
+    SchemaNode root = generateSchemaTree();
+    SchemaTreeVisitor visitor =
+        new SchemaTreeVisitor(root, new PartialPath("root.**.s1"), 0, 0, false);
+    checkVisitorResult(
+        visitor,
+        3,
+        new String[] {"root.sg.d1.s1", "root.sg.d2.s1", "root.sg.d2.a.s1"},
+        null,
+        new boolean[] {false, false, true});
   }
 
   private void testSchemaTree(SchemaNode root) throws Exception {


### PR DESCRIPTION
## Description

When matching `**.xx` with a `node`, we need to push two times. 
 1. One push for `xx` and `node.children()`; 
 2. the other push for `**.xx` and `node.children()`.

Before this change, if the `xx` cannot match `node.children`, the second push is lost. This PR fix this scenario.
