### PR TITLE
[IOTDB-3521] Procedure doesn't start when ConfigNode set the consensus protocol to StandAlone

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneServerImpl.java
@@ -48,6 +48,8 @@ public class StandAloneServerImpl implements IStateMachine {
   @Override
   public void start() {
     stateMachine.start();
+    // Notify itself as the leader
+    stateMachine.event().notifyLeaderChanged(peer.getGroupId(), peer.getEndpoint());
   }
 
   @Override


### PR DESCRIPTION
See description of [IOTDB-3521](https://issues.apache.org/jira/browse/IOTDB-3521)