### PR TITLE
Fix aligned data in memory query bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/MemAlignedPageReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/MemAlignedPageReader.java
@@ -101,10 +101,14 @@ public class MemAlignedPageReader implements IPageReader, IAlignedPageReader {
     for (int row = 0; row < tsBlock.getPositionCount(); row++) {
       long time = tsBlock.getTimeByIndex(row);
       Object value = tsBlock.getColumn(0).getObject(row);
-      if (!tsBlock.getColumn(0).isNull(row)
-          && (valueFilter == null || valueFilter.satisfy(time, value))) {
+      boolean valueIsNull = tsBlock.getColumn(0).isNull(row);
+      if ((valueFilter == null || !valueIsNull && valueFilter.satisfy(time, value))) {
         builder.getTimeColumnBuilder().write(timeColumn, row);
-        builder.getColumnBuilder(0).write(valueColumn, row);
+        if (!valueIsNull) {
+          builder.getColumnBuilder(0).write(valueColumn, row);
+        } else {
+          builder.getColumnBuilder(0).appendNull();
+        }
         satisfyInfo[row] = true;
         builder.declarePosition();
       }


### PR DESCRIPTION
## Description

Fix the query result of the mem data from aligned time series may less than they should be.

Before:
![15761653877637_ pic](https://user-images.githubusercontent.com/25913899/170912779-e305e23c-9d2d-4480-8809-fb845f888b6b.jpg)

Alfter:
![16001653880550_ pic](https://user-images.githubusercontent.com/25913899/170912816-0c2ce6e6-f7d1-428f-9ec1-6185ef6e3537.jpg)

To reproduce, use the test file below:
[AlignedWriteUtil.txt](https://github.com/apache/iotdb/files/8795248/AlignedWriteUtil.txt)


