### PR TITLE
[IOTDB-3178] Refactor integration test for the new cluster

### DIFF
--- a/.github/workflows/cluster-it.yml
+++ b/.github/workflows/cluster-it.yml
@@ -1,14 +1,14 @@
-name: Cluster Test
+name: New Cluster IT
 
 on:
   push:
     branches:
-      - test_cluster
+      - master
     paths-ignore:
       - 'docs/**'
   pull_request:
     branches:
-      - test_cluster
+      - master
     paths-ignore:
       - 'docs/**'
   # allow manually run the action:
@@ -27,9 +27,9 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        java: [ 8 ]
-        os: [ ubuntu-latest ]
-    runs-on: ${{ matrix.os}}
+        java: [ 8, 11, 17 ]
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -49,4 +49,12 @@ jobs:
         shell: bash
         # we do not compile client-cpp for saving time, it is tested in client.yml
         # we can skip influxdb-protocol because it has been tested separately in influxdb-protocol.yml
-        run: mvn -B clean verify -Dsession.test.skip=true -Diotdb.test.skip=true -Dcluster.test.skip=true -Dtsfile.test.skip=true -pl integration -am -PCluster
+        run: mvn -B clean verify -Dsession.test.skip=true -Diotdb.test.skip=true -Dcluster.test.skip=true -Dtsfile.test.skip=true -Dcommons.test.skip=true -Dconfignode.test.skip=true -Dconsensus.test.skip=true -pl integration-test -am -PClusterIT
+      - name: Upload Artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cluster-log-java${{ matrix.java }}-${{ runner.os }}
+          path: integration-test/target/cluster-logs
+          retention-days: 1
+

--- a/confignode/pom.xml
+++ b/confignode/pom.xml
@@ -30,9 +30,9 @@
     <artifactId>iotdb-confignode</artifactId>
     <name>IoTDB ConfigNode</name>
     <properties>
-        <iotdb.test.skip>false</iotdb.test.skip>
-        <iotdb.it.skip>${iotdb.test.skip}</iotdb.it.skip>
-        <iotdb.ut.skip>${iotdb.test.skip}</iotdb.ut.skip>
+        <confignode.test.skip>false</confignode.test.skip>
+        <confignode.it.skip>${confignode.test.skip}</confignode.it.skip>
+        <confignode.ut.skip>${confignode.test.skip}</confignode.ut.skip>
     </properties>
     <dependencies>
         <dependency>
@@ -102,6 +102,44 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--using `mvn test` to run UT, `mvn verify` to run ITs
+                        Reference: https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${confignode.ut.skip}</skipTests>
+                    <forkMode>pertest</forkMode>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>skipConfigNodeTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <confignode.test.skip>true</confignode.test.skip>
+                <confignode.ut.skip>true</confignode.ut.skip>
+                <confignode.it.skip>true</confignode.it.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>skipUT_ConfigNode_Tests</id>
+            <activation>
+                <property>
+                    <name>skipUTs</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <confignode.ut.skip>true</confignode.ut.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/confignode/src/assembly/resources/conf/logback.xml
+++ b/confignode/src/assembly/resources/conf/logback.xml
@@ -127,6 +127,16 @@
             <level>INFO</level>
         </filter>
     </appender>
+    <appender class="ch.qos.logback.core.FileAppender" name="ITForCluster">
+        <file>${IT_LOG_PATH:-/dev/null}</file>
+        <encoder>
+            <pattern>%d [%t] %-5p %C{25}:%L - %m %n</pattern>
+            <charset>utf-8</charset>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${IT_LOG_LEVEL:-OFF}</level>
+        </filter>
+    </appender>
     <root level="info">
         <appender-ref ref="FILEDEBUG"/>
         <appender-ref ref="FILEWARN"/>
@@ -134,6 +144,7 @@
         <appender-ref ref="FILEINFO"/>
         <appender-ref ref="FILEALL"/>
         <appender-ref ref="stdout"/>
+        <appender-ref ref="ITForCluster"/>
     </root>
     <logger level="info" name="org.apache.iotdb.confignode"/>
     <logger level="info" name="org.apache.ratis"/>

--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -29,6 +29,14 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>iotdb-consensus</artifactId>
     <name>IoTDB Consensus</name>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <ratis.version>2.3.0</ratis.version>
+        <consensus.test.skip>false</consensus.test.skip>
+        <consensus.it.skip>${consensus.test.skip}</consensus.it.skip>
+        <consensus.ut.skip>${consensus.test.skip}</consensus.ut.skip>
+    </properties>
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.apache.ratis/ratis-server -->
         <dependency>
