### PR TITLE
Use logical clock to fix clientManager test

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientFactoryProperty.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientFactoryProperty.java
@@ -23,6 +23,8 @@ import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 
+import java.util.concurrent.TimeUnit;
+
 public class ClientFactoryProperty {
 
   private final TProtocolFactory protocolFactory;
@@ -87,7 +89,7 @@ public class ClientFactoryProperty {
     private DefaultProperty() {}
 
     public static final boolean RPC_THRIFT_COMPRESSED_ENABLED = false;
-    public static final int CONNECTION_TIMEOUT_MS = 20_000;
+    public static final int CONNECTION_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(20);;
     public static final int SELECTOR_NUM_OF_ASYNC_CLIENT_MANAGER = 1;
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolProperty.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolProperty.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.commons.client;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 public class ClientPoolProperty<V> {
 
@@ -76,7 +77,7 @@ public class ClientPoolProperty<V> {
 
     private DefaultProperty() {}
 
-    public static final long WAIT_CLIENT_TIMEOUT_MS = 10_000;
+    public static final long WAIT_CLIENT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
     public static final int MAX_TOTAL_CLIENT_FOR_EACH_NODE = 100;
     public static final int MAX_IDLE_CLIENT_FOR_EACH_NODE = 100;
   }

--- a/node-commons/src/test/java/org/apache/iotdb/commons/ClientManagerTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/ClientManagerTest.java
@@ -236,7 +236,10 @@ public class ClientManagerTest {
     Assert.assertEquals(0, syncClusterManager.getPool().getNumIdle(endPoint));
 
     // get another sync client, should throw error and return null
+    long start = System.nanoTime();
     SyncDataNodeInternalServiceClient syncClient2 = syncClusterManager.borrowClient(endPoint);
+    long end = System.nanoTime();
+    Assert.assertTrue(end - start >= DefaultProperty.WAIT_CLIENT_TIMEOUT_MS * 1000);
     Assert.assertNull(syncClient2);
 
     // return one sync client
@@ -300,10 +303,10 @@ public class ClientManagerTest {
     Assert.assertEquals(0, syncClusterManager.getPool().getNumIdle(endPoint));
 
     // get another sync client, should wait waitClientTimeoutMS ms, throw error and return null
-    long start = System.currentTimeMillis();
+    long start = System.nanoTime();
     SyncDataNodeInternalServiceClient syncClient2 = syncClusterManager.borrowClient(endPoint);
-    long end = System.currentTimeMillis();
-    Assert.assertTrue(end - start >= waitClientTimeoutMS);
+    long end = System.nanoTime();
+    Assert.assertTrue(end - start >= waitClientTimeoutMS * 1000);
     Assert.assertNull(syncClient2);
 
     // return one sync client

--- a/node-commons/src/test/java/org/apache/iotdb/commons/ClientManagerTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/ClientManagerTest.java
@@ -239,7 +239,7 @@ public class ClientManagerTest {
     long start = System.nanoTime();
     SyncDataNodeInternalServiceClient syncClient2 = syncClusterManager.borrowClient(endPoint);
     long end = System.nanoTime();
-    Assert.assertTrue(end - start >= DefaultProperty.WAIT_CLIENT_TIMEOUT_MS * 1000);
+    Assert.assertTrue(end - start >= DefaultProperty.WAIT_CLIENT_TIMEOUT_MS * 1_000_000);
     Assert.assertNull(syncClient2);
 
     // return one sync client
@@ -306,7 +306,7 @@ public class ClientManagerTest {
     long start = System.nanoTime();
     SyncDataNodeInternalServiceClient syncClient2 = syncClusterManager.borrowClient(endPoint);
     long end = System.nanoTime();
-    Assert.assertTrue(end - start >= waitClientTimeoutMS * 1000);
+    Assert.assertTrue(end - start >= waitClientTimeoutMS * 1_000_000);
     Assert.assertNull(syncClient2);
 
     // return one sync client


### PR DESCRIPTION
Sometimes the CI is unstable, and calculating the time using physical time may cause the CI to fail