### PR TITLE
[IOTDB-3168][To rel/0.13] Fix the path with * could be executed successfully when inserting

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IOTDBInsertIT.java
@@ -157,6 +157,12 @@ public class IOTDBInsertIT {
     st1.execute("insert into root.t1.wf01.wt01(status, temperature) values(true, 20.1, false)");
   }
 
+  @Test(expected = Exception.class)
+  public void testInsertWithException6() throws SQLException {
+    Statement st1 = connection.createStatement();
+    st1.execute(" insert into root.t1.*.a(timestamp, b) values(1509465600000, true)");
+  }
+
   @Test
   public void testInsertWithDuplicatedMeasurements() {
     try (Statement st1 = connection.createStatement()) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/utils/MetaFormatUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/utils/MetaFormatUtils.java
@@ -82,7 +82,7 @@ public class MetaFormatUtils {
   private static void checkNameFormat(String name) throws MetadataException {
     if (!((name.startsWith("'") && name.endsWith("'"))
             || (name.startsWith("\"") && name.endsWith("\"")))
-        && (name.contains(".") ||  name.contains("*"))) {
+        && (name.contains(".") || name.contains("*"))) {
       throw new MetadataException(String.format("%s is an illegal name.", name));
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/utils/MetaFormatUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/utils/MetaFormatUtils.java
@@ -53,7 +53,6 @@ public class MetaFormatUtils {
     for (String name : timeseries.getNodes()) {
       try {
         checkReservedNames(name);
-        checkNameFormatIfHasstar(name);
         checkNameFormat(name);
       } catch (MetadataException e) {
         throw new IllegalPathException(timeseries.getFullPath(), e.getMessage());
@@ -83,21 +82,11 @@ public class MetaFormatUtils {
   private static void checkNameFormat(String name) throws MetadataException {
     if (!((name.startsWith("'") && name.endsWith("'"))
             || (name.startsWith("\"") && name.endsWith("\"")))
-        && name.contains(".")) {
+        && (name.contains(".") ||  name.contains("*"))) {
       throw new MetadataException(String.format("%s is an illegal name.", name));
     }
   }
 
-  /**  check whether the node name uses "*" correctly */
-  private static void checkNameFormatIfHasstar(String name) throws MetadataException {
-    if (!((name.startsWith("'") && name.endsWith("'"))
-            || (name.startsWith("\"") && name.endsWith("\"")))
-            &&  name.contains("*")
-
-    ) {
-      throw new MetadataException(String.format("%s is an illegal name.", name));
-    }
-  }
   /** check whether the node name is well formatted */
   public static void checkNodeName(String name) throws MetadataException {
     checkCharacters(name);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/utils/MetaFormatUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/utils/MetaFormatUtils.java
@@ -53,6 +53,7 @@ public class MetaFormatUtils {
     for (String name : timeseries.getNodes()) {
       try {
         checkReservedNames(name);
+        checkNameFormatIfHasstar(name);
         checkNameFormat(name);
       } catch (MetadataException e) {
         throw new IllegalPathException(timeseries.getFullPath(), e.getMessage());
@@ -87,6 +88,16 @@ public class MetaFormatUtils {
     }
   }
 
+  /**  check whether the node name uses "*" correctly */
+  private static void checkNameFormatIfHasstar(String name) throws MetadataException {
+    if (!((name.startsWith("'") && name.endsWith("'"))
+            || (name.startsWith("\"") && name.endsWith("\"")))
+            &&  name.contains("*")
+
+    ) {
+      throw new MetadataException(String.format("%s is an illegal name.", name));
+    }
+  }
   /** check whether the node name is well formatted */
   public static void checkNodeName(String name) throws MetadataException {
     checkCharacters(name);

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -109,7 +109,7 @@ public class IoTDB implements IoTDBMBean {
 
     // set recover config, avoid creating deleted time series when recovering wal
     boolean prevIsAutoCreateSchemaEnabled = config.isAutoCreateSchemaEnabled();
-    config.setAutoCreateSchemaEnabled(false);
+    config.setAutoCreateSchemaEnabled(true);
     boolean prevIsEnablePartialInsert = config.isEnablePartialInsert();
     config.setEnablePartialInsert(true);
 

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -109,7 +109,7 @@ public class IoTDB implements IoTDBMBean {
 
     // set recover config, avoid creating deleted time series when recovering wal
     boolean prevIsAutoCreateSchemaEnabled = config.isAutoCreateSchemaEnabled();
-    config.setAutoCreateSchemaEnabled(true);
+    config.setAutoCreateSchemaEnabled(false);
     boolean prevIsEnablePartialInsert = config.isEnablePartialInsert();
     config.setEnablePartialInsert(true);
 


### PR DESCRIPTION
##  By adding a function of "checkNameFormatIfHasstar" to "MetaFormatUnit.java". Introduce the "checkNameFormatIfHasstar" in "checkTimeseries".


### Create a new function in bb
  /**  check whether the node name uses "*" correctly */
  private static void checkNameFormatIfHasstar(String name) throws MetadataException {
    if (!((name.startsWith("'") && name.endsWith("'"))
            || (name.startsWith("\"") && name.endsWith("\"")))
            &&  name.contains("*")

    ) {
      throw new MetadataException(String.format("%s is an illegal name.", name));
    }
  }


### Content2 ...
  /** check whether the given path is well formatted */
  public static void checkTimeseries(PartialPath timeseries) throws IllegalPathException {
    try {
      checkCharacters(timeseries.getFullPath());
    } catch (MetadataException e) {
      throw new IllegalPathException(timeseries.getFullPath(), e.getMessage());
    }
    for (String name : timeseries.getNodes()) {
      try {
        checkReservedNames(name);
        checkNameFormatIfHasstar(name);
        checkNameFormat(name);
      } catch (MetadataException e) {
        throw new IllegalPathException(timeseries.getFullPath(), e.getMessage());
      }
    }
  }
