### PR TITLE
[IOTDB-3383] Refactor calcInputLocationList() in LocalExecutionPlanner

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/aggregation/timerangeiterator/TimeRangeIteratorFactory.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/aggregation/timerangeiterator/TimeRangeIteratorFactory.java
@@ -40,10 +40,10 @@ public class TimeRangeIteratorFactory {
       boolean isIntervalByMonth,
       boolean isSlidingStepByMonth,
       boolean leftCRightO,
-      boolean isPreAggr) {
+      boolean outputPartialTimeWindow) {
     long tmpInterval = isIntervalByMonth ? interval * MS_TO_MONTH : interval;
     long tmpSlidingStep = isSlidingStepByMonth ? slidingStep * MS_TO_MONTH : slidingStep;
-    if (isPreAggr && tmpInterval > tmpSlidingStep) {
+    if (outputPartialTimeWindow && tmpInterval > tmpSlidingStep) {
       if (!isIntervalByMonth && !isSlidingStepByMonth) {
         return new PreAggrWindowIterator(
             startTime, endTime, interval, slidingStep, isAscending, leftCRightO);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/AggregationOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/AggregationOperator.java
@@ -53,7 +53,7 @@ public class AggregationOperator implements ProcessOperator {
   private final TsBlock[] inputTsBlocks;
   private final TsBlockBuilder tsBlockBuilder;
 
-  private ITimeRangeIterator timeRangeIterator;
+  private final ITimeRangeIterator timeRangeIterator;
   // current interval of aggregation window [curStartTime, curEndTime)
   private TimeRange curTimeRange;
 
@@ -62,7 +62,8 @@ public class AggregationOperator implements ProcessOperator {
       List<Aggregator> aggregators,
       List<Operator> children,
       boolean ascending,
-      GroupByTimeParameter groupByTimeParameter) {
+      GroupByTimeParameter groupByTimeParameter,
+      boolean outputPartialTimeWindow) {
     this.operatorContext = operatorContext;
     this.aggregators = aggregators;
     this.children = children;
@@ -74,7 +75,8 @@ public class AggregationOperator implements ProcessOperator {
       dataTypes.addAll(Arrays.asList(aggregator.getOutputType()));
     }
     tsBlockBuilder = new TsBlockBuilder(dataTypes);
-    this.timeRangeIterator = initTimeRangeIterator(groupByTimeParameter, ascending, true);
+    this.timeRangeIterator =
+        initTimeRangeIterator(groupByTimeParameter, ascending, outputPartialTimeWindow);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/AggregationOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/AggregationOperator.java
@@ -98,7 +98,13 @@ public class AggregationOperator implements ProcessOperator {
     // update input tsBlock
     curTimeRange = timeRangeIterator.nextTimeRange();
     for (int i = 0; i < inputOperatorsCount; i++) {
+      if (inputTsBlocks[i] != null) {
+        continue;
+      }
       inputTsBlocks[i] = children.get(i).next();
+      if (inputTsBlocks[i] == null) {
+        return null;
+      }
     }
     // consume current input tsBlocks
     for (Aggregator aggregator : aggregators) {
@@ -106,6 +112,9 @@ public class AggregationOperator implements ProcessOperator {
       aggregator.processTsBlocks(inputTsBlocks);
     }
     // output result from aggregator
+    for (int i = 0; i < inputOperatorsCount; i++) {
+      inputTsBlocks[i] = null;
+    }
     return updateResultTsBlockFromAggregators(tsBlockBuilder, aggregators, timeRangeIterator);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/AggregationOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/AggregationOperator.java
@@ -98,7 +98,9 @@ public class AggregationOperator implements ProcessOperator {
   @Override
   public TsBlock next() {
     // update input tsBlock
-    curTimeRange = timeRangeIterator.nextTimeRange();
+    if (curTimeRange == null && timeRangeIterator.hasNextTimeRange()) {
+      curTimeRange = timeRangeIterator.nextTimeRange();
+    }
     for (int i = 0; i < inputOperatorsCount; i++) {
       if (inputTsBlocks[i] != null) {
         continue;
@@ -114,6 +116,7 @@ public class AggregationOperator implements ProcessOperator {
       aggregator.processTsBlocks(inputTsBlocks);
     }
     // output result from aggregator
+    curTimeRange = null;
     for (int i = 0; i < inputOperatorsCount; i++) {
       inputTsBlocks[i] = null;
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/AggregationOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/AggregationOperator.java
@@ -125,7 +125,7 @@ public class AggregationOperator implements ProcessOperator {
 
   @Override
   public boolean hasNext() {
-    return timeRangeIterator.hasNextTimeRange();
+    return curTimeRange != null || timeRangeIterator.hasNextTimeRange();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesAggregationScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesAggregationScanOperator.java
@@ -110,7 +110,9 @@ public class SeriesAggregationScanOperator implements DataSourceOperator {
    * timestamp, so it doesn't matter what the time range returns.
    */
   public static ITimeRangeIterator initTimeRangeIterator(
-      GroupByTimeParameter groupByTimeParameter, boolean ascending, boolean isPreAggr) {
+      GroupByTimeParameter groupByTimeParameter,
+      boolean ascending,
+      boolean outputPartialTimeWindow) {
     if (groupByTimeParameter == null) {
       return new SingleTimeWindowIterator(0, Long.MAX_VALUE);
     } else {
@@ -123,7 +125,7 @@ public class SeriesAggregationScanOperator implements DataSourceOperator {
           groupByTimeParameter.isIntervalByMonth(),
           groupByTimeParameter.isSlidingStepByMonth(),
           groupByTimeParameter.isLeftCRightO(),
-          isPreAggr);
+          outputPartialTimeWindow);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analyzer.java
@@ -655,7 +655,8 @@ public class Analyzer {
         Set<Expression> transformExpressions,
         Map<Expression, Expression> rawPathToGroupedPathMap) {
       GroupByLevelController groupByLevelController =
-          new GroupByLevelController(queryStatement.getGroupByLevelComponent().getLevels());
+          new GroupByLevelController(
+              queryStatement.getGroupByLevelComponent().getLevels(), typeProvider);
       for (Pair<Expression, String> measurementWithAlias : outputExpressions) {
         groupByLevelController.control(measurementWithAlias.left, measurementWithAlias.right);
       }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/GroupByLevelController.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/GroupByLevelController.java
@@ -61,12 +61,15 @@ public class GroupByLevelController {
    */
   private final Map<String, String> aliasToColumnMap;
 
-  public GroupByLevelController(int[] levels) {
+  private final TypeProvider typeProvider;
+
+  public GroupByLevelController(int[] levels, TypeProvider typeProvider) {
     this.levels = levels;
     this.groupedPathMap = new LinkedHashMap<>();
     this.rawPathToGroupedPathMap = new HashMap<>();
     this.columnToAliasMap = new HashMap<>();
     this.aliasToColumnMap = new HashMap<>();
+    this.typeProvider = typeProvider;
   }
 
   public void control(Expression expression, String alias) {
@@ -77,6 +80,7 @@ public class GroupByLevelController {
 
     PartialPath rawPath = ((TimeSeriesOperand) expression.getExpressions().get(0)).getPath();
     PartialPath groupedPath = generatePartialPathByLevel(rawPath.getNodes(), levels);
+    typeProvider.setType(groupedPath.getFullPath(), rawPath.getSeriesType());
 
     Expression rawPathExpression = new TimeSeriesOperand(rawPath);
     Expression groupedPathExpression = new TimeSeriesOperand(groupedPath);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanner.java
@@ -846,7 +846,7 @@ public class LocalExecutionPlanner {
               node.getPlanNodeId(),
               AggregationOperator.class.getSimpleName());
       return new AggregationOperator(
-          operatorContext, aggregators, children, ascending, node.getGroupByTimeParameter());
+          operatorContext, aggregators, children, ascending, node.getGroupByTimeParameter(), false);
     }
 
     @Override
@@ -953,7 +953,12 @@ public class LocalExecutionPlanner {
                 node.getPlanNodeId(),
                 AggregationOperator.class.getSimpleName());
         return new AggregationOperator(
-            operatorContext, aggregators, children, ascending, node.getGroupByTimeParameter());
+            operatorContext,
+            aggregators,
+            children,
+            ascending,
+            node.getGroupByTimeParameter(),
+            true);
       }
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanner.java
@@ -840,7 +840,7 @@ public class LocalExecutionPlanner {
                     context
                         .getTypeProvider()
                         // get the type of first inputExpression
-                        .getType(inputColumnNames.get(0)),
+                        .getType(descriptor.getInputExpressions().get(0).getExpressionString()),
                     ascending),
                 descriptor.getStep(),
                 inputLocationList));

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/parameter/AggregationDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/parameter/AggregationDescriptor.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,20 +73,16 @@ public class AggregationDescriptor {
     return outputColumnNames;
   }
 
-  public List<String> getInputColumnNames() {
+  public List<List<String>> getInputColumnNamesList() {
     if (step.isInputRaw()) {
       return inputExpressions.stream()
-          .map(Expression::getExpressionString)
+          .map(expression -> Collections.singletonList(expression.getExpressionString()))
           .collect(Collectors.toList());
     }
 
-    List<AggregationType> inputAggregationTypes = getActualAggregationTypes(step.isInputPartial());
-    List<String> inputColumnNames = new ArrayList<>();
+    List<List<String>> inputColumnNames = new ArrayList<>();
     for (Expression expression : inputExpressions) {
-      for (AggregationType funcName : inputAggregationTypes) {
-        inputColumnNames.add(
-            funcName.toString().toLowerCase() + "(" + expression.getExpressionString() + ")");
-      }
+      inputColumnNames.add(getInputColumnNames(expression));
     }
     return inputColumnNames;
   }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/AggregationOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/AggregationOperatorTest.java
@@ -316,6 +316,7 @@ public class AggregationOperatorTest {
         finalAggregators,
         children,
         true,
-        groupByTimeParameter);
+        groupByTimeParameter,
+        true);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/analyze/AggregationDescriptorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/analyze/AggregationDescriptorTest.java
@@ -145,20 +145,19 @@ public class AggregationDescriptorTest {
 
   @Test
   public void testInputColumnNames() {
-    List<String> expectedInputColumnNames =
+    List<List<List<String>>> expectedInputColumnNames =
         Arrays.asList(
-            "root.sg.d1.s1",
-            "count(root.sg.d1.s1)",
-            "sum(root.sg.d1.s1)",
-            "last_value(root.sg.d1.s1)",
-            "max_time(root.sg.d1.s1)",
-            "max_value(root.sg.d1.s1)");
+            Collections.singletonList(Collections.singletonList("root.sg.d1.s1")),
+            Collections.singletonList(Collections.singletonList("root.sg.d1.s1")),
+            Collections.singletonList(Arrays.asList("count(root.sg.d1.s1)", "sum(root.sg.d1.s1)")),
+            Collections.singletonList(
+                Arrays.asList("last_value(root.sg.d1.s1)", "max_time(root.sg.d1.s1)")),
+            Collections.singletonList(Collections.singletonList("max_value(root.sg.d1.s1)")),
+            Collections.singletonList(Collections.singletonList("count(root.sg.d1.s1)")));
     Assert.assertEquals(
         expectedInputColumnNames,
         aggregationDescriptorList.stream()
-            .map(AggregationDescriptor::getInputColumnNames)
-            .flatMap(List::stream)
-            .distinct()
+            .map(AggregationDescriptor::getInputColumnNamesList)
             .collect(Collectors.toList()));
   }
 
@@ -177,18 +176,24 @@ public class AggregationDescriptorTest {
 
   @Test
   public void testInputColumnNamesInGroupByLevel() {
-    List<String> expectedInputColumnNames =
+    List<List<List<String>>> expectedInputColumnNames =
         Arrays.asList(
-            "count(root.sg.d2.s1)",
-            "count(root.sg.d1.s1)",
-            "sum(root.sg.d1.s1)",
-            "sum(root.sg.d2.s1)");
+            Arrays.asList(
+                Collections.singletonList("count(root.sg.d2.s1)"),
+                Collections.singletonList("count(root.sg.d1.s1)")),
+            Arrays.asList(
+                Arrays.asList("count(root.sg.d1.s1)", "sum(root.sg.d1.s1)"),
+                Arrays.asList("count(root.sg.d2.s1)", "sum(root.sg.d2.s1)")),
+            Arrays.asList(
+                Collections.singletonList("count(root.sg.d2.s1)"),
+                Collections.singletonList("count(root.sg.d1.s1)")),
+            Arrays.asList(
+                Arrays.asList("count(root.sg.d1.s1)", "sum(root.sg.d1.s1)"),
+                Arrays.asList("count(root.sg.d2.s1)", "sum(root.sg.d2.s1)")));
     Assert.assertEquals(
         expectedInputColumnNames,
         groupByLevelDescriptorList.stream()
-            .map(GroupByLevelDescriptor::getInputColumnNames)
-            .flatMap(List::stream)
-            .distinct()
+            .map(GroupByLevelDescriptor::getInputColumnNamesList)
             .collect(Collectors.toList()));
   }
 


### PR DESCRIPTION
In this PR, I refactor calcInputLocationList() in LocalExecutionPlanner.

**Test result:**
```SQL
select last_value(s5), sum(s2), max_value(s3) from root.sg1.**;
```
![7579c97c7941470f0be74702aa4fffb](https://user-images.githubusercontent.com/36565497/171595377-9e40cb1a-563f-469e-aa92-0a74683a376c.png)

```SQL
select last_value(s5), sum(s2), max_value(s3) from root.sg1.** group by level = 1;
```
![f39a24b755ac3664ffde9be8be1d2e9](https://user-images.githubusercontent.com/36565497/171595392-a933ba70-1e8b-48d1-a1cb-38c1578add9a.png)

```SQL
select last_value(s5), sum(s2), max_value(s3) from root.sg1.** group by ([1,41), 10ms);
```
![8f21c4f17a02658c450507b9b5e0744](https://user-images.githubusercontent.com/36565497/171595414-8fc7e4f8-07b3-42fd-850a-50ace5b0ea00.png)

```SQL
select last_value(s5), sum(s2), max_value(s3) from root.sg1.** group by ([1,41), 10ms), level = 1;
```
![fe39d1306812a003a6406f84e858271](https://user-images.githubusercontent.com/36565497/171595434-15d5e3ca-ea70-42b4-8230-bb6a2a078bb6.png)

```SQL
select last_value(s5), sum(s2), max_value(s3) from root.sg1.** group by ([1,41), 10ms, 5ms);
```
![9a68dd65aac1d4b6f9d22fc4dc5816d](https://user-images.githubusercontent.com/36565497/171595449-e2934a4d-59af-41c4-ac9a-899457016214.png)

```SQL
select last_value(s5), sum(s2), max_value(s3) from root.sg1.** group by ([1,41), 10ms, 5ms), level = 1;
```
![a23c705a79f4de00661f50bfc1a714e](https://user-images.githubusercontent.com/36565497/171595463-47f25c6c-a7fb-4a2b-be02-76fb0f9b5598.png)