### PR TITLE
[IOTDB-3012][De-Singleton-1] remove singleton pattern for some classes

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/ClusterRPCService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/ClusterRPCService.java
@@ -39,11 +39,6 @@ public class ClusterRPCService extends ThriftService implements ClusterRPCServic
   private ClusterRPCService() {}
 
   @Override
-  public ThriftService getImplementation() {
-    return ClusterRPCServiceHolder.INSTANCE;
-  }
-
-  @Override
   public ServiceType getID() {
     return ServiceType.CLUSTER_RPC_SERVICE;
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/clusterinfo/ClusterInfoServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/clusterinfo/ClusterInfoServer.java
@@ -43,11 +43,6 @@ public class ClusterInfoServer extends ThriftService implements ClusterInfoServe
   }
 
   @Override
-  public ThriftService getImplementation() {
-    return getInstance();
-  }
-
-  @Override
   public void initTProcessor() {
     initSyncedServiceImpl(null);
     serviceImpl = new ClusterInfoServiceImpl();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/raft/DataRaftHeartBeatService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/raft/DataRaftHeartBeatService.java
@@ -23,18 +23,12 @@ import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.utils.ClusterUtils;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.service.ServiceType;
-import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
 
 public class DataRaftHeartBeatService extends AbstractDataRaftService
     implements DataRaftHeartBeatServiceMBean {
 
   private DataRaftHeartBeatService() {}
-
-  @Override
-  public ThriftService getImplementation() {
-    return DataRaftHeartBeatServiceHolder.INSTANCE;
-  }
 
   @Override
   public ServiceType getID() {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/raft/DataRaftService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/raft/DataRaftService.java
@@ -22,17 +22,11 @@ package org.apache.iotdb.cluster.server.raft;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.service.ServiceType;
-import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
 
 public class DataRaftService extends AbstractDataRaftService implements DataRaftServiceMBean {
 
   private DataRaftService() {}
-
-  @Override
-  public ThriftService getImplementation() {
-    return DataRaftServiceHolder.INSTANCE;
-  }
 
   @Override
   public ServiceType getID() {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/raft/MetaRaftHeartBeatService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/raft/MetaRaftHeartBeatService.java
@@ -23,18 +23,12 @@ import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.cluster.utils.ClusterUtils;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.service.ServiceType;
-import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
 
 public class MetaRaftHeartBeatService extends AbstractMetaRaftService
     implements MetaRaftHeartBeatServiceMBean {
 
   private MetaRaftHeartBeatService() {}
-
-  @Override
-  public ThriftService getImplementation() {
-    return MetaRaftHeartBeatServiceHolder.INSTANCE;
-  }
 
   @Override
   public ServiceType getID() {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/raft/MetaRaftService.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/raft/MetaRaftService.java
@@ -22,17 +22,11 @@ package org.apache.iotdb.cluster.server.raft;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.service.ServiceType;
-import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
 
 public class MetaRaftService extends AbstractMetaRaftService implements MetaRaftServiceMBean {
 
   private MetaRaftService() {}
-
-  @Override
-  public ThriftService getImplementation() {
-    return MetaRaftServiceHolder.INSTANCE;
-  }
 
   @Override
   public ServiceType getID() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -44,10 +44,11 @@ public class ConfigNode implements ConfigNodeMBean {
   private final RegisterManager registerManager = new RegisterManager();
 
   private final ConfigNodeRPCService configNodeRPCService;
-  private final ConfigNodeRPCServer configNodeRPCServer = new ConfigNodeRPCServer();
 
   private ConfigManager configManager;
 
+  public ConfigNode() {
+    this.configNodeRPCService = new ConfigNodeRPCService();
 
     try {
       this.configManager = new ConfigManager();
@@ -56,6 +57,7 @@ public class ConfigNode implements ConfigNodeMBean {
       stop();
       System.exit(0);
     }
+  }
 
   public static void main(String[] args) {
     new ConfigNodeCommandLine().doMain(args);

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -44,11 +44,10 @@ public class ConfigNode implements ConfigNodeMBean {
   private final RegisterManager registerManager = new RegisterManager();
 
   private final ConfigNodeRPCService configNodeRPCService;
+  private final ConfigNodeRPCServer configNodeRPCServer = new ConfigNodeRPCServer();
 
   private ConfigManager configManager;
 
-  private ConfigNode() {
-    this.configNodeRPCService = new ConfigNodeRPCService();
 
     try {
       this.configManager = new ConfigManager();
@@ -57,7 +56,6 @@ public class ConfigNode implements ConfigNodeMBean {
       stop();
       System.exit(0);
     }
-  }
 
   public static void main(String[] args) {
     new ConfigNodeCommandLine().doMain(args);
@@ -67,7 +65,7 @@ public class ConfigNode implements ConfigNodeMBean {
   private void setUp() throws StartupException, IOException {
     LOGGER.info("Setting up {}...", ConfigNodeConstant.GLOBAL_NAME);
     registerManager.register(new JMXService());
-    JMXService.registerMBean(getInstance(), mbeanName);
+    JMXService.registerMBean(this, mbeanName);
 
     configNodeRPCService.initSyncedServiceImpl(new ConfigNodeRPCServiceProcessor(configManager));
     registerManager.register(configNodeRPCService);
@@ -103,18 +101,5 @@ public class ConfigNode implements ConfigNodeMBean {
 
   public void stop() {
     deactivate();
-  }
-
-  private static class ConfigNodeHolder {
-
-    private static final ConfigNode INSTANCE = new ConfigNode();
-
-    private ConfigNodeHolder() {
-      // empty constructor
-    }
-  }
-
-  public static ConfigNode getInstance() {
-    return ConfigNodeHolder.INSTANCE;
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNodeCommandLine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNodeCommandLine.java
@@ -76,7 +76,7 @@ public class ConfigNodeCommandLine extends ServerCommandLine {
         LOGGER.error("Meet error when doing start checking", e);
         return -1;
       }
-      ConfigNode configNode = ConfigNode.getInstance();
+      ConfigNode configNode = new ConfigNode();
       configNode.active();
     } else if (MODE_ADD.equals(mode)) {
       // TODO: add node

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCService.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCService.java
@@ -35,15 +35,6 @@ public class ConfigNodeRPCService extends ThriftService implements ConfigNodeRPC
 
   private ConfigNodeRPCServiceProcessor configNodeRPCServiceProcessor;
 
-  public ConfigNodeRPCService() {
-    // Empty constructor
-  }
-
-  @Override
-  public ThriftService getImplementation() {
-    return this;
-  }
-
   @Override
   public ServiceType getID() {
     return ServiceType.CONFIG_NODE_SERVICE;

--- a/confignode/src/test/java/org/apache/iotdb/confignode/utils/ConfigNodeEnvironmentUtils.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/utils/ConfigNodeEnvironmentUtils.java
@@ -44,7 +44,7 @@ public class ConfigNodeEnvironmentUtils {
     LOGGER.debug("ConfigNodeEnvironmentUtils setup...");
 
     if (daemon == null) {
-      daemon = ConfigNode.getInstance();
+      daemon = new ConfigNode();
     }
 
     try {
@@ -93,7 +93,7 @@ public class ConfigNodeEnvironmentUtils {
   @TestOnly
   public static void reactiveDaemon() {
     if (daemon == null) {
-      daemon = ConfigNode.getInstance();
+      daemon = new ConfigNode();
       daemon.active();
     } else {
       activeDaemon();

--- a/node-commons/src/main/java/org/apache/iotdb/commons/service/ThriftService.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/service/ThriftService.java
@@ -63,11 +63,9 @@ public abstract class ThriftService implements IService {
     }
   }
 
-  public abstract ThriftService getImplementation();
-
   @Override
   public void start() throws StartupException {
-    JMXService.registerMBean(getImplementation(), mbeanName);
+    JMXService.registerMBean(this, mbeanName);
     startService();
   }
 

--- a/procedure/src/main/java/org/apache/iotdb/procedure/service/ProcedureServer.java
+++ b/procedure/src/main/java/org/apache/iotdb/procedure/service/ProcedureServer.java
@@ -73,11 +73,6 @@ public class ProcedureServer extends ThriftService implements ProcedureNodeMBean
   }
 
   @Override
-  public ThriftService getImplementation() {
-    return ProcedureServer.getInstance();
-  }
-
-  @Override
   public void initTProcessor()
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
     this.processor = new ProcedureService.Processor<>(client);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/DataBlockService.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/DataBlockService.java
@@ -43,11 +43,6 @@ public class DataBlockService extends ThriftService implements DataBlockServiceM
   private DataBlockService() {}
 
   @Override
-  public ThriftService getImplementation() {
-    return DataBlockManagerServiceHolder.INSTANCE;
-  }
-
-  @Override
   public void initTProcessor()
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
     initSyncedServiceImpl(null);

--- a/server/src/main/java/org/apache/iotdb/db/service/InfluxDBRPCService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/InfluxDBRPCService.java
@@ -38,11 +38,6 @@ public class InfluxDBRPCService extends ThriftService implements InfluxDBRPCServ
   }
 
   @Override
-  public ThriftService getImplementation() {
-    return getInstance();
-  }
-
-  @Override
   public void initTProcessor()
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
     impl =

--- a/server/src/main/java/org/apache/iotdb/db/service/InternalService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/InternalService.java
@@ -42,11 +42,6 @@ public class InternalService extends ThriftService implements InternalServiceMBe
   }
 
   @Override
-  public ThriftService getImplementation() {
-    return InternalServiceHolder.INSTANCE;
-  }
-
-  @Override
   public void initTProcessor()
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
     impl = new InternalServiceImpl();

--- a/server/src/main/java/org/apache/iotdb/db/service/RPCService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/RPCService.java
@@ -43,11 +43,6 @@ public class RPCService extends ThriftService implements RPCServiceMBean {
   }
 
   @Override
-  public ThriftService getImplementation() {
-    return getInstance();
-  }
-
-  @Override
   public void initTProcessor()
       throws ClassNotFoundException, IllegalAccessException, InstantiationException,
           NoSuchMethodException, InvocationTargetException {

--- a/server/src/main/java/org/apache/iotdb/db/sync/transport/server/TransportServerManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/transport/server/TransportServerManager.java
@@ -63,11 +63,6 @@ public class TransportServerManager extends ThriftService
   }
 
   @Override
-  public ThriftService getImplementation() {
-    return getInstance();
-  }
-
-  @Override
   public void initTProcessor() {
     initSyncedServiceImpl(null);
     serviceImpl = new TransportServiceImpl();


### PR DESCRIPTION
As have discussed, singleton pattern is making code inflexible, hard to make UI and IT tests. We shouldn't use singleton pattern too much. 

I'd like to propose several PRs to remove the singleton pattern for most of singleton pattern implementations before the `getInstance()` are widely used. This one is the first.