### PR TITLE
[IOTDB-2978][compaction error log ] Log level and "null" error message handling

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/LocalTsFileInput.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/LocalTsFileInput.java
@@ -160,7 +160,7 @@ public class LocalTsFileInput implements TsFileInput {
     } catch (ClosedByInterruptException e) {
       logger.warn(
           "Current thread is interrupted by another thread when it is blocked in an I/O operation upon a channel.");
-      return "";
+      return null;
     }
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/LocalTsFileInput.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/LocalTsFileInput.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -78,6 +79,10 @@ public class LocalTsFileInput implements TsFileInput {
   public int read(ByteBuffer dst) throws IOException {
     try {
       return channel.read(dst);
+    } catch (ClosedByInterruptException e) {
+      logger.warn(
+          "Current thread is interrupted by another thread when it is blocked in an I/O operation upon a channel.");
+      return -1;
     } catch (IOException e) {
       logger.error("Error happened while reading {} from current position", filePath);
       throw e;
@@ -88,6 +93,10 @@ public class LocalTsFileInput implements TsFileInput {
   public int read(ByteBuffer dst, long position) throws IOException {
     try {
       return channel.read(dst, position);
+    } catch (ClosedByInterruptException e) {
+      logger.warn(
+          "Current thread is interrupted by another thread when it is blocked in an I/O operation upon a channel.");
+      return -1;
     } catch (IOException e) {
       logger.error("Error happened while reading {} from position {}", filePath, position);
       throw e;
@@ -131,22 +140,28 @@ public class LocalTsFileInput implements TsFileInput {
 
   @Override
   public String readVarIntString(long offset) throws IOException {
-    ByteBuffer byteBuffer = ByteBuffer.allocate(5);
-    channel.read(byteBuffer, offset);
-    byteBuffer.flip();
-    int strLength = ReadWriteForEncodingUtils.readVarInt(byteBuffer);
-    if (strLength < 0) {
-      return null;
-    } else if (strLength == 0) {
+    try {
+      ByteBuffer byteBuffer = ByteBuffer.allocate(5);
+      channel.read(byteBuffer, offset);
+      byteBuffer.flip();
+      int strLength = ReadWriteForEncodingUtils.readVarInt(byteBuffer);
+      if (strLength < 0) {
+        return null;
+      } else if (strLength == 0) {
+        return "";
+      }
+      ByteBuffer strBuffer = ByteBuffer.allocate(strLength);
+      int varIntLength = ReadWriteForEncodingUtils.varIntSize(strLength);
+      byte[] bytes = new byte[strLength];
+      channel.read(strBuffer, offset + varIntLength);
+      strBuffer.flip();
+      strBuffer.get(bytes, 0, strLength);
+      return new String(bytes, 0, strLength);
+    } catch (ClosedByInterruptException e) {
+      logger.warn(
+          "Current thread is interrupted by another thread when it is blocked in an I/O operation upon a channel.");
       return "";
     }
-    ByteBuffer strBuffer = ByteBuffer.allocate(strLength);
-    int varIntLength = ReadWriteForEncodingUtils.varIntSize(strLength);
-    byte[] bytes = new byte[strLength];
-    channel.read(strBuffer, offset + varIntLength);
-    strBuffer.flip();
-    strBuffer.get(bytes, 0, strLength);
-    return new String(bytes, 0, strLength);
   }
 
   @Override


### PR DESCRIPTION
When a thread is been interrupted, it will throw:

(1) InterruptedException, when it is in sleep, wait, join blocking, etc.

(2) ClosedByInterruptException, when it is in the process of calling a blocking I/O operation on an interruptible channel (eg: serverSocketChannel.accept(), socketChannel.connect, socketChannel.open, socketChannel.read, socketChannel.write, fileChannel.read, fileChannel.write)

So here, we catch the InterruptedException and ClosedByInterruptException in compaction process and print warn logs.