### PR TITLE
[To rel/0.13][ISSUE-6171]Support createTimeseriesOfTemplate in Session

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
+++ b/integration/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
@@ -396,6 +396,49 @@ public class TemplateUT {
     }
   }
 
+  @Test
+  public void testActivateTemplate()
+      throws StatementExecutionException, IoTDBConnectionException, IOException {
+    Template temp1 = getTemplate("template1");
+
+    assertEquals("[]", session.showAllTemplates().toString());
+
+    session.createSchemaTemplate(temp1);
+
+    session.setSchemaTemplate("template1", "root.sg.v1");
+
+    try {
+      session.createTimeseriesOfTemplateOnPath("root.sg.v2");
+      fail();
+    } catch (Exception e) {
+      assertEquals("303: Path [root.sg.v2] has not been set any template.", e.getMessage());
+    }
+
+    session.createTimeseriesOfTemplateOnPath("root.sg.v1.d1");
+    assertEquals("[root.sg.v1.d1]", session.showPathsTemplateUsingOn("template1").toString());
+
+    assertEquals(
+        new HashSet<>(
+            Arrays.asList(
+                "Time",
+                "root.sg.v1.d1.x",
+                "root.sg.v1.d1.y",
+                "root.sg.v1.d1.GPS.x",
+                "root.sg.v1.d1.GPS.y",
+                "root.sg.v1.d1.vehicle.x",
+                "root.sg.v1.d1.vehicle.y",
+                "root.sg.v1.d1.vehicle.GPS.x",
+                "root.sg.v1.d1.vehicle.GPS.y")),
+        new HashSet<>(session.executeQueryStatement("SELECT * FROM root.**").getColumnNames()));
+
+    try {
+      session.unsetSchemaTemplate("root.sg.v1", "template1");
+      fail();
+    } catch (Exception e) {
+      assertEquals("326: Template is in use on root.sg.v1.d1", e.getMessage());
+    }
+  }
+
   private Template getTemplate(String name) throws StatementExecutionException {
     Template sessionTemplate = new Template(name, true);
     TemplateNode iNodeGPS = new InternalNode("GPS", false);

--- a/integration/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
+++ b/integration/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
@@ -414,6 +414,10 @@ public class TemplateUT {
       assertEquals("303: Path [root.sg.v2] has not been set any template.", e.getMessage());
     }
 
+    assertEquals(
+        new HashSet<>(Collections.singletonList("Time")),
+        new HashSet<>(session.executeQueryStatement("SELECT * FROM root.**").getColumnNames()));
+
     session.createTimeseriesOfTemplateOnPath("root.sg.v1.d1");
     assertEquals("[root.sg.v1.d1]", session.showPathsTemplateUsingOn("template1").toString());
 

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -53,6 +53,7 @@ import org.apache.iotdb.db.qp.physical.crud.InsertTabletPlan;
 import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.SelectIntoPlan;
 import org.apache.iotdb.db.qp.physical.crud.UDFPlan;
+import org.apache.iotdb.db.qp.physical.sys.ActivateTemplatePlan;
 import org.apache.iotdb.db.qp.physical.sys.AppendTemplatePlan;
 import org.apache.iotdb.db.qp.physical.sys.CreateAlignedTimeSeriesPlan;
 import org.apache.iotdb.db.qp.physical.sys.CreateMultiTimeSeriesPlan;
@@ -125,6 +126,7 @@ import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateResp;
 import org.apache.iotdb.service.rpc.thrift.TSRawDataQueryReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
+import org.apache.iotdb.service.rpc.thrift.TSSetUsingTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 import org.apache.iotdb.service.rpc.thrift.TSTracingInfo;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
@@ -2114,6 +2116,28 @@ public class TSServiceImpl implements TSIService.Iface {
 
     try {
       UnsetTemplatePlan plan = new UnsetTemplatePlan(req.prefixPath, req.templateName);
+      TSStatus status = serviceProvider.checkAuthority(plan, req.getSessionId());
+      return status != null ? status : executeNonQueryPlan(plan);
+    } catch (IllegalPathException e) {
+      return onIoTDBException(e, OperationType.EXECUTE_STATEMENT, e.getErrorCode());
+    }
+  }
+
+  @Override
+  public TSStatus setUsingTemplate(TSSetUsingTemplateReq req) throws TException {
+    if (!serviceProvider.checkLogin(req.getSessionId())) {
+      return getNotLoggedInStatus();
+    }
+
+    if (AUDIT_LOGGER.isDebugEnabled()) {
+      AUDIT_LOGGER.debug(
+          "Session-{} create timeseries of schema template on path {}",
+          SESSION_MANAGER.getCurrSessionId(),
+          req.getDstPath());
+    }
+
+    try {
+      ActivateTemplatePlan plan = new ActivateTemplatePlan(new PartialPath(req.getDstPath()));
       TSStatus status = serviceProvider.checkAuthority(plan, req.getSessionId());
       return status != null ? status : executeNonQueryPlan(plan);
     } catch (IllegalPathException e) {

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -2369,7 +2369,7 @@ public class Session {
     defaultSessionConnection.unsetSchemaTemplate(request);
   }
 
-  /** Set designated path using template, act like the sql-statement with same syntax. */
+  /** Set designated path using template, act like the sql-statement with same name and syntax. */
   public void createTimeseriesOfTemplateOnPath(String path)
       throws IoTDBConnectionException, StatementExecutionException {
     TSSetUsingTemplateReq request = new TSSetUsingTemplateReq();

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -44,6 +44,7 @@ import org.apache.iotdb.service.rpc.thrift.TSPruneSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateResp;
 import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TSSetUsingTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
 import org.apache.iotdb.session.template.MeasurementNode;
 import org.apache.iotdb.session.template.Template;
@@ -2366,6 +2367,14 @@ public class Session {
       throws IoTDBConnectionException, StatementExecutionException {
     TSUnsetSchemaTemplateReq request = getTSUnsetSchemaTemplateReq(prefixPath, templateName);
     defaultSessionConnection.unsetSchemaTemplate(request);
+  }
+
+  /** Set designated path using template, act like the sql-statement with same syntax. */
+  public void createTimeseriesOfTemplateOnPath(String path)
+      throws IoTDBConnectionException, StatementExecutionException {
+    TSSetUsingTemplateReq request = new TSSetUsingTemplateReq();
+    request.setDstPath(path);
+    defaultSessionConnection.setUsingTemplate(request);
   }
 
   public void dropSchemaTemplate(String templateName)

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -54,6 +54,7 @@ import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateResp;
 import org.apache.iotdb.service.rpc.thrift.TSRawDataQueryReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
+import org.apache.iotdb.service.rpc.thrift.TSSetUsingTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
 import org.apache.iotdb.session.util.SessionUtils;
@@ -915,6 +916,25 @@ public class SessionConnection {
         try {
           request.setSessionId(sessionId);
           RpcUtils.verifySuccess(client.unsetSchemaTemplate(request));
+        } catch (TException tException) {
+          throw new IoTDBConnectionException(tException);
+        }
+      } else {
+        throw new IoTDBConnectionException(MSG_RECONNECTION_FAIL);
+      }
+    }
+  }
+
+  protected void setUsingTemplate(TSSetUsingTemplateReq request)
+      throws IoTDBConnectionException, StatementExecutionException {
+    request.setSessionId(sessionId);
+    try {
+      RpcUtils.verifySuccess(client.setUsingTemplate(request));
+    } catch (TException e) {
+      if (reconnect()) {
+        try {
+          request.setSessionId(sessionId);
+          RpcUtils.verifySuccess(client.setUsingTemplate(request));
         } catch (TException tException) {
           throw new IoTDBConnectionException(tException);
         }

--- a/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -2128,6 +2128,24 @@ public class SessionPool {
     }
   }
 
+  public void createTimeseriesOfTemplateOnPath(String path)
+      throws IoTDBConnectionException, StatementExecutionException {
+    for (int i = 0; i < RETRY; i++) {
+      Session session = getSession();
+      try {
+        session.createTimeseriesOfTemplateOnPath(path);
+        putBack(session);
+      } catch (IoTDBConnectionException e) {
+        // TException means the connection is broken, remove it and get a new one.
+        logger.warn(String.format("create timeseries of template on [%s] failed", path), e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
+      } catch (StatementExecutionException | RuntimeException e) {
+        putBack(session);
+        throw e;
+      }
+    }
+  }
+
   public void dropSchemaTemplate(String templateName)
       throws StatementExecutionException, IoTDBConnectionException {
     for (int i = 0; i < RETRY; i++) {

--- a/thrift/src/main/thrift/rpc.thrift
+++ b/thrift/src/main/thrift/rpc.thrift
@@ -411,6 +411,11 @@ struct TSUnsetSchemaTemplateReq {
   3: required string templateName
 }
 
+struct TSSetUsingTemplateReq {
+  1: required i64 sessionId
+  2: required string dstPath
+}
+
 struct TSDropSchemaTemplateReq {
   1: required i64 sessionId
   2: required string templateName
@@ -510,6 +515,8 @@ service TSIService {
   TSStatus setSchemaTemplate(1:TSSetSchemaTemplateReq req);
 
   TSStatus unsetSchemaTemplate(1:TSUnsetSchemaTemplateReq req);
+
+  TSStatus setUsingTemplate(1:TSSetUsingTemplateReq req);
 
   TSStatus dropSchemaTemplate(1:TSDropSchemaTemplateReq req);
 


### PR DESCRIPTION
As issue-#6171 suggested, this PR adds an interface in `Session` and `SessionPool` to support create timeseries of schema template on a designated path if had been set a template, which acts like the sql-statement sharing the same syntax.