### PR TITLE
[IOTDB-2803] support AlterTimeseries sql

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/write/AlterTimeSeriesNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/write/AlterTimeSeriesNode.java
@@ -21,13 +21,17 @@ package org.apache.iotdb.db.mpp.sql.planner.plan.node.metedata.write;
 
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.mpp.sql.analyze.Analysis;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanNodeType;
 import org.apache.iotdb.db.mpp.sql.planner.plan.node.PlanVisitor;
+import org.apache.iotdb.db.mpp.sql.planner.plan.node.WritePlanNode;
 import org.apache.iotdb.db.mpp.sql.statement.metadata.AlterTimeSeriesStatement.AlterType;
 import org.apache.iotdb.tsfile.exception.NotImplementedException;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import com.google.common.collect.ImmutableList;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -35,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class AlterTimeSeriesNode extends PlanNode {
+public class AlterTimeSeriesNode extends WritePlanNode {
   private PartialPath path;
   private AlterType alterType;
 
@@ -52,6 +56,8 @@ public class AlterTimeSeriesNode extends PlanNode {
 
   private Map<String, String> tagsMap;
   private Map<String, String> attributesMap;
+
+  private TRegionReplicaSet regionReplicaSet;
 
   public AlterTimeSeriesNode(
       PlanNodeId id,
@@ -269,5 +275,22 @@ public class AlterTimeSeriesNode extends PlanNode {
   public int hashCode() {
     return Objects.hash(
         this.getPlanNodeId(), path, alias, alterType, alterMap, attributesMap, tagsMap);
+  }
+
+  @Override
+  public TRegionReplicaSet getRegionReplicaSet() {
+    return regionReplicaSet;
+  }
+
+  public void setRegionReplicaSet(TRegionReplicaSet regionReplicaSet) {
+    this.regionReplicaSet = regionReplicaSet;
+  }
+
+  @Override
+  public List<WritePlanNode> splitByPartition(Analysis analysis) {
+    TRegionReplicaSet regionReplicaSet =
+        analysis.getSchemaPartitionInfo().getSchemaRegionReplicaSet(path.getDevice());
+    setRegionReplicaSet(regionReplicaSet);
+    return ImmutableList.of(this);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/write/AlterTimeSeriesNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/write/AlterTimeSeriesNode.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.mpp.sql.planner.plan.node.metedata.write;
 
+import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.mpp.sql.analyze.Analysis;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/write/CreateAlignedTimeSeriesNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/sql/planner/plan/node/metedata/write/CreateAlignedTimeSeriesNode.java
@@ -376,11 +376,4 @@ public class CreateAlignedTimeSeriesNode extends WritePlanNode {
     setRegionReplicaSet(regionReplicaSet);
     return ImmutableList.of(this);
   }
-
-  //  @Override
-  //  public void executeOn(SchemaRegion schemaRegion) throws MetadataException {
-  //    schemaRegion.createAlignedTimeSeries((CreateAlignedTimeSeriesPlan)
-  // transferToPhysicalPlan());
-  //  }
-
 }


### PR DESCRIPTION
## Description
1 config node 1 datanode mode:
Do as the IoTDB User Guide:
![image](https://user-images.githubusercontent.com/17932988/165908342-15600b76-1847-4831-aac0-b2fb4deb7e04.png)
![image](https://user-images.githubusercontent.com/17932988/165908446-f6064b8a-0ee8-44c1-8fa2-27bdb390551f.png)

![image](https://user-images.githubusercontent.com/17932988/165909255-7bd553b1-fee0-4774-9d9b-ad050c7e509f.png)

All look good!

