### PR TITLE
[IOTDB-3504] Fix inferTypes, return value and column label of IN/LIKE…

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/unary/InExpression.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/unary/InExpression.java
@@ -22,6 +22,9 @@ package org.apache.iotdb.db.mpp.plan.expression.unary;
 import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
 import org.apache.iotdb.db.mpp.plan.expression.Expression;
 import org.apache.iotdb.db.mpp.plan.expression.ExpressionType;
+import org.apache.iotdb.db.mpp.plan.expression.leaf.ConstantOperand;
+import org.apache.iotdb.db.mpp.plan.expression.leaf.TimeSeriesOperand;
+import org.apache.iotdb.db.mpp.plan.expression.multi.FunctionExpression;
 import org.apache.iotdb.db.mpp.transformation.api.LayerPointReader;
 import org.apache.iotdb.db.mpp.transformation.dag.transformer.Transformer;
 import org.apache.iotdb.db.mpp.transformation.dag.transformer.unary.InTransformer;
@@ -65,20 +68,33 @@ public class InExpression extends UnaryExpression {
 
   @Override
   public TSDataType inferTypes(TypeProvider typeProvider) {
+    final String expressionString = toString();
+    if (!typeProvider.containsTypeInfoOf(expressionString)) {
+      expression.inferTypes(typeProvider);
+      typeProvider.setType(expressionString, TSDataType.BOOLEAN);
+    }
     return TSDataType.BOOLEAN;
   }
 
   @Override
   protected String getExpressionStringInternal() {
-    StringBuilder valuesStringBuilder = new StringBuilder();
+    StringBuilder stringBuilder = new StringBuilder();
+    if (expression instanceof FunctionExpression
+        || expression instanceof ConstantOperand
+        || expression instanceof TimeSeriesOperand) {
+      stringBuilder.append(expression).append(" IN (");
+    } else {
+      stringBuilder.append('(').append(expression).append(')').append(" IN (");
+    }
     Iterator<String> iterator = values.iterator();
     if (iterator.hasNext()) {
-      valuesStringBuilder.append(iterator.next());
+      stringBuilder.append(iterator.next());
     }
     while (iterator.hasNext()) {
-      valuesStringBuilder.append(", ").append(iterator.next());
+      stringBuilder.append(',').append(iterator.next());
     }
-    return expression + " IN (" + valuesStringBuilder + ")";
+    stringBuilder.append(')');
+    return stringBuilder.toString();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/unary/LikeExpression.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/unary/LikeExpression.java
@@ -122,6 +122,12 @@ public class LikeExpression extends UnaryExpression {
 
   @Override
   public TSDataType inferTypes(TypeProvider typeProvider) throws SemanticException {
+    final String expressionString = toString();
+    if (!typeProvider.containsTypeInfoOf(expressionString)) {
+      checkInputExpressionDataType(
+          expression.toString(), expression.inferTypes(typeProvider), TSDataType.TEXT);
+      typeProvider.setType(expressionString, TSDataType.BOOLEAN);
+    }
     return TSDataType.BOOLEAN;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/unary/RegularExpression.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/unary/RegularExpression.java
@@ -79,6 +79,12 @@ public class RegularExpression extends UnaryExpression {
 
   @Override
   public TSDataType inferTypes(TypeProvider typeProvider) throws SemanticException {
+    final String expressionString = toString();
+    if (!typeProvider.containsTypeInfoOf(expressionString)) {
+      checkInputExpressionDataType(
+          expression.toString(), expression.inferTypes(typeProvider), TSDataType.TEXT);
+      typeProvider.setType(expressionString, TSDataType.BOOLEAN);
+    }
     return TSDataType.BOOLEAN;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/transformer/unary/InTransformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/transformer/unary/InTransformer.java
@@ -96,51 +96,27 @@ public class InTransformer extends UnaryTransformer {
     switch (layerPointReaderDataType) {
       case INT32:
         int intValue = layerPointReader.currentInt();
-        if (satisfy.of(intValue)) {
-          cachedBoolean = true;
-        } else {
-          currentNull = true;
-        }
+        cachedBoolean = satisfy.of(intValue);
         break;
       case INT64:
         long longValue = layerPointReader.currentLong();
-        if (satisfy.of(longValue)) {
-          cachedBoolean = true;
-        } else {
-          currentNull = true;
-        }
+        cachedBoolean = satisfy.of(longValue);
         break;
       case FLOAT:
         float floatValue = layerPointReader.currentFloat();
-        if (satisfy.of(floatValue)) {
-          cachedBoolean = true;
-        } else {
-          currentNull = true;
-        }
+        cachedBoolean = satisfy.of(floatValue);
         break;
       case DOUBLE:
         double doubleValue = layerPointReader.currentDouble();
-        if (satisfy.of(doubleValue)) {
-          cachedBoolean = true;
-        } else {
-          currentNull = true;
-        }
+        cachedBoolean = satisfy.of(doubleValue);
         break;
       case BOOLEAN:
         boolean booleanValue = layerPointReader.currentBoolean();
-        if (satisfy.of(booleanValue)) {
-          cachedBoolean = true;
-        } else {
-          currentNull = true;
-        }
+        cachedBoolean = satisfy.of(booleanValue);
         break;
       case TEXT:
         Binary binaryValue = layerPointReader.currentBinary();
-        if (satisfy.of(binaryValue.getStringValue())) {
-          cachedBoolean = true;
-        } else {
-          currentNull = true;
-        }
+        cachedBoolean = satisfy.of(binaryValue.getStringValue());
         break;
       default:
         throw new QueryProcessException("unsupported data type: " + layerPointReader.getDataType());

--- a/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/transformer/unary/RegularTransformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/transformer/unary/RegularTransformer.java
@@ -50,10 +50,6 @@ public class RegularTransformer extends UnaryTransformer {
   @Override
   protected void transformAndCache() throws QueryProcessException, IOException {
     Binary binary = layerPointReader.currentBinary();
-    if (pattern.matcher(binary.getStringValue()).find()) {
-      cachedBoolean = true;
-    } else {
-      currentNull = true;
-    }
+    cachedBoolean = pattern.matcher(binary.getStringValue()).find();
   }
 }


### PR DESCRIPTION
1. Fix inferTypes of children expressions for nest expression in SELECT component;
2. Make IN/LIKE/REGEXP expression returns false instead of null  in SELECT component;
3. Alter column label for nest query combined with IN, like (s1 + s2) IN (1,2,3).