### PR TITLE
[IOTDB-3189] Fix compaction is not well-distributed across sgs

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionScheduler.java
@@ -127,7 +127,8 @@ public class CompactionScheduler {
                   task,
                   sequence,
                   performer,
-                  CompactionTaskManager.currentTaskNum));
+                  CompactionTaskManager.currentTaskNum,
+                  tsFileManager.getNextCompactionTaskId()));
     }
   }
 
@@ -160,7 +161,8 @@ public class CompactionScheduler {
                       .getConfig()
                       .getCrossCompactionPerformer()
                       .createInstance(),
-                  CompactionTaskManager.currentTaskNum));
+                  CompactionTaskManager.currentTaskNum,
+                  tsFileManager.getNextCompactionTaskId()));
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/comparator/DefaultCompactionTaskComparatorImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/comparator/DefaultCompactionTaskComparatorImpl.java
@@ -86,6 +86,12 @@ public class DefaultCompactionTaskComparatorImpl implements ICompactionTaskCompa
       return selectedFilesOfO2.size() - selectedFilesOfO1.size();
     }
 
+    // if the serial id of the tasks are different
+    // we prefer task with small serial id
+    if (o1.getSerialId() != o2.getSerialId()) {
+      return o1.getSerialId() > o2.getSerialId() ? 1 : -1;
+    }
+
     // if the size of selected files are different
     // we prefer to execute task with smaller file size
     // because small files can be compacted quickly
@@ -103,6 +109,13 @@ public class DefaultCompactionTaskComparatorImpl implements ICompactionTaskCompa
       // because this type of tasks consume fewer memory during execution
       return o1.getSelectedSequenceFiles().size() - o2.getSelectedSequenceFiles().size();
     }
+
+    // if the serial id of the tasks are different
+    // we prefer task with small serial id
+    if (o1.getSerialId() != o2.getSerialId()) {
+      return o1.getSerialId() > o2.getSerialId() ? 1 : -1;
+    }
+
     // we prefer the task with more unsequence files
     // because this type of tasks reduce more unsequence files
     return o2.getSelectedUnsequenceFiles().size() - o1.getSelectedUnsequenceFiles().size();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/comparator/DefaultCompactionTaskComparatorImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/comparator/DefaultCompactionTaskComparatorImpl.java
