### PR TITLE
[IOTDB-3146] add confignode to distribution package

### DIFF
--- a/.github/workflows/main-unix.yml
+++ b/.github/workflows/main-unix.yml
@@ -56,4 +56,4 @@ jobs:
         shell: bash
         # we do not compile client-cpp for saving time, it is tested in client.yml
         # old cluster is deprecated, skip the test
-        run: mvn -B clean verify -Dtest.port.closed=true -Dcluster.skip.test=true -P '!testcontainer'
+        run: mvn -B clean verify -Dtest.port.closed=true -Dcluster.test.skip=true -P '!testcontainer'

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2-
       - name: IT/UT Test
         # we do not compile client-cpp for saving time, it is tested in client.yml
-        run: mvn -B clean compile post-integration-test -Dcluster.skip.test=true -Dtest.port.closed=true -Pcode-coverage -P '!testcontainer,!influxdb-protocol'
+        run: mvn -B clean compile post-integration-test -Dcluster.test.skip=true -Dtest.port.closed=true -Pcode-coverage -P '!testcontainer,!influxdb-protocol'
       - name: Code Coverage (Coveralls)
         if: ${{ success() }}
         run: |

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -43,6 +43,7 @@
                             <target>
                                 <mkdir dir="target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode"/>
                                 <mkdir dir="target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode"/>
+                                <mkdir dir="target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/lib"/>
                                 <symlink link="${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode/lib" resource="../lib"/>
                                 <symlink link="${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode/lib" resource="../lib"/>
                             </target>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -43,8 +43,8 @@
                             <target>
                                 <mkdir dir="target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode"/>
                                 <mkdir dir="target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode"/>
-                                <symlink link="${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode/" resource="../lib"/>
-                                <symlink link="${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode/" resource="../lib"/>
+                                <symlink link="${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode/lib" resource="../lib"/>
+                                <symlink link="${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode/lib" resource="../lib"/>
                             </target>
                         </configuration>
                         <goals>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -33,6 +33,71 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>make dir for datanode</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>mkdir</executable>
+                            <arguments>
+                                <argument>-p</argument>
+                                <argument>target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>link datanode lib directory</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>ln</executable>
+                            <arguments>
+                                <argument>-sv</argument>
+                                <argument>../lib</argument>
+                                <argument>target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make dir for confignode</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>mkdir</executable>
+                            <arguments>
+                                <argument>-p</argument>
+                                <argument>target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>link confignode lib directory</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>ln</executable>
+                            <arguments>
+                                <argument>-sv</argument>
+                                <argument>../lib</argument>
+                                <argument>target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>${maven.assembly.version}</version>
@@ -48,7 +113,6 @@
                             <descriptors>
                                 <descriptor>src/assembly/all.xml</descriptor>
                                 <descriptor>src/assembly/server.xml</descriptor>
-                                <!--descriptor>src/assembly/cluster.xml</descriptor-->
                                 <descriptor>src/assembly/confignode.xml</descriptor>
                                 <descriptor>src/assembly/cli.xml</descriptor>
                                 <descriptor>src/assembly/grafana-connector.xml</descriptor>
@@ -86,7 +150,6 @@
                                         <include>apache-iotdb-${project.version}-all-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-server-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-cli-bin.zip</include>
-                                        <!--include>apache-iotdb-${project.version}-cluster-bin.zip</include-->
                                         <include>apache-iotdb-${project.version}-confignode-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-grafana-connector-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-client-cpp-${os.classifier}-bin.zip</include>
@@ -125,12 +188,6 @@
             <version>${project.version}</version>
             <type>pom</type>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.iotdb</groupId>-->
-        <!--            <artifactId>iotdb-cluster</artifactId>-->
-        <!--            <version>${project.version}</version>-->
-        <!--            <type>zip</type>-->
-        <!--        </dependency>-->
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-confignode</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -49,6 +49,7 @@
                                 <descriptor>src/assembly/all.xml</descriptor>
                                 <descriptor>src/assembly/server.xml</descriptor>
                                 <!--descriptor>src/assembly/cluster.xml</descriptor-->
+                                <descriptor>src/assembly/confignode.xml</descriptor>
                                 <descriptor>src/assembly/cli.xml</descriptor>
                                 <descriptor>src/assembly/grafana-connector.xml</descriptor>
                                 <descriptor>src/assembly/client-cpp.xml</descriptor>
