### PR TITLE
[IOTDB-3546] Add status code in wal filename to delete data without search index

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
@@ -232,6 +232,7 @@ public class IoTDBConstant {
   public static final String WAL_CHECKPOINT_FILE_SUFFIX = ".checkpoint";
   public static final String WAL_VERSION_ID = "versionId";
   public static final String WAL_START_SEARCH_INDEX = "startSearchIndex";
+  public static final String WAL_STATUS_CODE = "statusCode";
 
   // show cluster status
   public static final String NODE_TYPE_CONFIG_NODE = "ConfigNode";

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -56,11 +56,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AbstractMemTable implements IMemTable {
   /** each memTable node has a unique int value identifier, init when recovering wal */
-  public static final AtomicInteger memTableIdCounter = new AtomicInteger(-1);
+  public static final AtomicLong memTableIdCounter = new AtomicLong(-1);
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractMemTable.class);
   private static final int FIXED_SERIALIZED_SIZE = Byte.BYTES + 2 * Integer.BYTES + 6 * Long.BYTES;
@@ -97,7 +97,7 @@ public abstract class AbstractMemTable implements IMemTable {
 
   private long minPlanIndex = Long.MAX_VALUE;
 
-  private final int memTableId = memTableIdCounter.incrementAndGet();
+  private final long memTableId = memTableIdCounter.incrementAndGet();
 
   private final long createdTime = System.currentTimeMillis();
 
@@ -722,7 +722,7 @@ public abstract class AbstractMemTable implements IMemTable {
   }
 
   @Override
-  public int getMemTableId() {
+  public long getMemTableId() {
     return memTableId;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
@@ -181,7 +181,7 @@ public interface IMemTable extends WALEntryValue {
 
   long getMinPlanIndex();
 
-  int getMemTableId();
+  long getMemTableId();
 
   long getCreatedTime();
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
@@ -77,7 +77,7 @@ public class WALManager implements IService {
   }
 
   public void registerWALNode(
-      String applicantUniqueId, String logDirectory, int startFileVersion, long startSearchIndex) {
+      String applicantUniqueId, String logDirectory, long startFileVersion, long startSearchIndex) {
     String s = config.getDataRegionConsensusProtocolClass();
     if (config.getWalMode() == WALMode.DISABLE
         || !config

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/AbstractNodeAllocationStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/AbstractNodeAllocationStrategy.java
@@ -78,7 +78,7 @@ public abstract class AbstractNodeAllocationStrategy implements NodeAllocationSt
   }
 
   protected IWALNode createWALNode(
-      String identifier, String folder, int startFileVersion, long startSearchIndex) {
+      String identifier, String folder, long startFileVersion, long startSearchIndex) {
     try {
       return new WALNode(identifier, folder, startFileVersion, startSearchIndex);
     } catch (FileNotFoundException e) {

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
@@ -61,7 +61,7 @@ public class FirstCreateStrategy extends AbstractNodeAllocationStrategy {
   }
 
   public void registerWALNode(
-      String applicantUniqueId, String logDirectory, int startFileVersion, long startSearchIndex) {
+      String applicantUniqueId, String logDirectory, long startFileVersion, long startSearchIndex) {
     nodesLock.lock();
     try {
       if (identifier2Nodes.containsKey(applicantUniqueId)) {

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AbstractWALBuffer implements IWALBuffer {
   private static final Logger logger = LoggerFactory.getLogger(AbstractWALBuffer.class);
@@ -40,7 +40,7 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
   /** directory to store .wal files */
   protected final String logDirectory;
   /** current wal file version id */
-  protected final AtomicInteger currentWALFileVersion = new AtomicInteger();
+  protected final AtomicLong currentWALFileVersion = new AtomicLong();
   /** current search index */
   protected volatile long currentSearchIndex;
   /** current search index */
@@ -49,7 +49,7 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
   protected volatile ILogWriter currentWALFileWriter;
 
   public AbstractWALBuffer(
-      String identifier, String logDirectory, int startFileVersion, long startSearchIndex)
+      String identifier, String logDirectory, long startFileVersion, long startSearchIndex)
       throws FileNotFoundException {
     this.identifier = identifier;
     this.logDirectory = logDirectory;
@@ -69,7 +69,7 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
   }
 
   @Override
-  public int getCurrentWALFileVersion() {
+  public long getCurrentWALFileVersion() {
     return currentWALFileVersion.get();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/IWALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/IWALBuffer.java
@@ -35,7 +35,7 @@ public interface IWALBuffer extends AutoCloseable {
   void write(WALEntry walEntry);
 
   /** Get current log version id */
-  int getCurrentWALFileVersion();
+  long getCurrentWALFileVersion();
 
   /** Get current wal file's size */
   long getCurrentWALFileSize();

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/SignalWALEntry.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/SignalWALEntry.java
@@ -29,7 +29,7 @@ public class SignalWALEntry extends WALEntry {
   }
 
   public SignalWALEntry(SignalType signalType, boolean wait) {
-    super(Integer.MIN_VALUE, new DeletePlan(), wait);
+    super(Long.MIN_VALUE, new DeletePlan(), wait);
     this.signalType = signalType;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/WALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/WALBuffer.java
@@ -83,7 +83,7 @@ public class WALBuffer extends AbstractWALBuffer {
   }
 
   public WALBuffer(
-      String identifier, String logDirectory, int startFileVersion, long startSearchIndex)
+      String identifier, String logDirectory, long startFileVersion, long startSearchIndex)
       throws FileNotFoundException {
     super(identifier, logDirectory, startFileVersion, startSearchIndex);
     allocateBuffers();

--- a/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManager.java
@@ -56,11 +56,11 @@ public class CheckpointManager implements AutoCloseable {
   private final Lock infoLock = new ReentrantLock();
   // region these variables should be protected by infoLock
   /** memTable id -> memTable info */
-  private final Map<Integer, MemTableInfo> memTableId2Info = new HashMap<>();
+  private final Map<Long, MemTableInfo> memTableId2Info = new HashMap<>();
   /** cache the biggest byte buffer to serialize checkpoint */
   private volatile ByteBuffer cachedByteBuffer;
   /** max memTable id */
-  private int maxMemTableId = 0;
+  private long maxMemTableId = 0;
   /** current checkpoint file version id, only updated by fsyncAndDeleteThread */
   private int currentCheckPointFileVersion = 0;
   /** current checkpoint file log writer, only updated by fsyncAndDeleteThread */
@@ -85,8 +85,8 @@ public class CheckpointManager implements AutoCloseable {
     infoLock.lock();
     try {
       // log max memTable id
-      ByteBuffer tmpBuffer = ByteBuffer.allocate(Integer.BYTES);
-      tmpBuffer.putInt(maxMemTableId);
+      ByteBuffer tmpBuffer = ByteBuffer.allocate(Long.BYTES);
+      tmpBuffer.putLong(maxMemTableId);
       try {
         currentLogWriter.write(tmpBuffer);
       } catch (IOException e) {
@@ -126,7 +126,7 @@ public class CheckpointManager implements AutoCloseable {
   }
 
   /** make checkpoint for flush memTable info */
-  public void makeFlushMemTableCP(int memTableId) {
+  public void makeFlushMemTableCP(long memTableId) {
     infoLock.lock();
     try {
       MemTableInfo memTableInfo = memTableId2Info.remove(memTableId);

--- a/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManager.java
@@ -238,9 +238,9 @@ public class CheckpointManager implements AutoCloseable {
   /**
    * Get version id of first valid .wal file
    *
-   * @return Return {@link Integer#MIN_VALUE} if no file is valid
+   * @return Return {@link Long#MIN_VALUE} if no file is valid
    */
-  public int getFirstValidWALVersionId() {
+  public long getFirstValidWALVersionId() {
     List<MemTableInfo> memTableInfos;
     infoLock.lock();
     try {
@@ -248,7 +248,7 @@ public class CheckpointManager implements AutoCloseable {
     } finally {
       infoLock.unlock();
     }
-    int firstValidVersionId = memTableInfos.isEmpty() ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+    long firstValidVersionId = memTableInfos.isEmpty() ? Long.MIN_VALUE : Long.MAX_VALUE;
     for (MemTableInfo memTableInfo : memTableInfos) {
       firstValidVersionId = Math.min(firstValidVersionId, memTableInfo.getFirstFileVersionId());
     }

--- a/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/MemTableInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/MemTableInfo.java
@@ -33,8 +33,8 @@ import java.util.Objects;
  * file version id of its first {@link WALEntry}.
  */
 public class MemTableInfo implements SerializedSize {
-  /** memTable id 4 bytes, first version id 4 bytes */
-  private static final int FIXED_SERIALIZED_SIZE = Integer.BYTES * 2;
+  /** memTable id 4 bytes, first version id 8 bytes */
+  private static final int FIXED_SERIALIZED_SIZE = Integer.BYTES + Long.BYTES;
 
   /** memTable */
   private IMemTable memTable;
@@ -43,11 +43,11 @@ public class MemTableInfo implements SerializedSize {
   /** path of the tsFile which this memTable will be flushed to */
   private String tsFilePath;
   /** version id of the file where this memTable's first WALEntry is located */
-  private volatile int firstFileVersionId;
+  private volatile long firstFileVersionId;
 
   private MemTableInfo() {}
 
-  public MemTableInfo(IMemTable memTable, String tsFilePath, int firstFileVersionId) {
+  public MemTableInfo(IMemTable memTable, String tsFilePath, long firstFileVersionId) {
     this.memTable = memTable;
     this.memTableId = memTable.getMemTableId();
     this.tsFilePath = tsFilePath;
@@ -62,14 +62,14 @@ public class MemTableInfo implements SerializedSize {
   public void serialize(ByteBuffer buffer) {
     buffer.putInt(memTableId);
     ReadWriteIOUtils.write(tsFilePath, buffer);
-    buffer.putInt(firstFileVersionId);
+    buffer.putLong(firstFileVersionId);
   }
 
   public static MemTableInfo deserialize(DataInputStream stream) throws IOException {
     MemTableInfo memTableInfo = new MemTableInfo();
     memTableInfo.memTableId = stream.readInt();
     memTableInfo.tsFilePath = ReadWriteIOUtils.readString(stream);
-    memTableInfo.firstFileVersionId = stream.readInt();
+    memTableInfo.firstFileVersionId = stream.readLong();
     return memTableInfo;
   }
 
@@ -102,11 +102,11 @@ public class MemTableInfo implements SerializedSize {
     return tsFilePath;
   }
 
-  public int getFirstFileVersionId() {
+  public long getFirstFileVersionId() {
     return firstFileVersionId;
   }
 
-  public void setFirstFileVersionId(int firstFileVersionId) {
+  public void setFirstFileVersionId(long firstFileVersionId) {
     this.firstFileVersionId = firstFileVersionId;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/MemTableInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/checkpoint/MemTableInfo.java
@@ -33,13 +33,13 @@ import java.util.Objects;
  * file version id of its first {@link WALEntry}.
  */
 public class MemTableInfo implements SerializedSize {
-  /** memTable id 4 bytes, first version id 8 bytes */
-  private static final int FIXED_SERIALIZED_SIZE = Integer.BYTES + Long.BYTES;
+  /** memTable id 8 bytes, first version id 8 bytes */
+  private static final int FIXED_SERIALIZED_SIZE = Long.BYTES * 2;
 
   /** memTable */
   private IMemTable memTable;
   /** memTable id */
-  private int memTableId;
+  private long memTableId;
   /** path of the tsFile which this memTable will be flushed to */
   private String tsFilePath;
   /** version id of the file where this memTable's first WALEntry is located */
@@ -60,14 +60,14 @@ public class MemTableInfo implements SerializedSize {
   }
 
   public void serialize(ByteBuffer buffer) {
-    buffer.putInt(memTableId);
+    buffer.putLong(memTableId);
     ReadWriteIOUtils.write(tsFilePath, buffer);
     buffer.putLong(firstFileVersionId);
   }
 
   public static MemTableInfo deserialize(DataInputStream stream) throws IOException {
     MemTableInfo memTableInfo = new MemTableInfo();
-    memTableInfo.memTableId = stream.readInt();
+    memTableInfo.memTableId = stream.readLong();
     memTableInfo.tsFilePath = ReadWriteIOUtils.readString(stream);
     memTableInfo.firstFileVersionId = stream.readLong();
     return memTableInfo;
@@ -94,7 +94,7 @@ public class MemTableInfo implements SerializedSize {
     return memTable;
   }
 
-  public int getMemTableId() {
+  public long getMemTableId() {
     return memTableId;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/io/CheckpointReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/io/CheckpointReader.java
@@ -36,7 +36,7 @@ public class CheckpointReader {
   private static final Logger logger = LoggerFactory.getLogger(CheckpointReader.class);
 
   private final File logFile;
-  private int maxMemTableId;
+  private long maxMemTableId;
   private List<Checkpoint> checkpoints;
 
   public CheckpointReader(File logFile) {
@@ -48,7 +48,7 @@ public class CheckpointReader {
     checkpoints = new ArrayList<>();
     try (DataInputStream logStream =
         new DataInputStream(new BufferedInputStream(new FileInputStream(logFile)))) {
-      maxMemTableId = logStream.readInt();
+      maxMemTableId = logStream.readLong();
       while (logStream.available() > 0) {
         Checkpoint checkpoint = Checkpoint.deserialize(logStream);
         checkpoints.add(checkpoint);
@@ -59,7 +59,7 @@ public class CheckpointReader {
     }
   }
 
-  public int getMaxMemTableId() {
+  public long getMaxMemTableId() {
     return maxMemTableId;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/io/ILogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/io/ILogWriter.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.wal.io;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -57,4 +58,11 @@ public interface ILogWriter extends Closeable {
    * @return size
    */
   long size();
+
+  /**
+   * Gets the log file
+   *
+   * @return log file
+   */
+  File getLogFile();
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/io/LogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/io/LogWriter.java
@@ -80,6 +80,11 @@ public abstract class LogWriter implements ILogWriter {
   }
 
   @Override
+  public File getLogFile() {
+    return logFile;
+  }
+
+  @Override
   public void close() throws IOException {
     if (logChannel != null) {
       try {

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/IWALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/IWALNode.java
@@ -32,19 +32,19 @@ import org.apache.iotdb.db.wal.utils.listener.WALFlushListener;
 /** This interface provides uniform interface for writing wal and making checkpoints. */
 public interface IWALNode extends FlushListener, AutoCloseable, ConsensusReqReader, DataSet {
   /** Log InsertRowPlan */
-  WALFlushListener log(int memTableId, InsertRowPlan insertRowPlan);
+  WALFlushListener log(long memTableId, InsertRowPlan insertRowPlan);
 
   /** Log InsertRowNode */
-  WALFlushListener log(int memTableId, InsertRowNode insertRowNode);
+  WALFlushListener log(long memTableId, InsertRowNode insertRowNode);
 
   /** Log InsertTabletPlan */
-  WALFlushListener log(int memTableId, InsertTabletPlan insertTabletPlan, int start, int end);
+  WALFlushListener log(long memTableId, InsertTabletPlan insertTabletPlan, int start, int end);
 
   /** Log InsertTabletNode */
-  WALFlushListener log(int memTableId, InsertTabletNode insertTabletNode, int start, int end);
+  WALFlushListener log(long memTableId, InsertTabletNode insertTabletNode, int start, int end);
 
   /** Log DeletePlan */
-  WALFlushListener log(int memTableId, DeletePlan deletePlan);
+  WALFlushListener log(long memTableId, DeletePlan deletePlan);
 
   /** Callback when memTable created */
   void onMemTableCreated(IMemTable memTable, String targetTsFile);

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALFakeNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALFakeNode.java
@@ -45,29 +45,29 @@ public class WALFakeNode implements IWALNode {
   }
 
   @Override
-  public WALFlushListener log(int memTableId, InsertRowPlan insertRowPlan) {
+  public WALFlushListener log(long memTableId, InsertRowPlan insertRowPlan) {
     return getResult();
   }
 
   @Override
-  public WALFlushListener log(int memTableId, InsertRowNode insertRowNode) {
-    return getResult();
-  }
-
-  @Override
-  public WALFlushListener log(
-      int memTableId, InsertTabletPlan insertTabletPlan, int start, int end) {
+  public WALFlushListener log(long memTableId, InsertRowNode insertRowNode) {
     return getResult();
   }
 
   @Override
   public WALFlushListener log(
-      int memTableId, InsertTabletNode insertTabletNode, int start, int end) {
+      long memTableId, InsertTabletPlan insertTabletPlan, int start, int end) {
     return getResult();
   }
 
   @Override
-  public WALFlushListener log(int memTableId, DeletePlan deletePlan) {
+  public WALFlushListener log(
+      long memTableId, InsertTabletNode insertTabletNode, int start, int end) {
+    return getResult();
+  }
+
+  @Override
+  public WALFlushListener log(long memTableId, DeletePlan deletePlan) {
     return getResult();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -222,14 +222,14 @@ public class WALNode implements IWALNode {
     public void run() {
       // init firstValidVersionId
       firstValidVersionId = checkpointManager.getFirstValidWALVersionId();
-      if (firstValidVersionId == Integer.MIN_VALUE) {
+      if (firstValidVersionId == Long.MIN_VALUE) {
         // roll wal log writer to delete current wal file
         if (buffer.getCurrentWALFileSize() > 0) {
           rollWALFile();
         }
         // update firstValidVersionId
         firstValidVersionId = checkpointManager.getFirstValidWALVersionId();
-        if (firstValidVersionId == Integer.MIN_VALUE) {
+        if (firstValidVersionId == Long.MIN_VALUE) {
           firstValidVersionId = buffer.getCurrentWALFileVersion();
         }
       }
@@ -321,7 +321,7 @@ public class WALNode implements IWALNode {
       Matcher matcher = pattern.matcher(name);
       boolean toDelete = false;
       if (matcher.find()) {
-        int versionId = Integer.parseInt(matcher.group(IoTDBConstant.WAL_VERSION_ID));
+        long versionId = Long.parseLong(matcher.group(IoTDBConstant.WAL_VERSION_ID));
         toDelete = versionId < firstValidVersionId;
       }
       return toDelete;
@@ -815,7 +815,7 @@ public class WALNode implements IWALNode {
       Matcher matcher = pattern.matcher(name);
       boolean toSearch = false;
       if (matcher.find()) {
-        int versionId = Integer.parseInt(matcher.group(IoTDBConstant.WAL_VERSION_ID));
+        long versionId = Long.parseLong(matcher.group(IoTDBConstant.WAL_VERSION_ID));
         toSearch = versionId >= searchedFilesVersionId;
       }
       return toSearch;

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -287,6 +287,9 @@ public class WALNode implements IWALNode {
               : WALFileUtils.binarySearchFileBySearchIndex(
                   filesToDelete, safelyDeletedSearchIndex + 1);
       // delete files whose file status is CONTAINS_NONE_SEARCH_INDEX
+      if (endFileIndex == -1) {
+        endFileIndex++;
+      }
       while (endFileIndex < filesToDelete.length) {
         if (WALFileUtils.parseStatusCode(filesToDelete[endFileIndex].getName())
             == WALFileStatus.CONTAINS_SEARCH_INDEX) {

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -100,7 +100,7 @@ public class WALNode implements IWALNode {
    * memTable id -> memTable snapshot count, used to avoid write amplification caused by frequent
    * snapshot
    */
-  private final Map<Integer, Integer> memTableSnapshotCount = new ConcurrentHashMap<>();
+  private final Map<Long, Integer> memTableSnapshotCount = new ConcurrentHashMap<>();
   /**
    * total cost of flushedMemTables. when memControl enabled, cost is memTable ram cost, otherwise
    * cost is memTable count
@@ -128,13 +128,13 @@ public class WALNode implements IWALNode {
   }
 
   @Override
-  public WALFlushListener log(int memTableId, InsertRowPlan insertRowPlan) {
+  public WALFlushListener log(long memTableId, InsertRowPlan insertRowPlan) {
     WALEntry walEntry = new WALEntry(memTableId, insertRowPlan);
     return log(walEntry);
   }
 
   @Override
-  public WALFlushListener log(int memTableId, InsertRowNode insertRowNode) {
+  public WALFlushListener log(long memTableId, InsertRowNode insertRowNode) {
     if (insertRowNode.getSearchIndex() != NO_CONSENSUS_INDEX
         && insertRowNode.getSafelyDeletedSearchIndex() != DEFAULT_SAFELY_DELETED_SEARCH_INDEX) {
       safelyDeletedSearchIndex = insertRowNode.getSafelyDeletedSearchIndex();
@@ -145,14 +145,14 @@ public class WALNode implements IWALNode {
 
   @Override
   public WALFlushListener log(
-      int memTableId, InsertTabletPlan insertTabletPlan, int start, int end) {
+      long memTableId, InsertTabletPlan insertTabletPlan, int start, int end) {
     WALEntry walEntry = new WALEntry(memTableId, insertTabletPlan, start, end);
     return log(walEntry);
   }
 
   @Override
   public WALFlushListener log(
-      int memTableId, InsertTabletNode insertTabletNode, int start, int end) {
+      long memTableId, InsertTabletNode insertTabletNode, int start, int end) {
     if (insertTabletNode.getSearchIndex() != NO_CONSENSUS_INDEX
         && insertTabletNode.getSafelyDeletedSearchIndex() != DEFAULT_SAFELY_DELETED_SEARCH_INDEX) {
       safelyDeletedSearchIndex = insertTabletNode.getSafelyDeletedSearchIndex();
@@ -162,7 +162,7 @@ public class WALNode implements IWALNode {
   }
 
   @Override
-  public WALFlushListener log(int memTableId, DeletePlan deletePlan) {
+  public WALFlushListener log(long memTableId, DeletePlan deletePlan) {
     WALEntry walEntry = new WALEntry(memTableId, deletePlan);
     return log(walEntry);
   }

--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/CheckpointRecoverUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/CheckpointRecoverUtils.java
@@ -42,7 +42,7 @@ public class CheckpointRecoverUtils {
     // desc sort by version id
     CheckpointFileUtils.descSortByVersionId(checkpointFiles);
     // find last valid .checkpoint file and load checkpoints from it
-    int maxMemTableId = 0;
+    long maxMemTableId = 0;
     List<Checkpoint> checkpoints = null;
     for (File checkpointFile : checkpointFiles) {
       CheckpointReader reader = new CheckpointReader(checkpointFile);
@@ -56,7 +56,7 @@ public class CheckpointRecoverUtils {
       return new CheckpointInfo(0, Collections.emptyMap());
     }
     // recover memTables information by checkpoints
-    Map<Integer, MemTableInfo> memTableId2Info = new HashMap<>();
+    Map<Long, MemTableInfo> memTableId2Info = new HashMap<>();
     for (Checkpoint checkpoint : checkpoints) {
       switch (checkpoint.getType()) {
         case GLOBAL_MEMORY_TABLE_INFO:
@@ -77,19 +77,19 @@ public class CheckpointRecoverUtils {
   }
 
   public static class CheckpointInfo {
-    private final int maxMemTableId;
-    private final Map<Integer, MemTableInfo> memTableId2Info;
+    private final long maxMemTableId;
+    private final Map<Long, MemTableInfo> memTableId2Info;
 
-    public CheckpointInfo(int maxMemTableId, Map<Integer, MemTableInfo> memTableId2Info) {
+    public CheckpointInfo(long maxMemTableId, Map<Long, MemTableInfo> memTableId2Info) {
       this.maxMemTableId = maxMemTableId;
       this.memTableId2Info = memTableId2Info;
     }
 
-    public int getMaxMemTableId() {
+    public long getMaxMemTableId() {
       return maxMemTableId;
     }
 
-    public Map<Integer, MemTableInfo> getMemTableId2Info() {
+    public Map<Long, MemTableInfo> getMemTableId2Info() {
       return memTableId2Info;
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/WALNodeRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/WALNodeRecoverTask.java
@@ -55,7 +55,7 @@ public class WALNodeRecoverTask implements Runnable {
   /** latch to collect all nodes' recovery end information */
   private final CountDownLatch allNodesRecoveredLatch;
   /** version id of first valid .wal file */
-  private int firstValidVersionId = Integer.MAX_VALUE;
+  private long firstValidVersionId = Long.MAX_VALUE;
 
   private Map<Integer, MemTableInfo> memTableId2Info;
   private Map<Integer, UnsealedTsFileRecoverPerformer> memTableId2RecoverPerformer;
@@ -104,7 +104,7 @@ public class WALNodeRecoverTask implements Runnable {
       }
       // recover version id and search index
       long[] indexInfo = recoverLastSearchIndex();
-      int lastVersionId = (int) indexInfo[0];
+      long lastVersionId = indexInfo[0];
       long lastSearchIndex = indexInfo[1];
       WALManager.getInstance()
           .registerWALNode(
@@ -126,7 +126,7 @@ public class WALNodeRecoverTask implements Runnable {
     // get last search index from last wal file
     WALFileUtils.ascSortByVersionId(walFiles);
     File lastWALFile = walFiles[walFiles.length - 1];
-    int lastVersionId = WALFileUtils.parseVersionId(lastWALFile.getName());
+    long lastVersionId = WALFileUtils.parseVersionId(lastWALFile.getName());
     long lastSearchIndex = WALFileUtils.parseStartSearchIndex(lastWALFile.getName());
     WALFileStatus fileStatus = WALFileStatus.CONTAINS_NONE_SEARCH_INDEX;
     try (WALReader walReader = new WALReader(lastWALFile)) {

--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/WALNodeRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/WALNodeRecoverTask.java
@@ -42,7 +42,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /** This task is responsible for the recovery of one wal node. */
 public class WALNodeRecoverTask implements Runnable {
@@ -57,8 +57,8 @@ public class WALNodeRecoverTask implements Runnable {
   /** version id of first valid .wal file */
   private long firstValidVersionId = Long.MAX_VALUE;
 
-  private Map<Integer, MemTableInfo> memTableId2Info;
-  private Map<Integer, UnsealedTsFileRecoverPerformer> memTableId2RecoverPerformer;
+  private Map<Long, MemTableInfo> memTableId2Info;
+  private Map<Long, UnsealedTsFileRecoverPerformer> memTableId2RecoverPerformer;
 
   public WALNodeRecoverTask(File logDirectory, CountDownLatch allNodesRecoveredLatch) {
     this.logDirectory = logDirectory;
@@ -165,9 +165,9 @@ public class WALNodeRecoverTask implements Runnable {
     memTableId2Info = info.getMemTableId2Info();
     memTableId2RecoverPerformer = new HashMap<>();
     // update init memTable id
-    int maxMemTableId = info.getMaxMemTableId();
-    AtomicInteger memTableIdCounter = AbstractMemTable.memTableIdCounter;
-    int oldVal = memTableIdCounter.get();
+    long maxMemTableId = info.getMaxMemTableId();
+    AtomicLong memTableIdCounter = AbstractMemTable.memTableIdCounter;
+    long oldVal = memTableIdCounter.get();
     while (maxMemTableId > oldVal) {
       if (!memTableIdCounter.compareAndSet(oldVal, maxMemTableId)) {
         oldVal = memTableIdCounter.get();

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileStatus.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileStatus.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.wal.utils;
+
+/**
+ * This enumeration class annotates the status of wal file. This first bit is used to denote whether
+ * this contains search index.
+ */
+public enum WALFileStatus {
+  /** This file doesn't contain content needs searching */
+  CONTAINS_NONE_SEARCH_INDEX(0),
+  /** This file contains content needs searching */
+  CONTAINS_SEARCH_INDEX(1),
+  ;
+
+  private final int code;
+
+  WALFileStatus(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  public static WALFileStatus valueOf(int code) {
+    for (WALFileStatus status : WALFileStatus.values()) {
+      if (status.code == code) {
+        return status;
+      }
+    }
+    return null;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
@@ -28,23 +28,38 @@ import static org.apache.iotdb.commons.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.WAL_FILE_PREFIX;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.WAL_FILE_SUFFIX;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.WAL_START_SEARCH_INDEX;
+import static org.apache.iotdb.commons.conf.IoTDBConstant.WAL_STATUS_CODE;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.WAL_VERSION_ID;
 
 public class WALFileUtils {
   /**
    * versionId is a self-incremented id number, helping to maintain the order of wal files.
-   * startSearchIndex is the valid search index of last flushed wal entry. For example: <br>
-   * _0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
-   * _1-5.wal: -1, -1, -1, -1 <br>
-   * _2-5.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
-   * _3-12.wal: 12, 12, 12, 12, 12 <br>
-   * _4-12.wal: 12, 13, 14, 15, 16, -1 <br>
+   * startSearchIndex is the valid search index of last flushed wal entry. statusCode is the. For
+   * example: <br>
+   * _0-0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
+   * _1-5-1.wal: -1, -1, -1, -1 <br>
+   * _2-5-0.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
+   * _3-12-0.wal: 12, 12, 12, 12, 12 <br>
+   * _4-12-0.wal: 12, 13, 14, 15, 16, -1 <br>
    */
   public static final Pattern WAL_FILE_NAME_PATTERN =
       Pattern.compile(
           String.format(
-              "%s(?<%s>\\d+)-(?<%s>\\d+)\\%s$",
-              WAL_FILE_PREFIX, WAL_VERSION_ID, WAL_START_SEARCH_INDEX, WAL_FILE_SUFFIX));
+              "%s(?<%s>\\d+)-(?<%s>\\d+)-(?<%s>\\d+)\\%s$",
+              WAL_FILE_PREFIX,
+              WAL_VERSION_ID,
+              WAL_START_SEARCH_INDEX,
+              WAL_STATUS_CODE,
+              WAL_FILE_SUFFIX));
+
+  public static final String WAL_FILE_NAME_FORMAT =
+      WAL_FILE_PREFIX
+          + "%d"
+          + FILE_NAME_SEPARATOR
+          + "%d"
+          + FILE_NAME_SEPARATOR
+          + "%d"
+          + WAL_FILE_SUFFIX;
 
   /** Return true when this file is .wal file */
   public static boolean walFilenameFilter(File dir, String name) {
@@ -74,6 +89,15 @@ public class WALFileUtils {
     throw new RuntimeException("Invalid wal file name: " + filename);
   }
 
+  /** Parse status code from filename */
+  public static WALFileStatus parseStatusCode(String filename) {
+    Matcher matcher = WAL_FILE_NAME_PATTERN.matcher(filename);
+    if (matcher.find()) {
+      return WALFileStatus.valueOf(Integer.parseInt(matcher.group(WAL_STATUS_CODE)));
+    }
+    throw new RuntimeException("Invalid wal file name: " + filename);
+  }
+
   /** Sort wal files by version id with ascending order */
   public static void ascSortByVersionId(File[] walFiles) {
     Arrays.sort(walFiles, Comparator.comparingInt(file -> parseVersionId(file.getName())));
@@ -81,12 +105,13 @@ public class WALFileUtils {
 
   /**
    * Find index of the file which probably contains target insert plan. <br>
-   * Given wal files [ _0-0.wal, _1-5.wal, _2-5.wal, _3-12.wal, _4-12.wal ], details as below: <br>
-   * _0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
-   * _1-5.wal: -1, -1, -1, -1 <br>
-   * _2-5.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
-   * _3-12.wal: 12, 12, 12, 12, 12 <br>
-   * _4-12.wal: 12, 13, 14, 15, 16, -1 <br>
+   * Given wal files [ _0-0-0.wal, _1-5-1.wal, _2-5-0.wal, _3-12-0.wal, _4-12-0.wal ], details as
+   * below: <br>
+   * _0-0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
+   * _1-5-1.wal: -1, -1, -1, -1 <br>
+   * _2-5-0.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
+   * _3-12-0.wal: 12, 12, 12, 12, 12 <br>
+   * _4-12-0.wal: 12, 13, 14, 15, 16, -1 <br>
    * searching [1, 5] will return 0, searching [6, 12] will return 1, search [13, infinity) will
    * return 3， others will return -1
    *
@@ -124,7 +149,7 @@ public class WALFileUtils {
   }
 
   /** Get .wal filename */
-  public static String getLogFileName(int versionId, long startSearchIndex) {
-    return WAL_FILE_PREFIX + versionId + FILE_NAME_SEPARATOR + startSearchIndex + WAL_FILE_SUFFIX;
+  public static String getLogFileName(int versionId, long startSearchIndex, WALFileStatus status) {
+    return String.format(WAL_FILE_NAME_FORMAT, versionId, startSearchIndex, status.getCode());
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
@@ -72,10 +72,10 @@ public class WALFileUtils {
   }
 
   /** Parse version id from filename */
-  public static int parseVersionId(String filename) {
+  public static long parseVersionId(String filename) {
     Matcher matcher = WAL_FILE_NAME_PATTERN.matcher(filename);
     if (matcher.find()) {
-      return Integer.parseInt(matcher.group(WAL_VERSION_ID));
+      return Long.parseLong(matcher.group(WAL_VERSION_ID));
     }
     throw new RuntimeException("Invalid wal file name: " + filename);
   }
@@ -100,7 +100,7 @@ public class WALFileUtils {
 
   /** Sort wal files by version id with ascending order */
   public static void ascSortByVersionId(File[] walFiles) {
-    Arrays.sort(walFiles, Comparator.comparingInt(file -> parseVersionId(file.getName())));
+    Arrays.sort(walFiles, Comparator.comparingLong(file -> parseVersionId(file.getName())));
   }
 
   /**
@@ -149,7 +149,7 @@ public class WALFileUtils {
   }
 
   /** Get .wal filename */
-  public static String getLogFileName(int versionId, long startSearchIndex, WALFileStatus status) {
+  public static String getLogFileName(long versionId, long startSearchIndex, WALFileStatus status) {
     return String.format(WAL_FILE_NAME_FORMAT, versionId, startSearchIndex, status.getCode());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/tools/WalCheckerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/tools/WalCheckerTest.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.db.wal.io.ILogWriter;
 import org.apache.iotdb.db.wal.io.WALFileTest;
 import org.apache.iotdb.db.wal.io.WALWriter;
 import org.apache.iotdb.db.wal.utils.WALByteBufferForTest;
+import org.apache.iotdb.db.wal.utils.WALFileStatus;
 import org.apache.iotdb.db.wal.utils.WALFileUtils;
 
 import org.apache.commons.io.FileUtils;
@@ -80,7 +81,9 @@ public class WalCheckerTest {
         File walNodeDir = new File(tempRoot, String.valueOf(i));
         walNodeDir.mkdir();
 
-        File walFile = new File(walNodeDir, WALFileUtils.getLogFileName(i, 0));
+        File walFile =
+            new File(
+                walNodeDir, WALFileUtils.getLogFileName(i, 0, WALFileStatus.CONTAINS_SEARCH_INDEX));
         int fakeMemTableId = 1;
         List<WALEntry> walEntries = new ArrayList<>();
         walEntries.add(new WALEntry(fakeMemTableId, WALFileTest.getInsertRowPlan(DEVICE_ID)));
@@ -116,7 +119,9 @@ public class WalCheckerTest {
         File walNodeDir = new File(tempRoot, String.valueOf(i));
         walNodeDir.mkdir();
 
-        File walFile = new File(walNodeDir, WALFileUtils.getLogFileName(i, 0));
+        File walFile =
+            new File(
+                walNodeDir, WALFileUtils.getLogFileName(i, 0, WALFileStatus.CONTAINS_SEARCH_INDEX));
         int fakeMemTableId = 1;
         List<WALEntry> walEntries = new ArrayList<>();
         walEntries.add(new WALEntry(fakeMemTableId, WALFileTest.getInsertRowPlan(DEVICE_ID)));
@@ -157,7 +162,9 @@ public class WalCheckerTest {
         File walNodeDir = new File(tempRoot, String.valueOf(i));
         walNodeDir.mkdir();
 
-        File walFile = new File(walNodeDir, WALFileUtils.getLogFileName(i, 0));
+        File walFile =
+            new File(
+                walNodeDir, WALFileUtils.getLogFileName(i, 0, WALFileStatus.CONTAINS_SEARCH_INDEX));
 
         FileOutputStream fileOutputStream = new FileOutputStream(walFile);
         try {

--- a/server/src/test/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManagerTest.java
@@ -87,12 +87,12 @@ public class CheckpointManagerTest {
     int threadsNum = 5;
     ExecutorService executorService = Executors.newFixedThreadPool(threadsNum);
     List<Future<Void>> futures = new ArrayList<>();
-    Map<Integer, MemTableInfo> expectedMemTableId2Info = new ConcurrentHashMap<>();
-    Map<Integer, Integer> versionId2memTableId = new ConcurrentHashMap<>();
+    Map<Long, MemTableInfo> expectedMemTableId2Info = new ConcurrentHashMap<>();
+    Map<Long, Long> versionId2memTableId = new ConcurrentHashMap<>();
     // create 10 memTables, and flush the first 5 of them
     int memTablesNum = 10;
     for (int i = 0; i < memTablesNum; ++i) {
-      int versionId = i;
+      long versionId = i;
       Callable<Void> writeTask =
           () -> {
             String tsFilePath = logDirectory + File.separator + versionId + ".tsfile";
@@ -117,7 +117,7 @@ public class CheckpointManagerTest {
     // check first valid version id
     assertEquals(memTablesNum / 2, checkpointManager.getFirstValidWALVersionId());
     // recover info from checkpoint file
-    Map<Integer, MemTableInfo> actualMemTableId2Info =
+    Map<Long, MemTableInfo> actualMemTableId2Info =
         CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory)).getMemTableId2Info();
     assertEquals(expectedMemTableId2Info, actualMemTableId2Info);
   }
@@ -126,9 +126,9 @@ public class CheckpointManagerTest {
   public void testTriggerLogRoller() {
     // create memTables until reach LOG_SIZE_LIMIT, and flush the first 5 of them
     int size = 0;
-    int versionId = 0;
-    Map<Integer, MemTableInfo> expectedMemTableId2Info = new HashMap<>();
-    Map<Integer, Integer> versionId2memTableId = new HashMap<>();
+    long versionId = 0;
+    Map<Long, MemTableInfo> expectedMemTableId2Info = new HashMap<>();
+    Map<Long, Long> versionId2memTableId = new HashMap<>();
     while (size < config.getCheckpointFileSizeThresholdInByte()) {
       ++versionId;
       String tsFilePath = logDirectory + File.separator + versionId + ".tsfile";
@@ -157,7 +157,7 @@ public class CheckpointManagerTest {
     assertTrue(
         new File(logDirectory + File.separator + CheckpointFileUtils.getLogFileName(1)).exists());
     // recover info from checkpoint file
-    Map<Integer, MemTableInfo> actualMemTableId2Info =
+    Map<Long, MemTableInfo> actualMemTableId2Info =
         CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory)).getMemTableId2Info();
     assertEquals(expectedMemTableId2Info, actualMemTableId2Info);
   }

--- a/server/src/test/java/org/apache/iotdb/db/wal/io/CheckpointFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/io/CheckpointFileTest.java
@@ -69,13 +69,13 @@ public class CheckpointFileTest {
         new Checkpoint(
             CheckpointType.FLUSH_MEMORY_TABLE, Collections.singletonList(fakeMemTableInfo)));
     // test Checkpoint.serializedSize
-    int size = Integer.BYTES;
+    int size = Long.BYTES;
     for (Checkpoint checkpoint : expectedCheckpoints) {
       size += checkpoint.serializedSize();
     }
     ByteBuffer buffer = ByteBuffer.allocate(size);
     // test Checkpoint.serialize
-    buffer.putInt(0);
+    buffer.putLong(0);
     for (Checkpoint checkpoint : expectedCheckpoints) {
       checkpoint.serialize(buffer);
     }
@@ -112,13 +112,13 @@ public class CheckpointFileTest {
         new Checkpoint(
             CheckpointType.FLUSH_MEMORY_TABLE, Collections.singletonList(fakeMemTableInfo)));
     // test Checkpoint.serializedSize
-    int size = Integer.BYTES + Byte.BYTES;
+    int size = Long.BYTES + Byte.BYTES;
     for (Checkpoint checkpoint : expectedCheckpoints) {
       size += checkpoint.serializedSize();
     }
     ByteBuffer buffer = ByteBuffer.allocate(size);
     // test Checkpoint.serialize
-    buffer.putInt(0);
+    buffer.putLong(0);
     for (Checkpoint checkpoint : expectedCheckpoints) {
       checkpoint.serialize(buffer);
     }

--- a/server/src/test/java/org/apache/iotdb/db/wal/io/WALFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/io/WALFileTest.java
@@ -30,6 +30,8 @@ import org.apache.iotdb.db.qp.physical.crud.InsertTabletPlan;
 import org.apache.iotdb.db.wal.buffer.WALEntry;
 import org.apache.iotdb.db.wal.buffer.WALEntryType;
 import org.apache.iotdb.db.wal.utils.WALByteBufferForTest;
+import org.apache.iotdb.db.wal.utils.WALFileStatus;
+import org.apache.iotdb.db.wal.utils.WALFileUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.BitMap;
@@ -49,7 +51,10 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 public class WALFileTest {
-  private final File walFile = new File(TestConstant.BASE_OUTPUT_PATH.concat("_0.wal"));
+  private final File walFile =
+      new File(
+          TestConstant.BASE_OUTPUT_PATH.concat(
+              WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)));
   private final String devicePath = "root.test_sg.test_d";
 
   @Before

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
@@ -74,57 +74,57 @@ public class ConsensusReqReaderTest {
 
   /**
    * Generate wal files as below: <br>
-   * _0-0.wal: 1,-1 <br>
-   * _1-1.wal: 2,2,2 <br>
-   * _2-2.wal: 3,3 <br>
-   * _3-3.wal: 3,4 <br>
-   * _4-4.wal: 4 <br>
-   * _5-4.wal: 4,4,5 <br>
-   * _6-5.wal: 6 <br>
+   * _0-0-0.wal: 1,-1 <br>
+   * _1-1-0.wal: 2,2,2 <br>
+   * _2-2-0.wal: 3,3 <br>
+   * _3-3-0.wal: 3,4 <br>
+   * _4-4-0.wal: 4 <br>
+   * _5-4-0.wal: 4,4,5 <br>
+   * _6-5-0.wal: 6 <br>
    * 1 - InsertRowNode, 2 - InsertRowsOfOneDeviceNode, 3 - InsertRowsNode, 4 -
    * InsertMultiTabletsNode, 5 - InsertTabletNode, 6 - InsertRowNode
    */
   private void simulateFileScenario01() throws IllegalPathException {
     InsertTabletNode insertTabletNode;
     InsertRowNode insertRowNode;
-    // _0-0.wal
+    // _0-0-0.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(1);
     walNode.log(0, insertRowNode); // 1
     insertTabletNode = getInsertTabletNode(devicePath, new long[] {2});
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // -1
     walNode.rollWALFile();
-    // _1-1.wal
+    // _1-1-0.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(2);
     walNode.log(0, insertRowNode); // 2
     walNode.log(0, insertRowNode); // 2
     walNode.log(0, insertRowNode); // 2
     walNode.rollWALFile();
-    // _2-2.wal
+    // _2-2-0.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(3);
     walNode.log(0, insertRowNode); // 3
     walNode.log(0, insertRowNode); // 3
     walNode.rollWALFile();
-    // _3-3.wal
+    // _3-3-0.wal
     insertRowNode.setDevicePath(new PartialPath(devicePath + "test"));
     walNode.log(0, insertRowNode); // 3
     insertTabletNode = getInsertTabletNode(devicePath, new long[] {4});
     insertTabletNode.setSearchIndex(4);
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     walNode.rollWALFile();
-    // _4-4.wal
+    // _4-4-0.wal
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     walNode.rollWALFile();
-    // _5-4.wal
+    // _5-4-0.wal
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     insertTabletNode = getInsertTabletNode(devicePath, new long[] {5});
     insertTabletNode.setSearchIndex(5);
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 5
     walNode.rollWALFile();
-    // _6-5.wal
+    // _6-5-0.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(6);
     WALFlushListener walFlushListener = walNode.log(0, insertRowNode); // 6

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.db.wal.checkpoint.MemTableInfo;
 import org.apache.iotdb.db.wal.io.WALReader;
 import org.apache.iotdb.db.wal.recover.CheckpointRecoverUtils;
+import org.apache.iotdb.db.wal.utils.WALFileStatus;
 import org.apache.iotdb.db.wal.utils.WALFileUtils;
 import org.apache.iotdb.db.wal.utils.WALMode;
 import org.apache.iotdb.db.wal.utils.listener.WALFlushListener;
@@ -258,16 +259,32 @@ public class WALNodeTest {
     }
     walNode.onMemTableFlushed(memTable);
     walNode.onMemTableCreated(new PrimitiveMemTable(), tsFilePath);
-    // check existence of _0-0.wal file
+    // check existence of _0-0-0.wal file
     assertTrue(
-        new File(logDirectory + File.separator + WALFileUtils.getLogFileName(0, 0)).exists());
+        new File(
+                logDirectory
+                    + File.separator
+                    + WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_NONE_SEARCH_INDEX))
+            .exists());
     assertTrue(
-        new File(logDirectory + File.separator + WALFileUtils.getLogFileName(1, 0)).exists());
+        new File(
+                logDirectory
+                    + File.separator
+                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_NONE_SEARCH_INDEX))
+            .exists());
     walNode.deleteOutdatedFiles();
     assertFalse(
-        new File(logDirectory + File.separator + WALFileUtils.getLogFileName(0, 0)).exists());
+        new File(
+                logDirectory
+                    + File.separator
+                    + WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_NONE_SEARCH_INDEX))
+            .exists());
     assertTrue(
-        new File(logDirectory + File.separator + WALFileUtils.getLogFileName(1, 0)).exists());
+        new File(
+                logDirectory
+                    + File.separator
+                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_NONE_SEARCH_INDEX))
+            .exists());
     // check flush listeners
     try {
       for (WALFlushListener walFlushListener : walFlushListeners) {

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
@@ -215,7 +215,7 @@ public class WALNodeTest {
             IMemTable memTable = new PrimitiveMemTable();
             int memTableId = memTable.getMemTableId();
             String tsFilePath = logDirectory + File.separator + memTableId + ".tsfile";
-            int firstFileVersionId = walNode.getCurrentLogVersion();
+            long firstFileVersionId = walNode.getCurrentLogVersion();
             walNode.onMemTableCreated(memTable, tsFilePath);
             if (memTableId % 2 == 0) {
               walNode.onMemTableFlushed(memTable);

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
@@ -206,14 +206,14 @@ public class WALNodeTest {
     int threadsNum = 5;
     ExecutorService executorService = Executors.newFixedThreadPool(threadsNum);
     List<Future<Void>> futures = new ArrayList<>();
-    Map<Integer, MemTableInfo> expectedMemTableId2Info = new ConcurrentHashMap<>();
+    Map<Long, MemTableInfo> expectedMemTableId2Info = new ConcurrentHashMap<>();
     // create 10 memTables, and flush the first 5 of them
     int memTablesNum = 10;
     for (int i = 0; i < memTablesNum; ++i) {
       Callable<Void> writeTask =
           () -> {
             IMemTable memTable = new PrimitiveMemTable();
-            int memTableId = memTable.getMemTableId();
+            long memTableId = memTable.getMemTableId();
             String tsFilePath = logDirectory + File.separator + memTableId + ".tsfile";
             long firstFileVersionId = walNode.getCurrentLogVersion();
             walNode.onMemTableCreated(memTable, tsFilePath);
@@ -235,7 +235,7 @@ public class WALNodeTest {
       future.get();
     }
     // recover info from checkpoint file
-    Map<Integer, MemTableInfo> actualMemTableId2Info =
+    Map<Long, MemTableInfo> actualMemTableId2Info =
         CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory)).getMemTableId2Info();
     assertEquals(expectedMemTableId2Info, actualMemTableId2Info);
   }
@@ -246,7 +246,7 @@ public class WALNodeTest {
     // write until log is rolled
     long time = 0;
     IMemTable memTable = new PrimitiveMemTable();
-    int memTableId = memTable.getMemTableId();
+    long memTableId = memTable.getMemTableId();
     String tsFilePath = logDirectory + File.separator + memTableId + ".tsfile";
     walNode.onMemTableCreated(memTable, tsFilePath);
     while (walNode.getCurrentLogVersion() == 0) {

--- a/server/src/test/java/org/apache/iotdb/db/wal/recover/WALRecoverManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/recover/WALRecoverManagerTest.java
@@ -170,7 +170,7 @@ public class WALRecoverManagerTest {
     long firstWALVersionId = walBuffer.getCurrentWALFileVersion();
     for (int i = 0; i < threadsNum; ++i) {
       IMemTable fakeMemTable = new PrimitiveMemTable();
-      int memTableId = fakeMemTable.getMemTableId();
+      long memTableId = fakeMemTable.getMemTableId();
       Callable<Void> writeTask =
           () -> {
             checkpointManager.makeCreateMemTableCP(
@@ -228,7 +228,7 @@ public class WALRecoverManagerTest {
     long firstWALVersionId = walBuffer.getCurrentWALFileVersion();
     for (int i = 0; i < threadsNum; ++i) {
       IMemTable fakeMemTable = new PrimitiveMemTable();
-      int memTableId = fakeMemTable.getMemTableId();
+      long memTableId = fakeMemTable.getMemTableId();
       Callable<Void> writeTask =
           () -> {
             checkpointManager.makeCreateMemTableCP(

--- a/server/src/test/java/org/apache/iotdb/db/wal/recover/WALRecoverManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/recover/WALRecoverManagerTest.java
@@ -167,7 +167,7 @@ public class WALRecoverManagerTest {
     int threadsNum = 5;
     ExecutorService executorService = Executors.newFixedThreadPool(threadsNum);
     List<Future<Void>> futures = new ArrayList<>();
-    int firstWALVersionId = walBuffer.getCurrentWALFileVersion();
+    long firstWALVersionId = walBuffer.getCurrentWALFileVersion();
     for (int i = 0; i < threadsNum; ++i) {
       IMemTable fakeMemTable = new PrimitiveMemTable();
       int memTableId = fakeMemTable.getMemTableId();
@@ -201,7 +201,7 @@ public class WALRecoverManagerTest {
     }
     Thread.sleep(1_000);
     // write normal .wal files
-    int firstValidVersionId = walBuffer.getCurrentWALFileVersion();
+    long firstValidVersionId = walBuffer.getCurrentWALFileVersion();
     IMemTable targetMemTable = new PrimitiveMemTable();
     WALEntry walEntry =
         new WALEntry(targetMemTable.getMemTableId(), getInsertRowPlan(DEVICE2_NAME, 4L), true);
@@ -225,7 +225,7 @@ public class WALRecoverManagerTest {
     int threadsNum = 5;
     ExecutorService executorService = Executors.newFixedThreadPool(threadsNum);
     List<Future<Void>> futures = new ArrayList<>();
-    int firstWALVersionId = walBuffer.getCurrentWALFileVersion();
+    long firstWALVersionId = walBuffer.getCurrentWALFileVersion();
     for (int i = 0; i < threadsNum; ++i) {
       IMemTable fakeMemTable = new PrimitiveMemTable();
       int memTableId = fakeMemTable.getMemTableId();
@@ -259,7 +259,7 @@ public class WALRecoverManagerTest {
     }
     Thread.sleep(1_000);
     // write normal .wal files
-    int firstValidVersionId = walBuffer.getCurrentWALFileVersion();
+    long firstValidVersionId = walBuffer.getCurrentWALFileVersion();
     IMemTable targetMemTable = new PrimitiveMemTable();
     InsertRowPlan insertRowPlan = getInsertRowPlan(DEVICE2_NAME, 4L);
     targetMemTable.insert(insertRowPlan);

--- a/server/src/test/java/org/apache/iotdb/db/wal/utils/WALFileUtilsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/utils/WALFileUtilsTest.java
@@ -28,11 +28,11 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex01() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 5)),
-          new File(WALFileUtils.getLogFileName(2, 5)),
-          new File(WALFileUtils.getLogFileName(3, 12)),
-          new File(WALFileUtils.getLogFileName(4, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 0);
     Assert.assertEquals(-1, i);
@@ -42,11 +42,11 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex02() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 5)),
-          new File(WALFileUtils.getLogFileName(2, 5)),
-          new File(WALFileUtils.getLogFileName(3, 12)),
-          new File(WALFileUtils.getLogFileName(4, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 2);
     Assert.assertEquals(0, i);
@@ -56,11 +56,11 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex03() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 5)),
-          new File(WALFileUtils.getLogFileName(2, 5)),
-          new File(WALFileUtils.getLogFileName(3, 12)),
-          new File(WALFileUtils.getLogFileName(4, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 5);
     Assert.assertEquals(0, i);
@@ -70,11 +70,11 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex04() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 5)),
-          new File(WALFileUtils.getLogFileName(2, 5)),
-          new File(WALFileUtils.getLogFileName(3, 12)),
-          new File(WALFileUtils.getLogFileName(4, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 6);
     Assert.assertEquals(2, i);
@@ -84,11 +84,11 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex05() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 5)),
-          new File(WALFileUtils.getLogFileName(2, 5)),
-          new File(WALFileUtils.getLogFileName(3, 12)),
-          new File(WALFileUtils.getLogFileName(4, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 10);
     Assert.assertEquals(2, i);
@@ -98,11 +98,11 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex06() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 5)),
-          new File(WALFileUtils.getLogFileName(2, 5)),
-          new File(WALFileUtils.getLogFileName(3, 12)),
-          new File(WALFileUtils.getLogFileName(4, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 12);
     Assert.assertEquals(2, i);
@@ -112,11 +112,11 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex07() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 5)),
-          new File(WALFileUtils.getLogFileName(2, 5)),
-          new File(WALFileUtils.getLogFileName(3, 12)),
-          new File(WALFileUtils.getLogFileName(4, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, Long.MAX_VALUE);
     Assert.assertEquals(4, i);
@@ -126,11 +126,11 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex08() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 100)),
-          new File(WALFileUtils.getLogFileName(2, 200)),
-          new File(WALFileUtils.getLogFileName(3, 300)),
-          new File(WALFileUtils.getLogFileName(4, 400))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 100, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 200, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 300, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 400, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 10);
     Assert.assertEquals(0, i);
@@ -140,11 +140,11 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex09() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 100)),
-          new File(WALFileUtils.getLogFileName(2, 200)),
-          new File(WALFileUtils.getLogFileName(3, 300)),
-          new File(WALFileUtils.getLogFileName(4, 400))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 100, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 200, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 300, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 400, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 250);
     Assert.assertEquals(2, i);
@@ -154,18 +154,18 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex10() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 0)),
-          new File(WALFileUtils.getLogFileName(2, 0)),
-          new File(WALFileUtils.getLogFileName(3, 0)),
-          new File(WALFileUtils.getLogFileName(4, 5)),
-          new File(WALFileUtils.getLogFileName(5, 5)),
-          new File(WALFileUtils.getLogFileName(6, 5)),
-          new File(WALFileUtils.getLogFileName(7, 5)),
-          new File(WALFileUtils.getLogFileName(8, 12)),
-          new File(WALFileUtils.getLogFileName(9, 12)),
-          new File(WALFileUtils.getLogFileName(10, 12)),
-          new File(WALFileUtils.getLogFileName(11, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(5, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(6, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(7, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(8, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(9, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(10, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(11, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 5);
     Assert.assertEquals(3, i);
@@ -175,18 +175,18 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex11() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 0)),
-          new File(WALFileUtils.getLogFileName(2, 0)),
-          new File(WALFileUtils.getLogFileName(3, 0)),
-          new File(WALFileUtils.getLogFileName(4, 5)),
-          new File(WALFileUtils.getLogFileName(5, 5)),
-          new File(WALFileUtils.getLogFileName(6, 5)),
-          new File(WALFileUtils.getLogFileName(7, 5)),
-          new File(WALFileUtils.getLogFileName(8, 12)),
-          new File(WALFileUtils.getLogFileName(9, 12)),
-          new File(WALFileUtils.getLogFileName(10, 12)),
-          new File(WALFileUtils.getLogFileName(11, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(5, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(6, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(7, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(8, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(9, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(10, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(11, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 6);
     Assert.assertEquals(7, i);
@@ -196,18 +196,18 @@ public class WALFileUtilsTest {
   public void binarySearchFileBySearchIndex12() {
     File[] files =
         new File[] {
-          new File(WALFileUtils.getLogFileName(0, 0)),
-          new File(WALFileUtils.getLogFileName(1, 0)),
-          new File(WALFileUtils.getLogFileName(2, 0)),
-          new File(WALFileUtils.getLogFileName(3, 0)),
-          new File(WALFileUtils.getLogFileName(4, 5)),
-          new File(WALFileUtils.getLogFileName(5, 5)),
-          new File(WALFileUtils.getLogFileName(6, 5)),
-          new File(WALFileUtils.getLogFileName(7, 5)),
-          new File(WALFileUtils.getLogFileName(8, 12)),
-          new File(WALFileUtils.getLogFileName(9, 12)),
-          new File(WALFileUtils.getLogFileName(10, 12)),
-          new File(WALFileUtils.getLogFileName(11, 12))
+          new File(WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(2, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(3, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(4, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(5, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(6, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(7, 5, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(8, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(9, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(10, 12, WALFileStatus.CONTAINS_SEARCH_INDEX)),
+          new File(WALFileUtils.getLogFileName(11, 12, WALFileStatus.CONTAINS_SEARCH_INDEX))
         };
     int i = WALFileUtils.binarySearchFileBySearchIndex(files, 12);
     Assert.assertEquals(7, i);


### PR DESCRIPTION
This PR do three things:

1. Add status code in wal file name to delete data without search index when using multi-leader consensus
2. change version from int to long
3. change memtable id from int to long