### PR TITLE
Fix order by when aligned by device

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -932,3 +932,9 @@ timestamp_precision=ms
 ####################
 # Datatype: float
 # group_by_fill_cache_size_in_mb=1.0
+
+####################
+### Master-Slave Sync Configuration
+####################
+# Datatype: boolean
+enable_sync=true

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -277,6 +277,7 @@ public class PlanExecutor implements IPlanExecutor {
         return true;
       case INSERT:
         insert((InsertRowPlan) plan);
+        PlanSyncer.SyncInsertRowPlan((InsertRowPlan) plan);
         return true;
       case BATCH_INSERT_ONE_DEVICE:
         insert((InsertRowsOfOneDevicePlan) plan);

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanSyncer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanSyncer.java
@@ -1,0 +1,60 @@
+package org.apache.iotdb.db.qp.executor;
+
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.metadata.MManager;
+import org.apache.iotdb.db.metadata.path.PartialPath;
+import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+
+public class PlanSyncer {
+  static final Logger logger = LoggerFactory.getLogger(PlanSyncer.class);
+  static final Logger DEBUG_LOGGER = LoggerFactory.getLogger("QUERY_DEBUG");
+  static Boolean initialized = false;
+  static Boolean enableSync = false;
+
+  static Boolean initialize() {
+    if (!initialized) {
+      initialized = true;
+      URL url = IoTDBDescriptor.getInstance().getPropsUrl();
+      if (url == null) {
+        logger.warn("Couldn't load the configuration from any of the known sources.");
+        return false;
+      }
+
+      try (InputStream inputStream = url.openStream()) {
+        Properties properties = new Properties();
+        properties.load(inputStream);
+        enableSync = Boolean.parseBoolean(properties.getProperty("enable_sync"));
+      } catch (FileNotFoundException e) {
+        logger.warn("Fail to find config file {}", url, e);
+      } catch (IOException e) {
+        logger.warn("Cannot load config file, use default configuration", e);
+      } catch (Exception e) {
+        logger.warn("Incorrect format in config file, use default configuration", e);
+      }
+    }
+    return initialized;
+  }
+
+  public static void SyncInsertRowPlan(InsertRowPlan plan) {
+    initialize();
+    if (!enableSync) {
+      return;
+    }
+    MManager manager = MManager.getInstance();
+    PartialPath devicePath = plan.getDevicePath();
+    DEBUG_LOGGER.debug("Sync: {}", devicePath);
+    PartialPath path1 = devicePath.concatNode("pv_time");
+    DEBUG_LOGGER.debug("{} exists: {}", path1, manager.isPathExist(path1));
+    PartialPath path2 = devicePath.concatNode("__synced");
+    DEBUG_LOGGER.debug("{} exists: {}", path2, manager.isPathExist(path2));
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
@@ -105,7 +105,8 @@ public class RawDataQueryPlan extends QueryPlan {
     if (expression instanceof SingleSeriesExpression) {
       Path path = ((SingleSeriesExpression) expression).getSeriesPath();
       if (path instanceof AlignedPath) {
-        deviceToMeasurements.computeIfAbsent(path.getDevice(), key -> new HashSet<>())
+        deviceToMeasurements
+            .computeIfAbsent(path.getDevice(), key -> new HashSet<>())
             .addAll(((AlignedPath) path).getMeasurementList());
       } else {
         deviceToMeasurements

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
@@ -104,9 +104,14 @@ public class RawDataQueryPlan extends QueryPlan {
   public void updateDeviceMeasurementsUsingExpression(IExpression expression) {
     if (expression instanceof SingleSeriesExpression) {
       Path path = ((SingleSeriesExpression) expression).getSeriesPath();
-      deviceToMeasurements
-          .computeIfAbsent(path.getDevice(), key -> new HashSet<>())
-          .add(path.getMeasurement());
+      if (path instanceof AlignedPath) {
+        deviceToMeasurements.computeIfAbsent(path.getDevice(), key -> new HashSet<>())
+            .addAll(((AlignedPath) path).getMeasurementList());
+      } else {
+        deviceToMeasurements
+            .computeIfAbsent(path.getDevice(), key -> new HashSet<>())
+            .add(path.getMeasurement());
+      }
     } else if (expression instanceof IBinaryExpression) {
       updateDeviceMeasurementsUsingExpression(((IBinaryExpression) expression).getLeft());
       updateDeviceMeasurementsUsingExpression(((IBinaryExpression) expression).getRight());

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
@@ -83,7 +83,8 @@ public class AlignByDeviceDataSet extends QueryDataSet {
       throws QueryProcessException {
     super(null, null);
     // align by device's column number is different from other datasets
-    // TODO I don't know whether it's right or not in AlignedPath, remember to check here while
+    // TODO I don't know whether it's right or not in AlignedPath, remember to check
+    // here while
     // adapting AlignByDevice query for new vector
     super.columnNum = alignByDevicePlan.getMeasurements().size() + 1; // + 1 for 'device'
     this.measurements = alignByDevicePlan.getMeasurements();
@@ -161,15 +162,18 @@ public class AlignByDeviceDataSet extends QueryDataSet {
       // get filter to execute for the current device
       if (deviceToFilterMap != null) {
         IExpression newExpression = deviceToFilterMap.get(currentDevice);
-        this.expression = expression == null ? newExpression : BinaryExpression.or(expression, newExpression);
+        this.expression =
+            expression == null ? newExpression : BinaryExpression.or(expression, newExpression);
       }
     }
     if (dataSetType == DataSetType.GROUP_BY_TIME || dataSetType == DataSetType.GROUP_BY_FILL) {
-      this.expression = expression == null ? timeExpression : BinaryExpression.and(expression, timeExpression);
+      this.expression =
+          expression == null ? timeExpression : BinaryExpression.and(expression, timeExpression);
     }
     if (expression != null) {
       try {
-        this.expression = ExpressionOptimizer.getInstance().optimize(expression, new ArrayList<>(executePaths));
+        this.expression =
+            ExpressionOptimizer.getInstance().optimize(expression, new ArrayList<>(executePaths));
       } catch (QueryFilterOptimizationException e) {
         throw new IOException(e.getMessage());
       }
@@ -214,14 +218,13 @@ public class AlignByDeviceDataSet extends QueryDataSet {
         default:
           throw new IOException("unsupported DataSetType");
       }
-    } catch (QueryProcessException
-        | QueryFilterOptimizationException
-        | StorageEngineException e) {
+    } catch (QueryProcessException | QueryFilterOptimizationException | StorageEngineException e) {
       throw new IOException(e);
     }
 
     if (currentDataSet.getEndPoint() != null) {
-      org.apache.iotdb.service.rpc.thrift.EndPoint endPoint = new org.apache.iotdb.service.rpc.thrift.EndPoint();
+      org.apache.iotdb.service.rpc.thrift.EndPoint endPoint =
+          new org.apache.iotdb.service.rpc.thrift.EndPoint();
       endPoint.setIp(currentDataSet.getEndPoint().getIp());
       endPoint.setPort(currentDataSet.getEndPoint().getPort());
       throw new RedirectException(endPoint);
@@ -256,7 +259,8 @@ public class AlignByDeviceDataSet extends QueryDataSet {
     Field deviceField = new Field(TSDataType.TEXT);
     deviceField.setBinaryV(new Binary(currentDevice));
     rowRecord.addField(deviceField);
-    // device field should not be considered as a value field it should affect the WITHOUT NULL
+    // device field should not be considered as a value field it should affect the
+    // WITHOUT NULL
     // judgement
     rowRecord.resetNullFlag();
 

--- a/server/src/main/java/org/apache/iotdb/db/query/timegenerator/ServerTimeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/timegenerator/ServerTimeGenerator.java
@@ -31,7 +31,6 @@ import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.reader.series.SeriesRawDataBatchReader;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.expression.ExpressionType;
 import org.apache.iotdb.tsfile.read.expression.IBinaryExpression;
 import org.apache.iotdb.tsfile.read.expression.IExpression;


### PR DESCRIPTION
## Description

In version 0.13, when aligned by device, the records are sorted within device so the order is wrong.

![image](https://user-images.githubusercontent.com/86526634/167242294-c8356f51-9fc3-4bd6-92c6-a3e99e1f2d8e.png)

It is fixed by update the implementation of AlignByDeviceDataSet.java

![image](https://user-images.githubusercontent.com/86526634/167242442-6336ee47-04b6-4d42-9a6d-3c9bbd4fbafa.png)

<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read
    - [x] concurrent write
    - [x] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- AlignByDeviceDataSet.java
- RawDataQueryPlan.java
- ServerTimeGenerator.java