### PR TITLE
[IOTDB-3643] Replace bytebuffer with IOStream in schemaFetcher

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTree.java
@@ -34,7 +34,9 @@ import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
-import java.nio.ByteBuffer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -214,31 +216,31 @@ public class SchemaTree {
     }
   }
 
-  public void serialize(ByteBuffer buffer) {
-    root.serialize(buffer);
+  public void serialize(OutputStream outputStream) throws IOException {
+    root.serialize(outputStream);
   }
 
-  public static SchemaTree deserialize(ByteBuffer buffer) {
+  public static SchemaTree deserialize(InputStream inputStream) throws IOException {
 
     byte nodeType;
     int childNum;
     Deque<SchemaNode> stack = new ArrayDeque<>();
     SchemaNode child;
 
-    while (buffer.hasRemaining()) {
-      nodeType = ReadWriteIOUtils.readByte(buffer);
+    while (inputStream.available() > 0) {
+      nodeType = ReadWriteIOUtils.readByte(inputStream);
       if (nodeType == SCHEMA_MEASUREMENT_NODE) {
-        SchemaMeasurementNode measurementNode = SchemaMeasurementNode.deserialize(buffer);
+        SchemaMeasurementNode measurementNode = SchemaMeasurementNode.deserialize(inputStream);
         stack.push(measurementNode);
       } else {
         SchemaInternalNode internalNode;
         if (nodeType == SCHEMA_ENTITY_NODE) {
-          internalNode = SchemaEntityNode.deserialize(buffer);
+          internalNode = SchemaEntityNode.deserialize(inputStream);
         } else {
-          internalNode = SchemaInternalNode.deserialize(buffer);
+          internalNode = SchemaInternalNode.deserialize(inputStream);
         }
 
-        childNum = ReadWriteIOUtils.readInt(buffer);
+        childNum = ReadWriteIOUtils.readInt(inputStream);
         while (childNum > 0) {
           child = stack.pop();
           internalNode.addChild(child.getName(), child);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaEntityNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaEntityNode.java
@@ -21,7 +21,9 @@ package org.apache.iotdb.db.mpp.common.schematree.node;
 
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
-import java.nio.ByteBuffer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -99,18 +101,18 @@ public class SchemaEntityNode extends SchemaInternalNode {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
-    serializeChildren(buffer);
+  public void serialize(OutputStream outputStream) throws IOException {
+    serializeChildren(outputStream);
 
-    ReadWriteIOUtils.write(getType(), buffer);
-    ReadWriteIOUtils.write(name, buffer);
-    ReadWriteIOUtils.write(isAligned, buffer);
-    ReadWriteIOUtils.write(children.size(), buffer);
+    ReadWriteIOUtils.write(getType(), outputStream);
+    ReadWriteIOUtils.write(name, outputStream);
+    ReadWriteIOUtils.write(isAligned, outputStream);
+    ReadWriteIOUtils.write(children.size(), outputStream);
   }
 
-  public static SchemaEntityNode deserialize(ByteBuffer buffer) {
-    String name = ReadWriteIOUtils.readString(buffer);
-    boolean isAligned = ReadWriteIOUtils.readBool(buffer);
+  public static SchemaEntityNode deserialize(InputStream inputStream) throws IOException {
+    String name = ReadWriteIOUtils.readString(inputStream);
+    boolean isAligned = ReadWriteIOUtils.readBool(inputStream);
 
     SchemaEntityNode entityNode = new SchemaEntityNode(name);
     entityNode.setAligned(isAligned);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaInternalNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaInternalNode.java
@@ -21,7 +21,9 @@ package org.apache.iotdb.db.mpp.common.schematree.node;
 
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
-import java.nio.ByteBuffer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -75,22 +77,22 @@ public class SchemaInternalNode extends SchemaNode {
     return SCHEMA_INTERNAL_NODE;
   }
 
-  public void serialize(ByteBuffer buffer) {
-    serializeChildren(buffer);
+  public void serialize(OutputStream outputStream) throws IOException {
+    serializeChildren(outputStream);
 
-    ReadWriteIOUtils.write(getType(), buffer);
-    ReadWriteIOUtils.write(name, buffer);
-    ReadWriteIOUtils.write(children.size(), buffer);
+    ReadWriteIOUtils.write(getType(), outputStream);
+    ReadWriteIOUtils.write(name, outputStream);
+    ReadWriteIOUtils.write(children.size(), outputStream);
   }
 
-  protected void serializeChildren(ByteBuffer buffer) {
+  protected void serializeChildren(OutputStream outputStream) throws IOException {
     for (SchemaNode child : children.values()) {
-      child.serialize(buffer);
+      child.serialize(outputStream);
     }
   }
 
-  public static SchemaInternalNode deserialize(ByteBuffer buffer) {
-    String name = ReadWriteIOUtils.readString(buffer);
+  public static SchemaInternalNode deserialize(InputStream inputStream) throws IOException {
+    String name = ReadWriteIOUtils.readString(inputStream);
 
     return new SchemaInternalNode(name);
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaMeasurementNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaMeasurementNode.java
@@ -22,7 +22,9 @@ package org.apache.iotdb.db.mpp.common.schematree.node;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
-import java.nio.ByteBuffer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class SchemaMeasurementNode extends SchemaNode {
 
@@ -82,18 +84,18 @@ public class SchemaMeasurementNode extends SchemaNode {
   }
 
   @Override
-  public void serialize(ByteBuffer buffer) {
-    ReadWriteIOUtils.write(getType(), buffer);
-    ReadWriteIOUtils.write(name, buffer);
+  public void serialize(OutputStream outputStream) throws IOException {
+    ReadWriteIOUtils.write(getType(), outputStream);
+    ReadWriteIOUtils.write(name, outputStream);
 
-    ReadWriteIOUtils.write(alias, buffer);
-    schema.serializeTo(buffer);
+    ReadWriteIOUtils.write(alias, outputStream);
+    schema.serializeTo(outputStream);
   }
 
-  public static SchemaMeasurementNode deserialize(ByteBuffer buffer) {
-    String name = ReadWriteIOUtils.readString(buffer);
-    String alias = ReadWriteIOUtils.readString(buffer);
-    MeasurementSchema schema = MeasurementSchema.deserializeFrom(buffer);
+  public static SchemaMeasurementNode deserialize(InputStream inputStream) throws IOException {
+    String name = ReadWriteIOUtils.readString(inputStream);
+    String alias = ReadWriteIOUtils.readString(inputStream);
+    MeasurementSchema schema = MeasurementSchema.deserializeFrom(inputStream);
 
     SchemaMeasurementNode measurementNode = new SchemaMeasurementNode(name, schema);
     measurementNode.setAlias(alias);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaNode.java
@@ -21,7 +21,8 @@ package org.apache.iotdb.db.mpp.common.schematree.node;
 
 import org.apache.iotdb.commons.schema.tree.ITreeNode;
 
-import java.nio.ByteBuffer;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -78,5 +79,5 @@ public abstract class SchemaNode implements ITreeNode {
 
   public abstract byte getType();
 
-  public abstract void serialize(ByteBuffer buffer);
+  public abstract void serialize(OutputStream outputStream) throws IOException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
@@ -49,6 +49,8 @@ import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import io.airlift.concurrent.SetThreadName;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -126,8 +128,13 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
           Column column = tsBlock.get().getColumn(0);
           for (int i = 0; i < column.getPositionCount(); i++) {
             binary = column.getBinary(i);
-            fetchedSchemaTree = SchemaTree.deserialize(ByteBuffer.wrap(binary.getValues()));
-            result.mergeSchemaTree(fetchedSchemaTree);
+            try {
+              fetchedSchemaTree =
+                  SchemaTree.deserialize(new ByteArrayInputStream(binary.getValues()));
+              result.mergeSchemaTree(fetchedSchemaTree);
+            } catch (IOException e) {
+              // Totally memory operation. This case won't happen.
+            }
           }
         }
         return result;

--- a/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/SchemaTreeTest.java
@@ -34,7 +34,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.internal.util.collections.Sets;
 
-import java.nio.ByteBuffer;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -461,11 +462,11 @@ public class SchemaTreeTest {
   @Test
   public void testSerialization() throws Exception {
     SchemaNode root = generateSchemaTree();
-    ByteBuffer buffer = ByteBuffer.allocate(1024 * 1024);
-    root.serialize(buffer);
-    buffer.flip();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    root.serialize(outputStream);
 
-    SchemaTree schemaTree = SchemaTree.deserialize(buffer);
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+    SchemaTree schemaTree = SchemaTree.deserialize(inputStream);
 
     Pair<List<MeasurementPath>, Integer> visitResult =
         schemaTree.searchMeasurementPaths(new PartialPath("root.sg.**.status"), 2, 1, true);

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaFetchScanOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaFetchScanOperatorTest.java
@@ -43,7 +43,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -80,7 +80,7 @@ public class SchemaFetchScanOperatorTest {
     Assert.assertFalse(schemaFetchScanOperator.hasNext());
 
     Binary binary = tsBlock.getColumn(0).getBinary(0);
-    SchemaTree schemaTree = SchemaTree.deserialize(ByteBuffer.wrap(binary.getValues()));
+    SchemaTree schemaTree = SchemaTree.deserialize(new ByteArrayInputStream(binary.getValues()));
 
     DeviceSchemaInfo deviceSchemaInfo =
         schemaTree.searchDeviceSchemaInfo(


### PR DESCRIPTION
## Description

The byteBuffer doesn't support size extension, which is not friendly to scenarios with huge data size. 

Replace the byteBuffer usage in schemaFetcher with IOStream.