### PR TITLE
[IOTDB-3361] Exception if measurement is not exist in where clause in align by device

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/exception/sql/MeasurementNotExistException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/sql/MeasurementNotExistException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.exception.sql;
+
+public class MeasurementNotExistException extends SemanticException {
+
+  public MeasurementNotExistException(String message) {
+    super(message);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analyzer.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.partition.DataPartitionQueryParam;
 import org.apache.iotdb.commons.partition.SchemaNodeManagementPartition;
 import org.apache.iotdb.commons.partition.SchemaPartition;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.exception.sql.MeasurementNotExistException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.exception.sql.StatementAnalyzeException;
 import org.apache.iotdb.db.metadata.path.MeasurementPath;
@@ -91,6 +92,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -287,9 +289,21 @@ public class Analyzer {
 
           if (queryStatement.getWhereCondition() != null) {
             Map<String, Expression> deviceToQueryFilter = new HashMap<>();
-            for (PartialPath devicePath : deviceList) {
-              Expression queryFilter =
-                  analyzeWhereSplitByDevice(queryStatement, devicePath, schemaTree);
+            Iterator<PartialPath> deviceIterator = deviceList.iterator();
+            while (deviceIterator.hasNext()) {
+              PartialPath devicePath = deviceIterator.next();
+              Expression queryFilter = null;
+              try {
+                queryFilter = analyzeWhereSplitByDevice(queryStatement, devicePath, schemaTree);
+              } catch (SemanticException e) {
+                if (e instanceof MeasurementNotExistException) {
+                  logger.warn(e.getMessage());
+                  deviceIterator.remove();
+                  deviceToSourceExpressions.remove(devicePath.getFullPath());
+                  continue;
+                }
+                throw e;
+              }
               deviceToQueryFilter.put(devicePath.getFullPath(), queryFilter);
               updateSource(
                   queryFilter,

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.mpp.plan.analyze;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.exception.sql.MeasurementNotExistException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.metadata.path.MeasurementPath;
 import org.apache.iotdb.db.mpp.common.schematree.PathPatternTree;
@@ -506,9 +507,9 @@ public class ExpressionAnalyzer {
 
       List<MeasurementPath> noStarPaths = schemaTree.searchMeasurementPaths(concatPath).left;
       if (noStarPaths.size() == 0) {
-        throw new SemanticException(
+        throw new MeasurementNotExistException(
             String.format(
-                "ALIGN BY DEVICE: measurement '%s' does not exist in device '%s'",
+                "ALIGN BY DEVICE: Measurement '%s' does not exist in device '%s'",
                 measurement, devicePath));
       }
 


### PR DESCRIPTION
If some measurements are not exist in some devices in where clause in align by device, we just exclude these devices from query rather than throwing an exception.


Before:
<img width="964" alt="image" src="https://user-images.githubusercontent.com/34242296/172308332-c42369bf-8894-4f5e-95bc-bc94b65ad7a5.png">
After:
<img width="674" alt="image" src="https://user-images.githubusercontent.com/34242296/172308549-e0be49f6-e0a1-4d1e-a294-5ce2c571677b.png">
