### PR TITLE
[IOTDB-3420] [TO rel/0.13] fix show paths set schema template t1 error

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
@@ -1783,6 +1783,10 @@ public class MTree implements Serializable {
                 return true;
               }
 
+              if (node.isMeasurement()) {
+                return false;
+              }
+
               // if node not set template, go on traversing
               if (node.getSchemaTemplate() != null) {
                 // if set template, and equals to target or target for all, add to result

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
@@ -1784,7 +1784,7 @@ public class MTree implements Serializable {
               }
 
               if (node.isMeasurement()) {
-                return false;
+                return true;
               }
 
               // if node not set template, go on traversing


### PR DESCRIPTION
see detail: https://issues.apache.org/jira/browse/IOTDB-3420

after:
IoTDB> create timeseries root.sg.device1.t with datatype=BOOLEAN,encoding=PLAIN,compression=UNCOMPRESSED;
Msg: The statement is executed successfully.
IoTDB> create timeseries root.sg.device2.t1 with datatype=BOOLEAN,encoding=PLAIN,compression=UNCOMPRESSED;
Msg: The statement is executed successfully.
IoTDB> create schema template t1 (temperature FLOAT encoding=RLE, status BOOLEAN encoding=PLAIN compression=SNAPPY)
Msg: The statement is executed successfully.
IoTDB> set schema template t1 to root.sg.device1
Msg: The statement is executed successfully.
IoTDB> show paths set schema template t1
+----------------+
 |    child paths      |
+----------------+
 |root.sg.device1|
+----------------+
Total line number = 1
It costs 0.065s

![图片](https://user-images.githubusercontent.com/79885238/172405713-53561eab-d890-4c25-a84f-3b79b106c6c3.png)
