### PR TITLE
[IOTDB-3030] delete storage group with ** error

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
@@ -233,8 +233,11 @@ public class LocalConfigNode {
   public void deleteStorageGroup(PartialPath storageGroup) throws MetadataException {
 
     DeleteTimeSeriesPlan deleteTimeSeriesPlan =
-        SchemaSyncManager.getInstance()
-            .splitDeleteTimeseriesPlanByDevice(storageGroup.concatNode(MULTI_LEVEL_PATH_WILDCARD));
+        SchemaSyncManager.getInstance().isEnableSync()
+            ? SchemaSyncManager.getInstance()
+                .splitDeleteTimeseriesPlanByDevice(
+                    storageGroup.concatNode(MULTI_LEVEL_PATH_WILDCARD))
+            : null;
 
     deleteSchemaRegionsInStorageGroup(
         storageGroup, schemaPartitionTable.getSchemaRegionIdsByStorageGroup(storageGroup));


### PR DESCRIPTION
problem:
delete storage group with ** in path error, the storage group is created by select into statements.
error happens in parse delete storage group to device paths in sync.

solution:
block parse process when sync is not enable.
block storage groups with ** in path.
