### PR TITLE
[IOTDB-3184] Feature/delete timeseries

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceManager;
 import org.apache.iotdb.db.mpp.plan.planner.plan.FragmentInstance;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.DeleteRegionNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.DeleteTimeSeriesDataNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.InsertMultiTabletsNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.InsertRowNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.InsertRowsNode;
@@ -88,6 +89,14 @@ public class DataRegionStateMachine extends BaseStateMachine {
         region.syncDeleteDataFiles();
         StorageEngineV2.getInstance()
             .deleteDataRegion((DataRegionId) ((DeleteRegionNode) planNode).getConsensusGroupId());
+      } else if (planNode instanceof DeleteTimeSeriesDataNode) {
+        // TODO: consider timePartitionFilter and planIndex
+        region.delete(
+            ((DeleteTimeSeriesDataNode) planNode).getDeletedPath(),
+            Long.MIN_VALUE,
+            Long.MAX_VALUE,
+            Long.MAX_VALUE,
+            null);
       } else {
         logger.error("Unsupported plan node for writing to data region : {}", planNode);
         return StatusUtils.UNSUPPORTED_OPERATION;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
@@ -56,6 +56,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.CountTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.CreateAlignedTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.CreateTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.DeleteStorageGroupStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.DeleteTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.SetStorageGroupStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.SetTTLStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowDevicesStatement;
@@ -167,6 +168,17 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     createAlignedTimeSeriesStatement.setDevicePath(parseFullPath(ctx.fullPath()));
     parseAlignedMeasurements(ctx.alignedMeasurements(), createAlignedTimeSeriesStatement);
     return createAlignedTimeSeriesStatement;
+  }
+
+  @Override
+  public Statement visitDeleteTimeseries(IoTDBSqlParser.DeleteTimeseriesContext ctx) {
+    DeleteTimeSeriesStatement deleteTimeSeriesStatement = new DeleteTimeSeriesStatement();
+    List<PartialPath> partialPaths = new ArrayList<>();
+    for (IoTDBSqlParser.PrefixPathContext prefixPathContext : ctx.prefixPath()) {
+      partialPaths.add(parsePrefixPath(prefixPathContext));
+    }
+    deleteTimeSeriesStatement.setPartialPaths(partialPaths);
+    return deleteTimeSeriesStatement;
   }
 
   public void parseAlignedMeasurements(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanner.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iotdb.db.mpp.plan.planner;
 
+import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.mpp.common.MPPQueryContext;
 import org.apache.iotdb.db.mpp.plan.analyze.Analysis;
 import org.apache.iotdb.db.mpp.plan.optimization.PlanOptimizer;
 import org.apache.iotdb.db.mpp.plan.planner.plan.LogicalQueryPlan;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.DeleteTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.AlterTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateAlignedTimeSeriesNode;
@@ -48,6 +50,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.CountTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.CreateAlignedTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.CreateMultiTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.CreateTimeSeriesStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.DeleteTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.SchemaFetchStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowDevicesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowTimeSeriesStatement;
@@ -309,6 +312,13 @@ public class LogicalPlanner {
           alterTimeSeriesStatement.getAlias(),
           alterTimeSeriesStatement.getTagsMap(),
           alterTimeSeriesStatement.getAttributesMap());
+    }
+
+    @Override
+    public PlanNode visitDeleteTimeSeries(
+        DeleteTimeSeriesStatement DeleteTimeSeriesStatement, MPPQueryContext context) {
+      List<PartialPath> deletedPaths = DeleteTimeSeriesStatement.getPartialPaths();
+      return new DeleteTimeSeriesNode(context.getQueryId().genPlanNodeId(), deletedPaths);
     }
 
     @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/DeleteTimeSeriesNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/DeleteTimeSeriesNode.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.plan.planner.plan.node;
