### PR TITLE
[IOTDB-3125] IT case report Error RejectedExecutionException

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
@@ -163,6 +163,10 @@ public class WALManager implements IService {
       return;
     }
 
+    if (walDeleteThread == null) {
+      return;
+    }
+
     Future<?> future = walDeleteThread.submit(this::deleteOutdatedFiles);
     try {
       future.get();
@@ -203,6 +207,7 @@ public class WALManager implements IService {
 
     if (walDeleteThread != null) {
       shutdownThread(walDeleteThread, ThreadName.WAL_DELETE);
+      walDeleteThread = null;
     }
     clear();
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IOTDB-3125

 IT 报 RejectedExecutionException 的原因是：
1)  一些 IT case 使用 EnvironmentUtils#cleanEnv 去主动关闭一些 service。
2)  而进程退出时，又会触发运行一遍  showdown 流程，导致 WALManager 做了两次资源释放动作导致的。
3)  IT case 完成后，进程退出时才会触发这个 error log，所以 IT cases  仍然认为自己 test 结果是 passed。
这个问题只会出现在 IT 中。

