### PR TITLE
[IOTDB-2950]Fix concurrent bug of CachedMNodeContainer.putIfAbsent

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/CachedMNodeContainer.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/CachedMNodeContainer.java
@@ -107,6 +107,21 @@ public class CachedMNodeContainer implements ICachedMNodeContainer {
     return newChildBuffer.put(key, value);
   }
 
+  @Nullable
+  @Override
+  public synchronized IMNode putIfAbsent(String key, IMNode value) {
+
+    IMNode node = get(key);
+    if (node == null) {
+      if (newChildBuffer == null) {
+        newChildBuffer = new ConcurrentHashMap<>();
+      }
+      node = newChildBuffer.put(key, value);
+    }
+
+    return node;
+  }
+
   @Override
   public synchronized IMNode remove(Object key) {
     IMNode result = remove(childCache, key);


### PR DESCRIPTION
## Description


### One of the causes
The ```CachedMNodeContainer.putIfAbsent``` is not thread-safe, which may results in subTree loss or unexpected replacement when creating timeseries concurrently.

### Solution
Rewrite ```CachedMNodeContainer.putIfAbsent``` and make it synchronized.


