### PR TITLE
[To rel/0.12][IOTDB-3326] fix new series in unseq files are not merged into correct seqfiles

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeNewSeriesTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeNewSeriesTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.engine.merge;
+
+import org.apache.iotdb.db.constant.TestConstant;
+import org.apache.iotdb.db.engine.merge.manage.MergeResource;
+import org.apache.iotdb.db.engine.merge.task.MergeTask;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.exception.metadata.MetadataException;
+import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * In the test, the unseq file has a new series that has never been written to seq files. However,
+ * other timeseries of its belonging device have already been written to the seq files. As a result,
+ * the unseq file and seq file are device-level overlapped but not series-level overlapped, and the
+ * new series in the unseq file should be written into seq files according to their device time
+ * range.
+ */
+public class MergeNewSeriesTest extends MergeTest {
+
+  private MeasurementSchema[] unseqSchemas = new MeasurementSchema[1];
+
+  @Override
+  public void setUp() throws IOException, WriteProcessException, MetadataException {
+    measurementNum = 1;
+    deviceNum = 2;
+    seqFileNum = 2;
+    // unseq files are manually prepared because they will have new time series
+    unseqFileNum = 0;
+    super.setUp();
+  }
+
+  @Override
+  protected void prepareSeries() throws MetadataException {
+    super.prepareSeries();
+    unseqSchemas[0] = toMeasurementSchema(1);
+    createTimeseries(deviceIds, unseqSchemas);
+  }
+
+  @Override
+  void prepareFiles(int seqFileNum, int unseqFileNum) throws IOException, WriteProcessException {
+    // seq file1: root.MergeTest.d0.s0[0,99] root.MergeTest.d1.s0[0,99]
+    // seq file2: root.MergeTest.d0.s0[100,199] root.MergeTest.d1.s0[100,199]
+    super.prepareFiles(seqFileNum, unseqFileNum);
+    // unseq file1: root.MergeTest.d0.s1[0,99]
+    // unseq file2: root.MergeTest.d1.s1[100,199]
+    // unseq1 should be written into seq1 while unseq2 should be written into seq2
+    TsFileResource unseq1 = prepareResource(2);
+    unseqResources.add(unseq1);
+    TsFileResource unseq2 = prepareResource(3);
+    unseqResources.add(unseq2);
+
+    prepareFile(unseq1, 0, ptNum, 0, Arrays.copyOfRange(deviceIds, 0, 1), unseqSchemas);
+    prepareFile(unseq2, ptNum, ptNum, 0, Arrays.copyOfRange(deviceIds, 1, 2), unseqSchemas);
+  }
+
+  @Test
+  public void testFullMerge() throws Exception {
+    MergeTask mergeTask =
+        new MergeTask(
+            new MergeResource(seqResources, unseqResources),
+            TestConstant.OUTPUT_DATA_DIR,
+            (k, v, l) -> {},
+            "test",
+            true,
+            1,
+            MERGE_TEST_SG);
+    mergeTask.call();
+
+    // query root.MergeTest.d0.s1 from seq1
+    List<TsFileResource> resources = Collections.singletonList(seqResources.get(0));
+    queryAndCheck(
+        deviceIds[0], unseqSchemas[0], resources, checkResultFunc(0), checkResultCntFunc(ptNum));
+
+    // query root.MergeTest.d1.s1 from seq2
+    resources = Collections.singletonList(seqResources.get(1));
+    queryAndCheck(
+        deviceIds[1], unseqSchemas[0], resources, checkResultFunc(0), checkResultCntFunc(ptNum));
+
+    // query root.MergeTest.d0.s1 from seq2
+    resources = Collections.singletonList(seqResources.get(1));
+    queryAndCheck(
+        deviceIds[0], unseqSchemas[0], resources, checkResultFunc(0), checkResultCntFunc(0));
+
+    // query root.MergeTest.d1.s1 from seq1
+    resources = Collections.singletonList(seqResources.get(0));
+    queryAndCheck(
+        deviceIds[1], unseqSchemas[0], resources, checkResultFunc(0), checkResultCntFunc(0));
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeOverLapTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeOverLapTest.java
@@ -20,7 +20,6 @@
 
 package org.apache.iotdb.db.engine.merge;
 
-import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.engine.merge.manage.MergeResource;
 import org.apache.iotdb.db.engine.merge.task.MergeTask;
@@ -75,66 +74,7 @@ public class MergeOverLapTest extends MergeTest {
     FileUtils.deleteDirectory(tempSGDir);
   }
 
-  @Override
-  void prepareFiles(int seqFileNum, int unseqFileNum) throws IOException, WriteProcessException {
-    for (int i = 0; i < seqFileNum; i++) {
-      File file =
-          new File(
-              TestConstant.OUTPUT_DATA_DIR.concat(
-                  i
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + i
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + 0
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + 0
-                      + ".tsfile"));
-      TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
-      tsFileResource.setMinPlanIndex(i);
-      tsFileResource.setMaxPlanIndex(i);
-      seqResources.add(tsFileResource);
-      prepareFile(tsFileResource, i * ptNum, ptNum, 0);
-    }
-    for (int i = 0; i < unseqFileNum; i++) {
-      File file =
-          new File(
-              TestConstant.OUTPUT_DATA_DIR.concat(
-                  (10000 + i)
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + (10000 + i)
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + 0
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + 0
-                      + ".tsfile"));
-      TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
-      tsFileResource.setMaxPlanIndex(i + seqFileNum);
-      tsFileResource.setMinPlanIndex(i + seqFileNum);
-      unseqResources.add(tsFileResource);
-      prepareUnseqFile(tsFileResource, i * ptNum, ptNum * (i + 1) / unseqFileNum, 10000);
-    }
-    File file =
-        new File(
-            TestConstant.OUTPUT_DATA_DIR.concat(
-                unseqFileNum
-                    + IoTDBConstant.FILE_NAME_SEPARATOR
-                    + unseqFileNum
-                    + IoTDBConstant.FILE_NAME_SEPARATOR
-                    + 0
-                    + IoTDBConstant.FILE_NAME_SEPARATOR
-                    + 0
-                    + ".tsfile"));
-    TsFileResource tsFileResource = new TsFileResource(file);
-    tsFileResource.setClosed(true);
-    tsFileResource.setMinPlanIndex(seqFileNum + unseqFileNum);
-    tsFileResource.setMaxPlanIndex(seqFileNum + unseqFileNum);
-    unseqResources.add(tsFileResource);
-    prepareUnseqFile(tsFileResource, 0, ptNum * unseqFileNum, 20000);
-  }
-
-  private void prepareUnseqFile(
+  protected void prepareUnseqFile(
       TsFileResource tsFileResource, long timeOffset, long ptNum, long valueOffset)
       throws IOException, WriteProcessException {
     TsFileWriter fileWriter = new TsFileWriter(tsFileResource.getTsFile());

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTaskTest.java
@@ -125,14 +125,14 @@ public class MergeTaskTest extends MergeTest {
 
   @Test
   public void testMergeEndTime() throws Exception {
-    List<TsFileResource> testSeqResources = seqResources.subList(0, 3);
+    List<TsFileResource> testSeqResources = seqResources.subList(0, 5);
     List<TsFileResource> testUnseqResource = unseqResources.subList(5, 6);
     MergeTask mergeTask =
         new MergeTask(
             new MergeResource(testSeqResources, testUnseqResource),
             tempSGDir.getPath(),
             (k, v, l) -> {
-              assertEquals(499, k.get(2).getEndTime("root.mergeTest.device1"));
+              assertEquals(499, k.get(4).getEndTime("root.mergeTest.device1"));
             },
             "test",
             false,
@@ -646,7 +646,7 @@ public class MergeTaskTest extends MergeTest {
             tempSGDir.getPath(),
             (k, v, l) -> {
               try (TsFileSequenceReader reader =
-                  new TsFileSequenceReader(k.get(2).getTsFilePath())) {
+                  new TsFileSequenceReader(k.get(0).getTsFilePath())) {
                 List<ChunkMetadata> chunkMetadataList =
                     reader.getChunkMetadataList(
                         new PartialPath(deviceIds[0], measurementSchemas[2].getMeasurementId()));

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MergeTest.java
@@ -27,16 +27,21 @@ import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.merge.manage.MergeManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
+import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.metadata.PartialPath;
+import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.FileReaderManager;
+import org.apache.iotdb.db.query.reader.series.SeriesRawDataBatchReader;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.common.BatchData;
 import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 import org.apache.iotdb.tsfile.write.TsFileWriter;
 import org.apache.iotdb.tsfile.write.record.TSRecord;
 import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
@@ -53,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.iotdb.db.conf.IoTDBConstant.PATH_SEPARATOR;
+import static org.junit.Assert.assertEquals;
 
 abstract class MergeTest {
 
@@ -62,7 +68,9 @@ abstract class MergeTest {
   int unseqFileNum = 5;
   int measurementNum = 10;
   int deviceNum = 10;
+  // points of each series in a file
   long ptNum = 100;
+  // flush each time "flushInterval" points of all series are written
   long flushInterval = 20;
   TSEncoding encoding = TSEncoding.PLAIN;
 
@@ -100,18 +108,30 @@ abstract class MergeTest {
     MergeManager.getINSTANCE().stop();
   }
 
+  protected MeasurementSchema toMeasurementSchema(int measurementIndex) {
+    return new MeasurementSchema(
+        "sensor" + measurementIndex, TSDataType.DOUBLE, encoding, CompressionType.UNCOMPRESSED);
+  }
+
+  protected String toDeviceId(int deviceIndex) {
+    return MERGE_TEST_SG + PATH_SEPARATOR + "device" + deviceIndex;
+  }
+
   protected void prepareSeries() throws MetadataException {
     measurementSchemas = new MeasurementSchema[measurementNum];
     for (int i = 0; i < measurementNum; i++) {
-      measurementSchemas[i] =
-          new MeasurementSchema(
-              "sensor" + i, TSDataType.DOUBLE, encoding, CompressionType.UNCOMPRESSED);
+      measurementSchemas[i] = toMeasurementSchema(i);
     }
     deviceIds = new String[deviceNum];
     for (int i = 0; i < deviceNum; i++) {
-      deviceIds[i] = MERGE_TEST_SG + PATH_SEPARATOR + "device" + i;
+      deviceIds[i] = toDeviceId(i);
     }
     IoTDB.metaManager.setStorageGroup(new PartialPath(MERGE_TEST_SG));
+    createTimeseries(deviceIds, measurementSchemas);
+  }
+
+  protected void createTimeseries(String[] deviceIds, MeasurementSchema[] measurementSchemas)
+      throws MetadataException {
     for (String device : deviceIds) {
       for (MeasurementSchema measurementSchema : measurementSchemas) {
         PartialPath devicePath = new PartialPath(device);
@@ -125,66 +145,60 @@ abstract class MergeTest {
     }
   }
 
-  void prepareFiles(int seqFileNum, int unseqFileNum) throws IOException, WriteProcessException {
-    for (int i = 0; i < seqFileNum; i++) {
-      File file =
-          new File(
-              TestConstant.OUTPUT_DATA_DIR.concat(
-                  i
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + i
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + 0
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + 0
-                      + ".tsfile"));
-      TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
-      tsFileResource.setMinPlanIndex(i);
-      tsFileResource.setMaxPlanIndex(i);
-      tsFileResource.setVersion(i);
-      seqResources.add(tsFileResource);
-      prepareFile(tsFileResource, i * ptNum, ptNum, 0);
-    }
-    for (int i = 0; i < unseqFileNum; i++) {
-      File file =
-          new File(
-              TestConstant.OUTPUT_DATA_DIR.concat(
-                  (10000 + i)
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + (10000 + i)
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + 0
-                      + IoTDBConstant.FILE_NAME_SEPARATOR
-                      + 0
-                      + ".tsfile"));
-      TsFileResource tsFileResource = new TsFileResource(file);
-      tsFileResource.setClosed(true);
-      tsFileResource.setMinPlanIndex(i + seqFileNum);
-      tsFileResource.setMaxPlanIndex(i + seqFileNum);
-      tsFileResource.setVersion(i + seqFileNum);
-      unseqResources.add(tsFileResource);
-      prepareFile(tsFileResource, i * ptNum, ptNum * (i + 1) / unseqFileNum, 10000);
-    }
+  protected String toFileName(int fileIndex) {
+    return TestConstant.OUTPUT_DATA_DIR.concat(
+        fileIndex
+            + IoTDBConstant.FILE_NAME_SEPARATOR
+            + fileIndex
+            + IoTDBConstant.FILE_NAME_SEPARATOR
+            + 0
+            + IoTDBConstant.FILE_NAME_SEPARATOR
+            + 0
+            + ".tsfile");
+  }
 
-    File file =
-        new File(
-            TestConstant.OUTPUT_DATA_DIR.concat(
-                unseqFileNum
-                    + IoTDBConstant.FILE_NAME_SEPARATOR
-                    + unseqFileNum
-                    + IoTDBConstant.FILE_NAME_SEPARATOR
-                    + 0
-                    + IoTDBConstant.FILE_NAME_SEPARATOR
-                    + 0
-                    + ".tsfile"));
+  protected TsFileResource prepareResource(int fileIndex) {
+    File file = new File(toFileName(fileIndex));
     TsFileResource tsFileResource = new TsFileResource(file);
     tsFileResource.setClosed(true);
-    tsFileResource.setMinPlanIndex(seqFileNum + unseqFileNum);
-    tsFileResource.setMaxPlanIndex(seqFileNum + unseqFileNum);
-    tsFileResource.setVersion(seqFileNum + unseqFileNum);
-    unseqResources.add(tsFileResource);
-    prepareFile(tsFileResource, 0, ptNum * unseqFileNum, 20000);
+    tsFileResource.setMinPlanIndex(fileIndex);
+    tsFileResource.setMaxPlanIndex(fileIndex);
+    tsFileResource.setVersion(fileIndex);
+    return tsFileResource;
+  }
+
+  protected void prepareSeqFile(
+      TsFileResource tsFileResource, long timeOffset, long ptNum, long valueOffset)
+      throws IOException, WriteProcessException {
+    prepareFile(tsFileResource, timeOffset, ptNum, valueOffset);
+  }
+
+  protected void prepareUnseqFile(
+      TsFileResource tsFileResource, long timeOffset, long ptNum, long valueOffset)
+      throws IOException, WriteProcessException {
+    prepareFile(tsFileResource, timeOffset, ptNum, valueOffset);
+  }
+
+  void prepareFiles(int seqFileNum, int unseqFileNum) throws IOException, WriteProcessException {
+    // seq files, each has "ptNum" points of all series
+    for (int i = 0; i < seqFileNum; i++) {
+      TsFileResource tsFileResource = prepareResource(i);
+      seqResources.add(tsFileResource);
+      prepareSeqFile(tsFileResource, i * ptNum, ptNum, 0);
+    }
+    // unseq files, each overlaps ONE seq file and latter ones has more points
+    for (int i = 0; i < unseqFileNum; i++) {
+      TsFileResource tsFileResource = prepareResource(seqFileNum + i);
+      unseqResources.add(tsFileResource);
+      prepareUnseqFile(tsFileResource, i * ptNum, ptNum * (i + 1) / unseqFileNum, 10000);
+    }
+
+    if (unseqFileNum > 0) {
+      // an additional unseq file that overlaps ALL seq files
+      TsFileResource tsFileResource = prepareResource(seqFileNum + unseqFileNum);
+      unseqResources.add(tsFileResource);
+      prepareUnseqFile(tsFileResource, 0, ptNum * unseqFileNum, 20000);
+    }
   }
 
   void removeFiles(List<TsFileResource> seqResList, List<TsFileResource> unseqResList)
@@ -203,6 +217,17 @@ abstract class MergeTest {
 
   void prepareFile(TsFileResource tsFileResource, long timeOffset, long ptNum, long valueOffset)
       throws IOException, WriteProcessException {
+    prepareFile(tsFileResource, timeOffset, ptNum, valueOffset, deviceIds, measurementSchemas);
+  }
+
+  void prepareFile(
+      TsFileResource tsFileResource,
+      long timeOffset,
+      long ptNum,
+      long valueOffset,
+      String[] deviceIds,
+      MeasurementSchema[] measurementSchemas)
+      throws IOException, WriteProcessException {
     File tsfile = tsFileResource.getTsFile();
     if (!tsfile.getParentFile().exists()) {
       Assert.assertTrue(tsfile.getParentFile().mkdirs());
@@ -215,23 +240,88 @@ abstract class MergeTest {
       }
     }
     for (long i = timeOffset; i < timeOffset + ptNum; i++) {
-      for (int j = 0; j < deviceNum; j++) {
-        TSRecord record = new TSRecord(i, deviceIds[j]);
-        for (int k = 0; k < measurementNum; k++) {
+      for (String deviceId : deviceIds) {
+        TSRecord record = new TSRecord(i, deviceId);
+        for (MeasurementSchema measurementSchema : measurementSchemas) {
           record.addTuple(
               DataPoint.getDataPoint(
-                  measurementSchemas[k].getType(),
-                  measurementSchemas[k].getMeasurementId(),
+                  measurementSchema.getType(),
+                  measurementSchema.getMeasurementId(),
                   String.valueOf(i + valueOffset)));
         }
         fileWriter.write(record);
-        tsFileResource.updateStartTime(deviceIds[j], i);
-        tsFileResource.updateEndTime(deviceIds[j], i);
+        tsFileResource.updateStartTime(deviceId, i);
+        tsFileResource.updateEndTime(deviceId, i);
       }
       if ((i + 1) % flushInterval == 0) {
         fileWriter.flushAllChunkGroups();
       }
     }
     fileWriter.close();
+  }
+
+  @FunctionalInterface
+  protected interface QueryResultChecker {
+    void check(long time, Object value, int pointIndex);
+  }
+
+  @FunctionalInterface
+  protected interface QueryCntChecker {
+    void check(int cnt);
+  }
+
+  protected static QueryResultChecker checkResultFunc(long valueOffset) {
+    return (time, value, index) -> assertEquals(time + valueOffset, (double) value, 0.001);
+  }
+
+  protected static QueryCntChecker checkResultCntFunc(long expected) {
+    return cnt -> assertEquals(expected, cnt);
+  }
+
+  /**
+   * Query all points of a timeseries and check point by point.
+   *
+   * @param deviceId of the queried timeseries
+   * @param measurementSchema of the queried timeseries
+   * @param resources files to be queried
+   * @param resultChecker how should each point be examined
+   * @param cntChecker how should the final count be examined
+   * @throws IOException
+   * @throws IllegalPathException
+   */
+  protected static void queryAndCheck(
+      String deviceId,
+      MeasurementSchema measurementSchema,
+      List<TsFileResource> resources,
+      QueryResultChecker resultChecker,
+      QueryCntChecker cntChecker)
+      throws IOException, IllegalPathException {
+    QueryContext context = new QueryContext();
+    PartialPath path = new PartialPath(deviceId, measurementSchema.getMeasurementId());
+    IBatchReader tsFilesReader =
+        new SeriesRawDataBatchReader(
+            path,
+            measurementSchema.getType(),
+            context,
+            resources,
+            new ArrayList<>(),
+            null,
+            null,
+            true);
+    int cnt = 0;
+    try {
+      while (tsFilesReader.hasNextBatch()) {
+        BatchData batchData = tsFilesReader.nextBatch();
+        for (int i = 0; i < batchData.length(); i++) {
+          long time = batchData.getTimeByIndex(i);
+          Object value = batchData.getDoubleByIndex(i);
+          resultChecker.check(time, value, i);
+          cnt++;
+        }
+      }
+      cntChecker.check(cnt);
+    } finally {
+      tsFilesReader.close();
+    }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -47,6 +47,7 @@ import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 import org.apache.iotdb.tsfile.read.reader.page.PageReader;
 import org.apache.iotdb.tsfile.utils.BloomFilter;
 import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.utils.PreviewIterator;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
@@ -1480,6 +1481,88 @@ public class TsFileSequenceReader implements AutoCloseable {
         }
       }
     };
+  }
+
+  public class DeviceChunkMetaListIterator
+      implements PreviewIterator<Pair<String, List<ChunkMetadata>>> {
+
+    private String device;
+    Queue<Pair<Long, Long>> leafMeasurementNodePositions;
+    Queue<Pair<String, List<ChunkMetadata>>> currentEntryQueue;
+
+    public DeviceChunkMetaListIterator(String device) throws IOException {
+      this.device = device;
+      init();
+    }
+
+    private void init() throws IOException {
+      readFileMetadata();
+
+      MetadataIndexNode metadataIndexNode = tsFileMetaData.getMetadataIndex();
+      Pair<MetadataIndexEntry, Long> metadataIndexPair =
+          getMetadataAndEndOffset(metadataIndexNode, device, true, true);
+
+      if (metadataIndexPair == null) {
+        return;
+      }
+
+      leafMeasurementNodePositions = new LinkedList<>();
+      ByteBuffer buffer = readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right);
+      collectEachLeafMeasurementNodeOffsetRange(buffer, leafMeasurementNodePositions);
+      currentEntryQueue = new LinkedList<>();
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (currentEntryQueue != null && !currentEntryQueue.isEmpty()) {
+        return true;
+      }
+      if (leafMeasurementNodePositions == null || leafMeasurementNodePositions.isEmpty()) {
+        return false;
+      }
+
+      Pair<Long, Long> startEndPair = leafMeasurementNodePositions.remove();
+      try {
+        ByteBuffer nextBuffer = readData(startEndPair.left, startEndPair.right);
+        while (nextBuffer.hasRemaining()) {
+          TimeseriesMetadata timeseriesMetadata =
+              TimeseriesMetadata.deserializeFrom(nextBuffer, true);
+          currentEntryQueue.add(
+              new Pair<>(
+                  timeseriesMetadata.getMeasurementId(),
+                  timeseriesMetadata.getChunkMetadataList()));
+        }
+      } catch (IOException e) {
+        throw new TsFileRuntimeException(
+            "Error occurred while reading a time series metadata block.");
+      }
+
+      return !currentEntryQueue.isEmpty();
+    }
+
+    public Pair<String, List<ChunkMetadata>> next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      return currentEntryQueue.poll();
+    }
+
+    @Override
+    public Pair<String, List<ChunkMetadata>> previewNext() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      return currentEntryQueue.peek();
+    }
+  }
+
+  /**
+   * @return An iterator of entry ( measurement -> chunk metadata list ). When traversing it, you
+   *     will get chunk metadata lists according to the lexicographic order of the measurements.
+   */
+  public PreviewIterator<Pair<String, List<ChunkMetadata>>> getMeasurementChunkMetadataListIterator(
+      String device) throws IOException {
+    return new DeviceChunkMetaListIterator(device);
   }
 
   private void collectEachLeafMeasurementNodeOffsetRange(

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/PreviewIterator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/PreviewIterator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tsfile.utils;
+
+import java.util.Iterator;
+
+/** A PreviewIterator allows to see what the next value will be without moving the cursor. */
+public interface PreviewIterator<T> extends Iterator<T> {
+  T previewNext();
+}


### PR DESCRIPTION
Please refer to https://issues.apache.org/jira/browse/IOTDB-3326

New timeseries in unseq files are merged into the last seq file, which results in a problematic device time range in the last seq file. After this fix, new time series in unseq files will be merged into seq files according to the device-level time range overlap.