+
+import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.mpp.plan.analyze.Analysis;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.DeleteTimeSeriesSchemaNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.DeleteTimeSeriesDataNode;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DeleteTimeSeriesNode extends WritePlanNode {
+
+  private final List<PartialPath> deletedPaths;
+  private final Map<PartialPath, PlanNode> schemaRegionSpiltMap;
+  private final Map<PartialPath, List<PlanNode>> dataRegionSplitMap;
+
+  public DeleteTimeSeriesNode(PlanNodeId id, List<PartialPath> deletedPath) {
+    super(id);
+    this.deletedPaths = deletedPath;
+    this.schemaRegionSpiltMap = new HashMap<>();
+    this.dataRegionSplitMap = new HashMap<>();
+  }
+
+  public List<PartialPath> getDeletedPaths() {
+    return deletedPaths;
+  }
+
+  public Map<PartialPath, PlanNode> getSchemaRegionSpiltMap() {
+    return schemaRegionSpiltMap;
+  }
+
+  public Map<PartialPath, List<PlanNode>> getDataRegionSplitMap() {
+    return dataRegionSplitMap;
+  }
+
+  @Override
+  protected void serializeAttributes(ByteBuffer buffer) {
+    PlanNodeType.DELETE_TIMESERIES.serialize(buffer);
+    ReadWriteIOUtils.writeStringList(
+        deletedPaths.stream().map(PartialPath::getFullPath).collect(Collectors.toList()), buffer);
+  }
+
+  public static PlanNode deserialize(ByteBuffer buffer) {
+    List<PartialPath> deletedPath = new ArrayList<>();
+    ReadWriteIOUtils.readStringList(buffer).stream()
+        .map(
+            fullPath -> {
+              try {
+                return new PartialPath(fullPath);
+              } catch (IllegalPathException e) {
+                throw new IllegalArgumentException(
+                    "Cannot deserialize DeleteTimeSeriesSchemaNode", e);
+              }
+            })
+        .forEach(deletedPath::add);
+    PlanNodeId planNodeId = PlanNodeId.deserialize(buffer);
+    return new DeleteTimeSeriesNode(planNodeId, deletedPath);
+  }
+
+  @Override
+  public TRegionReplicaSet getRegionReplicaSet() {
+    return null;
+  }
+
+  @Override
+  public List<WritePlanNode> splitByPartition(Analysis analysis) {
+    for (PartialPath deletedPath : deletedPaths) {
+      String device = deletedPath.getDevice();
+      TRegionReplicaSet schemaRegionReplicaSet =
+          analysis.getSchemaPartitionInfo().getSchemaRegionReplicaSet(device);
+      DeleteTimeSeriesSchemaNode deleteTimeSeriesSchemaNode =
+          new DeleteTimeSeriesSchemaNode(this.getPlanNodeId(), deletedPath);
+      deleteTimeSeriesSchemaNode.setRegionReplicaSet(schemaRegionReplicaSet);
+      schemaRegionSpiltMap.putIfAbsent(deletedPath, deleteTimeSeriesSchemaNode);
+      List<TRegionReplicaSet> dataRegionReplicaSets =
+          analysis.getDataPartitionInfo().getDataRegionReplicaSet(device, null);
+      DeleteTimeSeriesDataNode deleteTimeSeriesDataNode =
+          new DeleteTimeSeriesDataNode(this.getPlanNodeId(), deletedPath);
+      for (TRegionReplicaSet dataRegionReplicaSet : dataRegionReplicaSets) {
+        deleteTimeSeriesDataNode.setRegionReplicaSet(dataRegionReplicaSet);
+        dataRegionSplitMap
+            .computeIfAbsent(deletedPath, k -> new ArrayList<>())
+            .add(deleteTimeSeriesDataNode);
+      }
+    }
+    return Collections.singletonList(this);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanNodeType.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanNodeType.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.AlterTimeSe
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateAlignedTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateMultiTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateTimeSeriesNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.DeleteTimeSeriesSchemaNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.AggregationNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.DeviceViewNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.ExchangeNode;
@@ -51,6 +52,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedSeriesAggreg
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedSeriesScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.SeriesAggregationScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.SeriesScanNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.DeleteTimeSeriesDataNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.InsertMultiTabletsNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.InsertRowNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.InsertRowsNode;
@@ -101,7 +103,10 @@ public enum PlanNodeType {
   SCHEMA_FETCH_MERGE((short) 36),
   TRANSFORM((short) 37),
   DELETE_REGION((short) 38),
-  CREATE_MULTI_TIME_SERIES((short) 39);
+  CREATE_MULTI_TIME_SERIES((short) 39),
+  DELETE_TIMESERIES((short) 40),
+  DELETE_TIMESERIES_SCHEMA((short) 41),
+  DELETE_TIMESERIES_DATA((short) 42);
 
   private final short nodeType;
 
@@ -205,6 +210,10 @@ public enum PlanNodeType {
         return DeleteRegionNode.deserialize(buffer);
       case 39:
         return CreateMultiTimeSeriesNode.deserialize(buffer);
+      case 41:
+        return DeleteTimeSeriesSchemaNode.deserialize(buffer);
+      case 42:
+        return DeleteTimeSeriesDataNode.deserialize(buffer);
       default:
         throw new IllegalArgumentException("Invalid node type: " + nodeType);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanVisitor.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.AlterTimeSe
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateAlignedTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateMultiTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateTimeSeriesNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.DeleteTimeSeriesSchemaNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.AggregationNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.DeviceMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.DeviceViewNode;
@@ -198,6 +199,10 @@ public abstract class PlanVisitor<R, C> {
   }
 
   public R visitDeleteRegion(DeleteRegionNode node, C context) {
+    return visitPlan(node, context);
+  }
+
+  public R visitDeleteTimeSeriesSchema(DeleteTimeSeriesSchemaNode node, C context) {
     return visitPlan(node, context);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/write/DeleteTimeSeriesSchemaNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/write/DeleteTimeSeriesSchemaNode.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write;
+
+import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.mpp.plan.analyze.Analysis;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeType;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanVisitor;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.WritePlanNode;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class DeleteTimeSeriesSchemaNode extends WritePlanNode {
+  private PartialPath deletedPath;
+  private TRegionReplicaSet schemaRegionReplicaSet;
+
+  public DeleteTimeSeriesSchemaNode(PlanNodeId id, PartialPath deletedPath) {
+    super(id);
+    this.deletedPath = deletedPath;
+  }
+
+  @Override
+  protected void serializeAttributes(ByteBuffer byteBuffer) {
+    PlanNodeType.DELETE_TIMESERIES_SCHEMA.serialize(byteBuffer);
+    ReadWriteIOUtils.write(deletedPath.getFullPath(), byteBuffer);
+  }
+
+  public static PlanNode deserialize(ByteBuffer buffer) {
+    PartialPath deletedPath;
+    try {
+      deletedPath = new PartialPath(ReadWriteIOUtils.readString(buffer));
+    } catch (IllegalPathException e) {
+      throw new IllegalArgumentException("Cannot deserialize DeleteTimeSeriesSchemaNode", e);
+    }
+    PlanNodeId planNodeId = PlanNodeId.deserialize(buffer);
+    return new DeleteTimeSeriesSchemaNode(planNodeId, deletedPath);
+  }
+
+  public PartialPath getDeletedPath() {
+    return deletedPath;
+  }
+
+  @Override
+  public TRegionReplicaSet getRegionReplicaSet() {
+    return schemaRegionReplicaSet;
+  }
+
+  public void setRegionReplicaSet(TRegionReplicaSet schemaRegionReplicaSet) {
+    this.schemaRegionReplicaSet = schemaRegionReplicaSet;
+  }
+
+  @Override
+  public <R, C> R accept(PlanVisitor<R, C> visitor, C schemaRegion) {
+    return visitor.visitDeleteTimeSeriesSchema(this, schemaRegion);
+  }
+
+  @Override
+  public List<WritePlanNode> splitByPartition(Analysis analysis) {
+    return null;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/DeleteTimeSeriesDataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/DeleteTimeSeriesDataNode.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.plan.planner.plan.node.write;
+
+import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.mpp.plan.analyze.Analysis;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeType;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.WritePlanNode;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class DeleteTimeSeriesDataNode extends WritePlanNode {
+
+  private PartialPath deletedPath;
+  private TRegionReplicaSet dataRegionReplicaSet;
+
+  public DeleteTimeSeriesDataNode(PlanNodeId id, PartialPath deletedPath) {
+    super(id);
+    this.deletedPath = deletedPath;
+  }
+
+  @Override
+  protected void serializeAttributes(ByteBuffer byteBuffer) {
+    PlanNodeType.DELETE_TIMESERIES_DATA.serialize(byteBuffer);
+    ReadWriteIOUtils.write(deletedPath.getFullPath(), byteBuffer);
+  }
+
+  public static DeleteTimeSeriesDataNode deserialize(ByteBuffer buffer) {
+    PartialPath deletedPath;
+    try {
+      deletedPath = new PartialPath(ReadWriteIOUtils.readString(buffer));
+    } catch (IllegalPathException e) {
+      throw new IllegalArgumentException("Cannot deserialize DeleteTimeSeriesDataNode", e);
+    }
+    PlanNodeId planNodeId = PlanNodeId.deserialize(buffer);
+    return new DeleteTimeSeriesDataNode(planNodeId, deletedPath);
+  }
+
+  public PartialPath getDeletedPath() {
+    return deletedPath;
+  }
+
+  @Override
+  public TRegionReplicaSet getRegionReplicaSet() {
+    return dataRegionReplicaSet;
+  }
+
+  public void setRegionReplicaSet(TRegionReplicaSet dataRegionReplicaSet) {
+    this.dataRegionReplicaSet = dataRegionReplicaSet;
+  }
+
+  @Override
+  public List<WritePlanNode> splitByPartition(Analysis analysis) {
+    return null;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/StatementVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/StatementVisitor.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.CreateAlignedTimeSeriesSt
 import org.apache.iotdb.db.mpp.plan.statement.metadata.CreateMultiTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.CreateTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.DeleteStorageGroupStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.DeleteTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.SchemaFetchStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.SetStorageGroupStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.SetTTLStatement;
@@ -182,5 +183,9 @@ public abstract class StatementVisitor<R, C> {
 
   public R visitSchemaFetch(SchemaFetchStatement schemaFetchStatement, C context) {
     return visitStatement(schemaFetchStatement, context);
+  }
+
+  public R visitDeleteTimeSeries(DeleteTimeSeriesStatement deleteTimeSeriesStatement, C context) {
+    return visitStatement(deleteTimeSeriesStatement, context);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/DeleteTimeSeriesStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/DeleteTimeSeriesStatement.java
@@ -17,44 +17,33 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.mpp.plan.planner.plan.node;
+package org.apache.iotdb.db.mpp.plan.statement.metadata;
 
-import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
-import org.apache.iotdb.db.mpp.plan.analyze.Analysis;
-import org.apache.iotdb.tsfile.exception.NotImplementedException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.mpp.plan.statement.Statement;
+import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
 
 import java.util.List;
 
-public abstract class WritePlanNode extends PlanNode {
+public class DeleteTimeSeriesStatement extends Statement {
 
-  protected WritePlanNode(PlanNodeId id) {
-    super(id);
+  List<PartialPath> partialPaths;
+
+  public List<PartialPath> getPartialPaths() {
+    return partialPaths;
   }
 
-  public abstract TRegionReplicaSet getRegionReplicaSet();
-
-  public abstract List<WritePlanNode> splitByPartition(Analysis analysis);
-
-  @Override
-  public List<PlanNode> getChildren() {
-    return null;
+  public void setPartialPaths(List<PartialPath> partialPaths) {
+    this.partialPaths = partialPaths;
   }
 
   @Override
-  public void addChild(PlanNode child) {}
-
-  @Override
-  public PlanNode clone() {
-    throw new NotImplementedException("clone of Insert is not implemented");
+  public List<PartialPath> getPaths() {
+    return partialPaths;
   }
 
   @Override
-  public int allowedChildCount() {
-    return NO_CHILD_ALLOWED;
-  }
-
-  @Override
-  public List<String> getOutputColumnNames() {
-    return null;
+  public <R, C> R accept(StatementVisitor<R, C> visitor, C context) {
+    return visitor.visitDeleteTimeSeries(this, context);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/node/write/DeleteTimeSeriesSerdeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/node/write/DeleteTimeSeriesSerdeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.plan.plan.node.write;
+
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeType;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.DeleteTimeSeriesSchemaNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.DeleteTimeSeriesDataNode;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class DeleteTimeSeriesSerdeTest {
+  @Test
+  public void testDataSerializeAndDeserialize() throws IllegalPathException {
+    DeleteTimeSeriesDataNode deleteTimeSeriesDataNode =
+        new DeleteTimeSeriesDataNode(
+            new PlanNodeId("plan node 1"), new PartialPath("root.sg.d.s1"));
+    ByteBuffer byteBuffer = ByteBuffer.allocate(10000);
+    deleteTimeSeriesDataNode.serialize(byteBuffer);
+    byteBuffer.flip();
+    Assert.assertEquals(PlanNodeType.DELETE_TIMESERIES_DATA.ordinal(), byteBuffer.getShort());
+    DeleteTimeSeriesDataNode deserialize =
+        (DeleteTimeSeriesDataNode) DeleteTimeSeriesDataNode.deserialize(byteBuffer);
+    Assert.assertTrue(deserialize.getDeletedPath().matchFullPath(new PartialPath("root.sg.d.s1")));
+  }
+
+  @Test
+  public void testSchemaSerializeAndDeserialize() throws IllegalPathException {
+    DeleteTimeSeriesSchemaNode deleteTimeSeriesDataNode =
+        new DeleteTimeSeriesSchemaNode(
+            new PlanNodeId("plan node 1"), new PartialPath("root.sg.d.s1"));
+    ByteBuffer byteBuffer = ByteBuffer.allocate(10000);
+    deleteTimeSeriesDataNode.serialize(byteBuffer);
+    byteBuffer.flip();
+    Assert.assertEquals(PlanNodeType.DELETE_TIMESERIES_SCHEMA.ordinal(), byteBuffer.getShort());
+    DeleteTimeSeriesSchemaNode deserialize =
+        (DeleteTimeSeriesSchemaNode) DeleteTimeSeriesSchemaNode.deserialize(byteBuffer);
+    Assert.assertTrue(deserialize.getDeletedPath().matchFullPath(new PartialPath("root.sg.d.s1")));
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/mpp/scheduler/FragmentInstanceDispatcherImplTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/scheduler/FragmentInstanceDispatcherImplTest.java
@@ -1,0 +1,99 @@
+package org.apache.iotdb.db.mpp.scheduler;
+
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.mpp.common.PlanFragmentId;
+import org.apache.iotdb.db.mpp.plan.analyze.QueryType;
+import org.apache.iotdb.db.mpp.plan.planner.plan.FragmentInstance;
+import org.apache.iotdb.db.mpp.plan.planner.plan.PlanFragment;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.DeleteTimeSeriesNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.DeleteTimeSeriesSchemaNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.write.DeleteTimeSeriesDataNode;
+import org.apache.iotdb.db.mpp.plan.scheduler.FragInstanceDispatchResult;
+import org.apache.iotdb.db.mpp.plan.scheduler.FragmentInstanceDispatcherImpl;
+import org.apache.iotdb.db.mpp.plan.scheduler.IFragInstanceDispatcher;
+
+import com.google.common.util.concurrent.SettableFuture;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FragmentInstanceDispatcherImpl.class})
+public class FragmentInstanceDispatcherImplTest {
+
+  private DeleteTimeSeriesNode deleteTimeSeriesNode;
+  private PartialPath s1;
+  private PartialPath s2;
+  IFragInstanceDispatcher dispatcher;
+  DeleteTimeSeriesNode nodeSpy;
+
+  public FragmentInstanceDispatcherImplTest() throws IllegalPathException {}
+
+  @Before
+  public void setUp() throws IllegalPathException {
+    List<PartialPath> deletedPaths = new ArrayList<>();
+    s1 = new PartialPath("root.sg.d.s1");
+    s2 = new PartialPath("root.sg.d.s2");
+    deletedPaths.add(s1);
+    deletedPaths.add(s2);
+    deleteTimeSeriesNode = new DeleteTimeSeriesNode(new PlanNodeId("1"), deletedPaths);
+    dispatcher =
+        new FragmentInstanceDispatcherImpl(
+            QueryType.WRITE,
+            Executors.newSingleThreadExecutor(),
+            Executors.newSingleThreadScheduledExecutor(),
+            null);
+    this.nodeSpy = Mockito.spy(deleteTimeSeriesNode);
+    Map<PartialPath, List<PlanNode>> dataRegionSet = new HashMap<>();
+    final DeleteTimeSeriesDataNode dataNode1 =
+        new DeleteTimeSeriesDataNode(new PlanNodeId("1"), s1);
+    final DeleteTimeSeriesDataNode dataNode2 =
+        new DeleteTimeSeriesDataNode(new PlanNodeId("1"), s2);
+    final DeleteTimeSeriesSchemaNode schemaNode1 =
+        new DeleteTimeSeriesSchemaNode(new PlanNodeId("1"), s1);
+    final DeleteTimeSeriesSchemaNode schemaNode2 =
+        new DeleteTimeSeriesSchemaNode(new PlanNodeId("1"), s2);
+    Map<PartialPath, PlanNode> schemaRegionSet = new HashMap<>();
+    dataRegionSet.put(s1, Collections.singletonList(dataNode1));
+    dataRegionSet.put(s2, Collections.singletonList(dataNode2));
+    schemaRegionSet.put(s1, schemaNode1);
+    schemaRegionSet.put(s2, schemaNode2);
+    PowerMockito.when(nodeSpy.getDataRegionSplitMap()).thenReturn(dataRegionSet);
+    PowerMockito.when(nodeSpy.getSchemaRegionSpiltMap()).thenReturn(schemaRegionSet);
+  }
+
+  @Test
+  public void testDispatchDelete() throws Exception {
+    final PlanFragmentId planFragmentId = new PlanFragmentId("1", 1);
+    FragmentInstance deleteInstance =
+        new FragmentInstance(
+            new PlanFragment(planFragmentId, nodeSpy),
+            planFragmentId.genFragmentInstanceId(),
+            null,
+            QueryType.WRITE);
+    final SettableFuture<FragInstanceDispatchResult> deleteFuture = SettableFuture.create();
+    deleteFuture.set(new FragInstanceDispatchResult(true));
+    PowerMockito.stub(
+            PowerMockito.method(FragmentInstanceDispatcherImpl.class, "dispatchWrite", List.class))
+        .toReturn(deleteFuture);
+    final Future<FragInstanceDispatchResult> dispatch =
+        dispatcher.dispatch(Collections.singletonList(deleteInstance));
+    Assert.assertTrue(dispatch.get().isSuccessful());
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/mpp/scheduler/FragmentInstanceDispatcherImplTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/scheduler/FragmentInstanceDispatcherImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iotdb.db.mpp.scheduler;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;

--- a/server/src/test/java/org/apache/iotdb/db/mpp/scheduler/FragmentInstanceDispatcherImplTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/scheduler/FragmentInstanceDispatcherImplTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -53,6 +54,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.*, com.sun.*"})
 @PrepareForTest({FragmentInstanceDispatcherImpl.class})
 public class FragmentInstanceDispatcherImplTest {
 

--- a/server/src/test/java/org/apache/iotdb/db/mpp/scheduler/FragmentInstanceDispatcherImplTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/scheduler/FragmentInstanceDispatcherImplTest.java
@@ -53,8 +53,8 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.*, com.sun.*"})
 @PrepareForTest({FragmentInstanceDispatcherImpl.class})
 public class FragmentInstanceDispatcherImplTest {
 
@@ -63,8 +63,6 @@ public class FragmentInstanceDispatcherImplTest {
   private PartialPath s2;
   IFragInstanceDispatcher dispatcher;
   DeleteTimeSeriesNode nodeSpy;
-
-  public FragmentInstanceDispatcherImplTest() throws IllegalPathException {}
 
   @Before
   public void setUp() throws IllegalPathException {


### PR DESCRIPTION
Prepare statement

set storage group to root.sg; 
create timeseries root.sg.d.s1 with datatype=INT32,encoding=RLE,compression=snappy;
create timeseries root.sg.d.s2 with datatype=INT32,encoding=RLE,compression=snappy;
create timeseries root.sg.d.s3 with datatype=INT32,encoding=RLE,compression=snappy; 
insert into root.sg.d(time,s1,s2,s3) values(1,1,2,3); 
insert into root.sg.d(time,s1,s2,s3) values(2,1,2,3); 
set storage group to root.sg1; 
create timeseries root.sg1.d.s1 with datatype=INT32,encoding=RLE,compression=snappy;
create timeseries root.sg1.d.s2 with datatype=INT32,encoding=RLE,compression=snappy;
create timeseries root.sg1.d.s3 with datatype=INT32,encoding=RLE,compression=snappy; 
insert into root.sg1.d(time,s1,s2,s3) values(1,1,2,3); 
insert into root.sg1.d(time,s1,s2,s3) values(2,1,2,3); 
set storage group to root.sg2; 
create timeseries root.sg2.d.s1 with datatype=INT32,encoding=RLE,compression=snappy;
create timeseries root.sg2.d.s2 with datatype=INT32,encoding=RLE,compression=snappy;
create timeseries root.sg2.d.s3 with datatype=INT32,encoding=RLE,compression=snappy; 
insert into root.sg2.d(time,s1,s2,s3) values(1,1,2,3); 
insert into root.sg2.d(time,s1,s2,s3) values(2,1,2,3); 

test1: delete single timeseries

![image](https://user-images.githubusercontent.com/82880298/168526745-0bc2a992-41ae-4f11-88df-f130b4994332.png)

test2: delete with "*"


