### PR TITLE
Modify the serialize/deserialize of MTreeAboveSG with stream & Add storageGroupNode to the result of MNodeAboveSGCollector

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
@@ -47,7 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -456,10 +456,9 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
     storageGroupReadWriteLock.readLock().lock();
     try {
       try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
-          ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
-        mTree.serialize(byteArrayOutputStream);
-        byteArrayOutputStream.writeTo(fileOutputStream);
-        fileOutputStream.flush();
+          BufferedOutputStream outputStream = new BufferedOutputStream(fileOutputStream)) {
+        mTree.serialize(outputStream);
+        outputStream.flush();
       }
       return tmpFile.renameTo(snapshotFile);
     } finally {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
@@ -46,12 +46,12 @@ import org.apache.iotdb.rpc.TSStatusCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -71,9 +71,6 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
   private final ReentrantReadWriteLock storageGroupReadWriteLock;
 
   private MTreeAboveSG mTree;
-
-  // The size of the buffer used for snapshot(temporary value)
-  private final int bufferSize = 10 * 1024 * 1024;
 
   private final String snapshotFileName = "cluster_schema.bin";
 
@@ -455,19 +452,17 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
     }
 
     File tmpFile = new File(snapshotFile.getAbsolutePath() + "-" + UUID.randomUUID());
