### PR TITLE
[IOTDB-3635][IOTDB-3583] Increase the stability of the getLeader interface

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -75,7 +75,6 @@ import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TStorageGroupSchema;
 import org.apache.iotdb.consensus.common.DataSet;
-import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.db.mpp.common.schematree.PathPatternTree;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -146,7 +145,7 @@ public class ConfigManager implements Manager {
     this.procedureManager = new ProcedureManager(this, procedureInfo);
     this.udfManager = new UDFManager(this, udfInfo);
     this.loadManager = new LoadManager(this);
-    this.consensusManager = new ConsensusManager(stateMachine);
+    this.consensusManager = new ConsensusManager(this, stateMachine);
   }
 
   public void close() throws IOException {
@@ -473,14 +472,21 @@ public class ConfigManager implements Manager {
   }
 
   private TSStatus confirmLeader() {
+    TSStatus result = new TSStatus();
+
     if (getConsensusManager().isLeader()) {
-      return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
+      return result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     } else {
-      Peer leader = consensusManager.getLeader(nodeManager.getOnlineConfigNodes());
-      return new TSStatus(TSStatusCode.NEED_REDIRECTION.getStatusCode())
-          .setRedirectNode(leader.getEndpoint())
-          .setMessage(
-              "The current ConfigNode is not leader. And ConfigNodeGroup is in leader election. Please redirect with a random ConfigNode.");
+      result.setCode(TSStatusCode.NEED_REDIRECTION.getStatusCode());
+      result.setMessage(
+          "The current ConfigNode is not leader, please redirect to a new ConfigNode.");
+
+      TConfigNodeLocation leaderLocation = consensusManager.getLeader();
+      if (leaderLocation != null) {
+        result.setRedirectNode(leaderLocation.getInternalEndPoint());
+      }
+
+      return result;
     }
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
@@ -165,7 +165,7 @@ public class ConsensusManager {
 
   /** @return ConfigNode-leader's location if leader exists, null otherwise. */
   public TConfigNodeLocation getLeader() {
-    for (int retry = 0; retry < 5; retry++) {
+    for (int retry = 0; retry < 50; retry++) {
       Peer leaderPeer = consensusImpl.getLeader(consensusGroupId);
       List<TConfigNodeLocation> onlineConfigNodes = getNodeManager().getOnlineConfigNodes();
       TConfigNodeLocation leaderLocation =
@@ -175,6 +175,12 @@ public class ConsensusManager {
               .orElse(null);
       if (leaderLocation != null) {
         return leaderLocation;
+      }
+
+      try {
+        TimeUnit.MILLISECONDS.sleep(100);
+      } catch (InterruptedException e) {
+        LOGGER.warn("ConsensusManager getLeader been interrupted, ", e);
       }
     }
     return null;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
@@ -49,10 +49,15 @@ public class ConsensusManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusManager.class);
   private static final ConfigNodeConfig conf = ConfigNodeDescriptor.getInstance().getConf();
+
+  private final Manager configManager;
+
   private ConsensusGroupId consensusGroupId;
   private IConsensus consensusImpl;
 
-  public ConsensusManager(PartitionRegionStateMachine stateMachine) throws IOException {
+  public ConsensusManager(Manager configManager, PartitionRegionStateMachine stateMachine)
+      throws IOException {
+    this.configManager = configManager;
     setConsensusLayer(stateMachine);
   }
 
@@ -158,15 +163,21 @@ public class ConsensusManager {
     return consensusImpl.isLeader(consensusGroupId);
   }
 
-  public Peer getLeader(List<TConfigNodeLocation> onlineConfigNodes) {
-    Peer leader = consensusImpl.getLeader(consensusGroupId);
-
-    TConfigNodeLocation nodeLocation =
-        onlineConfigNodes.stream()
-            .filter(e -> e.getConsensusEndPoint().equals(leader.getEndpoint()))
-            .findFirst()
-            .get();
-    return new Peer(consensusGroupId, nodeLocation.getInternalEndPoint());
+  /** @return ConfigNode-leader's location if leader exists, null otherwise. */
+  public TConfigNodeLocation getLeader() {
+    for (int retry = 0; retry < 5; retry++) {
+      Peer leaderPeer = consensusImpl.getLeader(consensusGroupId);
+      List<TConfigNodeLocation> onlineConfigNodes = getNodeManager().getOnlineConfigNodes();
+      TConfigNodeLocation leaderLocation =
+          onlineConfigNodes.stream()
+              .filter(leader -> leader.getConsensusEndPoint().equals(leaderPeer.getEndpoint()))
+              .findFirst()
+              .orElse(null);
+      if (leaderLocation != null) {
+        return leaderLocation;
+      }
+    }
+    return null;
   }
 
   public ConsensusGroupId getConsensusGroupId() {
@@ -175,6 +186,10 @@ public class ConsensusManager {
 
   public IConsensus getConsensusImpl() {
     return consensusImpl;
+  }
+
+  private NodeManager getNodeManager() {
+    return configManager.getNodeManager();
   }
 
   @TestOnly

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
@@ -213,9 +213,14 @@ public class NodeManager {
         }
 
         // Check whether the remove ConfigNode is leader
-        Peer leader = getConsensusManager().getLeader(getOnlineConfigNodes());
+        TConfigNodeLocation leader = getConsensusManager().getLeader();
+        if (leader == null) {
+          return new TSStatus(TSStatusCode.REMOVE_CONFIGNODE_FAILED.getStatusCode())
+              .setMessage(
+                  "Remove ConfigNode failed because the ConfigNodeGroup is on leader election, please retry.");
+        }
         if (leader
-            .getEndpoint()
+            .getInternalEndPoint()
             .equals(removeConfigNodeReq.getConfigNodeLocation().getInternalEndPoint())) {
           // transfer leader
           return transferLeader(removeConfigNodeReq, getConsensusManager().getConsensusGroupId());


### PR DESCRIPTION
ConsensusManager's getLeader interface returns the result for the consensusLayer. However, the consensusLayer's getLeader interface may return null when the consensusLayer is on leader election or when ConfigNode isn't added to any consensusGroup. Therefore, this PR optimizes the stability logic of the ConsensusManager's getLeader interface.