### PR TITLE
Fix the issue that LastQuery lack MergeNode in some FI

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/DistributionPlanContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/DistributionPlanContext.java
@@ -24,10 +24,12 @@ import org.apache.iotdb.db.mpp.common.MPPQueryContext;
 public class DistributionPlanContext {
   protected boolean isRoot;
   protected MPPQueryContext queryContext;
+  protected boolean forceAddParent;
 
   protected DistributionPlanContext(MPPQueryContext queryContext) {
     this.isRoot = true;
     this.queryContext = queryContext;
+    this.forceAddParent = false;
   }
 
   protected DistributionPlanContext copy() {
@@ -37,5 +39,9 @@ public class DistributionPlanContext {
   protected DistributionPlanContext setRoot(boolean isRoot) {
     this.isRoot = isRoot;
     return this;
+  }
+
+  protected void setForceAddParent(boolean forceAddParent) {
+    this.forceAddParent = forceAddParent;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
@@ -372,6 +372,9 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
 
   @Override
   public PlanNode visitLastQueryMerge(LastQueryMergeNode node, DistributionPlanContext context) {
+    // For last query, we need to keep every FI's root node is LastQueryMergeNode. So we
+    // force every region group have a parent node even if there is only 1 child for it.
+    context.setForceAddParent(true);
     return processRawMultiChildNode(node, context);
   }
 
@@ -419,7 +422,7 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
     final boolean[] addParent = {false};
     sourceGroup.forEach(
         (dataRegion, seriesScanNodes) -> {
-          if (seriesScanNodes.size() == 1) {
+          if (seriesScanNodes.size() == 1 && !context.forceAddParent) {
             root.addChild(seriesScanNodes.get(0));
           } else {
             if (!addParent[0]) {


### PR DESCRIPTION
## Description

After this change, it is ensured that every LastQueryScanNode will belong to a LastQueryMergeNode in one Fragment Instance, even though there is only one child for the parent LastQueryMergeNode

<img width="1126" alt="image" src="https://user-images.githubusercontent.com/18027703/172342831-a5508ac7-bff8-4498-911b-cae9cb506ec3.png">
