### PR TITLE
[IOTDB-3438] Fix empty WAL file

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -509,8 +509,16 @@ public class DataRegion {
     // recover and start timed compaction thread
     initCompaction();
 
-    logger.info(
-        "The data region {}[{}] is recovered successfully", logicalStorageGroupName, dataRegionId);
+    if (StorageEngine.getInstance().isAllSgReady()
+        || StorageEngineV2.getInstance().isAllSgReady()) {
+      logger.info(
+          "The data region {}[{}] is created successfully", logicalStorageGroupName, dataRegionId);
+    } else {
+      logger.info(
+          "The data region {}[{}] is recovered successfully",
+          logicalStorageGroupName,
+          dataRegionId);
+    }
   }
 
   private void initCompaction() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -509,7 +509,8 @@ public class DataRegion {
     // recover and start timed compaction thread
     initCompaction();
 
-    if (config.isMppMode() ? StorageEngineV2.getInstance().isAllSgReady()
+    if (config.isMppMode()
+        ? StorageEngineV2.getInstance().isAllSgReady()
         : StorageEngine.getInstance().isAllSgReady()) {
       logger.info(
           "The data region {}[{}] is created successfully", logicalStorageGroupName, dataRegionId);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -509,8 +509,8 @@ public class DataRegion {
     // recover and start timed compaction thread
     initCompaction();
 
-    if (StorageEngine.getInstance().isAllSgReady()
-        || StorageEngineV2.getInstance().isAllSgReady()) {
+    if (config.isMppMode() ? StorageEngineV2.getInstance().isAllSgReady()
+        : StorageEngine.getInstance().isAllSgReady()) {
       logger.info(
           "The data region {}[{}] is created successfully", logicalStorageGroupName, dataRegionId);
     } else {

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
@@ -52,7 +52,7 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
     this.logDirectory = logDirectory;
     File logDirFile = SystemFileFactory.INSTANCE.getFile(logDirectory);
     if (!logDirFile.exists() && logDirFile.mkdirs()) {
-      logger.info("create folder {} for wal buffer-{}.", logDirectory, identifier);
+      logger.info("Create folder {} for wal node-{}'s buffer.", logDirectory, identifier);
     }
     currentSearchIndex = startSearchIndex;
     currentWALFileVersion.set(startFileVersion);
@@ -68,6 +68,11 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
     return currentWALFileVersion.get();
   }
 
+  @Override
+  public long getCurrentWALFileSize() {
+    return currentWALFileWriter.size();
+  }
+
   /** Notice: only called by syncBufferThread and old log writer will be closed by this function. */
   protected void rollLogWriter(long searchIndex) throws IOException {
     currentWALFileWriter.close();
@@ -76,5 +81,6 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
             logDirectory,
             WALFileUtils.getLogFileName(currentWALFileVersion.incrementAndGet(), searchIndex));
     currentWALFileWriter = new WALWriter(nextLogFile);
+    logger.debug("Open new wal file {} for wal node-{}'s buffer.", nextLogFile, identifier);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/IWALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/IWALBuffer.java
@@ -37,6 +37,9 @@ public interface IWALBuffer extends AutoCloseable {
   /** Get current log version id */
   int getCurrentWALFileVersion();
 
+  /** Get current wal file's size */
+  long getCurrentWALFileSize();
+
   @Override
   void close();
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/io/ILogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/io/ILogWriter.java
@@ -55,7 +55,6 @@ public interface ILogWriter extends Closeable {
    * Returns the current size of this file.
    *
    * @return size
-   * @throws IOException if an I/O error occurs
    */
-  long size() throws IOException;
+  long size();
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/io/LogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/io/LogWriter.java
@@ -37,7 +37,6 @@ import java.nio.channels.FileChannel;
  * and writing {@link Checkpoint} into .checkpoint file.
  */
 public abstract class LogWriter implements ILogWriter {
-  public static final String FILE_PREFIX = "_";
   private static final Logger logger = LoggerFactory.getLogger(LogWriter.class);
 
   private final File logFile;
@@ -76,7 +75,7 @@ public abstract class LogWriter implements ILogWriter {
   }
 
   @Override
-  public long size() throws IOException {
+  public long size() {
     return size;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -221,13 +221,21 @@ public class WALNode implements IWALNode {
       firstValidVersionId = checkpointManager.getFirstValidWALVersionId();
       if (firstValidVersionId == Integer.MIN_VALUE) {
         // roll wal log writer to delete current wal file
-        rollWALFile();
+        if (buffer.getCurrentWALFileSize() > 0) {
+          rollWALFile();
+        }
         // update firstValidVersionId
         firstValidVersionId = checkpointManager.getFirstValidWALVersionId();
         if (firstValidVersionId == Integer.MIN_VALUE) {
           firstValidVersionId = buffer.getCurrentWALFileVersion();
         }
       }
+
+      logger.debug(
+          "Start deleting outdated wal files for wal node-{}, the first valid version id is {}, and the safely deleted search index is {}.",
+          identifier,
+          firstValidVersionId,
+          safelyDeletedSearchIndex);
 
       // delete outdated files
       deleteOutdatedFiles();
@@ -262,10 +270,13 @@ public class WALNode implements IWALNode {
     }
 
     private void deleteOutdatedFiles() {
+      int deletedFilesNum = 0;
       File[] filesToDelete = logDirectory.listFiles(this::filterFilesToDelete);
       if (filesToDelete != null) {
         for (File file : filesToDelete) {
-          if (!file.delete()) {
+          if (file.delete()) {
+            deletedFilesNum++;
+          } else {
             logger.info("Fail to delete outdated wal file {} of wal node-{}.", file, identifier);
           }
           // update totalRamCostOfFlushedMemTables
@@ -276,6 +287,10 @@ public class WALNode implements IWALNode {
           }
         }
       }
+      logger.debug(
+          "Successfully delete {} outdated wal files for wal node-{}.",
+          deletedFilesNum,
+          identifier);
     }
 
     private boolean filterFilesToDelete(File dir, String name) {


### PR DESCRIPTION
The empty wal file is produced by wal delete thread when dataregion's memtables are all flushed. To avoid this, wal delete thread will only roll wal file when wal file is not empty.