### PR TITLE
[IOTDB-3444] Make periodic serivce be scheduled more flexible

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -56,7 +56,7 @@
             <property name="format" value="schedule(AtFixedRate|WithFixedDelay)\("/>
             <property name="severity" value="error"/>
             <property name="ignoreComments" value="true"/>
-            <property name="message" value="Using ScheduledExecutorService::schedule(AtFixedRate|WithFixedDelay) directly is unsafe, please use ScheduledExecutorUtil::safelySchedule(AtFixedRate|WithFixedDelay) instead."/>
+            <property name="message" value="Using ScheduledExecutorService::schedule(AtFixedRate|WithFixedDelay) directly is unsafe, please use ScheduledExecutorUtil::(unsafely|safely)Schedule(AtFixedRate|WithFixedDelay) instead."/>
         </module>
         <!--WARNING severity rules, which may be promoted to error level-->
         <module name="OuterTypeFilename"/>

--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/ScheduledExecutorUtil.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/ScheduledExecutorUtil.java
@@ -53,17 +53,7 @@ public class ScheduledExecutorUtil {
       long initialDelay,
       long period,
       TimeUnit unit) {
-    return executor.scheduleAtFixedRate(
-        () -> {
-          try {
-            command.run();
-          } catch (Throwable t) {
-            logger.error("Schedule task failed", t);
-          }
-        },
-        initialDelay,
-        period,
-        unit);
+    return scheduleAtFixedRate(executor, command, initialDelay, period, unit, false);
   }
 
   /**
@@ -91,12 +81,104 @@ public class ScheduledExecutorUtil {
       long initialDelay,
       long delay,
       TimeUnit unit) {
+    return scheduleWithFixedDelay(executor, command, initialDelay, delay, unit, false);
+  }
+
+  /**
+   * A wrapper method to have the same semantic with {@link
+   * ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)}, except for
+   * logging an error log when any uncaught exception happens.
+   *
+   * @param executor the ScheduledExecutorService instance.
+   * @param command same parameter in {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable,
+   *     long, long, TimeUnit)}.
+   * @param initialDelay same parameter in {@link
+   *     ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)}.
+   * @param period same parameter in {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable,
+   *     long, long, TimeUnit)}.
+   * @param unit same parameter in {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable,
+   *     long, long, TimeUnit)}.
+   * @return the same return value of {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable,
+   *     long, long, TimeUnit)}.
+   */
+  @SuppressWarnings("unsafeThreadSchedule")
+  public static ScheduledFuture<?> unsafelyScheduleAtFixedRate(
+      ScheduledExecutorService executor,
+      Runnable command,
+      long initialDelay,
+      long period,
+      TimeUnit unit) {
+    return scheduleAtFixedRate(executor, command, initialDelay, period, unit, true);
+  }
+
+  /**
+   * A wrapper method to have the same semantic with {@link
+   * ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}, except for
+   * logging an error log when any uncaught exception happens.
+   *
+   * @param executor the ScheduledExecutorService instance.
+   * @param command same parameter in {@link
+   *     ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}.
+   * @param initialDelay same parameter in {@link
+   *     ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}.
+   * @param delay same parameter in {@link ScheduledExecutorService#scheduleWithFixedDelay(Runnable,
+   *     long, long, TimeUnit)}.
+   * @param unit same parameter in {@link ScheduledExecutorService#scheduleWithFixedDelay(Runnable,
+   *     long, long, TimeUnit)}.
+   * @return the same return value of {@link
+   *     ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}.
+   */
+  @SuppressWarnings("unsafeThreadSchedule")
+  public static ScheduledFuture<?> unsafelyScheduleWithFixedDelay(
+      ScheduledExecutorService executor,
+      Runnable command,
+      long initialDelay,
+      long delay,
+      TimeUnit unit) {
+    return scheduleWithFixedDelay(executor, command, initialDelay, delay, unit, true);
+  }
+
+  @SuppressWarnings("unsafeThreadSchedule")
+  private static ScheduledFuture<?> scheduleAtFixedRate(
+      ScheduledExecutorService executor,
+      Runnable command,
+      long initialDelay,
+      long period,
+      TimeUnit unit,
+      boolean unsafe) {
+    return executor.scheduleAtFixedRate(
+        () -> {
+          try {
+            command.run();
+          } catch (Throwable t) {
+            logger.error("Schedule task failed", t);
+            if (unsafe) {
+              throw t;
+            }
+          }
+        },
+        initialDelay,
+        period,
+        unit);
+  }
+
+  @SuppressWarnings("unsafeThreadSchedule")
+  private static ScheduledFuture<?> scheduleWithFixedDelay(
+      ScheduledExecutorService executor,
+      Runnable command,
+      long initialDelay,
+      long delay,
+      TimeUnit unit,
+      boolean unsafe) {
     return executor.scheduleWithFixedDelay(
         () -> {
           try {
             command.run();
           } catch (Throwable t) {
             logger.error("Schedule task failed", t);
+            if (unsafe) {
+              throw t;
+            }
           }
         },
         initialDelay,

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -290,7 +290,7 @@ public class StorageEngine implements IService {
     recover();
 
     ttlCheckThread = IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("TTL-Check");
-    ScheduledExecutorUtil.safelyScheduleAtFixedRate(
+    ScheduledExecutorUtil.unsafelyScheduleAtFixedRate(
         ttlCheckThread,
         this::checkTTL,
         TTL_CHECK_INTERVAL,

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngineV2.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngineV2.java
@@ -323,7 +323,7 @@ public class StorageEngineV2 implements IService {
     recover();
 
     ttlCheckThread = IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("TTL-Check");
-    ScheduledExecutorUtil.safelyScheduleAtFixedRate(
+    ScheduledExecutorUtil.unsafelyScheduleAtFixedRate(
         ttlCheckThread,
         this::checkTTL,
         TTL_CHECK_INTERVAL,

--- a/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
@@ -179,7 +179,7 @@ public class LocalConfigNode {
       if (config.getSyncMlogPeriodInMs() != 0) {
         timedForceMLogThread =
             IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("timedForceMLogThread");
-        ScheduledExecutorUtil.safelyScheduleAtFixedRate(
+        ScheduledExecutorUtil.unsafelyScheduleAtFixedRate(
             timedForceMLogThread,
             this::forceMlog,
             config.getSyncMlogPeriodInMs(),

--- a/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
@@ -176,7 +176,7 @@ public class WALManager implements IService {
   private void registerScheduleTask(long initDelayMs, long periodMs) {
     walDeleteThread =
         IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(ThreadName.WAL_DELETE.getName());
-    ScheduledExecutorUtil.safelyScheduleWithFixedDelay(
+    ScheduledExecutorUtil.unsafelyScheduleWithFixedDelay(
         walDeleteThread, this::deleteOutdatedFiles, initDelayMs, periodMs, TimeUnit.MILLISECONDS);
   }
 


### PR DESCRIPTION
Here we add two another unsafe wrapper methods to let those tasks which wants to quit schedule once an unexcepted exception happens. Next step is to ensure all the periodic services use the correct error handling strategy.