### PR TITLE
[IOTDB-3218] Datanode can not be stoped by using stop-server.sh

### DIFF
--- a/server/src/assembly/resources/sbin/stop-server.sh
+++ b/server/src/assembly/resources/sbin/stop-server.sh
@@ -41,6 +41,21 @@ if [ -z "$PID" ]; then
   exit 1
 fi
 
+PIDS=$(ps ax | grep -i 'IoTDB' | grep java | grep -v grep | awk '{print $1}')
+sig=0
+for every_pid in ${PIDS}
+do
+  if [ "$every_pid" = "$PID" ]; then
+    sig=1
+    break
+  fi
+done
+
+if [ $sig -eq 0 ]; then
+  echo "No IoTDB server to stop"
+  exit 1
+fi
+
 echo -n "Begin to stop IoTDB ..."
 kill -s TERM $PID
 for ((i=1; i<=1000;i++))   #check status in 100 sec


### PR DESCRIPTION
Datanodes can be killed by stop-server.sh, but we predict datanodes will be stopped by stop-datanode.sh
After this commit, the scripts of server can:

- stop-server.sh: stop iotdb instance by the rpc_port
- stop-datanode.sh: stop all data nodes process 