### PR TITLE
Optimize source handle error handling

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/DataBlockManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/DataBlockManager.java
@@ -291,6 +291,7 @@ public class DataBlockManager implements IDataBlockManager {
       TEndPoint remoteEndpoint,
       TFragmentInstanceId remoteFragmentInstanceId,
       String remotePlanNodeId,
+      // TODO: replace with callbacks to decouple DataBlockManager from FragmentInstanceContext
       FragmentInstanceContext instanceContext) {
     if (sinkHandles.containsKey(localFragmentInstanceId)) {
       throw new IllegalStateException("Sink handle for " + localFragmentInstanceId + " exists.");

--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/IDataBlockManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/IDataBlockManager.java
@@ -33,6 +33,7 @@ public interface IDataBlockManager {
    * @param endpoint Hostname and Port of the remote fragment instance where the data blocks should
    *     be sent to.
    * @param remotePlanNodeId The sink plan node ID of the remote fragment instance.
+   * @param instanceContext The context of local fragment instance.
    */
   ISinkHandle createSinkHandle(
       TFragmentInstanceId localFragmentInstanceId,
@@ -51,12 +52,14 @@ public interface IDataBlockManager {
    * @param endpoint Hostname and Port of the remote fragment instance where the data blocks should
    *     be received from.
    * @param remoteFragmentInstanceId ID of the remote fragment instance.
+   * @param onFailureCallback The callback on failure.
    */
   ISourceHandle createSourceHandle(
       TFragmentInstanceId localFragmentInstanceId,
       String localPlanNodeId,
       TEndPoint endpoint,
-      TFragmentInstanceId remoteFragmentInstanceId);
+      TFragmentInstanceId remoteFragmentInstanceId,
+      IDataBlockManagerCallback<Throwable> onFailureCallback);
 
   /**
    * Release all the related resources of a fragment instance, including data blocks that are not

--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/IDataBlockManagerCallback.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/IDataBlockManagerCallback.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.buffer;
+
+public interface IDataBlockManagerCallback<T> {
+  public void call(T argument);
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/ISinkHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/ISinkHandle.java
@@ -18,20 +18,20 @@
  */
 package org.apache.iotdb.db.mpp.buffer;
 
+import org.apache.iotdb.mpp.rpc.thrift.TFragmentInstanceId;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-import java.io.IOException;
 import java.util.List;
 
 public interface ISinkHandle {
 
+  /** Get the local fragment instance ID that this sink handle belongs to. */
+  TFragmentInstanceId getLocalFragmentInstanceId();
+
   /** Get the total amount of memory used by buffered tsblocks. */
   long getBufferRetainedSizeInBytes();
-
-  /** Get the number of buffered tsblocks. */
-  int getNumOfBufferedTsBlocks();
 
   /** Get a future that will be completed when the output buffer is not full. */
   ListenableFuture<Void> isFull();
@@ -48,7 +48,7 @@ public interface ISinkHandle {
    * tsblock call is ignored. This can happen with limit queries. A {@link RuntimeException} will be
    * thrown if any exception happened * during the data transmission.
    */
-  void send(int partition, List<TsBlock> tsBlocks) throws IOException;
+  void send(int partition, List<TsBlock> tsBlocks);
 
   /**
    * Notify the handle that no more tsblocks will be sent. Any future calls to send a tsblock should

--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/ISourceHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/ISourceHandle.java
@@ -18,14 +18,20 @@
  */
 package org.apache.iotdb.db.mpp.buffer;
 
+import org.apache.iotdb.mpp.rpc.thrift.TFragmentInstanceId;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.Closeable;
-import java.io.IOException;
 
 public interface ISourceHandle extends Closeable {
+
+  /** Get the local fragment instance ID that this source handle belongs to. */
+  TFragmentInstanceId getLocalFragmentInstanceId();
+
+  /** Get the local plan node ID that this source handle belongs to. */
+  String getLocalPlanNodeId();
 
   /** Get the total amount of memory used by buffered tsblocks. */
   long getBufferRetainedSizeInBytes();
@@ -34,7 +40,7 @@ public interface ISourceHandle extends Closeable {
    * Get a {@link TsBlock}. If the source handle is blocked, a null will be returned. A {@link
    * RuntimeException} will be thrown if any error happened.
    */
-  TsBlock receive() throws IOException;
+  TsBlock receive();
 
   /** If there are more tsblocks. */
   boolean isFinished();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/SourceHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/SourceHandle.java
@@ -67,11 +67,11 @@ public class SourceHandle implements ISourceHandle {
   private final Map<Integer, Long> sequenceIdToDataBlockSize = new HashMap<>();
 
   private volatile SettableFuture<Void> blocked = SettableFuture.create();
-  private long bufferRetainedSizeInBytes;
+  private long bufferRetainedSizeInBytes = 0L;
   private int currSequenceId = 0;
   private int nextSequenceId = 0;
   private int lastSequenceId = Integer.MAX_VALUE;
-  private boolean closed;
+  private boolean closed = false;
 
   public SourceHandle(
       TEndPoint remoteEndpoint,

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryExecution.java
@@ -46,11 +46,9 @@ import com.google.common.util.concurrent.SettableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -210,8 +208,7 @@ public class QueryExecution implements IQueryExecution {
         return null;
       }
       return resultHandle.receive();
-
-    } catch (ExecutionException | IOException | CancellationException e) {
+    } catch (ExecutionException e) {
       stateMachine.transitionToFailed(e);
       throwIfUnchecked(e.getCause());
       throw new RuntimeException(e.getCause());
@@ -284,7 +281,8 @@ public class QueryExecution implements IQueryExecution {
                   new TEndPoint(
                       context.getResultNodeContext().getUpStreamEndpoint().getIp(),
                       IoTDBDescriptor.getInstance().getConfig().getDataBlockManagerPort()),
-                  context.getResultNodeContext().getVirtualFragmentInstanceId().toThrift());
+                  context.getResultNodeContext().getVirtualFragmentInstanceId().toThrift(),
+                  stateMachine::transitionToFailed);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryExecution.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -208,7 +209,7 @@ public class QueryExecution implements IQueryExecution {
         return null;
       }
       return resultHandle.receive();
-    } catch (ExecutionException e) {
+    } catch (ExecutionException | CancellationException e) {
       stateMachine.transitionToFailed(e);
       throwIfUnchecked(e.getCause());
       throw new RuntimeException(e.getCause());

--- a/server/src/main/java/org/apache/iotdb/db/mpp/operator/source/ExchangeOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/operator/source/ExchangeOperator.java
@@ -25,8 +25,6 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-import java.io.IOException;
-
 public class ExchangeOperator implements SourceOperator {
 
   private final OperatorContext operatorContext;
@@ -51,12 +49,7 @@ public class ExchangeOperator implements SourceOperator {
 
   @Override
   public TsBlock next() {
-    try {
-      return sourceHandle.receive();
-    } catch (IOException e) {
-      throw new RuntimeException(
-          "Error happened while reading from source handle " + sourceHandle, e);
-    }
+    return sourceHandle.receive();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/LocalExecutionPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/LocalExecutionPlanner.java
@@ -356,7 +356,8 @@ public class LocalExecutionPlanner {
               new TEndPoint(
                   source.getIp(),
                   IoTDBDescriptor.getInstance().getConfig().getDataBlockManagerPort()),
-              remoteInstanceId.toThrift());
+              remoteInstanceId.toThrift(),
+              context.instanceContext::failed);
       return new ExchangeOperator(operatorContext, sourceHandle, node.getUpstreamPlanNodeId());
     }
 

--- a/server/src/test/java/org/apache/iotdb/db/mpp/buffer/SinkHandleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/buffer/SinkHandleTest.java
@@ -355,12 +355,12 @@ public class SinkHandleTest {
     List<TsBlock> mockTsBlocks = Utils.createMockTsBlocks(numOfMockTsBlock, mockTsBlockSize);
     // Construct a mock client.
     Client mockClient = Mockito.mock(Client.class);
-    TException exception = new TException("Mock exception");
+    TException mockException = new TException("Mock exception");
     try {
-      Mockito.doThrow(exception)
+      Mockito.doThrow(mockException)
           .when(mockClient)
           .onEndOfDataBlockEvent(Mockito.any(TEndOfDataBlockEvent.class));
-      Mockito.doThrow(exception)
+      Mockito.doThrow(mockException)
           .when(mockClient)
           .onNewDataBlockEvent(Mockito.any(TNewDataBlockEvent.class));
     } catch (TException e) {
@@ -413,7 +413,7 @@ public class SinkHandleTest {
       Assert.fail();
     }
 
-    Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onFailure(exception);
+    Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onFailure(sinkHandle, mockException);
 
     // Close the SinkHandle.
     try {

--- a/server/src/test/java/org/apache/iotdb/db/mpp/buffer/StubSinkHandle.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/buffer/StubSinkHandle.java
@@ -19,11 +19,11 @@
 package org.apache.iotdb.db.mpp.buffer;
 
 import org.apache.iotdb.db.mpp.execution.FragmentInstanceContext;
+import org.apache.iotdb.mpp.rpc.thrift.TFragmentInstanceId;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,12 +44,12 @@ public class StubSinkHandle implements ISinkHandle {
   }
 
   @Override
-  public long getBufferRetainedSizeInBytes() {
-    return 0;
+  public TFragmentInstanceId getLocalFragmentInstanceId() {
+    return null;
   }
 
   @Override
-  public int getNumOfBufferedTsBlocks() {
+  public long getBufferRetainedSizeInBytes() {
     return 0;
   }
 
@@ -64,7 +64,7 @@ public class StubSinkHandle implements ISinkHandle {
   }
 
   @Override
-  public void send(int partition, List<TsBlock> tsBlocks) throws IOException {
+  public void send(int partition, List<TsBlock> tsBlocks) {
     this.tsBlocks.addAll(tsBlocks);
   }
 


### PR DESCRIPTION
Add `SourceHandleListener#onFailure`. The method will be called when fatal exceptions happen during data transmission.
