### PR TITLE
Fix schema file with cache of size 1

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -456,9 +456,6 @@ public class SchemaFile implements ISchemaFile {
               childName, parent.getName(), actualSegAddr, pIdx, sIdx));
       e.printStackTrace();
       throw e;
-    } catch (NullPointerException e) {
-      e.printStackTrace();
-      throw e;
     }
   }
 
@@ -660,10 +657,6 @@ public class SchemaFile implements ISchemaFile {
 
     ISchemaPage curPage = getPageInstance(getPageIndex(curSegAddr));
 
-    if (curPage == null) {
-      throw new NullPointerException("");
-    }
-
     if (curPage.hasRecordKeyInSegment(recKey, curSegId)) {
       return curSegAddr;
     }
@@ -782,9 +775,6 @@ public class SchemaFile implements ISchemaFile {
       }
 
       if (pageInstCache.containsKey(pageIdx)) {
-        if (pageInstCache.get(pageIdx) == null) {
-          throw new NullPointerException("");
-        }
         return pageInstCache.get(pageIdx);
       }
     } finally {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -945,6 +945,7 @@ public class SchemaFile implements ISchemaFile {
     for (ISchemaPage page : dirtyPages.values()) {
       flushPageToFile(page);
     }
+    updateHeader();
     dirtyPages.clear();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -48,11 +48,14 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -110,6 +113,8 @@ public class SchemaFile implements ISchemaFile {
   private final PageLocks pageLocks;
   private ISchemaPage rootPage;
 
+  private final Map<Integer, ISchemaPage> dirtyPages;
+
   // attributes for file
   private File pmtFile;
   private FileChannel channel;
@@ -150,6 +155,7 @@ public class SchemaFile implements ISchemaFile {
     channel = new RandomAccessFile(pmtFile, "rw").getChannel();
     headerContent = ByteBuffer.allocate(SchemaFile.FILE_HEADER_SIZE);
     pageInstCache = Collections.synchronizedMap(new LinkedHashMap<>(PAGE_CACHE_SIZE, 1, true));
+    dirtyPages = new ConcurrentHashMap<>();
     evictLock = new ReentrantLock();
     pageLocks = new PageLocks();
     // will be overwritten if to init
@@ -164,6 +170,7 @@ public class SchemaFile implements ISchemaFile {
     channel = new RandomAccessFile(file, "rw").getChannel();
     headerContent = ByteBuffer.allocate(SchemaFile.FILE_HEADER_SIZE);
     pageInstCache = Collections.synchronizedMap(new LinkedHashMap<>(PAGE_CACHE_SIZE, 1, true));
+    dirtyPages = new ConcurrentHashMap<>();
     evictLock = new ReentrantLock();
     pageLocks = new PageLocks();
 
@@ -285,6 +292,8 @@ public class SchemaFile implements ISchemaFile {
       // throw exception if record larger than one page
       try {
         curPage = getPageInstance(pageIndex);
+
+        dirtyPages.putIfAbsent(curPage.getPageIndex(), curPage);
         long npAddress = curPage.write(curSegIdx, entry.getKey(), childBuffer);
 
         while (npAddress > 0) {
@@ -295,6 +304,8 @@ public class SchemaFile implements ISchemaFile {
           curPage = getPageInstance(pageIndex);
           npAddress = curPage.write(curSegIdx, entry.getKey(), childBuffer);
         }
+
+        dirtyPages.putIfAbsent(curPage.getPageIndex(), curPage);
 
       } catch (SchemaPageOverflowException e) {
         // there is no more next page, need allocate new page
@@ -321,6 +332,9 @@ public class SchemaFile implements ISchemaFile {
           setNodeAddress(node, curSegAddr);
           updateParentalRecord(node.getParent(), node.getName(), curSegAddr);
         }
+
+        dirtyPages.putIfAbsent(newPage.getPageIndex(), newPage);
+        dirtyPages.putIfAbsent(curPage.getPageIndex(), curPage);
 
         curPage = newPage;
         pageIndex = curPage.getPageIndex();
@@ -349,6 +363,7 @@ public class SchemaFile implements ISchemaFile {
         curPage = getPageInstance(getPageIndex(actualSegAddr));
         curSegIdx = getSegIndex(actualSegAddr);
 
+        dirtyPages.putIfAbsent(curPage.getPageIndex(), curPage);
         // if current segment has no more space for new record, it will re-allocate segment, if
         // failed, throw exception
         curPage.update(curSegIdx, entry.getKey(), childBuffer);
@@ -366,6 +381,8 @@ public class SchemaFile implements ISchemaFile {
           curPage.deleteSegment(curSegIdx);
           setNodeAddress(node, newSegAddr);
           updateParentalRecord(node.getParent(), node.getName(), newSegAddr);
+          dirtyPages.putIfAbsent(newPage.getPageIndex(), newPage);
+          dirtyPages.putIfAbsent(curPage.getPageIndex(), curPage);
         } else {
           // already full page segment, write updated record to another applicable segment or a
           // blank new one
@@ -381,20 +398,26 @@ public class SchemaFile implements ISchemaFile {
             if (nextSegAddr != -1) {
               ISchemaPage nextPage = getPageInstance(getPageIndex(nextSegAddr));
               nextPage.setPrevSegAddress(getSegIndex(nextSegAddr), existedSegAddr);
+              dirtyPages.putIfAbsent(nextPage.getPageIndex(), nextPage);
             }
 
             newPage.setNextSegAddress(getSegIndex(existedSegAddr), nextSegAddr);
             newPage.setPrevSegAddress(getSegIndex(existedSegAddr), actualSegAddr);
 
             curPage.setNextSegAddress(getSegIndex(actualSegAddr), existedSegAddr);
+            dirtyPages.putIfAbsent(newPage.getPageIndex(), newPage);
           }
 
-          getPageInstance(getPageIndex(existedSegAddr))
-              .write(getSegIndex(existedSegAddr), entry.getKey(), childBuffer);
+          ISchemaPage existedPage = getPageInstance(getPageIndex(existedSegAddr));
+          existedPage.write(getSegIndex(existedSegAddr), entry.getKey(), childBuffer);
           curPage.removeRecord(getSegIndex(actualSegAddr), entry.getKey());
+          dirtyPages.putIfAbsent(curPage.getPageIndex(), curPage);
+          dirtyPages.putIfAbsent(existedPage.getPageIndex(), existedPage);
         }
       }
     }
+
+    flushAllDirtyPages();
   }
 
   @Override
@@ -433,6 +456,9 @@ public class SchemaFile implements ISchemaFile {
           String.format(
               "Get child[%s] from parent[%s] failed, actualAddress:%s(%d, %d)",
               childName, parent.getName(), actualSegAddr, pIdx, sIdx));
+      e.printStackTrace();
+      throw e;
+    } catch (NullPointerException e) {
       e.printStackTrace();
       throw e;
     }
@@ -492,7 +518,7 @@ public class SchemaFile implements ISchemaFile {
   public void close() throws IOException {
     updateHeader();
     flushPageToFile(rootPage);
-    for (Map.Entry<Integer, ISchemaPage> entry : pageInstCache.entrySet()) {
+    for (Map.Entry<Integer, ISchemaPage> entry : dirtyPages.entrySet()) {
       flushPageToFile(entry.getValue());
     }
     channel.close();
@@ -502,7 +528,7 @@ public class SchemaFile implements ISchemaFile {
   public void sync() throws IOException {
     updateHeader();
     flushPageToFile(rootPage);
-    for (Map.Entry<Integer, ISchemaPage> entry : pageInstCache.entrySet()) {
+    for (Map.Entry<Integer, ISchemaPage> entry : dirtyPages.entrySet()) {
       flushPageToFile(entry.getValue());
     }
   }
@@ -510,6 +536,7 @@ public class SchemaFile implements ISchemaFile {
   @Override
   public void clear() throws IOException, MetadataException {
     pageInstCache.clear();
+    dirtyPages.clear();
     channel.close();
     rootPage = null;
     if (pmtFile.exists()) {
@@ -608,6 +635,7 @@ public class SchemaFile implements ISchemaFile {
       lastPageIndex = 0;
 
       pageInstCache.put(rootPage.getPageIndex(), rootPage);
+      dirtyPages.putIfAbsent(rootPage.getPageIndex(), rootPage);
     }
   }
 
@@ -747,6 +775,10 @@ public class SchemaFile implements ISchemaFile {
     try {
       pageLocks.readLock(pageIdx);
 
+      if (dirtyPages.containsKey(pageIdx)) {
+        return dirtyPages.get(pageIdx);
+      }
+
       if (pageInstCache.containsKey(pageIdx)) {
         return pageInstCache.get(pageIdx);
       }
@@ -760,8 +792,7 @@ public class SchemaFile implements ISchemaFile {
       ByteBuffer newBuf = ByteBuffer.allocate(PAGE_LENGTH);
 
       loadFromFile(newBuf, pageIdx);
-      addPageToCache(pageIdx, SchemaPage.loadPage(newBuf, pageIdx));
-      return pageInstCache.get(pageIdx);
+      return addPageToCache(pageIdx, SchemaPage.loadPage(newBuf, pageIdx));
     } finally {
       pageLocks.writeUnlock(pageIdx);
     }
@@ -772,14 +803,14 @@ public class SchemaFile implements ISchemaFile {
     return channel.read(dst, getPageAddress(pageIndex));
   }
 
-  private ISchemaPage allocateNewPage() throws IOException {
+  private synchronized ISchemaPage allocateNewPage() throws IOException {
     lastPageIndex += 1;
     ISchemaPage newPage = SchemaPage.initPage(ByteBuffer.allocate(PAGE_LENGTH), lastPageIndex);
-    addPageToCache(newPage.getPageIndex(), newPage);
-    return newPage;
+    dirtyPages.putIfAbsent(newPage.getPageIndex(), newPage);
+    return addPageToCache(newPage.getPageIndex(), newPage);
   }
 
-  private void addPageToCache(int pageIndex, ISchemaPage page) throws IOException {
+  private ISchemaPage addPageToCache(int pageIndex, ISchemaPage page) throws IOException {
     pageInstCache.put(pageIndex, page);
     // only one thread evicts and flushes pages
     if (evictLock.tryLock()) {
@@ -790,23 +821,15 @@ public class SchemaFile implements ISchemaFile {
           List<Integer> rmvIds = new ArrayList<>(pageInstCache.keySet()).subList(0, removeCnt);
 
           for (Integer id : rmvIds) {
-            // TODO: improve concurrent control
-            //  for any page involved in concurrent operation, it will not be evicted
-            //  this may produce an inefficient eviction
-            if (pageLocks.findLock(id).writeLock().tryLock()) {
-              try {
-                flushPageToFile(pageInstCache.get(id));
-                pageInstCache.remove(id);
-              } finally {
-                pageLocks.writeUnlock(id);
-              }
-            }
+            // dirty pages only flushed from dirtyPages
+            pageInstCache.remove(id);
           }
         }
       } finally {
         evictLock.unlock();
       }
     }
+    return page;
   }
 
   // endregion
@@ -833,6 +856,7 @@ public class SchemaFile implements ISchemaFile {
     parSegAddr = getTargetSegmentAddress(parSegAddr, key);
     ISchemaPage page = getPageInstance(getPageIndex(parSegAddr));
     ((SchemaPage) page).updateRecordSegAddr(getSegIndex(parSegAddr), key, newSegAddr);
+    dirtyPages.putIfAbsent(page.getPageIndex(), page);
   }
 
   static short reEstimateSegSize(int oldSize) {
@@ -914,6 +938,13 @@ public class SchemaFile implements ISchemaFile {
     src.getPageBuffer(srcBuf);
     srcBuf.clear();
     channel.write(srcBuf, getPageAddress(src.getPageIndex()));
+  }
+
+  private synchronized void flushAllDirtyPages() throws IOException {
+    for (ISchemaPage page : dirtyPages.values()) {
+      flushPageToFile(page);
+    }
+    dirtyPages.clear();
   }
 
   @TestOnly

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
@@ -292,12 +292,15 @@ public class SchemaFileTest {
         }
       }
 
-      ICachedMNodeContainer.getCachedMNodeContainer(sgNode).getNewChildBuffer().clear();
+      // update to entity
       i = 1000;
       while (i >= 0) {
+        long addr = getSegAddrInContainer(sgNode.getChild("dev_" + i));
         IMNode aDevice = new EntityMNode(sgNode, "dev_" + i);
+        sgNode.deleteChild(aDevice.getName());
         sgNode.addChild(aDevice);
-        ICachedMNodeContainer.getCachedMNodeContainer(sgNode).updateMNode(aDevice.getName());
+        moveToUpdateBuffer(sgNode, "dev_" + i);
+        ICachedMNodeContainer.getCachedMNodeContainer(aDevice).setSegmentAddress(addr);
         i--;
       }
 


### PR DESCRIPTION
## Description
Before this pull request, schema file stores all pages in a map, and only flushes dirty pages if the cache had no more space for new pages. 
With the cache map of size 1, a dirty page may be evicted from the cache during a method which modifies multi pages (like creating a new multi-page segment) and this makes a exception unexpected.

### What's new in this PR
Now, schema file uses an extra map called dirtyPages to collect all pages modified during write or delete method within the file instance, and flushes will occur before the method ends.