### PR TITLE
Pre-commit-hooks for dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ node3/
 antlr/gen/
 antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/gen/
 antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlLexer.tokens
+
+# git hooks
+tools/git-hooks/config.sh

--- a/docs/Development/ContributeGuide.md
+++ b/docs/Development/ContributeGuide.md
@@ -153,6 +153,16 @@ In IDEA, you can follow these steps to change those inconsistent style formattin
 4. Change 'Class count to use import with '\*'' to 999 or another very large number.
 5. Change 'Names to count to use static import with '\*'' to 999 or another very large number.
 
+## Use git-hooks
+
+Fortunately, IoTDB has pre-commit git-hooks to automatically do the code checks. 
+
+With the help of these pre-defined hooks, each time you commit your code, the code style check will be triggered. And if the code style is incorrect, the commit will be rejected locally, reducing the double check time by CI/CD.
+
+Besides, the smart selection mechanism will check only the changed modules to decrease the time of the code check.
+
+The hooks are under `tools/git-hooks`. See [Guide to to git-hooks](https://github.com/apache/iotdb/blob/master/tools/git-hooks/README.md) for more details.
+
 ## Contributing code
 
 You can go to jira to pick up the existing issue or create your own issue and get it. The comment says that I can do this issue.

--- a/docs/Development/ContributeGuide.md
+++ b/docs/Development/ContributeGuide.md
@@ -153,7 +153,7 @@ In IDEA, you can follow these steps to change those inconsistent style formattin
 4. Change 'Class count to use import with '\*'' to 999 or another very large number.
 5. Change 'Names to count to use static import with '\*'' to 999 or another very large number.
 
-## Use git-hooks
+## Use git-hooks(Optional)
 
 Fortunately, IoTDB has pre-commit git-hooks to automatically do the code checks. 
 

--- a/docs/zh/Development/ContributeGuide.md
+++ b/docs/zh/Development/ContributeGuide.md
@@ -120,6 +120,16 @@ plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) 和 [google
 4. 将“将 import 与‘*’搭配使用的类计数”改成 999 或者一个比较大的值。
 5. 将“将静态 import 与‘*’搭配使用的名称计数”改成 999 或者一个比较大的值。
 
+## 使用 git-hooks 自动检查
+
+为简化每次 commit 的工作，我们提供了一个基于 git-hooks 的自动代码检查脚本。
+
+在使用我们预定义的 git-hooks 时，每次 commit 代码时，都会触发代码检查。如果代码风格不符合要求，那么 commit 将被本地拒绝，减少 CI/CD 进行双重检查的时间。
+
+此外，预定义 git-hooks 中的智能选择机制只会检查更改过的模块，以减少代码检查的时间。
+
+git-hooks 工具位于 `tools/git-hooks` 目录下。更多详情请参阅 [Guide to to git-hooks](https://github.com/apache/iotdb/blob/master/tools/git-hooks/README.md)。
+
 ## 贡献代码
 
 可以到 jira 上领取现有 issue 或者自己创建 issue 再领取，评论说我要做这个 issue 就可以。

--- a/docs/zh/Development/ContributeGuide.md
+++ b/docs/zh/Development/ContributeGuide.md
@@ -120,7 +120,7 @@ plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) 和 [google
 4. 将“将 import 与‘*’搭配使用的类计数”改成 999 或者一个比较大的值。
 5. 将“将静态 import 与‘*’搭配使用的名称计数”改成 999 或者一个比较大的值。
 
-## 使用 git-hooks 自动检查
+## 使用 git-hooks 自动检查(可选)
 
 为简化每次 commit 的工作，我们提供了一个基于 git-hooks 的自动代码检查脚本。
 

--- a/tools/git-hooks/README.md
+++ b/tools/git-hooks/README.md
@@ -1,0 +1,71 @@
+# Guide to git hooks
+
+The pre-commit hooks enable auto checks before commits. So next time a single `git commit` should do all the style checks automatically.
+
+Currently, the support functionalities are:
+* Turn on/off the hook in local config files.
+* Auto `mvn spotless:apply` before commits
+* Auto `mvn validate` before commits
+* Smart selection of only the changed modules for validation
+
+## Installation
+
+All the files are under `tools/git-hooks`.
+
+### Windows
+
+Double click the `install.ps1`, and allow to execute in admin mode. Make sure that the Git for Windows is the default git on Windows.
+
+**Note**: Windows support is based on the [Git for Windows](https://gitforwindows.org/), which provide a minimal shell environment called Git Bash. Actually, all these hooks on Windows are executed under the Git Bash environment, so the hook script can be somewhat platform-independent.
+
+### Unix
+
+```
+./install.sh
+```
+
+## Configuration
+
+After installation, a `config.sh` shall be created. Modification to the `config.sh` file would take effect the next time you commit.
+
+All the configurable options is in `config.sample.sh`.
+
+```sh
+# enable the pre-commit hooks, 0 - off, 1 - on
+export IOTDB_GIT_HOOKS=1
+# maven path
+# If in Git Bash, replace all '\' to '/', and change the driver path from 'C:\' to '/c/
+# No escape character is needed.
+# Example:
+#   export IOTDB_MAVEN_PATH="/c/Program Files/apache-maven-3.6/bin/mvn"
+export IOTDB_MAVEN_PATH="mvn"
+# git path
+# If in Git Bash, see 'IOTDB_MAVEN_PATH'
+export IOTDB_GIT_PATH="git"
+# smart select the changed java module, 0 - off, 1 - on
+export IOTDB_SMART_JAVA_MODULES=1
+# auto spotless:apply, 0 - off, 1 - on
+export IOTDB_SPOTLESS_APPLY=0
+# maven validate, 0 - off, 1 - on
+export IOTDB_VALIDATE=1
+# 0 - discard all, 1 - logs on errors, 2 - stdout, 3 - stdout & logs on errors
+export IOTDB_VERBOSE=2
+```
+
+**Note 1 for Windows user**: If you are on Windows, pay attention to the `IOTDB_MAVEN_PATH` and `IOTDB_GIT_PATH`. Since the hook script is executed under Git Bash, you must make sure the Git Bash could get to the maven & git binary file correctly. The path expression in Git Bash is slightly different from Windows. Check the examples in config file carefully.
+
+**Note 2 for Windows user**: The easiest way to handle these binary path is to put them into the %PATH% environment variable in Windows. Then the default configuration should work well.
+
+## Uninstall
+
+See `uninstall.ps1` and `uninstall.sh`.
+
+## Pipeline
+
+The overall pipeline of the hook script:
+1. `IOTDB_GIT_HOOKS` checks if the hook is on
+2. `IOTDB_SMART_JAVA_MODULES` to select only the changed modules
+3. `IOTDB_SPOTLESS_APPLY` runs `mvn spotless:apply`
+4. `IOTDB_VALIDATE` runs `mvn validate` or `mvn -pl <changed_modules> validate`
+
+The hook is tested on both Linux and Windows.

--- a/tools/git-hooks/README.md
+++ b/tools/git-hooks/README.md
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 # Guide to git hooks
 
 The pre-commit hooks enable auto checks before commits. So next time a single `git commit` should do all the style checks automatically.

--- a/tools/git-hooks/README.md
+++ b/tools/git-hooks/README.md
@@ -65,7 +65,7 @@ export IOTDB_GIT_PATH="git"
 # smart select the changed java module, 0 - off, 1 - on
 export IOTDB_SMART_JAVA_MODULES=1
 # auto spotless:apply, 0 - off, 1 - on
-export IOTDB_SPOTLESS_APPLY=0
+export IOTDB_SPOTLESS_APPLY=1
 # maven validate, 0 - off, 1 - on
 export IOTDB_VALIDATE=1
 # 0 - discard all, 1 - logs on errors, 2 - stdout, 3 - stdout & logs on errors

--- a/tools/git-hooks/config.sample.sh
+++ b/tools/git-hooks/config.sample.sh
@@ -23,8 +23,13 @@
 # enable the pre-commit hooks, 0 - off, 1 - on
 export IOTDB_GIT_HOOKS=1
 # maven path
+# If in Git Bash, replace all '\' to '/', and change the driver path from 'C:\' to '/c/
+# No escape character is needed.
+# Example:
+#   export IOTDB_MAVEN_PATH="/c/Program Files/apache-maven-3.6/bin/mvn"
 export IOTDB_MAVEN_PATH="mvn"
 # git path
+# If in Git Bash, see 'IOTDB_MAVEN_PATH'
 export IOTDB_GIT_PATH="git"
 # smart select the changed java module, 0 - off, 1 - on
 export IOTDB_SMART_JAVA_MODULES=1

--- a/tools/git-hooks/config.sample.sh
+++ b/tools/git-hooks/config.sample.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 ################################################################################
-##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
 ##
 ##  Licensed to the Apache Software Foundation (ASF) under one or more
 ##  contributor license agreements.  See the NOTICE file distributed with

--- a/tools/git-hooks/config.sample.sh
+++ b/tools/git-hooks/config.sample.sh
@@ -23,9 +23,13 @@
 export IOTDB_GIT_HOOKS=1
 # maven path
 export IOTDB_MAVEN_PATH="mvn"
+# git path
+export IOTDB_GIT_PATH="git"
+# smart select the changed java module, 0 - off, 1 - on
+export IOTDB_SMART_JAVA_MODULES=1
 # auto spotless:apply, 0 - off, 1 - on
 export IOTDB_SPOTLESS_APPLY=0
 # maven validate, 0 - off, 1 - on
 export IOTDB_VALIDATE=1
-# 0 - discard all, 1 - logs on errors, 2 - stdout, 3 - stdout & logs on error
+# 0 - discard all, 1 - logs on errors, 2 - stdout, 3 - stdout & logs on errors
 export IOTDB_VERBOSE=2

--- a/tools/git-hooks/config.sample.sh
+++ b/tools/git-hooks/config.sample.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+################################################################################
+##
+##  Licensed to the Apache Software Foundation (ASF) under one or more
+##  contributor license agreements.  See the NOTICE file distributed with
+##  this work for additional information regarding copyright ownership.
+##  The ASF licenses this file to You under the Apache License, Version 2.0
+##  (the "License"); you may not use this file except in compliance with
+##  the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+##
+################################################################################
+
+# enable the pre-commit hooks, 0 - off, 1 - on
+export IOTDB_GIT_HOOKS=1
+# maven path
+export IOTDB_MAVEN_PATH="mvn"
+# auto spotless:apply, 0 - off, 1 - on
+export IOTDB_SPOTLESS_APPLY=0
+# maven validate, 0 - off, 1 - on
+export IOTDB_VALIDATE=1
+# 0 - discard all, 1 - logs on errors, 2 - stdout, 3 - stdout & logs on error
+export IOTDB_VERBOSE=2

--- a/tools/git-hooks/config.sample.sh
+++ b/tools/git-hooks/config.sample.sh
@@ -33,7 +33,7 @@ export IOTDB_GIT_PATH="git"
 # smart select the changed java module, 0 - off, 1 - on
 export IOTDB_SMART_JAVA_MODULES=1
 # auto spotless:apply, 0 - off, 1 - on
-export IOTDB_SPOTLESS_APPLY=0
+export IOTDB_SPOTLESS_APPLY=1
 # maven validate, 0 - off, 1 - on
 export IOTDB_VALIDATE=1
 # 0 - discard all, 1 - logs on errors, 2 - stdout, 3 - stdout & logs on errors

--- a/tools/git-hooks/install.ps1
+++ b/tools/git-hooks/install.ps1
@@ -1,5 +1,4 @@
 ################################################################################
-##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
 ##
 ##  Licensed to the Apache Software Foundation (ASF) under one or more
 ##  contributor license agreements.  See the NOTICE file distributed with

--- a/tools/git-hooks/install.ps1
+++ b/tools/git-hooks/install.ps1
@@ -1,0 +1,100 @@
+################################################################################
+##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
+##
+##  Licensed to the Apache Software Foundation (ASF) under one or more
+##  contributor license agreements.  See the NOTICE file distributed with
+##  this work for additional information regarding copyright ownership.
+##  The ASF licenses this file to You under the Apache License, Version 2.0
+##  (the "License"); you may not use this file except in compliance with
+##  the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+##
+################################################################################
+
+if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
+    Start-Process -FilePath PowerShell.exe -Verb Runas -ArgumentList "-File `"$($MyInvocation.MyCommand.Path)`"  `"$($MyInvocation.MyCommand.UnboundArguments)`""
+    exit
+}
+
+Push-Location $PSScriptRoot
+
+# project directory
+$PROJECT_DIR="..\.."
+# hooks directory
+$HOOKS_DIR="$PROJECT_DIR\.git\hooks"
+# tool directory rel to project
+$REL_SCRIPT_DIR="tools\git-hooks"
+
+# config sample filename rel to script dir
+$REL_CONFIG_SAMPLE_FILE="config.sample.sh"
+# config filename rel to script dir
+$REL_CONFIG_FILE="config.sh"
+
+function Check-Paths {
+    Write-Output "Checking paths..."
+    if (-Not(Test-Path -Path "$PROJECT_DIR" -PathType Container)) {
+        throw "Project directory '$PROJECT_DIR' does not exist."
+    }
+    if (-Not(Test-Path -Path "$HOOKS_DIR" -PathType Container)) {
+        throw "Hooks directory '$HOOKS_DIR' does not exist."
+    }
+}
+
+function Install {
+    # create the relative symlink of pre-commit script
+    if (Test-Path -Path "$PROJECT_DIR\$REL_SCRIPT_DIR\pre-commit" -PathType Leaf) {
+        Write-Warning "Overwriting '$PROJECT_DIR\$REL_SCRIPT_DIR\pre-commit'"
+    }
+    New-Item -ItemType SymbolicLink -Force `
+        -Path "$HOOKS_DIR\pre-commit" `
+        -Target "$PROJECT_DIR\$REL_SCRIPT_DIR\pre-commit" `
+        | Out-Null
+    if (-Not($?)) {
+        throw "Fail to create symlink for pre-commit script."
+    }
+    # create the relative symlink of config file
+    if (-Not(Test-Path -Path "$REL_CONFIG_FILE" -PathType Leaf)) {
+        if (-Not(Test-Path -Path "$REL_CONFIG_SAMPLE_FILE")) {
+            throw "Could not find '$REL_CONFIG_SAMPLE_FILE'."
+        }
+        Copy-Item -Path "$REL_CONFIG_SAMPLE_FILE" -Destination "$REL_CONFIG_FILE"
+    } else {
+        Write-Warning "$REL_CONFIG_FILE is already existed. Ignored."
+    }
+    New-Item -ItemType SymbolicLink -Force `
+        -Path "$HOOKS_DIR\config.sh" `
+        -Target "$PROJECT_DIR\$REL_SCRIPT_DIR\config.sh" `
+        | Out-Null
+    if (-Not($?)) {
+        throw "Fail to create symlink for config file."
+    }
+    # finished
+    Write-Output "Installed hooks."
+}
+
+function Main {
+    Write-Output "Installing pre-commit hook..."
+    Check-Paths
+    Install
+}
+
+trap [Exception] {
+    $e=$_.Exception.Message
+    $lineno=$_.Exception.InvocationInfo.ScriptLineNumber
+    Write-Error "Caught exception: $e at line $lineno"
+    Write-Error "Installation failed."
+    Read-Host -Prompt "Press Enter to exit"
+    exit 1
+}
+
+Main
+Pop-Location
+Write-Host "Installation succeed." -ForegroundColor Cyan
+Read-Host -Prompt "Press Enter to exit"

--- a/tools/git-hooks/install.ps1
+++ b/tools/git-hooks/install.ps1
@@ -48,8 +48,9 @@ function Check-Paths {
 
 function Install {
     # create the relative symlink of pre-commit script
-    if (Test-Path -Path "$PROJECT_DIR\$REL_SCRIPT_DIR\pre-commit" -PathType Leaf) {
-        Write-Warning "Overwriting '$PROJECT_DIR\$REL_SCRIPT_DIR\pre-commit'"
+    Write-Output "Installing pre-commit hook to '$HOOKS_DIR/pre-commit'..."
+    if (Test-Path -Path "$HOOKS_DIR\pre-commit" -PathType Leaf) {
+        Write-Warning "Overwriting '$HOOKS_DIR\pre-commit'"
     }
     New-Item -ItemType SymbolicLink -Force `
         -Path "$HOOKS_DIR\pre-commit" `
@@ -59,6 +60,7 @@ function Install {
         throw "Fail to create symlink for pre-commit script."
     }
     # create the relative symlink of config file
+    Write-Output "Creating '$REL_CONFIG_FILE'..."
     if (-Not(Test-Path -Path "$REL_CONFIG_FILE" -PathType Leaf)) {
         if (-Not(Test-Path -Path "$REL_CONFIG_SAMPLE_FILE")) {
             throw "Could not find '$REL_CONFIG_SAMPLE_FILE'."

--- a/tools/git-hooks/install.sh
+++ b/tools/git-hooks/install.sh
@@ -34,14 +34,20 @@ REL_CONFIG_SAMPLE_FILE="config.sample.sh"
 # config filename rel to script dir
 REL_CONFIG_FILE="config.sh"
 
+# color
+Red="\x1B[31m"
+Green="\x1B[32m"
+Yellow="\x1B[33m"
+NC="\x1B[0m"
+
 check_paths() {
     echo "Checking paths..."
     if [ ! -d "$PROJECT_DIR" ]; then
-        echo "ERROR: Project directory '$PROJECT_DIR' does not exist." >&2
+        printf "${Red}ERROR: Project directory '$PROJECT_DIR' does not exist.${NC}\n" >&2
         exit 1
     fi
     if [ ! -d "$HOOKS_DIR" ]; then
-        echo "ERROR: Hooks directory '$HOOKS_DIR' does not exist." >&2
+        printf "${Red}ERROR: Hooks directory '$HOOKS_DIR' does not exist.${NC}\n" >&2
         exit 1
     fi
 }
@@ -49,11 +55,11 @@ check_paths() {
 install() {
     # create the relative symlink of pre-commit script
     if [ -f "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" ] || [ -L "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" ]; then
-        echo "WARN: Overwriting '$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit'"
+        printf "${Yellow}WARN: Overwriting '$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit'${NC}\n"
     fi
     ln -sf "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" "$HOOKS_DIR/pre-commit" || exit 1
     if [ -f "pre-commit" ] && [ ! -x "pre-commit" ]; then
-        echo "ERROR: 'pre-commit' has no execute permission. Try to grant it the 'x' permission."
+        printf "${Yellow}ERROR: 'pre-commit' has no execute permission. Try to grant it the 'x' permission.${NC}\n"
         exit 1
     fi
     # create the relative symlink of config file
@@ -62,7 +68,7 @@ install() {
         test -f "$REL_CONFIG_SAMPLE_FILE" || { echo "ERROR: Could not find '$REL_CONFIG_SAMPLE_FILE'." >&2; exit 1; }
         cp "$REL_CONFIG_SAMPLE_FILE" "$REL_CONFIG_FILE"
     else
-        echo "WARN: $REL_CONFIG_FILE is already existed. Ignored."
+        printf "${Yellow}WARN: $REL_CONFIG_FILE is already existed. Ignored.${NC}\n"
     fi
     ln -sf "$PROJECT_DIR/$REL_SCRIPT_DIR/$REL_CONFIG_FILE" "$HOOKS_DIR/$REL_CONFIG_FILE" || exit 1
     # finished
@@ -73,6 +79,7 @@ main() {
     echo "Installing pre-commit hook..."
     check_paths
     install
+    printf "${Green}Installation succeed.${NC}\n"
 }
 
 main

--- a/tools/git-hooks/install.sh
+++ b/tools/git-hooks/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 ################################################################################
+##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
 ##
 ##  Licensed to the Apache Software Foundation (ASF) under one or more
 ##  contributor license agreements.  See the NOTICE file distributed with
@@ -46,10 +47,10 @@ check_paths() {
 }
 
 install() {
-    if [ -f "$INSTALL_PATH" ] || [ -L "$INSTALL_PATH" ]; then
-        echo "WARN: Overwriting '$INSTALL_PATH'"
-    fi
     # create the relative symlink of pre-commit script
+    if [ -f "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" ] || [ -L "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" ]; then
+        echo "WARN: Overwriting '$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit'"
+    fi
     ln -sf "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" "$HOOKS_DIR/pre-commit" || exit 1
     if [ -f "pre-commit" ] && [ ! -x "pre-commit" ]; then
         echo "ERROR: 'pre-commit' has no execute permission. Try to grant it the 'x' permission."

--- a/tools/git-hooks/install.sh
+++ b/tools/git-hooks/install.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 ################################################################################
-##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
 ##
 ##  Licensed to the Apache Software Foundation (ASF) under one or more
 ##  contributor license agreements.  See the NOTICE file distributed with

--- a/tools/git-hooks/install.sh
+++ b/tools/git-hooks/install.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+################################################################################
+##
+##  Licensed to the Apache Software Foundation (ASF) under one or more
+##  contributor license agreements.  See the NOTICE file distributed with
+##  this work for additional information regarding copyright ownership.
+##  The ASF licenses this file to You under the Apache License, Version 2.0
+##  (the "License"); you may not use this file except in compliance with
+##  the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+##
+################################################################################
+
+# script directory
+cd $(dirname "$0") || exit 1
+# project directory
+PROJECT_DIR="../.."
+# hooks directory
+HOOKS_DIR="$PROJECT_DIR/.git/hooks"
+# tool directory rel to project
+REL_SCRIPT_DIR="tools/git-hooks"
+
+# config sample filename rel to script dir
+REL_CONFIG_SAMPLE_FILE="config.sample.sh"
+# config filename rel to script dir
+REL_CONFIG_FILE="config.sh"
+
+check_paths() {
+    echo "Checking paths..."
+    if [ ! -d "$PROJECT_DIR" ]; then
+        echo "ERROR: Project directory '$PROJECT_DIR' does not exist." >&2
+        exit 1
+    fi
+    if [ ! -d "$HOOKS_DIR" ]; then
+        echo "ERROR: Hooks directory '$HOOKS_DIR' does not exist." >&2
+        exit 1
+    fi
+}
+
+install() {
+    if [ -f "$INSTALL_PATH" ] || [ -L "$INSTALL_PATH" ]; then
+        echo "WARN: Overwriting '$INSTALL_PATH'"
+    fi
+    # create the relative symlink of pre-commit script
+    ln -sf "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" "$HOOKS_DIR/pre-commit" || exit 1
+    if [ -f "pre-commit" ] && [ ! -x "pre-commit" ]; then
+        echo "ERROR: 'pre-commit' has no execute permission. Try to grant it the 'x' permission."
+        exit 1
+    fi
+    # create the relative symlink of config file
+    if [ ! -f "$REL_CONFIG_FILE" ]; then
+        # if `config.sh` not exists in this directory, create it from sample
+        test -f "$REL_CONFIG_SAMPLE_FILE" || { echo "ERROR: Could not find '$REL_CONFIG_SAMPLE_FILE'." >&2; exit 1; }
+        cp "$REL_CONFIG_SAMPLE_FILE" "$REL_CONFIG_FILE"
+    else
+        echo "WARN: $REL_CONFIG_FILE is already existed. Ignored."
+    fi
+    ln -sf "$PROJECT_DIR/$REL_SCRIPT_DIR/$REL_CONFIG_FILE" "$HOOKS_DIR/$REL_CONFIG_FILE" || exit 1
+    # finished
+    echo "Installed hooks."
+}
+
+main() {
+    echo "Installing pre-commit hook..."
+    check_paths
+    install
+}
+
+main

--- a/tools/git-hooks/install.sh
+++ b/tools/git-hooks/install.sh
@@ -53,8 +53,9 @@ check_paths() {
 
 install() {
     # create the relative symlink of pre-commit script
-    if [ -f "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" ] || [ -L "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" ]; then
-        printf "${Yellow}WARN: Overwriting '$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit'${NC}\n"
+    echo "Installing pre-commit hook to '$HOOKS_DIR/pre-commit'..."
+    if [ -f "$HOOKS_DIR/pre-commit" ] || [ -L "$HOOKS_DIR/pre-commit" ]; then
+        printf "${Yellow}WARN: Overwriting '$HOOKS_DIR/pre-commit'${NC}\n"
     fi
     ln -sf "$PROJECT_DIR/$REL_SCRIPT_DIR/pre-commit" "$HOOKS_DIR/pre-commit" || exit 1
     if [ -f "pre-commit" ] && [ ! -x "pre-commit" ]; then
@@ -62,6 +63,7 @@ install() {
         exit 1
     fi
     # create the relative symlink of config file
+    echo "Creating '$REL_CONFIG_FILE'..."
     if [ ! -f "$REL_CONFIG_FILE" ]; then
         # if `config.sh` not exists in this directory, create it from sample
         test -f "$REL_CONFIG_SAMPLE_FILE" || { echo "ERROR: Could not find '$REL_CONFIG_SAMPLE_FILE'." >&2; exit 1; }

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -62,6 +62,24 @@ main() {
         exit 0
     fi
 
+    # get all changed module path
+    changed_files=$($IOTDB_GIT_PATH diff --name-only --cached)
+    changed_java_modules=""
+    smart_args=""
+    for line in $changed_files; do
+        mod=$(echo "$line" | cut -d '/' -f 1)
+        if [ -f "$mod/pom.xml" ]; then
+            changed_java_modules="${changed_java_modules}${mod},"
+        fi
+    done
+    if [ "$IOTDB_SMART_JAVA_MODULES" -ne 0 ]; then
+        # prepare the smart module selection args
+        echo "$PROMPT Changed java module: $changed_java_modules"
+        if [ -n "$changed_java_modules" ]; then
+            smart_args="-pl $changed_java_modules"
+        fi
+    fi
+
     # change log level
     if [ "$IOTDB_VERBOSE" -eq 1 ]; then
         LOG_OUT_PATH="$(mktemp --suff .log)"
@@ -74,7 +92,11 @@ main() {
     # spotless:apply
     if [ "$IOTDB_SPOTLESS_APPLY" -ne 0 ]; then
         echo "$PROMPT Apply spotless:apply..."
-        exec_with_log "$IOTDB_MAVEN_PATH spotless:apply"
+        if [ "$IOTDB_SMART_JAVA_MODULES" -eq 0 ] || [ -n "$smart_args" ]; then
+            exec_with_log "$IOTDB_MAVEN_PATH $smart_args spotless:apply"
+        else
+            echo "$PROMPT No changed module for spotless:apply."
+        fi
         if [ "$?" -ne 0 ]; then
             on_error "spotless:apply failed."
         fi
@@ -83,7 +105,11 @@ main() {
     # maven validate
     if [ "$IOTDB_VALIDATE" -ne 0 ]; then
         echo "$PROMPT Validating..."
-        exec_with_log "$IOTDB_MAVEN_PATH validate"
+        if [ "$IOTDB_SMART_JAVA_MODULES" -eq 0 ] || [ -n "$smart_args" ]; then
+            exec_with_log "$IOTDB_MAVEN_PATH $smart_args validate"
+        else
+            echo "$PROMPT No changed module for validating."
+        fi
         if [ "$?" -ne 0 ]; then
             on_error "maven validate failed."
         fi

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 ################################################################################
+##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
 ##
 ##  Licensed to the Apache Software Foundation (ASF) under one or more
 ##  contributor license agreements.  See the NOTICE file distributed with
@@ -30,8 +31,11 @@ PROMPT="Pre-commit-hooks:"
 LOG_OUT_PATH="/dev/null"
 
 exec_with_log() {
-    if [ "$IOTDB_VERBOSE" -le 2 ]; then
+    if [ "$IOTDB_VERBOSE" -le 1 ]; then
         eval "$*" > "$LOG_OUT_PATH" 2>&1
+    elif [ "$IOTDB_VERBOSE" -eq 2 ]; then
+        # compatible with git bash
+        eval "$*" 2>&1
     else
         eval "$*" 2>&1 | tee "$LOG_OUT_PATH"
     fi
@@ -84,6 +88,7 @@ main() {
     if [ "$IOTDB_VERBOSE" -eq 1 ]; then
         LOG_OUT_PATH="$(mktemp --suff .log)"
     elif [ "$IOTDB_VERBOSE" -eq 2 ]; then
+        # not used in git bash
         LOG_OUT_PATH="/dev/stdout"
     elif [ "$IOTDB_VERBOSE" -ge 3 ]; then
         LOG_OUT_PATH="$(mktemp --suff .log)"
@@ -93,7 +98,7 @@ main() {
     if [ "$IOTDB_SPOTLESS_APPLY" -ne 0 ]; then
         echo "$PROMPT Apply spotless:apply..."
         if [ "$IOTDB_SMART_JAVA_MODULES" -eq 0 ] || [ -n "$smart_args" ]; then
-            exec_with_log "$IOTDB_MAVEN_PATH $smart_args spotless:apply"
+            exec_with_log "\"$IOTDB_MAVEN_PATH\" $smart_args spotless:apply"
         else
             echo "$PROMPT No changed module for spotless:apply."
         fi
@@ -106,7 +111,7 @@ main() {
     if [ "$IOTDB_VALIDATE" -ne 0 ]; then
         echo "$PROMPT Validating..."
         if [ "$IOTDB_SMART_JAVA_MODULES" -eq 0 ] || [ -n "$smart_args" ]; then
-            exec_with_log "$IOTDB_MAVEN_PATH $smart_args validate"
+            exec_with_log "\"$IOTDB_MAVEN_PATH\" $smart_args validate"
         else
             echo "$PROMPT No changed module for validating."
         fi

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 ################################################################################
-##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
 ##
 ##  Licensed to the Apache Software Foundation (ASF) under one or more
 ##  contributor license agreements.  See the NOTICE file distributed with

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+################################################################################
+##
+##  Licensed to the Apache Software Foundation (ASF) under one or more
+##  contributor license agreements.  See the NOTICE file distributed with
+##  this work for additional information regarding copyright ownership.
+##  The ASF licenses this file to You under the Apache License, Version 2.0
+##  (the "License"); you may not use this file except in compliance with
+##  the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+##
+################################################################################
+
+PROJECT_DIR="../.."
+REL_HOOKS_DIR=".git/hooks"
+
+cd "$(dirname $0)/$PROJECT_DIR" || exit 1
+
+PROMPT="Pre-commit-hooks:"
+
+# default 0 level log path
+LOG_OUT_PATH="/dev/null"
+
+exec_with_log() {
+    if [ "$IOTDB_VERBOSE" -le 2 ]; then
+        eval "$*" > "$LOG_OUT_PATH" 2>&1
+    else
+        eval "$*" 2>&1 | tee "$LOG_OUT_PATH"
+    fi
+}
+
+on_error() {
+    if [ "$#" -eq 0 ]; then
+        echo "ERROR: 'on_error' must have at least 1 args."
+        exit 1
+    fi
+    echo "$PROMPT [ERROR] $*"
+    if [ "$IOTDB_VERBOSE" -eq 1 ] || [ "$IOTDB_VERBOSE" -ge 3 ]; then
+        echo "$PROMPT Log of last step is saved at $LOG_OUT_PATH"
+    fi
+    exit 1
+}
+
+load_config() {
+    . "./$REL_HOOKS_DIR/config.sh"
+}
+
+main() {
+    load_config
+
+    # enable hooks
+    if [ "$IOTDB_GIT_HOOKS" -eq 0 ]; then
+        echo "$PROMPT Skip git hooks."
+        exit 0
+    fi
+
+    # change log level
+    if [ "$IOTDB_VERBOSE" -eq 1 ]; then
+        LOG_OUT_PATH="$(mktemp --suff .log)"
+    elif [ "$IOTDB_VERBOSE" -eq 2 ]; then
+        LOG_OUT_PATH="/dev/stdout"
+    elif [ "$IOTDB_VERBOSE" -ge 3 ]; then
+        LOG_OUT_PATH="$(mktemp --suff .log)"
+    fi
+
+    # spotless:apply
+    if [ "$IOTDB_SPOTLESS_APPLY" -ne 0 ]; then
+        echo "$PROMPT Apply spotless:apply..."
+        exec_with_log "$IOTDB_MAVEN_PATH spotless:apply"
+        if [ "$?" -ne 0 ]; then
+            on_error "spotless:apply failed."
+        fi
+    fi
+
+    # maven validate
+    if [ "$IOTDB_VALIDATE" -ne 0 ]; then
+        echo "$PROMPT Validating..."
+        exec_with_log "$IOTDB_MAVEN_PATH validate"
+        if [ "$?" -ne 0 ]; then
+            on_error "maven validate failed."
+        fi
+    fi
+
+    # remove useless log
+    if [ "$IOTDB_VERBOSE" -eq 1 ] || [ "$IOTDB_VERBOSE" -ge 3 ]; then
+        rm "$LOG_OUT_PATH"
+    fi
+}
+
+main

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -108,7 +108,7 @@ main() {
 
     # maven validate
     if [ "$IOTDB_VALIDATE" -ne 0 ]; then
-        echo "$PROMPT Validating..."
+        echo "$PROMPT Validating with 'mvn validate'..."
         if [ "$IOTDB_SMART_JAVA_MODULES" -eq 0 ] || [ -n "$smart_args" ]; then
             exec_with_log "\"$IOTDB_MAVEN_PATH\" $smart_args validate"
         else

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -40,6 +40,16 @@ exec_with_log() {
     fi
 }
 
+# update all the file indices after the hook modified the files
+update_changed_file_indices() {
+    echo "Updating changed files indices..."
+    for line in $(git diff --name-only --cached); do
+        if [ -f "$line" ]; then
+            "$IOTDB_GIT_PATH" add -u "$line"
+        fi
+    done
+}
+
 on_error() {
     if [ "$#" -eq 0 ]; then
         echo "ERROR: 'on_error' must have at least 1 args."
@@ -104,6 +114,7 @@ main() {
         if [ "$?" -ne 0 ]; then
             on_error "spotless:apply failed."
         fi
+        update_changed_file_indices
     fi
 
     # maven validate

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -42,8 +42,8 @@ exec_with_log() {
 
 # update all the file indices after the hook modified the files
 update_changed_file_indices() {
-    echo "Updating changed files indices..."
-    for line in $(git diff --name-only --cached); do
+    echo "$PROMPT Updating changed files indices..."
+    for line in $("$IOTDB_GIT_PATH" diff --name-only --cached); do
         if [ -f "$line" ]; then
             "$IOTDB_GIT_PATH" add -u "$line"
         fi
@@ -76,7 +76,7 @@ main() {
     fi
 
     # get all changed module path
-    changed_files=$($IOTDB_GIT_PATH diff --name-only --cached)
+    changed_files=$("$IOTDB_GIT_PATH" diff --name-only --cached)
     changed_java_modules=""
     smart_args=""
     for line in $changed_files; do

--- a/tools/git-hooks/uninstall.ps1
+++ b/tools/git-hooks/uninstall.ps1
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 ################################################################################
 ##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
 ##
@@ -20,17 +18,16 @@
 ##
 ################################################################################
 
-# enable the pre-commit hooks, 0 - off, 1 - on
-export IOTDB_GIT_HOOKS=1
-# maven path
-export IOTDB_MAVEN_PATH="mvn"
-# git path
-export IOTDB_GIT_PATH="git"
-# smart select the changed java module, 0 - off, 1 - on
-export IOTDB_SMART_JAVA_MODULES=1
-# auto spotless:apply, 0 - off, 1 - on
-export IOTDB_SPOTLESS_APPLY=0
-# maven validate, 0 - off, 1 - on
-export IOTDB_VALIDATE=1
-# 0 - discard all, 1 - logs on errors, 2 - stdout, 3 - stdout & logs on errors
-export IOTDB_VERBOSE=2
+Push-Location $PSScriptRoot
+
+# project directory
+$PROJECT_DIR="..\.."
+# hooks directory
+$HOOKS_DIR="$PROJECT_DIR\.git\hooks"
+
+Remove-Item -Path "$HOOKS_DIR\config.sh"
+Remove-Item -Path "$HOOKS_DIR\pre-commit"
+
+Pop-Location
+Write-Host "Uninstallation succeed." -ForegroundColor Cyan
+Read-Host -Prompt "Press Enter to exit"

--- a/tools/git-hooks/uninstall.ps1
+++ b/tools/git-hooks/uninstall.ps1
@@ -1,5 +1,4 @@
 ################################################################################
-##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
 ##
 ##  Licensed to the Apache Software Foundation (ASF) under one or more
 ##  contributor license agreements.  See the NOTICE file distributed with

--- a/tools/git-hooks/uninstall.sh
+++ b/tools/git-hooks/uninstall.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+################################################################################
+##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
+##
+##  Licensed to the Apache Software Foundation (ASF) under one or more
+##  contributor license agreements.  See the NOTICE file distributed with
+##  this work for additional information regarding copyright ownership.
+##  The ASF licenses this file to You under the Apache License, Version 2.0
+##  (the "License"); you may not use this file except in compliance with
+##  the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+##
+################################################################################
+
+# script directory
+cd $(dirname "$0") || exit 1
+# project directory
+PROJECT_DIR="../.."
+# hooks directory
+HOOKS_DIR="$PROJECT_DIR/.git/hooks"
+
+# color
+Green="\x1B[32m"
+NC="\x1B[0m"
+
+rm -f "$HOOKS_DIR/config.sh"
+rm -f "$HOOKS_DIR/pre-commit"
+
+printf "${Green}Uninstallation succeed.${NC}\n"

--- a/tools/git-hooks/uninstall.sh
+++ b/tools/git-hooks/uninstall.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 ################################################################################
-##  Copyright 2022 leonardodalinky(linkyy2000313@gmail.com)
 ##
 ##  Licensed to the Apache Software Foundation (ASF) under one or more
 ##  contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Hi my IoTDB friends!👋

🎉After spending days on the git hooks mechanism, the pre-commit hooks for us developers is ready now! 🎉

## Description

The pre-commit hooks enable auto checks before commits. So next time a single `git commit` should do all the style checks automatically.

Currently, the support functionalities are:
* Turn on/off the hook in local config files.
* Auto `mvn spotless:apply` before commits
* Auto `mvn validate` before commits
* Smart selection of only the changed modules for validation

## Installation

All the files are under `tools/git-hooks`.

### Windows

Double click the `install.ps1`, and allow to execute in admin mode. Make sure that the Git for Windows is the default git on Windows.

**Note**: Windows support is based on the [Git for Windows](https://gitforwindows.org/), which provide a minimal shell environment called Git Bash. Actually, all these hooks on Windows are executed under the Git Bash environment, so the hook script can be somewhat platform-independent.

### Unix

```
./install.sh
```

## Configuration

After installation, a `config.sh` shall be created. Modification to the `config.sh` file would take effect the next time you commit.

All the configurable options is in `config.sample.sh`.

```sh
# enable the pre-commit hooks, 0 - off, 1 - on
export IOTDB_GIT_HOOKS=1
# maven path
# If in Git Bash, replace all '\' to '/', and change the driver path from 'C:\' to '/c/
# No escape character is needed.
# Example:
#   export IOTDB_MAVEN_PATH="/c/Program Files/apache-maven-3.6/bin/mvn"
export IOTDB_MAVEN_PATH="mvn"
# git path
# If in Git Bash, see 'IOTDB_MAVEN_PATH'
export IOTDB_GIT_PATH="git"
# smart select the changed java module, 0 - off, 1 - on
export IOTDB_SMART_JAVA_MODULES=1
# auto spotless:apply, 0 - off, 1 - on
export IOTDB_SPOTLESS_APPLY=0
# maven validate, 0 - off, 1 - on
export IOTDB_VALIDATE=1
# 0 - discard all, 1 - logs on errors, 2 - stdout, 3 - stdout & logs on errors
export IOTDB_VERBOSE=2
```

**Note 1 for Windows user**: If you are on Windows, pay attention to the `IOTDB_MAVEN_PATH` and `IOTDB_GIT_PATH`. Since the hook script is executed under Git Bash, you must make sure the Git Bash could get to the maven & git binary file correctly. The path expression in Git Bash is slightly different from Windows. Check the examples in config file carefully.

**Note 2 for Windows user**: The easiest way to handle these binary path is to put them into the %PATH% environment variable in Windows. Then the default configuration should work well.

## Uninstall

See `uninstall.ps1` and `uninstall.sh`.

## Pipeline

The overall pipeline of the hook script:
1. `IOTDB_GIT_HOOKS` checks if the hook is on
2. `IOTDB_SMART_JAVA_MODULES` to select only the changed modules
3. `IOTDB_SPOTLESS_APPLY` runs `mvn spotless:apply`
4. `IOTDB_VALIDATE` runs `mvn validate` or `mvn -pl <changed_modules> validate`

The hook is tested on both Linux and Windows.

## Doc

Not sure where to place the entire documentation. Any suggestion?
