### PR TITLE
[IOTDB-3200] [PartitionInfo] replace bytebuffer with stream

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
@@ -460,7 +460,7 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
     } finally {
       buffer.clear();
       for (int retry = 0; retry < 5; retry++) {
-        if (tmpFile.delete()) {
+        if (!tmpFile.exists() || tmpFile.delete()) {
           break;
         } else {
           LOGGER.warn(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
@@ -305,12 +305,23 @@ public class NodeInfo implements SnapshotProcessor {
       serializeDrainingDataNodes(dataOutputStream, protocol);
 
       fileOutputStream.flush();
+
+      fileOutputStream.close();
+
+      return tmpFile.renameTo(snapshotFile);
+
     } finally {
       configNodeInfoReadWriteLock.readLock().unlock();
       dataNodeInfoReadWriteLock.readLock().unlock();
+      for (int retry = 0; retry < 5; retry++) {
+        if (!tmpFile.exists() || tmpFile.delete()) {
+          break;
+        } else {
+          LOGGER.warn(
+              "Can't delete temporary snapshot file: {}, retrying...", tmpFile.getAbsolutePath());
+        }
+      }
     }
-
-    return tmpFile.renameTo(snapshotFile);
   }
 
   private void serializeOnlineDataNode(DataOutputStream outputStream, TProtocol protocol)

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/PartitionInfo.java
@@ -89,9 +89,6 @@ public class PartitionInfo implements SnapshotProcessor {
   private final ReentrantReadWriteLock dataPartitionReadWriteLock;
   private final DataPartition dataPartition;
 
-  // The size of the buffer used for snapshot(temporary value)
-  private final int bufferSize = 10 * 1024 * 1024;
-
   private final String snapshotFileName = "partition_info.bin";
 
   public PartitionInfo() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigRequestExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigRequestExecutor.java
@@ -175,11 +175,21 @@ public class ConfigRequestExecutor {
 
   public boolean takeSnapshot(File snapshotDir) {
 
-    if (!snapshotDir.exists() && !snapshotDir.mkdirs()) {
-      LOGGER.error("snapshot directory [{}] can not be created.", snapshotDir.getAbsolutePath());
-      return false;
+    // consensus layer needs to ensure that the directory exists.
+    // if it does not exist, print a log to warn there may have a problem.
+    if (!snapshotDir.exists()) {
+      LOGGER.warn(
+          "snapshot directory [{}] is not exist,start to create it.",
+          snapshotDir.getAbsolutePath());
+      // try to create a directory to enable snapshot operation
+      if (!snapshotDir.mkdirs()) {
+        LOGGER.error("snapshot directory [{}] can not be created.", snapshotDir.getAbsolutePath());
+        return false;
+      }
     }
 
+    // If the directory is not empty, we should not continue the snapshot operation,
+    // which may result in incorrect results.
     File[] fileList = snapshotDir.listFiles();
     if (fileList != null && fileList.length > 0) {
       LOGGER.error("snapshot directory [{}] is not empty.", snapshotDir.getAbsolutePath());

--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
@@ -128,6 +128,7 @@ public class PartitionInfoTest {
         dataMap_before = partitionInfo.getDataPartition().getDataPartitionMap();
     int nextId = partitionInfo.getNextRegionGroupId();
 
+    Map<TConsensusGroupId, Long> counter_before = partitionInfo.getRegionSlotsCounter();
     partitionInfo.processTakeSnapshot(snapshotDir);
     partitionInfo.clear();
     partitionInfo.processLoadSnapshot(snapshotDir);
@@ -157,9 +158,7 @@ public class PartitionInfoTest {
         partitionInfo.getSchemaPartition().getSchemaPartitionMap());
 
     Assert.assertEquals(2, partitionInfo.getRegionSlotsCounter().size());
-    for (Long count : partitionInfo.getRegionSlotsCounter().values()) {
-      Assert.assertEquals(1, count.intValue());
-    }
+    Assert.assertEquals(counter_before, partitionInfo.getRegionSlotsCounter());
 
     Assert.assertEquals(dataMap_before, partitionInfo.getDataPartition().getDataPartitionMap());
   }

--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
@@ -123,6 +123,9 @@ public class PartitionInfoTest {
             generateTConsensusGroupId(
                 testFlag.DataPartition.getFlag(), TConsensusGroupType.DataRegion));
     partitionInfo.createDataPartition(createDataPartitionReq);
+
+    Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>>
+        dataMap_before = partitionInfo.getDataPartition().getDataPartitionMap();
     int nextId = partitionInfo.getNextRegionGroupId();
 
     partitionInfo.processTakeSnapshot(snapshotDir);
@@ -150,10 +153,6 @@ public class PartitionInfoTest {
     Assert.assertEquals(dataRegionReplicaSet, reloadTRegionReplicaSet.get(0));
 
     Assert.assertEquals(
-        createDataPartitionReq.getAssignedDataPartition(),
-        partitionInfo.getDataPartition().getDataPartitionMap());
-
-    Assert.assertEquals(
         createSchemaPartitionReq.getAssignedSchemaPartition(),
         partitionInfo.getSchemaPartition().getSchemaPartitionMap());
 
@@ -161,6 +160,8 @@ public class PartitionInfoTest {
     for (Long count : partitionInfo.getRegionSlotsCounter().values()) {
       Assert.assertEquals(1, count.intValue());
     }
+
+    Assert.assertEquals(dataMap_before, partitionInfo.getDataPartition().getDataPartitionMap());
   }
 
   private TRegionReplicaSet generateTRegionReplicaSet(
@@ -199,19 +200,30 @@ public class PartitionInfoTest {
 
   private CreateDataPartitionReq generateCreateDataPartitionReq(
       int startFlag, TConsensusGroupId tConsensusGroupId) {
+    startFlag = startFlag / 10;
     CreateDataPartitionReq createSchemaPartitionReq = new CreateDataPartitionReq();
     // Map<StorageGroup, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionMessage>>>>
     Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>>
         dataPartitionMap = new HashMap<>();
 
     Map<TTimePartitionSlot, List<TRegionReplicaSet>> relationInfo = new HashMap<>();
-    relationInfo.put(
-        new TTimePartitionSlot(System.currentTimeMillis() / 1000),
-        Collections.singletonList(generateTRegionReplicaSet(startFlag, tConsensusGroupId)));
+
+    List<TRegionReplicaSet> tRegionReplicaSets = new ArrayList<>();
+
+    for (int i = 0; i <= startFlag; i++) {
+      for (int j = 0; j <= startFlag; j++) {
+        tRegionReplicaSets.add(generateTRegionReplicaSet(j + startFlag, tConsensusGroupId));
+      }
+      relationInfo.put(
+          new TTimePartitionSlot((System.currentTimeMillis() / 1000) + i), tRegionReplicaSets);
+    }
 
     Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>> slotInfo =
         new HashMap<>();
-    slotInfo.put(new TSeriesPartitionSlot(startFlag), relationInfo);
+
+    for (int i = 0; i <= startFlag; i++) {
+      slotInfo.put(new TSeriesPartitionSlot(startFlag + i), relationInfo);
+    }
 
     dataPartitionMap.put("root.test.data.sg", slotInfo);
     createSchemaPartitionReq.setAssignedDataPartition(dataPartitionMap);

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartition.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartition.java
@@ -261,16 +261,9 @@ public class DataPartition extends Partition {
             seriesPartitionSlotMapEntry.getValue().entrySet()) {
           timePartitionSlotListEntry.getKey().write(protocol);
           ReadWriteIOUtils.write(timePartitionSlotListEntry.getValue().size(), dataOutputStream);
-          timePartitionSlotListEntry
-              .getValue()
-              .forEach(
-                  x -> {
-                    try {
-                      x.write(protocol);
-                    } catch (TException e) {
-                      throw new RuntimeException(e);
-                    }
-                  });
+          for (TRegionReplicaSet tRegionReplicaSet : timePartitionSlotListEntry.getValue()) {
+            tRegionReplicaSet.write(protocol);
+          }
         }
       }
     }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/SchemaPartition.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/SchemaPartition.java
@@ -23,15 +23,11 @@ import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.TByteBuffer;
-import org.apache.thrift.transport.TIOStreamTransport;
-import org.apache.thrift.transport.TTransport;
 
-import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -174,55 +170,51 @@ public class SchemaPartition extends Partition {
         .put(seriesPartitionSlot, regionReplicaSet);
   }
 
-  public void serialize(ByteBuffer buffer) throws IOException, TException {
-    try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
-      for (Entry<String, Map<TSeriesPartitionSlot, TRegionReplicaSet>> entry :
-          schemaPartitionMap.entrySet()) {
-        ReadWriteIOUtils.write(entry.getKey(), byteArrayOutputStream);
-        writeMap(entry.getValue(), byteArrayOutputStream);
-      }
-      byte[] toArray = byteArrayOutputStream.toByteArray();
-      buffer.putInt(toArray.length);
-      buffer.put(toArray);
+  public void serialize(DataOutputStream dataOutputStream, TProtocol protocol)
+      throws IOException, TException {
+    dataOutputStream.writeInt(schemaPartitionMap.size());
+    for (Entry<String, Map<TSeriesPartitionSlot, TRegionReplicaSet>> entry :
+        schemaPartitionMap.entrySet()) {
+      ReadWriteIOUtils.write(entry.getKey(), dataOutputStream);
+      writeMap(entry.getValue(), dataOutputStream, protocol);
     }
   }
 
-  public void deserialize(ByteBuffer buffer) throws TException, IOException {
-    int length = buffer.getInt();
-    byte[] result = new byte[length];
-    buffer.get(result);
-    ByteBuffer byteBuffer = ByteBuffer.wrap(result);
-    while (byteBuffer.hasRemaining()) {
-      String key = ReadWriteIOUtils.readString(byteBuffer);
-      Map<TSeriesPartitionSlot, TRegionReplicaSet> value = readMap(byteBuffer);
+  public void deserialize(DataInputStream dataInputStream, TProtocol protocol)
+      throws TException, IOException {
+    int size = dataInputStream.readInt();
+    while (size > 0) {
+      String key = ReadWriteIOUtils.readString(dataInputStream);
+      Map<TSeriesPartitionSlot, TRegionReplicaSet> value = readMap(dataInputStream, protocol);
       schemaPartitionMap.put(key, value);
+      size--;
     }
   }
 
-  private Map<TSeriesPartitionSlot, TRegionReplicaSet> readMap(ByteBuffer buffer)
-      throws TException {
+  private Map<TSeriesPartitionSlot, TRegionReplicaSet> readMap(
+      DataInputStream dataInputStream, TProtocol protocol) throws TException, IOException {
+    int size = dataInputStream.readInt();
     Map<TSeriesPartitionSlot, TRegionReplicaSet> result = new HashMap<>();
-    try (TTransport transport = new TByteBuffer(buffer)) {
-      TProtocol protocol = new TBinaryProtocol(transport);
+    while (size > 0) {
       TSeriesPartitionSlot tSeriesPartitionSlot = new TSeriesPartitionSlot();
       tSeriesPartitionSlot.read(protocol);
       TRegionReplicaSet tRegionReplicaSet = new TRegionReplicaSet();
       tRegionReplicaSet.read(protocol);
       result.put(tSeriesPartitionSlot, tRegionReplicaSet);
+      size--;
     }
     return result;
   }
 
   private void writeMap(
       Map<TSeriesPartitionSlot, TRegionReplicaSet> valueMap,
-      ByteArrayOutputStream byteArrayOutputStream)
-      throws TException {
-    try (TIOStreamTransport tioStreamTransport = new TIOStreamTransport(byteArrayOutputStream)) {
-      TProtocol protocol = new TBinaryProtocol(tioStreamTransport);
-      for (Entry<TSeriesPartitionSlot, TRegionReplicaSet> entry : valueMap.entrySet()) {
-        entry.getKey().write(protocol);
-        entry.getValue().write(protocol);
-      }
+      DataOutputStream dataOutputStream,
+      TProtocol protocol)
+      throws TException, IOException {
+    dataOutputStream.writeInt(valueMap.size());
+    for (Entry<TSeriesPartitionSlot, TRegionReplicaSet> entry : valueMap.entrySet()) {
+      entry.getKey().write(protocol);
+      entry.getValue().write(protocol);
     }
   }
 }


### PR DESCRIPTION
This PR has:
- [x] Replace bytebuffer with stream in `PartitionInfo`.
- [x] Fixed incorrect serialization of multiple sub-maps in `dataPartitionMap`
- [x] Resolve snapshot temporary file deletion failure.
