### PR TITLE
Fix the issue that EndTime in FragmentInstanceContext is not set

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/Coordinator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/Coordinator.java
@@ -31,7 +31,6 @@ import org.apache.iotdb.db.mpp.sql.analyze.QueryType;
 import org.apache.iotdb.db.mpp.sql.statement.ConfigStatement;
 import org.apache.iotdb.db.mpp.sql.statement.Statement;
 
-import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,9 +103,7 @@ public class Coordinator {
   }
 
   public IQueryExecution getQueryExecution(QueryId queryId) {
-    IQueryExecution execution = queryExecutionMap.get(queryId);
-    Validate.notNull(execution, "invalid queryId %s", queryId.getId());
-    return execution;
+    return queryExecutionMap.get(queryId);
   }
 
   // TODO: (xingtanzjr) need to redo once we have a concrete policy for the threadPool management

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/FragmentInstanceContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/FragmentInstanceContext.java
@@ -107,7 +107,7 @@ public class FragmentInstanceContext extends QueryContext {
 
       // use compare and set from initial value to avoid overwriting if there
       // were a duplicate notification, which shouldn't happen
-      executionEndTime.compareAndSet(null, now);
+      executionEndTime.compareAndSet(END_TIME_INITIAL_VALUE, now);
       endNanos.compareAndSet(0, System.nanoTime());
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/FragmentInstanceContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/FragmentInstanceContext.java
@@ -36,7 +36,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class FragmentInstanceContext extends QueryContext {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FragmentInstanceContext.class);
-
+  private static final long END_TIME_INITIAL_VALUE = -1L;
   private final FragmentInstanceId id;
 
   // TODO if we split one fragment instance into multiple pipelines to run, we need to replace it
@@ -75,6 +75,7 @@ public class FragmentInstanceContext extends QueryContext {
       FragmentInstanceId id, FragmentInstanceStateMachine stateMachine) {
     this.id = id;
     this.stateMachine = stateMachine;
+    this.executionEndTime.set(END_TIME_INITIAL_VALUE);
   }
 
   public void start() {

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
@@ -800,7 +800,10 @@ public class DataNodeTSIServiceImpl implements TSIEventHandler {
   }
 
   private void cleanupQueryExecution(Long queryId) {
-    COORDINATOR.getQueryExecution(genQueryId(queryId)).stopAndCleanup();
+    IQueryExecution queryExecution = COORDINATOR.getQueryExecution(genQueryId(queryId));
+    if (queryExecution != null) {
+      queryExecution.stopAndCleanup();
+    }
   }
 
   private QueryId genQueryId(long id) {


### PR DESCRIPTION
## Description
1. When the FragmentInstance is not complete, its `endTime` is not set. It will lead to NPE when parse it to `long` when fetching FragmentInstance status.
2. Fix an issue that the coordinator cannot cleanup QueryExecution if the QueryExecution throws exception when constructing, which will lead to client stuck.