### PR TITLE
Fix the issue that query is not removed from QueryExecutionMap

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/Coordinator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/Coordinator.java
@@ -137,6 +137,10 @@ public class Coordinator {
     return queryExecutionMap.get(queryId);
   }
 
+  public void removeQueryExecution(Long queryId) {
+    queryExecutionMap.remove(queryId);
+  }
+
   // TODO: (xingtanzjr) need to redo once we have a concrete policy for the threadPool management
   private ExecutorService getQueryExecutor() {
     return IoTDBThreadPoolFactory.newFixedThreadPool(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
@@ -126,7 +126,6 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
           result.mergeSchemaTree(fetchedSchemaTree);
         }
       }
-      coordinator.getQueryExecution(queryId).stopAndCleanup();
       coordinator.removeQueryExecution(queryId);
       return result;
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
@@ -126,6 +126,8 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
           result.mergeSchemaTree(fetchedSchemaTree);
         }
       }
+      coordinator.getQueryExecution(queryId).stopAndCleanup();
+      coordinator.removeQueryExecution(queryId);
       return result;
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
@@ -1304,6 +1304,7 @@ public class DataNodeTSIServiceImpl implements TSIEventHandler {
       try (SetThreadName threadName = new SetThreadName(queryExecution.getQueryId())) {
         LOGGER.info("stop and clean up");
         queryExecution.stopAndCleanup();
+        COORDINATOR.removeQueryExecution(queryId);
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
@@ -626,6 +626,7 @@ public class DataNodeTSIServiceImpl implements TSIEventHandler {
         resp.setIsAlign(true);
 
         QUERY_TIME_MANAGER.unRegisterQuery(req.queryId, false);
+        COORDINATOR.removeQueryExecution(req.queryId);
         return resp;
       }
     } catch (Exception e) {


### PR DESCRIPTION
## Description
In current implementation, the query won't be removed from QueryExecutionMap, which lead to lots of memory usage for schema fetching.

This PR added a method to remove specific QueryExecution according to its QueryId.

> (DONE): The query from client is still not be removed when finished. We'll consider how to handle this issue smoothly later