### PR TITLE
[IOTDB-3505] The region dirs are not deleted when the storage group is deleted in MultiLeaderConsensus

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderConsensus.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.commons.service.RegisterManager;
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.consensus.IConsensus;
 import org.apache.iotdb.consensus.IStateMachine;
 import org.apache.iotdb.consensus.IStateMachine.Registry;
@@ -48,7 +49,6 @@ import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -186,13 +186,7 @@ public class MultiLeaderConsensus implements IConsensus {
         (k, v) -> {
           exist.set(true);
           v.stop();
-          String path = buildPeerDir(groupId);
-          try {
-            Files.delete(Paths.get(path));
-          } catch (IOException e) {
-            logger.warn(
-                "Unable to delete consensus dir for group {} at {} because {}", groupId, path, e);
-          }
+          FileUtils.deleteDirectory(new File(buildPeerDir(groupId)));
           return null;
         });
 

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.consensus.standalone;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.consensus.IConsensus;
 import org.apache.iotdb.consensus.IStateMachine;
 import org.apache.iotdb.consensus.IStateMachine.Registry;
@@ -43,7 +44,6 @@ import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -168,13 +168,7 @@ class StandAloneConsensus implements IConsensus {
         (k, v) -> {
           exist.set(true);
           v.stop();
-          String path = buildPeerDir(groupId);
-          try {
-            Files.delete(Paths.get(path));
-          } catch (IOException e) {
-            logger.warn(
-                "Unable to delete consensus dir for group {} at {} because {}", groupId, path, e);
-          }
+          FileUtils.deleteDirectory(new File(buildPeerDir(groupId)));
           return null;
         });
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/EmptyStateMachine.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/EmptyStateMachine.java
@@ -17,10 +17,9 @@
  * under the License.
  */
 
-package org.apache.iotdb.consensus.standalone;
+package org.apache.iotdb.consensus;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.consensus.IStateMachine;
 import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.consensus.common.request.IConsensusRequest;
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.commons.consensus.DataRegionId;
 import org.apache.iotdb.commons.consensus.PartitionRegionId;
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.consensus.ConsensusFactory;
+import org.apache.iotdb.consensus.EmptyStateMachine;
 import org.apache.iotdb.consensus.IConsensus;
 import org.apache.iotdb.consensus.IStateMachine;
 import org.apache.iotdb.consensus.common.DataSet;

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 public class FileUtils {
-  private static Logger logger = LoggerFactory.getLogger(FileUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(FileUtils.class);
 
   private static final int bufferSize = 1024;
 


### PR DESCRIPTION
see [jira3505](https://issues.apache.org/jira/browse/IOTDB-3505)