### PR TITLE
[IOTDB-3582] Fix client connections leak caused by delete storage group

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncDataNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncDataNodeClientPool.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/** Asynchronously send RPC requests to DataNodes. See mpp.thrift for more details. */
+/** Synchronously send RPC requests to DataNodes. See mpp.thrift for more details. */
 public class SyncDataNodeClientPool {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SyncDataNodeClientPool.class);
@@ -57,10 +57,8 @@ public class SyncDataNodeClientPool {
 
   public TSStatus invalidatePartitionCache(
       TEndPoint endPoint, TInvalidateCacheReq invalidateCacheReq) {
-    SyncDataNodeInternalServiceClient client;
     TSStatus status;
-    try {
-      client = clientManager.borrowClient(endPoint);
+    try (SyncDataNodeInternalServiceClient client = clientManager.borrowClient(endPoint)) {
       status = client.invalidatePartitionCache(invalidateCacheReq);
       LOGGER.info("Invalid Schema Cache {} successfully", invalidateCacheReq);
     } catch (IOException e) {


### PR DESCRIPTION
Use try-with-resources to return client

During executing test.sh, client threads did not increase rapidly.
![image](https://user-images.githubusercontent.com/82880298/174761095-febd42e1-48e1-4d49-9154-a696dc301736.png)

![image](https://user-images.githubusercontent.com/82880298/174760743-bf2c02ae-2934-4ff4-97f9-acad9b2bbfb8.png)

_test.sh_ and _suite.sql_ are attached to https://issues.apache.org/jira/browse/IOTDB-3582
