### PR TITLE
[IOTDB-3049]Sync Sender loss data when restart IoTDB with data in working memtable

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -690,6 +690,9 @@ public class DataRegion {
     TsFileResource tsFileResource = recoverPerformer.getTsFileResource();
     if (!recoverPerformer.canWrite()) {
       // cannot write, just close it
+      if (tsFileSyncManager.isEnableSync()) {
+        tsFileSyncManager.collectRealTimeTsFile(tsFileResource.getTsFile());
+      }
       try {
         tsFileResource.close();
       } catch (IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
@@ -397,7 +397,7 @@ public class TsFileManager {
         isRealTimeTsFile = tsFileProcessor.isMemtableNotNull();
       }
       File tsFile = tsFileResource.getTsFile();
-      if (!isRealTimeTsFile && !syncManager.isTsFileAlreadyBeCollected(tsFile)) {
+      if (!isRealTimeTsFile) {
         File mods = new File(tsFileResource.getModFile().getFilePath());
         long modsOffset = mods.exists() ? mods.length() : 0L;
         File hardlink = syncManager.createHardlink(tsFile, modsOffset);

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/TsFilePipe.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/TsFilePipe.java
@@ -174,13 +174,20 @@ public class TsFilePipe implements Pipe {
   }
 
   public File createHistoryTsFileHardlink(File tsFile, long modsOffset) {
+    collectRealTimeDataLock.lock(); // synchronize the pipeLog.isHardlinkExist
     try {
+      if (pipeLog.isHardlinkExist(tsFile)) {
+        return null;
+      }
+
       return pipeLog.createTsFileAndModsHardlink(tsFile, modsOffset);
     } catch (IOException e) {
       logger.error(
           String.format("Create hardlink for history tsfile %s error.", tsFile.getPath()), e);
+      return null;
+    } finally {
+      collectRealTimeDataLock.unlock();
     }
-    return null;
   }
 
   public void collectRealTimeDeletion(Deletion deletion) {
@@ -212,6 +219,10 @@ public class TsFilePipe implements Pipe {
   public void collectRealTimeTsFile(File tsFile) {
     collectRealTimeDataLock.lock();
     try {
+      if (pipeLog.isHardlinkExist(tsFile)) {
+        return;
+      }
+
       maxSerialNumber += 1L;
       File hardlink = pipeLog.createTsFileHardlink(tsFile);
       PipeData tsFileData =

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/recovery/TsFilePipeLogger.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/recovery/TsFilePipeLogger.java
@@ -49,6 +49,11 @@ public class TsFilePipeLogger {
     tsFileDir = SyncPathUtil.getSenderFileDataDir(tsFilePipe.getName(), tsFilePipe.getCreateTime());
   }
 
+  public boolean isHardlinkExist(File tsFile) {
+    File link = new File(tsFileDir, getRelativeFilePath(tsFile));
+    return link.exists();
+  }
+
   /** make hard link for tsfile * */
   public File createTsFileAndModsHardlink(File tsFile, long modsOffset) throws IOException {
     File mods = new File(tsFile.getPath() + ModificationFile.FILE_SUFFIX);


### PR DESCRIPTION
problem:
  Data loss happens when sender shutdowns with data in working memtable.
  When restarting IoTDB, WAL will restore all data in unsealed tsfile and close it, but this tsfile is not collected by running pipe.

solution:
  add TsfFileSyncManager#collectRealTimeTsFile in DataRegion#callbackAfterUnsealedTsFileRecovered
  add TsFilePipeLogger#isHardlinkExist to judge if the tsfile hardlink is created or not, and simplified the process of collecting history tsfile.
  add IT