### PR TITLE
Fix SchemaTree SearchDeviceSchema NPE

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTree.java
@@ -115,6 +115,10 @@ public class SchemaTree {
       cur = cur.getChild(nodes[i]);
     }
 
+    if (cur == null) {
+      return null;
+    }
+
     List<SchemaMeasurementNode> measurementNodeList = new ArrayList<>();
     SchemaNode node;
     for (String measurement : measurements) {

--- a/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeTest.java
@@ -537,6 +537,19 @@ public class SchemaTreeTest {
     testSchemaTree(schemaTree.getRoot());
   }
 
+  @Test
+  public void testMergeSchemaTreeAndSearchDeviceSchemaInfo() throws Exception {
+    SchemaTree schemaTree = new SchemaTree();
+    for (SchemaTree tree : generateSchemaTrees()) {
+      schemaTree.mergeSchemaTree(tree);
+    }
+    PartialPath devicePath = new PartialPath("root.sg.d99999");
+    List<String> measurements = new ArrayList<>();
+    measurements.add("s1");
+    measurements.add("s2");
+    schemaTree.searchDeviceSchemaInfo(devicePath, measurements);
+  }
+
   private List<SchemaTree> generateSchemaTrees() throws Exception {
     List<SchemaTree> schemaTreeList = new ArrayList<>();
     SchemaTree schemaTree;


### PR DESCRIPTION
## Description

To reproduce, add the following UT in SchemaTreeTest.

```java
@Test
public void testMergeSchemaTreeAndSearchDeviceSchemaInfo() throws Exception {
  SchemaTree schemaTree = new SchemaTree();
  for (SchemaTree tree : generateSchemaTrees()) {
    schemaTree.mergeSchemaTree(tree);
  }
  PartialPath devicePath = new PartialPath("root.sg.d99999");
  List<String> measurements = new ArrayList<>();
  measurements.add("s1");
  measurements.add("s2");
  schemaTree.searchDeviceSchemaInfo(devicePath, measurements);
}
```