### PR TITLE
[IOTDB-3008] move partial path to commons

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/reader/ClusterReaderFactory.java
@@ -54,6 +54,7 @@ import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.path.MeasurementPath;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.metadata.utils.ResourceByPathUtils;
 import org.apache.iotdb.db.query.aggregation.AggregationType;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
@@ -555,15 +556,16 @@ public class ClusterReaderFactory {
     QueryDataSource queryDataSource =
         QueryResourceManager.getInstance().getQueryDataSource(path, context, timeFilter, ascending);
     valueFilter = queryDataSource.updateFilterUsingTTL(valueFilter);
-    return path.createSeriesReader(
-        allSensors,
-        dataType,
-        context,
-        queryDataSource,
-        timeFilter,
-        valueFilter,
-        new SlotTsFileFilter(requiredSlots),
-        ascending);
+    return ResourceByPathUtils.getResourceInstance(path)
+        .createSeriesReader(
+            allSensors,
+            dataType,
+            context,
+            queryDataSource,
+            timeFilter,
+            valueFilter,
+            new SlotTsFileFilter(requiredSlots),
+            ascending);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.idtable.entry.DeviceIDFactory;
 import org.apache.iotdb.db.metadata.idtable.entry.IDeviceID;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.metadata.utils.ResourceByPathUtils;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.write.InsertRowNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.write.InsertTabletNode;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
@@ -634,7 +635,8 @@ public abstract class AbstractMemTable implements IMemTable {
   public ReadOnlyMemChunk query(
       PartialPath fullPath, long ttlLowerBound, List<Pair<Modification, IMemTable>> modsToMemtable)
       throws IOException, QueryProcessException {
-    return fullPath.getReadOnlyMemChunkFromMemTable(this, modsToMemtable, ttlLowerBound);
+    return ResourceByPathUtils.getResourceInstance(fullPath)
+        .getReadOnlyMemChunkFromMemTable(this, modsToMemtable, ttlLowerBound);
   }
 
   @SuppressWarnings("squid:S3776") // high Cognitive Complexity

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -46,6 +46,7 @@ import org.apache.iotdb.db.metadata.idtable.entry.DeviceIDFactory;
 import org.apache.iotdb.db.metadata.idtable.entry.IDeviceID;
 import org.apache.iotdb.db.metadata.path.AlignedPath;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.metadata.utils.ResourceByPathUtils;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.write.InsertRowNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.write.InsertTabletNode;
 import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
@@ -1482,7 +1483,8 @@ public class TsFileProcessor {
         }
 
         List<IChunkMetadata> chunkMetadataList =
-            seriesPath.getVisibleMetadataListFromWriter(writer, tsFileResource, context);
+            ResourceByPathUtils.getResourceInstance(seriesPath)
+                .getVisibleMetadataListFromWriter(writer, tsFileResource, context);
 
         // get in memory data
         if (!readOnlyMemChunks.isEmpty() || !chunkMetadataList.isEmpty()) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -33,6 +33,7 @@ import org.apache.iotdb.db.engine.storagegroup.timeindex.TimeIndexLevel;
 import org.apache.iotdb.db.engine.upgrade.UpgradeTask;
 import org.apache.iotdb.db.exception.PartitionViolationException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.metadata.utils.ResourceByPathUtils;
 import org.apache.iotdb.db.query.filter.TsFileFilter;
 import org.apache.iotdb.db.service.UpgradeSevice;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
@@ -1001,8 +1002,9 @@ public class TsFileResource {
     for (PartialPath path : pathToChunkMetadataListMap.keySet()) {
       pathToTimeSeriesMetadataMap.put(
           path,
-          path.generateTimeSeriesMetadata(
-              pathToReadOnlyMemChunkMap.get(path), pathToChunkMetadataListMap.get(path)));
+          ResourceByPathUtils.getResourceInstance(path)
+              .generateTimeSeriesMetadata(
+                  pathToReadOnlyMemChunkMap.get(path), pathToChunkMetadataListMap.get(path)));
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/path/AlignedPath.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/path/AlignedPath.java
@@ -19,58 +19,23 @@
 
 package org.apache.iotdb.db.metadata.path;
 
-import org.apache.iotdb.commons.utils.TestOnly;
-import org.apache.iotdb.db.engine.memtable.AlignedWritableMemChunk;
-import org.apache.iotdb.db.engine.memtable.AlignedWritableMemChunkGroup;
-import org.apache.iotdb.db.engine.memtable.IMemTable;
-import org.apache.iotdb.db.engine.memtable.IWritableMemChunkGroup;
-import org.apache.iotdb.db.engine.modification.Deletion;
-import org.apache.iotdb.db.engine.modification.Modification;
-import org.apache.iotdb.db.engine.modification.ModificationFile;
-import org.apache.iotdb.db.engine.querycontext.AlignedReadOnlyMemChunk;
-import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
-import org.apache.iotdb.db.engine.querycontext.ReadOnlyMemChunk;
-import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
-import org.apache.iotdb.db.exception.query.QueryProcessException;
-import org.apache.iotdb.db.metadata.idtable.entry.DeviceIDFactory;
-import org.apache.iotdb.db.metadata.idtable.entry.IDeviceID;
-import org.apache.iotdb.db.query.context.QueryContext;
-import org.apache.iotdb.db.query.executor.fill.AlignedLastPointReader;
-import org.apache.iotdb.db.query.filter.TsFileFilter;
-import org.apache.iotdb.db.query.reader.series.AlignedSeriesReader;
-import org.apache.iotdb.db.utils.QueryUtils;
-import org.apache.iotdb.db.utils.datastructure.TVList;
-import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
-import org.apache.iotdb.tsfile.file.metadata.AlignedTimeSeriesMetadata;
-import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
-import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
-import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
-import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
-import org.apache.iotdb.tsfile.read.common.TimeRange;
-import org.apache.iotdb.tsfile.read.filter.basic.Filter;
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.VectorMeasurementSchema;
-import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * VectorPartialPath represents many fullPaths of aligned timeseries. In the AlignedPath, the nodes
@@ -248,240 +213,6 @@ public class AlignedPath extends PartialPath {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), measurementList);
-  }
-
-  @Override
-  public AlignedLastPointReader createLastPointReader(
-      TSDataType dataType,
-      Set<String> deviceMeasurements,
-      QueryContext context,
-      QueryDataSource dataSource,
-      long queryTime,
-      Filter timeFilter) {
-    return new AlignedLastPointReader(
-        this, dataType, deviceMeasurements, context, dataSource, queryTime, timeFilter);
-  }
-
-  @Override
-  public AlignedSeriesReader createSeriesReader(
-      Set<String> allSensors,
-      TSDataType dataType,
-      QueryContext context,
-      QueryDataSource dataSource,
-      Filter timeFilter,
-      Filter valueFilter,
-      TsFileFilter fileFilter,
-      boolean ascending) {
-    return new AlignedSeriesReader(
-        this,
-        allSensors,
-        dataType,
-        context,
-        dataSource,
-        timeFilter,
-        valueFilter,
-        fileFilter,
-        ascending);
-  }
-
-  @Override
-  @TestOnly
-  public AlignedSeriesReader createSeriesReader(
-      Set<String> allSensors,
-      TSDataType dataType,
-      QueryContext context,
-      List<TsFileResource> seqFileResource,
-      List<TsFileResource> unseqFileResource,
-      Filter timeFilter,
-      Filter valueFilter,
-      boolean ascending) {
-    return new AlignedSeriesReader(
-        this,
-        allSensors,
-        dataType,
-        context,
-        seqFileResource,
-        unseqFileResource,
-        timeFilter,
-        valueFilter,
-        ascending);
-  }
-
-  @Override
-  public TsFileResource createTsFileResource(
-      List<ReadOnlyMemChunk> readOnlyMemChunk,
-      List<IChunkMetadata> chunkMetadataList,
-      TsFileResource originTsFileResource)
-      throws IOException {
-    TsFileResource tsFileResource =
-        new TsFileResource(this, readOnlyMemChunk, chunkMetadataList, originTsFileResource);
-    tsFileResource.setTimeSeriesMetadata(
-        this, generateTimeSeriesMetadata(readOnlyMemChunk, chunkMetadataList));
-    return tsFileResource;
-  }
-
-  /**
-   * Because the unclosed tsfile don't have TimeSeriesMetadata and memtables in the memory don't
-   * have chunkMetadata, but query will use these, so we need to generate it for them.
-   */
-  public AlignedTimeSeriesMetadata generateTimeSeriesMetadata(
-      List<ReadOnlyMemChunk> readOnlyMemChunk, List<IChunkMetadata> chunkMetadataList)
-      throws IOException {
-    TimeseriesMetadata timeTimeSeriesMetadata = new TimeseriesMetadata();
-    timeTimeSeriesMetadata.setOffsetOfChunkMetaDataList(-1);
-    timeTimeSeriesMetadata.setDataSizeOfChunkMetaDataList(-1);
-    timeTimeSeriesMetadata.setMeasurementId("");
-    timeTimeSeriesMetadata.setTSDataType(TSDataType.VECTOR);
-
-    Statistics<? extends Serializable> timeStatistics =
-        Statistics.getStatsByType(timeTimeSeriesMetadata.getTSDataType());
-
-    // init each value time series meta
-    List<TimeseriesMetadata> valueTimeSeriesMetadataList = new ArrayList<>();
-    for (IMeasurementSchema valueChunkMetadata : schemaList) {
-      TimeseriesMetadata valueMetadata = new TimeseriesMetadata();
-      valueMetadata.setOffsetOfChunkMetaDataList(-1);
-      valueMetadata.setDataSizeOfChunkMetaDataList(-1);
-      valueMetadata.setMeasurementId(valueChunkMetadata.getMeasurementId());
-      valueMetadata.setTSDataType(valueChunkMetadata.getType());
-      valueMetadata.setStatistics(Statistics.getStatsByType(valueChunkMetadata.getType()));
-      valueTimeSeriesMetadataList.add(valueMetadata);
-    }
-
-    boolean[] exist = new boolean[schemaList.size()];
-    for (IChunkMetadata chunkMetadata : chunkMetadataList) {
-      AlignedChunkMetadata alignedChunkMetadata = (AlignedChunkMetadata) chunkMetadata;
-      timeStatistics.mergeStatistics(alignedChunkMetadata.getTimeChunkMetadata().getStatistics());
-      for (int i = 0; i < valueTimeSeriesMetadataList.size(); i++) {
-        if (alignedChunkMetadata.getValueChunkMetadataList().get(i) != null) {
-          exist[i] = true;
-          valueTimeSeriesMetadataList
-              .get(i)
-              .getStatistics()
-              .mergeStatistics(
-                  alignedChunkMetadata.getValueChunkMetadataList().get(i).getStatistics());
-        }
-      }
-    }
-
-    for (ReadOnlyMemChunk memChunk : readOnlyMemChunk) {
-      if (!memChunk.isEmpty()) {
-        AlignedChunkMetadata alignedChunkMetadata =
-            (AlignedChunkMetadata) memChunk.getChunkMetaData();
-        timeStatistics.mergeStatistics(alignedChunkMetadata.getTimeChunkMetadata().getStatistics());
-        for (int i = 0; i < valueTimeSeriesMetadataList.size(); i++) {
-          if (alignedChunkMetadata.getValueChunkMetadataList().get(i) != null) {
-            exist[i] = true;
-            valueTimeSeriesMetadataList
-                .get(i)
-                .getStatistics()
-                .mergeStatistics(
-                    alignedChunkMetadata.getValueChunkMetadataList().get(i).getStatistics());
-          }
-        }
-      }
-    }
-    timeTimeSeriesMetadata.setStatistics(timeStatistics);
-
-    for (int i = 0; i < valueTimeSeriesMetadataList.size(); i++) {
-      if (!exist[i]) {
-        valueTimeSeriesMetadataList.set(i, null);
-      }
-    }
-
-    return new AlignedTimeSeriesMetadata(timeTimeSeriesMetadata, valueTimeSeriesMetadataList);
-  }
-
-  @Override
-  public ReadOnlyMemChunk getReadOnlyMemChunkFromMemTable(
-      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound)
-      throws QueryProcessException, IOException {
-    Map<IDeviceID, IWritableMemChunkGroup> memTableMap = memTable.getMemTableMap();
-    IDeviceID deviceID = DeviceIDFactory.getInstance().getDeviceID(this);
-
-    // check If memtable contains this path
-    if (!memTableMap.containsKey(deviceID)) {
-      return null;
-    }
-    AlignedWritableMemChunk alignedMemChunk =
-        ((AlignedWritableMemChunkGroup) memTableMap.get(deviceID)).getAlignedMemChunk();
-    boolean containsMeasurement = false;
-    for (String measurement : measurementList) {
-      if (alignedMemChunk.containsMeasurement(measurement)) {
-        containsMeasurement = true;
-        break;
-      }
-    }
-    if (!containsMeasurement) {
-      return null;
-    }
-    // get sorted tv list is synchronized so different query can get right sorted list reference
-    TVList alignedTvListCopy = alignedMemChunk.getSortedTvListForQuery(schemaList);
-    int curSize = alignedTvListCopy.rowCount();
-    List<List<TimeRange>> deletionList = null;
-    if (modsToMemtable != null) {
-      deletionList = constructDeletionList(memTable, modsToMemtable, timeLowerBound);
-    }
-    return new AlignedReadOnlyMemChunk(
-        getMeasurementSchema(), alignedTvListCopy, curSize, deletionList);
-  }
-
-  private List<List<TimeRange>> constructDeletionList(
-      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound) {
-    List<List<TimeRange>> deletionList = new ArrayList<>();
-    for (String measurement : measurementList) {
-      List<TimeRange> columnDeletionList = new ArrayList<>();
-      columnDeletionList.add(new TimeRange(Long.MIN_VALUE, timeLowerBound));
-      for (Modification modification : getModificationsForMemtable(memTable, modsToMemtable)) {
-        if (modification instanceof Deletion) {
-          Deletion deletion = (Deletion) modification;
-          PartialPath fullPath = this.concatNode(measurement);
-          if (deletion.getPath().matchFullPath(fullPath)
-              && deletion.getEndTime() > timeLowerBound) {
-            long lowerBound = Math.max(deletion.getStartTime(), timeLowerBound);
-            columnDeletionList.add(new TimeRange(lowerBound, deletion.getEndTime()));
-          }
-        }
-      }
-      deletionList.add(TimeRange.sortAndMerge(columnDeletionList));
-    }
-    return deletionList;
-  }
-
-  @Override
-  public List<IChunkMetadata> getVisibleMetadataListFromWriter(
-      RestorableTsFileIOWriter writer, TsFileResource tsFileResource, QueryContext context) {
-    ModificationFile modificationFile = tsFileResource.getModFile();
-    List<List<Modification>> modifications = context.getPathModifications(modificationFile, this);
-
-    List<AlignedChunkMetadata> chunkMetadataList = new ArrayList<>();
-    List<ChunkMetadata> timeChunkMetadataList =
-        writer.getVisibleMetadataList(getDevice(), "", getSeriesType());
-    List<List<ChunkMetadata>> valueChunkMetadataList = new ArrayList<>();
-    for (int i = 0; i < measurementList.size(); i++) {
-      valueChunkMetadataList.add(
-          writer.getVisibleMetadataList(
-              getDevice(), measurementList.get(i), schemaList.get(i).getType()));
-    }
-
-    for (int i = 0; i < timeChunkMetadataList.size(); i++) {
-      List<IChunkMetadata> valueChunkMetadata = new ArrayList<>();
-      // if all the sub sensors doesn't exist, it will be false
-      boolean exits = false;
-      for (List<ChunkMetadata> chunkMetadata : valueChunkMetadataList) {
-        boolean currentExist = i < chunkMetadata.size();
-        exits = (exits || currentExist);
-        valueChunkMetadata.add(currentExist ? chunkMetadata.get(i) : null);
-      }
-      if (exits) {
-        chunkMetadataList.add(
-            new AlignedChunkMetadata(timeChunkMetadataList.get(i), valueChunkMetadata));
-      }
-    }
-
-    QueryUtils.modifyAlignedChunkMetaData(chunkMetadataList, modifications);
-    chunkMetadataList.removeIf(context::chunkNotSatisfy);
-    return new ArrayList<>(chunkMetadataList);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/path/MeasurementPath.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/path/MeasurementPath.java
@@ -19,50 +19,17 @@
 package org.apache.iotdb.db.metadata.path;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
-import org.apache.iotdb.commons.utils.TestOnly;
-import org.apache.iotdb.db.engine.memtable.IMemTable;
-import org.apache.iotdb.db.engine.memtable.IWritableMemChunk;
-import org.apache.iotdb.db.engine.memtable.IWritableMemChunkGroup;
-import org.apache.iotdb.db.engine.modification.Deletion;
-import org.apache.iotdb.db.engine.modification.Modification;
-import org.apache.iotdb.db.engine.modification.ModificationFile;
-import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
-import org.apache.iotdb.db.engine.querycontext.ReadOnlyMemChunk;
-import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
-import org.apache.iotdb.db.exception.query.QueryProcessException;
-import org.apache.iotdb.db.metadata.idtable.entry.DeviceIDFactory;
-import org.apache.iotdb.db.metadata.idtable.entry.IDeviceID;
-import org.apache.iotdb.db.query.context.QueryContext;
-import org.apache.iotdb.db.query.executor.fill.LastPointReader;
-import org.apache.iotdb.db.query.filter.TsFileFilter;
-import org.apache.iotdb.db.query.reader.series.SeriesReader;
-import org.apache.iotdb.db.utils.QueryUtils;
-import org.apache.iotdb.db.utils.datastructure.TVList;
-import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
-import org.apache.iotdb.tsfile.file.metadata.ITimeSeriesMetadata;
-import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
-import org.apache.iotdb.tsfile.read.common.TimeRange;
-import org.apache.iotdb.tsfile.read.filter.basic.Filter;
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.VectorMeasurementSchema;
-import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public class MeasurementPath extends PartialPath {
 
@@ -166,155 +133,6 @@ public class MeasurementPath extends PartialPath {
   }
 
   @Override
-  public LastPointReader createLastPointReader(
-      TSDataType dataType,
-      Set<String> deviceMeasurements,
-      QueryContext context,
-      QueryDataSource dataSource,
-      long queryTime,
-      Filter timeFilter) {
-    return new LastPointReader(
-        this, dataType, deviceMeasurements, context, dataSource, queryTime, timeFilter);
-  }
-
-  public SeriesReader createSeriesReader(
-      Set<String> allSensors,
-      TSDataType dataType,
-      QueryContext context,
-      QueryDataSource dataSource,
-      Filter timeFilter,
-      Filter valueFilter,
-      TsFileFilter fileFilter,
-      boolean ascending) {
-    return new SeriesReader(
-        this,
-        allSensors,
-        dataType,
-        context,
-        dataSource,
-        timeFilter,
-        valueFilter,
-        fileFilter,
-        ascending);
-  }
-
-  @TestOnly
-  public SeriesReader createSeriesReader(
-      Set<String> allSensors,
-      TSDataType dataType,
-      QueryContext context,
-      List<TsFileResource> seqFileResource,
-      List<TsFileResource> unseqFileResource,
-      Filter timeFilter,
-      Filter valueFilter,
-      boolean ascending) {
-    allSensors.add(this.getMeasurement());
-    return new SeriesReader(
-        this,
-        allSensors,
-        dataType,
-        context,
-        seqFileResource,
-        unseqFileResource,
-        timeFilter,
-        valueFilter,
-        ascending);
-  }
-
-  @Override
-  public TsFileResource createTsFileResource(
-      List<ReadOnlyMemChunk> readOnlyMemChunk,
-      List<IChunkMetadata> chunkMetadataList,
-      TsFileResource originTsFileResource)
-      throws IOException {
-    TsFileResource tsFileResource =
-        new TsFileResource(this, readOnlyMemChunk, chunkMetadataList, originTsFileResource);
-    tsFileResource.setTimeSeriesMetadata(
-        this, generateTimeSeriesMetadata(readOnlyMemChunk, chunkMetadataList));
-    return tsFileResource;
-  }
-
-  /**
-   * Because the unclosed tsfile don't have TimeSeriesMetadata and memtables in the memory don't
-   * have chunkMetadata, but query will use these, so we need to generate it for them.
-   */
-  public ITimeSeriesMetadata generateTimeSeriesMetadata(
-      List<ReadOnlyMemChunk> readOnlyMemChunk, List<IChunkMetadata> chunkMetadataList)
-      throws IOException {
-    TimeseriesMetadata timeSeriesMetadata = new TimeseriesMetadata();
-    timeSeriesMetadata.setMeasurementId(measurementSchema.getMeasurementId());
-    timeSeriesMetadata.setTSDataType(measurementSchema.getType());
-    timeSeriesMetadata.setOffsetOfChunkMetaDataList(-1);
-    timeSeriesMetadata.setDataSizeOfChunkMetaDataList(-1);
-
-    Statistics<? extends Serializable> seriesStatistics =
-        Statistics.getStatsByType(timeSeriesMetadata.getTSDataType());
-    // flush chunkMetadataList one by one
-    for (IChunkMetadata chunkMetadata : chunkMetadataList) {
-      seriesStatistics.mergeStatistics(chunkMetadata.getStatistics());
-    }
-
-    for (ReadOnlyMemChunk memChunk : readOnlyMemChunk) {
-      if (!memChunk.isEmpty()) {
-        seriesStatistics.mergeStatistics(memChunk.getChunkMetaData().getStatistics());
-      }
-    }
-    timeSeriesMetadata.setStatistics(seriesStatistics);
-    return timeSeriesMetadata;
-  }
-
-  @Override
-  public ReadOnlyMemChunk getReadOnlyMemChunkFromMemTable(
-      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound)
-      throws QueryProcessException, IOException {
-    Map<IDeviceID, IWritableMemChunkGroup> memTableMap = memTable.getMemTableMap();
-    IDeviceID deviceID = DeviceIDFactory.getInstance().getDeviceID(getDevicePath());
-    // check If Memtable Contains this path
-    if (!memTableMap.containsKey(deviceID)
-        || !memTableMap.get(deviceID).contains(getMeasurement())) {
-      return null;
-    }
-    IWritableMemChunk memChunk = memTableMap.get(deviceID).getMemChunkMap().get(getMeasurement());
-    // get sorted tv list is synchronized so different query can get right sorted list reference
-    TVList chunkCopy = memChunk.getSortedTvListForQuery();
-    int curSize = chunkCopy.rowCount();
-    List<TimeRange> deletionList = null;
-    if (modsToMemtable != null) {
-      deletionList = constructDeletionList(memTable, modsToMemtable, timeLowerBound);
-    }
-    return new ReadOnlyMemChunk(
-        getMeasurement(),
-        measurementSchema.getType(),
-        measurementSchema.getEncodingType(),
-        chunkCopy,
-        measurementSchema.getProps(),
-        curSize,
-        deletionList);
-  }
-
-  /**
-   * construct a deletion list from a memtable.
-   *
-   * @param memTable memtable
-   * @param timeLowerBound time water mark
-   */
-  private List<TimeRange> constructDeletionList(
-      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound) {
-    List<TimeRange> deletionList = new ArrayList<>();
-    deletionList.add(new TimeRange(Long.MIN_VALUE, timeLowerBound));
-    for (Modification modification : getModificationsForMemtable(memTable, modsToMemtable)) {
-      if (modification instanceof Deletion) {
-        Deletion deletion = (Deletion) modification;
-        if (deletion.getPath().matchFullPath(this) && deletion.getEndTime() > timeLowerBound) {
-          long lowerBound = Math.max(deletion.getStartTime(), timeLowerBound);
-          deletionList.add(new TimeRange(lowerBound, deletion.getEndTime()));
-        }
-      }
-    }
-    return TimeRange.sortAndMerge(deletionList);
-  }
-
-  @Override
   public MeasurementPath clone() {
     MeasurementPath newMeasurementPath = null;
     try {
@@ -325,21 +143,6 @@ public class MeasurementPath extends PartialPath {
       logger.warn("path is illegal: {}", this.getFullPath(), e);
     }
     return newMeasurementPath;
-  }
-
-  @Override
-  public List<IChunkMetadata> getVisibleMetadataListFromWriter(
-      RestorableTsFileIOWriter writer, TsFileResource tsFileResource, QueryContext context) {
-    ModificationFile modificationFile = tsFileResource.getModFile();
-    List<Modification> modifications = context.getPathModifications(modificationFile, this);
-
-    List<IChunkMetadata> chunkMetadataList =
-        new ArrayList<>(
-            writer.getVisibleMetadataList(getDevice(), getMeasurement(), getSeriesType()));
-
-    QueryUtils.modifyChunkMetaData(chunkMetadataList, modifications);
-    chunkMetadataList.removeIf(context::chunkNotSatisfy);
-    return chunkMetadataList;
   }
 
   public void serialize(ByteBuffer byteBuffer) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/path/PartialPath.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/path/PartialPath.java
@@ -19,41 +19,24 @@
 package org.apache.iotdb.db.metadata.path;
 
 import org.apache.iotdb.commons.utils.TestOnly;
-import org.apache.iotdb.db.engine.memtable.IMemTable;
-import org.apache.iotdb.db.engine.modification.Modification;
-import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
-import org.apache.iotdb.db.engine.querycontext.ReadOnlyMemChunk;
-import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
-import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.utils.MetaUtils;
-import org.apache.iotdb.db.query.context.QueryContext;
-import org.apache.iotdb.db.query.executor.fill.LastPointReader;
-import org.apache.iotdb.db.query.filter.TsFileFilter;
-import org.apache.iotdb.db.query.reader.series.SeriesReader;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
-import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
-import org.apache.iotdb.tsfile.file.metadata.ITimeSeriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
-import org.apache.iotdb.tsfile.read.filter.basic.Filter;
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
-import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
 
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -484,88 +467,9 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
     return ret;
   }
 
-  public LastPointReader createLastPointReader(
-      TSDataType dataType,
-      Set<String> deviceMeasurements,
-      QueryContext context,
-      QueryDataSource dataSource,
-      long queryTime,
-      Filter timeFilter) {
-    throw new UnsupportedOperationException("Should call exact sub class!");
-  }
-
-  public SeriesReader createSeriesReader(
-      Set<String> allSensors,
-      TSDataType dataType,
-      QueryContext context,
-      QueryDataSource dataSource,
-      Filter timeFilter,
-      Filter valueFilter,
-      TsFileFilter fileFilter,
-      boolean ascending) {
-    throw new UnsupportedOperationException("Should call exact sub class!");
-  }
-
-  @TestOnly
-  public SeriesReader createSeriesReader(
-      Set<String> allSensors,
-      TSDataType dataType,
-      QueryContext context,
-      List<TsFileResource> seqFileResource,
-      List<TsFileResource> unseqFileResource,
-      Filter timeFilter,
-      Filter valueFilter,
-      boolean ascending) {
-    throw new UnsupportedOperationException("Should call exact sub class!");
-  }
-
-  public TsFileResource createTsFileResource(
-      List<ReadOnlyMemChunk> readOnlyMemChunk,
-      List<IChunkMetadata> chunkMetadataList,
-      TsFileResource originTsFileResource)
-      throws IOException {
-    throw new UnsupportedOperationException("Should call exact sub class!");
-  }
-
-  public ITimeSeriesMetadata generateTimeSeriesMetadata(
-      List<ReadOnlyMemChunk> readOnlyMemChunk, List<IChunkMetadata> chunkMetadataList)
-      throws IOException {
-    throw new UnsupportedOperationException("Should call exact sub class!");
-  }
-
-  /**
-   * get the ReadOnlyMemChunk from the given MemTable.
-   *
-   * @return ReadOnlyMemChunk
-   */
-  public ReadOnlyMemChunk getReadOnlyMemChunkFromMemTable(
-      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound)
-      throws QueryProcessException, IOException {
-    throw new UnsupportedOperationException("Should call exact sub class!");
-  }
-
-  /** get modifications from a memtable. */
-  protected List<Modification> getModificationsForMemtable(
-      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable) {
-    List<Modification> modifications = new ArrayList<>();
-    boolean foundMemtable = false;
-    for (Pair<Modification, IMemTable> entry : modsToMemtable) {
-      if (foundMemtable || entry.right.equals(memTable)) {
-        modifications.add(entry.left);
-        foundMemtable = true;
-      }
-    }
-    return modifications;
-  }
-
   @Override
   public PartialPath clone() {
     return new PartialPath(this.getNodes().clone());
-  }
-
-  public List<IChunkMetadata> getVisibleMetadataListFromWriter(
-      RestorableTsFileIOWriter writer, TsFileResource tsFileResource, QueryContext context) {
-    throw new UnsupportedOperationException("Should call exact sub class!");
   }
 
   public void serialize(ByteBuffer byteBuffer) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/utils/ResourceByPathUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/utils/ResourceByPathUtils.java
@@ -1,0 +1,607 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.metadata.utils;
+
+import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.db.engine.memtable.AlignedWritableMemChunk;
+import org.apache.iotdb.db.engine.memtable.AlignedWritableMemChunkGroup;
+import org.apache.iotdb.db.engine.memtable.IMemTable;
+import org.apache.iotdb.db.engine.memtable.IWritableMemChunk;
+import org.apache.iotdb.db.engine.memtable.IWritableMemChunkGroup;
+import org.apache.iotdb.db.engine.modification.Deletion;
+import org.apache.iotdb.db.engine.modification.Modification;
+import org.apache.iotdb.db.engine.modification.ModificationFile;
+import org.apache.iotdb.db.engine.querycontext.AlignedReadOnlyMemChunk;
+import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
+import org.apache.iotdb.db.engine.querycontext.ReadOnlyMemChunk;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.exception.query.QueryProcessException;
+import org.apache.iotdb.db.metadata.idtable.entry.DeviceIDFactory;
+import org.apache.iotdb.db.metadata.idtable.entry.IDeviceID;
+import org.apache.iotdb.db.metadata.path.AlignedPath;
+import org.apache.iotdb.db.metadata.path.MeasurementPath;
+import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.query.context.QueryContext;
+import org.apache.iotdb.db.query.executor.fill.AlignedLastPointReader;
+import org.apache.iotdb.db.query.executor.fill.LastPointReader;
+import org.apache.iotdb.db.query.filter.TsFileFilter;
+import org.apache.iotdb.db.query.reader.series.AlignedSeriesReader;
+import org.apache.iotdb.db.query.reader.series.SeriesReader;
+import org.apache.iotdb.db.utils.QueryUtils;
+import org.apache.iotdb.db.utils.datastructure.TVList;
+import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.AlignedTimeSeriesMetadata;
+import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.ITimeSeriesMetadata;
+import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
+import org.apache.iotdb.tsfile.read.common.TimeRange;
+import org.apache.iotdb.tsfile.read.filter.basic.Filter;
+import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
+import org.apache.iotdb.tsfile.write.schema.VectorMeasurementSchema;
+import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.iotdb.db.metadata.path.AlignedPath.VECTOR_PLACEHOLDER;
+
+/**
+ * Obtain required resources through path, such as readers and writers and etc. AlignedPath and
+ * MeasurementPath have different implementations, and the default PartialPath should not use it.
+ */
+public abstract class ResourceByPathUtils {
+
+  public static ResourceByPathUtils getResourceInstance(PartialPath path) {
+    if (path instanceof AlignedPath) {
+      return new AlignedResourceByPathUtils(path);
+    } else if (path instanceof MeasurementPath) {
+      return new MeasurementResourceByPathUtils(path);
+    }
+    throw new UnsupportedOperationException("Should call exact sub class!");
+  }
+
+  public abstract LastPointReader createLastPointReader(
+      TSDataType dataType,
+      Set<String> deviceMeasurements,
+      QueryContext context,
+      QueryDataSource dataSource,
+      long queryTime,
+      Filter timeFilter);
+
+  public abstract SeriesReader createSeriesReader(
+      Set<String> allSensors,
+      TSDataType dataType,
+      QueryContext context,
+      QueryDataSource dataSource,
+      Filter timeFilter,
+      Filter valueFilter,
+      TsFileFilter fileFilter,
+      boolean ascending);
+
+  @TestOnly
+  public abstract SeriesReader createSeriesReader(
+      Set<String> allSensors,
+      TSDataType dataType,
+      QueryContext context,
+      List<TsFileResource> seqFileResource,
+      List<TsFileResource> unseqFileResource,
+      Filter timeFilter,
+      Filter valueFilter,
+      boolean ascending);
+
+  public abstract TsFileResource createTsFileResource(
+      List<ReadOnlyMemChunk> readOnlyMemChunk,
+      List<IChunkMetadata> chunkMetadataList,
+      TsFileResource originTsFileResource)
+      throws IOException;
+
+  public abstract ITimeSeriesMetadata generateTimeSeriesMetadata(
+      List<ReadOnlyMemChunk> readOnlyMemChunk, List<IChunkMetadata> chunkMetadataList)
+      throws IOException;
+
+  public abstract ReadOnlyMemChunk getReadOnlyMemChunkFromMemTable(
+      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound)
+      throws QueryProcessException, IOException;
+
+  public abstract List<IChunkMetadata> getVisibleMetadataListFromWriter(
+      RestorableTsFileIOWriter writer, TsFileResource tsFileResource, QueryContext context);
+
+  /** get modifications from a memtable. */
+  protected List<Modification> getModificationsForMemtable(
+      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable) {
+    List<Modification> modifications = new ArrayList<>();
+    boolean foundMemtable = false;
+    for (Pair<Modification, IMemTable> entry : modsToMemtable) {
+      if (foundMemtable || entry.right.equals(memTable)) {
+        modifications.add(entry.left);
+        foundMemtable = true;
+      }
+    }
+    return modifications;
+  }
+}
+
+class AlignedResourceByPathUtils extends ResourceByPathUtils {
+
+  AlignedPath partialPath;
+
+  public AlignedResourceByPathUtils(PartialPath partialPath) {
+    this.partialPath = (AlignedPath) partialPath;
+  }
+
+  @Override
+  public AlignedLastPointReader createLastPointReader(
+      TSDataType dataType,
+      Set<String> deviceMeasurements,
+      QueryContext context,
+      QueryDataSource dataSource,
+      long queryTime,
+      Filter timeFilter) {
+    return new AlignedLastPointReader(
+        partialPath, dataType, deviceMeasurements, context, dataSource, queryTime, timeFilter);
+  }
+
+  @Override
+  public AlignedSeriesReader createSeriesReader(
+      Set<String> allSensors,
+      TSDataType dataType,
+      QueryContext context,
+      QueryDataSource dataSource,
+      Filter timeFilter,
+      Filter valueFilter,
+      TsFileFilter fileFilter,
+      boolean ascending) {
+    return new AlignedSeriesReader(
+        partialPath,
+        allSensors,
+        dataType,
+        context,
+        dataSource,
+        timeFilter,
+        valueFilter,
+        fileFilter,
+        ascending);
+  }
+
+  @Override
+  @TestOnly
+  public AlignedSeriesReader createSeriesReader(
+      Set<String> allSensors,
+      TSDataType dataType,
+      QueryContext context,
+      List<TsFileResource> seqFileResource,
+      List<TsFileResource> unseqFileResource,
+      Filter timeFilter,
+      Filter valueFilter,
+      boolean ascending) {
+    return new AlignedSeriesReader(
+        partialPath,
+        allSensors,
+        dataType,
+        context,
+        seqFileResource,
+        unseqFileResource,
+        timeFilter,
+        valueFilter,
+        ascending);
+  }
+
+  @Override
+  public TsFileResource createTsFileResource(
+      List<ReadOnlyMemChunk> readOnlyMemChunk,
+      List<IChunkMetadata> chunkMetadataList,
+      TsFileResource originTsFileResource)
+      throws IOException {
+    TsFileResource tsFileResource =
+        new TsFileResource(partialPath, readOnlyMemChunk, chunkMetadataList, originTsFileResource);
+    tsFileResource.setTimeSeriesMetadata(
+        partialPath, generateTimeSeriesMetadata(readOnlyMemChunk, chunkMetadataList));
+    return tsFileResource;
+  }
+
+  /**
+   * Because the unclosed tsfile don't have TimeSeriesMetadata and memtables in the memory don't
+   * have chunkMetadata, but query will use these, so we need to generate it for them.
+   */
+  @Override
+  public AlignedTimeSeriesMetadata generateTimeSeriesMetadata(
+      List<ReadOnlyMemChunk> readOnlyMemChunk, List<IChunkMetadata> chunkMetadataList)
+      throws IOException {
+    TimeseriesMetadata timeTimeSeriesMetadata = new TimeseriesMetadata();
+    timeTimeSeriesMetadata.setOffsetOfChunkMetaDataList(-1);
+    timeTimeSeriesMetadata.setDataSizeOfChunkMetaDataList(-1);
+    timeTimeSeriesMetadata.setMeasurementId("");
+    timeTimeSeriesMetadata.setTSDataType(TSDataType.VECTOR);
+
+    Statistics<? extends Serializable> timeStatistics =
+        Statistics.getStatsByType(timeTimeSeriesMetadata.getTSDataType());
+
+    // init each value time series meta
+    List<TimeseriesMetadata> valueTimeSeriesMetadataList = new ArrayList<>();
+    for (IMeasurementSchema valueChunkMetadata : (partialPath.getSchemaList())) {
+      TimeseriesMetadata valueMetadata = new TimeseriesMetadata();
+      valueMetadata.setOffsetOfChunkMetaDataList(-1);
+      valueMetadata.setDataSizeOfChunkMetaDataList(-1);
+      valueMetadata.setMeasurementId(valueChunkMetadata.getMeasurementId());
+      valueMetadata.setTSDataType(valueChunkMetadata.getType());
+      valueMetadata.setStatistics(Statistics.getStatsByType(valueChunkMetadata.getType()));
+      valueTimeSeriesMetadataList.add(valueMetadata);
+    }
+
+    boolean[] exist = new boolean[partialPath.getSchemaList().size()];
+    for (IChunkMetadata chunkMetadata : chunkMetadataList) {
+      AlignedChunkMetadata alignedChunkMetadata = (AlignedChunkMetadata) chunkMetadata;
+      timeStatistics.mergeStatistics(alignedChunkMetadata.getTimeChunkMetadata().getStatistics());
+      for (int i = 0; i < valueTimeSeriesMetadataList.size(); i++) {
+        if (alignedChunkMetadata.getValueChunkMetadataList().get(i) != null) {
+          exist[i] = true;
+          valueTimeSeriesMetadataList
+              .get(i)
+              .getStatistics()
+              .mergeStatistics(
+                  alignedChunkMetadata.getValueChunkMetadataList().get(i).getStatistics());
+        }
+      }
+    }
+
+    for (ReadOnlyMemChunk memChunk : readOnlyMemChunk) {
+      if (!memChunk.isEmpty()) {
+        AlignedChunkMetadata alignedChunkMetadata =
+            (AlignedChunkMetadata) memChunk.getChunkMetaData();
+        timeStatistics.mergeStatistics(alignedChunkMetadata.getTimeChunkMetadata().getStatistics());
+        for (int i = 0; i < valueTimeSeriesMetadataList.size(); i++) {
+          if (alignedChunkMetadata.getValueChunkMetadataList().get(i) != null) {
+            exist[i] = true;
+            valueTimeSeriesMetadataList
+                .get(i)
+                .getStatistics()
+                .mergeStatistics(
+                    alignedChunkMetadata.getValueChunkMetadataList().get(i).getStatistics());
+          }
+        }
+      }
+    }
+    timeTimeSeriesMetadata.setStatistics(timeStatistics);
+
+    for (int i = 0; i < valueTimeSeriesMetadataList.size(); i++) {
+      if (!exist[i]) {
+        valueTimeSeriesMetadataList.set(i, null);
+      }
+    }
+
+    return new AlignedTimeSeriesMetadata(timeTimeSeriesMetadata, valueTimeSeriesMetadataList);
+  }
+
+  @Override
+  public ReadOnlyMemChunk getReadOnlyMemChunkFromMemTable(
+      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound)
+      throws QueryProcessException, IOException {
+    Map<IDeviceID, IWritableMemChunkGroup> memTableMap = memTable.getMemTableMap();
+    IDeviceID deviceID = DeviceIDFactory.getInstance().getDeviceID(partialPath);
+
+    // check If memtable contains this path
+    if (!memTableMap.containsKey(deviceID)) {
+      return null;
+    }
+    AlignedWritableMemChunk alignedMemChunk =
+        ((AlignedWritableMemChunkGroup) memTableMap.get(deviceID)).getAlignedMemChunk();
+    boolean containsMeasurement = false;
+    for (String measurement : partialPath.getMeasurementList()) {
+      if (alignedMemChunk.containsMeasurement(measurement)) {
+        containsMeasurement = true;
+        break;
+      }
+    }
+    if (!containsMeasurement) {
+      return null;
+    }
+    // get sorted tv list is synchronized so different query can get right sorted list reference
+    TVList alignedTvListCopy = alignedMemChunk.getSortedTvListForQuery(partialPath.getSchemaList());
+    int curSize = alignedTvListCopy.rowCount();
+    List<List<TimeRange>> deletionList = null;
+    if (modsToMemtable != null) {
+      deletionList = constructDeletionList(memTable, modsToMemtable, timeLowerBound);
+    }
+    return new AlignedReadOnlyMemChunk(
+        getMeasurementSchema(), alignedTvListCopy, curSize, deletionList);
+  }
+
+  public VectorMeasurementSchema getMeasurementSchema() {
+    List<String> measurementList = partialPath.getMeasurementList();
+    TSDataType[] types = new TSDataType[measurementList.size()];
+    TSEncoding[] encodings = new TSEncoding[measurementList.size()];
+
+    for (int i = 0; i < measurementList.size(); i++) {
+      types[i] = partialPath.getSchemaList().get(i).getType();
+      encodings[i] = partialPath.getSchemaList().get(i).getEncodingType();
+    }
+    String[] array = new String[measurementList.size()];
+    for (int i = 0; i < array.length; i++) {
+      array[i] = measurementList.get(i);
+    }
+    return new VectorMeasurementSchema(
+        VECTOR_PLACEHOLDER,
+        array,
+        types,
+        encodings,
+        partialPath.getSchemaList().get(0).getCompressor());
+  }
+
+  private List<List<TimeRange>> constructDeletionList(
+      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound) {
+    List<List<TimeRange>> deletionList = new ArrayList<>();
+    for (String measurement : partialPath.getMeasurementList()) {
+      List<TimeRange> columnDeletionList = new ArrayList<>();
+      columnDeletionList.add(new TimeRange(Long.MIN_VALUE, timeLowerBound));
+      for (Modification modification : getModificationsForMemtable(memTable, modsToMemtable)) {
+        if (modification instanceof Deletion) {
+          Deletion deletion = (Deletion) modification;
+          PartialPath fullPath = partialPath.concatNode(measurement);
+          if (deletion.getPath().matchFullPath(fullPath)
+              && deletion.getEndTime() > timeLowerBound) {
+            long lowerBound = Math.max(deletion.getStartTime(), timeLowerBound);
+            columnDeletionList.add(new TimeRange(lowerBound, deletion.getEndTime()));
+          }
+        }
+      }
+      deletionList.add(TimeRange.sortAndMerge(columnDeletionList));
+    }
+    return deletionList;
+  }
+
+  @Override
+  public List<IChunkMetadata> getVisibleMetadataListFromWriter(
+      RestorableTsFileIOWriter writer, TsFileResource tsFileResource, QueryContext context) {
+    ModificationFile modificationFile = tsFileResource.getModFile();
+    List<List<Modification>> modifications =
+        context.getPathModifications(modificationFile, partialPath);
+
+    List<AlignedChunkMetadata> chunkMetadataList = new ArrayList<>();
+    List<ChunkMetadata> timeChunkMetadataList =
+        writer.getVisibleMetadataList(partialPath.getDevice(), "", partialPath.getSeriesType());
+    List<List<ChunkMetadata>> valueChunkMetadataList = new ArrayList<>();
+    for (int i = 0; i < partialPath.getMeasurementList().size(); i++) {
+      valueChunkMetadataList.add(
+          writer.getVisibleMetadataList(
+              partialPath.getDevice(),
+              partialPath.getMeasurementList().get(i),
+              partialPath.getSchemaList().get(i).getType()));
+    }
+
+    for (int i = 0; i < timeChunkMetadataList.size(); i++) {
+      List<IChunkMetadata> valueChunkMetadata = new ArrayList<>();
+      // if all the sub sensors doesn't exist, it will be false
+      boolean exits = false;
+      for (List<ChunkMetadata> chunkMetadata : valueChunkMetadataList) {
+        boolean currentExist = i < chunkMetadata.size();
+        exits = (exits || currentExist);
+        valueChunkMetadata.add(currentExist ? chunkMetadata.get(i) : null);
+      }
+      if (exits) {
+        chunkMetadataList.add(
+            new AlignedChunkMetadata(timeChunkMetadataList.get(i), valueChunkMetadata));
+      }
+    }
+
+    QueryUtils.modifyAlignedChunkMetaData(chunkMetadataList, modifications);
+    chunkMetadataList.removeIf(context::chunkNotSatisfy);
+    return new ArrayList<>(chunkMetadataList);
+  }
+}
+
+class MeasurementResourceByPathUtils extends ResourceByPathUtils {
+
+  MeasurementPath partialPath;
+
+  protected MeasurementResourceByPathUtils(PartialPath partialPath) {
+    this.partialPath = (MeasurementPath) partialPath;
+  }
+
+  @Override
+  public LastPointReader createLastPointReader(
+      TSDataType dataType,
+      Set<String> deviceMeasurements,
+      QueryContext context,
+      QueryDataSource dataSource,
+      long queryTime,
+      Filter timeFilter) {
+    return new LastPointReader(
+        partialPath, dataType, deviceMeasurements, context, dataSource, queryTime, timeFilter);
+  }
+
+  @Override
+  public SeriesReader createSeriesReader(
+      Set<String> allSensors,
+      TSDataType dataType,
+      QueryContext context,
+      QueryDataSource dataSource,
+      Filter timeFilter,
+      Filter valueFilter,
+      TsFileFilter fileFilter,
+      boolean ascending) {
+    return new SeriesReader(
+        partialPath,
+        allSensors,
+        dataType,
+        context,
+        dataSource,
+        timeFilter,
+        valueFilter,
+        fileFilter,
+        ascending);
+  }
+
+  @TestOnly
+  public SeriesReader createSeriesReader(
+      Set<String> allSensors,
+      TSDataType dataType,
+      QueryContext context,
+      List<TsFileResource> seqFileResource,
+      List<TsFileResource> unseqFileResource,
+      Filter timeFilter,
+      Filter valueFilter,
+      boolean ascending) {
+    allSensors.add(partialPath.getMeasurement());
+    return new SeriesReader(
+        partialPath,
+        allSensors,
+        dataType,
+        context,
+        seqFileResource,
+        unseqFileResource,
+        timeFilter,
+        valueFilter,
+        ascending);
+  }
+
+  @Override
+  public TsFileResource createTsFileResource(
+      List<ReadOnlyMemChunk> readOnlyMemChunk,
+      List<IChunkMetadata> chunkMetadataList,
+      TsFileResource originTsFileResource)
+      throws IOException {
+    TsFileResource tsFileResource =
+        new TsFileResource(partialPath, readOnlyMemChunk, chunkMetadataList, originTsFileResource);
+    tsFileResource.setTimeSeriesMetadata(
+        partialPath, generateTimeSeriesMetadata(readOnlyMemChunk, chunkMetadataList));
+    return tsFileResource;
+  }
+
+  /**
+   * Because the unclosed tsfile don't have TimeSeriesMetadata and memtables in the memory don't
+   * have chunkMetadata, but query will use these, so we need to generate it for them.
+   */
+  @Override
+  public ITimeSeriesMetadata generateTimeSeriesMetadata(
+      List<ReadOnlyMemChunk> readOnlyMemChunk, List<IChunkMetadata> chunkMetadataList)
+      throws IOException {
+    TimeseriesMetadata timeSeriesMetadata = new TimeseriesMetadata();
+    timeSeriesMetadata.setMeasurementId(partialPath.getMeasurementSchema().getMeasurementId());
+    timeSeriesMetadata.setTSDataType(partialPath.getMeasurementSchema().getType());
+    timeSeriesMetadata.setOffsetOfChunkMetaDataList(-1);
+    timeSeriesMetadata.setDataSizeOfChunkMetaDataList(-1);
+
+    Statistics<? extends Serializable> seriesStatistics =
+        Statistics.getStatsByType(timeSeriesMetadata.getTSDataType());
+    // flush chunkMetadataList one by one
+    for (IChunkMetadata chunkMetadata : chunkMetadataList) {
+      seriesStatistics.mergeStatistics(chunkMetadata.getStatistics());
+    }
+
+    for (ReadOnlyMemChunk memChunk : readOnlyMemChunk) {
+      if (!memChunk.isEmpty()) {
+        seriesStatistics.mergeStatistics(memChunk.getChunkMetaData().getStatistics());
+      }
+    }
+    timeSeriesMetadata.setStatistics(seriesStatistics);
+    return timeSeriesMetadata;
+  }
+
+  @Override
+  public ReadOnlyMemChunk getReadOnlyMemChunkFromMemTable(
+      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound)
+      throws QueryProcessException, IOException {
+    Map<IDeviceID, IWritableMemChunkGroup> memTableMap = memTable.getMemTableMap();
+    IDeviceID deviceID = DeviceIDFactory.getInstance().getDeviceID(partialPath.getDevicePath());
+    // check If Memtable Contains this path
+    if (!memTableMap.containsKey(deviceID)
+        || !memTableMap.get(deviceID).contains(partialPath.getMeasurement())) {
+      return null;
+    }
+    IWritableMemChunk memChunk =
+        memTableMap.get(deviceID).getMemChunkMap().get(partialPath.getMeasurement());
+    // get sorted tv list is synchronized so different query can get right sorted list reference
+    TVList chunkCopy = memChunk.getSortedTvListForQuery();
+    int curSize = chunkCopy.rowCount();
+    List<TimeRange> deletionList = null;
+    if (modsToMemtable != null) {
+      deletionList = constructDeletionList(memTable, modsToMemtable, timeLowerBound);
+    }
+    return new ReadOnlyMemChunk(
+        partialPath.getMeasurement(),
+        partialPath.getMeasurementSchema().getType(),
+        partialPath.getMeasurementSchema().getEncodingType(),
+        chunkCopy,
+        partialPath.getMeasurementSchema().getProps(),
+        curSize,
+        deletionList);
+  }
+  /**
+   * construct a deletion list from a memtable.
+   *
+   * @param memTable memtable
+   * @param timeLowerBound time water mark
+   */
+  private List<TimeRange> constructDeletionList(
+      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable, long timeLowerBound) {
+    List<TimeRange> deletionList = new ArrayList<>();
+    deletionList.add(new TimeRange(Long.MIN_VALUE, timeLowerBound));
+    for (Modification modification : getModificationsForMemtable(memTable, modsToMemtable)) {
+      if (modification instanceof Deletion) {
+        Deletion deletion = (Deletion) modification;
+        if (deletion.getPath().matchFullPath(partialPath)
+            && deletion.getEndTime() > timeLowerBound) {
+          long lowerBound = Math.max(deletion.getStartTime(), timeLowerBound);
+          deletionList.add(new TimeRange(lowerBound, deletion.getEndTime()));
+        }
+      }
+    }
+    return TimeRange.sortAndMerge(deletionList);
+  }
+  /** get modifications from a memtable. */
+  protected List<Modification> getModificationsForMemtable(
+      IMemTable memTable, List<Pair<Modification, IMemTable>> modsToMemtable) {
+    List<Modification> modifications = new ArrayList<>();
+    boolean foundMemtable = false;
+    for (Pair<Modification, IMemTable> entry : modsToMemtable) {
+      if (foundMemtable || entry.right.equals(memTable)) {
+        modifications.add(entry.left);
+        foundMemtable = true;
+      }
+    }
+    return modifications;
+  }
+
+  @Override
+  public List<IChunkMetadata> getVisibleMetadataListFromWriter(
+      RestorableTsFileIOWriter writer, TsFileResource tsFileResource, QueryContext context) {
+    ModificationFile modificationFile = tsFileResource.getModFile();
+    List<Modification> modifications = context.getPathModifications(modificationFile, partialPath);
+
+    List<IChunkMetadata> chunkMetadataList =
+        new ArrayList<>(
+            writer.getVisibleMetadataList(
+                partialPath.getDevice(),
+                partialPath.getMeasurement(),
+                partialPath.getSeriesType()));
+
+    QueryUtils.modifyChunkMetaData(chunkMetadataList, modifications);
+    chunkMetadataList.removeIf(context::chunkNotSatisfy);
+    return chunkMetadataList;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.metadata.idtable.entry.TimeseriesID;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
 import org.apache.iotdb.db.metadata.path.MeasurementPath;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.metadata.utils.ResourceByPathUtils;
 import org.apache.iotdb.db.qp.physical.crud.LastQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
@@ -283,8 +284,7 @@ public class LastQueryExecutor {
           QueryResourceManager.getInstance()
               .getQueryDataSource(seriesPaths.get(i), context, filter, ascending);
       LastPointReader lastReader =
-          seriesPaths
-              .get(i)
+          ResourceByPathUtils.getResourceInstance(seriesPaths.get(i))
               .createLastPointReader(
                   dataTypes.get(i),
                   deviceMeasurementsMap.getOrDefault(

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesAggregateReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesAggregateReader.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.metadata.utils.ResourceByPathUtils;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.filter.TsFileFilter;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -48,15 +49,16 @@ public class SeriesAggregateReader implements IAggregateReader {
       TsFileFilter fileFilter,
       boolean ascending) {
     this.seriesReader =
-        seriesPath.createSeriesReader(
-            allSensors,
-            dataType,
-            context,
-            dataSource,
-            timeFilter,
-            valueFilter,
-            fileFilter,
-            ascending);
+        ResourceByPathUtils.getResourceInstance(seriesPath)
+            .createSeriesReader(
+                allSensors,
+                dataType,
+                context,
+                dataSource,
+                timeFilter,
+                valueFilter,
+                fileFilter,
+                ascending);
   }
 
   @TestOnly

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesRawDataBatchReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesRawDataBatchReader.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.metadata.utils.ResourceByPathUtils;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.filter.TsFileFilter;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -58,15 +59,16 @@ public class SeriesRawDataBatchReader implements ManagedSeriesReader {
       TsFileFilter fileFilter,
       boolean ascending) {
     this.seriesReader =
-        seriesPath.createSeriesReader(
-            allSensors,
-            dataType,
-            context,
-            dataSource,
-            timeFilter,
-            valueFilter,
-            fileFilter,
-            ascending);
+        ResourceByPathUtils.getResourceInstance(seriesPath)
+            .createSeriesReader(
+                allSensors,
+                dataType,
+                context,
+                dataSource,
+                timeFilter,
+                valueFilter,
+                fileFilter,
+                ascending);
   }
 
   @TestOnly
@@ -82,15 +84,16 @@ public class SeriesRawDataBatchReader implements ManagedSeriesReader {
       boolean ascending) {
     Set<String> allSensors = new HashSet<>();
     this.seriesReader =
-        seriesPath.createSeriesReader(
-            allSensors,
-            dataType,
-            context,
-            seqFileResource,
-            unseqFileResource,
-            timeFilter,
-            valueFilter,
-            ascending);
+        ResourceByPathUtils.getResourceInstance(seriesPath)
+            .createSeriesReader(
+                allSensors,
+                dataType,
+                context,
+                seqFileResource,
+                unseqFileResource,
+                timeFilter,
+                valueFilter,
+                ascending);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReaderByTimestamp.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesReaderByTimestamp.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.metadata.utils.ResourceByPathUtils;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.filter.TsFileFilter;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -50,8 +51,9 @@ public class SeriesReaderByTimestamp implements IReaderByTimestamp {
       boolean ascending) {
     Filter timeFilter = TimeFilter.defaultTimeFilter(ascending);
     this.seriesReader =
-        seriesPath.createSeriesReader(
-            allSensors, dataType, context, dataSource, timeFilter, null, fileFilter, ascending);
+        ResourceByPathUtils.getResourceInstance(seriesPath)
+            .createSeriesReader(
+                allSensors, dataType, context, dataSource, timeFilter, null, fileFilter, ascending);
     this.ascending = ascending;
   }
 


### PR DESCRIPTION
see [IOTDB-3008](https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-3008)

When moving the `PartialPath` to the `Commons` module, we need to extract the server-related interfaces from the `Partial Path` first.

I'll move the `PartialPath` to the `node-commons` directory when work on the new architecture is finished.