### PR TITLE
[IOTDB-3350] Recover wal search index when recovering from multi-leader

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -3541,6 +3541,7 @@ public class DataRegion {
     return idTable;
   }
 
+  /** This method could only be used in multi-leader consensus */
   public IWALNode getWALNode() {
     if (!config
         .getDataRegionConsensusProtocolClass()

--- a/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
@@ -75,7 +75,9 @@ public class WALManager implements IService {
     return walNodesManager.applyForWALNode(applicantUniqueId);
   }
 
-  public void registerWALNode(String applicantUniqueId, String logDirectory, int startFileVersion) {
+  public void registerWALNode(
+      String applicantUniqueId, String logDirectory, int startFileVersion, long startSearchIndex) {
+    String s = config.getDataRegionConsensusProtocolClass();
     if (config.getWalMode() == WALMode.DISABLE
         || !config
             .getDataRegionConsensusProtocolClass()
@@ -84,7 +86,7 @@ public class WALManager implements IService {
     }
 
     ((FirstCreateStrategy) walNodesManager)
-        .registerWALNode(applicantUniqueId, logDirectory, startFileVersion);
+        .registerWALNode(applicantUniqueId, logDirectory, startFileVersion, startSearchIndex);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/AbstractNodeAllocationStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/AbstractNodeAllocationStrategy.java
@@ -77,9 +77,10 @@ public abstract class AbstractNodeAllocationStrategy implements NodeAllocationSt
     }
   }
 
-  protected IWALNode createWALNode(String identifier, String folder, int startFileVersion) {
+  protected IWALNode createWALNode(
+      String identifier, String folder, int startFileVersion, long startSearchIndex) {
     try {
-      return new WALNode(identifier, folder, startFileVersion);
+      return new WALNode(identifier, folder, startFileVersion, startSearchIndex);
     } catch (FileNotFoundException e) {
       logger.error("Fail to create wal node", e);
       return WALFakeNode.getFailureInstance(e);

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
@@ -60,14 +60,16 @@ public class FirstCreateStrategy extends AbstractNodeAllocationStrategy {
     }
   }
 
-  public void registerWALNode(String applicantUniqueId, String logDirectory, int startFileVersion) {
+  public void registerWALNode(
+      String applicantUniqueId, String logDirectory, int startFileVersion, long startSearchIndex) {
     nodesLock.lock();
     try {
       if (identifier2Nodes.containsKey(applicantUniqueId)) {
         return;
       }
 
-      IWALNode walNode = createWALNode(applicantUniqueId, logDirectory, startFileVersion);
+      IWALNode walNode =
+          createWALNode(applicantUniqueId, logDirectory, startFileVersion, startSearchIndex);
       if (walNode instanceof WALNode) {
         // avoid deletion
         ((WALNode) walNode).setSafelyDeletedSearchIndex(Long.MIN_VALUE);

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
@@ -41,11 +41,12 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
   /** current wal file version id */
   protected final AtomicInteger currentWALFileVersion = new AtomicInteger();
   /** current search index */
-  protected volatile long currentSearchIndex = 0;
+  protected volatile long currentSearchIndex;
   /** current wal file log writer */
   protected volatile ILogWriter currentWALFileWriter;
 
-  public AbstractWALBuffer(String identifier, String logDirectory, int startFileVersion)
+  public AbstractWALBuffer(
+      String identifier, String logDirectory, int startFileVersion, long startSearchIndex)
       throws FileNotFoundException {
     this.identifier = identifier;
     this.logDirectory = logDirectory;
@@ -53,6 +54,7 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
     if (!logDirFile.exists() && logDirFile.mkdirs()) {
       logger.info("create folder {} for wal buffer-{}.", logDirectory, identifier);
     }
+    currentSearchIndex = startSearchIndex;
     currentWALFileVersion.set(startFileVersion);
     currentWALFileWriter =
         new WALWriter(

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/WALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/WALBuffer.java
@@ -78,12 +78,13 @@ public class WALBuffer extends AbstractWALBuffer {
   private final ExecutorService syncBufferThread;
 
   public WALBuffer(String identifier, String logDirectory) throws FileNotFoundException {
-    this(identifier, logDirectory, 0);
+    this(identifier, logDirectory, 0, 0L);
   }
 
-  public WALBuffer(String identifier, String logDirectory, int startFileVersion)
+  public WALBuffer(
+      String identifier, String logDirectory, int startFileVersion, long startSearchIndex)
       throws FileNotFoundException {
-    super(identifier, logDirectory, startFileVersion);
+    super(identifier, logDirectory, startFileVersion, startSearchIndex);
     allocateBuffers();
     serializeThread =
         IoTDBThreadPoolFactory.newSingleThreadExecutor(

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -109,17 +109,18 @@ public class WALNode implements IWALNode {
   private volatile long safelyDeletedSearchIndex = DEFAULT_SAFELY_DELETED_SEARCH_INDEX;
 
   public WALNode(String identifier, String logDirectory) throws FileNotFoundException {
-    this(identifier, logDirectory, 0);
+    this(identifier, logDirectory, 0, 0L);
   }
 
-  public WALNode(String identifier, String logDirectory, int startFileVersion)
+  public WALNode(
+      String identifier, String logDirectory, int startFileVersion, long startSearchIndex)
       throws FileNotFoundException {
     this.identifier = identifier;
     this.logDirectory = SystemFileFactory.INSTANCE.getFile(logDirectory);
     if (!this.logDirectory.exists() && this.logDirectory.mkdirs()) {
       logger.info("create folder {} for wal node-{}.", logDirectory, identifier);
     }
-    this.buffer = new WALBuffer(identifier, logDirectory, startFileVersion);
+    this.buffer = new WALBuffer(identifier, logDirectory, startFileVersion, startSearchIndex);
     this.checkpointManager = new CheckpointManager(identifier, logDirectory);
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategyTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategyTest.java
@@ -108,7 +108,8 @@ public class FirstCreateStrategyTest {
     try {
       for (int i = 0; i < 12; i++) {
         String identifier = String.valueOf(i % 6);
-        roundRobinStrategy.registerWALNode(identifier, walDirs[0] + File.separator + identifier, 0);
+        roundRobinStrategy.registerWALNode(
+            identifier, walDirs[0] + File.separator + identifier, 0, 0L);
         IWALNode walNode = roundRobinStrategy.applyForWALNode(identifier);
         if (i < 6) {
           walNodes[i] = walNode;


### PR DESCRIPTION
Currently, the wal search index is always 0 when restart, causing some data unreachable. We should recover the search index when multi-leader consensus enabled.