@@ -58,9 +66,58 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <ratis.version>2.3.0</ratis.version>
-    </properties>
+    <build>
+        <plugins>
+            <!-- generate test codes into test-jar-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--using `mvn test` to run UT, `mvn verify` to run ITs
+                        Reference: https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${consensus.ut.skip}</skipTests>
+                    <forkMode>pertest</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>skipConsensusTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <consensus.test.skip>true</consensus.test.skip>
+                <consensus.ut.skip>true</consensus.ut.skip>
+                <consensus.it.skip>true</consensus.it.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>skipUT_Consensus_Tests</id>
+            <activation>
+                <property>
+                    <name>skipUTs</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <consensus.ut.skip>true</consensus.ut.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -1,0 +1,124 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+Integration Test For the New MPP Cluster
+===================
+
+Integration test for the new mpp cluster are in this module.
+
+Now integration testing supports three modes the Cluster mode, the Local Standalone mode and the Remote mode.
+
+Integration Testing with Cluster Mode
+-------------------
+
+You can run the integration test in cluster mode. At present, we have implemented a pseudo cluster with 3 config nodes and 3 data nodes.
+(As the test cases and the test environment are decoupled, we can easily implement other pseudo cluster or even a docker-based cluster later.)
+
+The maven command is:
+```
+mvn clean verify -Dsession.test.skip=true -Diotdb.test.skip=true -Dcluster.test.skip=true -Dtsfile.test.skip=true -Dcommons.test.skip=true -Dconfignode.test.skip=true -Dconsensus.test.skip=true -pl integration-test -am -PClusterIT
+```
+Notice that, this above maven command only run IT.
+
+-------
+
+Run in IntelliJ in cluster mode is so easy,
+- Step 0. Optionally, when you run the test for the first time, or when you change the code of the module that the integration test module depends on, you may need to use the following command to generate `integration/target/template-node` for nodes of the pseudo cluster.
+```
+mvn clean package -pl integration-test -am -DskipTests -PClusterIT
+```
+
+- Step 1. Run(Menu) -> Edit Configurations...  
+  ![Run(Menu)](https://github.com/apache/iotdb-bin-resources/blob/main/integration/pic/Run(Menu).png?raw=true)
+
+
+- Step 2. Add New Configuration -> JUnit  
+  ![Add New Configuration](https://github.com/apache/iotdb-bin-resources/blob/main/integration/pic/Add_New_Configuration.png?raw=true)
+
+
+- Step 3. Input some fields as the following picture  
+  ![ClusterIT Category](https://github.com/apache/iotdb-bin-resources/blob/main/integration-test/pic/ClusterIT_Category.png?raw=true)
+
+Integration Testing with Local Standalone Mode
+-------------------
+
+Integration testing with local standalone mode can be run with both maven and IDEs like IntelliJ.
+
+The maven command is:
+```
+mvn clean verify -Dsession.test.skip=true -Diotdb.test.skip=true -Dcluster.test.skip=true -Dtsfile.test.skip=true -Dcommons.test.skip=true -Dconfignode.test.skip=true -Dconsensus.test.skip=true -pl integration-test -am
+```
+
+-------
+And if you want to run IT in the IDE like IntelliJ, you need to achieve the effect as the `LocalStandalone` profile in maven. Follow Steps 1-4 to achieve it.
+
+- Step 1. Run(Menu) -> Edit Configurations...  
+  ![Run(Menu)](https://github.com/apache/iotdb-bin-resources/blob/main/integration/pic/Run(Menu).png?raw=true)
+
+
+- Step 2. Add New Configuration -> JUnit  
+  ![Add New Configuration](https://github.com/apache/iotdb-bin-resources/blob/main/integration/pic/Add_New_Configuration.png?raw=true)
+
+
+- Step 3. Input some fields as the following picture  
+  ![StandaloneIT Category](https://github.com/apache/iotdb-bin-resources/blob/main/integration-test/pic/StandaloneIT_Category.png?raw=true)
+
+
+- Step 4. Pay attention to the `Fork mode` in `Modify options`: you need to change `None` to `class` in `Fork mode`  
+  ![Fork mode](https://github.com/apache/iotdb-bin-resources/blob/main/integration/pic/Fork_mode.png?raw=true)
+
+
+Integration Testing with Remote Mode
+-------------------
+
+You can also run the integration test in remote mode. The remote server can be a standalone server or a server of a cluster.
+
+The maven command is:
+```
+mvn clean verify -pl integration-test -am -PRemoteIT -DRemoteIp=127.0.0.1 -DRemotePort=6667
+```
+
+Writing a New Test
+-------------------
+
+## What should we cover in integration tests
+
+For every end-user functionality provided by IoTDB, we should have an integration test verifying the correctness.
+
+## Rules to be followed while writing a new integration test
+
+### Every Integration Test must follow these rules:
+
+1) The name of the test file must end with a suffix "IT"
+2) Tests are to be written in Junit style
+3) Put appropriate annotation `@Category` on the class or the test level
+4) It's highly recommend that, use `statement.execute()` to do manipulate action with SQL like CREATE/INSERT/DELETE, and use `statement.executeQuery()` to do query action with SQL like SELECT
+
+### About the annotation:
+You can put the annotation `@Category({LocalStandaloneTest.class, ClusterTest.class, RemoteTest.class})` on the class or the test level.
+And you can use these annotations individually or in combination.
+
+`LocalStandaloneTest.class` stands for you want your test run in the local standalone mode.
+
+`ClusterTest.class` stands for you want your test run in the cluster mode.
+
+`RemoteTest.class` stands for you want your test run in the remote mode.
+

--- a/integration-test/checkstyle.xml
+++ b/integration-test/checkstyle.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<!--
+    Note: Checkstyle configuration under integration-test module only validates the code styles about test cases.
+    Other codes rules should be referenced the checkstyle.xml under the project root folder
+ -->
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="severity" value="error"/>
+    <property name="fileExtensions" value="java"/>
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="^.*([\\/]src[\\/]main|[\\/]src[\\/]test[\\/]java[\\/]org[\\/]apache[\\/]iotdb[\\/]session)[\\/].*$"/>
+    </module>
+    <module name="TreeWalker">
+        <module name="ImportControl">
+            <property name="file" value="integration-test/import-control.xml"/>
+            <property name="path" value="^.*IT\.java$"/>
+            <message key="import.control.disallowed" value="{0} is not allowed to use in integration test."/>
+        </module>
+    </module>
+</module>

--- a/integration-test/import-control.xml
+++ b/integration-test/import-control.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE import-control PUBLIC "-//Checkstyle//DTD ImportControl Configuration 1.4//EN" "https://checkstyle.org/dtds/import_control_1_4.dtd">
+
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<import-control pkg="org.apache.iotdb.db.it">
+    <allow pkg="java.util"/>
+    <allow pkg="java.sql"/>
+    <allow pkg="java.io"/>
+    <allow pkg="org\.junit.*" regex="true"/>
+    <allow pkg="org\.apache\.iotdb\.itbase" regex="true"/>
+    <allow pkg="org\.apache\.iotdb\.it.*" regex="true"/>
+    <disallow class="java.sql.DriverManager"/>
+    <disallow class="javax.sql.DataSource"/>
+    <disallow pkg="org.apache.iotdb.jdbc.*"/>
+</import-control>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -27,7 +27,7 @@
         <version>0.14.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>integration</artifactId>
+    <artifactId>integration-test</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
@@ -43,11 +43,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
-            <artifactId>iotdb-cluster</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -57,14 +52,13 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>iotdb-confignode</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>${awaitility.version}</version>
-            <scope>test</scope>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
     <dependencyManagement>
@@ -83,7 +77,7 @@
     </dependencyManagement>
     <profiles>
         <profile>
-            <id>LocalStandalone</id>
+            <id>LocalStandaloneIT</id>
             <properties>
                 <test.includedGroups>org.apache.iotdb.itbase.category.LocalStandaloneIT</test.includedGroups>
                 <test.excludedGroups/>
@@ -111,7 +105,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>integration-test-Standalone</id>
+                                <id>standalone-integration-test</id>
                                 <goals>
                                     <goal>integration-test</goal>
                                 </goals>
@@ -125,7 +119,7 @@
                                     <systemPropertyVariables>
                                         <TestEnv>Standalone</TestEnv>
                                     </systemPropertyVariables>
-                                    <summaryFile>target/failsafe-reports/failsafe-summary-LocalStandalone.xml</summaryFile>
+                                    <summaryFile>target/failsafe-reports/failsafe-summary-LocalStandaloneIT.xml</summaryFile>
                                 </configuration>
                             </execution>
                             <execution>
@@ -135,7 +129,7 @@
                                 </goals>
                                 <configuration>
                                     <summaryFiles>
-                                        <summaryFile>target/failsafe-reports/failsafe-summary-LocalStandalone.xml</summaryFile>
+                                        <summaryFile>target/failsafe-reports/failsafe-summary-LocalStandaloneIT.xml</summaryFile>
                                     </summaryFiles>
                                 </configuration>
                             </execution>
@@ -145,7 +139,7 @@
             </build>
         </profile>
         <profile>
-            <id>Remote</id>
+            <id>RemoteIT</id>
             <properties>
                 <test.includedGroups>org.apache.iotdb.itbase.category.RemoteIT</test.includedGroups>
                 <test.excludedGroups/>
@@ -173,7 +167,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>integration-test-Remote</id>
+                                <id>remote-integration-test</id>
                                 <goals>
                                     <goal>integration-test</goal>
                                 </goals>
@@ -188,7 +182,7 @@
                                     <systemPropertyVariables>
                                         <TestEnv>Remote</TestEnv>
                                     </systemPropertyVariables>
-                                    <summaryFile>target/failsafe-reports/failsafe-summary-Remote.xml</summaryFile>
+                                    <summaryFile>target/failsafe-reports/failsafe-summary-RemoteIT.xml</summaryFile>
                                 </configuration>
                             </execution>
                             <execution>
@@ -199,7 +193,7 @@
                                 <configuration>
                                     <skipTests>false</skipTests>
                                     <summaryFiles>
-                                        <summaryFile>target/failsafe-reports/failsafe-summary-Remote.xml</summaryFile>
+                                        <summaryFile>target/failsafe-reports/failsafe-summary-RemoteIT.xml</summaryFile>
                                     </summaryFiles>
                                 </configuration>
                             </execution>
@@ -209,9 +203,9 @@
             </build>
         </profile>
         <profile>
-            <id>Cluster</id>
+            <id>ClusterIT</id>
             <properties>
-                <test.includedGroups>org.apache.iotdb.itbase.category.ClusterTest</test.includedGroups>
+                <test.includedGroups>org.apache.iotdb.itbase.category.ClusterIT</test.includedGroups>
                 <test.excludedGroups/>
             </properties>
             <activation>
@@ -239,14 +233,14 @@
                         <executions>
                             <!-- Package binaries-->
                             <execution>
-                                <id>cluster-assembly</id>
+                                <id>cluster-test-assembly</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>single</goal>
                                 </goals>
                                 <configuration>
                                     <descriptors>
-                                        <descriptor>src/assembly/cluster.xml</descriptor>
+                                        <descriptor>src/assembly/cluster-test.xml</descriptor>
                                     </descriptors>
                                     <finalName>template-node</finalName>
                                     <appendAssemblyId>false</appendAssemblyId>
@@ -259,7 +253,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>integration-test-Cluster</id>
+                                <id>cluster-integration-test</id>
                                 <goals>
                                     <goal>integration-test</goal>
                                 </goals>
@@ -267,13 +261,14 @@
                                     <groups>${test.includedGroups}</groups>
                                     <excludedGroups>${test.excludedGroups}</excludedGroups>
                                     <useSystemClassLoader>false</useSystemClassLoader>
-                                    <threadCount>1</threadCount>
-                                    <forkCount>1</forkCount>
+                                    <parallel>classes</parallel>
+                                    <useUnlimitedThreads>true</useUnlimitedThreads>
+                                    <forkCount>8</forkCount>
                                     <reuseForks>false</reuseForks>
                                     <systemPropertyVariables>
-                                        <TestEnv>FiveNodeCluster1</TestEnv>
+                                        <TestEnv>Cluster1</TestEnv>
                                     </systemPropertyVariables>
-                                    <summaryFile>target/failsafe-reports/failsafe-summary-Cluster.xml</summaryFile>
+                                    <summaryFile>target/failsafe-reports/failsafe-summary-ClusterIT.xml</summaryFile>
                                 </configuration>
                             </execution>
                             <execution>
@@ -283,7 +278,7 @@
                                 </goals>
                                 <configuration>
                                     <summaryFiles>
-                                        <summaryFile>target/failsafe-reports/failsafe-summary-Cluster.xml</summaryFile>
+                                        <summaryFile>target/failsafe-reports/failsafe-summary-ClusterIT.xml</summaryFile>
                                     </summaryFiles>
                                 </configuration>
                             </execution>

--- a/integration-test/src/assembly/cluster-test.xml
+++ b/integration-test/src/assembly/cluster-test.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<assembly>
+    <id>cluster-test</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <outputDirectory>datanode/conf</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/server/src/assembly/resources/conf</directory>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>confignode/conf</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/confignode/src/assembly/resources/conf</directory>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>datanode/conf</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/metrics/interface/src/main/assembly/resources/conf</directory>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>datanode/sbin</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/server/src/assembly/resources/sbin</directory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>confignode/sbin</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/confignode/src/assembly/resources/sbin</directory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>tools</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/server/src/assembly/resources/tools</directory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>datanode/sbin</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/cli/src/assembly/resources/sbin</directory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>tools</outputDirectory>
+            <directory>${maven.multiModuleProjectDirectory}/cli/src/assembly/resources/tools</directory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>${maven.multiModuleProjectDirectory}/server/src/assembly/resources/conf/iotdb-env.sh</source>
+            <destName>datanode/conf/iotdb-env.sh</destName>
+            <fileMode>0755</fileMode>
+        </file>
+    </files>
+</assembly>

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Accumulator.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Accumulator.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.Row;
+import org.apache.iotdb.commons.udf.api.access.RowIterator;
+import org.apache.iotdb.commons.udf.api.access.RowWindow;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameterValidator;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.RowByRowAccessStrategy;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.SlidingSizeWindowAccessStrategy;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.SlidingTimeWindowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class Accumulator implements UDTF {
+
+  private static final Logger logger = LoggerFactory.getLogger(Accumulator.class);
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator.validateInputSeriesDataType(0, TSDataType.INT32, TSDataType.DOUBLE);
+  }
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    logger.debug("Accumulator#beforeStart");
+    configurations.setOutputDataType(TSDataType.INT32);
+    switch (parameters.getStringOrDefault(
+        ExampleUDFConstant.ACCESS_STRATEGY_KEY, ExampleUDFConstant.ACCESS_STRATEGY_ROW_BY_ROW)) {
+      case ExampleUDFConstant.ACCESS_STRATEGY_SLIDING_SIZE:
+        configurations.setAccessStrategy(
+            new SlidingSizeWindowAccessStrategy(
+                parameters.getInt(ExampleUDFConstant.WINDOW_SIZE_KEY)));
+        break;
+      case ExampleUDFConstant.ACCESS_STRATEGY_SLIDING_TIME:
+        configurations.setAccessStrategy(
+            new SlidingTimeWindowAccessStrategy(
+                parameters.getLong(ExampleUDFConstant.TIME_INTERVAL_KEY),
+                parameters.getLong(ExampleUDFConstant.SLIDING_STEP_KEY),
+                parameters.getLong(ExampleUDFConstant.DISPLAY_WINDOW_BEGIN_KEY),
+                parameters.getLong(ExampleUDFConstant.DISPLAY_WINDOW_END_KEY)));
+        break;
+      case ExampleUDFConstant.ACCESS_STRATEGY_ROW_BY_ROW:
+      default:
+        configurations.setAccessStrategy(new RowByRowAccessStrategy());
+    }
+  }
+
+  @Override
+  public void transform(Row row, PointCollector collector) throws IOException {
+    collector.putInt(row.getTime(), row.getInt(0));
+  }
+
+  @Override
+  public void transform(RowWindow rowWindow, PointCollector collector) throws IOException {
+    int accumulator = 0;
+    RowIterator rowIterator = rowWindow.getRowIterator();
+    while (rowIterator.hasNextRow()) {
+      switch (rowWindow.getDataType(0)) {
+        case INT32:
+          accumulator += rowIterator.next().getInt(0);
+          break;
+        case DOUBLE:
+          accumulator += (int) rowIterator.next().getDouble(0);
+          break;
+      }
+    }
+    if (rowWindow.windowSize() != 0) {
+      collector.putInt(rowWindow.getRow(0).getTime(), accumulator);
+    }
+  }
+
+  @Override
+  public void beforeDestroy() {
+    logger.debug("Accumulator#beforeDestroy");
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Adder.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Adder.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.Row;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameterValidator;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.RowByRowAccessStrategy;
+import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class Adder implements UDTF {
+
+  private static final Logger logger = LoggerFactory.getLogger(Adder.class);
+
+  private double addend;
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator
+        .validateInputSeriesNumber(2)
+        .validateInputSeriesDataType(
+            0, TSDataType.INT32, TSDataType.INT64, TSDataType.FLOAT, TSDataType.DOUBLE)
+        .validateInputSeriesDataType(
+            1, TSDataType.INT32, TSDataType.INT64, TSDataType.FLOAT, TSDataType.DOUBLE);
+  }
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    logger.debug("Adder#beforeStart");
+    addend = parameters.getFloatOrDefault("addend", 0);
+    configurations
+        .setOutputDataType(TSDataType.INT64)
+        .setAccessStrategy(new RowByRowAccessStrategy());
+  }
+
+  @Override
+  public void transform(Row row, PointCollector collector) throws Exception {
+    if (row.isNull(0) || row.isNull(1)) {
+      return;
+    }
+    collector.putLong(
+        row.getTime(), (long) (extractDoubleValue(row, 0) + extractDoubleValue(row, 1) + addend));
+  }
+
+  private double extractDoubleValue(Row row, int index) throws IOException {
+    double value;
+    switch (row.getDataType(index)) {
+      case INT32:
+        value = row.getInt(index);
+        break;
+      case INT64:
+        value = (double) row.getLong(index);
+        break;
+      case FLOAT:
+        value = row.getFloat(index);
+        break;
+      case DOUBLE:
+        value = row.getDouble(index);
+        break;
+      default:
+        throw new UnSupportedDataTypeException(row.getDataType(index).toString());
+    }
+    return value;
+  }
+
+  @Override
+  public void beforeDestroy() {
+    logger.debug("Adder#beforeDestroy");
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Counter.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Counter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.Row;
+import org.apache.iotdb.commons.udf.api.access.RowWindow;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.RowByRowAccessStrategy;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.SlidingSizeWindowAccessStrategy;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.SlidingTimeWindowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class Counter implements UDTF {
+
+  private static final Logger logger = LoggerFactory.getLogger(Counter.class);
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    logger.debug("Counter#beforeStart");
+    configurations.setOutputDataType(TSDataType.INT32);
+    switch (parameters.getStringOrDefault(
+        ExampleUDFConstant.ACCESS_STRATEGY_KEY, ExampleUDFConstant.ACCESS_STRATEGY_ROW_BY_ROW)) {
+      case ExampleUDFConstant.ACCESS_STRATEGY_SLIDING_SIZE:
+        configurations.setAccessStrategy(
+            new SlidingSizeWindowAccessStrategy(
+                parameters.getInt(ExampleUDFConstant.WINDOW_SIZE_KEY)));
+        break;
+      case ExampleUDFConstant.ACCESS_STRATEGY_SLIDING_TIME:
+        configurations.setAccessStrategy(
+            parameters.hasAttribute(ExampleUDFConstant.SLIDING_STEP_KEY)
+                    && parameters.hasAttribute(ExampleUDFConstant.DISPLAY_WINDOW_BEGIN_KEY)
+                    && parameters.hasAttribute(ExampleUDFConstant.DISPLAY_WINDOW_END_KEY)
+                ? new SlidingTimeWindowAccessStrategy(
+                    parameters.getLong(ExampleUDFConstant.TIME_INTERVAL_KEY),
+                    parameters.getLong(ExampleUDFConstant.SLIDING_STEP_KEY),
+                    parameters.getLong(ExampleUDFConstant.DISPLAY_WINDOW_BEGIN_KEY),
+                    parameters.getLong(ExampleUDFConstant.DISPLAY_WINDOW_END_KEY))
+                : new SlidingTimeWindowAccessStrategy(
+                    parameters.getLong(ExampleUDFConstant.TIME_INTERVAL_KEY)));
+        break;
+      case ExampleUDFConstant.ACCESS_STRATEGY_ROW_BY_ROW:
+      default:
+        configurations.setAccessStrategy(new RowByRowAccessStrategy());
+    }
+  }
+
+  @Override
+  public void transform(Row row, PointCollector collector) throws Exception {
+    collector.putInt(row.getTime(), 1);
+  }
+
+  @Override
+  public void transform(RowWindow rowWindow, PointCollector collector) throws IOException {
+    if (rowWindow.windowSize() != 0) {
+      collector.putInt(rowWindow.getRow(0).getTime(), rowWindow.windowSize());
+    }
+  }
+
+  @Override
+  public void beforeDestroy() {
+    logger.debug("Counter#beforeDestroy");
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/ExampleUDFConstant.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/ExampleUDFConstant.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.query.udf.example;
+
+public class ExampleUDFConstant {
+  public static final String ACCESS_STRATEGY_KEY = "access";
+  public static final String ACCESS_STRATEGY_ROW_BY_ROW = "row-by-row";
+  public static final String ACCESS_STRATEGY_SLIDING_SIZE = "size";
+  public static final String ACCESS_STRATEGY_SLIDING_TIME = "time";
+  public static final String WINDOW_SIZE_KEY = "windowSize";
+  public static final String TIME_INTERVAL_KEY = "timeInterval";
+  public static final String SLIDING_STEP_KEY = "slidingStep";
+  public static final String DISPLAY_WINDOW_BEGIN_KEY = "displayWindowBegin";
+  public static final String DISPLAY_WINDOW_END_KEY = "displayWindowEnd";
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Max.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Max.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.Row;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameterValidator;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.RowByRowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class Max implements UDTF {
+
+  private static final Logger logger = LoggerFactory.getLogger(Max.class);
+
+  private Long time;
+  private int value;
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator.validateInputSeriesNumber(1).validateInputSeriesDataType(0, TSDataType.INT32);
+  }
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    logger.debug("Max#beforeStart");
+    configurations
+        .setOutputDataType(TSDataType.INT32)
+        .setAccessStrategy(new RowByRowAccessStrategy());
+  }
+
+  @Override
+  public void transform(Row row, PointCollector collector) throws IOException {
+    int candidateValue = row.getInt(0);
+    if (time == null || value < candidateValue) {
+      time = row.getTime();
+      value = candidateValue;
+    }
+  }
+
+  @Override
+  public void terminate(PointCollector collector) throws IOException {
+    if (time != null) {
+      collector.putInt(time, value);
+    }
+  }
+
+  @Override
+  public void beforeDestroy() {
+    logger.debug("Max#beforeDestroy");
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Multiplier.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/Multiplier.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.Row;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameterValidator;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.RowByRowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Multiplier implements UDTF {
+
+  private static final Logger logger = LoggerFactory.getLogger(Multiplier.class);
+
+  private long a;
+  private long b;
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator.validateInputSeriesNumber(1).validateInputSeriesDataType(0, TSDataType.INT64);
+  }
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    logger.debug("Multiplier#beforeStart");
+    a = parameters.getLongOrDefault("a", 0);
+    b = parameters.getLongOrDefault("b", 0);
+    configurations
+        .setOutputDataType(TSDataType.INT64)
+        .setAccessStrategy(new RowByRowAccessStrategy());
+  }
+
+  @Override
+  public void transform(Row row, PointCollector collector) throws Exception {
+    collector.putLong(row.getTime(), row.getLong(0) * a * b);
+  }
+
+  @Override
+  public void beforeDestroy() {
+    logger.debug("Multiplier#beforeDestroy");
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/SlidingSizeWindowConstructorTester0.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/SlidingSizeWindowConstructorTester0.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.RowWindow;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.SlidingSizeWindowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SlidingSizeWindowConstructorTester0 implements UDTF {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(SlidingSizeWindowConstructorTester0.class);
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    logger.debug("SlidingSizeWindowConstructorTester0#beforeStart");
+    int windowSize = parameters.getInt("windowSize");
+    int slidingStep = parameters.getInt("slidingStep");
+    configurations
+        .setOutputDataType(TSDataType.INT32)
+        .setAccessStrategy(new SlidingSizeWindowAccessStrategy(windowSize, slidingStep));
+  }
+
+  @Override
+  public void transform(RowWindow rowWindow, PointCollector collector) throws Exception {
+    if (rowWindow.windowSize() != 0) {
+      collector.putInt(rowWindow.getRow(0).getTime(), rowWindow.windowSize());
+    }
+  }
+
+  @Override
+  public void beforeDestroy() {
+    logger.debug("SlidingSizeWindowConstructorTester0#beforeDestroy");
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/SlidingSizeWindowConstructorTester1.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/SlidingSizeWindowConstructorTester1.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.Row;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameterValidator;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.RowByRowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SlidingSizeWindowConstructorTester1 implements UDTF {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(SlidingSizeWindowConstructorTester1.class);
+
+  private int consumptionPoint;
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator.validateInputSeriesNumber(1).validateInputSeriesDataType(0, TSDataType.INT32);
+  }
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    logger.debug("SlidingSizeWindowConstructorTester1#beforeStart");
+    consumptionPoint = parameters.getInt("consumptionPoint");
+    configurations
+        .setOutputDataType(TSDataType.INT32)
+        .setAccessStrategy(new RowByRowAccessStrategy());
+  }
+
+  @Override
+  public void transform(Row row, PointCollector collector) throws Exception {
+    if (row.getTime() == consumptionPoint) {
+      collector.putInt(row.getTime(), row.getInt(0));
+    }
+  }
+
+  @Override
+  public void beforeDestroy() {
+    logger.debug("SlidingSizeWindowConstructorTester1#beforeDestroy");
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/SlidingTimeWindowConstructionTester.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/SlidingTimeWindowConstructionTester.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.RowIterator;
+import org.apache.iotdb.commons.udf.api.access.RowWindow;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameterValidator;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.SlidingTimeWindowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class SlidingTimeWindowConstructionTester implements UDTF {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(SlidingTimeWindowConstructionTester.class);
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator.validateInputSeriesNumber(1).validateInputSeriesDataType(0, TSDataType.INT32);
+  }
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    logger.debug("SlidingTimeWindowConstructionTester#beforeStart");
+    long timeInterval = parameters.getLong(ExampleUDFConstant.TIME_INTERVAL_KEY);
+    configurations
+        .setOutputDataType(TSDataType.INT32)
+        .setAccessStrategy(new SlidingTimeWindowAccessStrategy(timeInterval));
+  }
+
+  @Override
+  public void transform(RowWindow rowWindow, PointCollector collector) throws IOException {
+    int accumulator = 0;
+    RowIterator rowIterator = rowWindow.getRowIterator();
+    while (rowIterator.hasNextRow()) {
+      accumulator += rowIterator.next().getInt(0);
+    }
+    if (rowWindow.windowSize() != 0) {
+      collector.putInt(rowWindow.getRow(0).getTime(), accumulator);
+    }
+  }
+
+  @Override
+  public void beforeDestroy() {
+    logger.debug("SlidingTimeWindowConstructionTester#beforeDestroy");
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/TerminateTester.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/TerminateTester.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.Row;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.RowByRowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TerminateTester implements UDTF {
+
+  private static final Logger logger = LoggerFactory.getLogger(TerminateTester.class);
+
+  private Long maxTime;
+  private int count;
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    logger.debug("TerminateTester#beforeStart");
+    configurations
+        .setOutputDataType(TSDataType.INT32)
+        .setAccessStrategy(new RowByRowAccessStrategy());
+    maxTime = null;
+    count = 0;
+  }
+
+  @Override
+  public void transform(Row row, PointCollector collector) throws Exception {
+    maxTime = row.getTime();
+    ++count;
+
+    collector.putInt(maxTime, 1);
+  }
+
+  @Override
+  public void terminate(PointCollector collector) throws Exception {
+    if (maxTime != null) {
+      collector.putInt(maxTime + 1, count);
+    }
+  }
+
+  @Override
+  public void beforeDestroy() {
+    logger.debug("TerminateTester#beforeDestroy");
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/ValidateTester.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/ValidateTester.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameterValidator;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.RowByRowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+public class ValidateTester implements UDTF {
+
+  @Override
+  public void validate(UDFParameterValidator validator) throws Exception {
+    validator
+        .validateRequiredAttribute("k")
+        .validateInputSeriesNumber(2)
+        .validateInputSeriesDataType(0, TSDataType.INT32, TSDataType.INT64)
+        .validateInputSeriesDataType(1, TSDataType.INT32, TSDataType.INT64);
+  }
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    configurations
+        .setAccessStrategy(new RowByRowAccessStrategy())
+        .setOutputDataType(TSDataType.INT32);
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/WindowStartEnd.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/WindowStartEnd.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example;
+
+import org.apache.iotdb.commons.udf.api.UDTF;
+import org.apache.iotdb.commons.udf.api.access.RowWindow;
+import org.apache.iotdb.commons.udf.api.collector.PointCollector;
+import org.apache.iotdb.commons.udf.api.customizer.config.UDTFConfigurations;
+import org.apache.iotdb.commons.udf.api.customizer.parameter.UDFParameters;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.SlidingSizeWindowAccessStrategy;
+import org.apache.iotdb.commons.udf.api.customizer.strategy.SlidingTimeWindowAccessStrategy;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import java.io.IOException;
+
+public class WindowStartEnd implements UDTF {
+
+  @Override
+  public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations) {
+    configurations.setOutputDataType(TSDataType.INT64);
+    if (ExampleUDFConstant.ACCESS_STRATEGY_SLIDING_SIZE.equals(
+        parameters.getString(ExampleUDFConstant.ACCESS_STRATEGY_KEY))) {
+      configurations.setAccessStrategy(
+          parameters.hasAttribute(ExampleUDFConstant.SLIDING_STEP_KEY)
+              ? new SlidingSizeWindowAccessStrategy(
+                  parameters.getInt(ExampleUDFConstant.WINDOW_SIZE_KEY),
+                  parameters.getInt(ExampleUDFConstant.SLIDING_STEP_KEY))
+              : new SlidingSizeWindowAccessStrategy(
+                  parameters.getInt(ExampleUDFConstant.WINDOW_SIZE_KEY)));
+    } else {
+      configurations.setAccessStrategy(
+          parameters.hasAttribute(ExampleUDFConstant.SLIDING_STEP_KEY)
+                  && parameters.hasAttribute(ExampleUDFConstant.DISPLAY_WINDOW_BEGIN_KEY)
+                  && parameters.hasAttribute(ExampleUDFConstant.DISPLAY_WINDOW_END_KEY)
+              ? new SlidingTimeWindowAccessStrategy(
+                  parameters.getLong(ExampleUDFConstant.TIME_INTERVAL_KEY),
+                  parameters.getLong(ExampleUDFConstant.SLIDING_STEP_KEY),
+                  parameters.getLong(ExampleUDFConstant.DISPLAY_WINDOW_BEGIN_KEY),
+                  parameters.getLong(ExampleUDFConstant.DISPLAY_WINDOW_END_KEY))
+              : new SlidingTimeWindowAccessStrategy(
+                  parameters.getLong(ExampleUDFConstant.TIME_INTERVAL_KEY)));
+    }
+  }
+
+  @Override
+  public void transform(RowWindow rowWindow, PointCollector collector) throws IOException {
+    collector.putLong(rowWindow.windowStartTime(), rowWindow.windowEndTime());
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/Cluster1Env.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/Cluster1Env.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Cluster1Env extends ClusterEnvBase {
+  private static final Logger logger = LoggerFactory.getLogger(Cluster1Env.class);
+
+  @Override
+  public void initBeforeClass() throws InterruptedException {
+    logger.debug("=======start init class=======");
+    super.initEnvironment(3, 3);
+  }
+
+  @Override
+  public void initBeforeTest() throws InterruptedException {
+    logger.debug("=======start init test=======");
+    super.initEnvironment(3, 3);
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/ClusterEnvBase.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/ClusterEnvBase.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import org.apache.iotdb.itbase.env.BaseEnv;
+import org.apache.iotdb.jdbc.Config;
+import org.apache.iotdb.jdbc.Constant;
+import org.apache.iotdb.jdbc.IoTDBConnection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.apache.iotdb.jdbc.Config.VERSION;
+import static org.junit.Assert.fail;
+
+public abstract class ClusterEnvBase implements BaseEnv {
+  private static final Logger logger = LoggerFactory.getLogger(ClusterEnvBase.class);
+  private List<ConfigNode> configNodes;
+  private List<DataNode> dataNodes;
+
+  protected void initEnvironment(int configNodesNum, int dataNodesNum) throws InterruptedException {
+    this.configNodes = new ArrayList<>();
+    this.dataNodes = new ArrayList<>();
+
+    String testName = getTestClassName();
+
+    ConfigNode seedConfigNode = new ConfigNode(true, "", testName);
+    seedConfigNode.createDir();
+    seedConfigNode.changeConfig(null);
+    seedConfigNode.start();
+    String targetConfignode = seedConfigNode.getIpAndPortString();
+    this.configNodes.add(seedConfigNode);
+    logger.info("In test " + testName + " SeedConfigNode " + seedConfigNode.getId() + " started.");
+
+    for (int i = 1; i < configNodesNum; i++) {
+      ConfigNode configNode = new ConfigNode(false, targetConfignode, testName);
+      configNode.createDir();
+      configNode.changeConfig(null);
+      configNode.start();
+      this.configNodes.add(configNode);
+      logger.info("In test " + testName + " ConfigNode " + configNode.getId() + " started.");
+    }
+
+    for (int i = 0; i < dataNodesNum; i++) {
+      DataNode dataNode = new DataNode(targetConfignode, testName);
+      dataNode.createDir();
+      dataNode.changeConfig(ConfigFactory.getConfig().getEngineProperties());
+      dataNode.start();
+      this.dataNodes.add(dataNode);
+      logger.info("In test " + testName + " DataNode " + dataNode.getId() + " started.");
+    }
+
+    testWorking();
+  }
+
+  private void cleanupEnvironment() {
+    for (DataNode dataNode : this.dataNodes) {
+      dataNode.stop();
+      dataNode.waitingToShutDown();
+      dataNode.destroyDir();
+    }
+    for (ConfigNode configNode : this.configNodes) {
+      configNode.stop();
+      configNode.waitingToShutDown();
+      configNode.destroyDir();
+    }
+  }
+
+  public String getTestClassName() {
+    StackTraceElement stack[] = Thread.currentThread().getStackTrace();
+    for (int i = 0; i < stack.length; i++) {
+      String className = stack[i].getClassName();
+      if (className.endsWith("IT")) {
+        return className.substring(className.lastIndexOf(".") + 1);
+      }
+    }
+    return "UNKNOWN-IT";
+  }
+
+  public String getTestClassNameAndDate() {
+    Date date = new Date();
+    SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd-HHmmss");
+    StackTraceElement stack[] = Thread.currentThread().getStackTrace();
+    for (int i = 0; i < stack.length; i++) {
+      String className = stack[i].getClassName();
+      if (className.endsWith("IT")) {
+        return className.substring(className.lastIndexOf(".") + 1) + "-" + formatter.format(date);
+      }
+    }
+    return "IT";
+  }
+
+  public void testWorking() throws InterruptedException {
+    int counter = 0;
+    Thread.sleep(2000);
+
+    do {
+      Thread.sleep(1000);
+
+      counter++;
+      if (counter > 30) {
+        fail("After 30 times retry, the cluster can't work!");
+      }
+
+      try (IoTDBConnection connection = getConnection(60);
+          Statement statement = connection.createStatement()) {
+        statement.execute("SET STORAGE GROUP TO root.test" + counter);
+        statement.execute(
+            "CREATE TIMESERIES root.test" + counter + ".d0.s0 WITH DATATYPE=INT32, ENCODING=RLE");
+        if (statement.execute("SHOW TIMESERIES")) {
+          ResultSet resultSet = statement.getResultSet();
+          if (resultSet.next()) {
+            statement.execute("DELETE STORAGE GROUP root.*");
+            break;
+          }
+        }
+
+      } catch (SQLException e) {
+        logger.debug(counter + " time(s) connect to cluster failed!", e);
+      }
+    } while (true);
+  }
+
+  @Override
+  public void cleanAfterClass() {
+    cleanupEnvironment();
+  }
+
+  @Override
+  public void cleanAfterTest() {
+    cleanupEnvironment();
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    Connection connection = null;
+
+    try {
+      Class.forName(Config.JDBC_DRIVER_NAME);
+      connection =
+          DriverManager.getConnection(
+              Config.IOTDB_URL_PREFIX
+                  + this.dataNodes.get(0).getIp()
+                  + ":"
+                  + this.dataNodes.get(0).getPort(),
+              System.getProperty("User", "root"),
+              System.getProperty("Password", "root"));
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+      fail();
+    }
+    return connection;
+  }
+
+  public IoTDBConnection getConnection(int queryTimeout) throws SQLException {
+    IoTDBConnection connection = null;
+    try {
+      Class.forName(Config.JDBC_DRIVER_NAME);
+      connection =
+          (IoTDBConnection)
+              DriverManager.getConnection(
+                  Config.IOTDB_URL_PREFIX
+                      + this.dataNodes.get(0).getIp()
+                      + ":"
+                      + this.dataNodes.get(0).getPort(),
+                  System.getProperty("User", "root"),
+                  System.getProperty("Password", "root"));
+      connection.setQueryTimeout(queryTimeout);
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+      fail();
+    }
+    return connection;
+  }
+
+  @Override
+  public Connection getConnection(Constant.Version version) throws SQLException {
+    Connection connection = null;
+    try {
+      Class.forName(Config.JDBC_DRIVER_NAME);
+      connection =
+          DriverManager.getConnection(
+              Config.IOTDB_URL_PREFIX
+                  + this.dataNodes.get(0).getIp()
+                  + ":"
+                  + this.dataNodes.get(0).getPort()
+                  + "?"
+                  + VERSION
+                  + "="
+                  + version.toString(),
+              System.getProperty("User", "root"),
+              System.getProperty("Password", "root"));
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+      fail();
+    }
+    return connection;
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/ClusterEnvConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/ClusterEnvConfig.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import org.apache.iotdb.itbase.env.BaseConfig;
+
+import java.util.Properties;
+
+public class ClusterEnvConfig implements BaseConfig {
+  private final Properties engineProperties;
+  private final Properties clusterProperties;
+
+  public ClusterEnvConfig() {
+    engineProperties = new Properties();
+    clusterProperties = new Properties();
+  }
+
+  public void clearAllProperties() {
+    engineProperties.clear();
+    clusterProperties.clear();
+  }
+
+  public Properties getEngineProperties() {
+    return this.engineProperties;
+  }
+
+  public Properties getClusterProperties() {
+    return this.clusterProperties;
+  }
+
+  public BaseConfig setMaxNumberOfPointsInPage(int maxNumberOfPointsInPage) {
+    engineProperties.setProperty(
+        "max_number_of_points_in_page", String.valueOf(maxNumberOfPointsInPage));
+    return this;
+  }
+
+  public BaseConfig setPageSizeInByte(int pageSizeInByte) {
+    engineProperties.setProperty("page_size_in_byte", String.valueOf(pageSizeInByte));
+    return this;
+  }
+
+  public BaseConfig setGroupSizeInByte(int groupSizeInByte) {
+    engineProperties.setProperty("group_size_in_byte", String.valueOf(groupSizeInByte));
+    return this;
+  }
+
+  public BaseConfig setMemtableSizeThreshold(long memtableSizeThreshold) {
+    engineProperties.setProperty("memtable_size_threshold", String.valueOf(memtableSizeThreshold));
+    return this;
+  }
+
+  public BaseConfig setDataRegionNum(int dataRegionNum) {
+    engineProperties.setProperty("data_region_num", String.valueOf(dataRegionNum));
+    return this;
+  }
+
+  public BaseConfig setPartitionInterval(long partitionInterval) {
+    engineProperties.setProperty("partition_interval", String.valueOf(partitionInterval));
+    return this;
+  }
+
+  public BaseConfig setCompressor(String compressor) {
+    engineProperties.setProperty("compressor", compressor);
+    return this;
+  }
+
+  public BaseConfig setMaxQueryDeduplicatedPathNum(int maxQueryDeduplicatedPathNum) {
+    engineProperties.setProperty(
+        "max_deduplicated_path_num", String.valueOf(maxQueryDeduplicatedPathNum));
+    return this;
+  }
+
+  public BaseConfig setRpcThriftCompressionEnable(boolean rpcThriftCompressionEnable) {
+    engineProperties.setProperty(
+        "rpc_thrift_compression_enable", String.valueOf(rpcThriftCompressionEnable));
+    return this;
+  }
+
+  public BaseConfig setRpcAdvancedCompressionEnable(boolean rpcAdvancedCompressionEnable) {
+    engineProperties.setProperty(
+        "rpc_advanced_compression_enable", String.valueOf(rpcAdvancedCompressionEnable));
+    return this;
+  }
+
+  public BaseConfig setEnablePartition(boolean enablePartition) {
+    engineProperties.setProperty("enable_partition", String.valueOf(enablePartition));
+    return this;
+  }
+
+  public BaseConfig setUdfCollectorMemoryBudgetInMB(float udfCollectorMemoryBudgetInMB) {
+    // udf_memory_budget_in_mb
+    // udf_reader_transformer_collector_memory_proportion
+    engineProperties.setProperty(
+        "udf_memory_budget_in_mb", String.valueOf(udfCollectorMemoryBudgetInMB * 3));
+    return this;
+  }
+
+  public BaseConfig setUdfTransformerMemoryBudgetInMB(float udfTransformerMemoryBudgetInMB) {
+    engineProperties.setProperty(
+        "udf_memory_budget_in_mb", String.valueOf(udfTransformerMemoryBudgetInMB * 3));
+    return this;
+  }
+
+  public BaseConfig setUdfReaderMemoryBudgetInMB(float udfReaderMemoryBudgetInMB) {
+    engineProperties.setProperty(
+        "udf_memory_budget_in_mb", String.valueOf(udfReaderMemoryBudgetInMB * 3));
+    return this;
+  }
+
+  public BaseConfig setEnableSeqSpaceCompaction(boolean enableSeqSpaceCompaction) {
+    engineProperties.setProperty(
+        "enable_seq_space_compaction", String.valueOf(enableSeqSpaceCompaction));
+    return this;
+  }
+
+  public BaseConfig setEnableUnseqSpaceCompaction(boolean enableUnseqSpaceCompaction) {
+    engineProperties.setProperty(
+        "enable_unseq_space_compaction", String.valueOf(enableUnseqSpaceCompaction));
+    return this;
+  }
+
+  public BaseConfig setEnableCrossSpaceCompaction(boolean enableCrossSpaceCompaction) {
+    engineProperties.setProperty(
+        "enable_cross_space_compaction", String.valueOf(enableCrossSpaceCompaction));
+    return this;
+  }
+
+  public BaseConfig setEnableIDTable(boolean isEnableIDTable) {
+    engineProperties.setProperty("enable_id_table", String.valueOf(isEnableIDTable));
+    return this;
+  }
+
+  public BaseConfig setDeviceIDTransformationMethod(String deviceIDTransformationMethod) {
+    engineProperties.setProperty("device_id_transformation_method", deviceIDTransformationMethod);
+    return this;
+  }
+
+  public BaseConfig setAutoCreateSchemaEnabled(boolean enableAutoCreateSchema) {
+    clusterProperties.setProperty(
+        "enable_auto_create_schema", String.valueOf(enableAutoCreateSchema));
+    return this;
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/ClusterNodeBase.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/ClusterNodeBase.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import org.apache.iotdb.itbase.env.BaseNode;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.fail;
+
+public abstract class ClusterNodeBase implements BaseNode {
+  private static final Logger logger = LoggerFactory.getLogger(ClusterNodeBase.class);
+
+  private final String templateNodePath =
+      System.getProperty("user.dir") + File.separator + "target" + File.separator + "template-node";
+
+  private String id;
+  private final String ip = "127.0.0.1";
+  private int rpcPort;
+
+  private String nodePath;
+  private String scriptPath;
+  private String logPath;
+
+  private Process instance;
+
+  protected void setId(String id) {
+    this.id = id;
+  }
+
+  protected String getId() {
+    return this.id;
+  }
+
+  protected void setPort(int rpcPort) {
+    this.rpcPort = rpcPort;
+  }
+
+  protected String getNodePath() {
+    return this.nodePath;
+  }
+
+  protected void setNodePath(String nodePath) {
+    this.nodePath = nodePath;
+  }
+
+  protected void setScriptPath(String scriptPath) {
+    this.scriptPath = scriptPath;
+  }
+
+  protected void setLogPath(String logPath) {
+    this.logPath = logPath;
+  }
+
+  protected int[] searchAvailablePorts() {
+    String cmd = "lsof -iTCP -sTCP:LISTEN -P -n | awk '{print $9}' | grep -E ";
+    boolean flag = true;
+    int portStart = 10001;
+
+    do {
+      int randomPortStart = 1000 + (int) (Math.random() * (1999 - 1000));
+      randomPortStart = randomPortStart * 10 + 1;
+      String path =
+          System.getProperty("user.dir")
+              + File.separator
+              + "target"
+              + File.separator
+              + "node"
+              + randomPortStart;
+      if (new File(path).exists()) {
+        continue;
+      }
+
+      StringBuilder port = new StringBuilder(randomPortStart);
+      for (int i = 0; i < 9; i++) {
+        port.append("|");
+        randomPortStart++;
+        port.append(randomPortStart);
+      }
+
+      try {
+        Process proc = Runtime.getRuntime().exec(cmd + "\"" + port + "\"");
+        BufferedReader br = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+        String line;
+        while ((line = br.readLine()) != null) {
+          logger.debug(line);
+        }
+        if (proc.waitFor() == 1) {
+          flag = false;
+          portStart = randomPortStart - 9;
+        }
+      } catch (IOException | InterruptedException ex) {
+        // ignore
+      }
+    } while (flag);
+
+    return IntStream.rangeClosed(portStart, portStart + 9).toArray();
+  }
+
+  @Override
+  public void createDir() {
+    // Copy templateNodePath to nodePath
+    try {
+      FileUtils.copyDirectoryToDirectory(new File(this.templateNodePath), new File(this.nodePath));
+      new File(this.scriptPath).setExecutable(true);
+    } catch (IOException ex) {
+      fail("Copy node dir failed. " + ex);
+    }
+  }
+
+  @Override
+  public void destroyDir() {
+    // rm this.path
+    try {
+      FileUtils.forceDelete(new File(this.nodePath));
+    } catch (IOException ex) {
+      fail("Delete node dir failed. " + ex);
+    }
+  }
+
+  @Override
+  public void start() {
+    try {
+      ProcessBuilder processBuilder =
+          new ProcessBuilder(this.scriptPath)
+              .redirectOutput(new File("/dev/null"))
+              .redirectError(new File("/dev/null"));
+      processBuilder.environment().put("IT_LOG_PATH", this.logPath);
+      processBuilder.environment().put("IT_LOG_LEVEL", "DEBUG");
+      this.instance = processBuilder.start();
+    } catch (IOException ex) {
+      fail("Start node failed. " + ex);
+    }
+  }
+
+  @Override
+  public void stop() {
+    this.instance.destroy();
+  }
+
+  @Override
+  public void waitingToShutDown() {
+    while (this.instance.isAlive()) {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        logger.error("Waiting node to shutdown." + e);
+      }
+    }
+  }
+
+  @Override
+  public String getIp() {
+    return ip;
+  }
+
+  @Override
+  public int getPort() {
+    return rpcPort;
+  }
+
+  @Override
+  public String getIpAndPortString() {
+    return this.getIp() + ":" + this.rpcPort;
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/ConfigFactory.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/ConfigFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import org.apache.iotdb.itbase.env.BaseConfig;
+
+public class ConfigFactory {
+  private static BaseConfig config;
+
+  public static BaseConfig getConfig() {
+    if (config == null) {
+      try {
+        switch (System.getProperty("TestEnv", "Standalone")) {
+          case "Standalone":
+            config =
+                (BaseConfig)
+                    Class.forName("org.apache.iotdb.db.integration.env.StandaloneEnvConfig")
+                        .newInstance();
+            break;
+          case "Remote":
+            config = new RemoteEnvConfig();
+            break;
+          case "Cluster1":
+            config = new ClusterEnvConfig();
+            break;
+          default:
+            throw new ClassNotFoundException("The Property class of TestEnv not found");
+        }
+      } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+        e.printStackTrace();
+        System.exit(-1);
+      }
+    }
+    return config;
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/ConfigNode.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/ConfigNode.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.Assert.fail;
+
+public class ConfigNode extends ClusterNodeBase {
+
+  private final int consensusPort;
+  private final String configPath;
+  private final String targetConfignode;
+
+  public ConfigNode(boolean isSeed, String targetConfignode, String testName) {
+
+    int[] portList = super.searchAvailablePorts();
+    super.setPort(portList[0]);
+    this.consensusPort = portList[1];
+
+    super.setId("node" + this.getPort());
+
+    String nodePath =
+        System.getProperty("user.dir") + File.separator + "target" + File.separator + super.getId();
+    super.setNodePath(nodePath);
+
+    String logPath =
+        System.getProperty("user.dir")
+            + File.separator
+            + "target"
+            + File.separator
+            + "cluster-logs"
+            + File.separator
+            + testName
+            + File.separator
+            + "Config"
+            + super.getId()
+            + ".log";
+    super.setLogPath(logPath);
+
+    String scriptPath =
+        super.getNodePath()
+            + File.separator
+            + "template-node"
+            + File.separator
+            + "confignode"
+            + File.separator
+            + "sbin"
+            + File.separator
+            + "start-confignode"
+            + ".sh";
+    super.setScriptPath(scriptPath);
+
+    this.configPath =
+        super.getNodePath()
+            + File.separator
+            + "template-node"
+            + File.separator
+            + "confignode"
+            + File.separator
+            + "conf"
+            + File.separator
+            + "iotdb-confignode.properties";
+
+    if (isSeed) {
+      this.targetConfignode = getIpAndPortString();
+    } else {
+      this.targetConfignode = targetConfignode;
+    }
+  }
+
+  @Override
+  public void changeConfig(Properties properties) {
+    try {
+      Properties configProperties = new Properties();
+      configProperties.load(new FileInputStream(this.configPath));
+      configProperties.setProperty("rpc_address", super.getIp());
+      configProperties.setProperty("rpc_port", String.valueOf(super.getPort()));
+      configProperties.setProperty("consensus_port", String.valueOf(this.consensusPort));
+      configProperties.setProperty("target_confignode", this.targetConfignode);
+      configProperties.setProperty(
+          "config_node_consensus_protocol_class",
+          "org.apache.iotdb.consensus.ratis.RatisConsensus");
+      configProperties.setProperty(
+          "data_region_consensus_protocol_class",
+          "org.apache.iotdb.consensus.ratis.RatisConsensus");
+      if (properties != null && !properties.isEmpty()) {
+        configProperties.putAll(properties);
+      }
+      configProperties.store(new FileWriter(this.configPath), null);
+    } catch (IOException ex) {
+      fail("Change the config of config node failed. " + ex);
+    }
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/DataNode.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/DataNode.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.Assert.fail;
+
+public class DataNode extends ClusterNodeBase {
+
+  private final String targetConfignode;
+  private final String configPath;
+
+  private final int dataBlockManagerPort;
+  private final int internalPort;
+  private final int dataRegionConsensusPort;
+  private final int schemaRegionConsensusPort;
+
+  public DataNode(String targetConfignode, String testName) {
+
+    this.targetConfignode = targetConfignode;
+
+    int[] portList = super.searchAvailablePorts();
+    super.setPort(portList[0]);
+    this.dataBlockManagerPort = portList[1];
+    this.internalPort = portList[2];
+    this.dataRegionConsensusPort = portList[3];
+    this.schemaRegionConsensusPort = portList[4];
+
+    super.setId("node" + this.getPort());
+
+    String nodePath =
+        System.getProperty("user.dir") + File.separator + "target" + File.separator + super.getId();
+    super.setNodePath(nodePath);
+
+    String logPath =
+        System.getProperty("user.dir")
+            + File.separator
+            + "target"
+            + File.separator
+            + "cluster-logs"
+            + File.separator
+            + testName
+            + File.separator
+            + "Data"
+            + super.getId()
+            + ".log";
+    super.setLogPath(logPath);
+
+    String scriptPath =
+        super.getNodePath()
+            + File.separator
+            + "template-node"
+            + File.separator
+            + "datanode"
+            + File.separator
+            + "sbin"
+            + File.separator
+            + "start-datanode"
+            + ".sh";
+    super.setScriptPath(scriptPath);
+
+    this.configPath =
+        super.getNodePath()
+            + File.separator
+            + "template-node"
+            + File.separator
+            + "datanode"
+            + File.separator
+            + "conf"
+            + File.separator
+            + "iotdb-engine.properties";
+  }
+
+  @Override
+  public void changeConfig(Properties properties) {
+    try {
+      Properties configProperties = new Properties();
+      configProperties.load(new FileInputStream(this.configPath));
+      configProperties.setProperty("rpc_address", super.getIp());
+      configProperties.setProperty("internal_ip", "127.0.0.1");
+      configProperties.setProperty("rpc_port", String.valueOf(super.getPort()));
+      configProperties.setProperty(
+          "data_block_manager_port", String.valueOf(this.dataBlockManagerPort));
+      configProperties.setProperty("internal_port", String.valueOf(this.internalPort));
+      configProperties.setProperty(
+          "data_region_consensus_port", String.valueOf(this.dataRegionConsensusPort));
+      configProperties.setProperty(
+          "schema_region_consensus_port", String.valueOf(this.schemaRegionConsensusPort));
+      configProperties.setProperty("config_nodes", this.targetConfignode);
+      if (properties != null && !properties.isEmpty()) {
+        configProperties.putAll(properties);
+      }
+      configProperties.store(new FileWriter(this.configPath), null);
+    } catch (IOException ex) {
+      fail("Change the config of data node failed. " + ex);
+    }
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/EnvFactory.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/EnvFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import org.apache.iotdb.itbase.env.BaseEnv;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EnvFactory {
+  private static BaseEnv env;
+  private static final Logger logger = LoggerFactory.getLogger(EnvFactory.class);
+
+  public static BaseEnv getEnv() {
+    if (env == null) {
+      try {
+        logger.debug(">>>>>>>" + System.getProperty("TestEnv"));
+        switch (System.getProperty("TestEnv", "Standalone")) {
+          case "Standalone":
+            env = (BaseEnv) Class.forName("org.apache.iotdb.db.it.env.StandaloneEnv").newInstance();
+            break;
+          case "Remote":
+            env = new RemoteServerEnv();
+            break;
+          case "Cluster1":
+            env = new Cluster1Env();
+            break;
+          default:
+            throw new ClassNotFoundException("The Property class of TestEnv not found");
+        }
+      } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+        e.printStackTrace();
+        System.exit(-1);
+      }
+    }
+    return env;
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/RemoteEnvConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/RemoteEnvConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import org.apache.iotdb.itbase.env.BaseConfig;
+
+public class RemoteEnvConfig implements BaseConfig {}

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/RemoteServerEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/RemoteServerEnv.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.it.env;
+
+import org.apache.iotdb.itbase.env.BaseEnv;
+import org.apache.iotdb.jdbc.Config;
+import org.apache.iotdb.jdbc.Constant;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.apache.iotdb.jdbc.Config.VERSION;
+import static org.junit.Assert.fail;
+
+public class RemoteServerEnv implements BaseEnv {
+  private String ip_addr = System.getProperty("RemoteIp", "127.0.0.1");
+  private String port = System.getProperty("RemotePort", "6667");
+  private String user = System.getProperty("RemoteUser", "root");
+  private String password = System.getProperty("RemotePassword", "root");
+
+  @Override
+  public void initBeforeClass() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("SET STORAGE GROUP TO root.init;");
+      statement.execute("DELETE STORAGE GROUP root;");
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Override
+  public void cleanAfterClass() {}
+
+  @Override
+  public void initBeforeTest() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("SET STORAGE GROUP TO root.init;");
+      statement.execute("DELETE STORAGE GROUP root;");
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Override
+  public void cleanAfterTest() {}
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    Connection connection = null;
+    try {
+      Class.forName(Config.JDBC_DRIVER_NAME);
+      connection =
+          DriverManager.getConnection(
+              Config.IOTDB_URL_PREFIX + ip_addr + ":" + port, user, password);
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+      fail();
+    }
+    return connection;
+  }
+
+  @Override
+  public Connection getConnection(Constant.Version version) throws SQLException {
+    Connection connection = null;
+    try {
+      Class.forName(Config.JDBC_DRIVER_NAME);
+      connection =
+          DriverManager.getConnection(
+              Config.IOTDB_URL_PREFIX
+                  + ip_addr
+                  + ":"
+                  + port
+                  + "?"
+                  + VERSION
+                  + "="
+                  + version.toString(),
+              user,
+              password);
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+      fail();
+    }
+    return connection;
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/category/ClusterIT.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/category/ClusterIT.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.itbase.category;
+
+public interface ClusterIT {}

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/category/LocalStandaloneIT.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/category/LocalStandaloneIT.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.itbase.category;
+
+public interface LocalStandaloneIT {}

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/category/RemoteIT.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/category/RemoteIT.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.itbase.category;
+
+public interface RemoteIT {}

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseConfig.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.itbase.env;
+
+import java.util.Properties;
+
+public interface BaseConfig {
+
+  default void clearAllProperties() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("Method clearAllProperties not implement");
+  }
+
+  default Properties getEngineProperties() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("Method getEngineProperties not implement");
+  }
+
+  default Properties getClusterProperties() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("Method getClusterProperties not implement");
+  }
+
+  default BaseConfig setMaxNumberOfPointsInPage(int maxNumberOfPointsInPage) {
+    return this;
+  }
+
+  default BaseConfig setPageSizeInByte(int pageSizeInByte) {
+    return this;
+  }
+
+  default BaseConfig setGroupSizeInByte(int groupSizeInByte) {
+    return this;
+  }
+
+  default BaseConfig setMemtableSizeThreshold(long memtableSizeThreshold) {
+    return this;
+  }
+
+  default BaseConfig setDataRegionNum(int dataRegionNum) {
+    return this;
+  }
+
+  default BaseConfig setPartitionInterval(long partitionInterval) {
+    return this;
+  }
+
+  default BaseConfig setCompressor(String compressor) {
+    return this;
+  }
+
+  default BaseConfig setMaxQueryDeduplicatedPathNum(int maxQueryDeduplicatedPathNum) {
+    return this;
+  }
+
+  default BaseConfig setRpcThriftCompressionEnable(boolean rpcThriftCompressionEnable) {
+    return this;
+  }
+
+  default BaseConfig setRpcAdvancedCompressionEnable(boolean rpcAdvancedCompressionEnable) {
+    return this;
+  }
+
+  default BaseConfig setEnablePartition(boolean enablePartition) {
+    return this;
+  }
+
+  default BaseConfig setUdfCollectorMemoryBudgetInMB(float udfCollectorMemoryBudgetInMB) {
+    return this;
+  }
+
+  default BaseConfig setUdfTransformerMemoryBudgetInMB(float udfTransformerMemoryBudgetInMB) {
+    return this;
+  }
+
+  default BaseConfig setUdfReaderMemoryBudgetInMB(float udfReaderMemoryBudgetInMB) {
+    return this;
+  }
+
+  default BaseConfig setEnableSeqSpaceCompaction(boolean enableSeqSpaceCompaction) {
+    return this;
+  }
+
+  default BaseConfig setEnableUnseqSpaceCompaction(boolean enableUnseqSpaceCompaction) {
+    return this;
+  }
+
+  default BaseConfig setEnableCrossSpaceCompaction(boolean enableCrossSpaceCompaction) {
+    return this;
+  }
+
+  default BaseConfig setEnableIDTable(boolean isEnableIDTable) {
+    return this;
+  }
+
+  default BaseConfig setDeviceIDTransformationMethod(String deviceIDTransformationMethod) {
+    return this;
+  }
+
+  default BaseConfig setAutoCreateSchemaEnabled(boolean enableAutoCreateSchema) {
+    return this;
+  }
+}

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.itbase.env;
+
+import org.apache.iotdb.jdbc.Constant;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface BaseEnv {
+
+  void initBeforeClass() throws InterruptedException;
+
+  void cleanAfterClass();
+
+  void initBeforeTest() throws InterruptedException;
+
+  void cleanAfterTest();
+
+  Connection getConnection() throws SQLException;
+
+  Connection getConnection(Constant.Version version) throws SQLException;
+}

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseNode.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseNode.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.itbase.env;
+
+import java.util.Properties;
+
+public interface BaseNode {
+
+  void createDir();
+
+  void destroyDir();
+
+  void changeConfig(Properties properties);
+
+  void start();
+
+  void stop();
+
+  void waitingToShutDown();
+
+  String getIp();
+
+  int getPort();
+
+  String getIpAndPortString();
+}

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExampleIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExampleIT.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.it;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/** This is an example for integration test. */
+@Category({LocalStandaloneIT.class, ClusterIT.class})
+public class IoTDBExampleIT {
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvFactory.getEnv().initBeforeTest();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanAfterTest();
+  }
+
+  @Test
+  public void exampleTest() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+}

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExampleParallel1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExampleParallel1IT.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.it;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/** This is an example for integration test. */
+@Category({LocalStandaloneIT.class, ClusterIT.class})
+public class IoTDBExampleParallel1IT {
+  @Before
+  public void setUp() throws Exception {
+    EnvFactory.getEnv().initBeforeTest();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanAfterTest();
+  }
+
+  @Test
+  public void exampleTest() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+
+  @Test
+  public void exampleTest1() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+}

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExampleParallel2IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExampleParallel2IT.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.it;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/** This is an example for integration test. */
+@Category({LocalStandaloneIT.class, ClusterIT.class})
+public class IoTDBExampleParallel2IT {
+  @Before
+  public void setUp() throws Exception {
+    EnvFactory.getEnv().initBeforeTest();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanAfterTest();
+  }
+
+  @Test
+  public void exampleTest() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+
+  @Test
+  public void exampleTest1() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+
+  @Test
+  public void exampleTest2() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+}

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExampleParallel3IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExampleParallel3IT.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.it;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/** This is an example for integration test. */
+@Category({LocalStandaloneIT.class, ClusterIT.class})
+public class IoTDBExampleParallel3IT {
+  @Before
+  public void setUp() throws Exception {
+    EnvFactory.getEnv().initBeforeTest();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanAfterTest();
+  }
+
+  @Test
+  public void exampleTest() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+
+  @Test
+  public void exampleTest1() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+
+  @Test
+  public void exampleTest2() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+
+  @Test
+  public void exampleTest3() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("set storage group to root.sg");
+      statement.executeQuery("show storage group");
+      ResultSet resultSet = statement.getResultSet();
+      if (resultSet.next()) {
+        String storageGroupPath = resultSet.getString("storage group");
+        Assert.assertEquals("root.sg", storageGroupPath);
+      } else {
+        Assert.fail("This ResultSet is empty.");
+      }
+    }
+  }
+}

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/env/StandaloneEnv.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/env/StandaloneEnv.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.it.env;
+
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.itbase.env.BaseEnv;
+import org.apache.iotdb.jdbc.Config;
+import org.apache.iotdb.jdbc.Constant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.apache.iotdb.jdbc.Config.VERSION;
+import static org.junit.Assert.fail;
+
+/** This class is used by EnvFactory with using reflection. */
+public class StandaloneEnv implements BaseEnv {
+  Logger logger = LoggerFactory.getLogger(StandaloneEnv.class);
+
+  @Override
+  public void initBeforeClass() {
+    EnvironmentUtils.envSetUp();
+  }
+
+  @Override
+  public void cleanAfterClass() {
+    cleanAfterTest();
+  }
+
+  @Override
+  public void initBeforeTest() {
+
+    EnvironmentUtils.envSetUp();
+  }
+
+  @Override
+  public void cleanAfterTest() {
+    try {
+      EnvironmentUtils.cleanEnv();
+    } catch (Exception e) {
+      e.printStackTrace();
+      System.exit(-1);
+    }
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    try {
+      Class.forName(Config.JDBC_DRIVER_NAME);
+      return DriverManager.getConnection(
+          Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+      fail();
+    }
+    return null;
+  }
+
+  @Override
+  public Connection getConnection(Constant.Version version) throws SQLException {
+    try {
+      Class.forName(Config.JDBC_DRIVER_NAME);
+      return DriverManager.getConnection(
+          Config.IOTDB_URL_PREFIX + "127.0.0.1:6667" + "?" + VERSION + "=" + version.toString(),
+          "root",
+          "root");
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+      fail();
+    }
+    return null;
+  }
+}

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/env/StandaloneEnvConfig.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/env/StandaloneEnvConfig.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.it.env;
+
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.itbase.env.BaseConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+
+/** This class is used by ConfigFactory with using reflection. */
+public class StandaloneEnvConfig implements BaseConfig {
+
+  public BaseConfig setMaxNumberOfPointsInPage(int maxNumberOfPointsInPage) {
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(maxNumberOfPointsInPage);
+    return this;
+  }
+
+  public BaseConfig setPageSizeInByte(int pageSizeInByte) {
+    TSFileDescriptor.getInstance().getConfig().setPageSizeInByte(pageSizeInByte);
+    return this;
+  }
+
+  public BaseConfig setGroupSizeInByte(int groupSizeInByte) {
+    TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(groupSizeInByte);
+    return this;
+  }
+
+  public BaseConfig setMemtableSizeThreshold(long memtableSizeThreshold) {
+    IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(memtableSizeThreshold);
+    return this;
+  }
+
+  public BaseConfig setDataRegionNum(int dataRegionNum) {
+    IoTDBDescriptor.getInstance().getConfig().setDataRegionNum(dataRegionNum);
+    return this;
+  }
+
+  public BaseConfig setPartitionInterval(long partitionInterval) {
+    IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(partitionInterval);
+    return this;
+  }
+
+  public BaseConfig setCompressor(String compressor) {
+    TSFileDescriptor.getInstance().getConfig().setCompressor(compressor);
+    return this;
+  }
+
+  public BaseConfig setMaxQueryDeduplicatedPathNum(int maxQueryDeduplicatedPathNum) {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setMaxQueryDeduplicatedPathNum(maxQueryDeduplicatedPathNum);
+    return this;
+  }
+
+  public BaseConfig setRpcThriftCompressionEnable(boolean rpcThriftCompressionEnable) {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setRpcThriftCompressionEnable(rpcThriftCompressionEnable);
+    return this;
+  }
+
+  public BaseConfig setRpcAdvancedCompressionEnable(boolean rpcAdvancedCompressionEnable) {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setRpcAdvancedCompressionEnable(rpcAdvancedCompressionEnable);
+    return this;
+  }
+
+  public BaseConfig setEnablePartition(boolean enablePartition) {
+    IoTDBDescriptor.getInstance().getConfig().setEnablePartition(enablePartition);
+    return this;
+  }
+
+  public BaseConfig setUdfCollectorMemoryBudgetInMB(float udfCollectorMemoryBudgetInMB) {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setUdfCollectorMemoryBudgetInMB(udfCollectorMemoryBudgetInMB);
+    return this;
+  }
+
+  public BaseConfig setUdfTransformerMemoryBudgetInMB(float udfTransformerMemoryBudgetInMB) {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setUdfTransformerMemoryBudgetInMB(udfTransformerMemoryBudgetInMB);
+    return this;
+  }
+
+  public BaseConfig setUdfReaderMemoryBudgetInMB(float udfReaderMemoryBudgetInMB) {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setUdfReaderMemoryBudgetInMB(udfReaderMemoryBudgetInMB);
+    return this;
+  }
+
+  public BaseConfig setEnableSeqSpaceCompaction(boolean enableSeqSpaceCompaction) {
+    IoTDBDescriptor.getInstance().getConfig().setEnableSeqSpaceCompaction(enableSeqSpaceCompaction);
+    return this;
+  }
+
+  public BaseConfig setEnableUnseqSpaceCompaction(boolean enableUnseqSpaceCompaction) {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setEnableUnseqSpaceCompaction(enableUnseqSpaceCompaction);
+    return this;
+  }
+
+  public BaseConfig setEnableCrossSpaceCompaction(boolean enableCrossSpaceCompaction) {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setEnableCrossSpaceCompaction(enableCrossSpaceCompaction);
+    return this;
+  }
+
+  public BaseConfig setEnableIDTable(boolean isEnableIDTable) {
+    IoTDBDescriptor.getInstance().getConfig().setEnableIDTable(isEnableIDTable);
+    return this;
+  }
+
+  public BaseConfig setDeviceIDTransformationMethod(String deviceIDTransformationMethod) {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setDeviceIDTransformationMethod(deviceIDTransformationMethod);
+    return this;
+  }
+
+  public BaseConfig setAutoCreateSchemaEnabled(boolean enableAutoCreateSchema) {
+    IoTDBDescriptor.getInstance().getConfig().setAutoCreateSchemaEnabled(enableAutoCreateSchema);
+    return this;
+  }
+}

--- a/integration-test/src/test/resources/iotdb-engine.properties
+++ b/integration-test/src/test/resources/iotdb-engine.properties
@@ -1,0 +1,21 @@
+#Licensed to the Apache Software Foundation (ASF) under one
+#or more contributor license agreements.  See the NOTICE file
+#distributed with this work for additional information
+#regarding copyright ownership.  The ASF licenses this file
+#to you under the Apache License, Version 2.0 (the
+#"License"); you may not use this file except in compliance
+#with the License.  You may obtain a copy of the License at
+#
+#http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing,
+#software distributed under the License is distributed on an
+#"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#KIND, either express or implied.  See the License for the
+#specific language governing permissions and limitations
+#under the License.
+
+base_dir=target/tmp
+data_dirs=target/data
+wal_dir=target/wal
+sync_dir=target/sync

--- a/integration-test/src/test/resources/logback-test.xml
+++ b/integration-test/src/test/resources/logback-test.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<configuration debug="false">
+    <property name="LOG_PATH" value="target/logs"/>
+    <!-- prevent logback from outputting its own status at the start of every log -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+    <appender class="ch.qos.logback.core.ConsoleAppender" name="stdout">
+        <Target>System.out</Target>
+        <encoder>
+            <pattern>%-5p [%d] [%thread] %C:%L - %m %n</pattern>
+            <charset>utf-8</charset>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+    </appender>
+    <!--<logger name="org.apache.iotdb.db.utils.OpenFileNumUtil" level="debug" />-->
+    <!--<logger name="org.apache.iotdb.db.utils.OpenFileNumUtilTest" level="debug" />-->
+    <!-- do not print "Can't get the cpu ratio,because this OS:mac os x is not support in test"-->
+    <logger name="org.apache.iotdb.db.metrics.server.ServerArgument" level="ERROR"/>
+    <!-- enable me if you want to monitor when files are opened and closed.
+    <logger name="FileMonitor" level="info"/>
+    -->
+    <logger name="org.apache.iotdb.db.sync" level="INFO"/>
+    <logger name="org.apache.iotdb.db.engine.merge" level="INFO"/>
+    <logger name="org.apache.iotdb.commons.service.ThriftServiceThread" level="INFO"/>
+    <logger name="org.eclipse.jetty.util.thread.QueuedThreadPool" level="INFO"/>
+    <logger name="org.apache.iotdb.db.service.metrics.MetricsService" level="INFO"/>
+    <logger name="org.apache.iotdb.db.engine.flush.FlushManager" level="INFO"/>
+    <logger name="org.apache.iotdb.db.integration.IoTDBCompactionIT" level="INFO"/>
+    <logger name="org.apache.iotdb.commons.service.RegisterManager" level="INFO"/>
+    <logger name="org.apache.iotdb.db.service.IoTDB" level="WARN"/>
+    <logger name="org.apache.iotdb.db.service.RPCService" level="INFO"/>
+    <logger name="org.apache.iotdb.db.service.MQTTService" level="INFO"/>
+    <logger name="DETAILED_FAILURE_QUERY_TRACE" level="ERROR"/>
+    <root level="INFO">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>

--- a/integration/checkstyle.xml
+++ b/integration/checkstyle.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<!--
+    Note: Checkstyle configuration under integration module only validates the code styles about test cases.
+    Other codes rules should be referenced the checkstyle.xml under the project root folder
+ -->
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="severity" value="error"/>
+    <property name="fileExtensions" value="java"/>
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern"
+                  value="^.*([\\/]src[\\/]main|[\\/]src[\\/]test[\\/]java[\\/]org[\\/]apache[\\/]iotdb[\\/]session)[\\/].*$"/>
+    </module>
+    <!--    <module name="RegexpOnFilename">-->
+    <!--        <property name="fileNamePattern" value="^.*IT\.java$"/>-->
+    <!--        <property name="match" value="false"/>-->
+    <!--    </module>-->
+    <module name="TreeWalker">
+        <module name="ImportControl">
+            <property name="file" value="integration/import-control.xml"/>
+            <property name="path" value="!(
+                |^.*IoTDBSchemaTemplateIT\.java$|
+                |^.*IoTDBSeriesReaderIT\.java$|
+                |^.*IoTDBCompactionIT\.java$|
+                |^.*IoTDBAggregationByLevelIT\.java$|
+                |^.*IoTDBUDFNestAggregationIT\.java$|
+                |^.*IoTDBAggregationDeleteIT\.java$|
+                |^.*IoTDBUserDefinedAggregationFunctionIT\.java$|
+                |^.*IoTDBAggregationIT\.java$|
+                |^.*IoTDBAggregationSmallDataIT\.java$|
+                |^.*IoTDBAggregationLargeDataIT\.java$|
+                |^.*IoTDBPartialInsertionIT\.java$|
+                |^.*IoTDBInsertWithoutTimeIT\.java$|
+                |^.*IoTDBUDFManagementIT\.java$|
+                |^.*IoTDBMultiSeriesIT\.java$|
+                |^.*IoTDBDisableAlignIT\.java$|
+                |^.*IoTDBManageTsFileResourceIT\.java$|
+                |^.*IoTDBInsertMultiRowIT\.java$|
+                |^.*IoTDBQueryWithComplexValueFilterIT\.java$|
+                |^.*IoTDBUDTFHybridQueryIT\.java$|
+                |^.*IoTDBQueryMemoryControlIT\.java$|
+                |^.*IoTDBClearCacheIT\.java$|
+                |^.*IoTDBTracingIT\.java$|
+                |^.*IoTDBLoadExternalTsFileWithTimePartitionIT\.java$|
+                |^.*IoTDBKillQueryIT\.java$|
+                |^.*IoTDBCompactionWithIDTableIT\.java$|
+                |^.*IoTDBMultiStatementsIT\.java$|
+                |^.*IoTDBArithmeticIT\.java$|
+                |^.*IoTDBQueryWithIDTableIT\.java$|
+                |^.*IoTDBDaemonIT\.java$|
+                |^.*IoTDBEncodingIT\.java$|
+                |^.*IoTDBNestedQueryIT\.java$|
+                |^.*IoTDBSelectSchemaIT\.java$|
+                |^.*IoTDBSortedShowTimeseriesIT\.java$|
+                |^.*IoTDBFillIT\.java$|
+                |^.*IoTDBSelectCompareExpressionIT\.java$|
+                |^.*IoTDBFilePathUtilsIT\.java$|
+                |^.*IoTDBTtlIT\.java$|
+                |^.*IoTDBUnseqOverlappedPageIT\.java$|
+                |^.*IoTDBVersionIT\.java$|
+                |^.*IoTDBCreateTimeseriesIT\.java$|
+                |^.*IoTDBCompressTypeIT\.java$|
+                |^.*IoTDBTagAlterIT\.java$|
+                |^.*IoTDBQueryDemoIT\.java$|
+                |^.*IoTDBNumberPathIT\.java$|
+                |^.*IoTDBSettleIT\.java$|
+                |^.*IoTDBOverlappedPageIT\.java$|
+                |^.*IoTDBDatetimeFormatIT\.java$|
+                |^.*IoTDBInIT\.java$|
+                |^.*IoTDBMetadataFetchIT\.java$|
+                |^.*IoTDBFloatPrecisionIT\.java$|
+                |^.*IoTDBRecoverIT\.java$|
+                |^.*IoTDBFuzzyQueryIT\.java$|
+                |^.*IoTDBAliasIT\.java$|
+                |^.*IoTDBUDFWindowQueryIT\.java$|
+                |^.*IoTDBAuthorizationIT\.java$|
+                |^.*IoTDBTriggerManagementIT\.java$|
+                |^.*IoTDBRecoverUnclosedIT\.java$|
+                |^.*IoTDBCreateAlignedTimeseriesIT\.java$|
+                |^.*IoTDBSameMeasurementsDifferentTypesIT\.java$|
+                |^.*IoTDBRpcCompressionIT\.java$|
+                |^.*IoTDBAlignByDeviceIT\.java$|
+                |^.*IoTDBLastQueryWithoutLastCacheWithDeletion2IT\.java$|
+                |^.*IoTDBGroupByQueryWithoutValueFilterIT\.java$|
+                |^.*IoTDBInsertAlignedValuesIT\.java$|
+                |^.*IoTDBAggregationWithoutValueFilterWithDeletion2IT\.java$|
+                |^.*IoTDBAggregationWithoutValueFilterIT\.java$|
+                |^.*IoTDBRawQueryWithoutValueFilterWithDeletion2IT\.java$|
+                |^.*IoTDBLoadExternalAlignedTsFileIT\.java$|
+                |^.*IoTDBLastQueryWithDeletionIT\.java$|
+                |^.*IoTDBGroupByQueryWithValueFilterWithDeletion2IT\.java$|
+                |^.*IoTDBGroupBySlidingWindowQueryWithoutValueFilterIT\.java$|
+                |^.*IoTDBRawQueryWithValueFilterIT\.java$|
+                |^.*IoTDBLastQuery2IT\.java$|
+                |^.*IoTDBLastQueryWithDeletion2IT\.java$|
+                |^.*IoTDBAggregationWithValueFilterIT\.java$|
+                |^.*IoTDBRawQueryWithoutValueFilter3IT\.java$|
+                |^.*IoTDBLastQueryIT\.java$|
+                |^.*IoTDBGroupByFillQueryBigDataIT\.java$|
+                |^.*IoTDBGroupByQueryWithValueFilterWithDeletionIT\.java$|
+                |^.*IoTDBAlignByDeviceIT\.java$|
+                |^.*IoTDBAggregationWithValueFilterWithDeletion2IT\.java$|
+                |^.*IoTDBGroupByQueryWithoutValueFilterWithDeletion2IT\.java$|
+                |^.*IoTDBAggregationWithoutValueFilter2IT\.java$|
+                |^.*IoTDBAggregationWithValueFilter2IT\.java$|
+                |^.*IoTDBRawQueryWithValueFilterWithDeletion2IT\.java$|
+                |^.*IoTDBGroupByFillQueryIT\.java$|
+                |^.*IoTDBDeleteTimeseriesIT\.java$|
+                |^.*IoTDBDeletionIT\.java$|
+                |^.*IoTDBRawQueryWithoutValueFilterWithDeletionIT\.java$|
+                |^.*IoTDBLastQueryWithoutLastCache2IT\.java$|
+                |^.*IoTDBRawQueryWithoutValueFilterIT\.java$|
+                |^.*IoTDBLastQueryWithoutLastCacheIT\.java$|
+                |^.*IoTDBGroupByQueryWithoutValueFilter2IT\.java$|
+                |^.*IoTDBGroupByQueryWithValueFilter2IT\.java$|
+                |^.*IoTDBGroupByQueryWithoutValueFilterWithDeletionIT\.java$|
+                |^.*IoTDBAggregationWithValueFilterWithDeletionIT\.java$|
+                |^.*IoTDBRawQueryWithValueFilterWithDeletionIT\.java$|
+                |^.*IoTDBAggregationGroupByLevelIT\.java$|
+                |^.*IoTDBAlignByDevice2IT\.java$|
+                |^.*IoTDBRawQueryWithValueFilter2IT\.java$|
+                |^.*IoTDBGroupBySlidingWindowQueryWithValueFilterIT\.java$|
+                |^.*IoTDBRawQueryWithoutValueFilter2IT\.java$|
+                |^.*AlignedWriteUtil\.java$|
+                |^.*IoTDBLastQueryWithoutLastCacheWithDeletionIT\.java$|
+                |^.*IoTDBGroupByQueryWithValueFilterIT\.java$|
+                |^.*IoTDBAggregationWithoutValueFilterWithDeletionIT\.java$|
+                |^.*IoTDBMultiDeviceIT\.java$|
+                |^.*IoTDBQueryVersionAdaptionIT\.java$|
+                |^.*IoTDBSyntaxConventionVersionAdaptionIT\.java$|
+                |^.*IoTDBDDLVersionAdaptionIT\.java$|
+                |^.*IoTDBDeletionVersionAdaptionIT\.java$|
+                |^.*IoTDBCreateStorageGroupIT\.java$|
+                |^.*StandaloneEnv\.java$|
+                |^.*StandaloneEnvConfig\.java$|
+                |^.*IoTDBCompleteIT\.java$|
+                |^.*IOTDBGroupByInnerIntervalIT\.java$|
+                |^.*IoTDBGroupByFillWithRangeIT\.java$|
+                |^.*IoTDBGroupByUnseqIT\.java$|
+                |^.*IOTDBGroupByIT\.java$|
+                |^.*IoTDBGroupByFillIT\.java$|
+                |^.*IoTDBGroupByMonthFillIT\.java$|
+                |^.*IoTDBGroupByFillMixPathsIT\.java$|
+                |^.*IoTDBGroupByMonthIT\.java$|
+                |^.*IoTDBResultSetIT\.java$|
+                |^.*IoTDBSimpleQueryIT\.java$|
+                |^.*IoTDBDeleteStorageGroupIT\.java$|
+                |^.*IOTDBInsertIT\.java$|
+                |^.*IoTDBTagIT\.java$|
+                |^.*IoTDBDeleteTimeseriesIT\.java$|
+                |^.*IoTDBDeletionIT\.java$|
+                |^.*IoTDBExecuteBatchIT\.java$|
+                |^.*IoTDBMaxTimeQueryIT\.java$|
+                |^.*IoTDBSensorUpdateIT\.java$|
+                |^.*IoTDBWithoutNullAllFilterIT\.java$|
+                |^.*IoTDBWithoutNullAnyFilterIT\.java$|
+                |^.*IoTDBRemovePartitionIT\.java$|
+                |^.*IoTDBUDTFAlignByTimeQueryIT\.java$|
+                |^.*IoTDBAutoCreateSchemaIT\.java$|
+                |^.*IoTDBQueryTimeoutIT\.java$|
+                |^.*IoTDBLoadExternalTsfileIT\.java$|
+                |^.*IoTDBSessionTimeoutIT\.java$|
+                |^.*IoTDBAsIT\.java$|
+                |^.*IoTDBPathNumOverLimitIT\.java$|
+                |^.*IoTDBFlushQueryMergeIT\.java$|
+                |^.*IoTDBSelectIntoIT\.java$|
+                |^.*IoTDBMultiOverlappedChunkInUnseqIT\.java$|
+                |^.*IoTDBInsertWithQueryIT\.java$|
+                |^.*IoTDBTimeZoneIT\.java$|
+                |^.*IoTDBTriggerExecutionIT\.java$|
+                |^.*IoTDBWithoutAllNullIT\.java$|
+                |^.*IoTDBLimitSlimitIT\.java$|
+                |^.*IoTDBLargeDataIT\.java$|
+                |^.*IoTDBResultMetadataIT\.java$|
+                |^.*IoTDBWithoutAnyNullIT\.java$|
+                |^.*IoTDBQuotedPathIT\.java$|
+                |^.*TransportClientMock\.java$|
+                |^.*IoTDBSyncReceiverLoaderIT\.java$|
+                |^.*IoTDBSyncSenderIT\.java$|
+                |^.*IoTDBSyncReceiverIT\.java$|
+                |^.*IoTDBSyncReceiverCollectorIT\.java$|
+                |^.*SyncTestUtil\.java$|
+                |^.*IoTDBUDTFBuiltinFunctionIT\.java$|
+                |^.*IoTDBInsertNaNIT\.java$|
+                |^.*IoTDBLastIT\.java$|
+                |^.*IoTDBNewTsFileCompactionIT\.java$|
+                |^.*IoTDBSequenceDataQueryIT\.java$|
+                |^.*IoTDBTimePartitionIT\.java$|
+                |^.*IoTDBCloseIT\.java$|
+                |^.*IoTDBQueryWithRecreatedTimeseriesIT\.java$|
+                |^.*IoTDBEngineTimeGeneratorIT\.java$|
+                |^.*IoTDBCheckConfigIT\.java$|
+                |^.*IoTDBMultiOverlappedPageIT\.java$|
+                |^.*IoTDBAlignedTimeSeriesCompactionIT\.java$|
+                |^.*IoTDBRestartIT\.java$|
+                |^.*IoTDBSyntaxConventionIT\.java$|
+                |^.*IoTDBUDTFNonAlignQueryIT\.java$|
+                |^.*IoTDBSetSystemReadOnlyWritableIT\.java$|
+                |^.*IoTDBContinuousQueryIT\.java$|
+                |^.*IoTDBSizeTieredCompactionIT\.java$|)"/>
+            <message key="import.control.disallowed" value="{0} is not allowed to use in integration test."/>
+        </module>
+    </module>
+</module>

--- a/integration/import-control.xml
+++ b/integration/import-control.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE import-control PUBLIC "-//Checkstyle//DTD ImportControl Configuration 1.4//EN" "https://checkstyle.org/dtds/import_control_1_4.dtd">
+
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<import-control pkg="org.apache.iotdb.db.integration">
+    <allow pkg="java.util"/>
+    <allow pkg="java.sql"/>
+    <allow pkg="java.io"/>
+    <allow pkg="org\.junit.*" regex="true"/>
+    <allow pkg="org\.apache\.iotdb\.itbase" regex="true"/>
+    <allow pkg="org\.apache\.iotdb\.integration\.*" regex="true"/>
+    <disallow class="java.sql.DriverManager"/>
+    <disallow class="javax.sql.DataSource"/>
+    <disallow pkg="org.apache.iotdb.jdbc.*"/>
+</import-control>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <module>client-cpp</module>
         <module>metrics</module>
         <module>integration</module>
+        <module>integration-test</module>
         <module>consensus</module>
         <module>external-pipe-api</module>
         <module>library-udf</module>
@@ -999,6 +1000,7 @@
                             <!-- configure your formatting preferences here (see link below) -->
                             <indentSize>4</indentSize>
                             <excludes>**/target/**</excludes>
+                            <excludes>**/checkstyle.xml</excludes>
                         </configuration>
                     </execution>
                 </executions>

--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -265,6 +265,16 @@
             <level>INFO</level>
         </filter>
     </appender>
+    <appender class="ch.qos.logback.core.FileAppender" name="ITForCluster">
+        <file>${IT_LOG_PATH:-/dev/null}</file>
+        <encoder>
+            <pattern>%d [%t] %-5p %C{25}:%L - %m %n</pattern>
+            <charset>utf-8</charset>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${IT_LOG_LEVEL:-OFF}</level>
+        </filter>
+    </appender>
     <root level="info">
         <appender-ref ref="FILETRACE"/>
         <appender-ref ref="FILEDEBUG"/>
@@ -273,6 +283,7 @@
         <appender-ref ref="FILEINFO"/>
         <appender-ref ref="FILEALL"/>
         <appender-ref ref="stdout"/>
+        <appender-ref ref="ITForCluster"/>
     </root>
     <logger level="OFF" name="io.moquette.broker.metrics.MQTTMessageLogger"/>
     <logger level="info" name="org.apache.iotdb.db.service"/>

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -280,19 +280,9 @@ public class IoTDBConfig {
   /** Consensus directory. */
   private String consensusDir = IoTDBConstant.DEFAULT_BASE_DIR + File.separator + "consensus";
 
-  private String dataRegionConsensusDir =
-      IoTDBConstant.DEFAULT_BASE_DIR
-          + File.separator
-          + "consensus"
-          + File.separator
-          + "data_region";
+  private String dataRegionConsensusDir = consensusDir + File.separator + "data_region";
 
-  private String schemaRegionConsensusDir =
-      IoTDBConstant.DEFAULT_BASE_DIR
-          + File.separator
-          + "consensus"
-          + File.separator
-          + "schema_region";
+  private String schemaRegionConsensusDir = consensusDir + File.separator + "schema_region";
 
   /** Maximum MemTable number. Invalid when enableMemControl is true. */
   private int maxMemtableNumber = 0;
@@ -1040,6 +1030,8 @@ public class IoTDBConfig {
     syncDir = addHomeDir(syncDir);
     tracingDir = addHomeDir(tracingDir);
     consensusDir = addHomeDir(consensusDir);
+    dataRegionConsensusDir = addHomeDir(dataRegionConsensusDir);
+    schemaRegionConsensusDir = addHomeDir(schemaRegionConsensusDir);
     indexRootFolder = addHomeDir(indexRootFolder);
     extDir = addHomeDir(extDir);
     udfDir = addHomeDir(udfDir);


### PR DESCRIPTION
New feature:
- Adapt for the new cluster of MPP.
- Add the log record for every node in the cluster integration test.
- Parallel to do cluster integration test.

TODO:
- [x] Add the whitelist for IT files in this module.
- [x] The log record files can be downloaded.
- [x] To integrate with GitHub action.
- [x] Finish the README. 
- [ ] Finish the user document.

Use command below to do test:
`mvn spotless:apply clean verify -Dsession.test.skip=true -Diotdb.test.skip=true -Dcluster.test.skip=true -Dtsfile.test.skip=true -Dcommons.test.skip=true -Dconfignode.test.skip=true -pl integration-test -am -PClusterIT`