@@ -37,9 +37,7 @@ public class DefaultCompactionTaskComparatorImpl implements ICompactionTaskCompa
     if ((((o1 instanceof InnerSpaceCompactionTask) && (o2 instanceof CrossSpaceCompactionTask))
         || ((o2 instanceof InnerSpaceCompactionTask)
             && (o1 instanceof CrossSpaceCompactionTask)))) {
-      if (config.getCompactionPriority() == CompactionPriority.BALANCE) {
-        return 0;
-      } else if (config.getCompactionPriority() == CompactionPriority.INNER_CROSS) {
+      if (config.getCompactionPriority() != CompactionPriority.CROSS_INNER) {
         return o1 instanceof InnerSpaceCompactionTask ? -1 : 1;
       } else {
         return o1 instanceof CrossSpaceCompactionTask ? -1 : 1;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
@@ -64,12 +64,14 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
       List<TsFileResource> selectedSequenceFiles,
       List<TsFileResource> selectedUnsequenceFiles,
       ICrossCompactionPerformer performer,
-      AtomicInteger currentTaskNum) {
+      AtomicInteger currentTaskNum,
+      long serialId) {
     super(
         tsFileManager.getStorageGroupName() + "-" + tsFileManager.getDataRegion(),
         timePartition,
         tsFileManager,
-        currentTaskNum);
+        currentTaskNum,
+        serialId);
     this.selectedSequenceFiles = selectedSequenceFiles;
     this.selectedUnsequenceFiles = selectedUnsequenceFiles;
     this.seqTsFileResourceList = tsFileManager.getSequenceListByTimePartition(timePartition);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
@@ -66,12 +66,14 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       List<TsFileResource> selectedTsFileResourceList,
       boolean sequence,
       ICompactionPerformer performer,
-      AtomicInteger currentTaskNum) {
+      AtomicInteger currentTaskNum,
+      long serialId) {
     super(
         tsFileManager.getStorageGroupName() + "-" + tsFileManager.getDataRegion(),
         timePartition,
         tsFileManager,
-        currentTaskNum);
+        currentTaskNum,
+        serialId);
     this.selectedTsFileResourceList = selectedTsFileResourceList;
     this.sequence = sequence;
     this.performer = performer;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/AbstractCompactionTask.java
@@ -49,16 +49,19 @@ public abstract class AbstractCompactionTask implements Callable<CompactionTaskS
   protected volatile boolean finished = false;
   protected ICompactionPerformer performer;
   protected int hashCode = -1;
+  protected long serialId;
 
   public AbstractCompactionTask(
       String fullStorageGroupName,
       long timePartition,
       TsFileManager tsFileManager,
-      AtomicInteger currentTaskNum) {
+      AtomicInteger currentTaskNum,
+      long serialId) {
     this.fullStorageGroupName = fullStorageGroupName;
     this.timePartition = timePartition;
     this.tsFileManager = tsFileManager;
     this.currentTaskNum = currentTaskNum;
+    this.serialId = serialId;
   }
 
   public abstract void setSourceFilesToCompactionCandidate();
@@ -132,5 +135,9 @@ public abstract class AbstractCompactionTask implements Callable<CompactionTaskS
 
   public boolean isTaskFinished() {
     return finished;
+  }
+
+  public long getSerialId() {
+    return serialId;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -60,6 +61,7 @@ public class TsFileManager {
   private List<TsFileResource> unsequenceRecoverTsFileResources = new ArrayList<>();
 
   private boolean allowCompaction = true;
+  private AtomicLong currentCompactionTaskSerialId = new AtomicLong(0);
 
   public TsFileManager(String storageGroupName, String dataRegion, String storageGroupDir) {
     this.storageGroupName = storageGroupName;
@@ -424,5 +426,9 @@ public class TsFileManager {
     } else {
       return cmp;
     }
+  }
+
+  public long getNextCompactionTaskId() {
+    return currentCompactionTaskSerialId.getAndIncrement();
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManagerTest.java
@@ -80,7 +80,8 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
             seqResources,
             true,
             new ReadChunkCompactionPerformer(seqResources),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     InnerSpaceCompactionTask task2 =
         new InnerSpaceCompactionTask(
             0,
@@ -88,7 +89,8 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
             seqResources,
             true,
             new ReadChunkCompactionPerformer(seqResources),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     seqResources.get(0).readLock();
     CompactionTaskManager manager = CompactionTaskManager.getInstance();
     try {
@@ -141,7 +143,8 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
             seqResources,
             true,
             new ReadChunkCompactionPerformer(seqResources),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     InnerSpaceCompactionTask task2 =
         new InnerSpaceCompactionTask(
             0,
@@ -149,7 +152,8 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
             seqResources,
             true,
             new ReadChunkCompactionPerformer(seqResources),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     seqResources.get(0).readLock();
     try {
       CompactionTaskManager manager = CompactionTaskManager.getInstance();
@@ -203,7 +207,8 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
             seqResources,
             true,
             new ReadChunkCompactionPerformer(seqResources),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     InnerSpaceCompactionTask task2 =
         new InnerSpaceCompactionTask(
             0,
@@ -211,7 +216,8 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
             seqResources,
             true,
             new ReadChunkCompactionPerformer(seqResources),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     CompactionTaskManager manager = CompactionTaskManager.getInstance();
     Assert.assertTrue(manager.addTaskToWaitingQueue(task1));
     manager.submitTaskFromTaskQueue();
@@ -254,7 +260,8 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
             seqResources,
             true,
             new ReadChunkCompactionPerformer(seqResources),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     CompactionTaskManager manager = CompactionTaskManager.getInstance();
     manager.restart();
     seqResources.get(0).readLock();
@@ -298,7 +305,8 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
             seqResources,
             true,
             new ReadChunkCompactionPerformer(seqResources),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     CompactionTaskManager.getInstance().addTaskToWaitingQueue(task);
 
     for (TsFileResource resource : seqResources) {
@@ -326,7 +334,8 @@ public class CompactionTaskManagerTest extends InnerCompactionTest {
             seqResources,
             unseqResources,
             new ReadPointCompactionPerformer(),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
 
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.isCompactionCandidate());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
@@ -441,7 +441,8 @@ public class CrossSpaceCompactionTest {
                         .getConfig()
                         .getCrossCompactionPerformer()
                         .createInstance(),
-                    new AtomicInteger(0));
+                    new AtomicInteger(0),
+                    0);
             compactionTask.call();
             List<TsFileResource> targetTsfileResourceList = new ArrayList<>();
             for (TsFileResource seqResource : seqResources) {
@@ -745,7 +746,8 @@ public class CrossSpaceCompactionTest {
                         .getConfig()
                         .getCrossCompactionPerformer()
                         .createInstance(),
-                    new AtomicInteger(0));
+                    new AtomicInteger(0),
+                    0);
             compactionTask.call();
             List<TsFileResource> targetTsfileResourceList = new ArrayList<>();
             for (TsFileResource seqResource : seqResources.subList(1, 4)) {
@@ -1048,7 +1050,8 @@ public class CrossSpaceCompactionTest {
                         .getConfig()
                         .getCrossCompactionPerformer()
                         .createInstance(),
-                    new AtomicInteger(0));
+                    new AtomicInteger(0),
+                    0);
             compactionTask.call();
             List<TsFileResource> targetTsfileResourceList = new ArrayList<>();
             for (TsFileResource seqResource : seqResources.subList(1, 4)) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionTest.java
@@ -226,7 +226,8 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
             seqResources,
             unseqResources,
             new ReadPointCompactionPerformer(),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     task.call();
 
     for (TsFileResource resource : seqResources) {
@@ -462,7 +463,8 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
             seqResources,
             unseqResources,
             new ReadPointCompactionPerformer(),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     task.call();
 
     for (TsFileResource resource : seqResources) {
@@ -608,7 +610,8 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
             seqResources,
             unseqResources,
             new ReadPointCompactionPerformer(),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     task.setSourceFilesToCompactionCandidate();
     task.checkValidAndSetMerging();
     // delete data in source file during compaction
@@ -717,7 +720,8 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
             seqResources,
             unseqResources,
             new ReadPointCompactionPerformer(),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     task.setSourceFilesToCompactionCandidate();
     task.checkValidAndSetMerging();
     // delete data in source file during compaction

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionEmptyTsFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionEmptyTsFileTest.java
@@ -82,7 +82,8 @@ public class InnerCompactionEmptyTsFileTest extends InnerCompactionTest {
             unseqResources.subList(0, 3),
             false,
             new ReadPointCompactionPerformer(),
-            new AtomicInteger(0));
+            new AtomicInteger(0),
+            0);
     Future<CompactionTaskSummary> future = CompactionTaskManager.getInstance().submitTask(task);
     Assert.assertTrue(future.get().isSuccess());
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/DataRegionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/DataRegionTest.java
@@ -785,7 +785,8 @@ public class DataRegionTest {
               dataRegion.getSequenceFileList(),
               true,
               new ReadChunkCompactionPerformer(dataRegion.getSequenceFileList()),
-              new AtomicInteger(0));
+              new AtomicInteger(0),
+              0);
       CompactionTaskManager.getInstance().submitTask(task);
       Thread.sleep(20);
       StorageEngine.getInstance().deleteStorageGroup(new PartialPath(storageGroup));

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
@@ -729,7 +729,8 @@ public class StorageGroupProcessorTest {
               processor.getSequenceFileList(),
               true,
               new ReadChunkCompactionPerformer(processor.getSequenceFileList()),
-              new AtomicInteger(0));
+              new AtomicInteger(0),
+              0);
       CompactionTaskManager.getInstance().submitTask(task);
       Thread.sleep(20);
       StorageEngine.getInstance().deleteStorageGroup(new PartialPath(storageGroup));


### PR DESCRIPTION
See [IOTDB-3189](https://issues.apache.org/jira/browse/IOTDB-3189).

In present IoTDB compaction task submitted order set by the `ICompactionTaskComparator`, currently this interface only has `DefaultCompactionTaskComparator` an implementation. `DefaultCompactionTaskComparator` compares the compaction task priority with following several aspects:
- Whether the compaction priority of the system is Balance. If not, the prior one is inner space task or cross space task.
- For inner space compaction, compare whether the tasks are sequence, compaction task level,compaction files version number, total number of compaction files, and total size of compaction files
- For cross space compaction, compare the total number of files and the total size of them.
- 
Different storage groups are not considered in this comparison. Therefore, when the tasks of different storage groups are compared side by side, it is easy to create uneven storage combinations. For example, if two SG groups commit a large number of compacton tasks in the sequence space with the same number of files, the same file size, and the same file level, the system may compact tasks in only one storage group due to the different submission timing.

To balance compaction tasks between different storage groups, when all other things being equal, each compaction task can be assigned a unique serial id that is counted individually by each virtual storage group and monotonically increases from zero. If two compaction tasks are from different storage groups, their sequence numbers are compared; the compaction task with a smaller sequence number has a higher priority. After adjustment, compaction priority comparison becomes
- Whether the compaction priority of the system is Balance. If not, the prior one is inner space task or cross space task.
- For inner space compaction, compare whether the tasks are sequence, compaction task level,compaction files version number, total number of compaction files, the serial number of compaction tasks, and the total size of files
- For a cross space compaction, compare the total number of compaction files, the sequence number of compaction tasks, and the total size of files.