### PR TITLE
[IOTDB-3544] Packaging udf-api as dependency jar in build

### DIFF
--- a/udf-api/pom.xml
+++ b/udf-api/pom.xml
@@ -28,4 +28,33 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>udf-api</artifactId>
+    <profiles>
+        <profile>
+            <id>get-jar-with-dependencies</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>${maven.assembly.version}</version>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <!-- this is used for inheritance merges -->
+                                <phase>package</phase>
+                                <!-- bind to the packaging phase -->
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
See JIRA: https://issues.apache.org/jira/browse/IOTDB-3544

As we want to release udf-api as a dependency jar for users, it should be packaged during the build.