### PR TITLE
[IOTDB-3026] fix cannot load tsfile correctly after restart iotdb

### DIFF
--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/snapshot/FileSnapshotTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/snapshot/FileSnapshotTest.java
@@ -119,10 +119,10 @@ public class FileSnapshotTest extends DataSnapshotTest {
     }
     DataRegion processor =
         StorageEngine.getInstance().getProcessor(new PartialPath(TestUtils.getTestSg(0)));
-    assertEquals(9, processor.getPartitionMaxFileVersions(0));
+    assertEquals(10, processor.getPartitionMaxFileVersions(0));
     List<TsFileResource> loadedFiles = processor.getSequenceFileList();
     assertEquals(tsFileResources.size(), loadedFiles.size());
-    for (int i = 0; i < 9; i++) {
+    for (int i = 0; i < loadedFiles.size(); i++) {
       assertEquals(i, loadedFiles.get(i).getMaxPlanIndex());
     }
     assertEquals(0, processor.getUnSequenceFileList().size());
@@ -163,10 +163,10 @@ public class FileSnapshotTest extends DataSnapshotTest {
       }
       DataRegion processor =
           StorageEngine.getInstance().getProcessor(new PartialPath(TestUtils.getTestSg(0)));
-      assertEquals(9, processor.getPartitionMaxFileVersions(0));
+      assertEquals(10, processor.getPartitionMaxFileVersions(0));
       List<TsFileResource> loadedFiles = processor.getSequenceFileList();
       assertEquals(tsFileResources.size(), loadedFiles.size());
-      for (int i = 0; i < 9; i++) {
+      for (int i = 0; i < loadedFiles.size(); i++) {
         assertEquals(i, loadedFiles.get(i).getMaxPlanIndex());
       }
       assertEquals(0, processor.getUnSequenceFileList().size());
@@ -213,10 +213,10 @@ public class FileSnapshotTest extends DataSnapshotTest {
     }
     DataRegion processor =
         StorageEngine.getInstance().getProcessor(new PartialPath(TestUtils.getTestSg(0)));
-    assertEquals(9, processor.getPartitionMaxFileVersions(0));
+    assertEquals(10, processor.getPartitionMaxFileVersions(0));
     List<TsFileResource> loadedFiles = processor.getSequenceFileList();
     assertEquals(tsFileResources.size(), loadedFiles.size());
-    for (int i = 0; i < 9; i++) {
+    for (int i = 0; i < loadedFiles.size(); i++) {
       assertEquals(i, loadedFiles.get(i).getMaxPlanIndex());
       ModificationFile modFile = loadedFiles.get(i).getModFile();
       assertTrue(modFile.exists());
@@ -253,10 +253,10 @@ public class FileSnapshotTest extends DataSnapshotTest {
     for (int j = 0; j < 10; j++) {
       DataRegion processor =
           StorageEngine.getInstance().getProcessor(new PartialPath(TestUtils.getTestSg(j)));
-      assertEquals(9, processor.getPartitionMaxFileVersions(0));
+      assertEquals(10, processor.getPartitionMaxFileVersions(0));
       List<TsFileResource> loadedFiles = processor.getSequenceFileList();
       assertEquals(10, loadedFiles.size());
-      for (int i = 0; i < 9; i++) {
+      for (int i = 0; i < loadedFiles.size(); i++) {
         assertEquals(i, loadedFiles.get(i).getMaxPlanIndex());
       }
       assertEquals(0, processor.getUnSequenceFileList().size());
@@ -299,10 +299,10 @@ public class FileSnapshotTest extends DataSnapshotTest {
     }
     DataRegion processor =
         StorageEngine.getInstance().getProcessor(new PartialPath(TestUtils.getTestSg(0)));
-    assertEquals(10, processor.getPartitionMaxFileVersions(0));
+    assertEquals(11, processor.getPartitionMaxFileVersions(0));
     List<TsFileResource> loadedFiles = processor.getSequenceFileList();
     assertEquals(tsFileResources.size(), loadedFiles.size());
-    for (int i = 0; i < 9; i++) {
+    for (int i = 0; i < loadedFiles.size(); i++) {
       assertEquals(i, loadedFiles.get(i).getMaxPlanIndex());
     }
     assertEquals(1, processor.getUnSequenceFileList().size());

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/snapshot/PartitionedSnapshotTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/snapshot/PartitionedSnapshotTest.java
@@ -112,10 +112,10 @@ public class PartitionedSnapshotTest extends DataSnapshotTest {
     }
     DataRegion processor =
         StorageEngine.getInstance().getProcessor(new PartialPath(TestUtils.getTestSg(0)));
-    assertEquals(9, processor.getPartitionMaxFileVersions(0));
+    assertEquals(10, processor.getPartitionMaxFileVersions(0));
     List<TsFileResource> loadedFiles = processor.getSequenceFileList();
     assertEquals(tsFileResources.size(), loadedFiles.size());
-    for (int i = 0; i < 9; i++) {
+    for (int i = 0; i < loadedFiles.size(); i++) {
       assertEquals(i, loadedFiles.get(i).getMaxPlanIndex());
     }
     assertEquals(0, processor.getUnSequenceFileList().size());
@@ -189,7 +189,7 @@ public class PartitionedSnapshotTest extends DataSnapshotTest {
       }
       DataRegion processor =
           StorageEngine.getInstance().getProcessor(new PartialPath(TestUtils.getTestSg(0)));
-      assertEquals(-1, processor.getPartitionMaxFileVersions(0));
+      assertEquals(0, processor.getPartitionMaxFileVersions(0));
       List<TsFileResource> loadedFiles = processor.getSequenceFileList();
       assertEquals(0, loadedFiles.size());
       assertEquals(0, processor.getUnSequenceFileList().size());

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/snapshot/PullSnapshotTaskTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/snapshot/PullSnapshotTaskTest.java
@@ -294,7 +294,7 @@ public class PullSnapshotTaskTest extends DataSnapshotTest {
     }
     DataRegion processor =
         StorageEngine.getInstance().getProcessor(new PartialPath(TestUtils.getTestSg(0)));
-    assertEquals(9, processor.getPartitionMaxFileVersions(0));
+    assertEquals(10, processor.getPartitionMaxFileVersions(0));
     List<TsFileResource> loadedFiles = processor.getSequenceFileList();
     assertEquals(tsFileResources.size(), loadedFiles.size());
     for (int i = 0; i < 9; i++) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -2716,7 +2716,7 @@ public class DataRegion {
   }
 
   private long getAndSetNewVersion(long timePartitionId, TsFileResource tsFileResource) {
-    long version = partitionMaxFileVersions.getOrDefault(timePartitionId, -1L) + 1;
+    long version = partitionMaxFileVersions.getOrDefault(timePartitionId, 0L) + 1;
     partitionMaxFileVersions.put(timePartitionId, version);
     tsFileResource.setVersion(version);
     return version;

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -3348,7 +3348,7 @@ public class DataRegion {
 
   @TestOnly
   public long getPartitionMaxFileVersions(long partitionId) {
-    return partitionMaxFileVersions.getOrDefault(partitionId, -1L);
+    return partitionMaxFileVersions.getOrDefault(partitionId, 0L);
   }
 
   public void addSettleFilesToList(


### PR DESCRIPTION
The version number should start from 1, not from 0. Otherwise, partitionMaxFileVersions cannot be computed correctly after iotdb restart(in `updatePartitionFileVersion`). If load tsfile, the version number will be 0, which is duplicated.
