### PR TITLE
[IOTDB-3417] Group by month unit bug in MPP

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/aggregation/timerangeiterator/TimeRangeIteratorFactory.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/aggregation/timerangeiterator/TimeRangeIteratorFactory.java
@@ -28,8 +28,7 @@ public class TimeRangeIteratorFactory {
   /**
    * The method returns different implements of ITimeRangeIterator depending on the parameters.
    *
-   * <p>Note: interval and slidingStep stand for the milliseconds if not grouped by month, or the
-   * month count if grouped by month.
+   * <p>Note: interval and slidingStep is always stand for the milliseconds in this method.
    */
   public static ITimeRangeIterator getTimeRangeIterator(
       long startTime,
@@ -41,9 +40,12 @@ public class TimeRangeIteratorFactory {
       boolean isSlidingStepByMonth,
       boolean leftCRightO,
       boolean outputPartialTimeWindow) {
-    long tmpInterval = isIntervalByMonth ? interval * MS_TO_MONTH : interval;
-    long tmpSlidingStep = isSlidingStepByMonth ? slidingStep * MS_TO_MONTH : slidingStep;
-    if (outputPartialTimeWindow && tmpInterval > tmpSlidingStep) {
+    long originInterval = interval;
+    long originSlidingStep = slidingStep;
+    interval = isIntervalByMonth ? interval / MS_TO_MONTH : interval;
+    slidingStep = isSlidingStepByMonth ? slidingStep / MS_TO_MONTH : slidingStep;
+
+    if (outputPartialTimeWindow && originInterval > originSlidingStep) {
       if (!isIntervalByMonth && !isSlidingStepByMonth) {
         return new PreAggrWindowIterator(
             startTime, endTime, interval, slidingStep, isAscending, leftCRightO);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/parameter/GroupByTimeParameter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/parameter/GroupByTimeParameter.java
@@ -25,9 +25,12 @@ import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
-import static org.apache.iotdb.db.qp.utils.DatetimeUtils.MS_TO_MONTH;
-
-/** The parameter of `GROUP BY TIME` */
+/**
+ * The parameter of `GROUP BY TIME`.
+ *
+ * <p>Remember: interval and slidingStep is always in timestamp unit before transforming to
+ * timeRangeIterator even if it's by month unit.
+ */
 public class GroupByTimeParameter {
 
   // [startTime, endTime)
@@ -138,9 +141,7 @@ public class GroupByTimeParameter {
   }
 
   public boolean hasOverlap() {
-    long tmpInterval = isIntervalByMonth ? interval * MS_TO_MONTH : interval;
-    long tmpSlidingStep = isSlidingStepByMonth ? slidingStep * MS_TO_MONTH : slidingStep;
-    return tmpInterval > tmpSlidingStep;
+    return interval > slidingStep;
   }
 
   public void serialize(ByteBuffer buffer) {

--- a/server/src/test/java/org/apache/iotdb/db/mpp/aggregation/TimeRangeIteratorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/aggregation/TimeRangeIteratorTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 
 public class TimeRangeIteratorTest {
 
+  private static final long MS_TO_MONTH = 30 * 86400_000L;
+
   @Test
   public void testNotSplitTimeRange() {
     String[] res = {
@@ -260,27 +262,35 @@ public class TimeRangeIteratorTest {
     };
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            1604102400000L, 1617148800000L, 1, 1, true, true, true, true, false),
+            1604102400000L,
+            1617148800000L,
+            MS_TO_MONTH,
+            MS_TO_MONTH,
+            true,
+            true,
+            true,
+            true,
+            false),
         res1);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            1604102400000L, 1617148800000L, 1, 1, true, true, true, true, true),
+            1604102400000L, 1617148800000L, MS_TO_MONTH, MS_TO_MONTH, true, true, true, true, true),
         res1);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            1604102400000L, 1617148800000L, 864000000, 1, true, false, true, true, false),
+            1604102400000L, 1617148800000L, 864000000, MS_TO_MONTH, true, false, true, true, false),
         res2);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            1604102400000L, 1617148800000L, 864000000, 1, true, false, true, true, true),
+            1604102400000L, 1617148800000L, 864000000, MS_TO_MONTH, true, false, true, true, true),
         res2);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            1604102400000L, 1617148800000L, 1, 864000000, true, true, false, true, false),
+            1604102400000L, 1617148800000L, MS_TO_MONTH, 864000000, true, true, false, true, false),
         res3);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            1604102400000L, 1617148800000L, 1, 864000000, true, true, false, true, true),
+            1604102400000L, 1617148800000L, MS_TO_MONTH, 864000000, true, true, false, true, true),
         res4);
   }
 


### PR DESCRIPTION
interval and slidingStep is always in timestamp unit before transforming to timeRangeIterator even if it's by month unit.