### PR TITLE
[IOTDB-3476] remove error log when update cache

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterPartitionFetcher.java
@@ -604,8 +604,7 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
             }
           }
           if (null == storageGroup) {
-            logger.error(
-                "Failed to get the storage group of {} when update SchemaPartitionCache", device);
+            // device not exist
             continue;
           }
           TSeriesPartitionSlot seriesPartitionSlot =


### PR DESCRIPTION
See more details: https://issues.apache.org/jira/browse/IOTDB-3476.

If storage group is null, means that the device may not exist in iotdb and there are no need to update cache, so it isn't a error log.