### PR TITLE
[To rel/0.13][ISSUE-5964] Fix bug of aligned timeseries time duplicated aggregation

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBAggregationWithoutValueFilterIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBAggregationWithoutValueFilterIT.java
@@ -453,4 +453,48 @@ public class IoTDBAggregationWithoutValueFilterIT {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void sumAlignedWithDuplicateTimeTest() throws ClassNotFoundException {
+    double[][] retArray = {{33.0, 33.0}};
+    String[] columnNames = {"sum(root.sg5.d1.success)", "sum(root.sg5.d1.fail)"};
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection =
+            DriverManager.getConnection(
+                Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("insert into root.sg5.d1(timestamp,success,fail) aligned values(1,10,10);");
+      statement.execute("insert into root.sg5.d1(timestamp,success,fail) aligned values(1,11,11);");
+      statement.execute("insert into root.sg5.d1(timestamp,success,fail) aligned values(2,11,11);");
+      statement.execute("insert into root.sg5.d1(timestamp,success,fail) aligned values(3,11,11);");
+      boolean hasResultSet = statement.execute("select sum(success), sum(fail) from root.sg5.d1");
+      Assert.assertTrue(hasResultSet);
+      try (ResultSet resultSet = statement.getResultSet()) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        Map<String, Integer> map = new HashMap<>();
+        for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+          map.put(resultSetMetaData.getColumnName(i), i);
+        }
+        assertEquals(columnNames.length, resultSetMetaData.getColumnCount());
+        int cnt = 0;
+        while (resultSet.next()) {
+          double[] ans = new double[columnNames.length];
+          StringBuilder builder = new StringBuilder();
+          // No need to add time column for aggregation query
+          for (int i = 0; i < columnNames.length; i++) {
+            String columnName = columnNames[i];
+            int index = map.get(columnName);
+            ans[i] = Double.parseDouble(resultSet.getString(index));
+          }
+          assertArrayEquals(retArray[cnt], ans, DELTA);
+          cnt++;
+        }
+        assertEquals(1, cnt);
+      }
+
+    } catch (SQLException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/querycontext/AlignedReadOnlyMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/querycontext/AlignedReadOnlyMemChunk.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.reader.IPointReader;
+import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.VectorMeasurementSchema;
 
@@ -95,12 +96,26 @@ public class AlignedReadOnlyMemChunk extends ReadOnlyMemChunk {
         new ChunkMetadata(measurementUid, TSDataType.VECTOR, 0, timeStatistics);
     List<IChunkMetadata> valueChunkMetadataList = new ArrayList<>();
     // update time chunk
+    boolean[] timeDuplicateInfo = null;
     for (int row = 0; row < alignedChunkData.rowCount(); row++) {
-      timeStatistics.update(alignedChunkData.getTime(row));
+      if (row == alignedChunkData.rowCount() - 1
+          || alignedChunkData.getTime(row) != alignedChunkData.getTime(row + 1)) {
+        timeStatistics.update(alignedChunkData.getTime(row));
+      } else {
+        if (timeDuplicateInfo == null) {
+          timeDuplicateInfo = new boolean[alignedChunkData.rowCount()];
+        }
+        timeDuplicateInfo[row] = true;
+      }
     }
     timeStatistics.setEmpty(false);
     // update value chunk
     for (int column = 0; column < measurementList.size(); column++) {
+      // Pair of Time and Index
+      Pair<Long, Integer> lastValidPointIndexForTimeDupCheck = null;
+      if (timeDuplicateInfo != null) {
+        lastValidPointIndexForTimeDupCheck = new Pair<>(Long.MIN_VALUE, null);
+      }
       Statistics valueStatistics = Statistics.getStatsByType(dataTypeList.get(column));
       IChunkMetadata valueChunkMetadata =
           new ChunkMetadata(
@@ -112,7 +127,30 @@ public class AlignedReadOnlyMemChunk extends ReadOnlyMemChunk {
       }
       for (int row = 0; row < alignedChunkData.rowCount(); row++) {
         long time = alignedChunkData.getTime(row);
-        int originRowIndex = alignedChunkData.getValueIndex(row);
+        // skip time duplicated rows
+        if (timeDuplicateInfo != null) {
+          if (!alignedChunkData.isValueMarked(alignedChunkData.getValueIndex(row), column)) {
+            lastValidPointIndexForTimeDupCheck.left = time;
+            lastValidPointIndexForTimeDupCheck.right = alignedChunkData.getValueIndex(row);
+          }
+          if (timeDuplicateInfo[row]) {
+            continue;
+          }
+        }
+        // The part of code solves the following problem:
+        // Time: 1,2,2,3
+        // Value: 1,2,null,null
+        // When rowIndex:1, pair(min,null), timeDuplicateInfo:false, write(T:1,V:1)
+        // When rowIndex:2, pair(2,2), timeDuplicateInfo:true, skip writing value
+        // When rowIndex:3, pair(2,2), timeDuplicateInfo:false, T:2!=air.left:2, write(T:2,V:2)
+        // When rowIndex:4, pair(2,2), timeDuplicateInfo:false, T:3!=pair.left:2, write(T:3,V:null)
+        int originRowIndex;
+        if (lastValidPointIndexForTimeDupCheck != null
+            && (alignedChunkData.getTime(row) == lastValidPointIndexForTimeDupCheck.left)) {
+          originRowIndex = lastValidPointIndexForTimeDupCheck.right;
+        } else {
+          originRowIndex = alignedChunkData.getValueIndex(row);
+        }
         boolean isNull = alignedChunkData.isValueMarked(originRowIndex, column);
         if (isNull) {
           continue;


### PR DESCRIPTION
## Description

Fix the bug ISSUE-5964 .

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
