### PR TITLE
Fix the bug that return is missing in getSchemaPartition()

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -333,6 +333,7 @@ public class ConfigManager implements Manager {
                 new HashMap<>(),
                 IoTDBDescriptor.getInstance().getConfig().getSeriesPartitionExecutorClass(),
                 IoTDBDescriptor.getInstance().getConfig().getSeriesPartitionSlotNum()));
+        return resp;
       }
 
       getSchemaPartitionReq.setPartitionSlotsMap(


### PR DESCRIPTION
## Description
A `return` is missing. When the related Region is empty, we need to return the empty resp immediately.