### PR TITLE
[IOTDB-3045] Deleted timeseries are created again after restart

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBRestartIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBRestartIT.java
@@ -312,12 +312,17 @@ public class IoTDBRestartIT {
 
       boolean hasResultSet = statement.execute("select * from root.**");
       assertTrue(hasResultSet);
-      ResultSet resultSet = statement.getResultSet();
-      int cnt = 0;
-      while (resultSet.next()) {
-        cnt++;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        int cnt = 0;
+        Assert.assertEquals(3, resultSet.getMetaData().getColumnCount());
+        while (resultSet.next()) {
+          Assert.assertEquals("1", resultSet.getString(1));
+          Assert.assertEquals(null, resultSet.getString(2));
+          Assert.assertEquals("2.2", resultSet.getString(3));
+          cnt++;
+        }
+        assertEquals(1, cnt);
       }
-      assertEquals(1, cnt);
     }
 
     EnvironmentUtils.cleanEnv();
@@ -345,12 +350,16 @@ public class IoTDBRestartIT {
 
       boolean hasResultSet = statement.execute("select * from root.**");
       assertTrue(hasResultSet);
-      ResultSet resultSet = statement.getResultSet();
-      int cnt = 0;
-      while (resultSet.next()) {
-        cnt++;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        int cnt = 0;
+        Assert.assertEquals(2, resultSet.getMetaData().getColumnCount());
+        while (resultSet.next()) {
+          Assert.assertEquals("1", resultSet.getString(1));
+          Assert.assertEquals("2.2", resultSet.getString(2));
+          cnt++;
+        }
+        assertEquals(1, cnt);
       }
-      assertEquals(1, cnt);
     }
 
     EnvironmentUtils.cleanEnv();

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -117,7 +117,7 @@ public class IoTDB implements IoTDBMBean {
       return;
     }
 
-    // set recover config
+    // set recover config, avoid creating deleted time series when recovering wal
     boolean prevIsAutoCreateSchemaEnabled = config.isAutoCreateSchemaEnabled();
     config.setAutoCreateSchemaEnabled(false);
     boolean prevIsEnablePartialInsert = config.isEnablePartialInsert();

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.commons.service.JMXService;
 import org.apache.iotdb.commons.service.RegisterManager;
 import org.apache.iotdb.commons.service.StartupChecks;
+import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.IoTDBStartCheck;
 import org.apache.iotdb.db.conf.rest.IoTDBRestServiceCheck;
@@ -66,6 +67,7 @@ public class IoTDB implements IoTDBMBean {
   private static final Logger logger = LoggerFactory.getLogger(IoTDB.class);
   private final String mbeanName =
       String.format("%s:%s=%s", IoTDBConstant.IOTDB_PACKAGE, IoTDBConstant.JMX_TYPE, "IoTDB");
+  private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static final RegisterManager registerManager = new RegisterManager();
   public static LocalSchemaProcessor schemaProcessor = LocalSchemaProcessor.getInstance();
   public static LocalConfigNode configManager = LocalConfigNode.getInstance();
@@ -114,6 +116,13 @@ public class IoTDB implements IoTDBMBean {
           "{}: failed to start because some checks failed. ", IoTDBConstant.GLOBAL_DB_NAME, e);
       return;
     }
+
+    // set recover config
+    boolean prevIsAutoCreateSchemaEnabled = config.isAutoCreateSchemaEnabled();
+    config.setAutoCreateSchemaEnabled(false);
+    boolean prevIsEnablePartialInsert = config.isEnablePartialInsert();
+    config.setEnablePartialInsert(true);
+
     try {
       setUp();
     } catch (StartupException | QueryProcessException e) {
@@ -122,6 +131,11 @@ public class IoTDB implements IoTDBMBean {
       logger.error("{} exit", IoTDBConstant.GLOBAL_DB_NAME);
       return;
     }
+
+    // reset config
+    config.setAutoCreateSchemaEnabled(prevIsAutoCreateSchemaEnabled);
+    config.setEnablePartialInsert(prevIsEnablePartialInsert);
+
     logger.info("{} has started.", IoTDBConstant.GLOBAL_DB_NAME);
   }
 


### PR DESCRIPTION
Deleted timeseries are created again after restart because auto create timeseries is enabled when wal checks the timeseries schema. To fix this problem, I disable auto create timeseries and enable partial insert when recovering.