### PR TITLE
[IOTDB-3458] Fix incorrect error handling strategy of some periodic services

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -290,7 +290,7 @@ public class StorageEngine implements IService {
     recover();
 
     ttlCheckThread = IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("TTL-Check");
-    ScheduledExecutorUtil.unsafelyScheduleAtFixedRate(
+    ScheduledExecutorUtil.safelyScheduleAtFixedRate(
         ttlCheckThread,
         this::checkTTL,
         TTL_CHECK_INTERVAL,
@@ -343,22 +343,14 @@ public class StorageEngine implements IService {
   }
 
   private void timedFlushSeqMemTable() {
-    try {
-      for (StorageGroupManager processor : processorMap.values()) {
-        processor.timedFlushSeqMemTable();
-      }
-    } catch (Exception e) {
-      logger.error("An error occurred when timed flushing sequence memtables", e);
+    for (StorageGroupManager processor : processorMap.values()) {
+      processor.timedFlushSeqMemTable();
     }
   }
 
   private void timedFlushUnseqMemTable() {
-    try {
-      for (StorageGroupManager processor : processorMap.values()) {
-        processor.timedFlushUnseqMemTable();
-      }
-    } catch (Exception e) {
-      logger.error("An error occurred when timed flushing unsequence memtables", e);
+    for (StorageGroupManager processor : processorMap.values()) {
+      processor.timedFlushUnseqMemTable();
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngineV2.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngineV2.java
@@ -323,7 +323,7 @@ public class StorageEngineV2 implements IService {
     recover();
 
     ttlCheckThread = IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("TTL-Check");
-    ScheduledExecutorUtil.unsafelyScheduleAtFixedRate(
+    ScheduledExecutorUtil.safelyScheduleAtFixedRate(
         ttlCheckThread,
         this::checkTTL,
         TTL_CHECK_INTERVAL,
@@ -378,26 +378,18 @@ public class StorageEngineV2 implements IService {
   }
 
   private void timedFlushSeqMemTable() {
-    try {
-      for (DataRegion dataRegion : dataRegionMap.values()) {
-        if (dataRegion != null) {
-          dataRegion.timedFlushSeqMemTable();
-        }
+    for (DataRegion dataRegion : dataRegionMap.values()) {
+      if (dataRegion != null) {
+        dataRegion.timedFlushSeqMemTable();
       }
-    } catch (Exception e) {
-      logger.error("An error occurred when timed flushing sequence memtables", e);
     }
   }
 
   private void timedFlushUnseqMemTable() {
-    try {
-      for (DataRegion dataRegion : dataRegionMap.values()) {
-        if (dataRegion != null) {
-          dataRegion.timedFlushUnseqMemTable();
-        }
+    for (DataRegion dataRegion : dataRegionMap.values()) {
+      if (dataRegion != null) {
+        dataRegion.timedFlushUnseqMemTable();
       }
-    } catch (Exception e) {
-      logger.error("An error occurred when timed flushing unsequence memtables", e);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
@@ -176,7 +176,7 @@ public class WALManager implements IService {
   private void registerScheduleTask(long initDelayMs, long periodMs) {
     walDeleteThread =
         IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(ThreadName.WAL_DELETE.getName());
-    ScheduledExecutorUtil.unsafelyScheduleWithFixedDelay(
+    ScheduledExecutorUtil.safelyScheduleWithFixedDelay(
         walDeleteThread, this::deleteOutdatedFiles, initDelayMs, periodMs, TimeUnit.MILLISECONDS);
   }
 


### PR DESCRIPTION
The following tasks has been fixed according to the doc https://apache-iotdb.feishu.cn/docx/doxcnT0NAd2Ug80JXQ68HaTpo3g
- timedForceMLogThread: From continuously to abort.
- Timed-Flush-Seq-Memtable(Both in StorageEngine and StorageEngineV2):  From continuously to abort, and remove outer try-catch.
- Timed-Flush-UnSeq-Memtable(Both in StorageEngine and StorageEngineV2):  From continuously to abort, and remove outer try-catch.
- TTL-check(Both in StorageEngine and StorageEngineV2): From abort to continuously.
- WAL-delete: From abort to continuously.