### PR TITLE
[IOTDB-3014] [Rocksdb_based] OOM

### DIFF
--- a/server/src/assembly/resources/conf/schema-rocksdb.properties
+++ b/server/src/assembly/resources/conf/schema-rocksdb.properties
@@ -28,18 +28,26 @@
 ### Cache Configuration
 ####################
 # A proper cache size can speed up metadata query.You can configure the cache size as required.
+# By default, the block cache is calculated based on parameter 'write_read_schema_free_memory_proportion' in 'iotdb-engine.properties'.
+# Assuming 30GB of memory allocated to the schema, that will allocate 30GB to the following configuration items in proportion.
 
 # Datatype: long
-# LRU block cache size
-# Block cache is where RocksDB caches data in memory for reads.
-# The block cache stores uncompressed blocks.The default is 20 GB.
-# block_cache_size=21474836480
+# LRU block cache size. Block cache is where RocksDB caches data in memory for reads.
+# The block cache stores uncompressed blocks.
+# The default value is 2/3 of the schema memory configured for parameter
+# 'write_read_schema_free_memory_proportion' in the 'iotdb-engine.properties'.
+# For example, if the total configured memory size is 30GB and the schema ratio is 1/10,
+# the default value is 30GB * 1/10 * 2/3
+# block_cache_size=2147483648
 
 # Datatype: long
-# LRU block cache size
-# Block cache is where RocksDB caches data in memory for reads.
-# The block cache stores compressed blocks.The default is 10 GB.
-# block_cache_compressed_size=10737418240
+# LRU block cache size. Block cache is where RocksDB caches data in memory for reads.
+# The block cache stores compressed blocks.
+# The default value is 1/3 of the schema memory configured for parameter
+# 'write_read_schema_free_memory_proportion' in the 'iotdb-engine.properties'.
+# For example, if the total configured memory size is 30GB and the schema ratio is 1/10,
+# the default value is 30GB * 1/10 * 1/3
+# block_cache_compressed_size=1073741824
 
 ####################
 ### Professional Configuration

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaConfLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaConfLoader.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.metadata.schemaregion.rocksdb;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 
 import org.rocksdb.util.SizeUnit;
 import org.slf4j.Logger;
@@ -44,8 +45,10 @@ public class RSchemaConfLoader {
   private long blockSize = 4 * SizeUnit.KB;
   private long writeBufferSize = 64 * SizeUnit.KB;
   private long maxTotalWalSize = 64 * SizeUnit.KB;
-  private long blockCache = 20L * 1024 * 1024 * 1024;
-  private long blockCacheCompressed = 10L * 1024 * 1024 * 1024;
+  private long blockCache =
+      IoTDBDescriptor.getInstance().getConfig().getAllocateMemoryForSchema() * 2 / 3;
+  private long blockCacheCompressed =
+      IoTDBDescriptor.getInstance().getConfig().getAllocateMemoryForSchema() / 3;
 
   private static final String ROCKSDB_CONFIG_FILE_NAME = "schema-rocksdb.properties";
   private static final Logger logger = LoggerFactory.getLogger(RSchemaConfLoader.class);


### PR DESCRIPTION
Block cache defaults to 30GB, which seems too large.  
Updated to calculate by configuration.  