### PR TITLE
[IOTDB-3573] Fix IT test stucked by JDBC infinite network timeout

### DIFF
--- a/.github/workflows/standalone-it-for-mpp.yml
+++ b/.github/workflows/standalone-it-for-mpp.yml
@@ -22,7 +22,7 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
 jobs:
-  unix:
+  StandaloneMppIT:
     strategy:
       fail-fast: false
       max-parallel: 20

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -32,6 +32,13 @@
         <integrationTest.forkCount>1</integrationTest.forkCount>
         <integrationTest.randomSelectWriteNode>true</integrationTest.randomSelectWriteNode>
         <integrationTest.readAndVerifyWithMultiNode>true</integrationTest.readAndVerifyWithMultiNode>
+        <integrationTest.launchNodeInSameJVM>true</integrationTest.launchNodeInSameJVM>
+        <integrationTest.parallelMode>none</integrationTest.parallelMode>
+        <integrationTest.nodeMaxHeapSize>200m</integrationTest.nodeMaxHeapSize>
+        <integrationTest.nodeNewHeapSize>200m</integrationTest.nodeNewHeapSize>
+        <integrationTest.testEnv/>
+        <integrationTest.excludedGroups/>
+        <integrationTest.includedGroups/>
     </properties>
     <dependencies>
         <dependency>
@@ -80,346 +87,189 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <build>
+        <plugins>
+            <!-- skip default-test -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- If the test starts separate processes, we should package first -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.version}</version>
+                <configuration>
+                    <skipAssembly>${integrationTest.launchNodeInSameJVM}</skipAssembly>
+                </configuration>
+                <executions>
+                    <!-- Package binaries-->
+                    <execution>
+                        <id>cluster-test-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/mpp-test.xml</descriptor>
+                            </descriptors>
+                            <finalName>template-node</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- If the test starts separate processes, we can set maximum-heap and new-heap size -->
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <configuration>
+                    <skip>${integrationTest.launchNodeInSameJVM}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <basedir>${project.build.directory}/template-node</basedir>
+                            <regex>true</regex>
+                            <commentsEnabled>false</commentsEnabled>
+                            <includes>
+                                <include>datanode/conf/iotdb-env.sh</include>
+                                <include>confignode/conf/confignode-env.sh</include>
+                                <include>datanode/conf/iotdb-env.bat</include>
+                                <include>confignode/conf/confignode-env.bat</include>
+                            </includes>
+                            <replacements>
+                                <replacement>
+                                    <token>#HEAP_NEWSIZE=.*</token>
+                                    <value>HEAP_NEWSIZE="${integrationTest.nodeNewHeapSize}"</value>
+                                </replacement>
+                                <replacement>
+                                    <token>#MAX_HEAP_SIZE=.*</token>
+                                    <value>MAX_HEAP_SIZE="${integrationTest.nodeMaxHeapSize}"</value>
+                                </replacement>
+                                <replacement>
+                                    <token>@REM set HEAP_NEWSIZE.*</token>
+                                    <value>set HEAP_NEWSIZE="${integrationTest.nodeNewHeapSize}"</value>
+                                </replacement>
+                                <replacement>
+                                    <token>@REM set MAX_HEAP_SIZE=.*</token>
+                                    <value>set MAX_HEAP_SIZE="${integrationTest.nodeMaxHeapSize}"</value>
+                                </replacement>
+                            </replacements>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <groups>${integrationTest.includedGroups}</groups>
+                            <excludedGroups>${integrationTest.excludedGroups}</excludedGroups>
+                            <useSystemClassLoader>false</useSystemClassLoader>
+                            <parallel>${integrationTest.parallelMode}</parallel>
+                            <useUnlimitedThreads>true</useUnlimitedThreads>
+                            <forkCount>${integrationTest.forkCount}</forkCount>
+                            <reuseForks>false</reuseForks>
+                            <systemPropertyVariables>
+                                <TestEnv>${integrationTest.testEnv}</TestEnv>
+                                <RandomSelectWriteNode>${integrationTest.randomSelectWriteNode}</RandomSelectWriteNode>
+                                <ReadAndVerifyWithMultiNode>${integrationTest.readAndVerifyWithMultiNode}</ReadAndVerifyWithMultiNode>
+                            </systemPropertyVariables>
+                            <summaryFile>target/failsafe-reports/failsafe-summary-IT.xml</summaryFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <summaryFiles>
+                                <summaryFile>target/failsafe-reports/failsafe-summary-IT.xml</summaryFile>
+                            </summaryFiles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>LocalStandaloneIT</id>
             <properties>
