### PR TITLE
[IOTDB-2880] Fix NPE occured in ci test

### DIFF
--- a/procedure/src/main/java/org/apache/iotdb/procedure/ProcedureExecutor.java
+++ b/procedure/src/main/java/org/apache/iotdb/procedure/ProcedureExecutor.java
@@ -177,7 +177,9 @@ public class ProcedureExecutor<Env> {
         }
       }
       RootProcedureStack rootStack = rollbackStack.get(rootProcedureId);
-      rootStack.loadStack(proc);
+      if (rootStack != null) {
+        rootStack.loadStack(proc);
+      }
       proc.setRootProcedureId(rootProcedureId);
       switch (proc.getState()) {
         case RUNNABLE:

--- a/procedure/src/main/java/org/apache/iotdb/procedure/ProcedureExecutor.java
+++ b/procedure/src/main/java/org/apache/iotdb/procedure/ProcedureExecutor.java
@@ -257,7 +257,7 @@ public class ProcedureExecutor<Env> {
         .values()
         .forEach(
             procedure -> {
-              while (true) {
+              while (procedure != null) {
                 if (restored.contains(procedure.getProcId())) {
                   restoreLocks(stack, restored);
                   return;

--- a/procedure/src/test/java/org/apache/iotdb/procedure/TestProcedureBase.java
+++ b/procedure/src/test/java/org/apache/iotdb/procedure/TestProcedureBase.java
@@ -44,9 +44,9 @@ public class TestProcedureBase {
   @After
   public void tearDown() {
     this.procStore.stop();
-    this.procStore.cleanup();
     this.procExecutor.stop();
     this.procExecutor.join();
+    this.procStore.cleanup();
   }
 
   protected void initExecutor() {

--- a/procedure/src/test/java/org/apache/iotdb/procedure/store/TestProcedureStore.java
+++ b/procedure/src/test/java/org/apache/iotdb/procedure/store/TestProcedureStore.java
@@ -101,11 +101,6 @@ public class TestProcedureStore extends TestProcedureBase {
     ProcedureTestUtil.waitForProcedure(procExecutor, rootId);
     Assert.assertEquals(
         procExecutor.getResultOrProcedure(rootId).getState(), ProcedureState.SUCCESS);
-    try {
-      FileUtils.cleanDirectory(new File(TEST_DIR));
-    } catch (IOException e) {
-      System.out.println("clean dir failed." + e);
-    }
   }
 
   private void assertProc(Procedure proc, Class clazz, long procId, ProcedureState state) {

--- a/procedure/src/test/java/org/apache/iotdb/procedure/store/TestProcedureStore.java
+++ b/procedure/src/test/java/org/apache/iotdb/procedure/store/TestProcedureStore.java
@@ -28,9 +28,12 @@ import org.apache.iotdb.procedure.entity.StuckSTMProcedure;
 import org.apache.iotdb.procedure.util.ProcedureTestUtil;
 import org.apache.iotdb.service.rpc.thrift.ProcedureState;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -61,8 +64,12 @@ public class TestProcedureStore extends TestProcedureBase {
         procedureList.get(0).getClass(),
         procedureList.get(0).getProcId(),
         procedureList.get(0).getState());
-
     this.procStore.cleanup();
+    try {
+      FileUtils.cleanDirectory(new File(TEST_DIR));
+    } catch (IOException e) {
+      System.out.println("clean dir failed." + e);
+    }
   }
 
   @Test
@@ -94,6 +101,11 @@ public class TestProcedureStore extends TestProcedureBase {
     ProcedureTestUtil.waitForProcedure(procExecutor, rootId);
     Assert.assertEquals(
         procExecutor.getResultOrProcedure(rootId).getState(), ProcedureState.SUCCESS);
+    try {
+      FileUtils.cleanDirectory(new File(TEST_DIR));
+    } catch (IOException e) {
+      System.out.println("clean dir failed." + e);
+    }
   }
 
   private void assertProc(Procedure proc, Class clazz, long procId, ProcedureState state) {


### PR DESCRIPTION
Test directory clean may failed occasionally at _After()_ method. Ensure it at last.

![image](https://user-images.githubusercontent.com/82880298/164581939-134bdae6-830e-4f56-a7d0-765087d7ee36.png)
