### PR TITLE
[IOTDB-2960]Add partition cache

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -1012,6 +1012,11 @@ timestamp_precision=ms
 # Datatype: int
 # datanode_schema_cache_size=10000
 
+# cache size for partition.
+# This cache is used to improve partition fetch from config node.
+# Datatype: int
+# partition_cache_size=10000
+
 ####################
 ### Schema File Configuration
 ####################

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -896,6 +896,12 @@ public class IoTDBConfig {
    */
   private int dataNodeSchemaCacheSize = 10000;
 
+  /**
+   * Cache size of partition cache in {@link
+   * org.apache.iotdb.db.mpp.sql.analyze.ClusterPartitionFetcher}
+   */
+  private int partitionCacheSize = 1000;
+
   public float getUdfMemoryBudgetInMB() {
     return udfMemoryBudgetInMB;
   }
@@ -2828,5 +2834,13 @@ public class IoTDBConfig {
 
   public void setDataNodeSchemaCacheSize(int dataNodeSchemaCacheSize) {
     this.dataNodeSchemaCacheSize = dataNodeSchemaCacheSize;
+  }
+
+  public int getPartitionCacheSize() {
+    return partitionCacheSize;
+  }
+
+  public void setPartitionCacheSize(int partitionCacheSize) {
+    this.partitionCacheSize = partitionCacheSize;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -900,7 +900,7 @@ public class IoTDBConfig {
    * Cache size of partition cache in {@link
    * org.apache.iotdb.db.mpp.sql.analyze.ClusterPartitionFetcher}
    */
-  private int partitionCacheSize = 1000;
+  private int partitionCacheSize = 10000;
 
   public float getUdfMemoryBudgetInMB() {
     return udfMemoryBudgetInMB;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1598,6 +1598,11 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "data_block_manager_keep_alive_time_in_ms",
                 Integer.toString(conf.getDataBlockManagerKeepAliveTimeInMs()))));
+
+    conf.setPartitionCacheSize(
+        Integer.parseInt(
+            properties.getProperty(
+                "partition_cache_size", Integer.toString(conf.getPartitionCacheSize()))));
   }
 
   /** Get default encode algorithm by data type */

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
@@ -312,7 +312,7 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
             schemaPartitionCache.getIfPresent(device);
         if (null == schemaPartitionCacheValue) {
           // if one device not find, then return cache miss.
-          logger.error("Failed to find schema partition");
+          logger.debug("Failed to find schema partition");
           return null;
         }
         String storageGroupName = schemaPartitionCacheValue.getStorageGroup();
@@ -324,7 +324,7 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
         regionReplicaSetMap.put(
             seriesPartitionSlot, schemaPartitionCacheValue.getRegionReplicaSet());
       }
-      logger.error("Hit schema partition");
+      logger.debug("Hit schema partition");
       // cache hit
       return new SchemaPartition(
           schemaPartitionMap, seriesSlotExecutorName, seriesPartitionSlotNum);
@@ -349,7 +349,7 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
           if (null == dataPartitionQueryParam.getTimePartitionSlotList()
               || 0 == dataPartitionQueryParam.getTimePartitionSlotList().size()) {
             // if query all data, cache miss
-            logger.error("Failed to find data partition");
+            logger.debug("Failed to find data partition");
             return null;
           }
           TSeriesPartitionSlot seriesPartitionSlot =
@@ -368,14 +368,14 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
                 dataPartitionCache.getIfPresent(dataPartitionCacheKey);
             if (null == regionReplicaSets) {
               // if one time partition not find, cache miss
-              logger.error("Failed to find data partition");
+              logger.debug("Failed to find data partition");
               return null;
             }
             timePartitionSlotListMap.put(timePartitionSlot, regionReplicaSets);
           }
         }
       }
-      logger.error("Hit data partition");
+      logger.debug("Hit data partition");
       // cache hit
       return new DataPartition(dataPartitionMap, seriesSlotExecutorName, seriesPartitionSlotNum);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
@@ -433,7 +433,7 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
 
     /** invalid schemaPartitionCache by device */
     public void invalidSchemaPartitionCache(String device) {
-      // TODO this method should be called in two situation: 1. redirect status 2. config node trigger
+      // TODO should be called in two situation: 1. redirect status 2. config node trigger
       schemaPartitionCache.invalidate(device);
     }
 
@@ -442,7 +442,7 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
         String storageGroup,
         TSeriesPartitionSlot seriesPartitionSlot,
         TTimePartitionSlot timePartitionSlot) {
-      // TODO this method should be called in two situation: 1. redirect status 2. config node trigger
+      // TODO should be called in two situation: 1. redirect status 2. config node trigger
       DataPartitionCacheKey dataPartitionCacheKey =
           new DataPartitionCacheKey(storageGroup, seriesPartitionSlot, timePartitionSlot);
       dataPartitionCache.invalidate(dataPartitionCacheKey);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
@@ -51,8 +51,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,30 +88,12 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
     } catch (IoTDBConnectionException | BadNodeUrlException e) {
       throw new StatementAnalyzeException("Couldn't connect config node");
     }
