### PR TITLE
[IOTDB-3599] Delete storage group should delete wal node when using multi-leader consensus

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -129,6 +129,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -181,6 +182,10 @@ public class DataRegion {
    * partitionLatestFlushedTimeForEachDevice)
    */
   private final ReadWriteLock insertLock = new ReentrantReadWriteLock();
+  /** condition to safely delete data region */
+  private final Condition deletedCondition = insertLock.writeLock().newCondition();
+  /** data region has been deleted or not */
+  private volatile boolean deleted = false;
   /** closeStorageGroupCondition is used to wait for all currently closing TsFiles to be done. */
   private final Object closeStorageGroupCondition = new Object();
   /**
@@ -3670,6 +3675,32 @@ public class DataRegion {
     // identifier should be same with getTsFileProcessor method
     return WALManager.getInstance()
         .applyForWALNode(logicalStorageGroupName + FILE_NAME_SEPARATOR + dataRegionId);
+  }
+
+  /** Wait for this data region successfully deleted */
+  public void waitForDeleted() {
+    writeLock("waitForDeleted");
+    try {
+      if (!deleted) {
+        deletedCondition.await();
+      }
+    } catch (InterruptedException e) {
+      logger.error("Interrupted When waiting for data region deleted.");
+      Thread.currentThread().interrupt();
+    } finally {
+      writeUnlock();
+    }
+  }
+
+  /** Release all threads waiting for this data region successfully deleted */
+  public void markDeleted() {
+    deleted = true;
+    writeLock("markDeleted");
+    try {
+      deletedCondition.signalAll();
+    } finally {
+      writeUnlock();
+    }
   }
 
   @TestOnly

--- a/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
@@ -58,9 +58,10 @@ public class WALManager implements IService {
   private ScheduledExecutorService walDeleteThread;
 
   private WALManager() {
-    if (config
-        .getDataRegionConsensusProtocolClass()
-        .equals(ConsensusFactory.MultiLeaderConsensus)) {
+    if (config.isClusterMode()
+        && config
+            .getDataRegionConsensusProtocolClass()
+            .equals(ConsensusFactory.MultiLeaderConsensus)) {
       walNodesManager = new FirstCreateStrategy();
     } else {
       walNodesManager = new RoundRobinStrategy(MAX_WAL_NODE_NUM);
@@ -76,10 +77,12 @@ public class WALManager implements IService {
     return walNodesManager.applyForWALNode(applicantUniqueId);
   }
 
+  /** WAL node will be registered only when using multi-leader consensus protocol */
   public void registerWALNode(
       String applicantUniqueId, String logDirectory, int startFileVersion, long startSearchIndex) {
     String s = config.getDataRegionConsensusProtocolClass();
     if (config.getWalMode() == WALMode.DISABLE
+        || !config.isClusterMode()
         || !config
             .getDataRegionConsensusProtocolClass()
             .equals(ConsensusFactory.MultiLeaderConsensus)) {
@@ -88,6 +91,19 @@ public class WALManager implements IService {
 
     ((FirstCreateStrategy) walNodesManager)
         .registerWALNode(applicantUniqueId, logDirectory, startFileVersion, startSearchIndex);
+  }
+
+  /** WAL node will be deleted only when using multi-leader consensus protocol */
+  public void deleteWALNode(String applicantUniqueId) {
+    if (config.getWalMode() == WALMode.DISABLE
+        || !config.isClusterMode()
+        || !config
+            .getDataRegionConsensusProtocolClass()
+            .equals(ConsensusFactory.MultiLeaderConsensus)) {
+      return;
+    }
+
+    ((FirstCreateStrategy) walNodesManager).deleteWALNode(applicantUniqueId);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.wal.allocation;
 
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.wal.node.IWALNode;
 import org.apache.iotdb.db.wal.node.WALNode;
 
@@ -74,6 +75,21 @@ public class FirstCreateStrategy extends AbstractNodeAllocationStrategy {
         // avoid deletion
         ((WALNode) walNode).setSafelyDeletedSearchIndex(Long.MIN_VALUE);
         identifier2Nodes.put(applicantUniqueId, (WALNode) walNode);
+      }
+    } finally {
+      nodesLock.unlock();
+    }
+  }
+
+  public void deleteWALNode(String applicantUniqueId) {
+    nodesLock.lock();
+    try {
+      WALNode walNode = identifier2Nodes.remove(applicantUniqueId);
+      if (walNode != null) {
+        walNode.close();
+        if (walNode.getLogDirectory().exists()) {
+          FileUtils.deleteDirectory(walNode.getLogDirectory());
+        }
       }
     } finally {
       nodesLock.unlock();

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -807,6 +807,10 @@ public class WALNode implements IWALNode {
     checkpointManager.close();
   }
 
+  public File getLogDirectory() {
+    return logDirectory;
+  }
+
   @TestOnly
   boolean isAllWALEntriesConsumed() {
     return buffer.isAllWALEntriesConsumed();


### PR DESCRIPTION
Fix two problem:

1. Delete wal node when deleting storage group
2. Make data region deletion thread-safe