### PR TITLE
[IOTDB-3109]Fix wrong sender IP shown in receiver

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/service/TransportHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/service/TransportHandler.java
@@ -87,8 +87,7 @@ public class TransportHandler {
         localIP = inetAddress.getHostAddress();
       }
     } catch (UnknownHostException | SocketException e) {
-      logger.error(
-          String.format("Get local host error when create transport handler, because %s.", e));
+      logger.error(String.format("Get local host error when create transport handler."), e);
       localIP = SyncConstant.UNKNOWN_IP;
     }
     return localIP;


### PR DESCRIPTION
Problem:
  Wrong IP of sender is shown on the receiver.
Solution:
  Java will get IP from /etc/hosts, which can be modified by user. To obtain correct IP of sender, I add if statement in TransportHandler to judge the InetAddress.getLocalHost() is loopback address or not. If the IP address is loopback address, it will establish a UDP socket to receiver to get the correct IP.
Reference:
https://stackoverflow.com/questions/2381316/java-inetaddress-getlocalhost-returns-127-0-0-1-how-to-get-real-ip
https://stackoverflow.com/questions/9481865/getting-the-ip-address-of-the-current-machine-using-java