### PR TITLE
[IOTDB-3261][IOTDB-3332] Make the RegionBalancer thread-safe

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RegionBalancer.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RegionBalancer.java
@@ -41,12 +41,9 @@ import java.util.List;
 public class RegionBalancer {
 
   private final Manager configManager;
-  private final IRegionAllocator regionAllocator;
 
   public RegionBalancer(Manager configManager) {
     this.configManager = configManager;
-    // TODO: The RegionAllocator should be configurable
-    this.regionAllocator = new CopySetRegionAllocator();
   }
 
   /**
@@ -63,6 +60,7 @@ public class RegionBalancer {
       List<String> storageGroups, TConsensusGroupType consensusGroupType, int regionNum)
       throws NotEnoughDataNodeException, MetadataException {
     CreateRegionsReq createRegionsReq = new CreateRegionsReq();
+    IRegionAllocator regionAllocator = genRegionAllocator();
 
     List<TDataNodeInfo> onlineDataNodes = getNodeManager().getOnlineDataNodes(-1);
     List<TRegionReplicaSet> allocatedRegions = getPartitionManager().getAllocatedRegions();
@@ -97,6 +95,11 @@ public class RegionBalancer {
     }
 
     return createRegionsReq;
+  }
+
+  private IRegionAllocator genRegionAllocator() {
+    // TODO: The RegionAllocator should be configurable
+    return new CopySetRegionAllocator();
   }
 
   private NodeManager getNodeManager() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/allocator/CopySetRegionAllocator.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/allocator/CopySetRegionAllocator.java
@@ -45,7 +45,7 @@ public class CopySetRegionAllocator implements IRegionAllocator {
   private List<TDataNodeLocation> weightList;
 
   public CopySetRegionAllocator() {
-    // Empty constructor
+    this.weightList = new ArrayList<>();
   }
 
   @Override
@@ -74,7 +74,6 @@ public class CopySetRegionAllocator implements IRegionAllocator {
       intersectionSize += 1;
     }
 
-    clear();
     result.setRegionId(consensusGroupId);
     return result;
   }
@@ -97,7 +96,6 @@ public class CopySetRegionAllocator implements IRegionAllocator {
       }
     }
 
-    weightList = new ArrayList<>();
     for (Map.Entry<TDataNodeLocation, Integer> countEntry : countMap.entrySet()) {
       int weight = maximumRegionNum - countEntry.getValue() + 1;
       // Repeatedly add DataNode copies equal to the number of their weights
@@ -157,12 +155,5 @@ public class CopySetRegionAllocator implements IRegionAllocator {
       }
     }
     return true;
-  }
-
-  private void clear() {
-    maxId = 0;
-    intersectionSize = 0;
-    weightList.clear();
-    weightList = null;
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/allocator/IRegionAllocator.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/allocator/IRegionAllocator.java
@@ -24,6 +24,10 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 
 import java.util.List;
 
+/**
+ * The IRegionAllocator is a functional interface, which means a new functional class who implements
+ * the IRegionAllocator must be created for each Region allocation.
+ */
 public interface IRegionAllocator {
 
   /**


### PR DESCRIPTION
The reason why cause the [IOTDB-3261](https://issues.apache.org/jira/browse/IOTDB-3261) and [IOTDB-3332](https://issues.apache.org/jira/browse/IOTDB-3332) is that, the RegionAllocator is now not thread-safe. Therefore, when the Regions are allocated concurrently will cause the NPE.