### PR TITLE
[IOTDB-3030] delete storage group with ** error

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBDeleteStorageGroupIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBDeleteStorageGroupIT.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.itbase.category.RemoteTest;
 import org.apache.iotdb.jdbc.IoTDBSQLException;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -178,6 +179,29 @@ public class IoTDBDeleteStorageGroupIT {
         }
       }
       assertEquals(1, count);
+    }
+  }
+
+  @Test
+  public void testSelectIntoAndDeleteStorageGroup() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          "create schema template t1 (temperature FLOAT encoding=RLE, status BOOLEAN encoding=PLAIN compression=SNAPPY)");
+      statement.execute("set schema template t1 to root.sg1.d1;");
+      statement.execute("create timeseries of schema template on root.sg1.d1;");
+      statement.execute("show timeseries root.sg1.**;");
+      statement.execute("show devices root.sg1.**;");
+      statement.execute("insert into root.sg1.d1(time, temperature, status) values(1, 1, TRUE);");
+      statement.execute(
+          "insert into root.sg1.d1(time, temperature, status) values(2, 2, FALSE), (3, 3, TRUE);");
+      statement.execute("select temperature into h1 from root.sg1.**;");
+      statement.execute("select temperature,h1 from root.sg1.**;");
+      statement.execute("show schema templates;");
+      statement.execute("delete storage group root.**;");
+      statement.execute("drop schema template t1;");
+    } catch (Exception e) {
+      Assert.fail();
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
@@ -233,8 +233,11 @@ public class LocalConfigNode {
   public void deleteStorageGroup(PartialPath storageGroup) throws MetadataException {
 
     DeleteTimeSeriesPlan deleteTimeSeriesPlan =
-        SchemaSyncManager.getInstance()
-            .splitDeleteTimeseriesPlanByDevice(storageGroup.concatNode(MULTI_LEVEL_PATH_WILDCARD));
+        SchemaSyncManager.getInstance().isEnableSync()
+            ? SchemaSyncManager.getInstance()
+                .splitDeleteTimeseriesPlanByDevice(
+                    storageGroup.concatNode(MULTI_LEVEL_PATH_WILDCARD))
+            : null;
 
     deleteSchemaRegionsInStorageGroup(
         storageGroup, schemaPartitionTable.getSchemaRegionIdsByStorageGroup(storageGroup));


### PR DESCRIPTION
problem:
When disable sync, we still splitDeleteTimeseriesPlanByDevice in delete storage group, this is not needed.

solution:
Only splitDeleteTimeseriesPlanByDevice in delete storage group when sync is enabled.