### PR TITLE
Filter non schemaRegionDir

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
@@ -97,8 +97,13 @@ public class SchemaEngine {
       }
 
       for (File schemaRegionDir : schemaRegionDirs) {
-        SchemaRegionId schemaRegionId =
-            new SchemaRegionId(Integer.parseInt(schemaRegionDir.getName()));
+        SchemaRegionId schemaRegionId;
+        try {
+          schemaRegionId = new SchemaRegionId(Integer.parseInt(schemaRegionDir.getName()));
+        } catch (NumberFormatException e) {
+          // the dir/file is not schemaRegionDir, ignore this.
+          continue;
+        }
         createSchemaRegion(storageGroup, schemaRegionId);
         schemaRegionIdList.add(schemaRegionId);
       }


### PR DESCRIPTION
## Description


### Cause
In Mac os, there are hidden dirs or files, named with ```.DS_Store``` suffix. When recover schemaEngine and such dirs or files is scanned, NumberFormatException will be thrown.

### Solution
When encountering NumberFormatException, ignore this and skip this dir, since a schemaRegion dir is named after a numeric number.
