### PR TITLE
[IOTDB-3210]fix npe

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -18,8 +18,10 @@
  */
 package org.apache.iotdb.db.service;
 
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
+import org.apache.iotdb.db.metadata.schemaregion.SchemaEngineMode;
 import org.apache.iotdb.db.utils.MemUtils;
 import org.apache.iotdb.db.wal.WALManager;
 
@@ -34,7 +36,10 @@ public class IoTDBShutdownHook extends Thread {
   public void run() {
     CompactionTaskManager.getInstance().stop();
     // close rocksdb if possible to avoid lose data
-    IoTDB.configManager.clear();
+    if (SchemaEngineMode.valueOf(IoTDBDescriptor.getInstance().getConfig().getSchemaEngineMode())
+        .equals(SchemaEngineMode.Rocksdb_based)) {
+      IoTDB.configManager.clear();
+    }
 
     // == flush data to Tsfile and remove WAL log files
     StorageEngine.getInstance().syncCloseAllProcessor();


### PR DESCRIPTION
## Description

### Problem
see IOTDB-3210

### Cause
When shutDown the system, the metadata component will be cleared, during which some attributes and variables will be set to null to release resource. If there's insertion during system shutdown, it may encounter a cleared metadata module and trigger auto create schema, and this is why there's npe.

### Solution
The metadata clear in shutDownHook is aimed to shut down rocksdb when using rocksdb schema engine mode. Thus add the check before execution.

### Future work
Add some client connection and request execution control, and Polish the elegant system exit/shutdown process.