### PR TITLE
[IOTDB-3271] Wrong multi IP for one sender in receiver

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/sync/IoTDBSyncReceiverIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/sync/IoTDBSyncReceiverIT.java
@@ -109,7 +109,7 @@ public class IoTDBSyncReceiverIT {
     }
     Pipe pipe = new TsFilePipe(createdTime1, pipeName1, null, 0, false);
     client = new TransportClient(pipe, "127.0.0.1", 6670, "127.0.0.1");
-    remoteIp1 = InetAddress.getLocalHost().getHostAddress();
+    remoteIp1 = "127.0.0.1";
     client.handshake();
   }
 

--- a/integration/src/test/java/org/apache/iotdb/db/integration/sync/IoTDBSyncReceiverIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/sync/IoTDBSyncReceiverIT.java
@@ -108,7 +108,7 @@ public class IoTDBSyncReceiverIT {
       Assert.fail("Failed to start pipe server because " + e.getMessage());
     }
     Pipe pipe = new TsFilePipe(createdTime1, pipeName1, null, 0, false);
-    client = new TransportClient(pipe, "127.0.0.1", 6670);
+    client = new TransportClient(pipe, "127.0.0.1", 6670, "127.0.0.1");
     remoteIp1 = InetAddress.getLocalHost().getHostAddress();
     client.handshake();
   }

--- a/integration/src/test/java/org/apache/iotdb/db/integration/sync/IoTDBSyncReceiverIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/sync/IoTDBSyncReceiverIT.java
@@ -57,7 +57,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.net.InetAddress;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/service/TransportHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/service/TransportHandler.java
@@ -62,7 +62,8 @@ public class TransportHandler {
   public TransportHandler(Pipe pipe, IoTDBPipeSink pipeSink) {
     this.pipeName = pipe.getName();
     this.createTime = pipe.getCreateTime();
-    this.transportClient = new TransportClient(pipe, pipeSink.getIp(), pipeSink.getPort());
+    this.localIP = getLocalIP(pipeSink);
+    this.transportClient = new TransportClient(pipe, pipeSink.getIp(), pipeSink.getPort(), localIP);
 
     this.transportExecutorService =
         IoTDBThreadPoolFactory.newSingleThreadExecutor(
@@ -70,8 +71,6 @@ public class TransportHandler {
     this.heartbeatExecutorService =
         IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(
             ThreadName.SYNC_SENDER_HEARTBEAT.getName() + "-" + pipeName);
-
-    this.localIP = getLocalIP(pipeSink);
   }
 
   private String getLocalIP(IoTDBPipeSink pipeSink) {

--- a/server/src/test/java/org/apache/iotdb/db/sync/transport/TransportServiceTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/transport/TransportServiceTest.java
@@ -71,7 +71,7 @@ public class TransportServiceTest {
 
   @Before
   public void setUp() throws Exception {
-    remoteIp1 = InetAddress.getLocalHost().getHostAddress();
+    remoteIp1 = "127.0.0.1";
     fileDir = new File(SyncPathUtil.getReceiverFileDataDir(pipeName1, remoteIp1, createdTime1));
     pipeDataQueue =
         PipeDataQueueFactory.getBufferedPipeDataQueue(

--- a/server/src/test/java/org/apache/iotdb/db/sync/transport/TransportServiceTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/transport/TransportServiceTest.java
@@ -131,7 +131,10 @@ public class TransportServiceTest {
     Pipe pipe = new TsFilePipe(createdTime1, pipeName1, null, 0, false);
     TransportClient client =
         new TransportClient(
-            pipe, "127.0.0.1", IoTDBDescriptor.getInstance().getConfig().getPipeServerPort());
+            pipe,
+            "127.0.0.1",
+            IoTDBDescriptor.getInstance().getConfig().getPipeServerPort(),
+            "127.0.0.1");
     client.handshake();
     for (PipeData pipeData : pipeDataList) {
       client.senderTransport(pipeData);

--- a/server/src/test/java/org/apache/iotdb/db/sync/transport/TransportServiceTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/transport/TransportServiceTest.java
@@ -52,7 +52,6 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
-import java.net.InetAddress;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Problem:
1、In Receiver，set 127.0.1.1 to hostname in "/etc/hosts".
2、In Sender， start pipserver；
      In Receiver，create pipesink ...， create pip ...，start pip ...
ERROR:  3、Now, in Receiver, at "data/sync/receiver" , created two folder
I think， The two folders point to the same host(Sender，192.168.130.12
ERROR:  4、 start writing data...
In Receiver，the data will sync to folder  ***-127.0.1.1, not the truth folder(192.168.130.12)
And, the sent data was not automatically moved to the data folder
ERROR: 5、
In this commit，The first start pipe is worked，After that, stop pipe and start pipe are not working
Solution:
Two different IP in TransportClient, change them into one.