-                <test.includedGroups>org.apache.iotdb.itbase.category.LocalStandaloneIT</test.includedGroups>
-                <test.excludedGroups/>
+                <integrationTest.includedGroups>org.apache.iotdb.itbase.category.LocalStandaloneIT</integrationTest.includedGroups>
+                <integrationTest.excludedGroups/>
+                <integrationTest.testEnv>Standalone</integrationTest.testEnv>
             </properties>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <build>
-                <plugins>
-                    <!-- skip default-test -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>standalone-integration-test</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                                <configuration>
-                                    <groups>${test.includedGroups}</groups>
-                                    <excludedGroups>${test.excludedGroups}</excludedGroups>
-                                    <useSystemClassLoader>false</useSystemClassLoader>
-                                    <threadCount>1</threadCount>
-                                    <forkCount>1</forkCount>
-                                    <reuseForks>false</reuseForks>
-                                    <systemPropertyVariables>
-                                        <TestEnv>Standalone</TestEnv>
-                                    </systemPropertyVariables>
-                                    <summaryFile>target/failsafe-reports/failsafe-summary-LocalStandaloneIT.xml</summaryFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>verify</id>
-                                <goals>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <summaryFiles>
-                                        <summaryFile>target/failsafe-reports/failsafe-summary-LocalStandaloneIT.xml</summaryFile>
-                                    </summaryFiles>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
+        <!-- Currently RemoteIT is not working as it lacks of the remote endpoint parameters -->
         <profile>
             <id>RemoteIT</id>
             <properties>
-                <test.includedGroups>org.apache.iotdb.itbase.category.RemoteIT</test.includedGroups>
-                <test.excludedGroups/>
+                <integrationTest.includedGroups>org.apache.iotdb.itbase.category.RemoteIT</integrationTest.includedGroups>
+                <integrationTest.excludedGroups/>
+                <integrationTest.testEnv>Remote</integrationTest.testEnv>
             </properties>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-            <build>
-                <plugins>
-                    <!-- skip default-test -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>remote-integration-test</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                                <configuration>
-                                    <skipTests>false</skipTests>
-                                    <groups>${test.includedGroups}</groups>
-                                    <excludedGroups>${test.excludedGroups}</excludedGroups>
-                                    <useSystemClassLoader>false</useSystemClassLoader>
-                                    <threadCount>1</threadCount>
-                                    <forkCount>1</forkCount>
-                                    <reuseForks>false</reuseForks>
-                                    <systemPropertyVariables>
-                                        <TestEnv>Remote</TestEnv>
-                                    </systemPropertyVariables>
-                                    <summaryFile>target/failsafe-reports/failsafe-summary-RemoteIT.xml</summaryFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>verify</id>
-                                <goals>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <skipTests>false</skipTests>
-                                    <summaryFiles>
-                                        <summaryFile>target/failsafe-reports/failsafe-summary-RemoteIT.xml</summaryFile>
-                                    </summaryFiles>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>ClusterIT</id>
             <properties>
-                <test.includedGroups>org.apache.iotdb.itbase.category.ClusterIT</test.includedGroups>
-                <test.excludedGroups/>
+                <integrationTest.includedGroups>org.apache.iotdb.itbase.category.ClusterIT</integrationTest.includedGroups>
+                <integrationTest.excludedGroups/>
+                <integrationTest.testEnv>Cluster1</integrationTest.testEnv>
+                <integrationTest.launchNodeInSameJVM>false</integrationTest.launchNodeInSameJVM>
+                <integrationTest.randomSelectWriteNode>true</integrationTest.randomSelectWriteNode>
+                <integrationTest.readAndVerifyWithMultiNode>true</integrationTest.readAndVerifyWithMultiNode>
+                <integrationTest.parallelMode>classes</integrationTest.parallelMode>
             </properties>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-            <build>
-                <plugins>
-                    <!-- skip default-test -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <version>${maven.assembly.version}</version>
-                        <executions>
-                            <!-- Package binaries-->
-                            <execution>
-                                <id>cluster-test-assembly</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <descriptors>
-                                        <descriptor>src/assembly/mpp-test.xml</descriptor>
-                                    </descriptors>
-                                    <finalName>template-node</finalName>
-                                    <appendAssemblyId>false</appendAssemblyId>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.6.0</version>
-                        <executions>
-                            <execution>
-                                <id>append</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>bash</executable>
-                                    <arguments>
-                                        <argument>src/script/append-to-env.sh</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>cluster-integration-test</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                                <configuration>
-                                    <groups>${test.includedGroups}</groups>
-                                    <excludedGroups>${test.excludedGroups}</excludedGroups>
-                                    <useSystemClassLoader>false</useSystemClassLoader>
-                                    <parallel>classes</parallel>
-                                    <useUnlimitedThreads>true</useUnlimitedThreads>
-                                    <forkCount>${integrationTest.forkCount}</forkCount>
-                                    <reuseForks>false</reuseForks>
-                                    <systemPropertyVariables>
-                                        <TestEnv>Cluster1</TestEnv>
-                                        <RandomSelectWriteNode>${integrationTest.randomSelectWriteNode}</RandomSelectWriteNode>
-                                        <ReadAndVerifyWithMultiNode>${integrationTest.readAndVerifyWithMultiNode}</ReadAndVerifyWithMultiNode>
-                                    </systemPropertyVariables>
-                                    <summaryFile>target/failsafe-reports/failsafe-summary-ClusterIT.xml</summaryFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>verify</id>
-                                <goals>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <summaryFiles>
-                                        <summaryFile>target/failsafe-reports/failsafe-summary-ClusterIT.xml</summaryFile>
-                                    </summaryFiles>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>LocalStandaloneOnMppIT</id>
             <properties>
