### PR TITLE
[IOTDB-3260] Fix npe while concurrent delete storage group

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -242,7 +242,7 @@ public class PartitionInfo implements SnapshotProcessor {
       if (storageGroupPartitionTable == null) {
         return;
       }
-      deletedRegionSet.addAll(storageGroupPartitionTables.get(req.getName()).getAllReplicaSets());
+      deletedRegionSet.addAll(storageGroupPartitionTable.getAllReplicaSets());
       // Clean the cache
       storageGroupPartitionTables.remove(req.getName());
     }


### PR DESCRIPTION
## Description


### NPE Cause

When executing predelete and delete sg on partitionInfo, the target storageGroupPartitionTable will be taken from a concurrentHashMap. If the deletion is executed concurrently, the taken table may be null since there may be some thread else delete the table, which may results in NPE if there's no check.

### Solution
Before invoke any interface of storageGroupPartitionTable taken from the map, check whether the table is null.


