### PR TITLE
Fix the bug that the judgement of hasResultSet is skipped

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
@@ -626,7 +626,9 @@ public class DataNodeTSIServiceImpl implements TSIEventHandler {
         resp.setIsAlign(true);
 
         QUERY_TIME_MANAGER.unRegisterQuery(req.queryId, false);
-        COORDINATOR.removeQueryExecution(req.queryId);
+        if (!hasResultSet) {
+          COORDINATOR.removeQueryExecution(req.queryId);
+        }
         return resp;
       }
     } catch (Exception e) {


### PR DESCRIPTION
Fix the bug that the judgement of hasResultSet is skipped. 

There is a bug in last PR https://github.com/apache/iotdb/pull/6278. We can only remove the queryExecution when the query has no more result set