### PR TITLE
[IOTDB-3439] Move Setting up RPC Service to the last step of starting DataNode

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartition.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartition.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -100,8 +100,6 @@ public class DataNode implements DataNodeMBean {
 
   public static void main(String[] args) {
     new DataNodeServerCommandLine().doMain(args);
-
-
   }
 
   protected void serverCheckAndInit() throws ConfigurationException, IOException {

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -100,6 +100,8 @@ public class DataNode implements DataNodeMBean {
 
   public static void main(String[] args) {
     new DataNodeServerCommandLine().doMain(args);
+
+
   }
 
   protected void serverCheckAndInit() throws ConfigurationException, IOException {


### PR DESCRIPTION
1. 启动 InternalService (`prepareJoinCluster()`)

2. DataNode 本地 setup (`active()`)

   *  SchemaEngine 根据本地 data/system/schema 目录获得sg名和regionId，恢复 SchemaRegion
   *  StorageEngine 根据本地 data/system/storage_group 目录获得sg名和regionId，恢复 DataRegion
   *  DataNode 根据 data/system/schema/system.properties 恢复DataNodeID
   *  根据共识组日志恢复 Region 共识组
   *  恢复并启动其他IService

3. DataNode 向 ConfigNode 汇报本地状态并注册（`joinCluster()`）

   * DataNode首先需要成功连接上config node集群
     1. 根据iotdb-engine.properties读取配置文件中的target config node，连接target config node进行注册。
     2. 若连接失败，则根据data/system/schema/system.properties读取持久化的confignode list，尝试进行连接。（data/system/schema/system.properties中的config node list会在每次confignode-datanode心跳时更新，进行持久化）
     3. 若能成功连接上config node，则无论注册成功与否，config node都会返回完整的config node list给datanode，datanode在内存中保存config node list。若连接失败，datanode 启动失败

   * 通过 registerDataNode 接口向 ConfigNode 发送
     *  TDataNodeLocation
     *  DataNodeID （重启时获取，新的DataNode不存在）
     *  Map<存储组、DataRegion信息>
     *  Map<存储组、SchemaRegion信息>
   * ConfigNode返回注册结果
     * Global config。
     * Confignode list

4. ConfigNode 针对 DataNode 状态进行处理

   * 判断 DataNode 是否已经在集群中
   * 检查 DataNode Region 信息是否和 ConfigNode 中一致

5. 启动 RPC Service （`setUpRPCService()`）