### PR TITLE
[IOTDB-3584] Snapshot unstable due to segment size

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
@@ -519,8 +519,8 @@ public class RatisConfig {
       private SizeInBytes queueByteLimit = SizeInBytes.valueOf("64MB");
       private int purgeGap = 1024;
       private boolean purgeUptoSnapshotIndex = false;
-      private SizeInBytes segmentSizeMax = SizeInBytes.valueOf("8MB");
-      private int segmentCacheNumMax = 6;
+      private SizeInBytes segmentSizeMax = SizeInBytes.valueOf("128MB");
+      private int segmentCacheNumMax = 2;
       private SizeInBytes segmentCacheSizeMax = SizeInBytes.valueOf("200MB");
       private SizeInBytes preallocatedSize = SizeInBytes.valueOf("4MB");
       private SizeInBytes writeBufferSize = SizeInBytes.valueOf("64KB");


### PR DESCRIPTION
When 400000 raft logs append, Ratis will ask statemachine to take a snapshot and purge the logs.
Currently, log segment size is 8MB, which means 400000 logs will add to 10000+ logs files, and purge them will take up to 10 seconds, which is longer enough to cause the current leader to step down.
Therefore, in this PR I change to segment size to 128 MB to reduce file numbers and corresponding purge time.