### PR TITLE
[IOTDB-3021] Fix sink/source handle memory leak

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/DataBlockManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/DataBlockManager.java
@@ -54,7 +54,7 @@ public class DataBlockManager implements IDataBlockManager {
   public interface SourceHandleListener {
     void onFinished(ISourceHandle sourceHandle);
 
-    void onClosed(ISourceHandle sourceHandle);
+    void onAborted(ISourceHandle sourceHandle);
 
     void onFailure(ISourceHandle sourceHandle, Throwable t);
   }
@@ -62,7 +62,7 @@ public class DataBlockManager implements IDataBlockManager {
   public interface SinkHandleListener {
     void onFinish(ISinkHandle sinkHandle);
 
-    void onClosed(ISinkHandle sinkHandle);
+    void onEndOfBlocks(ISinkHandle sinkHandle);
 
     void onAborted(ISinkHandle sinkHandle);
 
@@ -130,7 +130,7 @@ public class DataBlockManager implements IDataBlockManager {
           || sourceHandles
               .get(e.getTargetFragmentInstanceId())
               .get(e.getTargetPlanNodeId())
-              .isClosed()) {
+              .isAborted()) {
         throw new TException(
             "Target fragment instance not found. Fragment instance ID: "
                 + e.getTargetFragmentInstanceId()
@@ -156,7 +156,7 @@ public class DataBlockManager implements IDataBlockManager {
           || sourceHandles
               .get(e.getTargetFragmentInstanceId())
               .get(e.getTargetPlanNodeId())
-              .isClosed()) {
+              .isAborted()) {
         throw new TException(
             "Target fragment instance not found. Fragment instance ID: "
                 + e.getTargetFragmentInstanceId()
@@ -200,7 +200,7 @@ public class DataBlockManager implements IDataBlockManager {
     }
 
     @Override
-    public void onClosed(ISourceHandle sourceHandle) {
+    public void onAborted(ISourceHandle sourceHandle) {
       onFinished(sourceHandle);
     }
 
@@ -236,7 +236,7 @@ public class DataBlockManager implements IDataBlockManager {
     }
 
     @Override
-    public void onClosed(ISinkHandle sinkHandle) {
+    public void onEndOfBlocks(ISinkHandle sinkHandle) {
       context.transitionToFlushing();
     }
 
@@ -379,7 +379,7 @@ public class DataBlockManager implements IDataBlockManager {
       Map<String, SourceHandle> planNodeIdToSourceHandle = sourceHandles.get(fragmentInstanceId);
       for (Entry<String, SourceHandle> entry : planNodeIdToSourceHandle.entrySet()) {
         logger.info("Close source handle {}", sourceHandles);
-        entry.getValue().close();
+        entry.getValue().abort();
       }
       sourceHandles.remove(fragmentInstanceId);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/ISinkHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/ISinkHandle.java
@@ -51,26 +51,19 @@ public interface ISinkHandle {
   void send(int partition, List<TsBlock> tsBlocks);
 
   /**
-   * Notify the handle that no more tsblocks will be sent. Any future calls to send a tsblock should
-   * be ignored.
+   * Notify the handle that there are no more tsblocks. Any future calls to send a tsblock should be
+   * ignored.
    */
   void setNoMoreTsBlocks();
 
-  /** If the handle is closed. */
-  boolean isClosed();
+  /** If the handle is aborted. */
+  boolean isAborted();
 
   /**
-   * If no more tsblocks will be sent and all the tsblocks have been fetched by downstream fragment
-   * instances.
+   * If there are no more tsblocks to be sent and all the tsblocks have been fetched by downstream
+   * fragment instances.
    */
   boolean isFinished();
-
-  /**
-   * Close the handle. The output buffer will not be cleared until all tsblocks are fetched by
-   * downstream instances. A {@link RuntimeException} will be thrown if any exception happened
-   * during the data transmission.
-   */
-  void close();
 
   /**
    * Abort the sink handle. Discard all tsblocks which may still be in the memory buffer and cancel

--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/ISourceHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/ISourceHandle.java
@@ -23,9 +23,7 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-import java.io.Closeable;
-
-public interface ISourceHandle extends Closeable {
+public interface ISourceHandle {
 
   /** Get the local fragment instance ID that this source handle belongs to. */
   TFragmentInstanceId getLocalFragmentInstanceId();
@@ -48,13 +46,12 @@ public interface ISourceHandle extends Closeable {
   /** Get a future that will be completed when the input buffer is not empty. */
   ListenableFuture<Void> isBlocked();
 
-  /** If this handle is closed. */
-  boolean isClosed();
+  /** If this handle is aborted. */
+  boolean isAborted();
 
   /**
-   * Close the handle. Discard all tsblocks which may still be in the memory buffer and complete the
+   * Abort the handle. Discard all tsblocks which may still be in the memory buffer and complete the
    * future returned by {@link #isBlocked()}.
    */
-  @Override
-  void close();
+  void abort();
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/buffer/SourceHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/buffer/SourceHandle.java
@@ -69,12 +69,17 @@ public class SourceHandle implements ISourceHandle {
   private final IClientManager<TEndPoint, SyncDataNodeDataBlockServiceClient>
       dataBlockServiceClientManager;
 
-  private volatile SettableFuture<Void> blocked = SettableFuture.create();
+  private SettableFuture<Void> blocked = SettableFuture.create();
+
+  private ListenableFuture<Void> blockedOnMemory;
+
+  /** The actual buffered memory in bytes, including the amount of memory being reserved. */
   private long bufferRetainedSizeInBytes = 0L;
+
   private int currSequenceId = 0;
   private int nextSequenceId = 0;
   private int lastSequenceId = Integer.MAX_VALUE;
-  private boolean closed = false;
+  private boolean aborted = false;
 
   public SourceHandle(
       TEndPoint remoteEndpoint,
@@ -99,25 +104,24 @@ public class SourceHandle implements ISourceHandle {
   }
 
   @Override
-  public TsBlock receive() {
-    if (closed) {
-      throw new IllegalStateException("Source handle is closed.");
+  public synchronized TsBlock receive() {
+    if (aborted) {
+      throw new IllegalStateException("Source handle is aborted.");
     }
     if (!blocked.isDone()) {
       throw new IllegalStateException("Source handle is blocked.");
     }
-    TsBlock tsBlock;
-    synchronized (this) {
-      tsBlock = sequenceIdToTsBlock.remove(currSequenceId);
-      currSequenceId += 1;
-      bufferRetainedSizeInBytes -= tsBlock.getRetainedSizeInBytes();
-      localMemoryManager
-          .getQueryPool()
-          .free(localFragmentInstanceId.getQueryId(), tsBlock.getRetainedSizeInBytes());
 
-      if (sequenceIdToTsBlock.isEmpty() && !isFinished()) {
-        blocked = SettableFuture.create();
-      }
+    TsBlock tsBlock;
+    tsBlock = sequenceIdToTsBlock.remove(currSequenceId);
+    currSequenceId += 1;
+    bufferRetainedSizeInBytes -= tsBlock.getRetainedSizeInBytes();
+    localMemoryManager
+        .getQueryPool()
+        .free(localFragmentInstanceId.getQueryId(), tsBlock.getRetainedSizeInBytes());
+
+    if (sequenceIdToTsBlock.isEmpty() && !isFinished()) {
+      blocked = SettableFuture.create();
     }
     if (isFinished()) {
       sourceHandleListener.onFinished(this);
@@ -127,10 +131,17 @@ public class SourceHandle implements ISourceHandle {
   }
 
   private synchronized void trySubmitGetDataBlocksTask() {
+    if (aborted) {
+      return;
+    }
+    if (blockedOnMemory != null && !blockedOnMemory.isDone()) {
+      return;
+    }
+
     final int startSequenceId = nextSequenceId;
     int endSequenceId = nextSequenceId;
     long reservedBytes = 0L;
-    ListenableFuture<?> future = null;
+    ListenableFuture<Void> future = null;
     while (sequenceIdToDataBlockSize.containsKey(endSequenceId)) {
       Long bytesToReserve = sequenceIdToDataBlockSize.get(endSequenceId);
       if (bytesToReserve == null) {
@@ -140,11 +151,10 @@ public class SourceHandle implements ISourceHandle {
           localMemoryManager
               .getQueryPool()
               .reserve(localFragmentInstanceId.getQueryId(), bytesToReserve);
-      if (future.isDone()) {
-        endSequenceId += 1;
-        reservedBytes += bytesToReserve;
-        bufferRetainedSizeInBytes += bytesToReserve;
-      } else {
+      bufferRetainedSizeInBytes += bytesToReserve;
+      endSequenceId += 1;
+      reservedBytes += bytesToReserve;
+      if (!future.isDone()) {
         break;
       }
     }
@@ -154,38 +164,17 @@ public class SourceHandle implements ISourceHandle {
       return;
     }
 
-    if (future.isDone()) {
-      nextSequenceId = endSequenceId;
-      executorService.submit(new GetDataBlocksTask(startSequenceId, endSequenceId, reservedBytes));
-    } else {
-      nextSequenceId = endSequenceId + 1;
+    nextSequenceId = endSequenceId;
+    executorService.submit(new GetDataBlocksTask(startSequenceId, endSequenceId, reservedBytes));
+    if (!future.isDone()) {
+      blockedOnMemory = future;
       // The future being not completed indicates,
       //   1. Memory has been reserved for blocks in [startSequenceId, endSequenceId).
-      //   2. Memory reservation for block whose sequence ID equals endSequenceId is blocked.
+      //   2. Memory reservation for block whose sequence ID equals endSequenceId - 1 is blocked.
       //   3. Have not reserve memory for the rest of blocks.
       //
-      //  startSequenceId             endSequenceId  endSequenceId + 1
+      //  startSequenceId          endSequenceId - 1  endSequenceId
       //         |-------- reserved --------|--- blocked ---|--- not reserved ---|
-
-      if (endSequenceId > startSequenceId) {
-        // Memory has been reserved. Submit a GetDataBlocksTask for these blocks.
-        executorService.submit(
-            new GetDataBlocksTask(startSequenceId, endSequenceId, reservedBytes));
-      }
-
-      // Submit a GetDataBlocksTask when memory is freed.
-      final int sequenceIdOfUnReservedDataBlock = endSequenceId;
-      final long sizeOfUnReservedDataBlock = sequenceIdToDataBlockSize.get(endSequenceId);
-      future.addListener(
-          () -> {
-            executorService.submit(
-                new GetDataBlocksTask(
-                    sequenceIdOfUnReservedDataBlock,
-                    sequenceIdOfUnReservedDataBlock + 1,
-                    sizeOfUnReservedDataBlock));
-            bufferRetainedSizeInBytes += sizeOfUnReservedDataBlock;
-          },
-          executorService);
 
       // Schedule another call of trySubmitGetDataBlocksTask for the rest of blocks.
       future.addListener(SourceHandle.this::trySubmitGetDataBlocksTask, executorService);
@@ -193,9 +182,9 @@ public class SourceHandle implements ISourceHandle {
   }
 
   @Override
-  public ListenableFuture<Void> isBlocked() {
-    if (closed) {
-      throw new IllegalStateException("Source handle is closed.");
+  public synchronized ListenableFuture<Void> isBlocked() {
+    if (aborted) {
+      throw new IllegalStateException("Source handle is aborted.");
     }
     return nonCancellationPropagating(blocked);
   }
@@ -204,6 +193,9 @@ public class SourceHandle implements ISourceHandle {
     this.lastSequenceId = lastSequenceId;
     if (!blocked.isDone() && remoteTsBlockedConsumedUp()) {
       blocked.set(null);
+    }
+    if (isFinished()) {
+      sourceHandleListener.onFinished(this);
     }
   }
 
@@ -215,13 +207,14 @@ public class SourceHandle implements ISourceHandle {
   }
 
   @Override
-  public synchronized void close() {
-    if (closed) {
+  public synchronized void abort() {
+    if (aborted) {
       return;
     }
     if (blocked != null && !blocked.isDone()) {
       blocked.cancel(true);
     }
+    bufferRetainedSizeInBytes -= localMemoryManager.getQueryPool().tryCancel(blockedOnMemory);
     sequenceIdToDataBlockSize.clear();
     if (bufferRetainedSizeInBytes > 0) {
       localMemoryManager
@@ -229,8 +222,8 @@ public class SourceHandle implements ISourceHandle {
           .free(localFragmentInstanceId.getQueryId(), bufferRetainedSizeInBytes);
       bufferRetainedSizeInBytes = 0;
     }
-    closed = true;
-    sourceHandleListener.onClosed(this);
+    aborted = true;
+    sourceHandleListener.onAborted(this);
   }
 
   @Override
@@ -267,8 +260,8 @@ public class SourceHandle implements ISourceHandle {
   }
 
   @Override
-  public boolean isClosed() {
-    return closed;
+  public boolean isAborted() {
+    return aborted;
   }
 
   @Override
@@ -335,7 +328,7 @@ public class SourceHandle implements ISourceHandle {
             tsBlocks.add(tsBlock);
           }
           synchronized (SourceHandle.this) {
-            if (closed) {
+            if (aborted) {
               return;
             }
             for (int i = startSequenceId; i < endSequenceId; i++) {
@@ -372,7 +365,6 @@ public class SourceHandle implements ISourceHandle {
           }
         }
       }
-      // TODO: try to issue another GetDataBlocksTask to make the query run faster.
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/Driver.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/Driver.java
@@ -365,7 +365,7 @@ public abstract class Driver implements IDriver {
 
     try {
       root.close();
-      sinkHandle.close();
+      sinkHandle.setNoMoreTsBlocks();
     } catch (InterruptedException t) {
       // don't record the stack
       wasInterrupted = true;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryExecution.java
@@ -206,7 +206,7 @@ public class QueryExecution implements IQueryExecution {
     //   1. The client fetch all the result and the ResultHandle is finished.
     //   2. The client's connection is closed that all owned QueryExecution should be cleaned up
     if (resultHandle != null && resultHandle.isFinished()) {
-      resultHandle.close();
+      resultHandle.abort();
     }
   }
 
@@ -220,7 +220,7 @@ public class QueryExecution implements IQueryExecution {
   @Override
   public TsBlock getBatchResult() {
     try {
-      if (resultHandle.isClosed() || resultHandle.isFinished()) {
+      if (resultHandle.isAborted() || resultHandle.isFinished()) {
         return null;
       }
       ListenableFuture<Void> blocked = resultHandle.isBlocked();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/memory/MemoryPool.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/memory/MemoryPool.java
@@ -22,8 +22,9 @@ package org.apache.iotdb.db.mpp.memory;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.Validate;
+
+import javax.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Iterator;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/memory/MemoryPool.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/memory/MemoryPool.java
@@ -35,7 +35,7 @@ import java.util.Queue;
 /** A thread-safe memory pool. */
 public class MemoryPool {
 
-  private static class MemoryReservationFuture<V> extends AbstractFuture<V> {
+  public static class MemoryReservationFuture<V> extends AbstractFuture<V> {
     private final String queryId;
     private final long bytes;
 
@@ -133,6 +133,31 @@ public class MemoryPool {
     return true;
   }
 
+  /**
+   * Cancel the specified memory reservation. If the reservation has finished, do nothing.
+   *
+   * @param future The future returned from {@link #reserve(String, long)}
+   * @return If the future has not complete, return the number of bytes being reserved. Otherwise,
+   *     return 0.
+   */
+  public synchronized long tryCancel(ListenableFuture<Void> future) {
+    Validate.notNull(future);
+    if (future.isDone()) {
+      return 0L;
+    }
+    Iterator<MemoryReservationFuture<Void>> iterator = memoryReservationFutures.iterator();
+    while (iterator.hasNext()) {
+      MemoryReservationFuture<Void> f = iterator.next();
+      if (future.equals(f)) {
+        f.cancel(true);
+        iterator.remove();
+        return f.getBytes();
+      }
+    }
+
+    return 0L;
+  }
+
   public synchronized void free(String queryId, long bytes) {
     Validate.notNull(queryId);
     Validate.isTrue(bytes > 0L);
@@ -155,12 +180,6 @@ public class MemoryPool {
     Iterator<MemoryReservationFuture<Void>> iterator = memoryReservationFutures.iterator();
     while (iterator.hasNext()) {
       MemoryReservationFuture<Void> future = iterator.next();
-
-      if (future.isCancelled()) {
-        iterator.remove();
-        continue;
-      }
-
       long bytesToReserve = future.getBytes();
       if (maxBytes - reservedBytes < bytesToReserve) {
         return;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/memory/MemoryPool.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/memory/MemoryPool.java
@@ -22,9 +22,8 @@ package org.apache.iotdb.db.mpp.memory;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import org.apache.commons.lang3.Validate;
-
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.Validate;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -141,14 +140,14 @@ public class MemoryPool {
    *     return 0.
    */
   public synchronized long tryCancel(ListenableFuture<Void> future) {
+    if (future.isDone()) {
+      return 0L;
+    }
+
     Validate.notNull(future);
     Validate.isTrue(
         future instanceof MemoryReservationFuture,
         "invalid future type " + future.getClass().getSimpleName());
-
-    if (future.isDone()) {
-      return 0L;
-    }
     future.cancel(true);
     return ((MemoryReservationFuture<Void>) future).getBytes();
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/operator/source/ExchangeOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/operator/source/ExchangeOperator.java
@@ -81,6 +81,6 @@ public class ExchangeOperator implements SourceOperator {
 
   @Override
   public void close() throws Exception {
-    sourceHandle.close();
+    sourceHandle.abort();
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/buffer/StubSinkHandle.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/buffer/StubSinkHandle.java
@@ -69,10 +69,16 @@ public class StubSinkHandle implements ISinkHandle {
   }
 
   @Override
-  public void setNoMoreTsBlocks() {}
+  public void setNoMoreTsBlocks() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    instanceContext.transitionToFlushing();
+  }
 
   @Override
-  public boolean isClosed() {
+  public boolean isAborted() {
     return closed;
   }
 
@@ -82,16 +88,8 @@ public class StubSinkHandle implements ISinkHandle {
   }
 
   @Override
-  public void close() {
-    if (closed) {
-      return;
-    }
-    closed = true;
-    instanceContext.transitionToFlushing();
-  }
-
-  @Override
   public void abort() {
+    closed = true;
     tsBlocks.clear();
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/mpp/memory/MemoryPoolTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/memory/MemoryPoolTest.java
@@ -247,4 +247,29 @@ public class MemoryPoolTest {
     } catch (IllegalArgumentException ignore) {
     }
   }
+
+  @Test
+  public void testTryCancelBlockedReservation() {
+    String queryId = "q0";
+    // Run out of memory.
+    Assert.assertTrue(pool.tryReserve(queryId, 512L));
+
+    ListenableFuture<Void> f = pool.reserve(queryId, 256L);
+    Assert.assertFalse(f.isDone());
+    // Cancel the reservation.
+    Assert.assertEquals(256L, pool.tryCancel(f));
+    Assert.assertTrue(f.isDone());
+    Assert.assertTrue(f.isCancelled());
+  }
+
+  @Test
+  public void testTryCancelCompletedReservation() {
+    String queryId = "q0";
+    ListenableFuture<Void> f = pool.reserve(queryId, 256L);
+    Assert.assertTrue(f.isDone());
+    // Cancel the reservation.
+    Assert.assertEquals(0L, pool.tryCancel(f));
+    Assert.assertTrue(f.isDone());
+    Assert.assertFalse(f.isCancelled());
+  }
 }


### PR DESCRIPTION
1. Fix sink/source handle memory leak
2. Fix SourceHandle#setNoMoreTsBlocks doesn't trigger listener
3. rename SinkHandle#close to setNoMoreTsBlocks
4. rename SourceHandle#close to abort for consistency