### PR TITLE
Fix getLeader NPE and ConfigNode expension failure

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncConfigNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncConfigNodeClientPool.java
@@ -40,7 +40,7 @@ public class SyncConfigNodeClientPool {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SyncConfigNodeClientPool.class);
 
-  private static final int retryNum = 5;
+  private static final int retryNum = 6;
 
   private final IClientManager<TEndPoint, SyncConfigNodeIServiceClient> clientManager;
 
@@ -71,7 +71,7 @@ public class SyncConfigNodeClientPool {
         return client.registerConfigNode(req);
       } catch (Exception e) {
         LOGGER.warn("Register ConfigNode failed, retrying {}...", retry, e);
-        doRetryWait();
+        doRetryWait(retry);
       }
     }
     LOGGER.error("Register ConfigNode failed");
@@ -92,7 +92,7 @@ public class SyncConfigNodeClientPool {
         return client.addConsensusGroup(registerResp);
       } catch (Exception e) {
         LOGGER.warn("Add Consensus Group failed, retrying {} ...", retry, e);
-        doRetryWait();
+        doRetryWait(retry);
       }
     }
     LOGGER.error("Add ConsensusGroup failed");
@@ -126,7 +126,7 @@ public class SyncConfigNodeClientPool {
           return status;
         } catch (Exception e) {
           LOGGER.warn("Remove ConfigNode failed, retrying...", e);
-          doRetryWait();
+          doRetryWait(retry);
         }
       }
     }
@@ -145,7 +145,7 @@ public class SyncConfigNodeClientPool {
         return client.stopConfigNode(configNodeLocation);
       } catch (Exception e) {
         LOGGER.warn("Stop ConfigNode failed, retrying...", e);
-        doRetryWait();
+        doRetryWait(retry);
       }
     }
     LOGGER.error("Stop ConfigNode failed");
@@ -153,9 +153,9 @@ public class SyncConfigNodeClientPool {
         .setMessage("All retry failed.");
   }
 
-  private void doRetryWait() {
+  private void doRetryWait(int retryNum) {
     try {
-      TimeUnit.MILLISECONDS.sleep(100);
+      TimeUnit.MILLISECONDS.sleep(100L * (long) Math.pow(2, retryNum));
     } catch (InterruptedException e) {
       LOGGER.error("Retry wait failed.", e);
     }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
@@ -167,14 +167,16 @@ public class ConsensusManager {
   public TConfigNodeLocation getLeader() {
     for (int retry = 0; retry < 50; retry++) {
       Peer leaderPeer = consensusImpl.getLeader(consensusGroupId);
-      List<TConfigNodeLocation> onlineConfigNodes = getNodeManager().getOnlineConfigNodes();
-      TConfigNodeLocation leaderLocation =
-          onlineConfigNodes.stream()
-              .filter(leader -> leader.getConsensusEndPoint().equals(leaderPeer.getEndpoint()))
-              .findFirst()
-              .orElse(null);
-      if (leaderLocation != null) {
-        return leaderLocation;
+      if (leaderPeer != null) {
+        List<TConfigNodeLocation> onlineConfigNodes = getNodeManager().getOnlineConfigNodes();
+        TConfigNodeLocation leaderLocation =
+            onlineConfigNodes.stream()
+                .filter(leader -> leader.getConsensusEndPoint().equals(leaderPeer.getEndpoint()))
+                .findFirst()
+                .orElse(null);
+        if (leaderLocation != null) {
+          return leaderLocation;
+        }
       }
 
       try {


### PR DESCRIPTION
1. Avoid getLeader NPE from consensusLayer
2. Using exponential retry logic in SyncConfigNodeClient