### PR TITLE
[IOTDB-3608]Modify bloom cache

### DIFF
--- a/example/tsfile/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
+++ b/example/tsfile/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
@@ -46,14 +46,15 @@ import java.util.Map;
 /** This tool is used to read TsFile sequentially, including nonAligned or aligned timeseries. */
 public class TsFileSequenceRead {
   // if you wanna print detailed datas in pages, then turn it true.
-  private static boolean printDetail = false;
+  private static boolean printDetail = true;
 
   @SuppressWarnings({
     "squid:S3776",
     "squid:S106"
   }) // Suppress high Cognitive Complexity and Standard outputs warning
   public static void main(String[] args) throws IOException {
-    String filename = "test.tsfile";
+    String filename =
+        "/Users/bensonchou/PersonalFiles/IOTDB/projects/choubenson/iotdb/server/target/data/sequence/root.compactionTest/0/0/1655457100633-2-0-1.tsfile";
     if (args.length >= 1) {
       filename = args[0];
     }

--- a/example/tsfile/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
+++ b/example/tsfile/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
@@ -46,15 +46,14 @@ import java.util.Map;
 /** This tool is used to read TsFile sequentially, including nonAligned or aligned timeseries. */
 public class TsFileSequenceRead {
   // if you wanna print detailed datas in pages, then turn it true.
-  private static boolean printDetail = true;
+  private static boolean printDetail = false;
 
   @SuppressWarnings({
     "squid:S3776",
     "squid:S106"
   }) // Suppress high Cognitive Complexity and Standard outputs warning
   public static void main(String[] args) throws IOException {
-    String filename =
-        "/Users/bensonchou/PersonalFiles/IOTDB/projects/choubenson/iotdb/server/target/data/sequence/root.compactionTest/0/0/1655457100633-2-0-1.tsfile";
+    String filename = "test.tsfile";
     if (args.length >= 1) {
       filename = args[0];
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/BloomFilterCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/BloomFilterCache.java
@@ -148,6 +148,7 @@ public class BloomFilterCache {
     // share this String.
     private final String filePath;
     private final String tsFilePrefixPath;
+    private final long timestamp;
     private final long tsFileVersion;
     // high 32 bit is compaction level, low 32 bit is merge count
     private final long compactionVersion;
@@ -159,6 +160,7 @@ public class BloomFilterCache {
       this.tsFilePrefixPath = tsFilePrefixPathAndTsFileVersionPair.left;
       this.tsFileVersion = tsFilePrefixPathAndTsFileVersionPair.right[0];
       this.compactionVersion = tsFilePrefixPathAndTsFileVersionPair.right[1];
+      this.timestamp = tsFilePrefixPathAndTsFileVersionPair.right[2];
     }
 
     @Override
@@ -172,7 +174,8 @@ public class BloomFilterCache {
       BloomFilterCache.BloomFilterCacheKey that = (BloomFilterCache.BloomFilterCacheKey) o;
       return tsFileVersion == that.tsFileVersion
           && compactionVersion == that.compactionVersion
-          && tsFilePrefixPath.equals(that.tsFilePrefixPath);
+          && tsFilePrefixPath.equals(that.tsFilePrefixPath)
+          && timestamp == that.timestamp;
     }
 
     @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -268,6 +268,7 @@ public class TimeSeriesMetadataCache {
 
     private final String filePath;
     private final String tsFilePrefixPath;
+    private final long timestamp;
     private final long tsFileVersion;
     // high 32 bit is compaction level, low 32 bit is merge count
     private final long compactionVersion;
@@ -281,6 +282,7 @@ public class TimeSeriesMetadataCache {
       this.tsFilePrefixPath = tsFilePrefixPathAndTsFileVersionPair.left;
       this.tsFileVersion = tsFilePrefixPathAndTsFileVersionPair.right[0];
       this.compactionVersion = tsFilePrefixPathAndTsFileVersionPair.right[1];
+      this.timestamp = tsFilePrefixPathAndTsFileVersionPair.right[2];
       this.device = device;
       this.measurement = measurement;
     }
@@ -298,7 +300,8 @@ public class TimeSeriesMetadataCache {
           && Objects.equals(device, that.device)
           && tsFileVersion == that.tsFileVersion
           && compactionVersion == that.compactionVersion
-          && tsFilePrefixPath.equals(that.tsFilePrefixPath);
+          && tsFilePrefixPath.equals(that.tsFilePrefixPath)
+          && timestamp == that.timestamp;
     }
 
     @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceM
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
-import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
+import org.apache.iotdb.db.engine.storagegroup.TsFileName;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.query.control.FileReaderManager;
@@ -106,18 +106,19 @@ public class CompactionUtils {
       List<TsFileResource> unseqResources,
       List<TsFileResource> targetResources)
       throws IOException {
-    // target file may less than source seq files, so we should find each target file with its
-    // corresponding source seq file.
-    Map<String, TsFileResource> seqFileInfoMap = new HashMap<>();
+    // target file may more or less than source seq files, so we should find each target file with
+    // its corresponding source seq file.
+    Map<Long, TsFileResource> seqFileInfoMap = new HashMap<>();
     for (TsFileResource tsFileResource : seqResources) {
       seqFileInfoMap.put(
-          TsFileNameGenerator.increaseCrossCompactionCnt(tsFileResource.getTsFile()).getName(),
-          tsFileResource);
+          TsFileName.parse(tsFileResource.getTsFile().getName()).getTime(), tsFileResource);
     }
     // update each target mods file.
     for (TsFileResource tsFileResource : targetResources) {
       updateOneTargetMods(
-          tsFileResource, seqFileInfoMap.get(tsFileResource.getTsFile().getName()), unseqResources);
+          tsFileResource,
+          seqFileInfoMap.get(TsFileName.parse(tsFileResource.getTsFile().getName()).getTime()),
+          unseqResources);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
@@ -54,7 +54,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -116,6 +120,7 @@ public class ReadPointCompactionPerformer
               device, deviceIterator, compactionWriter, queryContext, queryDataSource);
         }
       }
+
       compactionWriter.endFile();
       updateDeviceStartTimeAndEndTime(targetFiles, compactionWriter);
       updatePlanIndexes(targetFiles, seqFiles, unseqFiles);
@@ -241,6 +246,8 @@ public class ReadPointCompactionPerformer
           .getTsFile()
           .getName()
           .equals(targetFileWriters.get(fileWriterIndex).getFile().getName())) {
+        // Only update the last target file of each seq file, because the others have been updated
+        // before opening a new target file.
         compactionWriter.updateDeviceStartTimeAndEndTime(
             resource, targetFileWriters.get(fileWriterIndex++));
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
@@ -43,24 +43,17 @@ import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.reader.series.SeriesRawDataBatchReader;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.QueryUtils;
-import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.BatchData;
 import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -122,7 +115,6 @@ public class ReadPointCompactionPerformer
               device, deviceIterator, compactionWriter, queryContext, queryDataSource);
         }
       }
-
       compactionWriter.endFile();
       updateDeviceStartTimeAndEndTime(targetFiles, compactionWriter);
       updatePlanIndexes(targetFiles, seqFiles, unseqFiles);
@@ -183,6 +175,7 @@ public class ReadPointCompactionPerformer
       writeWithReader(compactionWriter, dataBatchReader, 0);
       compactionWriter.endMeasurement(0);
       compactionWriter.endChunkGroup();
+      compactionWriter.checkFileSizeAndMayOpenANewFile();
     }
   }
 
