### PR TITLE
Abandon set ttl, schema replication factor, data replication factor, time partition interval to specific storage group

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
@@ -1725,6 +1725,10 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
   private void parseStorageGroupAttributesClause(
       SetStorageGroupStatement setStorageGroupStatement,
       IoTDBSqlParser.StorageGroupAttributesClauseContext ctx) {
+    if (ctx.storageGroupAttributeClause().size() != 0) {
+      throw new RuntimeException(
+          "Currently not support set ttl, schemaReplication factor, dataReplication factor, time partition interval to specific storage group.");
+    }
     for (IoTDBSqlParser.StorageGroupAttributeClauseContext attribute :
         ctx.storageGroupAttributeClause()) {
       if (attribute.TTL() != null) {


### PR DESCRIPTION
Currently abandon set ttl, schema replication factor, data replication factor, time partition interval to specific storage group.

Test on 3C3D:
<img width="1481" alt="image" src="https://user-images.githubusercontent.com/46039728/173298224-204ee97f-92fa-4599-8e5e-15d3c7bc7093.png">