-    ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
 
     storageGroupReadWriteLock.readLock().lock();
     try {
       try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
-          FileChannel fileChannel = fileOutputStream.getChannel()) {
-        mTree.serialize(buffer);
-        buffer.flip();
-        fileChannel.write(buffer);
+          ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+        mTree.serialize(byteArrayOutputStream);
+        byteArrayOutputStream.writeTo(fileOutputStream);
+        fileOutputStream.flush();
       }
       return tmpFile.renameTo(snapshotFile);
     } finally {
-      buffer.clear();
       for (int retry = 0; retry < 5; retry++) {
         if (!tmpFile.exists() || tmpFile.delete()) {
           break;
@@ -491,16 +486,11 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
       return;
     }
     storageGroupReadWriteLock.writeLock().lock();
-    ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
     try (FileInputStream fileInputStream = new FileInputStream(snapshotFile);
-        FileChannel fileChannel = fileInputStream.getChannel()) {
-      // get buffer from fileChannel
-      fileChannel.read(buffer);
+        BufferedInputStream bufferedInputStream = new BufferedInputStream(fileInputStream)) {
       mTree.clear();
-      buffer.flip();
-      mTree.deserialize(buffer);
+      mTree.deserialize(bufferedInputStream);
     } finally {
-      buffer.clear();
       storageGroupReadWriteLock.writeLock().unlock();
     }
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/ThriftConfigNodeSerDeUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/ThriftConfigNodeSerDeUtils.java
@@ -25,9 +25,12 @@ import org.apache.iotdb.confignode.rpc.thrift.TStorageGroupSchema;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TByteBuffer;
+import org.apache.thrift.transport.TIOStreamTransport;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 /** Utils for serialize and deserialize all the data struct defined by thrift-confignode */
@@ -49,6 +52,18 @@ public class ThriftConfigNodeSerDeUtils {
     return new TBinaryProtocol(transport);
   }
 
+  private static TBinaryProtocol generateWriteProtocol(OutputStream outputStream)
+      throws TTransportException {
+    TIOStreamTransport tioStreamTransport = new TIOStreamTransport(outputStream);
+    return new TBinaryProtocol(tioStreamTransport);
+  }
+
+  private static TBinaryProtocol generateReadProtocol(InputStream inputStream)
+      throws TTransportException {
+    TIOStreamTransport tioStreamTransport = new TIOStreamTransport(inputStream);
+    return new TBinaryProtocol(tioStreamTransport);
+  }
+
   public static void serializeTStorageGroupSchema(
       TStorageGroupSchema storageGroupSchema, ByteBuffer buffer) {
     try {
@@ -62,6 +77,25 @@ public class ThriftConfigNodeSerDeUtils {
     TStorageGroupSchema storageGroupSchema = new TStorageGroupSchema();
     try {
       storageGroupSchema.read(generateReadProtocol(buffer));
+    } catch (TException e) {
+      throw new ThriftSerDeException("Read TStorageGroupSchema failed: ", e);
+    }
+    return storageGroupSchema;
+  }
+
+  public static void serializeTStorageGroupSchema(
+      TStorageGroupSchema storageGroupSchema, OutputStream outputStream) {
+    try {
+      storageGroupSchema.write(generateWriteProtocol(outputStream));
+    } catch (TException e) {
+      throw new ThriftSerDeException("Write TStorageGroupSchema failed: ", e);
+    }
+  }
+
+  public static TStorageGroupSchema deserializeTStorageGroupSchema(InputStream inputStream) {
+    TStorageGroupSchema storageGroupSchema = new TStorageGroupSchema();
+    try {
+      storageGroupSchema.read(generateReadProtocol(inputStream));
     } catch (TException e) {
       throw new ThriftSerDeException("Read TStorageGroupSchema failed: ", e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSG.java
@@ -47,7 +47,9 @@ import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -529,39 +531,41 @@ public class MTreeAboveSG {
     }
   }
 
-  public void serialize(ByteBuffer buffer) {
-    serializeInternalNode((InternalMNode) this.root, buffer);
+  public void serialize(OutputStream outputStream) throws IOException {
+    serializeInternalNode((InternalMNode) this.root, outputStream);
   }
 
-  private void serializeInternalNode(InternalMNode node, ByteBuffer buffer) {
+  private void serializeInternalNode(InternalMNode node, OutputStream outputStream)
+      throws IOException {
     for (IMNode child : node.getChildren().values()) {
       if (child.isStorageGroup()) {
-        serializeStorageGroupNode((StorageGroupMNode) child, buffer);
+        serializeStorageGroupNode((StorageGroupMNode) child, outputStream);
       } else {
-        serializeInternalNode((InternalMNode) child, buffer);
+        serializeInternalNode((InternalMNode) child, outputStream);
       }
     }
 
-    buffer.put(INTERNAL_MNODE_TYPE);
-    ReadWriteIOUtils.write(node.getName(), buffer);
-    ReadWriteIOUtils.write(node.getChildren().size(), buffer);
+    ReadWriteIOUtils.write(INTERNAL_MNODE_TYPE, outputStream);
+    ReadWriteIOUtils.write(node.getName(), outputStream);
+    ReadWriteIOUtils.write(node.getChildren().size(), outputStream);
   }
 
-  private void serializeStorageGroupNode(StorageGroupMNode storageGroupNode, ByteBuffer buffer) {
-    buffer.put(STORAGE_GROUP_MNODE_TYPE);
-    ReadWriteIOUtils.write(storageGroupNode.getName(), buffer);
+  private void serializeStorageGroupNode(
+      StorageGroupMNode storageGroupNode, OutputStream outputStream) throws IOException {
+    ReadWriteIOUtils.write(STORAGE_GROUP_MNODE_TYPE, outputStream);
+    ReadWriteIOUtils.write(storageGroupNode.getName(), outputStream);
     ThriftConfigNodeSerDeUtils.serializeTStorageGroupSchema(
-        storageGroupNode.getStorageGroupSchema(), buffer);
+        storageGroupNode.getStorageGroupSchema(), outputStream);
   }
 
-  public void deserialize(ByteBuffer buffer) {
-    byte type = buffer.get();
+  public void deserialize(InputStream inputStream) throws IOException {
+    byte type = ReadWriteIOUtils.readByte(inputStream);
     if (type != STORAGE_GROUP_MNODE_TYPE) {
       logger.error("Wrong node type. Cannot deserialize MTreeAboveSG from given buffer");
       return;
     }
 
-    StorageGroupMNode storageGroupMNode = deserializeStorageGroupMNode(buffer);
+    StorageGroupMNode storageGroupMNode = deserializeStorageGroupMNode(inputStream);
     InternalMNode internalMNode;
 
     Stack<InternalMNode> stack = new Stack<>();
@@ -571,11 +575,11 @@ public class MTreeAboveSG {
     int childNum = 0;
 
     while (!PATH_ROOT.equals(name)) {
-      type = buffer.get();
+      type = ReadWriteIOUtils.readByte(inputStream);
       switch (type) {
         case INTERNAL_MNODE_TYPE:
-          internalMNode = deserializeInternalMNode(buffer);
-          childNum = ReadWriteIOUtils.readInt(buffer);
+          internalMNode = deserializeInternalMNode(inputStream);
+          childNum = ReadWriteIOUtils.readInt(inputStream);
           while (childNum > 0) {
             internalMNode.addChild(stack.pop());
             childNum--;
@@ -584,7 +588,7 @@ public class MTreeAboveSG {
           name = internalMNode.getName();
           break;
         case STORAGE_GROUP_MNODE_TYPE:
-          storageGroupMNode = deserializeStorageGroupMNode(buffer);
+          storageGroupMNode = deserializeStorageGroupMNode(inputStream);
           childNum = 0;
           stack.push(storageGroupMNode);
           name = storageGroupMNode.getName();
@@ -597,15 +601,16 @@ public class MTreeAboveSG {
     this.root = stack.peek();
   }
 
-  private InternalMNode deserializeInternalMNode(ByteBuffer buffer) {
-    return new InternalMNode(null, ReadWriteIOUtils.readString(buffer));
+  private InternalMNode deserializeInternalMNode(InputStream inputStream) throws IOException {
+    return new InternalMNode(null, ReadWriteIOUtils.readString(inputStream));
   }
 
-  private StorageGroupMNode deserializeStorageGroupMNode(ByteBuffer buffer) {
+  private StorageGroupMNode deserializeStorageGroupMNode(InputStream inputStream)
+      throws IOException {
     StorageGroupMNode storageGroupMNode =
-        new StorageGroupMNode(null, ReadWriteIOUtils.readString(buffer));
+        new StorageGroupMNode(null, ReadWriteIOUtils.readString(inputStream));
     storageGroupMNode.setStorageGroupSchema(
-        ThriftConfigNodeSerDeUtils.deserializeTStorageGroupSchema(buffer));
+        ThriftConfigNodeSerDeUtils.deserializeTStorageGroupSchema(inputStream));
     return storageGroupMNode;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MNodeAboveSGCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MNodeAboveSGCollector.java
@@ -37,20 +37,22 @@ public abstract class MNodeAboveSGCollector<T> extends MNodeCollector<T> {
 
   @Override
   protected boolean processInternalMatchedMNode(IMNode node, int idx, int level) {
+    boolean shouldSkipSubtree = super.processInternalMatchedMNode(node, idx, level);
     if (node.isStorageGroup()) {
       involvedStorageGroupMNodes.add(node.getPartialPath());
       return true;
     }
-    return super.processInternalMatchedMNode(node, idx, level);
+    return shouldSkipSubtree;
   }
 
   @Override
   protected boolean processFullMatchedMNode(IMNode node, int idx, int level) {
+    boolean shouldSkipSubtree = super.processFullMatchedMNode(node, idx, level);
     if (node.isStorageGroup()) {
       involvedStorageGroupMNodes.add(node.getPartialPath());
       return true;
     }
-    return super.processFullMatchedMNode(node, idx, level);
+    return shouldSkipSubtree;
   }
 
   public Set<PartialPath> getInvolvedStorageGroupMNodes() {

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSGTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -107,7 +108,7 @@ public class MTreeAboveSGTest {
       Set<String> result2 = root.getChildNodeNameInNextLevel(new PartialPath("root.a")).left;
       Set<String> result3 = root.getChildNodeNameInNextLevel(new PartialPath("root")).left;
       assertEquals(new HashSet<>(), result1);
-      assertEquals(new HashSet<>(Collections.emptyList()), result2);
+      assertEquals(new HashSet<>(Arrays.asList("d0", "d5")), result2);
       assertEquals(new HashSet<>(Collections.singletonList("a")), result3);
 
       // if child node is nll   will return  null HashSet

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSGTest.java
@@ -32,7 +32,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -311,12 +312,12 @@ public class MTreeAboveSGTest {
       storageGroupMNode.setTimePartitionInterval(i);
     }
 
-    ByteBuffer byteBuffer = ByteBuffer.allocate(1024 * 1024);
-    root.serialize(byteBuffer);
-    byteBuffer.flip();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    root.serialize(outputStream);
 
     MTreeAboveSG newTree = new MTreeAboveSG();
-    newTree.deserialize(byteBuffer);
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+    newTree.deserialize(inputStream);
 
     for (int i = 0; i < pathList.length; i++) {
       newTree.isStorageGroup(pathList[i]);

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeAboveSGTest.java
@@ -276,6 +276,10 @@ public class MTreeAboveSGTest {
     Assert.assertEquals(0, result.left.size());
     Assert.assertEquals(2, result.right.size());
 
+    result = root.getNodesListInGivenLevel(new PartialPath("root.**"), 1, false, null);
+    Assert.assertEquals(2, result.left.size());
+    Assert.assertEquals(2, result.right.size());
+
     result = root.getNodesListInGivenLevel(new PartialPath("root.*.*"), 2, false, null);
     Assert.assertEquals(0, result.left.size());
     Assert.assertEquals(2, result.right.size());


### PR DESCRIPTION
## Description


### Modify the serialize/deserialize of MTreeAboveSG with stream
Bytebuffer doesn't support capacity dynamic extension and will occupy more memory resource.

Use BufferedOutputStream and BufferedInputStream to implement serialize and deserialize of MTreeAboveSG separately.

### Add storageGroupNode to the result of MNodeAboveSGCollector
If a storageGroupNode matches the given node query and it doesn't have any schemaPartition, it will be missed since it has not been put to result set while traverse the MTreeAboveSG and there's no related schemaRegion to traverse.

Try add node to result set before storage group check.
