### PR TITLE
[IOTDB-3505] Fix NPE when regionCleaner deletes schema regions after restart.

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
@@ -330,6 +330,10 @@ public class SchemaEngine {
   public synchronized void deleteSchemaRegion(SchemaRegionId schemaRegionId)
       throws MetadataException {
     ISchemaRegion schemaRegion = schemaRegionMap.get(schemaRegionId);
+    if (schemaRegion == null) {
+      logger.warn("SchemaRegion(id = {}) has been deleted, skiped", schemaRegionId);
+      return;
+    }
     schemaRegion.deleteSchemaRegion();
     schemaRegionMap.remove(schemaRegionId);
 


### PR DESCRIPTION
 _deletedRegionSet_  is not cleared but the schema regions has been deleted  because client is closed accidently. And When do deletion again, NPE occurs.

After fixed, deleted schemaRegions are skipped:

2022-06-16 19:38:14,758 [pool-1-IoTDB-InternalServiceRPC-Client-4] WARN o.a.i.d.m.s.SchemaEngine:334 - SchemaRegion(id = SchemaRegion[0]) has been deleted, skiped 
2022-06-16 19:38:14,758 [pool-1-IoTDB-InternalServiceRPC-Client-4] WARN o.a.i.d.m.s.SchemaEngine:334 - SchemaRegion(id = SchemaRegion[26]) has been deleted, skiped 