### PR TITLE
[IOTDB-3078]upgrade spotless and code format version. Add instruction for spotles…

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,20 @@ and "`antlr/target/generated-sources/antlr4`" need to be added to sources roots 
 **In IDEA, you just need to right click on the root project name and choose "`Maven->Reload Project`" after 
 you run `mvn package` successfully.**
 
+#### Spotless problem
+**NOTE**: IF you are using JDK16+, you have to create a file called `jvm.config`,
+put it under `.mvn/`, before you use `spotless:apply`. The file contains the following content:
+```
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+```
+
+This is [an issue of Spotless](https://github.com/diffplug/spotless/issues/834),
+Once the issue is fixed, we can remove this file.
+
 ### Configurations
 
 configuration files are under "conf" folder

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -161,6 +161,19 @@ git checkout vx.x.x
 
 **IDEA的操作方法：在上述maven命令编译好后，右键项目名称，选择"`Maven->Reload project`"，即可。**
 
+#### Spotless问题（JDK16+）
+**NOTE**: 如果你在使用 JDK16+, 并且要做`spotless:apply`或者`spotless:check`，
+那么需要在`.mvn/`文件夹下创建一个文件 `jvm.config`, 内容如下:
+```
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+```
+这是spotless依赖的googlecodeformat的 [问题](https://github.com/diffplug/spotless/issues/834),
+近期可能会被官方解决。
+
 ### 配置
 
 配置文件在"conf"文件夹下

--- a/docs/Development/ContributeGuide.md
+++ b/docs/Development/ContributeGuide.md
@@ -101,9 +101,8 @@ Precautions:
 We use the [Spotless
 plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) together with [google-java-format](https://github.com/google/google-java-format) to format our Java code. You can configure your IDE to automatically apply formatting on saving with these steps(Take idea as an example):
 
-1. Download the [google-java-format
-   plugin v1.15.0.0](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/161816) (JDK1.8 needs [google-java-format
-   plugin v1.7.0.5](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/83169)), it can be installed in IDEA (Preferences -> plugins -> search google-java-format), [More detailed setup manual](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides)
+1. Download the  [google-java-format
+   plugin v1.7.0.5](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/83169), it can be installed in IDEA (Preferences -> plugins -> search google-java-format), [More detailed setup manual](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides)
 2. Install the plugin from disk (Plugins -> little gear icon -> "Install plugin from disk" -> Navigate to downloaded zip file)
 3. In the plugin settings, enable the plugin and keep the default Google code style (2-space indents)
 4. Remember to never update this plugin to a later version，until Spotless was upgraded to version 1.8+.

--- a/docs/Development/ContributeGuide.md
+++ b/docs/Development/ContributeGuide.md
@@ -102,7 +102,8 @@ We use the [Spotless
 plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) together with [google-java-format](https://github.com/google/google-java-format) to format our Java code. You can configure your IDE to automatically apply formatting on saving with these steps(Take idea as an example):
 
 1. Download the [google-java-format
-   plugin v1.15.0.0](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/161816), it can be installed in IDEA (Preferences -> plugins -> search google-java-format), [More detailed setup manual](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides)
+   plugin v1.15.0.0](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/161816) (JDK1.8 needs [google-java-format
+   plugin v1.7.0.5](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/83169)), it can be installed in IDEA (Preferences -> plugins -> search google-java-format), [More detailed setup manual](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides)
 2. Install the plugin from disk (Plugins -> little gear icon -> "Install plugin from disk" -> Navigate to downloaded zip file)
 3. In the plugin settings, enable the plugin and keep the default Google code style (2-space indents)
 4. Remember to never update this plugin to a later version，until Spotless was upgraded to version 1.8+.

--- a/docs/Development/ContributeGuide.md
+++ b/docs/Development/ContributeGuide.md
@@ -102,7 +102,7 @@ We use the [Spotless
 plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) together with [google-java-format](https://github.com/google/google-java-format) to format our Java code. You can configure your IDE to automatically apply formatting on saving with these steps(Take idea as an example):
 
 1. Download the [google-java-format
-   plugin v1.7.0.5](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/83169), it can be installed in IDEA (Preferences -> plugins -> search google-java-format), [More detailed setup manual](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides)
+   plugin v1.15.0.0](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/161816), it can be installed in IDEA (Preferences -> plugins -> search google-java-format), [More detailed setup manual](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides)
 2. Install the plugin from disk (Plugins -> little gear icon -> "Install plugin from disk" -> Navigate to downloaded zip file)
 3. In the plugin settings, enable the plugin and keep the default Google code style (2-space indents)
 4. Remember to never update this plugin to a later version，until Spotless was upgraded to version 1.8+.
@@ -119,6 +119,22 @@ plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) together wi
    <blank line>
    import static all other imports
 ```
+8. Before you submit codes, you can use `mvn spotless:check` to check your codes manually,
+and use `mvn spotless:apply` to format your codes.
+
+**NOTICE (if you are using JDK16+)**: IF you are using JDK16+, you have to create a file called 
+`jvm.config`, put it under `.mvn/`, before you use `spotless:apply`. 
+The file contains the following content:
+```
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+```
+
+This is [an issue of Spotless](https://github.com/diffplug/spotless/issues/834),
+Once the issue is fixed, we can remove this file.
 
 ## Code Sytle
 We use the [maven-checkstyle-plugin](https://checkstyle.sourceforge.io/config_filefilters.html) to make Java codes obey a consistent ruleset defined in [checkstyle.xml](https://github.com/apache/iotdb/blob/master/checkstyle.xml) under the project root.

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,8 @@
         <swagger.core.version>1.5.18</swagger.core.version>
         <servlet.api.version>2.5</servlet.api.version>
         <openapi.generator.version>5.0.0</openapi.generator.version>
+        <!-- JDK1.8 only support google java format 1.7-->
+        <google.java.format.version>1.7</google.java.format.version>
     </properties>
     <!--
         if we claim dependencies in dependencyManagement, then we do not claim
@@ -714,7 +716,7 @@
                     <configuration>
                         <java>
                             <googleJavaFormat>
-                                <version>1.15.0</version>
+                                <version>${google.java.format.version}</version>
                                 <style>GOOGLE</style>
                             </googleJavaFormat>
                             <importOrder>
@@ -1145,6 +1147,7 @@
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>
+                <google.java.format.version>1.15.0</google.java.format.version>
             </properties>
             <dependencies>
                 <!-- for jdk-11 -->

--- a/pom.xml
+++ b/pom.xml
@@ -1177,8 +1177,7 @@
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>
-                <!-- the following command does not work for fix spotless problem. can be deleted once the spotless problem is finally fixed.-->
-<!--                <argLine>&#45;&#45;illegal-access=permit &#45;&#45;add-opens=java.base/java.util.concurrent=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.lang=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.util=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.nio=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.io=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.net=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>-->
+                <argLine>--illegal-access=permit --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
             </properties>
         </profile>
         <!--
@@ -1498,7 +1497,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>@{surefire.jacoco.args} -Xmx1024m</argLine>
+                            <argLine>${argLine} @{surefire.jacoco.args} -Xmx1024m</argLine>
                         </configuration>
                     </plugin>
                     <!-- for IT-->
@@ -1506,7 +1505,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <argLine>@{failsafe.jacoco.args} -Xmx1024m</argLine>
+                            <argLine>${argLine} @{failsafe.jacoco.args} -Xmx1024m</argLine>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <client-cpp>false</client-cpp>
         <!-- disable enforcer by default-->
         <enforcer.skip>true</enforcer.skip>
-        <spotless.version>2.4.2</spotless.version>
+        <spotless.version>2.22.3</spotless.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
         <!-- for REST service -->
@@ -714,7 +714,7 @@
                     <configuration>
                         <java>
                             <googleJavaFormat>
-                                <version>1.7</version>
+                                <version>1.15.0</version>
                                 <style>GOOGLE</style>
                             </googleJavaFormat>
                             <importOrder>
@@ -1172,7 +1172,8 @@
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>
-                <argLine>--illegal-access=permit --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
+                <!-- the following command does not work for fix spotless problem. can be deleted once the spotless problem is finally fixed.-->
+<!--                <argLine>&#45;&#45;illegal-access=permit &#45;&#45;add-opens=java.base/java.util.concurrent=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.lang=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.util=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.nio=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.io=ALL-UNNAMED &#45;&#45;add-opens=java.base/java.net=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED &#45;&#45;add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>-->
             </properties>
         </profile>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1147,7 +1147,9 @@
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>
-                <google.java.format.version>1.15.0</google.java.format.version>
+                <!-- change to 1.15.0 will modify many codes (all are javadocs), we change it to 1.15.0
+                until: 1. spotless + jdk16 is fixed; and 2. iotdb decides to do not support jdk8-->
+                <google.java.format.version>1.7</google.java.format.version>
             </properties>
             <dependencies>
                 <!-- for jdk-11 -->


### PR DESCRIPTION
When using JDK17 to run spotless plugin, there will be errors:
```
 Execution default-cli of goal com.diffplug.spotless:spotless-maven-plugin:2.22.3:apply failed: java.lang.reflect.InvocationTargetException: class com.google.googlejavaformat.java.JavaInput (in unnamed module @0x7c447c76) cannot access class com.sun.tools.javac.parser.Tokens$TokenKind (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.parser to unnamed module @0x7c447c76 -> [Help 1]
```

Many solutions told us to add some arguments of JVM.

However, IT DOES NOT WORK by using `maven-compiler-plugin`.

It is because when we use `mvn spotless:apply`, it is not in the `compile` lifecycle 

while maven-compiler-plugin is built for the compile lifecycle....

(So, if IoTDB needs some JVM arguments when compiling IoTDB, we can use the plugin).


Two temporary solutions (see [1]) are:

1. use `MAVEN_OPTS` environment:
```
export MAVEN_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
```

2. add a jvm.config file to .mvn folder:
```
--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
```

Notice that do not add those content when you are using JDK8.

Fortunately, the issue will be fixed quickly, see [1] and [2]. 

[1] https://github.com/diffplug/spotless/issues/834
[2] https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md 