### PR TITLE
[IOTDB-3529] Rename Region to RegionGroup

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/AsyncDataNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/AsyncDataNodeClientPool.java
@@ -28,7 +28,7 @@ import org.apache.iotdb.commons.client.async.AsyncDataNodeInternalServiceClient;
 import org.apache.iotdb.confignode.client.handlers.CreateRegionHandler;
 import org.apache.iotdb.confignode.client.handlers.FunctionManagementHandler;
 import org.apache.iotdb.confignode.client.handlers.HeartbeatHandler;
-import org.apache.iotdb.confignode.consensus.request.write.CreateRegionsReq;
+import org.apache.iotdb.confignode.consensus.request.write.CreateRegionGroupsReq;
 import org.apache.iotdb.mpp.rpc.thrift.TCreateDataRegionReq;
 import org.apache.iotdb.mpp.rpc.thrift.TCreateFunctionRequest;
 import org.apache.iotdb.mpp.rpc.thrift.TCreateSchemaRegionReq;
@@ -62,10 +62,10 @@ public class AsyncDataNodeClientPool {
   /**
    * Execute CreateRegionsReq asynchronously
    *
-   * @param createRegionsReq CreateRegionsReq
+   * @param createRegionGroupsReq CreateRegionsReq
    * @param ttlMap Map<StorageGroupName, TTL>
    */
-  public void createRegions(CreateRegionsReq createRegionsReq, Map<String, Long> ttlMap) {
+  public void createRegions(CreateRegionGroupsReq createRegionGroupsReq, Map<String, Long> ttlMap) {
 
     // Index of each Region
     int index = 0;
@@ -76,7 +76,7 @@ public class AsyncDataNodeClientPool {
 
     // Assign an independent index to each Region
     for (Map.Entry<String, List<TRegionReplicaSet>> entry :
-        createRegionsReq.getRegionMap().entrySet()) {
+        createRegionGroupsReq.getRegionMap().entrySet()) {
       for (TRegionReplicaSet regionReplicaSet : entry.getValue()) {
         regionNum += regionReplicaSet.getDataNodeLocationsSize();
         for (TDataNodeLocation dataNodeLocation : regionReplicaSet.getDataNodeLocations()) {
@@ -91,7 +91,7 @@ public class AsyncDataNodeClientPool {
     BitSet bitSet = new BitSet(regionNum);
     for (int retry = 0; retry < 3; retry++) {
       CountDownLatch latch = new CountDownLatch(regionNum - bitSet.cardinality());
-      createRegionsReq
+      createRegionGroupsReq
           .getRegionMap()
           .forEach(
               (storageGroup, regionReplicaSets) -> {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigRequest.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigRequest.java
@@ -30,7 +30,7 @@ import org.apache.iotdb.confignode.consensus.request.read.GetStorageGroupReq;
 import org.apache.iotdb.confignode.consensus.request.write.ApplyConfigNodeReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateDataPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateFunctionReq;
-import org.apache.iotdb.confignode.consensus.request.write.CreateRegionsReq;
+import org.apache.iotdb.confignode.consensus.request.write.CreateRegionGroupsReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateSchemaPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.write.DeleteProcedureReq;
 import org.apache.iotdb.confignode.consensus.request.write.DeleteRegionsReq;
@@ -122,8 +122,8 @@ public abstract class ConfigRequest implements IConsensusRequest {
         case GetStorageGroup:
           req = new GetStorageGroupReq();
           break;
-        case CreateRegions:
-          req = new CreateRegionsReq();
+        case CreateRegionGroups:
+          req = new CreateRegionGroupsReq();
           break;
         case DeleteRegions:
           req = new DeleteRegionsReq();

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigRequestType.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigRequestType.java
@@ -30,7 +30,7 @@ public enum ConfigRequestType {
   PreDeleteStorageGroup,
   GetStorageGroup,
   CountStorageGroup,
-  CreateRegions,
+  CreateRegionGroups,
   DeleteRegions,
   GetSchemaPartition,
   CreateSchemaPartition,

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/CreateRegionGroupsReq.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/CreateRegionGroupsReq.java
@@ -35,13 +35,13 @@ import java.util.Objects;
 import java.util.TreeMap;
 
 /** Create regions for specific StorageGroups */
-public class CreateRegionsReq extends ConfigRequest {
+public class CreateRegionGroupsReq extends ConfigRequest {
 
   // Map<StorageGroupName, List<TRegionReplicaSet>>
   private final Map<String, List<TRegionReplicaSet>> regionMap;
 
-  public CreateRegionsReq() {
-    super(ConfigRequestType.CreateRegions);
+  public CreateRegionGroupsReq() {
+    super(ConfigRequestType.CreateRegionGroups);
     this.regionMap = new TreeMap<>();
   }
 
@@ -57,7 +57,7 @@ public class CreateRegionsReq extends ConfigRequest {
 
   @Override
   protected void serializeImpl(DataOutputStream stream) throws IOException {
-    stream.writeInt(ConfigRequestType.CreateRegions.ordinal());
+    stream.writeInt(ConfigRequestType.CreateRegionGroups.ordinal());
 
     stream.writeInt(regionMap.size());
     for (Entry<String, List<TRegionReplicaSet>> entry : regionMap.entrySet()) {
@@ -91,7 +91,7 @@ public class CreateRegionsReq extends ConfigRequest {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    CreateRegionsReq that = (CreateRegionsReq) o;
+    CreateRegionGroupsReq that = (CreateRegionGroupsReq) o;
     return regionMap.equals(that.regionMap);
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
@@ -28,7 +28,7 @@ import org.apache.iotdb.commons.partition.SchemaPartitionTable;
 import org.apache.iotdb.confignode.client.AsyncDataNodeClientPool;
 import org.apache.iotdb.confignode.client.handlers.HeartbeatHandler;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
-import org.apache.iotdb.confignode.consensus.request.write.CreateRegionsReq;
+import org.apache.iotdb.confignode.consensus.request.write.CreateRegionGroupsReq;
 import org.apache.iotdb.confignode.exception.NotEnoughDataNodeException;
 import org.apache.iotdb.confignode.exception.StorageGroupNotExistsException;
 import org.apache.iotdb.confignode.manager.ClusterSchemaManager;
@@ -87,22 +87,22 @@ public class LoadManager implements Runnable {
   public void initializeRegions(
       List<String> storageGroups, TConsensusGroupType consensusGroupType, int regionNum)
       throws NotEnoughDataNodeException, StorageGroupNotExistsException {
-    CreateRegionsReq createRegionsReq =
+    CreateRegionGroupsReq createRegionGroupsReq =
         regionBalancer.genRegionsAllocationPlan(storageGroups, consensusGroupType, regionNum);
-    createRegionsOnDataNodes(createRegionsReq);
+    createRegionsOnDataNodes(createRegionGroupsReq);
 
-    getConsensusManager().write(createRegionsReq);
+    getConsensusManager().write(createRegionGroupsReq);
   }
 
-  private void createRegionsOnDataNodes(CreateRegionsReq createRegionsReq)
+  private void createRegionsOnDataNodes(CreateRegionGroupsReq createRegionGroupsReq)
       throws StorageGroupNotExistsException {
     Map<String, Long> ttlMap = new HashMap<>();
-    for (String storageGroup : createRegionsReq.getRegionMap().keySet()) {
+    for (String storageGroup : createRegionGroupsReq.getRegionMap().keySet()) {
       ttlMap.put(
           storageGroup,
           getClusterSchemaManager().getStorageGroupSchemaByName(storageGroup).getTTL());
     }
-    AsyncDataNodeClientPool.getInstance().createRegions(createRegionsReq, ttlMap);
+    AsyncDataNodeClientPool.getInstance().createRegions(createRegionGroupsReq, ttlMap);
   }
 
   /**

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RegionBalancer.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RegionBalancer.java
@@ -22,7 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeInfo;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
-import org.apache.iotdb.confignode.consensus.request.write.CreateRegionsReq;
+import org.apache.iotdb.confignode.consensus.request.write.CreateRegionGroupsReq;
 import org.apache.iotdb.confignode.exception.NotEnoughDataNodeException;
 import org.apache.iotdb.confignode.exception.StorageGroupNotExistsException;
 import org.apache.iotdb.confignode.manager.ClusterSchemaManager;
@@ -56,10 +56,10 @@ public class RegionBalancer {
    * @throws NotEnoughDataNodeException When the number of DataNodes is not enough for allocation
    * @throws StorageGroupNotExistsException When some StorageGroups don't exist
    */
-  public CreateRegionsReq genRegionsAllocationPlan(
+  public CreateRegionGroupsReq genRegionsAllocationPlan(
       List<String> storageGroups, TConsensusGroupType consensusGroupType, int regionNum)
       throws NotEnoughDataNodeException, StorageGroupNotExistsException {
-    CreateRegionsReq createRegionsReq = new CreateRegionsReq();
+    CreateRegionGroupsReq createRegionGroupsReq = new CreateRegionGroupsReq();
     IRegionAllocator regionAllocator = genRegionAllocator();
 
     List<TDataNodeInfo> onlineDataNodes = getNodeManager().getOnlineDataNodes(-1);
@@ -88,13 +88,13 @@ public class RegionBalancer {
                 replicationFactor,
                 new TConsensusGroupId(
                     consensusGroupType, getPartitionManager().generateNextRegionGroupId()));
-        createRegionsReq.addRegion(storageGroup, newRegion);
+        createRegionGroupsReq.addRegion(storageGroup, newRegion);
 
         allocatedRegions.add(newRegion);
       }
     }
 
-    return createRegionsReq;
+    return createRegionGroupsReq;
   }
 
   private IRegionAllocator genRegionAllocator() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigRequestExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigRequestExecutor.java
@@ -33,7 +33,7 @@ import org.apache.iotdb.confignode.consensus.request.read.GetStorageGroupReq;
 import org.apache.iotdb.confignode.consensus.request.write.ApplyConfigNodeReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateDataPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateFunctionReq;
-import org.apache.iotdb.confignode.consensus.request.write.CreateRegionsReq;
+import org.apache.iotdb.confignode.consensus.request.write.CreateRegionGroupsReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateSchemaPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.write.DeleteProcedureReq;
 import org.apache.iotdb.confignode.consensus.request.write.DeleteStorageGroupReq;
@@ -159,8 +159,8 @@ public class ConfigRequestExecutor {
         return clusterSchemaInfo.setDataReplicationFactor((SetDataReplicationFactorReq) req);
       case SetTimePartitionInterval:
         return clusterSchemaInfo.setTimePartitionInterval((SetTimePartitionIntervalReq) req);
-      case CreateRegions:
-        return partitionInfo.createRegions((CreateRegionsReq) req);
+      case CreateRegionGroups:
+        return partitionInfo.createRegionGroups((CreateRegionGroupsReq) req);
       case CreateSchemaPartition:
         return partitionInfo.createSchemaPartition((CreateSchemaPartitionReq) req);
       case CreateDataPartition:

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -33,7 +33,7 @@ import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.read.GetDataPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.read.GetSchemaPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateDataPartitionReq;
-import org.apache.iotdb.confignode.consensus.request.write.CreateRegionsReq;
+import org.apache.iotdb.confignode.consensus.request.write.CreateRegionGroupsReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateSchemaPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.write.DeleteStorageGroupReq;
 import org.apache.iotdb.confignode.consensus.request.write.PreDeleteStorageGroupReq;
@@ -166,19 +166,19 @@ public class PartitionInfo implements SnapshotProcessor {
   }
 
   /**
-   * Thread-safely cache allocation result of new Regions
+   * Thread-safely cache allocation result of new RegionGroups
    *
    * @param req CreateRegionsReq
    * @return SUCCESS_STATUS
    */
-  public TSStatus createRegions(CreateRegionsReq req) {
+  public TSStatus createRegionGroups(CreateRegionGroupsReq req) {
     TSStatus result;
     AtomicInteger maxRegionId = new AtomicInteger(Integer.MIN_VALUE);
 
     req.getRegionMap()
         .forEach(
             (storageGroup, regionReplicaSets) -> {
-              storageGroupPartitionTables.get(storageGroup).createRegions(regionReplicaSets);
+              storageGroupPartitionTables.get(storageGroup).createRegionGroups(regionReplicaSets);
               regionReplicaSets.forEach(
                   regionReplicaSet ->
                       maxRegionId.set(

--- a/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigRequestSerDeTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigRequestSerDeTest.java
@@ -42,7 +42,7 @@ import org.apache.iotdb.confignode.consensus.request.read.GetSchemaPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.read.GetStorageGroupReq;
 import org.apache.iotdb.confignode.consensus.request.write.ApplyConfigNodeReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateDataPartitionReq;
-import org.apache.iotdb.confignode.consensus.request.write.CreateRegionsReq;
+import org.apache.iotdb.confignode.consensus.request.write.CreateRegionGroupsReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateSchemaPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.write.DeleteProcedureReq;
 import org.apache.iotdb.confignode.consensus.request.write.DeleteRegionsReq;
@@ -187,7 +187,7 @@ public class ConfigRequestSerDeTest {
     dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010));
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010));
 
-    CreateRegionsReq req0 = new CreateRegionsReq();
+    CreateRegionGroupsReq req0 = new CreateRegionGroupsReq();
     TRegionReplicaSet dataRegionSet = new TRegionReplicaSet();
     dataRegionSet.setRegionId(new TConsensusGroupId(TConsensusGroupType.DataRegion, 0));
     dataRegionSet.setDataNodeLocations(Collections.singletonList(dataNodeLocation));
@@ -198,8 +198,8 @@ public class ConfigRequestSerDeTest {
     schemaRegionSet.setDataNodeLocations(Collections.singletonList(dataNodeLocation));
     req0.addRegion("root.sg1", schemaRegionSet);
 
-    CreateRegionsReq req1 =
-        (CreateRegionsReq) ConfigRequest.Factory.create(req0.serializeToByteBuffer());
+    CreateRegionGroupsReq req1 =
+        (CreateRegionGroupsReq) ConfigRequest.Factory.create(req0.serializeToByteBuffer());
     Assert.assertEquals(req0, req1);
   }
 

--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
@@ -30,7 +30,7 @@ import org.apache.iotdb.commons.partition.DataPartitionTable;
 import org.apache.iotdb.commons.partition.SchemaPartitionTable;
 import org.apache.iotdb.commons.partition.SeriesPartitionTable;
 import org.apache.iotdb.confignode.consensus.request.write.CreateDataPartitionReq;
-import org.apache.iotdb.confignode.consensus.request.write.CreateRegionsReq;
+import org.apache.iotdb.confignode.consensus.request.write.CreateRegionGroupsReq;
 import org.apache.iotdb.confignode.consensus.request.write.CreateSchemaPartitionReq;
 import org.apache.iotdb.confignode.consensus.request.write.SetStorageGroupReq;
 import org.apache.iotdb.confignode.persistence.partition.PartitionInfo;
@@ -98,24 +98,24 @@ public class PartitionInfoTest {
     partitionInfo.setStorageGroup(new SetStorageGroupReq(new TStorageGroupSchema("root.test")));
 
     // Create a SchemaRegion
-    CreateRegionsReq createRegionsReq = new CreateRegionsReq();
+    CreateRegionGroupsReq createRegionGroupsReq = new CreateRegionGroupsReq();
     TRegionReplicaSet schemaRegionReplicaSet =
         generateTRegionReplicaSet(
             testFlag.SchemaPartition.getFlag(),
             generateTConsensusGroupId(
                 testFlag.SchemaPartition.getFlag(), TConsensusGroupType.SchemaRegion));
-    createRegionsReq.addRegion("root.test", schemaRegionReplicaSet);
-    partitionInfo.createRegions(createRegionsReq);
+    createRegionGroupsReq.addRegion("root.test", schemaRegionReplicaSet);
+    partitionInfo.createRegionGroups(createRegionGroupsReq);
 
     // Create a DataRegion
-    createRegionsReq = new CreateRegionsReq();
+    createRegionGroupsReq = new CreateRegionGroupsReq();
     TRegionReplicaSet dataRegionReplicaSet =
         generateTRegionReplicaSet(
             testFlag.DataPartition.getFlag(),
             generateTConsensusGroupId(
                 testFlag.DataPartition.getFlag(), TConsensusGroupType.DataRegion));
-    createRegionsReq.addRegion("root.test", dataRegionReplicaSet);
-    partitionInfo.createRegions(createRegionsReq);
+    createRegionGroupsReq.addRegion("root.test", dataRegionReplicaSet);
+    partitionInfo.createRegionGroups(createRegionGroupsReq);
 
     // Create a SchemaPartition
     CreateSchemaPartitionReq createSchemaPartitionReq =


### PR DESCRIPTION
Most operations involving Regions in ConfigNode are based on consensus groups. Therefore, we need to specify the names of some classes in package confignode