### PR TITLE
[IOTDB-3127] Fix tree traverse algorithm

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
@@ -121,18 +121,18 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Ite
 
   private R consumeNextMatchedNode() {
     R result = generateResult();
-    if (nextMatchedNode != null && shouldVisitSubtree) {
-      if (patternIndexOfMatchedNode == nodes.length) {
-        pushChildrenWhilePrefixMatch(
-            nextMatchedNode, patternIndexOfMatchedNode, lastMultiLevelWildcardIndexOfMatchedNode);
-      } else if (patternIndexOfMatchedNode == nodes.length - 1) {
-        pushChildrenWhileTail(
-            nextMatchedNode, patternIndexOfMatchedNode, lastMultiLevelWildcardIndexOfMatchedNode);
-      } else {
-        pushChildrenWhileInternal(
-            nextMatchedNode, patternIndexOfMatchedNode, lastMultiLevelWildcardIndexOfMatchedNode);
-      }
+
+    if (patternIndexOfMatchedNode == nodes.length) {
+      pushChildrenWhilePrefixMatch(
+          nextMatchedNode, patternIndexOfMatchedNode, lastMultiLevelWildcardIndexOfMatchedNode);
+    } else if (patternIndexOfMatchedNode == nodes.length - 1) {
+      pushChildrenWhileTail(
+          nextMatchedNode, patternIndexOfMatchedNode, lastMultiLevelWildcardIndexOfMatchedNode);
+    } else {
+      pushChildrenWhileInternal(
+          nextMatchedNode, patternIndexOfMatchedNode, lastMultiLevelWildcardIndexOfMatchedNode);
     }
+
     nextMatchedNode = null;
     return result;
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
@@ -122,6 +122,7 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Ite
   private R consumeNextMatchedNode() {
     R result = generateResult();
 
+    // after the node be consumed, the subTree should be considered.
     if (patternIndexOfMatchedNode == nodes.length) {
       pushChildrenWhilePrefixMatch(
           nextMatchedNode, patternIndexOfMatchedNode, lastMultiLevelWildcardIndexOfMatchedNode);
@@ -180,8 +181,7 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Ite
         shouldVisitSubtree = processFullMatchedNode(node) && isInternalNode(node);
 
         if (nextMatchedNode != null) {
-          patternIndexOfMatchedNode = patternIndex;
-          lastMultiLevelWildcardIndexOfMatchedNode = lastMultiLevelWildcardIndex;
+          saveNextMatchedNodeContext(patternIndex, lastMultiLevelWildcardIndex);
           return;
         }
 
@@ -197,8 +197,7 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Ite
           shouldVisitSubtree = processFullMatchedNode(node) && isInternalNode(node);
 
           if (nextMatchedNode != null) {
-            patternIndexOfMatchedNode = patternIndex;
-            lastMultiLevelWildcardIndexOfMatchedNode = lastMultiLevelWildcardIndex;
+            saveNextMatchedNodeContext(patternIndex, lastMultiLevelWildcardIndex);
             return;
           }
 
@@ -209,8 +208,7 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Ite
           shouldVisitSubtree = processInternalMatchedNode(node) && isInternalNode(node);
 
           if (nextMatchedNode != null) {
-            patternIndexOfMatchedNode = patternIndex;
-            lastMultiLevelWildcardIndexOfMatchedNode = lastMultiLevelWildcardIndex;
+            saveNextMatchedNodeContext(patternIndex, lastMultiLevelWildcardIndex);
             return;
           }
 
@@ -228,8 +226,7 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Ite
         shouldVisitSubtree = processInternalMatchedNode(node) && isInternalNode(node);
 
         if (nextMatchedNode != null) {
-          patternIndexOfMatchedNode = lastMatchIndex;
-          lastMultiLevelWildcardIndexOfMatchedNode = lastMultiLevelWildcardIndex;
+          saveNextMatchedNodeContext(lastMatchIndex, lastMultiLevelWildcardIndex);
           return;
         }
 
@@ -238,6 +235,16 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Ite
         }
       }
     }
+  }
+
+  /**
+   * The context, mainly the matching info, of nextedMatchedNode should be saved. When the
+   * nextedMatchedNode is consumed, the saved info will be used to process its subtree.
+   */
+  private void saveNextMatchedNodeContext(
+      int patternIndexOfMatchedNode, int lastMultiLevelWildcardIndexOfMatchedNode) {
+    this.patternIndexOfMatchedNode = patternIndexOfMatchedNode;
+    this.lastMultiLevelWildcardIndexOfMatchedNode = lastMultiLevelWildcardIndexOfMatchedNode;
   }
 
   /**

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
@@ -61,17 +61,17 @@ import static org.apache.iotdb.commons.conf.IoTDBConstant.ONE_LEVEL_PATH_WILDCAR
  */
 public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Iterator<R> {
 
-  // command parameter
+  // command parameters
   protected final N root;
   protected final String[] nodes;
   protected final boolean isPrefixMatch;
 
-  // run time parameter
+  // run time parameters
   protected final Deque<VisitorStackEntry<N>> visitorStack = new ArrayDeque<>();
   protected final Deque<AncestorStackEntry<N>> ancestorStack = new ArrayDeque<>();
   protected boolean shouldVisitSubtree;
 
-  // result parameter
+  // result parameters
   protected N nextMatchedNode;
   protected int patternIndexOfMatchedNode;
   protected int lastMultiLevelWildcardIndexOfMatchedNode;

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
@@ -61,15 +61,18 @@ import static org.apache.iotdb.commons.conf.IoTDBConstant.ONE_LEVEL_PATH_WILDCAR
  */
 public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Iterator<R> {
 
+  // command parameter
   protected final N root;
   protected final String[] nodes;
   protected final boolean isPrefixMatch;
 
+  // run time parameter
   protected final Deque<VisitorStackEntry<N>> visitorStack = new ArrayDeque<>();
   protected final Deque<AncestorStackEntry<N>> ancestorStack = new ArrayDeque<>();
-
-  protected N nextMatchedNode;
   protected boolean shouldVisitSubtree;
+
+  // result parameter
+  protected N nextMatchedNode;
   protected int patternIndexOfMatchedNode;
   protected int lastMultiLevelWildcardIndexOfMatchedNode;
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.metadata.tree;
+package org.apache.iotdb.commons.schema.tree;
 
 import org.apache.iotdb.commons.path.PartialPath;
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
@@ -66,12 +66,12 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R> implements Ite
   protected final String[] nodes;
   protected final boolean isPrefixMatch;
 
-  // run time parameters
+  // run time variables
   protected final Deque<VisitorStackEntry<N>> visitorStack = new ArrayDeque<>();
   protected final Deque<AncestorStackEntry<N>> ancestorStack = new ArrayDeque<>();
   protected boolean shouldVisitSubtree;
 
-  // result parameters
+  // result variables
   protected N nextMatchedNode;
   protected int patternIndexOfMatchedNode;
   protected int lastMultiLevelWildcardIndexOfMatchedNode;

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitorWithLimitOffset.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitorWithLimitOffset.java
@@ -98,9 +98,4 @@ public abstract class AbstractTreeVisitorWithLimitOffset<N extends ITreeNode, R>
   public int getNextOffset() {
     return curOffset + 1;
   }
-
-  @Override
-  protected boolean processInternalMatchedNode(N node) {
-    return false;
-  }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitorWithLimitOffset.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitorWithLimitOffset.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.metadata.tree;
+package org.apache.iotdb.commons.schema.tree;
 
 import org.apache.iotdb.commons.path.PartialPath;
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/ITreeNode.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/ITreeNode.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.metadata.tree;
+package org.apache.iotdb.commons.schema.tree;
 
 public interface ITreeNode {
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaNode.java
@@ -19,7 +19,7 @@
 
 package org.apache.iotdb.db.mpp.common.schematree.node;
 
-import org.apache.iotdb.db.metadata.tree.ITreeNode;
+import org.apache.iotdb.commons.schema.tree.ITreeNode;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeDeviceVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeDeviceVisitor.java
@@ -35,11 +35,16 @@ public class SchemaTreeDeviceVisitor extends SchemaTreeVisitor<DeviceSchemaInfo>
   }
 
   @Override
+  protected boolean processInternalMatchedNode(SchemaNode node) {
+    return true;
+  }
+
+  @Override
   protected boolean processFullMatchedNode(SchemaNode node) {
     if (node.isEntity()) {
       nextMatchedNode = node;
     }
-    return false;
+    return true;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeMeasurementVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeMeasurementVisitor.java
@@ -69,7 +69,7 @@ public class SchemaTreeMeasurementVisitor extends SchemaTreeVisitor<MeasurementP
         new MeasurementPath(
             generateFullPathNodes(nextMatchedNode),
             nextMatchedNode.getAsMeasurementNode().getSchema());
-    result.setUnderAlignedEntity(ancestorStack.peek().getAsEntityNode().isAligned());
+    result.setUnderAlignedEntity(ancestorStack.peek().getNode().getAsEntityNode().isAligned());
     String alias = nextMatchedNode.getAsMeasurementNode().getAlias();
     if (nodes[nodes.length - 1].equals(alias)) {
       result.setMeasurementAlias(alias);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeMeasurementVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeMeasurementVisitor.java
@@ -55,12 +55,17 @@ public class SchemaTreeMeasurementVisitor extends SchemaTreeVisitor<MeasurementP
   }
 
   @Override
+  protected boolean processInternalMatchedNode(SchemaNode node) {
+    return true;
+  }
+
+  @Override
   protected boolean processFullMatchedNode(SchemaNode node) {
     if (node.isMeasurement()) {
       nextMatchedNode = node;
-      return true;
+      return false;
     }
-    return false;
+    return true;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeVisitor.java
@@ -44,8 +44,8 @@ public abstract class SchemaTreeVisitor<R>
   }
 
   @Override
-  protected boolean isLeafNode(SchemaNode node) {
-    return node.isMeasurement();
+  protected boolean isInternalNode(SchemaNode node) {
+    return !node.isMeasurement();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeVisitor.java
@@ -20,7 +20,7 @@
 package org.apache.iotdb.db.mpp.common.schematree.visitor;
 
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.metadata.tree.AbstractTreeVisitorWithLimitOffset;
+import org.apache.iotdb.commons.schema.tree.AbstractTreeVisitorWithLimitOffset;
 import org.apache.iotdb.db.mpp.common.schematree.node.SchemaNode;
 
 import java.util.ArrayList;

--- a/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeTest.java
@@ -36,6 +36,7 @@ import org.mockito.internal.util.collections.Sets;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -435,10 +436,26 @@ public class SchemaTreeTest {
     Assert.assertEquals(2, deviceSchemaInfo.getMeasurements(Sets.newSet("*")).size());
 
     deviceSchemaInfoList = schemaTree.getMatchedDevices(new PartialPath("root.sg.*"), false);
+    deviceSchemaInfoList.sort(Comparator.comparing(DeviceSchemaInfo::getDevicePath));
     Assert.assertEquals(2, deviceSchemaInfoList.size());
+    Assert.assertEquals(new PartialPath("root.sg.d1"), deviceSchemaInfoList.get(0).getDevicePath());
+    Assert.assertEquals(new PartialPath("root.sg.d2"), deviceSchemaInfoList.get(1).getDevicePath());
 
     deviceSchemaInfoList = schemaTree.getMatchedDevices(new PartialPath("root.sg.**"), false);
+    deviceSchemaInfoList.sort(Comparator.comparing(DeviceSchemaInfo::getDevicePath));
     Assert.assertEquals(3, deviceSchemaInfoList.size());
+    Assert.assertEquals(new PartialPath("root.sg.d1"), deviceSchemaInfoList.get(0).getDevicePath());
+    Assert.assertEquals(new PartialPath("root.sg.d2"), deviceSchemaInfoList.get(1).getDevicePath());
+    Assert.assertEquals(
+        new PartialPath("root.sg.d2.a"), deviceSchemaInfoList.get(2).getDevicePath());
+
+    deviceSchemaInfoList = schemaTree.getMatchedDevices(new PartialPath("root.**"), false);
+    deviceSchemaInfoList.sort(Comparator.comparing(DeviceSchemaInfo::getDevicePath));
+    Assert.assertEquals(3, deviceSchemaInfoList.size());
+    Assert.assertEquals(new PartialPath("root.sg.d1"), deviceSchemaInfoList.get(0).getDevicePath());
+    Assert.assertEquals(new PartialPath("root.sg.d2"), deviceSchemaInfoList.get(1).getDevicePath());
+    Assert.assertEquals(
+        new PartialPath("root.sg.d2.a"), deviceSchemaInfoList.get(2).getDevicePath());
   }
 
   @Test


### PR DESCRIPTION
## Description

### 1. Move tree algorithm framework to node commons

### 2. Add status record to avoid repeating check
In ```findLastMatch``` procedure, the node matching will be repeated, implemented as nested loop. Add status record to reduce repeating check.


### 3. Refactor the sub tree visit condition to fix getMatchedDevice bug
#### 3.1 Cause
Before consuming the device node, the algorithm pushed the children into visitStack and the device node to ancestorStack. This will bring repeating device node name when constructing the result.

#### 3.2. Solution
Add ```shouldVisitSubtree``` variable to help control the process. When meeting a matched device node, save its matching info and context before return. After consuming the device node, process its subtree based on the saved info and context.
