### PR TITLE
[To rel/0.12] add log in query when a file does not contain a device that should in

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -333,7 +333,8 @@ public class TsFileSequenceReader implements AutoCloseable {
       if (ignoreNotExists) {
         return null;
       }
-      throw new IOException("Device {" + path.getDevice() + "} is not in tsFileMetaData");
+      logger.warn("Device {} is not in {}", path.getDevice(), file);
+      return null;
     }
     ByteBuffer buffer = readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right);
     MetadataIndexNode metadataIndexNode = deviceMetadataIndexNode;


### PR DESCRIPTION
When a device should be in a TsFile, we throw an exception when query. 
I change this to a warn log with file name.