-    initPartitionExecutor();
-  }
-
-  private void initPartitionExecutor() {
-    // TODO: @crz move to node-commons
-    try {
-      Class<?> executor = Class.forName(config.getSeriesPartitionExecutorClass());
-      Constructor<?> executorConstructor = executor.getConstructor(int.class);
-      this.partitionExecutor =
-          (SeriesPartitionExecutor)
-              executorConstructor.newInstance(config.getSeriesPartitionSlotNum());
-      this.partitionCache =
-          new PartitionCache(
-              config.getSeriesPartitionExecutorClass(), config.getSeriesPartitionSlotNum());
-    } catch (ClassNotFoundException
-        | NoSuchMethodException
-        | InstantiationException
-        | IllegalAccessException
-        | InvocationTargetException e) {
-      throw new StatementAnalyzeException(
-          String.format(
-              "Couldn't Constructor SeriesPartitionExecutor class: %s",
-              config.getSeriesPartitionExecutorClass()));
-    }
+    this.partitionExecutor =
+        SeriesPartitionExecutor.getSeriesPartitionExecutor(
+            config.getSeriesPartitionExecutorClass(), config.getSeriesPartitionSlotNum());
+    this.partitionCache =
+        new PartitionCache(
+            config.getSeriesPartitionExecutorClass(), config.getSeriesPartitionSlotNum());
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
@@ -431,22 +431,18 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
       }
     }
 
-    /**
-     * invalid schemaPartitionCache by device TODO this method should be called in two situation: 1.
-     * redirect status 2. config node trigger
-     */
+    /** invalid schemaPartitionCache by device */
     public void invalidSchemaPartitionCache(String device) {
+      // TODO this method should be called in two situation: 1. redirect status 2. config node trigger
       schemaPartitionCache.invalidate(device);
     }
 
-    /**
-     * invalid dataPartitionCache by sg, seriesPartitionSlot, timePartitionSlot TODO this method
-     * should be called in two situation: 1. redirect status 2. config node trigger
-     */
+    /** invalid dataPartitionCache by sg, seriesPartitionSlot, timePartitionSlot */
     public void invalidDataPartitionCache(
         String storageGroup,
         TSeriesPartitionSlot seriesPartitionSlot,
         TTimePartitionSlot timePartitionSlot) {
+      // TODO this method should be called in two situation: 1. redirect status 2. config node trigger
       DataPartitionCacheKey dataPartitionCacheKey =
           new DataPartitionCacheKey(storageGroup, seriesPartitionSlot, timePartitionSlot);
       dataPartitionCache.invalidate(dataPartitionCacheKey);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/ClusterPartitionFetcher.java
@@ -404,11 +404,11 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
   private class PartitionCache {
     /** the size of partitionCache */
     private final int cacheSize = config.getPartitionCacheSize();
-    /** the set of storage group */
+    /** the cache of storage group */
     private Set<String> storageGroupCache = Collections.synchronizedSet(new HashSet<>());
     /** device -> tRegionReplicaSet */
     private final Cache<String, TRegionReplicaSet> schemaPartitionCache;
-    /** storage_group, tSeriesPartitionSlot, tTimesereisPartitionSlot -> TRegionReplicaSets * */
+    /** tSeriesPartitionSlot, tTimesereisPartitionSlot -> TRegionReplicaSets * */
     private final Cache<DataPartitionCacheKey, List<TRegionReplicaSet>> dataPartitionCache;
     /** calculate slotId by device */
     private final String seriesSlotExecutorName;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/FakePartitionFetcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/FakePartitionFetcherImpl.java
@@ -140,8 +140,19 @@ public class FakePartitionFetcherImpl implements IPartitionFetcher {
   }
 
   @Override
+  public DataPartition getDataPartition(List<DataPartitionQueryParam> dataPartitionQueryParams) {
+    return null;
+  }
+
+  @Override
   public DataPartition getOrCreateDataPartition(
       Map<String, List<DataPartitionQueryParam>> sgNameToQueryParamsMap) {
+    return null;
+  }
+
+  @Override
+  public DataPartition getOrCreateDataPartition(
+      List<DataPartitionQueryParam> dataPartitionQueryParams) {
     return null;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/IPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/IPartitionFetcher.java
@@ -34,6 +34,10 @@ public interface IPartitionFetcher {
 
   DataPartition getDataPartition(Map<String, List<DataPartitionQueryParam>> sgNameToQueryParamsMap);
 
+  DataPartition getDataPartition(List<DataPartitionQueryParam> dataPartitionQueryParams);
+
   DataPartition getOrCreateDataPartition(
       Map<String, List<DataPartitionQueryParam>> sgNameToQueryParamsMap);
+
+  DataPartition getOrCreateDataPartition(List<DataPartitionQueryParam> dataPartitionQueryParams);
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/StandalonePartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/analyze/StandalonePartitionFetcher.java
@@ -109,8 +109,19 @@ public class StandalonePartitionFetcher implements IPartitionFetcher {
   }
 
   @Override
+  public DataPartition getDataPartition(List<DataPartitionQueryParam> dataPartitionQueryParams) {
+    return null;
+  }
+
+  @Override
   public DataPartition getOrCreateDataPartition(
       Map<String, List<DataPartitionQueryParam>> sgNameToQueryParamsMap) {
     return getDataPartition(sgNameToQueryParamsMap);
+  }
+
+  @Override
+  public DataPartition getOrCreateDataPartition(
+      List<DataPartitionQueryParam> dataPartitionQueryParams) {
+    return null;
   }
 }


### PR DESCRIPTION
Add partition cache in clusterParitionFetcher.
StorageGroupCache: storageGroupName
SchemaPartitionCache: device -> TRegionReplicaSet.
DataPartitionCache: TSeriesPartitionSlot, TTimePartitionSlot -> List
Notice: if there are no TTimePartitionSlot in DataPartitionQueryParam, it's means fetch all data so cache will miss all the time.

Besides, I have do test in 3 confifnodes and 3 datanodes cluster and run some scripts as follows:

<img width="518" alt="image" src="https://user-images.githubusercontent.com/46039728/165430737-32e321fe-cde8-4239-aaa3-986d5e87a213.png">
