### PR TITLE
[ISSUE-6171]Support createTimeseriesOfTemplate in Session 

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
+++ b/integration/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
@@ -392,6 +392,10 @@ public class TemplateUT {
       assertEquals("303: Path [root.sg.v2] has not been set any template.", e.getMessage());
     }
 
+    assertEquals(
+        new HashSet<>(Collections.singletonList("Time")),
+        new HashSet<>(session.executeQueryStatement("SELECT * FROM root.**").getColumnNames()));
+
     session.createTimeseriesOfTemplateOnPath("root.sg.v1.d1");
     assertEquals("[root.sg.v1.d1]", session.showPathsTemplateUsingOn("template1").toString());
 

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
@@ -99,6 +99,7 @@ import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateResp;
 import org.apache.iotdb.service.rpc.thrift.TSRawDataQueryReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
+import org.apache.iotdb.service.rpc.thrift.TSSetUsingTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
 
 import org.apache.thrift.TException;
@@ -1184,6 +1185,11 @@ public class DataNodeTSIServiceImpl implements TSIEventHandler {
 
   @Override
   public TSStatus setSchemaTemplate(TSSetSchemaTemplateReq req) throws TException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TSStatus setUsingTemplate(TSSetUsingTemplateReq req) throws TException {
     throw new UnsupportedOperationException();
   }
 

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -43,6 +43,7 @@ import org.apache.iotdb.service.rpc.thrift.TSPruneSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateResp;
 import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TSSetUsingTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
 import org.apache.iotdb.session.template.MeasurementNode;
 import org.apache.iotdb.session.template.Template;
@@ -2373,6 +2374,14 @@ public class Session {
     req.setQueryType(TemplateQueryType.SHOW_USING_TEMPLATES.ordinal());
     TSQueryTemplateResp resp = defaultSessionConnection.querySchemaTemplate(req);
     return resp.getMeasurements();
+  }
+
+  /** Set designated path using template, act like the sql-statement with same syntax. */
+  public void createTimeseriesOfTemplateOnPath(String path)
+      throws IoTDBConnectionException, StatementExecutionException {
+    TSSetUsingTemplateReq request = new TSSetUsingTemplateReq();
+    request.setDstPath(path);
+    defaultSessionConnection.setUsingTemplate(request);
   }
 
   public void unsetSchemaTemplate(String prefixPath, String templateName)

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -54,6 +54,7 @@ import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateResp;
 import org.apache.iotdb.service.rpc.thrift.TSRawDataQueryReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
+import org.apache.iotdb.service.rpc.thrift.TSSetUsingTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
 import org.apache.iotdb.session.util.SessionUtils;
 
@@ -895,6 +896,25 @@ public class SessionConnection {
         try {
           request.setSessionId(sessionId);
           RpcUtils.verifySuccess(client.setSchemaTemplate(request));
+        } catch (TException tException) {
+          throw new IoTDBConnectionException(tException);
+        }
+      } else {
+        throw new IoTDBConnectionException(MSG_RECONNECTION_FAIL);
+      }
+    }
+  }
+
+  protected void setUsingTemplate(TSSetUsingTemplateReq request)
+      throws IoTDBConnectionException, StatementExecutionException {
+    request.setSessionId(sessionId);
+    try {
+      RpcUtils.verifySuccess(client.setUsingTemplate(request));
+    } catch (TException e) {
+      if (reconnect()) {
+        try {
+          request.setSessionId(sessionId);
+          RpcUtils.verifySuccess(client.setUsingTemplate(request));
         } catch (TException tException) {
           throw new IoTDBConnectionException(tException);
         }

--- a/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -2108,6 +2108,24 @@ public class SessionPool {
     }
   }
 
+  public void createTimeseriesOfTemplateOnPath(String path)
+      throws IoTDBConnectionException, StatementExecutionException {
+    for (int i = 0; i < RETRY; i++) {
+      Session session = getSession();
+      try {
+        session.createTimeseriesOfTemplateOnPath(path);
+        putBack(session);
+      } catch (IoTDBConnectionException e) {
+        // TException means the connection is broken, remove it and get a new one.
+        logger.warn(String.format("create timeseries of template on [%s] failed", path), e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
+      } catch (StatementExecutionException | RuntimeException e) {
+        putBack(session);
+        throw e;
+      }
+    }
+  }
+
   public void unsetSchemaTemplate(String prefixPath, String templateName)
       throws StatementExecutionException, IoTDBConnectionException {
     for (int i = 0; i < RETRY; i++) {

--- a/thrift/src/main/thrift/rpc.thrift
+++ b/thrift/src/main/thrift/rpc.thrift
@@ -401,6 +401,11 @@ struct TSUnsetSchemaTemplateReq {
   3: required string templateName
 }
 
+struct TSSetUsingTemplateReq {
+  1: required i64 sessionId
+  2: required string dstPath
+}
+
 struct TSDropSchemaTemplateReq {
   1: required i64 sessionId
   2: required string templateName
@@ -494,6 +499,8 @@ service TSIService {
   common.TSStatus setSchemaTemplate(1:TSSetSchemaTemplateReq req);
 
   common.TSStatus unsetSchemaTemplate(1:TSUnsetSchemaTemplateReq req);
+
+  common.TSStatus setUsingTemplate(1:TSSetUsingTemplateReq req);
 
   common.TSStatus dropSchemaTemplate(1:TSDropSchemaTemplateReq req);
 }


### PR DESCRIPTION
As issue-#6171 suggested, this PR adds an interface in `Session` and `SessionPool` to support create timeseries of schema template on a designated path if had been set a template, which acts like the sql-statement sharing the same syntax.