### PR TITLE
[IOTDB-2995]SchemaFileSketcher will not delete empty .pst now

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -169,7 +169,6 @@ public class SchemaFile implements ISchemaFile {
 
     if (channel.size() <= 0) {
       channel.close();
-      file.deleteOnExit();
       throw new SchemaFileNotExists(file.getAbsolutePath());
     }
 


### PR DESCRIPTION
Before this PR, SchemaFileSketcher will delete an empty .pst file since it is useless. Then we found it is confusing for users, so now it will leave the empty file as it was.