### PR TITLE
[MPP][Bug hotfix] Support expressions in select and filter causes 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
@@ -94,10 +94,10 @@ public class FilterOperator extends TransformOperator {
   }
 
   private void iterateFilterReaderToNextValid() throws QueryProcessException, IOException {
-    while (filterPointReader.next()
-        && (filterPointReader.isCurrentNull() || !filterPointReader.currentBoolean())) {
+    do {
       filterPointReader.readyForNext();
-    }
+    } while (filterPointReader.next()
+        && (filterPointReader.isCurrentNull() || !filterPointReader.currentBoolean()));
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.mpp.execution.operator.Operator;
 import org.apache.iotdb.db.mpp.execution.operator.OperatorContext;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.query.expression.Expression;
 import org.apache.iotdb.db.query.udf.core.reader.LayerPointReader;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
@@ -36,6 +37,7 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class FilterOperator extends TransformOperator {
 
@@ -45,6 +47,7 @@ public class FilterOperator extends TransformOperator {
       OperatorContext operatorContext,
       Operator inputOperator,
       List<TSDataType> inputDataTypes,
+      Map<String, List<InputLocation>> inputLocations,
       Expression filterExpression,
       Expression[] outputExpressions,
       boolean keepNull,
@@ -55,6 +58,7 @@ public class FilterOperator extends TransformOperator {
         operatorContext,
         inputOperator,
         inputDataTypes,
+        inputLocations,
         bindExpressions(filterExpression, outputExpressions),
         keepNull,
         zoneId,
@@ -70,9 +74,10 @@ public class FilterOperator extends TransformOperator {
   }
 
   @Override
-  protected void initTransformers(TypeProvider typeProvider)
+  protected void initTransformers(
+      Map<String, List<InputLocation>> inputLocations, TypeProvider typeProvider)
       throws QueryProcessException, IOException {
-    super.initTransformers(typeProvider);
+    super.initTransformers(inputLocations, typeProvider);
 
     filterPointReader = transformers[transformers.length - 1];
     if (filterPointReader.getDataType() != TSDataType.BOOLEAN) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
@@ -161,6 +161,11 @@ public class FilterOperator extends TransformOperator {
   @Override
   public boolean hasNext() {
     try {
+      if (isFirstIteration) {
+        readyForFirstIteration();
+        isFirstIteration = false;
+      }
+
       return filterPointReader.next();
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
@@ -75,9 +75,11 @@ public class FilterOperator extends TransformOperator {
 
   @Override
   protected void initTransformers(
-      Map<String, List<InputLocation>> inputLocations, TypeProvider typeProvider)
+      Map<String, List<InputLocation>> inputLocations,
+      Expression[] outputExpressions,
+      TypeProvider typeProvider)
       throws QueryProcessException, IOException {
-    super.initTransformers(inputLocations, typeProvider);
+    super.initTransformers(inputLocations, outputExpressions, typeProvider);
 
     filterPointReader = transformers[transformers.length - 1];
     if (filterPointReader.getDataType() != TSDataType.BOOLEAN) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
@@ -141,6 +141,8 @@ public class FilterOperator extends TransformOperator {
 
         inputLayer.updateRowRecordListEvictionUpperBound();
       }
+
+      tsBlockBuilder.declarePositions(rowCount);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/FilterOperator.java
@@ -70,8 +70,9 @@ public class FilterOperator extends TransformOperator {
   }
 
   @Override
-  protected void initTransformers() throws QueryProcessException, IOException {
-    super.initTransformers();
+  protected void initTransformers(TypeProvider typeProvider)
+      throws QueryProcessException, IOException {
+    super.initTransformers(typeProvider);
 
     filterPointReader = transformers[transformers.length - 1];
     if (filterPointReader.getDataType() != TSDataType.BOOLEAN) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/TransformOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/TransformOperator.java
@@ -88,9 +88,8 @@ public class TransformOperator implements ProcessOperator {
 
     initInputLayer(inputDataTypes);
     initUdtfContext(zoneId);
-    initTransformers();
+    initTransformers(typeProvider);
     readyForFirstIteration();
-    updateTypeProvider(typeProvider);
   }
 
   private void initInputLayer(List<TSDataType> inputDataTypes) throws QueryProcessException {
@@ -106,7 +105,8 @@ public class TransformOperator implements ProcessOperator {
     udtfContext.constructUdfExecutors(outputExpressions);
   }
 
-  protected void initTransformers() throws QueryProcessException, IOException {
+  protected void initTransformers(TypeProvider typeProvider)
+      throws QueryProcessException, IOException {
     UDFRegistrationService.getInstance().acquireRegistrationLock();
     try {
       // This statement must be surrounded by the registration lock.
@@ -118,6 +118,7 @@ public class TransformOperator implements ProcessOperator {
                   inputLayer,
                   outputExpressions,
                   udtfContext,
+                  typeProvider,
                   udfTransformerMemoryBudgetInMB + udfCollectorMemoryBudgetInMB)
               .buildLayerMemoryAssigner()
               .buildResultColumnPointReaders()
@@ -146,12 +147,6 @@ public class TransformOperator implements ProcessOperator {
       }
       timeHeap.add(reader.currentTime());
       break;
-    }
-  }
-
-  private void updateTypeProvider(TypeProvider typeProvider) {
-    for (int i = 0; i < transformers.length; ++i) {
-      typeProvider.setType(outputExpressions[i].toString(), transformers[i].getDataType());
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/TransformOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/TransformOperator.java
@@ -67,6 +67,8 @@ public class TransformOperator implements ProcessOperator {
   protected final Expression[] outputExpressions;
   protected final boolean keepNull;
 
+  protected boolean isFirstIteration;
+
   protected RawQueryInputLayer inputLayer;
   protected UDTFContext udtfContext;
   protected LayerPointReader[] transformers;
@@ -89,10 +91,11 @@ public class TransformOperator implements ProcessOperator {
     this.outputExpressions = outputExpressions;
     this.keepNull = keepNull;
 
+    isFirstIteration = true;
+
     initInputLayer(inputDataTypes);
     initUdtfContext(zoneId);
     initTransformers(inputLocations, typeProvider);
-    readyForFirstIteration();
   }
 
   private void initInputLayer(List<TSDataType> inputDataTypes) throws QueryProcessException {
@@ -157,6 +160,15 @@ public class TransformOperator implements ProcessOperator {
 
   @Override
   public boolean hasNext() {
+    if (isFirstIteration) {
+      try {
+        readyForFirstIteration();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      isFirstIteration = false;
+    }
+
     return !timeHeap.isEmpty();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/TransformOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/TransformOperator.java
@@ -195,6 +195,8 @@ public class TransformOperator implements ProcessOperator {
 
         inputLayer.updateRowRecordListEvictionUpperBound();
       }
+
+      tsBlockBuilder.declarePositions(rowCount);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analyzer.java
@@ -342,6 +342,7 @@ public class Analyzer {
             alias = hasAlias ? resultColumn.getAlias() : alias;
             outputExpressions.add(new Pair<>(expressionWithoutAlias, alias));
             ExpressionAnalyzer.updateTypeProvider(expressionWithoutAlias, typeProvider);
+            expressionWithoutAlias.inferTypes(typeProvider);
             paginationController.consumeLimit();
           } else {
             break;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanner.java
@@ -455,12 +455,14 @@ public class LocalExecutionPlanner {
               TransformNode.class.getSimpleName());
       final Operator inputOperator = generateOnlyChildOperator(node, context);
       final List<TSDataType> inputDataTypes = getOutputColumnTypes(node, context.getTypeProvider());
+      final Map<String, List<InputLocation>> inputLocations = makeLayout(node);
 
       try {
         return new TransformOperator(
             operatorContext,
             inputOperator,
             inputDataTypes,
+            inputLocations,
             node.getOutputExpressions(),
             node.isKeepNull(),
             node.getZoneId(),
@@ -477,12 +479,14 @@ public class LocalExecutionPlanner {
               context.getNextOperatorId(), node.getPlanNodeId(), FilterNode.class.getSimpleName());
       final Operator inputOperator = generateOnlyChildOperator(node, context);
       final List<TSDataType> inputDataTypes = getOutputColumnTypes(node, context.getTypeProvider());
+      final Map<String, List<InputLocation>> inputLocations = makeLayout(node);
 
       try {
         return new FilterOperator(
             operatorContext,
             inputOperator,
             inputDataTypes,
+            inputLocations,
             node.getPredicate(),
             node.getOutputExpressions(),
             node.isKeepNull(),

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanner.java
@@ -454,7 +454,7 @@ public class LocalExecutionPlanner {
               node.getPlanNodeId(),
               TransformNode.class.getSimpleName());
       final Operator inputOperator = generateOnlyChildOperator(node, context);
-      final List<TSDataType> inputDataTypes = getOutputColumnTypes(node, context.getTypeProvider());
+      final List<TSDataType> inputDataTypes = getInputColumnTypes(node, context.getTypeProvider());
       final Map<String, List<InputLocation>> inputLocations = makeLayout(node);
 
       try {
@@ -478,7 +478,7 @@ public class LocalExecutionPlanner {
           context.instanceContext.addOperatorContext(
               context.getNextOperatorId(), node.getPlanNodeId(), FilterNode.class.getSimpleName());
       final Operator inputOperator = generateOnlyChildOperator(node, context);
-      final List<TSDataType> inputDataTypes = getOutputColumnTypes(node, context.getTypeProvider());
+      final List<TSDataType> inputDataTypes = getInputColumnTypes(node, context.getTypeProvider());
       final Map<String, List<InputLocation>> inputLocations = makeLayout(node);
 
       try {
@@ -678,6 +678,14 @@ public class LocalExecutionPlanner {
         tsBlockIndex++;
       }
       return outputMappings;
+    }
+
+    private List<TSDataType> getInputColumnTypes(PlanNode node, TypeProvider typeProvider) {
+      return node.getChildren().stream()
+          .map(PlanNode::getOutputColumnNames)
+          .flatMap(List::stream)
+          .map(typeProvider::getType)
+          .collect(Collectors.toList());
     }
 
     private List<TSDataType> getOutputColumnTypes(PlanNode node, TypeProvider typeProvider) {

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/Expression.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/Expression.java
@@ -139,12 +139,23 @@ public abstract class Expression {
 
   public abstract void updateStatisticsForMemoryAssigner(LayerMemoryAssigner memoryAssigner);
 
+  // TODO: remove after MPP finish
+  @Deprecated
   public abstract IntermediateLayer constructIntermediateLayer(
       long queryId,
       UDTFContext udtfContext,
       RawQueryInputLayer rawTimeSeriesInputLayer,
       Map<Expression, IntermediateLayer> expressionIntermediateLayerMap,
       Map<Expression, TSDataType> expressionDataTypeMap,
+      LayerMemoryAssigner memoryAssigner)
+      throws QueryProcessException, IOException;
+
+  public abstract IntermediateLayer constructIntermediateLayer(
+      long queryId,
+      UDTFContext udtfContext,
+      RawQueryInputLayer rawTimeSeriesInputLayer,
+      Map<Expression, IntermediateLayer> expressionIntermediateLayerMap,
+      TypeProvider typeProvider,
       LayerMemoryAssigner memoryAssigner)
       throws QueryProcessException, IOException;
 

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/Expression.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/Expression.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
 import org.apache.iotdb.db.query.expression.binary.AdditionExpression;
 import org.apache.iotdb.db.query.expression.binary.DivisionExpression;
@@ -135,7 +136,12 @@ public abstract class Expression {
 
   protected Integer inputColumnIndex = null;
 
+  // TODO: remove after MPP finish
+  @Deprecated
   public abstract void bindInputLayerColumnIndexWithExpression(UDTFPlan udtfPlan);
+
+  public abstract void bindInputLayerColumnIndexWithExpression(
+      Map<String, List<InputLocation>> inputLocations);
 
   public abstract void updateStatisticsForMemoryAssigner(LayerMemoryAssigner memoryAssigner);
 

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/binary/BinaryExpression.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/binary/BinaryExpression.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
 import org.apache.iotdb.db.query.expression.Expression;
 import org.apache.iotdb.db.query.udf.core.executor.UDTFContext;
@@ -192,10 +193,22 @@ public abstract class BinaryExpression extends Expression {
   }
 
   @Override
-  public void bindInputLayerColumnIndexWithExpression(UDTFPlan udtfPlan) {
+  public final void bindInputLayerColumnIndexWithExpression(UDTFPlan udtfPlan) {
     leftExpression.bindInputLayerColumnIndexWithExpression(udtfPlan);
     rightExpression.bindInputLayerColumnIndexWithExpression(udtfPlan);
     inputColumnIndex = udtfPlan.getReaderIndexByExpressionName(toString());
+  }
+
+  @Override
+  public final void bindInputLayerColumnIndexWithExpression(
+      Map<String, List<InputLocation>> inputLocations) {
+    leftExpression.bindInputLayerColumnIndexWithExpression(inputLocations);
+    rightExpression.bindInputLayerColumnIndexWithExpression(inputLocations);
+
+    final String digest = toString();
+    if (inputLocations.containsKey(digest)) {
+      inputColumnIndex = inputLocations.get(digest).get(0).getValueColumnIndex();
+    }
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/leaf/ConstantOperand.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/leaf/ConstantOperand.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import org.apache.commons.lang3.Validate;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +120,24 @@ public class ConstantOperand extends LeafOperand {
       throws QueryProcessException {
     if (!expressionIntermediateLayerMap.containsKey(this)) {
       expressionDataTypeMap.put(this, this.getDataType());
+      IntermediateLayer intermediateLayer =
+          new ConstantIntermediateLayer(this, queryId, memoryAssigner.assign());
+      expressionIntermediateLayerMap.put(this, intermediateLayer);
+    }
+
+    return expressionIntermediateLayerMap.get(this);
+  }
+
+  @Override
+  public IntermediateLayer constructIntermediateLayer(
+      long queryId,
+      UDTFContext udtfContext,
+      RawQueryInputLayer rawTimeSeriesInputLayer,
+      Map<Expression, IntermediateLayer> expressionIntermediateLayerMap,
+      TypeProvider typeProvider,
+      LayerMemoryAssigner memoryAssigner)
+      throws QueryProcessException, IOException {
+    if (!expressionIntermediateLayerMap.containsKey(this)) {
       IntermediateLayer intermediateLayer =
           new ConstantIntermediateLayer(this, queryId, memoryAssigner.assign());
       expressionIntermediateLayerMap.put(this, intermediateLayer);

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/leaf/ConstantOperand.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/leaf/ConstantOperand.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.query.expression.leaf;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
 import org.apache.iotdb.db.query.expression.Expression;
 import org.apache.iotdb.db.query.expression.ExpressionType;
@@ -101,6 +102,12 @@ public class ConstantOperand extends LeafOperand {
 
   @Override
   public void bindInputLayerColumnIndexWithExpression(UDTFPlan udtfPlan) {
+    // Do nothing
+  }
+
+  @Override
+  public void bindInputLayerColumnIndexWithExpression(
+      Map<String, List<InputLocation>> inputLocations) {
     // Do nothing
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/leaf/TimeSeriesOperand.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/leaf/TimeSeriesOperand.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.path.PathDeserializeUtil;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
 import org.apache.iotdb.db.query.expression.Expression;
 import org.apache.iotdb.db.query.expression.ExpressionType;
@@ -97,6 +98,15 @@ public class TimeSeriesOperand extends LeafOperand {
   @Override
   public void bindInputLayerColumnIndexWithExpression(UDTFPlan udtfPlan) {
     inputColumnIndex = udtfPlan.getReaderIndexByExpressionName(toString());
+  }
+
+  @Override
+  public void bindInputLayerColumnIndexWithExpression(
+      Map<String, List<InputLocation>> inputLocations) {
+    final String digest = toString();
+    if (inputLocations.containsKey(digest)) {
+      inputColumnIndex = inputLocations.get(digest).get(0).getValueColumnIndex();
+    }
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/leaf/TimestampOperand.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/leaf/TimestampOperand.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
 import org.apache.iotdb.db.query.expression.Expression;
 import org.apache.iotdb.db.query.expression.ExpressionType;
@@ -84,6 +85,12 @@ public class TimestampOperand extends LeafOperand {
 
   @Override
   public void bindInputLayerColumnIndexWithExpression(UDTFPlan udtfPlan) {
+    // do nothing
+  }
+
+  @Override
+  public void bindInputLayerColumnIndexWithExpression(
+      Map<String, List<InputLocation>> inputLocations) {
     // do nothing
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/multi/FunctionExpression.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/multi/FunctionExpression.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
 import org.apache.iotdb.db.qp.strategy.optimizer.ConcatPathOptimizer;
@@ -277,6 +278,19 @@ public class FunctionExpression extends Expression {
       expression.bindInputLayerColumnIndexWithExpression(udtfPlan);
     }
     inputColumnIndex = udtfPlan.getReaderIndexByExpressionName(toString());
+  }
+
+  @Override
+  public void bindInputLayerColumnIndexWithExpression(
+      Map<String, List<InputLocation>> inputLocations) {
+    for (Expression expression : expressions) {
+      expression.bindInputLayerColumnIndexWithExpression(inputLocations);
+    }
+
+    final String digest = toString();
+    if (inputLocations.containsKey(digest)) {
+      inputColumnIndex = inputLocations.get(digest).get(0).getValueColumnIndex();
+    }
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/multi/FunctionExpression.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/multi/FunctionExpression.java
@@ -293,6 +293,103 @@ public class FunctionExpression extends Expression {
       UDTFContext udtfContext,
       RawQueryInputLayer rawTimeSeriesInputLayer,
       Map<Expression, IntermediateLayer> expressionIntermediateLayerMap,
+      TypeProvider typeProvider,
+      LayerMemoryAssigner memoryAssigner)
+      throws QueryProcessException, IOException {
+    if (!expressionIntermediateLayerMap.containsKey(this)) {
+      float memoryBudgetInMB = memoryAssigner.assign();
+      Transformer transformer;
+      if (isBuiltInAggregationFunctionExpression) {
+        transformer =
+            new TransparentTransformer(
+                rawTimeSeriesInputLayer.constructValuePointReader(inputColumnIndex));
+      } else {
+        IntermediateLayer udfInputIntermediateLayer =
+            constructUdfInputIntermediateLayer(
+                queryId,
+                udtfContext,
+                rawTimeSeriesInputLayer,
+                expressionIntermediateLayerMap,
+                typeProvider,
+                memoryAssigner);
+        transformer =
+            constructUdfTransformer(
+                queryId, udtfContext, typeProvider, memoryAssigner, udfInputIntermediateLayer);
+      }
+      expressionIntermediateLayerMap.put(
+          this,
+          memoryAssigner.getReference(this) == 1
+              ? new SingleInputColumnSingleReferenceIntermediateLayer(
+                  this, queryId, memoryBudgetInMB, transformer)
+              : new SingleInputColumnMultiReferenceIntermediateLayer(
+                  this, queryId, memoryBudgetInMB, transformer));
+    }
+
+    return expressionIntermediateLayerMap.get(this);
+  }
+
+  private IntermediateLayer constructUdfInputIntermediateLayer(
+      long queryId,
+      UDTFContext udtfContext,
+      RawQueryInputLayer rawTimeSeriesInputLayer,
+      Map<Expression, IntermediateLayer> expressionIntermediateLayerMap,
+      TypeProvider typeProvider,
+      LayerMemoryAssigner memoryAssigner)
+      throws QueryProcessException, IOException {
+    List<IntermediateLayer> intermediateLayers = new ArrayList<>();
+    for (Expression expression : expressions) {
+      intermediateLayers.add(
+          expression.constructIntermediateLayer(
+              queryId,
+              udtfContext,
+              rawTimeSeriesInputLayer,
+              expressionIntermediateLayerMap,
+              typeProvider,
+              memoryAssigner));
+    }
+    return intermediateLayers.size() == 1
+        ? intermediateLayers.get(0)
+        : new MultiInputColumnIntermediateLayer(
+            this,
+            queryId,
+            memoryAssigner.assign(),
+            intermediateLayers.stream()
+                .map(IntermediateLayer::constructPointReader)
+                .collect(Collectors.toList()));
+  }
+
+  private UDFQueryTransformer constructUdfTransformer(
+      long queryId,
+      UDTFContext udtfContext,
+      TypeProvider typeProvider,
+      LayerMemoryAssigner memoryAssigner,
+      IntermediateLayer udfInputIntermediateLayer)
+      throws QueryProcessException, IOException {
+    UDTFExecutor executor = udtfContext.getExecutorByFunctionExpression(this);
+
+    executor.beforeStart(queryId, memoryAssigner.assign(), typeProvider);
+
+    AccessStrategy accessStrategy = executor.getConfigurations().getAccessStrategy();
+    switch (accessStrategy.getAccessStrategyType()) {
+      case ROW_BY_ROW:
+        return new UDFQueryRowTransformer(udfInputIntermediateLayer.constructRowReader(), executor);
+      case SLIDING_SIZE_WINDOW:
+      case SLIDING_TIME_WINDOW:
+        return new UDFQueryRowWindowTransformer(
+            udfInputIntermediateLayer.constructRowWindowReader(
+                accessStrategy, memoryAssigner.assign()),
+            executor);
+      default:
+        throw new UnsupportedOperationException("Unsupported transformer access strategy");
+    }
+  }
+
+  @Override
+  public IntermediateLayer constructIntermediateLayer(
+      long queryId,
+      UDTFContext udtfContext,
+      RawQueryInputLayer rawTimeSeriesInputLayer,
+      Map<Expression, IntermediateLayer> expressionIntermediateLayerMap,
       Map<Expression, TSDataType> expressionDataTypeMap,
       LayerMemoryAssigner memoryAssigner)
       throws QueryProcessException, IOException {
@@ -333,6 +430,8 @@ public class FunctionExpression extends Expression {
     return expressionIntermediateLayerMap.get(this);
   }
 
+  // TODO: remove it after MPP finished
+  @Deprecated
   private IntermediateLayer constructUdfInputIntermediateLayer(
       long queryId,
       UDTFContext udtfContext,
@@ -363,6 +462,8 @@ public class FunctionExpression extends Expression {
                 .collect(Collectors.toList()));
   }
 
+  // TODO: remove it after MPP finished
+  @Deprecated
   private UDFQueryTransformer constructUdfTransformer(
       long queryId,
       UDTFContext udtfContext,

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/unary/UnaryExpression.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/unary/UnaryExpression.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.query.expression.unary;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
+import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
 import org.apache.iotdb.db.qp.utils.WildcardsRemover;
 import org.apache.iotdb.db.query.expression.Expression;
@@ -123,6 +124,43 @@ public abstract class UnaryExpression extends Expression {
               memoryAssigner);
       Transformer transformer = constructTransformer(parentLayerPointReader.constructPointReader());
       expressionDataTypeMap.put(this, transformer.getDataType());
+
+      // SingleInputColumnMultiReferenceIntermediateLayer doesn't support ConstantLayerPointReader
+      // yet. And since a ConstantLayerPointReader won't produce too much IO,
+      // SingleInputColumnSingleReferenceIntermediateLayer could be a better choice.
+      expressionIntermediateLayerMap.put(
+          this,
+          memoryAssigner.getReference(this) == 1 || isConstantOperand()
+              ? new SingleInputColumnSingleReferenceIntermediateLayer(
+                  this, queryId, memoryBudgetInMB, transformer)
+              : new SingleInputColumnMultiReferenceIntermediateLayer(
+                  this, queryId, memoryBudgetInMB, transformer));
+    }
+
+    return expressionIntermediateLayerMap.get(this);
+  }
+
+  @Override
+  public IntermediateLayer constructIntermediateLayer(
+      long queryId,
+      UDTFContext udtfContext,
+      RawQueryInputLayer rawTimeSeriesInputLayer,
+      Map<Expression, IntermediateLayer> expressionIntermediateLayerMap,
+      TypeProvider typeProvider,
+      LayerMemoryAssigner memoryAssigner)
+      throws QueryProcessException, IOException {
+    if (!expressionIntermediateLayerMap.containsKey(this)) {
+      float memoryBudgetInMB = memoryAssigner.assign();
+
+      IntermediateLayer parentLayerPointReader =
+          expression.constructIntermediateLayer(
+              queryId,
+              udtfContext,
+              rawTimeSeriesInputLayer,
+              expressionIntermediateLayerMap,
+              typeProvider,
+              memoryAssigner);
+      Transformer transformer = constructTransformer(parentLayerPointReader.constructPointReader());
 
       // SingleInputColumnMultiReferenceIntermediateLayer doesn't support ConstantLayerPointReader
       // yet. And since a ConstantLayerPointReader won't produce too much IO,

--- a/server/src/main/java/org/apache/iotdb/db/query/expression/unary/UnaryExpression.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/expression/unary/UnaryExpression.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
 import org.apache.iotdb.db.qp.utils.WildcardsRemover;
 import org.apache.iotdb.db.query.expression.Expression;
@@ -94,6 +95,17 @@ public abstract class UnaryExpression extends Expression {
   public final void bindInputLayerColumnIndexWithExpression(UDTFPlan udtfPlan) {
     expression.bindInputLayerColumnIndexWithExpression(udtfPlan);
     inputColumnIndex = udtfPlan.getReaderIndexByExpressionName(toString());
+  }
+
+  @Override
+  public final void bindInputLayerColumnIndexWithExpression(
+      Map<String, List<InputLocation>> inputLocations) {
+    expression.bindInputLayerColumnIndexWithExpression(inputLocations);
+
+    final String digest = toString();
+    if (inputLocations.containsKey(digest)) {
+      inputColumnIndex = inputLocations.get(digest).get(0).getValueColumnIndex();
+    }
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/EvaluationDAGBuilder.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/EvaluationDAGBuilder.java
@@ -21,12 +21,14 @@ package org.apache.iotdb.db.query.udf.core.layer;
 
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.query.expression.Expression;
 import org.apache.iotdb.db.query.udf.core.executor.UDTFContext;
 import org.apache.iotdb.db.query.udf.core.reader.LayerPointReader;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class EvaluationDAGBuilder {
@@ -34,6 +36,7 @@ public class EvaluationDAGBuilder {
   private final long queryId;
 
   private final RawQueryInputLayer inputLayer;
+  private final Map<String, List<InputLocation>> inputLocations;
 
   private final Expression[] outputExpressions;
   private final LayerPointReader[] outputPointReaders;
@@ -52,12 +55,14 @@ public class EvaluationDAGBuilder {
   public EvaluationDAGBuilder(
       long queryId,
       RawQueryInputLayer inputLayer,
+      Map<String, List<InputLocation>> inputLocations,
       Expression[] outputExpressions,
       UDTFContext udtfContext,
       TypeProvider typeProvider,
       float memoryBudgetInMB) {
     this.queryId = queryId;
     this.inputLayer = inputLayer;
+    this.inputLocations = inputLocations;
     this.outputExpressions = outputExpressions;
     this.udtfContext = udtfContext;
     this.typeProvider = typeProvider;
@@ -75,6 +80,13 @@ public class EvaluationDAGBuilder {
       expression.updateStatisticsForMemoryAssigner(memoryAssigner);
     }
     memoryAssigner.build();
+    return this;
+  }
+
+  public EvaluationDAGBuilder bindInputLayerColumnIndexWithExpression() {
+    for (Expression expression : outputExpressions) {
+      expression.bindInputLayerColumnIndexWithExpression(inputLocations);
+    }
     return this;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/EvaluationDAGBuilder.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/EvaluationDAGBuilder.java
@@ -68,8 +68,7 @@ public class EvaluationDAGBuilder {
     this.typeProvider = typeProvider;
     this.udtfContext = udtfContext;
 
-    int size = inputLayer.getInputColumnCount();
-    outputPointReaders = new LayerPointReader[size];
+    outputPointReaders = new LayerPointReader[outputExpressions.length];
 
     memoryAssigner = new LayerMemoryAssigner(memoryBudgetInMB);
 

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/EvaluationDAGBuilder.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/EvaluationDAGBuilder.java
@@ -41,6 +41,8 @@ public class EvaluationDAGBuilder {
   private final Expression[] outputExpressions;
   private final LayerPointReader[] outputPointReaders;
 
+  private final TypeProvider typeProvider;
+
   private final UDTFContext udtfContext;
 
   private final LayerMemoryAssigner memoryAssigner;
@@ -50,22 +52,21 @@ public class EvaluationDAGBuilder {
   // sub-expressions, but they can share the same point reader. we cache the point reader here to
   // make sure that only one point reader will be built for one expression.
   private final Map<Expression, IntermediateLayer> expressionIntermediateLayerMap;
-  private final TypeProvider typeProvider;
 
   public EvaluationDAGBuilder(
       long queryId,
       RawQueryInputLayer inputLayer,
       Map<String, List<InputLocation>> inputLocations,
       Expression[] outputExpressions,
-      UDTFContext udtfContext,
       TypeProvider typeProvider,
+      UDTFContext udtfContext,
       float memoryBudgetInMB) {
     this.queryId = queryId;
     this.inputLayer = inputLayer;
     this.inputLocations = inputLocations;
     this.outputExpressions = outputExpressions;
-    this.udtfContext = udtfContext;
     this.typeProvider = typeProvider;
+    this.udtfContext = udtfContext;
 
     int size = inputLayer.getInputColumnCount();
     outputPointReaders = new LayerPointReader[size];

--- a/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/EvaluationDAGBuilder.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/udf/core/layer/EvaluationDAGBuilder.java
@@ -20,10 +20,10 @@
 package org.apache.iotdb.db.query.udf.core.layer;
 
 import org.apache.iotdb.db.exception.query.QueryProcessException;
+import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
 import org.apache.iotdb.db.query.expression.Expression;
 import org.apache.iotdb.db.query.udf.core.executor.UDTFContext;
 import org.apache.iotdb.db.query.udf.core.reader.LayerPointReader;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -47,18 +47,20 @@ public class EvaluationDAGBuilder {
   // sub-expressions, but they can share the same point reader. we cache the point reader here to
   // make sure that only one point reader will be built for one expression.
   private final Map<Expression, IntermediateLayer> expressionIntermediateLayerMap;
-  private final Map<Expression, TSDataType> expressionDataTypeMap;
+  private final TypeProvider typeProvider;
 
   public EvaluationDAGBuilder(
       long queryId,
       RawQueryInputLayer inputLayer,
       Expression[] outputExpressions,
       UDTFContext udtfContext,
+      TypeProvider typeProvider,
       float memoryBudgetInMB) {
     this.queryId = queryId;
     this.inputLayer = inputLayer;
     this.outputExpressions = outputExpressions;
     this.udtfContext = udtfContext;
+    this.typeProvider = typeProvider;
 
     int size = inputLayer.getInputColumnCount();
     outputPointReaders = new LayerPointReader[size];
@@ -66,7 +68,6 @@ public class EvaluationDAGBuilder {
     memoryAssigner = new LayerMemoryAssigner(memoryBudgetInMB);
 
     expressionIntermediateLayerMap = new HashMap<>();
-    expressionDataTypeMap = new HashMap<>();
   }
 
   public EvaluationDAGBuilder buildLayerMemoryAssigner() {
@@ -87,7 +88,7 @@ public class EvaluationDAGBuilder {
                   udtfContext,
                   inputLayer,
                   expressionIntermediateLayerMap,
-                  expressionDataTypeMap,
+                  typeProvider,
                   memoryAssigner)
               .constructPointReader();
     }


### PR DESCRIPTION
Bugfix list:

[reused TypeProvider in converting Expression->Transformer stage](https://github.com/apache/iotdb/commit/279f96667d85240f0d16df4e9be92bf9e5c7da9d)
 
[bind transformer input column with operator column input index](https://github.com/apache/iotdb/commit/5a3e4512f48a28cc6ededb13933ff6aa5b30cdf4)
 
[fix FilterOperator#iterateFilterReaderToNextValid()](https://github.com/apache/iotdb/commit/53b4c0f0e3b5a39688495a4e938bf5a1fa4c4b2a)
 
[invoke declarePositions(rowCount) in Operator#next()](https://github.com/apache/iotdb/commit/6b3fabfd29d1711d6c77617b6ba2171e88d72bc3)

[invoke readyForFirstIteration() in hasNext() instead of in constructor](https://github.com/apache/iotdb/commit/7e47110c8d6a151e2c411faf507c81e3a48c5fca)

[infer types in server/src/main/java/org/apache/iotdb/db/mpp/plan/anal…](https://github.com/apache/iotdb/commit/21ffbb8dd37acb91834bcf95fe91eda9b350264b) 
 
[bind input types](https://github.com/apache/iotdb/commit/666ee799e867848c507023ee59f47f9c4505c9d9)
 
[fix outputPointReaders construction](https://github.com/apache/iotdb/commit/e4f52ad0b55d8be9f8e8b1e80827f14972af2019)