### PR TITLE
[IOTDB-3033] Completing the query and writing interface compared to java

### DIFF
--- a/client-py/SessionAlignedTimeseriesExample.py
+++ b/client-py/SessionAlignedTimeseriesExample.py
@@ -201,6 +201,24 @@ with session.execute_query_statement(
     while session_data_set.has_next():
         print(session_data_set.next())
 
+# insert aligned string record into the database.
+time_list = [1, 2, 3]
+measurements_list = [
+    ["s_01", "s_02", "s_03"],
+    ["s_01", "s_02", "s_03"],
+    ["s_01", "s_02", "s_03"],
+]
+values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
+session.insert_aligned_string_records_of_one_device(
+    "root.sg_test_01.d_04",
+    time_list,
+    measurements_list,
+    values_list,
+)
+
+# delete storage group
+session.delete_storage_group("root.sg_test_01")
+
 # close session connection.
 session.close()
 

--- a/client-py/SessionExample.py
+++ b/client-py/SessionExample.py
@@ -280,6 +280,45 @@ with session.execute_query_statement(
     while session_data_set.has_next():
         print(session_data_set.next())
 
+# insert string records of one device
+time_list = [1, 2, 3]
+measurements_list = [
+    ["s_01", "s_02", "s_03"],
+    ["s_01", "s_02", "s_03"],
+    ["s_01", "s_02", "s_03"],
+]
+values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
+
+session.insert_string_records_of_one_device(
+    "root.sg_test_01.d_03", time_list, measurements_list, values_list,
+)
+
+# insert aligned string record into the database.
+time_list = [1, 2, 3]
+measurements_list = [
+    ["s_01", "s_02", "s_03"],
+    ["s_01", "s_02", "s_03"],
+    ["s_01", "s_02", "s_03"],
+]
+values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
+session.insert_aligned_string_records_of_one_device(
+    "root.sg_test_01.d_04", time_list, measurements_list, values_list,
+)
+
+with session.execute_raw_data_query(
+        ["root.sg_test_01.d_03.s_01", "root.sg_test_01.d_03.s_02"], 1, 4
+) as session_data_set:
+    session_data_set.set_fetch_size(1024)
+    while session_data_set.has_next():
+        print(session_data_set.next())
+
+with session.execute_last_data_query(
+        ["root.sg_test_01.d_03.s_01", "root.sg_test_01.d_03.s_02"], 0
+) as session_data_set:
+    session_data_set.set_fetch_size(1024)
+    while session_data_set.has_next():
+        print(session_data_set.next())
+
 # delete storage group
 session.delete_storage_group("root.sg_test_01")
 

--- a/client-py/SessionExample.py
+++ b/client-py/SessionExample.py
@@ -290,7 +290,10 @@ measurements_list = [
 values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
 
 session.insert_string_records_of_one_device(
-    "root.sg_test_01.d_03", time_list, measurements_list, values_list,
+    "root.sg_test_01.d_03",
+    time_list,
+    measurements_list,
+    values_list,
 )
 
 # insert aligned string record into the database.
@@ -302,18 +305,21 @@ measurements_list = [
 ]
 values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
 session.insert_aligned_string_records_of_one_device(
-    "root.sg_test_01.d_04", time_list, measurements_list, values_list,
+    "root.sg_test_01.d_04",
+    time_list,
+    measurements_list,
+    values_list,
 )
 
 with session.execute_raw_data_query(
-        ["root.sg_test_01.d_03.s_01", "root.sg_test_01.d_03.s_02"], 1, 4
+    ["root.sg_test_01.d_03.s_01", "root.sg_test_01.d_03.s_02"], 1, 4
 ) as session_data_set:
     session_data_set.set_fetch_size(1024)
     while session_data_set.has_next():
         print(session_data_set.next())
 
 with session.execute_last_data_query(
-        ["root.sg_test_01.d_03.s_01", "root.sg_test_01.d_03.s_02"], 0
+    ["root.sg_test_01.d_03.s_01", "root.sg_test_01.d_03.s_02"], 0
 ) as session_data_set:
     session_data_set.set_fetch_size(1024)
     while session_data_set.has_next():

--- a/client-py/SessionExample.py
+++ b/client-py/SessionExample.py
@@ -296,21 +296,6 @@ session.insert_string_records_of_one_device(
     values_list,
 )
 
-# insert aligned string record into the database.
-time_list = [1, 2, 3]
-measurements_list = [
-    ["s_01", "s_02", "s_03"],
-    ["s_01", "s_02", "s_03"],
-    ["s_01", "s_02", "s_03"],
-]
-values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
-session.insert_aligned_string_records_of_one_device(
-    "root.sg_test_01.d_04",
-    time_list,
-    measurements_list,
-    values_list,
-)
-
 with session.execute_raw_data_query(
     ["root.sg_test_01.d_03.s_01", "root.sg_test_01.d_03.s_02"], 1, 4
 ) as session_data_set:

--- a/client-py/iotdb/Session.py
+++ b/client-py/iotdb/Session.py
@@ -34,14 +34,19 @@ from .thrift.rpc.TSIService import (
     TSExecuteStatementReq,
     TSOpenSessionReq,
     TSCreateMultiTimeseriesReq,
-    TSCreateSchemaTemplateReq,
     TSCloseSessionReq,
     TSInsertTabletsReq,
     TSInsertRecordsReq,
     TSInsertRecordsOfOneDeviceReq,
 )
-from .thrift.rpc.ttypes import TSDeleteDataReq, TSProtocolVersion, TSSetTimeZoneReq, TSRawDataQueryReq, \
-    TSLastDataQueryReq, TSInsertStringRecordsOfOneDeviceReq
+from .thrift.rpc.ttypes import (
+    TSDeleteDataReq,
+    TSProtocolVersion,
+    TSSetTimeZoneReq,
+    TSRawDataQueryReq,
+    TSLastDataQueryReq,
+    TSInsertStringRecordsOfOneDeviceReq,
+)
 
 # for debug
 # from IoTDBConstants import *
@@ -67,13 +72,13 @@ class Session(object):
     DEFAULT_ZONE_ID = time.strftime("%z")
 
     def __init__(
-            self,
-            host,
-            port,
-            user=DEFAULT_USER,
-            password=DEFAULT_PASSWORD,
-            fetch_size=DEFAULT_FETCH_SIZE,
-            zone_id=DEFAULT_ZONE_ID,
+        self,
+        host,
+        port,
+        user=DEFAULT_USER,
+        password=DEFAULT_PASSWORD,
+        fetch_size=DEFAULT_FETCH_SIZE,
+        zone_id=DEFAULT_ZONE_ID,
     ):
         self.__host = host
         self.__port = port
@@ -195,15 +200,15 @@ class Session(object):
         return Session.verify_success(status)
 
     def create_time_series(
-            self,
-            ts_path,
-            data_type,
-            encoding,
-            compressor,
-            props=None,
-            tags=None,
-            attributes=None,
-            alias=None,
+        self,
+        ts_path,
+        data_type,
+        encoding,
+        compressor,
+        props=None,
+        tags=None,
+        attributes=None,
+        alias=None,
     ):
         """
         create single time series
@@ -238,7 +243,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def create_aligned_time_series(
-            self, device_id, measurements_lst, data_type_lst, encoding_lst, compressor_lst
+        self, device_id, measurements_lst, data_type_lst, encoding_lst, compressor_lst
     ):
         """
         create aligned time series
@@ -270,15 +275,15 @@ class Session(object):
         return Session.verify_success(status)
 
     def create_multi_time_series(
-            self,
-            ts_path_lst,
-            data_type_lst,
-            encoding_lst,
-            compressor_lst,
-            props_lst=None,
-            tags_lst=None,
-            attributes_lst=None,
-            alias_lst=None,
+        self,
+        ts_path_lst,
+        data_type_lst,
+        encoding_lst,
+        compressor_lst,
+        props_lst=None,
+        tags_lst=None,
+        attributes_lst=None,
+        alias_lst=None,
     ):
         """
         create multiple time series
@@ -375,7 +380,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_aligned_str_record(
-            self, device_id, timestamp, measurements, string_values
+        self, device_id, timestamp, measurements, string_values
     ):
         """special case for inserting one row of String (TEXT) value"""
         if type(string_values) == str:
@@ -421,7 +426,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_records(
-            self, device_ids, times, measurements_lst, types_lst, values_lst
+        self, device_ids, times, measurements_lst, types_lst, values_lst
     ):
         """
         insert multiple rows of data, records are independent to each other, in other words, there's no relationship
@@ -449,7 +454,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_aligned_record(
-            self, device_id, timestamp, measurements, data_types, values
+        self, device_id, timestamp, measurements, data_types, values
     ):
         """
         insert one row of aligned record into database, if you want improve your performance, please use insertTablet method
@@ -476,7 +481,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_aligned_records(
-            self, device_ids, times, measurements_lst, types_lst, values_lst
+        self, device_ids, times, measurements_lst, types_lst, values_lst
     ):
         """
         insert multiple aligned rows of data, records are independent to each other, in other words, there's no relationship
@@ -504,7 +509,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def test_insert_record(
-            self, device_id, timestamp, measurements, data_types, values
+        self, device_id, timestamp, measurements, data_types, values
     ):
         """
         this method NOT insert data into database and the server just return after accept the request, this method
@@ -529,7 +534,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def test_insert_records(
-            self, device_ids, times, measurements_lst, types_lst, values_lst
+        self, device_ids, times, measurements_lst, types_lst, values_lst
     ):
         """
         this method NOT insert data into database and the server just return after accept the request, this method
@@ -555,7 +560,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def gen_insert_record_req(
-            self, device_id, timestamp, measurements, data_types, values, is_aligned=False
+        self, device_id, timestamp, measurements, data_types, values, is_aligned=False
     ):
         if (len(values) != len(data_types)) or (len(values) != len(measurements)):
             raise RuntimeError(
@@ -572,7 +577,7 @@ class Session(object):
         )
 
     def gen_insert_str_record_req(
-            self, device_id, timestamp, measurements, data_types, values, is_aligned=False
+        self, device_id, timestamp, measurements, data_types, values, is_aligned=False
     ):
         if (len(values) != len(data_types)) or (len(values) != len(measurements)):
             raise RuntimeError(
@@ -583,19 +588,19 @@ class Session(object):
         )
 
     def gen_insert_records_req(
-            self,
-            device_ids,
-            times,
-            measurements_lst,
-            types_lst,
-            values_lst,
-            is_aligned=False,
+        self,
+        device_ids,
+        times,
+        measurements_lst,
+        types_lst,
+        values_lst,
+        is_aligned=False,
     ):
         if (
-                (len(device_ids) != len(measurements_lst))
-                or (len(times) != len(types_lst))
-                or (len(device_ids) != len(times))
-                or (len(times) != len(values_lst))
+            (len(device_ids) != len(measurements_lst))
+            or (len(times) != len(types_lst))
+            or (len(device_ids) != len(times))
+            or (len(times) != len(values_lst))
         ):
             raise RuntimeError(
                 "deviceIds, times, measurementsList and valuesList's size should be equal"
@@ -603,7 +608,7 @@ class Session(object):
 
         value_lst = []
         for values, data_types, measurements in zip(
-                values_lst, types_lst, measurements_lst
+            values_lst, types_lst, measurements_lst
         ):
             if (len(values) != len(data_types)) or (len(values) != len(measurements)):
                 raise RuntimeError(
@@ -686,7 +691,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_records_of_one_device(
-            self, device_id, times_list, measurements_list, types_list, values_list
+        self, device_id, times_list, measurements_list, types_list, values_list
     ):
         # sort by timestamp
         sorted_zipped = sorted(
@@ -702,7 +707,7 @@ class Session(object):
         )
 
     def insert_records_of_one_device_sorted(
-            self, device_id, times_list, measurements_list, types_list, values_list
+        self, device_id, times_list, measurements_list, types_list, values_list
     ):
         """
         Insert multiple rows, which can reduce the overhead of network. This method is just like jdbc
@@ -719,9 +724,9 @@ class Session(object):
         # check parameter
         size = len(times_list)
         if (
-                size != len(measurements_list)
-                or size != len(types_list)
-                or size != len(values_list)
+            size != len(measurements_list)
+            or size != len(types_list)
+            or size != len(values_list)
         ):
             raise RuntimeError(
                 "insert records of one device error: types, times, measurementsList and valuesList's size should be equal"
@@ -744,7 +749,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_aligned_records_of_one_device(
-            self, device_id, times_list, measurements_list, types_list, values_list
+        self, device_id, times_list, measurements_list, types_list, values_list
     ):
         # sort by timestamp
         sorted_zipped = sorted(
@@ -760,7 +765,7 @@ class Session(object):
         )
 
     def insert_aligned_records_of_one_device_sorted(
-            self, device_id, times_list, measurements_list, types_list, values_list
+        self, device_id, times_list, measurements_list, types_list, values_list
     ):
         """
         Insert multiple aligned rows, which can reduce the overhead of network. This method is just like jdbc
@@ -776,9 +781,9 @@ class Session(object):
         # check parameter
         size = len(times_list)
         if (
-                size != len(measurements_list)
-                or size != len(types_list)
-                or size != len(values_list)
+            size != len(measurements_list)
+            or size != len(types_list)
+            or size != len(values_list)
         ):
             raise RuntimeError(
                 "insert records of one device error: types, times, measurementsList and valuesList's size should be equal"
@@ -801,17 +806,17 @@ class Session(object):
         return Session.verify_success(status)
 
     def gen_insert_records_of_one_device_request(
-            self,
-            device_id,
-            times_list,
-            measurements_list,
-            values_list,
-            types_list,
-            is_aligned=False,
+        self,
+        device_id,
+        times_list,
+        measurements_list,
+        values_list,
+        types_list,
+        is_aligned=False,
     ):
         binary_value_list = []
         for values, data_types, measurements in zip(
-                values_list, types_list, measurements_list
+            values_list, types_list, measurements_list
         ):
             data_types = [data_type.value for data_type in data_types]
             if (len(values) != len(data_types)) or (len(values) != len(measurements)):
@@ -1025,9 +1030,18 @@ class Session(object):
         logger.error("error status is", status)
         return -1
 
-    def execute_raw_data_query(self, paths: list, start_time: int, end_time: int) -> SessionDataSet:
-        request = TSRawDataQueryReq(self.__session_id, paths, self.__fetch_size, startTime=start_time, endTime=end_time,
-                                    statementId=self.__statement_id, enableRedirectQuery=False)
+    def execute_raw_data_query(
+        self, paths: list, start_time: int, end_time: int
+    ) -> SessionDataSet:
+        request = TSRawDataQueryReq(
+            self.__session_id,
+            paths,
+            self.__fetch_size,
+            startTime=start_time,
+            endTime=end_time,
+            statementId=self.__statement_id,
+            enableRedirectQuery=False,
+        )
         resp = self.__client.executeRawDataQuery(request)
         return SessionDataSet(
             "",
@@ -1044,7 +1058,12 @@ class Session(object):
 
     def execute_last_data_query(self, paths: list, last_time: int) -> SessionDataSet:
         request = TSLastDataQueryReq(
-            self.__session_id, paths, self.__fetch_size, last_time, self.__statement_id, enableRedirectQuery=False
+            self.__session_id,
+            paths,
+            self.__fetch_size,
+            last_time,
+            self.__statement_id,
+            enableRedirectQuery=False,
         )
 
         resp = self.__client.executeLastDataQuery(request)
@@ -1062,43 +1081,57 @@ class Session(object):
         )
 
     def insert_string_records_of_one_device(
-            self, device_id: str, times: list, measurements_list: list, values_list: list, have_sorted: bool = False
+        self,
+        device_id: str,
+        times: list,
+        measurements_list: list,
+        values_list: list,
+        have_sorted: bool = False,
     ):
         if (len(times) != len(measurements_list)) or (len(times) != len(values_list)):
             raise RuntimeError(
                 "insert records of one device error: times, measurementsList and valuesList's size should be equal!"
             )
-        request = self.gen_insert_string_records_of_one_device_request(device_id, times, measurements_list, values_list,
-                                                                       have_sorted, False)
+        request = self.gen_insert_string_records_of_one_device_request(
+            device_id, times, measurements_list, values_list, have_sorted, False
+        )
         status = self.__client.insertStringRecordsOfOneDevice(request)
         logger.debug(
-            "insert one device {} message: {}".format(
-                device_id, status.message
-            )
+            "insert one device {} message: {}".format(device_id, status.message)
         )
 
         return Session.verify_success(status)
 
     def insert_aligned_string_records_of_one_device(
-            self, device_id: str, times: list, measurements_list: list, values: list, have_sorted: bool = False
+        self,
+        device_id: str,
+        times: list,
+        measurements_list: list,
+        values: list,
+        have_sorted: bool = False,
     ):
         if (len(times) != len(measurements_list)) or (len(times) != len(values)):
             raise RuntimeError(
                 "insert records of one device error: times, measurementsList and valuesList's size should be equal!"
             )
-        request = self.gen_insert_string_records_of_one_device_request(device_id, times, measurements_list, values,
-                                                                       have_sorted, True)
+        request = self.gen_insert_string_records_of_one_device_request(
+            device_id, times, measurements_list, values, have_sorted, True
+        )
         status = self.__client.insertStringRecordsOfOneDevice(request)
         logger.debug(
-            "insert one device {} message: {}".format(
-                device_id, status.message
-            )
+            "insert one device {} message: {}".format(device_id, status.message)
         )
 
         return Session.verify_success(status)
 
     def gen_insert_string_records_of_one_device_request(
-            self, device_id, times, measurements_list, values_list, have_sorted, is_aligned=False
+        self,
+        device_id,
+        times,
+        measurements_list,
+        values_list,
+        have_sorted,
+        is_aligned=False,
     ):
         if (len(times) != len(measurements_list)) or (len(times) != len(values_list)):
             raise RuntimeError(
@@ -1106,13 +1139,15 @@ class Session(object):
             )
         if not Session.check_sorted(times):
             # sort by timestamp
-            sorted_zipped = sorted(
-                zip(times, measurements_list, values_list)
-            )
+            sorted_zipped = sorted(zip(times, measurements_list, values_list))
             result = zip(*sorted_zipped)
-            times_list, measurements_list, values_list = [
-                list(x) for x in result
-            ]
-        request = TSInsertStringRecordsOfOneDeviceReq(self.__session_id, device_id, measurements_list, values_list,
-                                                      times, is_aligned)
+            times_list, measurements_list, values_list = [list(x) for x in result]
+        request = TSInsertStringRecordsOfOneDeviceReq(
+            self.__session_id,
+            device_id,
+            measurements_list,
+            values_list,
+            times,
+            is_aligned,
+        )
         return request

--- a/client-py/iotdb/Session.py
+++ b/client-py/iotdb/Session.py
@@ -40,7 +40,8 @@ from .thrift.rpc.TSIService import (
     TSInsertRecordsReq,
     TSInsertRecordsOfOneDeviceReq,
 )
-from .thrift.rpc.ttypes import TSDeleteDataReq, TSProtocolVersion, TSSetTimeZoneReq
+from .thrift.rpc.ttypes import TSDeleteDataReq, TSProtocolVersion, TSSetTimeZoneReq, TSRawDataQueryReq, \
+    TSLastDataQueryReq, TSInsertStringRecordsOfOneDeviceReq
 
 # for debug
 # from IoTDBConstants import *
@@ -66,13 +67,13 @@ class Session(object):
     DEFAULT_ZONE_ID = time.strftime("%z")
 
     def __init__(
-        self,
-        host,
-        port,
-        user=DEFAULT_USER,
-        password=DEFAULT_PASSWORD,
-        fetch_size=DEFAULT_FETCH_SIZE,
-        zone_id=DEFAULT_ZONE_ID,
+            self,
+            host,
+            port,
+            user=DEFAULT_USER,
+            password=DEFAULT_PASSWORD,
+            fetch_size=DEFAULT_FETCH_SIZE,
+            zone_id=DEFAULT_ZONE_ID,
     ):
         self.__host = host
         self.__port = port
@@ -194,15 +195,15 @@ class Session(object):
         return Session.verify_success(status)
 
     def create_time_series(
-        self,
-        ts_path,
-        data_type,
-        encoding,
-        compressor,
-        props=None,
-        tags=None,
-        attributes=None,
-        alias=None,
+            self,
+            ts_path,
+            data_type,
+            encoding,
+            compressor,
+            props=None,
+            tags=None,
+            attributes=None,
+            alias=None,
     ):
         """
         create single time series
@@ -237,7 +238,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def create_aligned_time_series(
-        self, device_id, measurements_lst, data_type_lst, encoding_lst, compressor_lst
+            self, device_id, measurements_lst, data_type_lst, encoding_lst, compressor_lst
     ):
         """
         create aligned time series
@@ -269,15 +270,15 @@ class Session(object):
         return Session.verify_success(status)
 
     def create_multi_time_series(
-        self,
-        ts_path_lst,
-        data_type_lst,
-        encoding_lst,
-        compressor_lst,
-        props_lst=None,
-        tags_lst=None,
-        attributes_lst=None,
-        alias_lst=None,
+            self,
+            ts_path_lst,
+            data_type_lst,
+            encoding_lst,
+            compressor_lst,
+            props_lst=None,
+            tags_lst=None,
+            attributes_lst=None,
+            alias_lst=None,
     ):
         """
         create multiple time series
@@ -374,7 +375,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_aligned_str_record(
-        self, device_id, timestamp, measurements, string_values
+            self, device_id, timestamp, measurements, string_values
     ):
         """special case for inserting one row of String (TEXT) value"""
         if type(string_values) == str:
@@ -420,7 +421,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_records(
-        self, device_ids, times, measurements_lst, types_lst, values_lst
+            self, device_ids, times, measurements_lst, types_lst, values_lst
     ):
         """
         insert multiple rows of data, records are independent to each other, in other words, there's no relationship
@@ -448,7 +449,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_aligned_record(
-        self, device_id, timestamp, measurements, data_types, values
+            self, device_id, timestamp, measurements, data_types, values
     ):
         """
         insert one row of aligned record into database, if you want improve your performance, please use insertTablet method
@@ -475,7 +476,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_aligned_records(
-        self, device_ids, times, measurements_lst, types_lst, values_lst
+            self, device_ids, times, measurements_lst, types_lst, values_lst
     ):
         """
         insert multiple aligned rows of data, records are independent to each other, in other words, there's no relationship
@@ -503,7 +504,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def test_insert_record(
-        self, device_id, timestamp, measurements, data_types, values
+            self, device_id, timestamp, measurements, data_types, values
     ):
         """
         this method NOT insert data into database and the server just return after accept the request, this method
@@ -528,7 +529,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def test_insert_records(
-        self, device_ids, times, measurements_lst, types_lst, values_lst
+            self, device_ids, times, measurements_lst, types_lst, values_lst
     ):
         """
         this method NOT insert data into database and the server just return after accept the request, this method
@@ -554,7 +555,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def gen_insert_record_req(
-        self, device_id, timestamp, measurements, data_types, values, is_aligned=False
+            self, device_id, timestamp, measurements, data_types, values, is_aligned=False
     ):
         if (len(values) != len(data_types)) or (len(values) != len(measurements)):
             raise RuntimeError(
@@ -571,7 +572,7 @@ class Session(object):
         )
 
     def gen_insert_str_record_req(
-        self, device_id, timestamp, measurements, data_types, values, is_aligned=False
+            self, device_id, timestamp, measurements, data_types, values, is_aligned=False
     ):
         if (len(values) != len(data_types)) or (len(values) != len(measurements)):
             raise RuntimeError(
@@ -582,19 +583,19 @@ class Session(object):
         )
 
     def gen_insert_records_req(
-        self,
-        device_ids,
-        times,
-        measurements_lst,
-        types_lst,
-        values_lst,
-        is_aligned=False,
+            self,
+            device_ids,
+            times,
+            measurements_lst,
+            types_lst,
+            values_lst,
+            is_aligned=False,
     ):
         if (
-            (len(device_ids) != len(measurements_lst))
-            or (len(times) != len(types_lst))
-            or (len(device_ids) != len(times))
-            or (len(times) != len(values_lst))
+                (len(device_ids) != len(measurements_lst))
+                or (len(times) != len(types_lst))
+                or (len(device_ids) != len(times))
+                or (len(times) != len(values_lst))
         ):
             raise RuntimeError(
                 "deviceIds, times, measurementsList and valuesList's size should be equal"
@@ -602,7 +603,7 @@ class Session(object):
 
         value_lst = []
         for values, data_types, measurements in zip(
-            values_lst, types_lst, measurements_lst
+                values_lst, types_lst, measurements_lst
         ):
             if (len(values) != len(data_types)) or (len(values) != len(measurements)):
                 raise RuntimeError(
@@ -685,7 +686,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_records_of_one_device(
-        self, device_id, times_list, measurements_list, types_list, values_list
+            self, device_id, times_list, measurements_list, types_list, values_list
     ):
         # sort by timestamp
         sorted_zipped = sorted(
@@ -701,7 +702,7 @@ class Session(object):
         )
 
     def insert_records_of_one_device_sorted(
-        self, device_id, times_list, measurements_list, types_list, values_list
+            self, device_id, times_list, measurements_list, types_list, values_list
     ):
         """
         Insert multiple rows, which can reduce the overhead of network. This method is just like jdbc
@@ -718,9 +719,9 @@ class Session(object):
         # check parameter
         size = len(times_list)
         if (
-            size != len(measurements_list)
-            or size != len(types_list)
-            or size != len(values_list)
+                size != len(measurements_list)
+                or size != len(types_list)
+                or size != len(values_list)
         ):
             raise RuntimeError(
                 "insert records of one device error: types, times, measurementsList and valuesList's size should be equal"
@@ -743,7 +744,7 @@ class Session(object):
         return Session.verify_success(status)
 
     def insert_aligned_records_of_one_device(
-        self, device_id, times_list, measurements_list, types_list, values_list
+            self, device_id, times_list, measurements_list, types_list, values_list
     ):
         # sort by timestamp
         sorted_zipped = sorted(
@@ -759,7 +760,7 @@ class Session(object):
         )
 
     def insert_aligned_records_of_one_device_sorted(
-        self, device_id, times_list, measurements_list, types_list, values_list
+            self, device_id, times_list, measurements_list, types_list, values_list
     ):
         """
         Insert multiple aligned rows, which can reduce the overhead of network. This method is just like jdbc
@@ -775,9 +776,9 @@ class Session(object):
         # check parameter
         size = len(times_list)
         if (
-            size != len(measurements_list)
-            or size != len(types_list)
-            or size != len(values_list)
+                size != len(measurements_list)
+                or size != len(types_list)
+                or size != len(values_list)
         ):
             raise RuntimeError(
                 "insert records of one device error: types, times, measurementsList and valuesList's size should be equal"
@@ -800,17 +801,17 @@ class Session(object):
         return Session.verify_success(status)
 
     def gen_insert_records_of_one_device_request(
-        self,
-        device_id,
-        times_list,
-        measurements_list,
-        values_list,
-        types_list,
-        is_aligned=False,
+            self,
+            device_id,
+            times_list,
+            measurements_list,
+            values_list,
+            types_list,
+            is_aligned=False,
     ):
         binary_value_list = []
         for values, data_types, measurements in zip(
-            values_list, types_list, measurements_list
+                values_list, types_list, measurements_list
         ):
             data_types = [data_type.value for data_type in data_types]
             if (len(values) != len(data_types)) or (len(values) != len(measurements)):
@@ -1023,3 +1024,95 @@ class Session(object):
 
         logger.error("error status is", status)
         return -1
+
+    def execute_raw_data_query(self, paths: list, start_time: int, end_time: int) -> SessionDataSet:
+        request = TSRawDataQueryReq(self.__session_id, paths, self.__fetch_size, startTime=start_time, endTime=end_time,
+                                    statementId=self.__statement_id, enableRedirectQuery=False)
+        resp = self.__client.executeRawDataQuery(request)
+        return SessionDataSet(
+            "",
+            resp.columns,
+            resp.dataTypeList,
+            resp.columnNameIndexMap,
+            resp.queryId,
+            self.__client,
+            self.__statement_id,
+            self.__session_id,
+            resp.queryDataSet,
+            resp.ignoreTimeStamp,
+        )
+
+    def execute_last_data_query(self, paths: list, last_time: int) -> SessionDataSet:
+        request = TSLastDataQueryReq(
+            self.__session_id, paths, self.__fetch_size, last_time, self.__statement_id, enableRedirectQuery=False
+        )
+
+        resp = self.__client.executeLastDataQuery(request)
+        return SessionDataSet(
+            "",
+            resp.columns,
+            resp.dataTypeList,
+            resp.columnNameIndexMap,
+            resp.queryId,
+            self.__client,
+            self.__statement_id,
+            self.__session_id,
+            resp.queryDataSet,
+            resp.ignoreTimeStamp,
+        )
+
+    def insert_string_records_of_one_device(
+            self, device_id: str, times: list, measurements_list: list, values_list: list, have_sorted: bool = False
+    ):
+        if (len(times) != len(measurements_list)) or (len(times) != len(values_list)):
+            raise RuntimeError(
+                "insert records of one device error: times, measurementsList and valuesList's size should be equal!"
+            )
+        request = self.gen_insert_string_records_of_one_device_request(device_id, times, measurements_list, values_list,
+                                                                       have_sorted, False)
+        status = self.__client.insertStringRecordsOfOneDevice(request)
+        logger.debug(
+            "insert one device {} message: {}".format(
+                device_id, status.message
+            )
+        )
+
+        return Session.verify_success(status)
+
+    def insert_aligned_string_records_of_one_device(
+            self, device_id: str, times: list, measurements_list: list, values: list, have_sorted: bool = False
+    ):
+        if (len(times) != len(measurements_list)) or (len(times) != len(values)):
+            raise RuntimeError(
+                "insert records of one device error: times, measurementsList and valuesList's size should be equal!"
+            )
+        request = self.gen_insert_string_records_of_one_device_request(device_id, times, measurements_list, values,
+                                                                       have_sorted, True)
+        status = self.__client.insertStringRecordsOfOneDevice(request)
+        logger.debug(
+            "insert one device {} message: {}".format(
+                device_id, status.message
+            )
+        )
+
+        return Session.verify_success(status)
+
+    def gen_insert_string_records_of_one_device_request(
+            self, device_id, times, measurements_list, values_list, have_sorted, is_aligned=False
+    ):
+        if (len(times) != len(measurements_list)) or (len(times) != len(values_list)):
+            raise RuntimeError(
+                "insert records of one device error: times, measurementsList and valuesList's size should be equal!"
+            )
+        if not Session.check_sorted(times):
+            # sort by timestamp
+            sorted_zipped = sorted(
+                zip(times, measurements_list, values_list)
+            )
+            result = zip(*sorted_zipped)
+            times_list, measurements_list, values_list = [
+                list(x) for x in result
+            ]
+        request = TSInsertStringRecordsOfOneDeviceReq(self.__session_id, device_id, measurements_list, values_list,
+                                                      times, is_aligned)
+        return request

--- a/client-py/tests/tablet_performance_comparison.py
+++ b/client-py/tests/tablet_performance_comparison.py
@@ -75,9 +75,9 @@ def generate_csv_data(
         if _type == TSDataType.BOOLEAN:
             return [random.randint(0, 1) == 1 for _ in range(_row)]
         elif _type == TSDataType.INT32:
-            return [random.randint(-(2**31), 2**31) for _ in range(_row)]
+            return [random.randint(-(2 ** 31), 2 ** 31) for _ in range(_row)]
         elif _type == TSDataType.INT64:
-            return [random.randint(-(2**63), 2**63) for _ in range(_row)]
+            return [random.randint(-(2 ** 63), 2 ** 63) for _ in range(_row)]
         elif _type == TSDataType.FLOAT:
             return [1.5 for _ in range(_row)]
         elif _type == TSDataType.DOUBLE:

--- a/client-py/tests/test_one_device.py
+++ b/client-py/tests/test_one_device.py
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Uncomment the following line to use apache-iotdb module installed by pip3
+
+from iotdb.Session import Session
+from iotdb.IoTDBContainer import IoTDBContainer
+
+# whether the test has passed
+final_flag = True
+failed_count = 0
+
+
+def test_fail():
+    global failed_count
+    global final_flag
+    final_flag = False
+    failed_count += 1
+
+
+def print_message(message):
+    print("*********")
+    print(message)
+    print("*********")
+
+
+def test_one_device():
+    with IoTDBContainer("iotdb:dev") as db:
+        db: IoTDBContainer
+        session = Session(db.get_container_host_ip(), db.get_exposed_port(6667))
+        session.open(False)
+
+        if not session.is_open():
+            print("can't open session")
+            exit(1)
+
+        # insert string records of one device
+        time_list = [1, 2, 3]
+        measurements_list = [
+            ["s_01", "s_02", "s_03"],
+            ["s_01", "s_02", "s_03"],
+            ["s_01", "s_02", "s_03"],
+        ]
+        values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
+
+        if (
+                session.insert_string_records_of_one_device(
+                    "root.str_test_01.d_01",
+                    time_list,
+                    measurements_list,
+                    values_list,
+                )
+                < 0
+        ):
+            test_fail()
+            print_message("insert string records of one device failed")
+
+        # insert aligned string record into the database.
+        time_list = [1, 2, 3]
+        measurements_list = [
+            ["s_01", "s_02", "s_03"],
+            ["s_01", "s_02", "s_03"],
+            ["s_01", "s_02", "s_03"],
+        ]
+        values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
+
+        if (
+                session.insert_aligned_string_records_of_one_device(
+                    "root.str_test_01.d_02",
+                    time_list,
+                    measurements_list,
+                    values_list,
+                )
+                < 0
+        ):
+            test_fail()
+            print_message("insert aligned record of one device failed")
+
+        # execute raw data query sql statement
+        session_data_set = session.execute_raw_data_query(
+            ["root.str_test_01.d_02.s_01", "root.str_test_01.d_02.s_02"], 1, 4
+        )
+        session_data_set.set_fetch_size(1024)
+        expect_count = 3
+        actual_count = 0
+        while session_data_set.has_next():
+            print(session_data_set.next())
+            actual_count += 1
+        session_data_set.close_operation_handle()
+
+        if actual_count != expect_count:
+            test_fail()
+            print_message(
+                "query count mismatch: expect count: "
+                + str(expect_count)
+                + " actual count: "
+                + str(actual_count)
+            )
+        assert actual_count == expect_count
+
+        # execute last data query sql statement
+        session_data_set = session.execute_last_data_query(
+            ["root.str_test_01.d_02.s_01", "root.str_test_01.d_02.s_02"], 0
+        )
+        session_data_set.set_fetch_size(1024)
+        expect_time = 3
+        actual_time = session_data_set.next().get_timestamp()
+        session_data_set.close_operation_handle()
+
+        if actual_time != expect_time:
+            test_fail()
+            print_message(
+                "query count mismatch: expect count: "
+                + str(expect_time)
+                + " actual count: "
+                + str(actual_time)
+            )
+        assert actual_time == expect_time
+
+        # close session connection.
+        session.close()
+
+
+if final_flag:
+    print("All executions done!!")
+else:
+    print("Some test failed, please have a check")
+    print("failed count: ", failed_count)
+    exit(1)

--- a/client-py/tests/test_one_device.py
+++ b/client-py/tests/test_one_device.py
@@ -56,16 +56,20 @@ def test_one_device():
             ["s_01", "s_02", "s_03"],
             ["s_01", "s_02", "s_03"],
         ]
-        values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
+        values_list = [
+            ["False", "22", "33"],
+            ["True", "1", "23"],
+            ["False", "15", "26"],
+        ]
 
         if (
-                session.insert_string_records_of_one_device(
-                    "root.str_test_01.d_01",
-                    time_list,
-                    measurements_list,
-                    values_list,
-                )
-                < 0
+            session.insert_string_records_of_one_device(
+                "root.str_test_01.d_01",
+                time_list,
+                measurements_list,
+                values_list,
+            )
+            < 0
         ):
             test_fail()
             print_message("insert string records of one device failed")
@@ -77,16 +81,20 @@ def test_one_device():
             ["s_01", "s_02", "s_03"],
             ["s_01", "s_02", "s_03"],
         ]
-        values_list = [["False", "22", "33"], ["True", "1", "23"], ["False", "15", "26"]]
+        values_list = [
+            ["False", "22", "33"],
+            ["True", "1", "23"],
+            ["False", "15", "26"],
+        ]
 
         if (
-                session.insert_aligned_string_records_of_one_device(
-                    "root.str_test_01.d_02",
-                    time_list,
-                    measurements_list,
-                    values_list,
-                )
-                < 0
+            session.insert_aligned_string_records_of_one_device(
+                "root.str_test_01.d_02",
+                time_list,
+                measurements_list,
+                values_list,
+            )
+            < 0
         ):
             test_fail()
             print_message("insert aligned record of one device failed")


### PR DESCRIPTION
[IOTDB-3033](https://issues.apache.org/jira/browse/IOTDB-3033)
Add a one device string insert interface; 
one device insert aligned string interface;
an interface for querying data by time, 
and an interface for querying the latest time.

Submit unit test script.
Submit a python client interface example.
In python, the query and insert interface is completed.

In the second commit, reformat code by black and flake8