### PR TITLE
[IOTDB-3306] Use rpc port check to avoid starting same IoTDB twice

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/service/AbstractThriftServiceThread.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/service/AbstractThriftServiceThread.java
@@ -223,45 +223,13 @@ public abstract class AbstractThriftServiceThread extends Thread {
 
   @SuppressWarnings("java:S2259")
   private TServerTransport openTransport(String bindAddress, int port) throws TTransportException {
-    int maxRetry = 5;
-    long retryIntervalMS = 5000;
-    TTransportException lastExp = null;
-    for (int i = 0; i < maxRetry; i++) {
-      try {
-        return new TServerSocket(new InetSocketAddress(bindAddress, port));
-      } catch (TTransportException e) {
-        lastExp = e;
-        try {
-          Thread.sleep(retryIntervalMS);
-        } catch (InterruptedException interruptedException) {
-          Thread.currentThread().interrupt();
-          break;
-        }
-      }
-    }
-    throw lastExp == null ? new TTransportException() : lastExp;
+    return new TServerSocket(new InetSocketAddress(bindAddress, port));
   }
 
   private TServerTransport openNonblockingTransport(
       String bindAddress, int port, int connectionTimeoutInMS) throws TTransportException {
-    int maxRetry = 5;
-    long retryIntervalMS = 5000;
-    TTransportException lastExp = null;
-    for (int i = 0; i < maxRetry; i++) {
-      try {
-        return new TNonblockingServerSocket(
-            new InetSocketAddress(bindAddress, port), connectionTimeoutInMS);
-      } catch (TTransportException e) {
-        lastExp = e;
-        try {
-          Thread.sleep(retryIntervalMS);
-        } catch (InterruptedException interruptedException) {
-          Thread.currentThread().interrupt();
-          break;
-        }
-      }
-    }
-    throw lastExp == null ? new TTransportException() : lastExp;
+    return new TNonblockingServerSocket(
+        new InetSocketAddress(bindAddress, port), connectionTimeoutInMS);
   }
 
   public void setThreadStopLatch(CountDownLatch threadStopLatch) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1222,7 +1222,7 @@ public class TsFileProcessor {
         MemTableFlushTask flushTask =
             new MemTableFlushTask(memTableToFlush, writer, storageGroupName);
         flushTask.syncFlushMemTable();
-      } catch (Exception e) {
+      } catch (Throwable e) {
         if (writer == null) {
           logger.info(
               "{}: {} is closed during flush, abandon flush task",

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -266,6 +266,10 @@ public class DataNode implements DataNodeMBean {
     Runtime.getRuntime().addShutdownHook(new IoTDBShutdownHook());
     setUncaughtExceptionHandler();
     initServiceProvider();
+    // in cluster mode, RPC service is not enabled.
+    if (IoTDBDescriptor.getInstance().getConfig().isEnableRpcService()) {
+      registerManager.register(RPCService.getInstance());
+    }
     registerManager.register(MetricsService.getInstance());
     logger.info("recover the schema...");
     initConfigManager();
@@ -288,11 +292,6 @@ public class DataNode implements DataNodeMBean {
 
     registerManager.register(ReceiverService.getInstance());
     registerManager.register(MetricsService.getInstance());
-
-    // in cluster mode, RPC service is not enabled.
-    if (IoTDBDescriptor.getInstance().getConfig().isEnableRpcService()) {
-      registerManager.register(RPCService.getInstance());
-    }
 
     initProtocols();
 

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -145,6 +145,10 @@ public class IoTDB implements IoTDBMBean {
     Runtime.getRuntime().addShutdownHook(new IoTDBShutdownHook());
     setUncaughtExceptionHandler();
     initServiceProvider();
+    // in cluster mode, RPC service is not enabled.
+    if (IoTDBDescriptor.getInstance().getConfig().isEnableRpcService()) {
+      registerManager.register(RPCService.getInstance());
+    }
     registerManager.register(MetricsService.getInstance());
     logger.info("recover the schema...");
     initConfigManager();
@@ -181,11 +185,6 @@ public class IoTDB implements IoTDBMBean {
                 + File.separator));
     registerManager.register(ReceiverService.getInstance());
     registerManager.register(MetricsService.getInstance());
-
-    // in cluster mode, RPC service is not enabled.
-    if (IoTDBDescriptor.getInstance().getConfig().isEnableRpcService()) {
-      registerManager.register(RPCService.getInstance());
-    }
 
     initProtocols();
     // in cluster mode, InfluxDBMManager has been initialized, so there is no need to init again to


### PR DESCRIPTION
## Description

Some users may starting same IoTDB twice, it may causes the TsFile flushed by two IoTDB processes.

In this PR, I made the following changes.
1. start the rpc service first, then the second IoTDB will stoped because of getting rpc port failed
2. removed the retry logic of getting rpc port