@@ -86,6 +87,7 @@
                                         <include>apache-iotdb-${project.version}-server-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-cli-bin.zip</include>
                                         <!--include>apache-iotdb-${project.version}-cluster-bin.zip</include-->
+                                        <include>apache-iotdb-${project.version}-confignode-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-grafana-connector-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-client-cpp-${os.classifier}-bin.zip</include>
                                         <include>apache-iotdb-${project.version}-grafana-plugin-bin.zip</include>
@@ -129,6 +131,12 @@
         <!--            <version>${project.version}</version>-->
         <!--            <type>zip</type>-->
         <!--        </dependency>-->
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>iotdb-confignode</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>client-cpp</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -33,67 +33,23 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>exec-maven-plugin</artifactId>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
                     <execution>
-                        <id>make dir for datanode</id>
                         <phase>package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
                         <configuration>
-                            <executable>mkdir</executable>
-                            <arguments>
-                                <argument>-p</argument>
-                                <argument>target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode</argument>
-                            </arguments>
+                            <target>
+                                <mkdir dir="target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode"/>
+                                <mkdir dir="target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode"/>
+                                <symlink link="${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode/" resource="../lib"/>
+                                <symlink link="${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode/" resource="../lib"/>
+                            </target>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>link datanode lib directory</id>
-                        <phase>package</phase>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>run</goal>
                         </goals>
-                        <configuration>
-                            <executable>ln</executable>
-                            <arguments>
-                                <argument>-sv</argument>
-                                <argument>../lib</argument>
-                                <argument>target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>make dir for confignode</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>mkdir</executable>
-                            <arguments>
-                                <argument>-p</argument>
-                                <argument>target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>link confignode lib directory</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>ln</executable>
-                            <arguments>
-                                <argument>-sv</argument>
-                                <argument>../lib</argument>
-                                <argument>target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode</argument>
-                            </arguments>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/distribution/src/assembly/all.xml
+++ b/distribution/src/assembly/all.xml
@@ -31,11 +31,18 @@
             <includes>
                 <include>*:iotdb-server:zip:*</include>
                 <include>*:iotdb-cli:zip:*</include>
-                <!--                <include>*:iotdb-cluster:zip:*</include>-->
+                <include>*:iotdb-confignode:zip:*</include>
             </includes>
             <outputDirectory>${file.separator}</outputDirectory>
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
             <unpack>true</unpack>
