### PR TITLE
Handle the scenarios that there is no data for storage group

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartition.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartition.java
@@ -41,6 +41,11 @@ public class DataPartition extends Partition {
     super(seriesSlotExecutorName, seriesPartitionSlotNum);
   }
 
+  @Override
+  public boolean isEmpty() {
+    return dataPartitionMap == null || dataPartitionMap.isEmpty();
+  }
+
   public DataPartition(
       Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>>
           dataPartitionMap,

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/Partition.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/Partition.java
@@ -38,4 +38,6 @@ public abstract class Partition {
   protected TSeriesPartitionSlot calculateDeviceGroupId(String deviceName) {
     return executor.getSeriesPartitionSlot(deviceName);
   }
+
+  public abstract boolean isEmpty();
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/SchemaPartition.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/SchemaPartition.java
@@ -36,6 +36,11 @@ public class SchemaPartition extends Partition {
     super(seriesSlotExecutorName, seriesPartitionSlotNum);
   }
 
+  @Override
+  public boolean isEmpty() {
+    return schemaPartitionMap == null || schemaPartitionMap.isEmpty();
+  }
+
   public SchemaPartition(
       Map<String, Map<TSeriesPartitionSlot, TRegionReplicaSet>> schemaPartitionMap,
       String seriesSlotExecutorName,

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTree.java
@@ -248,4 +248,8 @@ public class SchemaTree {
   SchemaNode getRoot() {
     return root;
   }
+
+  public boolean isEmpty() {
+    return root.getChildren() == null || root.getChildren().size() == 0;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analysis.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analysis.java
@@ -120,4 +120,9 @@ public class Analysis {
   public void setTypeProvider(TypeProvider typeProvider) {
     this.typeProvider = typeProvider;
   }
+
+  public boolean hasDataSource() {
+    return (dataPartition != null && !dataPartition.isEmpty())
+        || (schemaPartition != null && !schemaPartition.isEmpty());
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analyzer.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.db.exception.sql.StatementAnalyzeException;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.mpp.common.MPPQueryContext;
 import org.apache.iotdb.db.mpp.common.filter.QueryFilter;
+import org.apache.iotdb.db.mpp.common.header.DatasetHeader;
 import org.apache.iotdb.db.mpp.common.header.HeaderConstant;
 import org.apache.iotdb.db.mpp.common.schematree.PathPatternTree;
 import org.apache.iotdb.db.mpp.common.schematree.SchemaTree;
@@ -117,7 +118,12 @@ public class Analyzer {
 
         // request schema fetch API
         SchemaTree schemaTree = schemaFetcher.fetchSchema(patternTree);
-
+        // (xingtanzjr) If there is no leaf node in the schema tree, the query should be completed
+        // immediately
+        if (schemaTree.isEmpty()) {
+          analysis.setRespDatasetHeader(new DatasetHeader(new ArrayList<>(), false));
+          return analysis;
+        }
         // bind metadata, remove wildcards, and apply SLIMIT & SOFFSET
         TypeProvider typeProvider = new TypeProvider();
         rewrittenStatement =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -255,7 +255,7 @@ public class QueryExecution implements IQueryExecution {
   /** @return true if there is more tsblocks, otherwise false */
   @Override
   public boolean hasNextResult() {
-    return !resultHandle.isFinished();
+    return resultHandle != null && !resultHandle.isFinished();
   }
 
   /** return the result column count without the time column */


### PR DESCRIPTION
## Description
Before this change, there are 2 scenarios which are not handled by query.
1. Query schema if the storage group exists but there is no timeseries inside it.
2. Query the data if the storage group exists but there is no timeseries and data inside it.

After this change, the query in these two scenarios are like:

1. query schema
![image](https://user-images.githubusercontent.com/18027703/166434122-a5669620-bf36-4229-b290-93ec53c972fb.png)

2. query data
![image](https://user-images.githubusercontent.com/18027703/166434159-a3eccfbd-4907-4da5-909a-721c4e922503.png)