-                <test.includedGroups>org.apache.iotdb.itbase.category.LocalStandaloneIT</test.includedGroups>
-                <test.excludedGroups/>
+                <integrationTest.includedGroups>org.apache.iotdb.itbase.category.LocalStandaloneIT</integrationTest.includedGroups>
+                <integrationTest.excludedGroups/>
+                <integrationTest.testEnv>LocalStandaloneOnMpp</integrationTest.testEnv>
+                <integrationTest.launchNodeInSameJVM>false</integrationTest.launchNodeInSameJVM>
+                <integrationTest.randomSelectWriteNode>false</integrationTest.randomSelectWriteNode>
+                <integrationTest.readAndVerifyWithMultiNode>false</integrationTest.readAndVerifyWithMultiNode>
+                <integrationTest.parallelMode>classes</integrationTest.parallelMode>
             </properties>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-            <build>
-                <plugins>
-                    <!-- skip default-test -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <version>${maven.assembly.version}</version>
-                        <executions>
-                            <!-- Package binaries-->
-                            <execution>
-                                <id>cluster-test-assembly</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <descriptors>
-                                        <descriptor>src/assembly/mpp-test.xml</descriptor>
-                                    </descriptors>
-                                    <finalName>template-node</finalName>
-                                    <appendAssemblyId>false</appendAssemblyId>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.6.0</version>
-                        <executions>
-                            <execution>
-                                <id>append</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>bash</executable>
-                                    <arguments>
-                                        <argument>src/script/append-to-env.sh</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>standalone-integration-test</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                                <configuration>
-                                    <groups>${test.includedGroups}</groups>
-                                    <excludedGroups>${test.excludedGroups}</excludedGroups>
-                                    <useSystemClassLoader>false</useSystemClassLoader>
-                                    <parallel>classes</parallel>
-                                    <useUnlimitedThreads>true</useUnlimitedThreads>
-                                    <forkCount>${integrationTest.forkCount}</forkCount>
-                                    <reuseForks>false</reuseForks>
-                                    <systemPropertyVariables>
-                                        <TestEnv>LocalStandaloneOnMpp</TestEnv>
-                                        <RandomSelectWriteNode>false</RandomSelectWriteNode>
-                                        <ReadAndVerifyWithMultiNode>false</ReadAndVerifyWithMultiNode>
-                                    </systemPropertyVariables>
-                                    <summaryFile>target/failsafe-reports/failsafe-summary-LocalStandaloneOnMppIT.xml</summaryFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>verify</id>
-                                <goals>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <summaryFiles>
-                                        <summaryFile>target/failsafe-reports/failsafe-summary-LocalStandaloneOnMppIT.xml</summaryFile>
-                                    </summaryFiles>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/AbstractNodeWrapper.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/AbstractNodeWrapper.java
@@ -136,12 +136,20 @@ public abstract class AbstractNodeWrapper implements BaseNodeWrapper {
 
   @Override
   public void destroyDir() {
-    // rm this.path
-    try {
-      FileUtils.forceDelete(new File(getNodePath()));
-    } catch (IOException ex) {
-      fail("Delete node dir failed. " + ex);
+    for (int i = 0; i < 3; i++) {
+      try {
+        FileUtils.forceDelete(new File(getNodePath()));
+        return;
+      } catch (IOException ex) {
+        logger.error("Delete node dir failed. RetryTimes={}", i + 1, ex);
+        try {
+          TimeUnit.SECONDS.sleep(3);
+        } catch (InterruptedException e) {
+          fail("Delete node dir failed. " + e);
+        }
+      }
     }
+    fail("Delete node dir failed.");
   }
 
   @Override

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/runtime/ClusterTestStatement.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/runtime/ClusterTestStatement.java
@@ -88,7 +88,7 @@ public class ClusterTestStatement implements Statement {
                     try {
                       r.close();
                     } catch (SQLException e) {
-                      throw new RuntimeException(e);
+                      // Ignore close exceptions
                     }
                   }
                   return null;

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
@@ -56,4 +56,7 @@ public class Config {
 
   /** key of thrift max frame size */
   public static final String THRIFT_FRAME_MAX_SIZE = "thrift_max_frame_size";
+
+  /** key of underlying transport socketTimeout and connectionTimeout */
+  public static final String NETWORK_TIMEOUT = "network_timeout";
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -78,6 +78,12 @@ public class IoTDBConnection implements Connection {
    */
   private int queryTimeout = 0;
 
+  /**
+   * ConnectionTimeout and SocketTimeout. Unit: ms. If not set, default value 0 will be used, which
+   * means that there's no timeout in the client side.
+   */
+  private int networkTimeout = Config.DEFAULT_CONNECTION_TIMEOUT_MS;
+
   private ZoneId zoneId;
   private boolean autoCommit;
   private String url;
@@ -99,6 +105,7 @@ public class IoTDBConnection implements Connection {
     params = Utils.parseUrl(url, info);
     this.url = url;
     this.userName = info.get("user").toString();
+    this.networkTimeout = params.getNetworkTimeout();
     openTransport();
     if (Config.rpcThriftCompressionEnable) {
       setClient(new TSIService.Client(new TCompactProtocol(transport)));
@@ -274,7 +281,7 @@ public class IoTDBConnection implements Connection {
 
   @Override
   public int getNetworkTimeout() {
-    return Config.DEFAULT_CONNECTION_TIMEOUT_MS;
+    return networkTimeout;
   }
 
   @Override
@@ -451,7 +458,7 @@ public class IoTDBConnection implements Connection {
     RpcTransportFactory.setThriftMaxFrameSize(params.getThriftMaxFrameSize());
     transport =
         RpcTransportFactory.INSTANCE.getTransport(
-            params.getHost(), params.getPort(), Config.DEFAULT_CONNECTION_TIMEOUT_MS);
+            params.getHost(), params.getPort(), getNetworkTimeout());
     if (!transport.isOpen()) {
       transport.open();
     }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
@@ -34,6 +34,7 @@ public class IoTDBConnectionParams {
 
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;
   private int thriftMaxFrameSize = RpcUtils.THRIFT_FRAME_MAX_SIZE;
+  private int networkTimeout = Config.DEFAULT_CONNECTION_TIMEOUT_MS;
 
   public IoTDBConnectionParams(String url) {
     this.jdbcUriString = url;
@@ -109,5 +110,17 @@ public class IoTDBConnectionParams {
 
   public void setVersion(Constant.Version version) {
     this.version = version;
+  }
+
+  public void setNetworkTimeout(int networkTimeout) {
+    if (networkTimeout < 0) {
+      this.networkTimeout = Config.DEFAULT_CONNECTION_TIMEOUT_MS;
+    } else {
+      this.networkTimeout = networkTimeout;
+    }
+  }
+
+  public int getNetworkTimeout() {
+    return this.networkTimeout;
   }
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
@@ -74,6 +74,9 @@ public class Utils {
     if (info.containsKey(Config.VERSION)) {
       params.setVersion(Constant.Version.valueOf(info.getProperty(Config.VERSION)));
     }
+    if (info.containsKey(Config.NETWORK_TIMEOUT)) {
+      params.setNetworkTimeout(Integer.parseInt(info.getProperty(Config.NETWORK_TIMEOUT)));
+    }
 
     return params;
   }
@@ -108,6 +111,7 @@ public class Utils {
           }
           break;
         case Config.VERSION:
+        case Config.NETWORK_TIMEOUT:
           info.put(key, value);
           break;
         default:

--- a/server/src/test/java/org/apache/iotdb/db/protocol/rest/GrafanaApiServiceTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/protocol/rest/GrafanaApiServiceTest.java
@@ -46,7 +46,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class GrafanaApiServiceIT {
+public class GrafanaApiServiceTest {
   @Before
   public void setUp() throws Exception {
     EnvironmentUtils.envSetUp();

--- a/server/src/test/java/org/apache/iotdb/db/protocol/rest/IoTDBRestServiceTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/protocol/rest/IoTDBRestServiceTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @FixMethodOrder(MethodSorters.JVM)
-public class IoTDBRestServiceIT {
+public class IoTDBRestServiceTest {
   @Before
   public void setUp() throws Exception {
     EnvironmentUtils.envSetUp();

--- a/server/src/test/java/org/apache/iotdb/db/script/EnvScriptIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/script/EnvScriptIT.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/** This test case is strange that it relies on the maven output files */
 public class EnvScriptIT {
 
   @Before


### PR DESCRIPTION
This PR fixes:
1. Add a `network_timeout` parameter in JDBC URL to init the underlying transport with a non-zero network timeout.
2. Refine integration-test/pom.xml.
3. Rename some *IT files from IT to UT.