### PR TITLE
Implement CommonDescriptor and refactor CommonConfig usage

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConf.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConf.java
@@ -108,9 +108,6 @@ public class ConfigNodeConf {
   private String consensusDir =
       ConfigNodeConstant.DATA_DIR + File.separator + ConfigNodeConstant.CONSENSUS_FOLDER;
 
-  /** Default TTL for storage groups that are not set TTL by statements, in ms. */
-  private long defaultTTL = Long.MAX_VALUE;
-
   /** Time partition interval in seconds */
   private long timePartitionInterval = 604800;
 
@@ -126,7 +123,7 @@ public class ConfigNodeConf {
   /** The initial number of DataRegions of each StorageGroup */
   private int initialDataRegionCount = 1;
 
-  public ConfigNodeConf() {
+  ConfigNodeConf() {
     // empty constructor
   }
 
@@ -333,14 +330,6 @@ public class ConfigNodeConf {
 
   public void setDataDirs(String[] dataDirs) {
     this.dataDirs = dataDirs;
-  }
-
-  public long getDefaultTTL() {
-    return defaultTTL;
-  }
-
-  public void setDefaultTTL(long defaultTTL) {
-    this.defaultTTL = defaultTTL;
   }
 
   public int getSchemaReplicationFactor() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -212,7 +212,9 @@ public class ConfigNodeDescriptor {
       LOGGER.warn("Couldn't load ConfigNode conf file, use default config", e);
     } finally {
       conf.updatePath();
-      commonConfig.updatePath(System.getProperty(ConfigNodeConstant.CONFIGNODE_HOME, null));
+      commonDescriptor
+          .getConfig()
+          .updatePath(System.getProperty(ConfigNodeConstant.CONFIGNODE_HOME, null));
     }
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -206,6 +206,7 @@ public class ConfigNodeDescriptor {
 
       // commons
       commonDescriptor.loadCommonProps(properties);
+      commonDescriptor.initCommonConfigDir(conf.getSystemDir());
 
     } catch (IOException | BadNodeUrlException e) {
       LOGGER.warn("Couldn't load ConfigNode conf file, use default config", e);

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.confignode.conf;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.BadNodeUrlException;
 import org.apache.iotdb.commons.exception.ConfigurationException;
 import org.apache.iotdb.commons.exception.StartupException;
@@ -186,7 +187,7 @@ public class ConfigNodeStartupCheck {
             conf.getDataNodeConsensusProtocolClass(),
             conf.getSeriesPartitionSlotNum(),
             conf.getSeriesPartitionExecutorClass(),
-            conf.getDefaultTTL(),
+            CommonDescriptor.getInstance().getConfig().getDefaultTTL(),
             conf.getTimePartitionInterval(),
             conf.getSchemaReplicationFactor(),
             conf.getDataReplicationFactor());

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.confignode.manager;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.confignode.conf.ConfigNodeConf;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.ConfigRequest;
@@ -410,7 +411,7 @@ public class ConfigManager implements Manager {
               "Reject register, please ensure that the series_partition_executor_class are consistent.");
       return errorResp;
     }
-    if (req.getDefaultTTL() != conf.getDefaultTTL()) {
+    if (req.getDefaultTTL() != CommonDescriptor.getInstance().getConfig().getDefaultTTL()) {
       errorResp
           .getStatus()
           .setMessage("Reject register, please ensure that the default_ttl are consistent.");

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.confignode.service.thrift;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.auth.AuthException;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.ConfigRequestType;
@@ -128,7 +129,7 @@ public class ConfigNodeRPCServiceProcessor implements ConfigIService.Iface {
 
     // Set default configurations
     if (!storageGroupSchema.isSetTTL()) {
-      storageGroupSchema.setTTL(ConfigNodeDescriptor.getInstance().getConf().getDefaultTTL());
+      storageGroupSchema.setTTL(CommonDescriptor.getInstance().getConfig().getDefaultTTL());
     }
     if (!storageGroupSchema.isSetSchemaReplicationFactor()) {
       storageGroupSchema.setSchemaReplicationFactor(

--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTtlIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTtlIT.java
@@ -20,7 +20,7 @@
 
 package org.apache.iotdb.db.integration;
 
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.integration.env.EnvFactory;
 import org.apache.iotdb.itbase.category.ClusterTest;
 import org.apache.iotdb.itbase.category.LocalStandaloneTest;
@@ -191,7 +191,7 @@ public class IoTDBTtlIT {
 
   @Test
   public void testDefaultTTL() throws SQLException {
-    IoTDBDescriptor.getInstance().getConfig().setDefaultTTL(10000);
+    CommonDescriptor.getInstance().getConfig().setDefaultTTL(10000);
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
       statement.execute("SET STORAGE GROUP TO root.group1");
@@ -202,7 +202,7 @@ public class IoTDBTtlIT {
           result.equals("root.group1,10000\n" + "root.group2,10000\n")
               || result.equals("root.group2,10000\n" + "root.group1,10000\n"));
     } finally {
-      IoTDBDescriptor.getInstance().getConfig().setDefaultTTL(Long.MAX_VALUE);
+      CommonDescriptor.getInstance().getConfig().setDefaultTTL(Long.MAX_VALUE);
     }
   }
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/BasicAuthorizer.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/BasicAuthorizer.java
@@ -24,7 +24,7 @@ import org.apache.iotdb.commons.auth.entity.Role;
 import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.auth.role.IRoleManager;
 import org.apache.iotdb.commons.auth.user.IUserManager;
-import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.commons.service.IService;
 import org.apache.iotdb.commons.service.ServiceType;
@@ -85,9 +85,10 @@ public abstract class BasicAuthorizer implements IAuthorizer, IService {
       try {
         c =
             (Class<BasicAuthorizer>)
-                Class.forName(CommonConfig.getInstance().getAuthorizerProvider());
+                Class.forName(CommonDescriptor.getInstance().getConfig().getAuthorizerProvider());
         logger.info(
-            "Authorizer provider class: {}", CommonConfig.getInstance().getAuthorizerProvider());
+            "Authorizer provider class: {}",
+            CommonDescriptor.getInstance().getConfig().getAuthorizerProvider());
         instance = c.getDeclaredConstructor().newInstance();
       } catch (Exception e) {
         instance = null;

--- a/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/LocalFileAuthorizer.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/LocalFileAuthorizer.java
@@ -22,10 +22,11 @@ import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.role.LocalFileRoleManager;
 import org.apache.iotdb.commons.auth.user.LocalFileUserManager;
 import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 
 public class LocalFileAuthorizer extends BasicAuthorizer {
 
-  private static final CommonConfig config = CommonConfig.getInstance();
+  private static final CommonConfig config = CommonDescriptor.getInstance().getConfig();
 
   public LocalFileAuthorizer() throws AuthException {
     super(

--- a/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/OpenIdAuthorizer.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/OpenIdAuthorizer.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.auth.role.LocalFileRoleManager;
 import org.apache.iotdb.commons.auth.user.LocalFileUserManager;
 import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.RSAKey;
@@ -57,7 +58,7 @@ public class OpenIdAuthorizer extends BasicAuthorizer {
   public static final String IOTDB_ADMIN_ROLE_NAME = "iotdb_admin";
   public static final String OPENID_USER_PREFIX = "openid-";
 
-  private static final CommonConfig config = CommonConfig.getInstance();
+  private static final CommonConfig config = CommonDescriptor.getInstance().getConfig();
 
   private final RSAPublicKey providerKey;
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/BasicUserManager.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/BasicUserManager.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.commons.auth.user;
 import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.concurrent.HashLock;
-import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.utils.AuthUtils;
 
 import org.slf4j.Logger;
@@ -66,7 +66,7 @@ public abstract class BasicUserManager implements IUserManager {
   private void initAdmin() throws AuthException {
     User admin;
     try {
-      admin = getUser(CommonConfig.getInstance().getAdminName());
+      admin = getUser(CommonDescriptor.getInstance().getConfig().getAdminName());
     } catch (AuthException e) {
       logger.warn("Cannot load admin, Creating a new one.", e);
       admin = null;
@@ -74,8 +74,9 @@ public abstract class BasicUserManager implements IUserManager {
 
     if (admin == null) {
       createUser(
-          CommonConfig.getInstance().getAdminName(), CommonConfig.getInstance().getAdminPassword());
-      setUserUseWaterMark(CommonConfig.getInstance().getAdminName(), false);
+          CommonDescriptor.getInstance().getConfig().getAdminName(),
+          CommonDescriptor.getInstance().getConfig().getAdminPassword());
+      setUserUseWaterMark(CommonDescriptor.getInstance().getConfig().getAdminName(), false);
     }
     logger.info("Admin initialized");
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -49,20 +49,15 @@ public class CommonConfig {
   /** Default system file storage is in local file system (unsupported) */
   private FSType systemFileStorageFs = FSType.LOCAL;
 
-  private CommonConfig() {}
+  /**
+   * default TTL for storage groups that are not set TTL by statements, in ms.
+   *
+   * <p>Notice: if this property is changed, previous created storage group which are not set TTL
+   * will also be affected. Unit: millisecond
+   */
+  private long defaultTTL = Long.MAX_VALUE;
 
-  public static CommonConfig getInstance() {
-    return CommonConfig.CommonConfigHolder.INSTANCE;
-  }
-
-  private static class CommonConfigHolder {
-
-    private CommonConfigHolder() {
-      throw new IllegalAccessError("Utility class");
-    }
-
-    private static final CommonConfig INSTANCE = new CommonConfig();
-  }
+  CommonConfig() {}
 
   public String getEncryptDecryptProvider() {
     return encryptDecryptProvider;
@@ -134,5 +129,13 @@ public class CommonConfig {
 
   public void setSystemFileStorageFs(FSType systemFileStorageFs) {
     this.systemFileStorageFs = systemFileStorageFs;
+  }
+
+  public long getDefaultTTL() {
+    return defaultTTL;
+  }
+
+  public void setDefaultTTL(long defaultTTL) {
+    this.defaultTTL = defaultTTL;
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.conf;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Properties;
+
+public class CommonDescriptor {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CommonDescriptor.class);
+
+  private final CommonConfig config = new CommonConfig();
+
+  private CommonDescriptor() {}
+
+  public static CommonDescriptor getInstance() {
+    return CommonDescriptorHolder.INSTANCE;
+  }
+
+  private static class CommonDescriptorHolder {
+
+    private static final CommonDescriptor INSTANCE = new CommonDescriptor();
+
+    private CommonDescriptorHolder() {
+      // empty constructor
+    }
+  }
+
+  public CommonConfig getConfig() {
+    return config;
+  }
+
+  public void initCommonConfigDir(String systemDir) {
+    config.setUserFolder(systemDir + File.separator + "users");
+    config.setRoleFolder(systemDir + File.separator + "roles");
+  }
+
+  public void loadCommonProps(Properties properties) {
+
+    config.setAuthorizerProvider(
+        properties.getProperty("authorizer_provider_class", config.getAuthorizerProvider()));
+    // if using org.apache.iotdb.db.auth.authorizer.OpenIdAuthorizer, openID_url is needed.
+    config.setOpenIdProviderUrl(
+        properties.getProperty("openID_url", config.getOpenIdProviderUrl()));
+    config.setAdminName(properties.getProperty("admin_name", config.getAdminName()));
+
+    config.setAdminPassword(properties.getProperty("admin_password", config.getAdminPassword()));
+    config.setEncryptDecryptProvider(
+        properties.getProperty(
+            "iotdb_server_encrypt_decrypt_provider", config.getEncryptDecryptProvider()));
+
+    config.setEncryptDecryptProviderParameter(
+        properties.getProperty(
+            "iotdb_server_encrypt_decrypt_provider_parameter",
+            config.getEncryptDecryptProviderParameter()));
+
+    config.setDefaultTTL(
+        Long.parseLong(
+            properties.getProperty("default_ttl", String.valueOf(config.getDefaultTTL()))));
+  }
+}

--- a/node-commons/src/main/java/org/apache/iotdb/commons/file/SystemFileFactory.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/file/SystemFileFactory.java
@@ -19,7 +19,7 @@
 
 package org.apache.iotdb.commons.file;
 
-import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
 
 import java.io.File;
@@ -28,7 +28,8 @@ import java.net.URI;
 public enum SystemFileFactory {
   INSTANCE;
 
-  private static FSType fsType = CommonConfig.getInstance().getSystemFileStorageFs();
+  private static FSType fsType =
+      CommonDescriptor.getInstance().getConfig().getSystemFileStorageFs();
   private static final String UNSUPPORT_FILE_SYSTEM = "Unsupported file system: ";
 
   public File getFile(String pathname) {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.commons.utils;
 import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.entity.PathPrivilege;
 import org.apache.iotdb.commons.auth.entity.PrivilegeType;
-import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
@@ -178,15 +178,15 @@ public class AuthUtils {
    */
   public static String encryptPassword(String password) {
     return AsymmetricEncryptFactory.getEncryptProvider(
-            CommonConfig.getInstance().getEncryptDecryptProvider(),
-            CommonConfig.getInstance().getEncryptDecryptProviderParameter())
+            CommonDescriptor.getInstance().getConfig().getEncryptDecryptProvider(),
+            CommonDescriptor.getInstance().getConfig().getEncryptDecryptProviderParameter())
         .encrypt(password);
   }
 
   public static boolean validatePassword(String originPassword, String encryptPassword) {
     return AsymmetricEncryptFactory.getEncryptProvider(
-            CommonConfig.getInstance().getEncryptDecryptProvider(),
-            CommonConfig.getInstance().getEncryptDecryptProviderParameter())
+            CommonDescriptor.getInstance().getConfig().getEncryptDecryptProvider(),
+            CommonDescriptor.getInstance().getConfig().getEncryptDecryptProviderParameter())
         .validate(originPassword, encryptPassword);
   }
 

--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/mnode/RStorageGroupMNode.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/mnode/RStorageGroupMNode.java
@@ -19,9 +19,9 @@
 
 package org.apache.iotdb.db.metadata.schemaregion.rocksdb.mnode;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.confignode.rpc.thrift.TStorageGroupSchema;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.metadata.logfile.MLogWriter;
 import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
 import org.apache.iotdb.db.metadata.schemaregion.rocksdb.RSchemaConstants;
@@ -52,7 +52,7 @@ public class RStorageGroupMNode extends RInternalMNode implements IStorageGroupM
     super(fullPath, readWriteHandler);
     Object ttl = RSchemaUtils.parseNodeValue(value, RMNodeValueType.TTL);
     if (ttl == null) {
-      ttl = IoTDBDescriptor.getInstance().getConfig().getDefaultTTL();
+      ttl = CommonDescriptor.getInstance().getConfig().getDefaultTTL();
     }
     this.dataTTL = (long) ttl;
   }

--- a/server/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
@@ -22,7 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.authorizer.AuthorizerManager;
 import org.apache.iotdb.commons.auth.entity.PrivilegeType;
-import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.AuthUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TCheckUserPrivilegesReq;
@@ -49,7 +49,8 @@ import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onNPEOrUnexpectedExce
 
 public class AuthorityChecker {
 
-  private static final String SUPER_USER = CommonConfig.getInstance().getAdminName();
+  private static final String SUPER_USER =
+      CommonDescriptor.getInstance().getConfig().getAdminName();
   private static final Logger logger = LoggerFactory.getLogger(AuthorityChecker.class);
 
   private static AuthorizerManager authorizerManager = AuthorizerManager.getInstance();

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -687,14 +687,6 @@ public class IoTDBConfig {
   /** the default fill interval in LinearFill and PreviousFill, -1 means infinite past time */
   private int defaultFillInterval = -1;
 
-  /**
-   * default TTL for storage groups that are not set TTL by statements, in ms.
-   *
-   * <p>Notice: if this property is changed, previous created storage group which are not set TTL
-   * will also be affected. Unit: millisecond
-   */
-  private long defaultTTL = Long.MAX_VALUE;
-
   /** The default value of primitive array size in array pool */
   private int primitiveArraySize = 32;
 
@@ -883,6 +875,8 @@ public class IoTDBConfig {
    * org.apache.iotdb.db.mpp.plan.analyze.ClusterPartitionFetcher}
    */
   private int partitionCacheSize = 10000;
+
+  IoTDBConfig() {}
 
   public float getUdfMemoryBudgetInMB() {
     return udfMemoryBudgetInMB;
@@ -2133,14 +2127,6 @@ public class IoTDBConfig {
 
   void setKerberosPrincipal(String kerberosPrincipal) {
     this.kerberosPrincipal = kerberosPrincipal;
-  }
-
-  public long getDefaultTTL() {
-    return defaultTTL;
-  }
-
-  public void setDefaultTTL(long defaultTTL) {
-    this.defaultTTL = defaultTTL;
   }
 
   public int getThriftServerAwaitTimeForStopService() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -868,6 +868,10 @@ public class IoTDBDescriptor {
               properties.getProperty("kerberos_principal", conf.getKerberosPrincipal()));
       TSFileDescriptor.getInstance().getConfig().setBatchSize(conf.getBatchSize());
 
+      // commons
+      commonDescriptor.loadCommonProps(properties);
+      commonDescriptor.initCommonConfigDir(conf.getSystemDir());
+
       // timed flush memtable
       loadTimedService(properties);
 
@@ -892,8 +896,6 @@ public class IoTDBDescriptor {
       // shuffle
       loadShuffleProps(properties);
 
-      // commons
-      commonDescriptor.loadCommonProps(properties);
     } catch (FileNotFoundException e) {
       logger.warn("Fail to find config file {}", url, e);
     } catch (IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -904,7 +904,7 @@ public class IoTDBDescriptor {
     } finally {
       // update all data seriesPath
       conf.updatePath();
-      commonConfig.updatePath(System.getProperty(IoTDBConstant.IOTDB_HOME, null));
+      commonDescriptor.getConfig().updatePath(System.getProperty(IoTDBConstant.IOTDB_HOME, null));
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -895,7 +895,6 @@ public class IoTDBDescriptor {
 
       // shuffle
       loadShuffleProps(properties);
-
     } catch (FileNotFoundException e) {
       logger.warn("Fail to find config file {}", url, e);
     } catch (IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.ThriftConfigNodeSerDeUtils;
+import org.apache.iotdb.db.exception.metadata.PathAlreadyExistException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupAlreadySetException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.metadata.LocalSchemaProcessor;
@@ -38,6 +39,7 @@ import org.apache.iotdb.db.metadata.mtree.traverser.collector.MNodeAboveSGCollec
 import org.apache.iotdb.db.metadata.mtree.traverser.collector.StorageGroupCollector;
 import org.apache.iotdb.db.metadata.mtree.traverser.counter.CounterTraverser;
 import org.apache.iotdb.db.metadata.mtree.traverser.counter.StorageGroupCounter;
+import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.utils.MetaFormatUtils;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
@@ -95,17 +97,23 @@ public class MTreeAboveSG {
       throw new IllegalPathException(path.getFullPath());
     }
     IMNode cur = root;
+    Template upperTemplate = cur.getSchemaTemplate();
     int i = 1;
     // e.g., path = root.a.b.sg, create internal nodes for a, b
     while (i < nodeNames.length - 1) {
       IMNode temp = cur.getChild(nodeNames[i]);
       if (temp == null) {
+        if (cur.isUseTemplate() && upperTemplate.hasSchema(nodeNames[i])) {
+          throw new PathAlreadyExistException(
+              cur.getPartialPath().concatNode(nodeNames[i]).getFullPath());
+        }
         store.addChild(cur, nodeNames[i], new InternalMNode(cur, nodeNames[i]));
       } else if (temp.isStorageGroup()) {
         // before set storage group, check whether the storage group already exists
         throw new StorageGroupAlreadySetException(temp.getFullPath());
       }
       cur = cur.getChild(nodeNames[i]);
+      upperTemplate = cur.getSchemaTemplate() == null ? upperTemplate : cur.getSchemaTemplate();
       i++;
     }
 
@@ -120,6 +128,10 @@ public class MTreeAboveSG {
           throw new StorageGroupAlreadySetException(path.getFullPath(), true);
         }
       } else {
+        if (cur.isUseTemplate() && upperTemplate.hasSchema(nodeNames[i])) {
+          throw new PathAlreadyExistException(
+              cur.getPartialPath().concatNode(nodeNames[i]).getFullPath());
+        }
         IStorageGroupMNode storageGroupMNode =
             new StorageGroupMNode(
                 cur, nodeNames[i], CommonDescriptor.getInstance().getConfig().getDefaultTTL());

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/MemMTreeStore.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/MemMTreeStore.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iotdb.db.metadata.mtree.store;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.metadata.mnode.IEntityMNode;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
@@ -50,7 +50,7 @@ public class MemMTreeStore implements IMTreeStore {
           new StorageGroupMNode(
               null,
               rootPath.getTailNode(),
-              IoTDBDescriptor.getInstance().getConfig().getDefaultTTL());
+              CommonDescriptor.getInstance().getConfig().getDefaultTTL());
     } else {
       this.root = new InternalMNode(null, IoTDBConstant.PATH_ROOT);
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/MockSchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/MockSchemaFile.java
@@ -18,8 +18,8 @@
  */
 package org.apache.iotdb.db.metadata.mtree.store.disk.schemafile;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.metadata.mnode.EntityMNode;
 import org.apache.iotdb.db.metadata.mnode.IEntityMNode;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
@@ -59,7 +59,7 @@ public class MockSchemaFile implements ISchemaFile {
         new StorageGroupMNode(
             null,
             storageGroupPath.getTailNode(),
-            IoTDBDescriptor.getInstance().getConfig().getDefaultTTL());
+            CommonDescriptor.getInstance().getConfig().getDefaultTTL());
     writeMNode(storageGroupMNode);
     return cloneMNode(storageGroupMNode);
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.metadata.mtree.store.disk.schemafile;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.file.SystemFileFactory;
 import org.apache.iotdb.commons.utils.PathUtils;
@@ -187,7 +188,7 @@ public class SchemaFile implements ISchemaFile {
         sgName,
         schemaRegionId,
         true,
-        IoTDBDescriptor.getInstance().getConfig().getDefaultTTL(),
+        CommonDescriptor.getInstance().getConfig().getDefaultTTL(),
         false);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -27,7 +27,7 @@ import org.apache.iotdb.commons.auth.entity.Role;
 import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.concurrent.ThreadName;
-import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
@@ -2332,7 +2332,7 @@ public class PlanExecutor implements IPlanExecutor {
     List<PartialPath> headerList = new ArrayList<>();
     List<TSDataType> typeList = new ArrayList<>();
     int index = 0;
-    if (CommonConfig.getInstance().equals(userName)) {
+    if (CommonDescriptor.getInstance().getConfig().getAdminName().equals(userName)) {
       headerList.add(new PartialPath(COLUMN_PRIVILEGE, false));
       typeList.add(TSDataType.TEXT);
       ListDataSet dataSet = new ListDataSet(headerList, typeList);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletsPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertMultiTabletsPlan.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.StatusUtils;
-import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
@@ -396,7 +395,8 @@ public class InsertMultiTabletsPlan extends InsertPlan implements BatchPlan {
   public int getDifferentStorageGroupsCount() {
     if (differentStorageGroupsCount == null) {
       Set<String> insertPlanSGSet = new HashSet<>();
-      int defaultStorageGroupLevel = new IoTDBConfig().getDefaultStorageGroupLevel();
+      int defaultStorageGroupLevel =
+          IoTDBDescriptor.getInstance().getConfig().getDefaultStorageGroupLevel();
       for (InsertTabletPlan insertTabletPlan : insertTabletPlanList) {
         String[] nodes = insertTabletPlan.getDevicePath().getNodes();
         StringBuilder stringBuilder = new StringBuilder();

--- a/server/src/test/java/org/apache/iotdb/db/auth/authorizer/LocalFileAuthorizerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/auth/authorizer/LocalFileAuthorizerTest.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.commons.auth.authorizer.BasicAuthorizer;
 import org.apache.iotdb.commons.auth.authorizer.IAuthorizer;
 import org.apache.iotdb.commons.auth.entity.Role;
 import org.apache.iotdb.commons.auth.entity.User;
-import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 
 import org.junit.After;
@@ -256,7 +256,7 @@ public class LocalFileAuthorizerTest {
     IAuthorizer authorizer = BasicAuthorizer.getInstance();
     List<String> userList = authorizer.listAllUsers();
     assertEquals(1, userList.size());
-    assertEquals(CommonConfig.getInstance().getAdminName(), userList.get(0));
+    assertEquals(CommonDescriptor.getInstance().getConfig().getAdminName(), userList.get(0));
 
     int userCnt = 10;
     for (int i = 0; i < userCnt; i++) {

--- a/server/src/test/java/org/apache/iotdb/db/auth/authorizer/OpenIdAuthorizerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/auth/authorizer/OpenIdAuthorizerTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.auth.authorizer;
 import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.authorizer.OpenIdAuthorizer;
 import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
@@ -37,7 +38,7 @@ public class OpenIdAuthorizerTest {
 
   private static final String OPEN_ID_PUBLIC_JWK =
       "{\"kty\":\"RSA\",\"x5t#S256\":\"TZFbbj6HsRU28HYvrcVnDs03KreV3DE24-Cxb9EPdS4\",\"e\":\"AQAB\",\"use\":\"sig\",\"x5t\":\"l_N2UlC_a624iu5eYFypnB1Wr20\",\"kid\":\"q1-Wm0ozQ5O0mQH8-SJap2ZcN4MmucWwnQWKYxZJ4ow\",\"x5c\":[\"MIICmTCCAYECBgFyRdXW2DANBgkqhkiG9w0BAQsFADAQMQ4wDAYDVQQDDAVJb1REQjAeFw0yMDA1MjQwODM3MjJaFw0zMDA1MjQwODM5MDJaMBAxDjAMBgNVBAMMBUlvVERCMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAozDCZTVc9946VvhZ6E\\/OP8Yx6tJe0i9GR2Q9jR9S3jQoo0haT\\/P1b\\/zvQK52qA1xj6tBVg64xl3+LUxtCvh3HfAM5Q3PeSa0e2MkZaKCt335lKnKCSuaQGYoHULmg\\/FDOgCA0wJYOonGGJkgWmkzSAzdnHmBATosTl0XkBXHTdFOq5HaKw+bfghYp5097Gkl\\/Dp4sixVjIWLTh5l9diy4D\\/XKxadGumPCmTOS5E7y92jiHE64XFe1Q7v1qD+qKJKFvamAMIFPGBKegIajt42IcOIcIaJZnM1lBZApq1a\\/E6oL24QnP\\/j2e9coseDtGNywaADQdO8PaJadH\\/BV4aPCwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBX4rsWPIAwgSK6BEZmtEkh\\/FMfZtkvCFANpwkCX5Pph8yuk\\/8xrvx30yb4fIgqsxxQk6H+Q1qptm1cXs0tNu1yft+t+B2VuVjrWtkCkV0hAy6eZcdW411Pt523pHoOTxg6ehQd5DsvCIlsvWo83ePTKME+092vfs3irfQcRzc5xINdpopSvZlZuQ83tNEJY8gWvspQZr+uj8AP2x6w0BOrPJIiLlV+peNJuD3UgJKlSfOueKbKeM1kIVOG\\/a2AoEkBgqktnaIWzkXbk475\\/0xfGegsSZrxGR3\\/SA3jegS0sHFCY7\\/Ie\\/UvDgqMjd207oT64jxEGrd4mObxOx7aS0tp\"],\"alg\":\"RS256\",\"n\":\"ozDCZTVc9946VvhZ6E_OP8Yx6tJe0i9GR2Q9jR9S3jQoo0haT_P1b_zvQK52qA1xj6tBVg64xl3-LUxtCvh3HfAM5Q3PeSa0e2MkZaKCt335lKnKCSuaQGYoHULmg_FDOgCA0wJYOonGGJkgWmkzSAzdnHmBATosTl0XkBXHTdFOq5HaKw-bfghYp5097Gkl_Dp4sixVjIWLTh5l9diy4D_XKxadGumPCmTOS5E7y92jiHE64XFe1Q7v1qD-qKJKFvamAMIFPGBKegIajt42IcOIcIaJZnM1lBZApq1a_E6oL24QnP_j2e9coseDtGNywaADQdO8PaJadH_BV4aPCw\"}";
-  private static final CommonConfig config = CommonConfig.getInstance();
+  private static final CommonConfig config = CommonDescriptor.getInstance().getConfig();
 
   @Test
   public void loginWithJWT() throws AuthException, ParseException {

--- a/server/src/test/java/org/apache/iotdb/db/auth/user/LocalFileUserManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/auth/user/LocalFileUserManagerTest.java
@@ -22,7 +22,7 @@ import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.entity.PathPrivilege;
 import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.auth.user.LocalFileUserManager;
-import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.utils.AuthUtils;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
@@ -211,7 +211,7 @@ public class LocalFileUserManagerTest {
     // list users
     List<String> usernames = manager.listAllUsers();
     usernames.sort(null);
-    assertEquals(CommonConfig.getInstance().getAdminName(), usernames.get(0));
+    assertEquals(CommonDescriptor.getInstance().getConfig().getAdminName(), usernames.get(0));
     for (int i = 0; i < users.length - 1; i++) {
       assertEquals(users[i].getName(), usernames.get(i + 1));
     }

--- a/server/src/test/java/org/apache/iotdb/db/security/encrypt/MessageDigestEncryptTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/security/encrypt/MessageDigestEncryptTest.java
@@ -22,7 +22,7 @@ import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.entity.PathPrivilege;
 import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.auth.user.LocalFileUserManager;
-import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.security.encrypt.MessageDigestEncrypt;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
@@ -48,7 +48,7 @@ public class MessageDigestEncryptTest {
 
   @Before
   public void setUp() throws Exception {
-    CommonConfig.getInstance().setEncryptDecryptProvider(providerClass);
+    CommonDescriptor.getInstance().getConfig().setEncryptDecryptProvider(providerClass);
     EnvironmentUtils.envSetUp();
     testFolder = new File(TestConstant.BASE_OUTPUT_PATH.concat("test"));
     testFolder.mkdirs();


### PR DESCRIPTION
## Description


### Motivation
The config should be managed by a descriptor rather than make itself as a single tone.

### Modification
Implement CommonDescriptor and encapsulate the related init and load logic into it. Refactor the commonConfig access to CommonDescriptor.getInstance().getConfig

