### PR TITLE
[IOTDB-3315] Make unset of ttl in cluster mode same as 0.13.0 version.

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
@@ -84,7 +84,6 @@ public class IoTDBConstant {
   public static final String COLUMN_IS_ALIGNED = "isAligned";
   public static final String QUERY_ID = "queryId";
   public static final String STATEMENT = "statement";
-  public static final String TLL_NOT_SET = "not set";
 
   public static final String COLUMN_ROLE = "role";
   public static final String COLUMN_USER = "user";

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/HeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/HeaderConstant.java
@@ -141,7 +141,7 @@ public class HeaderConstant {
         new DatasetHeader(
             Arrays.asList(
                 new ColumnHeader(COLUMN_STORAGE_GROUP, TSDataType.TEXT),
-                new ColumnHeader(COLUMN_TTL, TSDataType.TEXT)),
+                new ColumnHeader(COLUMN_TTL, TSDataType.INT64)),
             true);
     showChildPathsHeader =
         new DatasetHeader(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/HeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/HeaderConstant.java
@@ -132,7 +132,7 @@ public class HeaderConstant {
         new DatasetHeader(
             Arrays.asList(
                 new ColumnHeader(COLUMN_STORAGE_GROUP, TSDataType.TEXT),
-                new ColumnHeader(COLUMN_TTL, TSDataType.TEXT),
+                new ColumnHeader(COLUMN_TTL, TSDataType.INT64),
                 new ColumnHeader(COLUMN_SCHEMA_REPLICATION_FACTOR, TSDataType.INT32),
                 new ColumnHeader(COLUMN_DATA_REPLICATION_FACTOR, TSDataType.INT32),
                 new ColumnHeader(COLUMN_TIME_PARTITION_INTERVAL, TSDataType.INT64)),

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ShowStorageGroupTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ShowStorageGroupTask.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.db.mpp.plan.execution.config;
 
 import org.apache.iotdb.commons.client.IClientManager;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.consensus.PartitionRegionId;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
@@ -106,11 +105,9 @@ public class ShowStorageGroupTask implements IConfigTask {
       builder.getTimeColumnBuilder().writeLong(0L);
       builder.getColumnBuilder(0).writeBinary(new Binary(storageGroup));
       if (Long.MAX_VALUE == storageGroupSchema.getTTL()) {
-        builder.getColumnBuilder(1).writeBinary(new Binary(IoTDBConstant.TLL_NOT_SET));
+        builder.getColumnBuilder(1).appendNull();
       } else {
-        builder
-            .getColumnBuilder(1)
-            .writeBinary(new Binary(String.valueOf(storageGroupSchema.getTTL())));
+        builder.getColumnBuilder(1).writeLong(storageGroupSchema.getTTL());
       }
       builder.getColumnBuilder(2).writeInt(storageGroupSchema.getSchemaReplicationFactor());
       builder.getColumnBuilder(3).writeInt(storageGroupSchema.getDataReplicationFactor());

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ShowTTLTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ShowTTLTask.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.db.mpp.plan.execution.config;
 
 import org.apache.iotdb.commons.client.IClientManager;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.consensus.PartitionRegionId;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
@@ -124,9 +123,9 @@ public class ShowTTLTask implements IConfigTask {
       builder.getTimeColumnBuilder().writeLong(0);
       builder.getColumnBuilder(0).writeBinary(new Binary(entry.getKey()));
       if (Long.MAX_VALUE == entry.getValue()) {
-        builder.getColumnBuilder(1).writeBinary(new Binary(IoTDBConstant.TLL_NOT_SET));
+        builder.getColumnBuilder(1).appendNull();
       } else {
-        builder.getColumnBuilder(1).writeBinary(new Binary(entry.getValue().toString()));
+        builder.getColumnBuilder(1).writeLong(entry.getValue());
       }
       builder.declarePosition();
     }


### PR DESCRIPTION
See more details: https://issues.apache.org/jira/browse/IOTDB-3315

Test on 3C3D:

<img width="904" alt="image" src="https://user-images.githubusercontent.com/46039728/170856857-9b1dda68-9f7a-4ae4-b50f-5aaad4026e0e.png">

<img width="313" alt="image" src="https://user-images.githubusercontent.com/46039728/170856863-b836b9d2-7da4-4e1c-aa82-298c03620937.png">
