### PR TITLE
Fix the issue that the QueryExecution may not be released

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/datatransfer/DataBlockManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/datatransfer/DataBlockManager.java
@@ -177,10 +177,10 @@ public class DataBlockManager implements IDataBlockManager {
                 .get(e.getTargetFragmentInstanceId())
                 .get(e.getTargetPlanNodeId())
                 .isAborted()) {
-          throw new TException(
-              "Target fragment instance not found. Fragment instance ID: "
-                  + e.getTargetFragmentInstanceId()
-                  + ".");
+          logger.warn(
+              "received onEndOfDataBlockEvent but the downstream FragmentInstance[{}] is not found",
+              e.getTargetFragmentInstanceId());
+          return;
         }
         SourceHandle sourceHandle =
             (SourceHandle)


### PR DESCRIPTION
## Description
1. In DataBlockServiceImpl, the target fragment instance may not be found because of finishing before receiving the event, which is possible. So we need to handle this scenario rather than throw Exception here.
2. In ClusterSchemaFetcher, we need to ensure the QueryExecution is always be removed so we use `try-finally` here to avoid runtime exception.