### PR TITLE
Fix the issue that FragmentInstance's status cannot be set to FINISHED

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/SinkHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/SinkHandle.java
@@ -202,7 +202,8 @@ public class SinkHandle implements ISinkHandle {
     }
     synchronized (this) {
       closed = true;
-      noMoreTsBlocks = true;
+      // synchronized is reentrant lock, wo we can invoke setNoMoreTsBlocks() here.
+      setNoMoreTsBlocks();
     }
     sinkHandleListener.onClosed(this);
     logger.info("Sink handle {} is closed.", this);
@@ -231,6 +232,14 @@ public class SinkHandle implements ISinkHandle {
   @Override
   public synchronized void setNoMoreTsBlocks() {
     noMoreTsBlocks = true;
+    // In current implementation, the onFinish() is only invoked when receiving the
+    // acknowledge event from SourceHandle. If the acknowledge event happens before
+    // the close(), the onFinish() won't be invoked and the instance's status will
+    // always be FLUSHING. We cannot ensure the sequence of `acknowledge event` and
+    // `close` so we need to do following check every time `noMoreTsBlocks` is updated.
+    if (isFinished()) {
+      sinkHandleListener.onFinish(this);
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description
In some scenario, the FragmentInstance's status is always `FLUSHING`, although the corresponding query is finished. It is because there is a corner case in SinkHandle which lead to the `onFinish()` method cannot be invoked.

The corner case is:
There are two conditions to be satisfied that the FragmentInstance's status will be set to FINISHED:
1. The `noMoreTsBlocks` is true
2. The cached TsBlocks has been sent.

And these two conditions will be checked every time the `acknowledge event` is received in SinkHandle; the `noMoreTsBlocks` will be set to true when the `close()` is invoked.

Before this change, if the last `acknowledge event` is received but the `close()` is still not invoked, we will lost the chance to set the FragmentInstance's status to FINISHED. 

## Changes
Fix the issue by adding finished status check every time the `noMoreTsBlocks` is invoked.