@@ -235,27 +228,20 @@ public class ReadPointCompactionPerformer
     }
 
     compactionWriter.endChunkGroup();
+    compactionWriter.checkFileSizeAndMayOpenANewFile();
   }
 
   private static void updateDeviceStartTimeAndEndTime(
       List<TsFileResource> targetResources, AbstractCompactionWriter compactionWriter) {
     List<TsFileIOWriter> targetFileWriters = compactionWriter.getFileIOWriter();
-    for (int i = 0; i < targetFileWriters.size(); i++) {
-      TsFileIOWriter fileIOWriter = targetFileWriters.get(i);
-      TsFileResource fileResource = targetResources.get(i);
-      // The tmp target file may does not have any data points written due to the existence of the
-      // mods file, and it will be deleted after compaction. So skip the target file that has been
-      // deleted.
-      if (!fileResource.getTsFile().exists()) {
-        continue;
-      }
-      for (Map.Entry<String, List<TimeseriesMetadata>> entry :
-          fileIOWriter.getDeviceTimeseriesMetadataMap().entrySet()) {
-        String device = entry.getKey();
-        for (TimeseriesMetadata timeseriesMetadata : entry.getValue()) {
-          fileResource.updateStartTime(device, timeseriesMetadata.getStatistics().getStartTime());
-          fileResource.updateEndTime(device, timeseriesMetadata.getStatistics().getEndTime());
-        }
+    int fileWriterIndex = 0;
+    for (TsFileResource resource : targetResources) {
+      if (resource
+          .getTsFile()
+          .getName()
+          .equals(targetFileWriters.get(fileWriterIndex).getFile().getName())) {
+        compactionWriter.updateDeviceStartTimeAndEndTime(
+            resource, targetFileWriters.get(fileWriterIndex++));
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
@@ -49,6 +49,7 @@ import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/AbstractCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/AbstractCompactionWriter.java
@@ -151,7 +151,7 @@ public abstract class AbstractCompactionWriter implements AutoCloseable {
     }
   }
 
-  protected boolean checkChunkSizeAndMayOpenANewChunk(TsFileIOWriter fileWriter, int subTaskId)
+  protected void checkChunkSizeAndMayOpenANewChunk(TsFileIOWriter fileWriter, int subTaskId)
       throws IOException {
     if (measurementPointCountArray[subTaskId] % 10 == 0 && checkChunkSize(subTaskId)) {
       flushChunkToFileWriter(fileWriter, subTaskId);
@@ -162,9 +162,7 @@ public abstract class AbstractCompactionWriter implements AutoCloseable {
           ProcessChunkType.DESERIALIZE_CHUNK,
           this.isAlign,
           chunkWriters[subTaskId].estimateMaxSeriesMemSize());
-      return true;
     }
-    return false;
   }
 
   protected boolean checkChunkSize(int subTaskId) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
@@ -107,10 +107,7 @@ public class CrossSpaceCompactionWriter extends AbstractCompactionWriter {
   public void write(long timestamp, Object value, int subTaskId) throws IOException {
     checkTimeAndMayFlushChunkToCurrentFile(timestamp, subTaskId);
     writeDataPoint(timestamp, value, subTaskId);
-    if (checkChunkSizeAndMayOpenANewChunk(
-        fileWriterList.get(seqFileIndexArray[subTaskId]), subTaskId)) {
-      // checkFileSizeAndMayOpenANewFile(subTaskId);
-    }
+    checkChunkSizeAndMayOpenANewChunk(fileWriterList.get(seqFileIndexArray[subTaskId]), subTaskId);
     isDeviceExistedInTargetFiles[seqFileIndexArray[subTaskId]] = true;
     isEmptyFile[seqFileIndexArray[subTaskId]] = false;
   }
@@ -160,24 +157,6 @@ public class CrossSpaceCompactionWriter extends AbstractCompactionWriter {
         // later than any seq files. Then write these data into the last target file.
         return;
       }
-    }
-  }
-
-  private void checkFileSizeAndMayOpenANewFile2(int subTaskId) throws IOException {
-    int fileIndex = seqFileIndexArray[subTaskId];
-    long estimateFileSize = fileWriterList.get(fileIndex).getIOWriterOut().getPosition();
-    if (estimateFileSize >= targetFileSizeThreshold) {
-      // end current target file
-      fileWriterList.get(fileIndex).endFile();
-      // add new target file resource
-      TsFileResource newTargetResource =
-          new TsFileResource(
-              TsFileNameGenerator.increaseFileVersion(targetResources.get(fileIndex).getTsFile()));
-      targetResources.add(fileIndex + 1, newTargetResource);
-      // replace target fileIOWriter
-      fileWriterList.remove(fileIndex);
-      fileWriterList.add(fileIndex, new TsFileIOWriter(newTargetResource.getTsFile()));
-      isEmptyFile[subTaskId] = true;
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/InnerSpaceCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/InnerSpaceCompactionWriter.java
@@ -85,6 +85,7 @@ public class InnerSpaceCompactionWriter extends AbstractCompactionWriter {
 
   @Override
   public void checkFileSizeAndMayOpenANewFile() throws IOException {
-    throw new RuntimeException("Does not support checkFileSizeAndMayOpenANewFile method.");
+    // In inner space compaction, size of target file is controlled in the process of selecting
+    // source files, so here we do nothing.
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/InnerSpaceCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/InnerSpaceCompactionWriter.java
@@ -82,4 +82,9 @@ public class InnerSpaceCompactionWriter extends AbstractCompactionWriter {
   public List<TsFileIOWriter> getFileIOWriter() {
     return Collections.singletonList(fileWriter);
   }
+
+  @Override
+  public void checkFileSizeAndMayOpenANewFile() throws IOException {
+    throw new RuntimeException("Does not support checkFileSizeAndMayOpenANewFile method.");
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileNameGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileNameGenerator.java
@@ -99,11 +99,11 @@ public class TsFileNameGenerator {
     return new File(path, tsFileName.toFileName());
   }
 
-  public static File increaseFileVersion(File tsFile){
-    String path=tsFile.getParent();
-    TsFileName tsFileName=TsFileName.parse(tsFile.getName());
-    tsFileName.setVersion(tsFileName.getVersion()+100000);
-    return new File(path,tsFileName.toFileName());
+  public static File increaseFileVersion(File tsFile) {
+    String path = tsFile.getParent();
+    TsFileName tsFileName = TsFileName.parse(tsFile.getName());
+    tsFileName.setVersion(tsFileName.getVersion() + 100000);
+    return new File(path, tsFileName.toFileName());
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileNameGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileNameGenerator.java
@@ -99,6 +99,13 @@ public class TsFileNameGenerator {
     return new File(path, tsFileName.toFileName());
   }
 
+  public static File increaseFileVersion(File tsFile){
+    String path=tsFile.getParent();
+    TsFileName tsFileName=TsFileName.parse(tsFile.getName());
+    tsFileName.setVersion(tsFileName.getVersion()+100000);
+    return new File(path,tsFileName.toFileName());
+  }
+
   /**
    * Create tmp target file for cross space compaction, in which each sequence source file has its
    * own tmp target file.

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -64,6 +64,7 @@ public class AbstractCompactionTest {
       TSFileDescriptor.getInstance().getConfig().getGroupSizeInByte();
   private static final int oldPagePointSize =
       TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
+  private static final long oldTargetCompactionFileSize=IoTDBDescriptor.getInstance().getConfig().getTargetCompactionFileSize();
 
   protected static File STORAGE_GROUP_DIR =
       new File(
@@ -260,6 +261,7 @@ public class AbstractCompactionTest {
     unseqResources.clear();
     IoTDB.configManager.clear();
     IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(oldTargetChunkSize);
+    IoTDBDescriptor.getInstance().getConfig().setTargetCompactionFileSize(oldTargetCompactionFileSize);
     TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(oldChunkGroupSize);
     TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(oldPagePointSize);
     EnvironmentUtils.cleanEnv();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -64,7 +64,8 @@ public class AbstractCompactionTest {
       TSFileDescriptor.getInstance().getConfig().getGroupSizeInByte();
   private static final int oldPagePointSize =
       TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
-  private static final long oldTargetCompactionFileSize=IoTDBDescriptor.getInstance().getConfig().getTargetCompactionFileSize();
+  private static final long oldTargetCompactionFileSize =
+      IoTDBDescriptor.getInstance().getConfig().getTargetCompactionFileSize();
 
   protected static File STORAGE_GROUP_DIR =
       new File(
@@ -261,7 +262,9 @@ public class AbstractCompactionTest {
     unseqResources.clear();
     IoTDB.configManager.clear();
     IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(oldTargetChunkSize);
-    IoTDBDescriptor.getInstance().getConfig().setTargetCompactionFileSize(oldTargetCompactionFileSize);
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setTargetCompactionFileSize(oldTargetCompactionFileSize);
     TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(oldChunkGroupSize);
     TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(oldPagePointSize);
     EnvironmentUtils.cleanEnv();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointCompactionPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointCompactionPerformerTest.java
@@ -46,13 +46,18 @@ import org.apache.iotdb.tsfile.utils.TsFileGeneratorUtils;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.PATH_SEPARATOR;
 import static org.junit.Assert.assertEquals;
@@ -3862,34 +3867,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
     new ReadPointCompactionPerformer(seqResources, unseqResources, targetResources).perform();
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
-
-    //    List<String> deviceIdList = new ArrayList<>();
-    //    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0");
-    //    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1");
-    //    for (int i = 0; i < 2; i++) {
-    //      Assert.assertTrue(
-    //          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
-    //      Assert.assertTrue(
-    //          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
-    //      Assert.assertFalse(
-    //          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
-    //      Assert.assertFalse(
-    //          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
-    //      check(targetResources.get(i), deviceIdList);
-    //    }
-    //    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2");
-    //    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
-    //    for (int i = 2; i < 4; i++) {
-    //      Assert.assertTrue(
-    //          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
-    //      Assert.assertTrue(
-    //          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
-    //      Assert.assertTrue(
-    //          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
-    //      Assert.assertTrue(
-    //          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
-    //      check(targetResources.get(i), deviceIdList);
-    //    }
 
     Map<String, Long> measurementMaxTime = new HashMap<>();
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionTest.java
@@ -72,6 +72,7 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
   public void setUp() throws IOException, WriteProcessException, MetadataException {
     super.setUp();
     IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(1024);
+    IoTDBDescriptor.getInstance().getConfig().setTargetCompactionFileSize(20480);
     Thread.currentThread().setName("pool-1-IoTDB-Compaction-1");
   }
 
@@ -212,8 +213,6 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
       }
     }
 
-    List<TsFileResource> targetResources =
-        CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
     TsFileManager tsFileManager =
         new TsFileManager(COMPACTION_TEST_SG, "0", STORAGE_GROUP_DIR.getPath());
     tsFileManager.addAll(seqResources, true);
@@ -227,6 +226,7 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0));
     task.call();
+    Assert.assertEquals(7, tsFileManager.getTsFileList(true).size());
 
     for (TsFileResource resource : seqResources) {
       resource.resetModFile();
@@ -458,6 +458,7 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0));
     task.call();
+    Assert.assertEquals(2, tsFileManager.getTsFileList(true).size());
 
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.getModFile().exists());
@@ -638,6 +639,7 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
       Assert.assertEquals(2, resource.getModFile().getModifications().size());
     }
     task.call();
+    Assert.assertEquals(7, vsgp.getTsFileManager().getTsFileList(true).size());
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.getTsFile().exists());
       Assert.assertFalse(resource.getModFile().exists());
@@ -756,6 +758,7 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
       Assert.assertEquals(3, resource.getModFile().getModifications().size());
     }
     task.call();
+    Assert.assertEquals(7, vsgp.getTsFileManager().getTsFileList(true).size());
     for (TsFileResource resource : seqResources) {
       Assert.assertFalse(resource.getTsFile().exists());
       Assert.assertFalse(resource.getModFile().exists());
@@ -770,6 +773,176 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
       Assert.assertTrue(seqResource.getModFile().exists());
       Assert.assertEquals(12, seqResource.getModFile().getModifications().size());
       Assert.assertFalse(seqResource.getCompactionModFile().exists());
+    }
+  }
+
+  /**
+   * Total 4 seq files and 4 unseq files, each file has different aligned timeseries.
+   *
+   * <p>Seq files<br>
+   * first and second file has d0 ~ d1 and s0 ~ s2, time range is 0 ~ 299 and 350 ~ 649, value range
+   * is 0 ~ 299 and 350 ~ 649.<br>
+   * third and forth file has d0 ~ d3 and s0 ~ S4,time range is 700 ~ 999 and 1050 ~ 1349, value
+   * range is 700 ~ 999 and 1050 ~ 1349.<br>
+   *
+   * <p>UnSeq files<br>
+   * first, second and third file has d0 ~ d2 and s0 ~ s3, time range is 20 ~ 219, 250 ~ 449 and 480
+   * ~ 679, value range is 10020 ~ 10219, 10250 ~ 10449 and 10480 ~ 10679.<br>
+   * forth and fifth file has d0 and s0 ~ s4, time range is 450 ~ 549 and 550 ~ 649, value range is
+   * 20450 ~ 20549 and 20550 ~ 20649.
+   */
+  @Test
+  public void testAlignedCrossSpaceCompactionWithDifferentTimeseriesAndSplitLargeFiles()
+      throws Exception {
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
+    registerTimeseriesInMManger(4, 5, true);
+    createFiles(2, 2, 3, 300, 0, 0, 50, 50, true, true);
+    createFiles(2, 4, 5, 300, 700, 700, 50, 50, true, true);
+    createFiles(3, 3, 4, 200, 20, 10020, 30, 30, true, false);
+    createFiles(2, 1, 5, 100, 450, 20450, 0, 0, true, false);
+
+    for (int i = TsFileGeneratorUtils.getAlignDeviceOffset();
+        i < TsFileGeneratorUtils.getAlignDeviceOffset() + 4;
+        i++) {
+      for (int j = 0; j < 5; j++) {
+        List<IMeasurementSchema> schemas = new ArrayList<>();
+        schemas.add(new MeasurementSchema("s" + j, TSDataType.INT64));
+        AlignedPath path =
+            new AlignedPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
+                Collections.singletonList("s" + j),
+                schemas);
+        IBatchReader tsFilesReader =
+            new SeriesRawDataBatchReader(
+                path,
+                TSDataType.VECTOR,
+                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                seqResources,
+                unseqResources,
+                null,
+                null,
+                true);
+        int count = 0;
+        while (tsFilesReader.hasNextBatch()) {
+          BatchData batchData = tsFilesReader.nextBatch();
+          while (batchData.hasCurrent()) {
+            if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
+                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
+                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+              assertEquals(
+                  batchData.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+            } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
+                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
+                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
+                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+              assertEquals(
+                  batchData.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+            } else {
+              assertEquals(
+                  batchData.currentTime(),
+                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+            }
+            count++;
+            batchData.next();
+          }
+        }
+        tsFilesReader.close();
+        if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
+          assertEquals(1280, count);
+        } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 1 && j < 4) {
+          assertEquals(1230, count);
+        } else if (i == TsFileGeneratorUtils.getAlignDeviceOffset()) {
+          assertEquals(800, count);
+        } else if ((i == TsFileGeneratorUtils.getAlignDeviceOffset() + 1 && j == 4)) {
+          assertEquals(600, count);
+        } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4) {
+          assertEquals(1200, count);
+        } else {
+          assertEquals(600, count);
+        }
+      }
+    }
+
+    TsFileManager tsFileManager =
+        new TsFileManager(COMPACTION_TEST_SG, "0", STORAGE_GROUP_DIR.getPath());
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+    CrossSpaceCompactionTask task =
+        new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            unseqResources,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0));
+    task.call();
+
+    Assert.assertEquals(7, tsFileManager.getTsFileList(true).size());
+
+    for (int i = TsFileGeneratorUtils.getAlignDeviceOffset();
+        i < TsFileGeneratorUtils.getAlignDeviceOffset() + 4;
+        i++) {
+      for (int j = 0; j < 5; j++) {
+        List<IMeasurementSchema> schemas = new ArrayList<>();
+        schemas.add(new MeasurementSchema("s" + j, TSDataType.INT64));
+        AlignedPath path =
+            new AlignedPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
+                Collections.singletonList("s" + j),
+                schemas);
+        IBatchReader tsFilesReader =
+            new SeriesRawDataBatchReader(
+                path,
+                TSDataType.VECTOR,
+                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                tsFileManager.getTsFileList(true),
+                new ArrayList<>(),
+                null,
+                null,
+                true);
+        int count = 0;
+        while (tsFilesReader.hasNextBatch()) {
+          BatchData batchData = tsFilesReader.nextBatch();
+          while (batchData.hasCurrent()) {
+            if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
+                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
+                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+              assertEquals(
+                  batchData.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+            } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
+                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
+                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
+                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+              assertEquals(
+                  batchData.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+            } else {
+              assertEquals(
+                  batchData.currentTime(),
+                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+            }
+            count++;
+            batchData.next();
+          }
+        }
+        tsFilesReader.close();
+        if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
+          assertEquals(1280, count);
+        } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 1 && j < 4) {
+          assertEquals(1230, count);
+        } else if (i == TsFileGeneratorUtils.getAlignDeviceOffset()) {
+          assertEquals(800, count);
+        } else if ((i == TsFileGeneratorUtils.getAlignDeviceOffset() + 1 && j == 4)) {
+          assertEquals(600, count);
+        } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4) {
+          assertEquals(1200, count);
+        } else {
+          assertEquals(600, count);
+        }
+      }
     }
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkMetadata.java
@@ -82,6 +82,9 @@ public class ChunkMetadata implements IChunkMetadata {
   // high 32 bit is compaction level, low 32 bit is merge count
   private long compactionVersion;
 
+  // used for ChunkCache, tsfile timestamp
+  private long timestamp;
+
   public ChunkMetadata() {}
 
   /**
@@ -250,7 +253,8 @@ public class ChunkMetadata implements IChunkMetadata {
     return offsetOfChunkHeader == that.offsetOfChunkHeader
         && version == that.version
         && compactionVersion == that.compactionVersion
-        && tsFilePrefixPath.equals(that.tsFilePrefixPath);
+        && tsFilePrefixPath.equals(that.tsFilePrefixPath)
+        && timestamp == that.timestamp;
   }
 
   @Override
@@ -326,6 +330,7 @@ public class ChunkMetadata implements IChunkMetadata {
     tsFilePrefixPath = tsFilePrefixPathAndTsFileVersionPair.left;
     this.version = tsFilePrefixPathAndTsFileVersionPair.right[0];
     this.compactionVersion = tsFilePrefixPathAndTsFileVersionPair.right[1];
+    this.timestamp = tsFilePrefixPathAndTsFileVersionPair.right[2];
   }
 
   @Override

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/FilePathUtils.java
@@ -114,13 +114,13 @@ public class FilePathUtils {
   }
 
   /**
-   * @return a long array whose length is 2, the first long value is tsfile version, second long
+   * @return a long array whose length is 3, the first long value is tsfile version, second long
    *     value is compaction version, high 32 bit is in-space compaction count, low 32 bit is
-   *     cross-space compaction count
+   *     cross-space compaction count, the third long value is timestamp.
    */
   private static long[] splitAndGetVersionArray(String tsFileName) {
     String[] names = tsFileName.split(FILE_NAME_SEPARATOR);
-    long[] versionArray = new long[2];
+    long[] versionArray = new long[3];
     if (names.length != 4) {
       return versionArray;
     }
@@ -128,6 +128,7 @@ public class FilePathUtils {
     versionArray[1] =
         (Long.parseLong(names[2]) << 32)
             | Long.parseLong(names[3].substring(0, names[3].length() - TSFILE_SUFFIX.length()));
+    versionArray[2] = Long.parseLong(names[0]);
     return versionArray;
   }
 
@@ -141,8 +142,8 @@ public class FilePathUtils {
 
   /**
    * pair.left tsFilePrefixPath, like data/data/sequence/root.sg1/0/0 pair.right is a long array
-   * whose length is 2 pair.right[0] is tsfile version pair.right[1] is compaction version, high 32
-   * bit is compaction level, low 32 bit is merge count
+   * whose length is 3, pair.right[0] is tsfile version, pair.right[1] is compaction version, high
+   * 32 bit is compaction level, low 32 bit is merge count, pair.right[2] is tsfile timestamp.
    */
   public static Pair<String, long[]> getTsFilePrefixPathAndTsFileVersionPair(
       String tsFileAbsolutePath) {


### PR DESCRIPTION
Now bloomFilterCache, chunkCache and timeseriesMetadataCache is based on sg, version and compactionVersion as the key, and for now the version allows duplicates, which will cause  fetching a wrong bloomFilterCache.
Solution: add timestamp of TsFile in the key.