### PR TITLE
[To rel/0.12] fix security manager permission.

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCheckConfigIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBCheckConfigIT.java
@@ -74,6 +74,12 @@ public class IoTDBCheckConfigIT {
               throw new AccessControlException("Wrong system config");
             }
           }
+
+          public void checkPermission(Permission permission, Object context) {
+            if (permission.getName().startsWith("exitVM")) {
+              throw new AccessControlException("Wrong system config");
+            }
+          }
         };
     System.setSecurityManager(securityManager);
     bytes = new ByteArrayOutputStream();


### PR DESCRIPTION
See more details: https://issues.apache.org/jira/browse/IOTDB-3404.

This mainly because some methods in security manager need to be overrided.