### PR TITLE
Add an error message for setting TTL when the storagegroup does not exist

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
@@ -204,6 +204,7 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
             .getStorageGroupSchema()
             .setTTL(req.getTTL());
         result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
+        result.setMessage("StorageGroup does not exist");
       } else {
         result.setCode(TSStatusCode.STORAGE_GROUP_NOT_EXIST.getStatusCode());
       }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
@@ -204,9 +204,9 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
             .getStorageGroupSchema()
             .setTTL(req.getTTL());
         result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
-        result.setMessage("StorageGroup does not exist");
       } else {
         result.setCode(TSStatusCode.STORAGE_GROUP_NOT_EXIST.getStatusCode());
+        result.setMessage("StorageGroup does not exist");
       }
     } catch (MetadataException e) {
       LOGGER.error("Error StorageGroup name", e);

--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTtlIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTtlIT.java
@@ -74,7 +74,6 @@ public class IoTDBTtlIT {
         statement.execute("SET TTL TO root.TTL_SG1.s1 1000");
       } catch (SQLException e) {
         assertEquals(TSStatusCode.STORAGE_GROUP_NOT_EXIST.getStatusCode(), e.getErrorCode());
-        assertEquals("StorageGroup does not exist", e.getMessage());
       }
 
       long now = System.currentTimeMillis();

--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTtlIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBTtlIT.java
@@ -74,6 +74,7 @@ public class IoTDBTtlIT {
         statement.execute("SET TTL TO root.TTL_SG1.s1 1000");
       } catch (SQLException e) {
         assertEquals(TSStatusCode.STORAGE_GROUP_NOT_EXIST.getStatusCode(), e.getErrorCode());
+        assertEquals("StorageGroup does not exist", e.getMessage());
       }
 
       long now = System.currentTimeMillis();


### PR DESCRIPTION
before：
IoTDB> set ttl to root.sgcc 3600
Msg: 500: [INTERNAL_SERVER_ERROR(500)] Exception occurred: "set ttl to root.sgcc 3600". executeStatement failed. error code: TSStatus(code:500, message:322: null)

after：
IoTDB> set ttl to root.sgcc 3600
Msg: 500: [INTERNAL_SERVER_ERROR(500)] Exception occurred: "set ttl to root.sgcc 3600". executeStatement failed. error code: TSStatus(code:500, message:322: StorageGroup does not exist)