### PR TITLE
[IoTDB-3437]Skip RegionReplicaSet in serialization of Fragment Instance

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/FragmentInstance.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/FragmentInstance.java
@@ -151,9 +151,6 @@ public class FragmentInstance implements IConsensusRequest {
     QueryType queryType = QueryType.values()[ReadWriteIOUtils.readInt(buffer)];
     FragmentInstance fragmentInstance =
         new FragmentInstance(planFragment, id, timeFilter, queryType);
-    boolean hasRegionReplicaSet = ReadWriteIOUtils.readBool(buffer);
-    fragmentInstance.regionReplicaSet =
-        hasRegionReplicaSet ? ThriftCommonsSerDeUtils.deserializeTRegionReplicaSet(buffer) : null;
     boolean hasHostDataNode = ReadWriteIOUtils.readBool(buffer);
     fragmentInstance.hostDataNode =
         hasHostDataNode ? ThriftCommonsSerDeUtils.deserializeTDataNodeLocation(buffer) : null;
@@ -170,10 +167,6 @@ public class FragmentInstance implements IConsensusRequest {
         timeFilter.serialize(outputStream);
       }
       ReadWriteIOUtils.write(type.ordinal(), outputStream);
-      ReadWriteIOUtils.write(regionReplicaSet != null, outputStream);
-      if (regionReplicaSet != null) {
-        ThriftCommonsSerDeUtils.serializeTRegionReplicaSet(regionReplicaSet, outputStream);
-      }
       ReadWriteIOUtils.write(hostDataNode != null, outputStream);
       if (hostDataNode != null) {
         ThriftCommonsSerDeUtils.serializeTDataNodeLocation(hostDataNode, outputStream);

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/FragmentInstanceSerdeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/FragmentInstanceSerdeTest.java
@@ -47,6 +47,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class FragmentInstanceSerdeTest {
 
@@ -75,6 +76,10 @@ public class FragmentInstanceSerdeTest {
 
     ByteBuffer byteBuffer = fragmentInstance.serializeToByteBuffer();
     FragmentInstance deserializeFragmentInstance = FragmentInstance.deserializeFrom(byteBuffer);
+    assertNull(deserializeFragmentInstance.getRegionReplicaSet());
+    // Because the RegionReplicaSet won't be considered in serialization, we need to set it
+    // from original object before comparison.
+    deserializeFragmentInstance.setRegionReplicaSet(fragmentInstance.getRegionReplicaSet());
     assertEquals(deserializeFragmentInstance, fragmentInstance);
   }
 
@@ -103,6 +108,8 @@ public class FragmentInstanceSerdeTest {
 
     ByteBuffer byteBuffer = fragmentInstance.serializeToByteBuffer();
     FragmentInstance deserializeFragmentInstance = FragmentInstance.deserializeFrom(byteBuffer);
+    assertNull(deserializeFragmentInstance.getRegionReplicaSet());
+    deserializeFragmentInstance.setRegionReplicaSet(fragmentInstance.getRegionReplicaSet());
     assertEquals(deserializeFragmentInstance, fragmentInstance);
   }
 


### PR DESCRIPTION
## Description
Skip `RegionReplicaSet` in serialization of Fragment Instance