### PR TITLE
[IOTDB-3286] False Carousel Ratio on Desktop Version Homepage

### DIFF
--- a/site/src/main/.vuepress/theme/global-components/IoTDB.vue
+++ b/site/src/main/.vuepress/theme/global-components/IoTDB.vue
@@ -48,11 +48,11 @@
     <p class="home-title" style="font-size: 50px;">Scenarios</p>
 
     <div class="block">
-        <el-carousel trigger="click" height="1000px" indicator-position="outside">
+        <el-carousel trigger="click" :height="autoHeight" indicator-position="outside">
           <el-carousel-item v-for="(item,index) in imgBlock" :key="index"  style="text-align:center;">
             <img :src="item.src" height="500px">
-            <h3 class="carousel-title" style="font-size: 30px;color: #fcac45;text-align: center;line-height: normal;">{{item.des}}</h3>
-            <p class="carousel-text" style="font-size: 18px;line-height: 22px;text-align:justify!important;font-weight:bold;">{{item.detail}}</p>
+            <h3 style="font-size: 30px;color: #fcac45;text-align: center;line-height: normal;">{{item.des}}</h3>
+            <p style="font-size: 18px;line-height: 22px;padding:15px;text-align:justify!important;font-weight:bold;">{{item.detail}}</p>
           </el-carousel-item>
         </el-carousel>
     </div>
@@ -171,6 +171,22 @@ export default {
       isHover: false
     };
   },
+  computed: {
+    autoHeight() {
+      let _w = document.documentElement.clientWidth || document.body.clientWidth;
+      let _h = 0;
+      if (_w >= 200 && _w < 768) {
+        _h = 925;
+      } else if (_w >= 768 && _w < 992) {
+        _h = 825;
+      } else if (_w >= 992 && _w < 1200) {
+        _h = 825;
+      } else if (_w >= 1200) {
+        _h = 750;
+      }
+      return _h + "px";
+    }
+  },
   methods: {
     addRoutes1() {
       this.$router.push("/Download/");
@@ -243,9 +259,6 @@ export default {
   .carousel-title {
     padding-top:0;
   }
-  .carousel-text {
-    padding:15px;
-  }
 }
 
 @media (min-width: 768px) {
@@ -254,12 +267,6 @@ export default {
   }
   .carousel-inner {
     min-height: 520px;
-  }
-  .carousel-title {
-    padding-top:100px;
-  }
-  .carousel-text {
-    padding:0 100px 0 100px;
   }
 }
 
@@ -270,12 +277,6 @@ export default {
   .carousel-inner {
     min-height: 580px;
   }
-  .carousel-title {
-    padding-top:100px;
-  }
-  .carousel-text {
-    padding:0 100px 0 100px;
-  }
 }
 
 @media (min-width: 1200px) {
@@ -284,12 +285,6 @@ export default {
   }
   .carousel-inner {
     min-height: 650px;
-  }
-  .carousel-title {
-    padding-top:100px;
-  }
-  .carousel-text {
-    padding:0 100px 0 100px;
   }
 }
 

--- a/site/src/main/.vuepress/theme/global-components/IoTDBZH.vue
+++ b/site/src/main/.vuepress/theme/global-components/IoTDBZH.vue
@@ -18,8 +18,6 @@
 
 <template >
   <div style="background:linear-gradient(top,#A2A2A2,#fff);">
-    
-    <div style="width:100%;margin: 0 auto;position: relative;height:480px;text-align:center;">
       <h2 class="h2" style="font-size:80px;">Apache IoTDB</h2>
       <p
         style="font-size: 20px;line-height:23px;margin: 10px 0 20px 0;font-family: 'Arimo', sans-serif;
@@ -46,17 +44,16 @@ Apache IoTDB 采用轻量式架构，具有高性能和丰富的功能，并与A
           style="font-size: 18px;letter-spacing: 0.03em;font-family: 'Arimo', sans-serif;"
           @click="addRoutes2"
         >快速开始</el-button>
-      </el-row>
     </div>
 
     <p class="home-title" style="font-size: 50px;">应用场景</p>
 
     <div class="block">
-        <el-carousel trigger="click" height="1000px" indicator-position="outside">
+        <el-carousel trigger="click" height="autoHeight" indicator-position="outside">
           <el-carousel-item v-for="(item,index) in imgBlock" :key="index"  style="text-align:center;">
             <img :src="item.src" height="500px">
-            <h3 class="carousel-title" style="font-size: 30px;color: #fcac45;text-align: center;line-height: normal;">{{item.des}}</h3>
-            <p class="carousel-text" style="font-size: 18px;line-height: 22px;text-align:justify!important;font-weight:bold;">{{item.detail}}</p>
+            <h3 style="font-size: 30px;color: #fcac45;text-align: center;line-height: normal;">{{item.des}}</h3>
+            <p style="font-size: 18px;padding:15px;line-height: 22px;text-align:justify!important;font-weight:bold;">{{item.detail}}</p>
           </el-carousel-item>
         </el-carousel>
     </div>
@@ -175,6 +172,22 @@ export default {
       isHover: false
     };
   },
+  computed: {
+    autoHeight() {
+      let _w = document.documentElement.clientWidth || document.body.clientWidth;
+      let _h = 0;
+      if (_w >= 200 && _w < 768) {
+        _h = 925;
+      } else if (_w >= 768 && _w < 992) {
+        _h = 825;
+      } else if (_w >= 992 && _w < 1200) {
+        _h = 825;
+      } else if (_w >= 1200) {
+        _h = 750;
+      }
+      return _h + "px";
+    }
+  },
   methods: {
     addRoutes1() {
       this.$router.push("/zh/Download/");
@@ -233,12 +246,6 @@ export default {
   .carousel-inner {
     min-height: 530px;
   }
-  .carousel-title {
-    padding-top:0;
-  }
-  .carousel-text {
-    padding:15px;
-  }
 }
 
 @media (min-width: 768px) {
@@ -247,12 +254,6 @@ export default {
   }
   .carousel-inner {
     min-height: 520px;
-  }
-  .carousel-title {
-    padding-top:100px;
-  }
-  .carousel-text {
-    padding:0 100px 0 100px;
   }
 }
 
@@ -263,12 +264,6 @@ export default {
   .carousel-inner {
     min-height: 580px;
   }
-  .carousel-title {
-    padding-top:100px;
-  }
-  .carousel-text {
-    padding:0 100px 0 100px;
-  }
 }
 
 @media (min-width: 1200px) {
@@ -277,12 +272,6 @@ export default {
   }
   .carousel-inner {
     min-height: 650px;
-  }
-  .carousel-title {
-    padding-top:100px;
-  }
-  .carousel-text {
-    padding:0 100px 0 100px;
   }
 }
 


### PR DESCRIPTION
## Description
[[IOTDB-3286] False Carousel Ratio on Desktop Version Homepage](https://issues.apache.org/jira/browse/IOTDB-3286)

I've implemented a script that could automatically adjust the carousel height due to the browser width. Please see the screenshots below:

Original (desktop version):
<img src="https://user-images.githubusercontent.com/34185019/170192920-dd061fa2-a0c2-4567-87ff-29e3d9d7c712.png" width="30%" height="20%">

New (desktop version):
<img src="https://user-images.githubusercontent.com/34185019/170193416-c7030006-1cff-46eb-b27b-785caa874765.png" width="30%" height="20%">

New (mobile version):
<img src="https://user-images.githubusercontent.com/34185019/170194094-95012b2e-7df5-4e04-abb9-3643d3dcf404.png" width="30%" height="20%">

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
