### PR TITLE
Fix the issue that sometimes the FragmentInstance may stuck in FLUSHING states

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/datatransfer/DataBlockManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/datatransfer/DataBlockManager.java
@@ -113,7 +113,6 @@ public class DataBlockManager implements IDataBlockManager {
       }
       ((SinkHandle) sinkHandles.get(e.getSourceFragmentInstanceId()))
           .acknowledgeTsBlock(e.getStartSequenceId(), e.getEndSequenceId());
-
     }
 
     @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/datatransfer/DataBlockManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/datatransfer/DataBlockManager.java
@@ -106,13 +106,16 @@ public class DataBlockManager implements IDataBlockManager {
           e.getEndSequenceId(),
           e.getSourceFragmentInstanceId());
       if (!sinkHandles.containsKey(e.getSourceFragmentInstanceId())) {
-        throw new TException(
-            "Source fragment instance not found. Fragment instance ID: "
-                + e.getSourceFragmentInstanceId()
-                + ".");
+        // In some scenario, when the SourceHandle sends the data block ACK event, its upstream may
+        // have already been stopped. For example, in the query whit LimitOperator, the downstream
+        // FragmentInstance may be finished, although the upstream is still working.
+        logger.warn(
+            "received ACK event but target fragment[{}] instance not found.",
+            e.getSourceFragmentInstanceId());
+      } else {
+        ((SinkHandle) sinkHandles.get(e.getSourceFragmentInstanceId()))
+            .acknowledgeTsBlock(e.getStartSequenceId(), e.getEndSequenceId());
       }
-      ((SinkHandle) sinkHandles.get(e.getSourceFragmentInstanceId()))
-          .acknowledgeTsBlock(e.getStartSequenceId(), e.getEndSequenceId());
     }
 
     @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/datatransfer/SourceHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/datatransfer/SourceHandle.java
@@ -320,6 +320,8 @@ public class SourceHandle implements ISourceHandle {
             TsBlock tsBlock = serde.deserialize(byteBuffer);
             tsBlocks.add(tsBlock);
           }
+          executorService.submit(
+              new SendAcknowledgeDataBlockEventTask(startSequenceId, endSequenceId));
           synchronized (SourceHandle.this) {
             if (aborted) {
               return;
@@ -331,8 +333,6 @@ public class SourceHandle implements ISourceHandle {
               blocked.set(null);
             }
           }
-          executorService.submit(
-              new SendAcknowledgeDataBlockEventTask(startSequenceId, endSequenceId));
           break;
         } catch (Throwable e) {
           logger.error(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
@@ -107,6 +107,8 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
     }
     SchemaTree result = new SchemaTree();
     while (coordinator.getQueryExecution(queryId).hasNextResult()) {
+      // The query will be transited to FINISHED when invoking getBatchResult() at the last time
+      // So we don't need to clean up it manually
       Optional<TsBlock> tsBlock = coordinator.getQueryExecution(queryId).getBatchResult();
       if (!tsBlock.isPresent()) {
         break;
@@ -121,8 +123,6 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
         result.mergeSchemaTree(fetchedSchemaTree);
       }
     }
-    // TODO: (xingtanzjr) need to release this query's resource here. This is a temporary way
-    coordinator.getQueryExecution(queryId).stopAndCleanup();
     return result;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -238,7 +238,9 @@ public class QueryExecution implements IQueryExecution {
       ListenableFuture<Void> blocked = resultHandle.isBlocked();
       blocked.get();
       if (resultHandle.isFinished()) {
-        releaseResource();
+        // Once the resultHandle is finished, we should transit the state of this query to FINISHED.
+        // So that the corresponding cleanup work could be triggered.
+        stateMachine.transitionToFinished();
         return Optional.empty();
       }
       return Optional.of(resultHandle.receive());

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/InternalServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/InternalServiceImpl.java
@@ -72,6 +72,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class InternalServiceImpl implements InternalService.Iface {
 
@@ -132,11 +133,14 @@ public class InternalServiceImpl implements InternalService.Iface {
 
   @Override
   public TCancelResp cancelQuery(TCancelQueryReq req) throws TException {
-
-    // TODO need to be implemented and currently in order not to print NotImplementedException log,
-    // we simply return null
+    List<FragmentInstanceId> taskIds =
+        req.getFragmentInstanceIds().stream()
+            .map(FragmentInstanceId::fromThrift)
+            .collect(Collectors.toList());
+    for (FragmentInstanceId taskId : taskIds) {
+      FragmentInstanceManager.getInstance().cancelTask(taskId);
+    }
     return new TCancelResp(true);
-    //    throw new NotImplementedException();
   }
 
   @Override

--- a/thrift/src/main/thrift/mpp.thrift
+++ b/thrift/src/main/thrift/mpp.thrift
@@ -105,6 +105,7 @@ struct TFragmentInstanceStateResp {
 
 struct TCancelQueryReq {
   1: required string queryId
+  2: required list<TFragmentInstanceId> fragmentInstanceIds
 }
 
 struct TCancelPlanFragmentReq {


### PR DESCRIPTION
## Description
In some scenario, some FragmentInstance may stuck in FLUSHING state, although the corresponding QueryExecution has already output the final results.

It is because in some query contains `LimitOperator`, the downstream fragment instance will only consume part of TsBlocks produced by its upstream and won't fetch all the TsBlocks. Therefore, the upstream's SinkHandle won't be finished because its TsBlocks are not consumed totally and it also won't receive all the ACK events. So the Fragment Instance which contains this SinkHandle will always stuck in the `FLUSHING` state.

## Solutions
1. Do `SendACK` in SourceHandle once it receives corresponding TsBlocks to avoid the inconsistency that it receives the TsBlock but doesn't send the ACK due to being aborted.
2. When the `ResultHandle` in QueryExecution is finished, transit the QueryExecution to FINISHED