### PR TITLE
[IOTDB-3335] Redundant data recovered by wal in multi-leader consensus

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -59,10 +59,11 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class AbstractMemTable implements IMemTable {
+  /** each memTable node has a unique int value identifier, init when recovering wal */
+  public static final AtomicInteger memTableIdCounter = new AtomicInteger(-1);
+
   private static final Logger logger = LoggerFactory.getLogger(AbstractMemTable.class);
   private static final int FIXED_SERIALIZED_SIZE = Byte.BYTES + 2 * Integer.BYTES + 6 * Long.BYTES;
-  /** each memTable node has a unique int value identifier */
-  private static final AtomicInteger memTableIdCounter = new AtomicInteger();
 
   private static final DeviceIDFactory deviceIDFactory = DeviceIDFactory.getInstance();
 
@@ -96,7 +97,7 @@ public abstract class AbstractMemTable implements IMemTable {
 
   private long minPlanIndex = Long.MAX_VALUE;
 
-  private final int memTableId = memTableIdCounter.getAndIncrement();
+  private final int memTableId = memTableIdCounter.incrementAndGet();
 
   private final long createdTime = System.currentTimeMillis();
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.file.SystemFileFactory;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.directories.DirectoryManager;
@@ -3541,7 +3542,9 @@ public class DataRegion {
   }
 
   public IWALNode getWALNode() {
-    if (!config.isClusterMode()) {
+    if (!config
+        .getDataRegionConsensusProtocolClass()
+        .equals(ConsensusFactory.MultiLeaderConsensus)) {
       throw new UnsupportedOperationException();
     }
     // identifier should be same with getTsFileProcessor method

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/AbstractNodeAllocationStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/AbstractNodeAllocationStrategy.java
@@ -76,4 +76,13 @@ public abstract class AbstractNodeAllocationStrategy implements NodeAllocationSt
       return WALFakeNode.getFailureInstance(e);
     }
   }
+
+  protected IWALNode createWALNode(String identifier, String folder, int startFileVersion) {
+    try {
+      return new WALNode(identifier, folder, startFileVersion);
+    } catch (FileNotFoundException e) {
+      logger.error("Fail to create wal node", e);
+      return WALFakeNode.getFailureInstance(e);
+    }
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
@@ -60,14 +60,14 @@ public class FirstCreateStrategy extends AbstractNodeAllocationStrategy {
     }
   }
 
-  public void registerWALNode(String applicantUniqueId, String logDirectory) {
+  public void registerWALNode(String applicantUniqueId, String logDirectory, int startFileVersion) {
     nodesLock.lock();
     try {
       if (identifier2Nodes.containsKey(applicantUniqueId)) {
         return;
       }
 
-      IWALNode walNode = createWALNode(applicantUniqueId, logDirectory);
+      IWALNode walNode = createWALNode(applicantUniqueId, logDirectory, startFileVersion);
       if (walNode instanceof WALNode) {
         // avoid deletion
         ((WALNode) walNode).setSafelyDeletedSearchIndex(Long.MIN_VALUE);

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
@@ -45,13 +45,15 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
   /** current wal file log writer */
   protected volatile ILogWriter currentWALFileWriter;
 
-  public AbstractWALBuffer(String identifier, String logDirectory) throws FileNotFoundException {
+  public AbstractWALBuffer(String identifier, String logDirectory, int startFileVersion)
+      throws FileNotFoundException {
     this.identifier = identifier;
     this.logDirectory = logDirectory;
     File logDirFile = SystemFileFactory.INSTANCE.getFile(logDirectory);
     if (!logDirFile.exists() && logDirFile.mkdirs()) {
       logger.info("create folder {} for wal buffer-{}.", logDirectory, identifier);
     }
+    currentWALFileVersion.set(startFileVersion);
     currentWALFileWriter =
         new WALWriter(
             SystemFileFactory.INSTANCE.getFile(

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/WALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/WALBuffer.java
@@ -78,7 +78,12 @@ public class WALBuffer extends AbstractWALBuffer {
   private final ExecutorService syncBufferThread;
 
   public WALBuffer(String identifier, String logDirectory) throws FileNotFoundException {
-    super(identifier, logDirectory);
+    this(identifier, logDirectory, 0);
+  }
+
+  public WALBuffer(String identifier, String logDirectory, int startFileVersion)
+      throws FileNotFoundException {
+    super(identifier, logDirectory, startFileVersion);
     allocateBuffers();
     serializeThread =
         IoTDBThreadPoolFactory.newSingleThreadExecutor(

--- a/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/MemTableInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/MemTableInfo.java
@@ -106,7 +106,6 @@ public class MemTableInfo implements SerializedSize {
     return firstFileVersionId;
   }
 
-  /** */
   public void setFirstFileVersionId(int firstFileVersionId) {
     this.firstFileVersionId = firstFileVersionId;
   }

--- a/server/src/main/java/org/apache/iotdb/db/wal/io/CheckpointReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/io/CheckpointReader.java
@@ -28,7 +28,7 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /** CheckpointReader is used to read all checkpoints from .checkpoint file. */
@@ -36,20 +36,19 @@ public class CheckpointReader {
   private static final Logger logger = LoggerFactory.getLogger(CheckpointReader.class);
 
   private final File logFile;
+  private int maxMemTableId;
+  private List<Checkpoint> checkpoints;
 
   public CheckpointReader(File logFile) {
     this.logFile = logFile;
+    init();
   }
 
-  /**
-   * Read all checkpoints from .checkpoint file.
-   *
-   * @return checkpoints
-   */
-  public List<Checkpoint> readAll() {
-    List<Checkpoint> checkpoints = new LinkedList<>();
+  private void init() {
+    checkpoints = new ArrayList<>();
     try (DataInputStream logStream =
         new DataInputStream(new BufferedInputStream(new FileInputStream(logFile)))) {
+      maxMemTableId = logStream.readInt();
       while (logStream.available() > 0) {
         Checkpoint checkpoint = Checkpoint.deserialize(logStream);
         checkpoints.add(checkpoint);
@@ -58,6 +57,13 @@ public class CheckpointReader {
       logger.warn(
           "Meet error when reading checkpoint file {}, skip broken checkpoints", logFile, e);
     }
+  }
+
+  public int getMaxMemTableId() {
+    return maxMemTableId;
+  }
+
+  public List<Checkpoint> getCheckpoints() {
     return checkpoints;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -109,12 +109,17 @@ public class WALNode implements IWALNode {
   private volatile long safelyDeletedSearchIndex = DEFAULT_SAFELY_DELETED_SEARCH_INDEX;
 
   public WALNode(String identifier, String logDirectory) throws FileNotFoundException {
+    this(identifier, logDirectory, 0);
+  }
+
+  public WALNode(String identifier, String logDirectory, int startFileVersion)
+      throws FileNotFoundException {
     this.identifier = identifier;
     this.logDirectory = SystemFileFactory.INSTANCE.getFile(logDirectory);
     if (!this.logDirectory.exists() && this.logDirectory.mkdirs()) {
       logger.info("create folder {} for wal node-{}.", logDirectory, identifier);
     }
-    this.buffer = new WALBuffer(identifier, logDirectory);
+    this.buffer = new WALBuffer(identifier, logDirectory, startFileVersion);
     this.checkpointManager = new CheckpointManager(identifier, logDirectory);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/CheckpointRecoverUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/CheckpointRecoverUtils.java
@@ -33,24 +33,27 @@ public class CheckpointRecoverUtils {
   private CheckpointRecoverUtils() {}
 
   /** Recover memTable information from checkpoint folder */
-  public static Map<Integer, MemTableInfo> recoverMemTableInfo(File logDirectory) {
+  public static CheckpointInfo recoverMemTableInfo(File logDirectory) {
     // find all .checkpoint file
     File[] checkpointFiles = CheckpointFileUtils.listAllCheckpointFiles(logDirectory);
     if (checkpointFiles == null) {
-      return Collections.emptyMap();
+      return new CheckpointInfo(0, Collections.emptyMap());
     }
     // desc sort by version id
     CheckpointFileUtils.descSortByVersionId(checkpointFiles);
     // find last valid .checkpoint file and load checkpoints from it
+    int maxMemTableId = 0;
     List<Checkpoint> checkpoints = null;
     for (File checkpointFile : checkpointFiles) {
-      checkpoints = new CheckpointReader(checkpointFile).readAll();
+      CheckpointReader reader = new CheckpointReader(checkpointFile);
+      maxMemTableId = reader.getMaxMemTableId();
+      checkpoints = reader.getCheckpoints();
       if (!checkpoints.isEmpty()) {
         break;
       }
     }
     if (checkpoints == null || checkpoints.isEmpty()) {
-      return Collections.emptyMap();
+      return new CheckpointInfo(0, Collections.emptyMap());
     }
     // recover memTables information by checkpoints
     Map<Integer, MemTableInfo> memTableId2Info = new HashMap<>();
@@ -59,6 +62,7 @@ public class CheckpointRecoverUtils {
         case GLOBAL_MEMORY_TABLE_INFO:
         case CREATE_MEMORY_TABLE:
           for (MemTableInfo memTableInfo : checkpoint.getMemTableInfos()) {
+            maxMemTableId = Math.max(maxMemTableId, memTableInfo.getMemTableId());
             memTableId2Info.put(memTableInfo.getMemTableId(), memTableInfo);
           }
           break;
@@ -69,6 +73,24 @@ public class CheckpointRecoverUtils {
           break;
       }
     }
-    return memTableId2Info;
+    return new CheckpointInfo(maxMemTableId, memTableId2Info);
+  }
+
+  public static class CheckpointInfo {
+    private final int maxMemTableId;
+    private final Map<Integer, MemTableInfo> memTableId2Info;
+
+    public CheckpointInfo(int maxMemTableId, Map<Integer, MemTableInfo> memTableId2Info) {
+      this.maxMemTableId = maxMemTableId;
+      this.memTableId2Info = memTableId2Info;
+    }
+
+    public int getMaxMemTableId() {
+      return maxMemTableId;
+    }
+
+    public Map<Integer, MemTableInfo> getMemTableId2Info() {
+      return memTableId2Info;
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/CheckpointFileUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/CheckpointFileUtils.java
@@ -34,7 +34,8 @@ public class CheckpointFileUtils {
    */
   public static final Pattern CHECKPOINT_FILE_NAME_PATTERN =
       Pattern.compile(
-          WAL_FILE_PREFIX + "(?<" + WAL_VERSION_ID + ">\\d+)\\" + WAL_CHECKPOINT_FILE_SUFFIX);
+          String.format(
+              "%s(?<%s>\\d+)\\%s$", WAL_FILE_PREFIX, WAL_VERSION_ID, WAL_CHECKPOINT_FILE_SUFFIX));
 
   /** Return true when this file is .checkpoint file */
   public static boolean checkpointFilenameFilter(File dir, String name) {

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
@@ -42,13 +42,9 @@ public class WALFileUtils {
    */
   public static final Pattern WAL_FILE_NAME_PATTERN =
       Pattern.compile(
-          WAL_FILE_PREFIX
-              + "(?<"
-              + WAL_VERSION_ID
-              + ">\\d+)-(?<"
-              + WAL_START_SEARCH_INDEX
-              + ">\\d+)\\"
-              + WAL_FILE_SUFFIX);
+          String.format(
+              "%s(?<%s>\\d+)-(?<%s>\\d+)\\%s$",
+              WAL_FILE_PREFIX, WAL_VERSION_ID, WAL_START_SEARCH_INDEX, WAL_FILE_SUFFIX));
 
   /** Return true when this file is .wal file */
   public static boolean walFilenameFilter(File dir, String name) {

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
@@ -34,11 +34,11 @@ public class WALFileUtils {
   /**
    * versionId is a self-incremented id number, helping to maintain the order of wal files.
    * startSearchIndex is the valid search index of last flushed wal entry. For example: <br>
-   * &nbsp _0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
-   * &nbsp _1-5.wal: -1, -1, -1, -1 <br>
-   * &nbsp _2-5.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
-   * &nbsp _3-12.wal: 12, 12, 12, 12, 12 <br>
-   * &nbsp _4-12.wal: 12, 13, 14, 15, 16, -1 <br>
+   * _0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
+   * _1-5.wal: -1, -1, -1, -1 <br>
+   * _2-5.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
+   * _3-12.wal: 12, 12, 12, 12, 12 <br>
+   * _4-12.wal: 12, 13, 14, 15, 16, -1 <br>
    */
   public static final Pattern WAL_FILE_NAME_PATTERN =
       Pattern.compile(
@@ -86,11 +86,11 @@ public class WALFileUtils {
   /**
    * Find index of the file which probably contains target insert plan. <br>
    * Given wal files [ _0-0.wal, _1-5.wal, _2-5.wal, _3-12.wal, _4-12.wal ], details as below: <br>
-   * &nbsp _0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
-   * &nbsp _1-5.wal: -1, -1, -1, -1 <br>
-   * &nbsp _2-5.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
-   * &nbsp _3-12.wal: 12, 12, 12, 12, 12 <br>
-   * &nbsp _4-12.wal: 12, 13, 14, 15, 16, -1 <br>
+   * _0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
+   * _1-5.wal: -1, -1, -1, -1 <br>
+   * _2-5.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
+   * _3-12.wal: 12, 12, 12, 12, 12 <br>
+   * _4-12.wal: 12, 13, 14, 15, 16, -1 <br>
    * searching [1, 5] will return 0, searching [6, 12] will return 1, search [13, infinity) will
    * return 3， others will return -1
    *

--- a/server/src/test/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategyTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategyTest.java
@@ -108,7 +108,7 @@ public class FirstCreateStrategyTest {
     try {
       for (int i = 0; i < 12; i++) {
         String identifier = String.valueOf(i % 6);
-        roundRobinStrategy.registerWALNode(identifier, walDirs[0] + File.separator + identifier);
+        roundRobinStrategy.registerWALNode(identifier, walDirs[0] + File.separator + identifier, 0);
         IWALNode walNode = roundRobinStrategy.applyForWALNode(identifier);
         if (i < 6) {
           walNodes[i] = walNode;

--- a/server/src/test/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManagerTest.java
@@ -77,7 +77,7 @@ public class CheckpointManagerTest {
     CheckpointReader checkpointReader =
         new CheckpointReader(
             new File(logDirectory + File.separator + CheckpointFileUtils.getLogFileName(0)));
-    List<Checkpoint> actualCheckpoints = checkpointReader.readAll();
+    List<Checkpoint> actualCheckpoints = checkpointReader.getCheckpoints();
     assertEquals(expectedCheckpoints, actualCheckpoints);
   }
 
@@ -118,7 +118,7 @@ public class CheckpointManagerTest {
     assertEquals(memTablesNum / 2, checkpointManager.getFirstValidWALVersionId());
     // recover info from checkpoint file
     Map<Integer, MemTableInfo> actualMemTableId2Info =
-        CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory));
+        CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory)).getMemTableId2Info();
     assertEquals(expectedMemTableId2Info, actualMemTableId2Info);
   }
 
@@ -158,7 +158,7 @@ public class CheckpointManagerTest {
         new File(logDirectory + File.separator + CheckpointFileUtils.getLogFileName(1)).exists());
     // recover info from checkpoint file
     Map<Integer, MemTableInfo> actualMemTableId2Info =
-        CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory));
+        CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory)).getMemTableId2Info();
     assertEquals(expectedMemTableId2Info, actualMemTableId2Info);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/wal/io/CheckpointFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/io/CheckpointFileTest.java
@@ -69,12 +69,13 @@ public class CheckpointFileTest {
         new Checkpoint(
             CheckpointType.FLUSH_MEMORY_TABLE, Collections.singletonList(fakeMemTableInfo)));
     // test Checkpoint.serializedSize
-    int size = 0;
+    int size = Integer.BYTES;
     for (Checkpoint checkpoint : expectedCheckpoints) {
       size += checkpoint.serializedSize();
     }
     ByteBuffer buffer = ByteBuffer.allocate(size);
     // test Checkpoint.serialize
+    buffer.putInt(0);
     for (Checkpoint checkpoint : expectedCheckpoints) {
       checkpoint.serialize(buffer);
     }
@@ -85,7 +86,7 @@ public class CheckpointFileTest {
     }
     // test CheckpointReader.readAll
     CheckpointReader checkpointReader = new CheckpointReader(checkpointFile);
-    List<Checkpoint> actualCheckpoints = checkpointReader.readAll();
+    List<Checkpoint> actualCheckpoints = checkpointReader.getCheckpoints();
     assertEquals(expectedCheckpoints, actualCheckpoints);
   }
 
@@ -93,7 +94,7 @@ public class CheckpointFileTest {
   public void testReadNotExistFile() throws IOException {
     if (checkpointFile.createNewFile()) {
       CheckpointReader checkpointReader = new CheckpointReader(checkpointFile);
-      List<Checkpoint> actualCheckpoints = checkpointReader.readAll();
+      List<Checkpoint> actualCheckpoints = checkpointReader.getCheckpoints();
       assertEquals(0, actualCheckpoints.size());
     }
   }
@@ -111,12 +112,13 @@ public class CheckpointFileTest {
         new Checkpoint(
             CheckpointType.FLUSH_MEMORY_TABLE, Collections.singletonList(fakeMemTableInfo)));
     // test Checkpoint.serializedSize
-    int size = Byte.BYTES;
+    int size = Integer.BYTES + Byte.BYTES;
     for (Checkpoint checkpoint : expectedCheckpoints) {
       size += checkpoint.serializedSize();
     }
     ByteBuffer buffer = ByteBuffer.allocate(size);
     // test Checkpoint.serialize
+    buffer.putInt(0);
     for (Checkpoint checkpoint : expectedCheckpoints) {
       checkpoint.serialize(buffer);
     }
@@ -129,7 +131,7 @@ public class CheckpointFileTest {
     }
     // test CheckpointWriter.readAll
     CheckpointReader checkpointReader = new CheckpointReader(checkpointFile);
-    List<Checkpoint> actualCheckpoints = checkpointReader.readAll();
+    List<Checkpoint> actualCheckpoints = checkpointReader.getCheckpoints();
     assertEquals(expectedCheckpoints, actualCheckpoints);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
@@ -74,13 +74,13 @@ public class ConsensusReqReaderTest {
 
   /**
    * Generate wal files as below: <br>
-   * &nbsp _0-0.wal: 1,-1 <br>
-   * &nbsp _1-1.wal: 2,2,2 <br>
-   * &nbsp _2-2.wal: 3,3 <br>
-   * &nbsp _3-3.wal: 3,4 <br>
-   * &nbsp _4-4.wal: 4 <br>
-   * &nbsp _5-4.wal: 4,4,5 <br>
-   * &nbsp _6-5.wal: 6 <br>
+   * _0-0.wal: 1,-1 <br>
+   * _1-1.wal: 2,2,2 <br>
+   * _2-2.wal: 3,3 <br>
+   * _3-3.wal: 3,4 <br>
+   * _4-4.wal: 4 <br>
+   * _5-4.wal: 4,4,5 <br>
+   * _6-5.wal: 6 <br>
    * 1 - InsertRowNode, 2 - InsertRowsOfOneDeviceNode, 3 - InsertRowsNode, 4 -
    * InsertMultiTabletsNode, 5 - InsertTabletNode, 6 - InsertRowNode
    */

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
@@ -235,7 +235,7 @@ public class WALNodeTest {
     }
     // recover info from checkpoint file
     Map<Integer, MemTableInfo> actualMemTableId2Info =
-        CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory));
+        CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory)).getMemTableId2Info();
     assertEquals(expectedMemTableId2Info, actualMemTableId2Info);
   }
 


### PR DESCRIPTION
Some data will be recovered wrongly because wal is kept, but memtable id still starts from 0 when using multi-leader consensus. So, I recover memtable id when using multi-leader consensus.