### PR TITLE
[IOTDB-3075] RatisConsensus UUID bugfix

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
@@ -69,6 +69,10 @@ public class Utils {
           groupType = PartitionRegionType;
           break;
         }
+      default:
+      {
+        return -1;
+      }
     }
     long groupCode = groupType << 32;
     groupCode += (long) consensusGroupId.getId();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
@@ -70,9 +70,9 @@ public class Utils {
           break;
         }
       default:
-      {
-        return -1;
-      }
+        {
+          return -1;
+        }
     }
     long groupCode = groupType << 32;
     groupCode += (long) consensusGroupId.getId();


### PR DESCRIPTION
## Description
Currently in Ratis, it requires 16-bytes-long ByteString as the unique RaftGroupID of a consensus raft group. However, internally Ratis extracts and only uses 6 bytes of the given RaftGroupID. In current group id encoding schema, we may encounter the situation where two 16bytes-id differ while there underlying 6bytes-id equals. Thus we need to reverse engineer and encode the total group information into 6bytes, uniquely.