+            <unpackOptions>
+                <excludes>
+                    <exclude>tools/**</exclude>
+                    <exclude>conf/**</exclude>
+                    <exclude>sbin/**</exclude>
+                </excludes>
+            </unpackOptions>
         </dependencySet>
         <dependencySet>
             <includes>
@@ -47,12 +54,16 @@
         </dependencySet>
     </dependencySets>
     <fileSets>
-        <!--        <fileSet>-->
-        <!--            <outputDirectory>conf</outputDirectory>-->
-        <!--            <directory>${maven.multiModuleProjectDirectory}/server/src/assembly/resources/conf</directory>-->
-        <!--        </fileSet>-->
         <fileSet>
-            <outputDirectory>conf</outputDirectory>
+            <outputDirectory>datanode/conf</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/server/src/assembly/resources/conf</directory>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>confignode/conf</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/confignode/src/assembly/resources/conf</directory>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>datanode/conf</outputDirectory>
             <directory>${maven.multiModuleProjectDirectory}/metrics/interface/src/main/assembly/resources/conf</directory>
         </fileSet>
         <fileSet>
@@ -60,8 +71,13 @@
             <directory>${maven.multiModuleProjectDirectory}/grafana-metrics-example</directory>
         </fileSet>
         <fileSet>
-            <outputDirectory>sbin</outputDirectory>
+            <outputDirectory>datanode/sbin</outputDirectory>
             <directory>${maven.multiModuleProjectDirectory}/server/src/assembly/resources/sbin</directory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>confignode/sbin</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/confignode/src/assembly/resources/sbin</directory>
             <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
@@ -70,7 +86,7 @@
             <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
-            <outputDirectory>sbin</outputDirectory>
+            <outputDirectory>datanode/sbin</outputDirectory>
             <directory>${maven.multiModuleProjectDirectory}/cli/src/assembly/resources/sbin</directory>
             <fileMode>0755</fileMode>
         </fileSet>
@@ -79,15 +95,14 @@
             <directory>${maven.multiModuleProjectDirectory}/cli/src/assembly/resources/tools</directory>
             <fileMode>0755</fileMode>
         </fileSet>
-        <!--        <fileSet>-->
-        <!--            <outputDirectory>conf</outputDirectory>-->
-        <!--            <directory>${maven.multiModuleProjectDirectory}/cluster/src/assembly/resources/conf</directory>-->
-        <!--        </fileSet>-->
-        <!--        <fileSet>-->
-        <!--            <outputDirectory>sbin</outputDirectory>-->
-        <!--            <directory>${maven.multiModuleProjectDirectory}/cluster/src/assembly/resources/sbin</directory>-->
-        <!--            <fileMode>0755</fileMode>-->
-        <!--        </fileSet>-->
+        <fileSet>
+            <outputDirectory>datanode</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/datanode</directory>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>confignode</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/distribution/target/apache-iotdb-${project.version}-all-bin/apache-iotdb-${project.version}-all-bin/confignode</directory>
+        </fileSet>
         <fileSet>
             <directory>${maven.multiModuleProjectDirectory}/docs</directory>
             <outputDirectory>docs</outputDirectory>
@@ -100,7 +115,7 @@
         </file>
         <file>
             <source>${maven.multiModuleProjectDirectory}/server/src/assembly/resources/conf/iotdb-env.sh</source>
-            <destName>conf/iotdb-env.sh</destName>
+            <destName>datanode/conf/iotdb-env.sh</destName>
             <fileMode>0755</fileMode>
         </file>
     </files>

--- a/distribution/src/assembly/confignode.xml
+++ b/distribution/src/assembly/confignode.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<assembly>
+    <id>confignode-bin</id>
+    <formats>
+        <format>dir</format>
+        <format>zip</format>
+    </formats>
+    <baseDirectory>apache-iotdb-${project.version}-confignode-bin</baseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <includes>
+                <include>*:iotdb-confignode:zip:*</include>
+            </includes>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+            <unpack>true</unpack>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${maven.multiModuleProjectDirectory}/confignode/src/assembly/resources/sbin</directory>
+            <outputDirectory>sbin</outputDirectory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>${maven.multiModuleProjectDirectory}/confignode/src/assembly/resources/conf</directory>
+            <outputDirectory>conf</outputDirectory>
+        </fileSet>
+        <!--    <fileSet>-->
+        <!--      <directory>${maven.multiModuleProjectDirectory}/confignode/src/assembly/resources/tools</directory>-->
+        <!--      <outputDirectory>tools</outputDirectory>-->
+        <!--      <fileMode>0755</fileMode>-->
+        <!--    </fileSet>-->
+    </fileSets>
+    <componentDescriptors>
+        <componentDescriptor>common-files.xml</componentDescriptor>
+    </componentDescriptors>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -1415,6 +1415,7 @@
                             <excludes>
                                 <exclude>org/apache/iotdb/service/sync/thrift/*</exclude>
                                 <exclude>org/apache/iotdb/service/rpc/thrift/*</exclude>
+                                <exclude>org/apache/iotdb/cluster/*</exclude>
                                 <exclude>org/apache/iotdb/cluster/rpc/thrift/*</exclude>
                                 <exclude>org/apache/iotdb/protocol/influxdb/rpc/thrift/*</exclude>
                                 <exclude>org/apache/iotdb/db/qp/sql/*</exclude>

--- a/testcontainer/pom.xml
+++ b/testcontainer/pom.xml
@@ -33,8 +33,8 @@
         <docker.build.executable>docker</docker.build.executable>
         <docker.build.single.argument>build -t apache/iotdb:maven-development -f ${basedir}/../docker/src/main/Dockerfile-single ${basedir}/../.</docker.build.single.argument>
         <docker.clean.single.argument>image rm apache/iotdb:maven-development</docker.clean.single.argument>
-<!--        <docker.build.cluster.argument>build -t apache/iotdb:cluster-maven-development -f ${basedir}/../docker/src/main/Dockerfile-cluster ${basedir}/../.</docker.build.cluster.argument>-->
-<!--        <docker.clean.cluster.argument>image rm apache/iotdb:cluster-maven-development</docker.clean.cluster.argument>-->
+        <!--        <docker.build.cluster.argument>build -t apache/iotdb:cluster-maven-development -f ${basedir}/../docker/src/main/Dockerfile-cluster ${basedir}/../.</docker.build.cluster.argument>-->
+        <!--        <docker.clean.cluster.argument>image rm apache/iotdb:cluster-maven-development</docker.clean.cluster.argument>-->
         <docker.build.sync.argument>build -t apache/iotdb:sync-maven-development -f ${basedir}/../docker/src/main/Dockerfile-single-tc ${basedir}/../.</docker.build.sync.argument>
         <docker.clean.sync.argument>image rm apache/iotdb:sync-maven-development</docker.clean.sync.argument>
     </properties>
@@ -90,18 +90,18 @@
                                     <commandlineArgs>${docker.build.single.argument}</commandlineArgs>
                                 </configuration>
                             </execution>
-<!--                            <execution>-->
-<!--                                <id>build-cluster-docker-image</id>-->
-<!--                                <phase>pre-integration-test</phase>-->
-<!--                                <goals>-->
-<!--                                    <goal>exec</goal>-->
-<!--                                </goals>-->
-<!--                                <configuration>-->
-<!--                                    <skip>${docker.test.skip}</skip>-->
-<!--                                    <executable>${docker.build.executable}</executable>-->
-<!--                                    <commandlineArgs>${docker.build.cluster.argument}</commandlineArgs>-->
-<!--                                </configuration>-->
-<!--                            </execution>-->
+                            <!--                            <execution>-->
+                            <!--                                <id>build-cluster-docker-image</id>-->
+                            <!--                                <phase>pre-integration-test</phase>-->
+                            <!--                                <goals>-->
+                            <!--                                    <goal>exec</goal>-->
+                            <!--                                </goals>-->
+                            <!--                                <configuration>-->
+                            <!--                                    <skip>${docker.test.skip}</skip>-->
+                            <!--                                    <executable>${docker.build.executable}</executable>-->
+                            <!--                                    <commandlineArgs>${docker.build.cluster.argument}</commandlineArgs>-->
+                            <!--                                </configuration>-->
+                            <!--                            </execution>-->
                             <execution>
                                 <id>build-sync-docker-image</id>
                                 <phase>pre-integration-test</phase>
@@ -126,18 +126,18 @@
                                     <commandlineArgs>${docker.clean.single.argument}</commandlineArgs>
                                 </configuration>
                             </execution>
-<!--                            <execution>-->
-<!--                                <id>clean-cluster-docker-image</id>-->
-<!--                                <phase>post-integration-test</phase>-->
-<!--                                <goals>-->
-<!--                                    <goal>exec</goal>-->
-<!--                                </goals>-->
-<!--                                <configuration>-->
-<!--                                    <skip>${docker.test.skip}</skip>-->
-<!--                                    <executable>${docker.build.executable}</executable>-->
-<!--                                    <commandlineArgs>${docker.clean.cluster.argument}</commandlineArgs>-->
-<!--                                </configuration>-->
-<!--                            </execution>-->
+                            <!--                            <execution>-->
+                            <!--                                <id>clean-cluster-docker-image</id>-->
+                            <!--                                <phase>post-integration-test</phase>-->
+                            <!--                                <goals>-->
+                            <!--                                    <goal>exec</goal>-->
+                            <!--                                </goals>-->
+                            <!--                                <configuration>-->
+                            <!--                                    <skip>${docker.test.skip}</skip>-->
+                            <!--                                    <executable>${docker.build.executable}</executable>-->
+                            <!--                                    <commandlineArgs>${docker.clean.cluster.argument}</commandlineArgs>-->
+                            <!--                                </configuration>-->
+                            <!--                            </execution>-->
                             <execution>
                                 <id>clean-sync-docker-image</id>
                                 <phase>post-integration-test</phase>


### PR DESCRIPTION
## Description

In this PR
 * Add confignode in distribution package, we can now execute `mvn clean package -pl distribution -am -DskipTests` to get the compiled confignode package.
 * fix CI still runs old cluster tests
 * Add confignode in all-in-one package

Now the all-in-one structure is

![image](https://user-images.githubusercontent.com/25913899/167783574-43bc44e8-1f8e-4d4a-aa35-c57dd78dc23d.png)
