### PR TITLE
[IOTDB-2930]Fix concurrent UnPin bug & Improve template implementation

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
@@ -292,7 +292,8 @@ public interface IMTreeBelowSG {
    * @return index on full path of the node which matches all measurements path with its
    *     upperTemplate.
    */
-  int getMountedNodeIndexOnMeasurementPath(PartialPath measurementPath) throws MetadataException;
+  int getMountedNodeIndexOnMeasurementPath(PartialPath devicePath, String[] measurements)
+      throws MetadataException;
 
   List<String> getPathsSetOnTemplate(String templateName) throws MetadataException;
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -1296,12 +1296,12 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
     IMNode cur = storageGroupMNode;
     IMNode child;
     Template upperTemplate = cur.getSchemaTemplate();
-    int index;
+    int index = levelOfSG + 1;
     boolean attemptToUseTemplate = false;
 
     try {
       // If there are nodes of target path on MTree, use it as possible.
-      for (index = levelOfSG + 1; index < nodes.length; index++) {
+      for (; index < nodes.length; index++) {
         upperTemplate = cur.getSchemaTemplate() != null ? cur.getSchemaTemplate() : upperTemplate;
         child = store.getChild(cur, nodes[index]);
         if (child == null) {
@@ -1318,7 +1318,9 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
         }
       }
     } finally {
-      unPinPath(cur);
+      if (index > levelOfSG + 1) {
+        unPinPath(cur);
+      }
     }
 
     if (!attemptToUseTemplate) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -80,6 +80,7 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.ONE_LEVEL_PATH_WILDCARD;
+import static org.apache.iotdb.commons.conf.IoTDBConstant.PATH_SEPARATOR;
 import static org.apache.iotdb.db.metadata.MetadataConstant.ALL_RESULT_NODES;
 import static org.apache.iotdb.db.metadata.lastCache.LastCacheManager.getLastTimeStamp;
 
@@ -111,7 +112,7 @@ import static org.apache.iotdb.db.metadata.lastCache.LastCacheManager.getLastTim
 public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
 
   private CachedMTreeStore store;
-  private IStorageGroupMNode storageGroupMNode;
+  private volatile IStorageGroupMNode storageGroupMNode;
   private int levelOfSG;
 
   // region MTree initialization, clear and serialization
@@ -1289,53 +1290,78 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
    * @return index on full path of the node which matches all measurements path with its
    *     upperTemplate.
    */
-  @Override
-  public int getMountedNodeIndexOnMeasurementPath(PartialPath measurementPath)
+  public int getMountedNodeIndexOnMeasurementPath(PartialPath devicePath, String[] measurements)
       throws MetadataException {
-    String[] fullPathNodes = measurementPath.getNodes();
+    String[] nodes = devicePath.getNodes();
     IMNode cur = storageGroupMNode;
     IMNode child;
     Template upperTemplate = cur.getSchemaTemplate();
+    int index;
+    boolean attemptToUseTemplate = false;
+
     try {
-      for (int index = levelOfSG + 1; index < fullPathNodes.length; index++) {
+      // If there are nodes of target path on MTree, use it as possible.
+      for (index = levelOfSG + 1; index < nodes.length; index++) {
         upperTemplate = cur.getSchemaTemplate() != null ? cur.getSchemaTemplate() : upperTemplate;
-        child = store.getChild(cur, fullPathNodes[index]);
+        child = store.getChild(cur, nodes[index]);
         if (child == null) {
-          if (upperTemplate != null) {
-            // for this fullPath, cur is the last node on MTree
-            // since upperTemplate exists, need to find the matched suffix path of fullPath and
-            // template
-            String suffixPath =
-                new PartialPath(Arrays.copyOfRange(fullPathNodes, index, fullPathNodes.length))
-                    .toString();
-
-            // if suffix matches template, then fullPathNodes[index-1] should be the node to use
-            // template on MTree
-            if (upperTemplate.hasSchema(suffixPath)) {
-              return index - 1;
-            }
-
-            // if suffix doesn't match, but first node name matched, it's an overlap with template
-            // cast exception for now
-            if (upperTemplate.getDirectNode(fullPathNodes[index]) != null) {
-              throw new TemplateImcompatibeException(
-                  measurementPath.getFullPath(), upperTemplate.getName(), fullPathNodes[index]);
-            }
-          } else {
+          if (upperTemplate == null) {
             // no matched child, no template, need to create device node as logical device path
-            return fullPathNodes.length - 1;
+            return nodes.length;
+          } else {
+            attemptToUseTemplate = true;
+            break;
           }
         } else {
           // has child on MTree
           cur = child;
         }
       }
-
-      // all nodes on path exist in MTree, device node should be the penultimate one
-      return fullPathNodes.length - 1;
     } finally {
       unPinPath(cur);
     }
+
+    if (!attemptToUseTemplate) {
+      // all nodes on path exist in MTree, device node should be the penultimate one
+      return nodes.length;
+    }
+
+    // The resting part of target path not exists on MTree, thus try to use template.
+    for (; index < nodes.length; index++) {
+      int fullPathLength = nodes.length - index + 1;
+      String[] suffixNodes = new String[fullPathLength];
+      System.arraycopy(nodes, index, suffixNodes, 0, nodes.length - index);
+      boolean hasAllMeasurements = true;
+
+      for (String measurement : measurements) {
+        // for this fullPath, cur is the last node on MTree
+        // since upperTemplate exists, need to find the matched suffix path of fullPath and
+        // template
+        suffixNodes[fullPathLength - 1] = measurement;
+        String suffixPath = String.join(String.valueOf(PATH_SEPARATOR), suffixNodes);
+
+        if (upperTemplate.hasSchema(suffixPath)) {
+          continue;
+        }
+
+        // if suffix doesn't match, but first node name matched, it's an overlap with template
+        // cast exception for now
+        if (upperTemplate.getDirectNode(nodes[index]) != null) {
+          throw new TemplateImcompatibeException(
+              devicePath.concatNode(measurement).getFullPath(),
+              upperTemplate.getName(),
+              nodes[index]);
+        }
+
+        hasAllMeasurements = false;
+      }
+
+      if (hasAllMeasurements) {
+        return index - 1;
+      }
+    }
+
+    return nodes.length;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -1370,37 +1370,12 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
     PartialPath devicePath = plan.getDevicePath();
     String[] measurementList = plan.getMeasurements();
     IMeasurementMNode[] measurementMNodes = plan.getMeasurementMNodes();
-    IMNode deviceMNode = null;
+    IMNode deviceMNode;
 
     // 1. get device node, set using template if accessed.
-    boolean mountedNodeFound = false;
-    boolean isDeviceInTemplate = false;
-    // check every measurement path
-    for (String measurementId : measurementList) {
-      PartialPath fullPath = devicePath.concatNode(measurementId);
-      int index = mtree.getMountedNodeIndexOnMeasurementPath(fullPath);
-      if ((index != fullPath.getNodeLength() - 1) && !mountedNodeFound) {
-        // this measurement is in template, need to assure mounted node exists and set using
-        // template.
-        // Without allowing overlap of template and MTree, this block run only once
-        String[] mountedPathNodes = Arrays.copyOfRange(fullPath.getNodes(), 0, index + 1);
-        IMNode mountedNode = getDeviceNodeWithAutoCreate(new PartialPath(mountedPathNodes));
-        if (!mountedNode.isUseTemplate()) {
-          mountedNode = setUsingSchemaTemplate(mountedNode);
-        }
-        mountedNodeFound = true;
-        if (index < devicePath.getNodeLength() - 1) {
-          deviceMNode =
-              mountedNode
-                  .getUpperTemplate()
-                  .getPathNodeInTemplate(
-                      new PartialPath(
-                          Arrays.copyOfRange(
-                              devicePath.getNodes(), index + 1, devicePath.getNodeLength())));
-          isDeviceInTemplate = true;
-        }
-      }
-    }
+    deviceMNode = getDeviceInTemplateIfUsingTemplate(devicePath, measurementList);
+    boolean isDeviceInTemplate = deviceMNode != null;
+
     // get logical device node, may be in template. will be multiple if overlap is allowed.
     if (!isDeviceInTemplate) {
       deviceMNode = getDeviceNodeWithAutoCreate(devicePath);
@@ -1474,6 +1449,38 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
           throw e;
         }
       }
+    }
+
+    return deviceMNode;
+  }
+
+  private IMNode getDeviceInTemplateIfUsingTemplate(
+      PartialPath devicePath, String[] measurementList) throws MetadataException, IOException {
+    // 1. get device node, set using template if accessed.
+    IMNode deviceMNode = null;
+
+    // check every measurement path
+    int index = mtree.getMountedNodeIndexOnMeasurementPath(devicePath, measurementList);
+    if (index == devicePath.getNodeLength()) {
+      return null;
+    }
+
+    // this measurement is in template, need to assure mounted node exists and set using
+    // template.
+    // Without allowing overlap of template and MTree, this block run only once
+    String[] mountedPathNodes = Arrays.copyOfRange(devicePath.getNodes(), 0, index + 1);
+    IMNode mountedNode = getDeviceNodeWithAutoCreate(new PartialPath(mountedPathNodes));
+    if (!mountedNode.isUseTemplate()) {
+      mountedNode = setUsingSchemaTemplate(mountedNode);
+    }
+    if (index < devicePath.getNodeLength() - 1) {
+      deviceMNode =
+          mountedNode
+              .getUpperTemplate()
+              .getPathNodeInTemplate(
+                  new PartialPath(
+                      Arrays.copyOfRange(
+                          devicePath.getNodes(), index + 1, devicePath.getNodeLength())));
     }
 
     return deviceMNode;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -718,14 +718,14 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
    *
    * @param path path
    */
-  public IMNode getDeviceNodeWithAutoCreate(PartialPath path, boolean autoCreateSchema)
+  private IMNode getDeviceNodeWithAutoCreate(PartialPath path)
       throws IOException, MetadataException {
     IMNode node;
     try {
       return mNodeCache.get(path);
     } catch (Exception e) {
       if (e.getCause() instanceof MetadataException) {
-        if (!autoCreateSchema) {
+        if (!config.isAutoCreateSchemaEnabled()) {
           throw new PathNotExistException(path.getFullPath());
         }
       } else {
@@ -740,13 +740,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
     return node;
   }
 
-  public IMNode getDeviceNodeWithAutoCreate(PartialPath path)
-      throws MetadataException, IOException {
-    return getDeviceNodeWithAutoCreate(path, config.isAutoCreateSchemaEnabled());
-  }
-
   public void autoCreateDeviceMNode(AutoCreateDeviceMNodePlan plan) throws MetadataException {
-    IMNode node = mtree.getDeviceNodeWithAutoCreating(plan.getPath());
+    mtree.getDeviceNodeWithAutoCreating(plan.getPath());
     if (!isRecovering) {
       try {
         logWriter.autoCreateDeviceMNode(plan);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -1134,8 +1134,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   }
 
   public IMeasurementMNode getMeasurementMNode(PartialPath fullPath) throws MetadataException {
-    IMeasurementMNode measurementMNode = mtree.getMeasurementMNode(fullPath);
-    return measurementMNode;
+    return mtree.getMeasurementMNode(fullPath);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -1530,19 +1530,23 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   private IMeasurementMNode findMeasurementInTemplate(IMNode deviceMNode, String measurement)
       throws MetadataException {
     Template curTemplate = deviceMNode.getUpperTemplate();
-    if (curTemplate != null) {
-      IMeasurementSchema schema = curTemplate.getSchema(measurement);
-      if (!deviceMNode.isUseTemplate()) {
-        deviceMNode = setUsingSchemaTemplate(deviceMNode);
-      }
 
-      if (schema != null) {
-        return MeasurementMNode.getMeasurementMNode(
-            deviceMNode.getAsEntityMNode(), measurement, schema, null);
-      }
+    if (curTemplate == null) {
       return null;
     }
-    return null;
+
+    IMeasurementSchema schema = curTemplate.getSchema(measurement);
+
+    if (schema == null) {
+      return null;
+    }
+
+    if (!deviceMNode.isUseTemplate()) {
+      deviceMNode = setUsingSchemaTemplate(deviceMNode);
+    }
+
+    return MeasurementMNode.getMeasurementMNode(
+        deviceMNode.getAsEntityMNode(), measurement, schema, null);
   }
 
   /** create timeseries ignoring PathAlreadyExistException */

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -742,7 +742,7 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
    *
    * @param path path
    */
-  public IMNode getDeviceNodeWithAutoCreate(PartialPath path, boolean autoCreateSchema)
+  private IMNode getDeviceNodeWithAutoCreate(PartialPath path)
       throws IOException, MetadataException {
     IMNode node;
     try {
@@ -756,7 +756,7 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
       }
     } catch (Exception e) {
       if (e.getCause() instanceof MetadataException) {
-        if (!autoCreateSchema) {
+        if (!config.isAutoCreateSchemaEnabled()) {
           throw new PathNotExistException(path.getFullPath());
         }
       } else {
@@ -769,11 +769,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
       logWriter.autoCreateDeviceMNode(new AutoCreateDeviceMNodePlan(node.getPartialPath()));
     }
     return node;
-  }
-
-  public IMNode getDeviceNodeWithAutoCreate(PartialPath path)
-      throws MetadataException, IOException {
-    return getDeviceNodeWithAutoCreate(path, config.isAutoCreateSchemaEnabled());
   }
 
   public void autoCreateDeviceMNode(AutoCreateDeviceMNodePlan plan) throws MetadataException {
@@ -1441,6 +1436,9 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
     // get logical device node, may be in template. will be multiple if overlap is allowed.
     if (!isDeviceInTemplate) {
       deviceMNode = getDeviceNodeWithAutoCreate(devicePath);
+      if (!deviceMNode.getCacheEntry().isPinned()) {
+        throw new RuntimeException("The device must pinned");
+      }
     }
     try {
       // check insert non-aligned InsertPlan for aligned timeseries

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -1436,9 +1436,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
     // get logical device node, may be in template. will be multiple if overlap is allowed.
     if (!isDeviceInTemplate) {
       deviceMNode = getDeviceNodeWithAutoCreate(devicePath);
-      if (!deviceMNode.getCacheEntry().isPinned()) {
-        throw new RuntimeException("The device must pinned");
-      }
     }
     try {
       // check insert non-aligned InsertPlan for aligned timeseries

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -1604,19 +1604,23 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   private IMeasurementMNode findMeasurementInTemplate(IMNode deviceMNode, String measurement)
       throws MetadataException {
     Template curTemplate = deviceMNode.getUpperTemplate();
-    if (curTemplate != null) {
-      IMeasurementSchema schema = curTemplate.getSchema(measurement);
-      if (!deviceMNode.isUseTemplate()) {
-        deviceMNode = setUsingSchemaTemplate(deviceMNode);
-      }
 
-      if (schema != null) {
-        return MeasurementMNode.getMeasurementMNode(
-            deviceMNode.getAsEntityMNode(), measurement, schema, null);
-      }
+    if (curTemplate == null) {
       return null;
     }
-    return null;
+
+    IMeasurementSchema schema = curTemplate.getSchema(measurement);
+
+    if (schema == null) {
+      return null;
+    }
+
+    if (!deviceMNode.isUseTemplate()) {
+      deviceMNode = setUsingSchemaTemplate(deviceMNode);
+    }
+
+    return MeasurementMNode.getMeasurementMNode(
+        deviceMNode.getAsEntityMNode(), measurement, schema, null);
   }
 
   /** create timeseries ignoring PathAlreadyExistException */


### PR DESCRIPTION
## Description


### Fix concurrent UnPin bug
After a thread unPin a node, it should check the cache status of the node. If the node is now not Pinned, then its parent should be unPin once, which means one of the children is not pinned any more. However, the operation and check should be synchronized, otherwise the change may result in multi threads get wrong cache status and do extra unpin, which may result in negative semaphore value.

### Improve template implementation
The old implementation of template check during insert takes low performance and is hard to understand. Thus the implementation is rewritten.
