### PR TITLE
Fix multi level sg creation bug

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/handlers/InitRegionHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/handlers/InitRegionHandler.java
@@ -22,12 +22,16 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.thrift.async.AsyncMethodCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.BitSet;
 import java.util.concurrent.CountDownLatch;
 
 /** Only use this handler when initialize Region to set StorageGroup */
 public class InitRegionHandler implements AsyncMethodCallback<TSStatus> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InitRegionHandler.class);
 
   private final int index;
   private final BitSet bitSet;
@@ -45,12 +49,15 @@ public class InitRegionHandler implements AsyncMethodCallback<TSStatus> {
       synchronized (bitSet) {
         bitSet.set(index);
       }
+    } else {
+      LOGGER.error(tsStatus.toString());
     }
     latch.countDown();
   }
 
   @Override
   public void onError(Exception e) {
+    LOGGER.error(e.getMessage());
     latch.countDown();
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
@@ -86,7 +86,9 @@ public class ClusterSchemaInfo {
       mTree.setStorageGroup(partialPathName);
 
       // Set StorageGroupSchema
-      mTree.getStorageGroupNodeByPath(partialPathName).setStorageGroupSchema(storageGroupSchema);
+      mTree
+          .getStorageGroupNodeByStorageGroupPath(partialPathName)
+          .setStorageGroupSchema(storageGroupSchema);
 
       result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
 
@@ -134,7 +136,10 @@ public class ClusterSchemaInfo {
     try {
       PartialPath path = new PartialPath(req.getStorageGroup());
       if (mTree.isStorageGroupAlreadySet(path)) {
-        mTree.getStorageGroupNodeByPath(path).getStorageGroupSchema().setTTL(req.getTTL());
+        mTree
+            .getStorageGroupNodeByStorageGroupPath(path)
+            .getStorageGroupSchema()
+            .setTTL(req.getTTL());
         result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
       } else {
         result.setCode(TSStatusCode.STORAGE_GROUP_NOT_EXIST.getStatusCode());
@@ -157,7 +162,7 @@ public class ClusterSchemaInfo {
       PartialPath path = new PartialPath(req.getStorageGroup());
       if (mTree.isStorageGroupAlreadySet(path)) {
         mTree
-            .getStorageGroupNodeByPath(path)
+            .getStorageGroupNodeByStorageGroupPath(path)
             .getStorageGroupSchema()
             .setSchemaReplicationFactor(req.getSchemaReplicationFactor());
         result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
@@ -182,7 +187,7 @@ public class ClusterSchemaInfo {
       PartialPath path = new PartialPath(req.getStorageGroup());
       if (mTree.isStorageGroupAlreadySet(path)) {
         mTree
-            .getStorageGroupNodeByPath(path)
+            .getStorageGroupNodeByStorageGroupPath(path)
             .getStorageGroupSchema()
             .setDataReplicationFactor(req.getDataReplicationFactor());
         result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
@@ -207,7 +212,7 @@ public class ClusterSchemaInfo {
       PartialPath path = new PartialPath(req.getStorageGroup());
       if (mTree.isStorageGroupAlreadySet(path)) {
         mTree
-            .getStorageGroupNodeByPath(path)
+            .getStorageGroupNodeByStorageGroupPath(path)
             .getStorageGroupSchema()
             .setTimePartitionInterval(req.getTimePartitionInterval());
         result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
@@ -269,7 +274,8 @@ public class ClusterSchemaInfo {
       List<PartialPath> matchedPaths = mTree.getBelongedStorageGroups(patternPath);
       for (PartialPath path : matchedPaths) {
         schemaMap.put(
-            path.getFullPath(), mTree.getStorageGroupNodeByPath(path).getStorageGroupSchema());
+            path.getFullPath(),
+            mTree.getStorageGroupNodeByStorageGroupPath(path).getStorageGroupSchema());
       }
       result.setSchemaMap(schemaMap);
       result.setStatus(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
@@ -312,7 +318,8 @@ public class ClusterSchemaInfo {
     storageGroupReadWriteLock.readLock().lock();
     try {
       StorageGroupMNode mNode =
-          (StorageGroupMNode) mTree.getStorageGroupNodeByPath(new PartialPath(storageGroup));
+          (StorageGroupMNode)
+              mTree.getStorageGroupNodeByStorageGroupPath(new PartialPath(storageGroup));
       switch (type) {
         case SchemaRegion:
           result = mNode.getStorageGroupSchema().getSchemaRegionGroupIds();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
@@ -333,15 +333,33 @@ public class MTreeAboveSG {
    * device], throw exception Get storage group node, if the give path is not a storage group, throw
    * exception
    */
-  public IStorageGroupMNode getStorageGroupNodeByStorageGroupPath(PartialPath path)
+  public IStorageGroupMNode getStorageGroupNodeByStorageGroupPath(PartialPath storageGroupPath)
       throws MetadataException {
-    IStorageGroupMNode node = getStorageGroupNodeByPath(path);
-    if (!node.getPartialPath().equals(path)) {
-      throw new MNodeTypeMismatchException(
-          path.getFullPath(), MetadataConstant.STORAGE_GROUP_MNODE_TYPE);
+    String[] nodes = storageGroupPath.getNodes();
+    if (nodes.length == 0 || !nodes[0].equals(root.getName())) {
+      throw new IllegalPathException(storageGroupPath.getFullPath());
+    }
+    IMNode cur = root;
+    for (int i = 1; i < nodes.length - 1; i++) {
+      cur = cur.getChild(nodes[i]);
+      if (cur == null) {
+        throw new StorageGroupNotSetException(storageGroupPath.getFullPath());
+      }
+      if (cur.isStorageGroup()) {
+        throw new StorageGroupAlreadySetException(cur.getFullPath());
+      }
     }
 
-    return node;
+    cur = cur.getChild(nodes[nodes.length - 1]);
+    if (cur == null) {
+      throw new StorageGroupNotSetException(storageGroupPath.getFullPath());
+    }
+    if (cur.isStorageGroup()) {
+      return cur.getAsStorageGroupMNode();
+    } else {
+      throw new MNodeTypeMismatchException(
+          storageGroupPath.getFullPath(), MetadataConstant.STORAGE_GROUP_MNODE_TYPE);
+    }
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
@@ -329,8 +329,7 @@ public class MTreeAboveSG {
   }
 
   /**
-   * E.g., root.sg is storage group given [root, sg], return the MNode of root.sg given [root, sg,
-   * device], throw exception Get storage group node, if the give path is not a storage group, throw
+   * E.g., root.sg is storage group given [root, sg], if the give path is not a storage group, throw
    * exception
    */
   public IStorageGroupMNode getStorageGroupNodeByStorageGroupPath(PartialPath storageGroupPath)

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
@@ -207,9 +207,8 @@ public class SchemaEngine {
   private ISchemaRegion createSchemaRegionWithoutExistenceCheck(
       PartialPath storageGroup, SchemaRegionId schemaRegionId) throws MetadataException {
     ISchemaRegion schemaRegion = null;
-    this.localStorageGroupSchemaManager.ensureStorageGroup(storageGroup);
     IStorageGroupMNode storageGroupMNode =
-        this.localStorageGroupSchemaManager.getStorageGroupNodeByStorageGroupPath(storageGroup);
+        this.localStorageGroupSchemaManager.ensureStorageGroupByStorageGroupPath(storageGroup);
     switch (this.schemaRegionStoredMode) {
       case Memory:
         schemaRegion = new SchemaRegionMemoryImpl(storageGroup, schemaRegionId, storageGroupMNode);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
@@ -47,14 +47,6 @@ public interface IStorageGroupSchemaManager {
   void setStorageGroup(PartialPath path) throws MetadataException;
 
   /**
-   * different with LocalConfigNode.ensureStorageGroup, this method won't init storageGroup
-   * resources.
-   *
-   * @param path storage group path
-   */
-  void ensureStorageGroup(PartialPath path) throws MetadataException;
-
-  /**
    * Delete storage groups of given paths from MTree. Log format: "delete_storage_group,sg1,sg2,sg3"
    */
   void deleteStorageGroup(PartialPath storageGroup) throws MetadataException;
@@ -155,6 +147,15 @@ public interface IStorageGroupSchemaManager {
 
   /** Get all storage group MNodes */
   List<IStorageGroupMNode> getAllStorageGroupNodes();
+
+  /**
+   * Different with LocalConfigNode.ensureStorageGroup, this method won't init storageGroup
+   * resources and the input is the target storage group path.
+   *
+   * @param storageGroup storage group path
+   */
+  IStorageGroupMNode ensureStorageGroupByStorageGroupPath(PartialPath storageGroup)
+      throws MetadataException;
 
   /**
    * Check whether the storage group of given path is set. The path may be a prefix path of some

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
@@ -133,15 +133,6 @@ public interface IStorageGroupSchemaManager {
    */
   int getStorageGroupNum(PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException;
 
-  /**
-   * E.g., root.sg is storage group given [root, sg], return the MNode of root.sg given [root, sg],
-   * return the MNode of root.sg Get storage group node by path. Give path like [root, sg, device],
-   * MNodeTypeMismatchException will be thrown. If storage group is not set,
-   * StorageGroupNotSetException will be thrown.
-   */
-  IStorageGroupMNode getStorageGroupNodeByStorageGroupPath(PartialPath path)
-      throws MetadataException;
-
   /** Get storage group node by path. the give path don't need to be storage group path. */
   IStorageGroupMNode getStorageGroupNodeByPath(PartialPath path) throws MetadataException;
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
@@ -153,7 +153,7 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
   public IStorageGroupMNode ensureStorageGroupByStorageGroupPath(PartialPath storageGroup)
       throws MetadataException {
     try {
-      return getStorageGroupNodeByStorageGroupPath(storageGroup);
+      return mtree.getStorageGroupNodeByStorageGroupPath(storageGroup);
     } catch (StorageGroupNotSetException e) {
       try {
         setStorageGroup(storageGroup);
@@ -169,7 +169,7 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
         }
       }
 
-      return getStorageGroupNodeByStorageGroupPath(storageGroup);
+      return mtree.getStorageGroupNodeByStorageGroupPath(storageGroup);
     }
   }
 
@@ -241,12 +241,6 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
   public int getStorageGroupNum(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     return mtree.getStorageGroupNum(pathPattern, isPrefixMatch);
-  }
-
-  @Override
-  public IStorageGroupMNode getStorageGroupNodeByStorageGroupPath(PartialPath path)
-      throws MetadataException {
-    return mtree.getStorageGroupNodeByStorageGroupPath(path);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
@@ -28,7 +28,6 @@ import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.metadata.LocalSchemaProcessor;
 import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
 import org.apache.iotdb.db.metadata.mtree.MTreeAboveSG;
-import org.apache.iotdb.db.metadata.utils.MetaUtils;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.sys.DeleteStorageGroupPlan;
 import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
@@ -151,17 +150,13 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
   }
 
   @Override
-  public void ensureStorageGroup(PartialPath path) throws MetadataException {
+  public IStorageGroupMNode ensureStorageGroupByStorageGroupPath(PartialPath storageGroup)
+      throws MetadataException {
     try {
-      getBelongedStorageGroup(path);
+      return getStorageGroupNodeByStorageGroupPath(storageGroup);
     } catch (StorageGroupNotSetException e) {
-      if (!config.isAutoCreateSchemaEnabled()) {
-        throw e;
-      }
-      PartialPath storageGroupPath =
-          MetaUtils.getStorageGroupPathByLevel(path, config.getDefaultStorageGroupLevel());
       try {
-        setStorageGroup(storageGroupPath);
+        setStorageGroup(storageGroup);
       } catch (StorageGroupAlreadySetException storageGroupAlreadySetException) {
         // do nothing
         // concurrent timeseries creation may result concurrent ensureStorageGroup
@@ -173,6 +168,8 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
           throw storageGroupAlreadySetException;
         }
       }
+
+      return getStorageGroupNodeByStorageGroupPath(storageGroup);
     }
   }
 


### PR DESCRIPTION
## Description


### Cause
The storage group info management of dataNode went wrong when createSchemaRegion. The localStorageGroupSchemaManager go through the auto create sg logic with normal path rather than specified storage group path. It means when the target storage group path is root.a.sg, the sg created by ensureStorageGroup method is root.a since the default sg level is 1.

### Solution
rewrite the logic of localStorageGroupSchemaManager.ensureStorageGroup
rename it to ensureStorageGroupByStorageGroupPath


### Result screenshot

![image](https://user-images.githubusercontent.com/38524330/167544543-59400801-d200-4f72-b67b-9571fd1464af.png)
