### PR TITLE
[IOTDB-3649] Fix stack overflow when deleting wal

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -215,8 +215,11 @@ public class WALNode implements IWALNode {
   }
 
   private class DeleteOutdatedFileTask implements Runnable {
+    private static final int MAX_RECURSION_TIME = 5;
     /** .wal files whose version ids are less than first valid version id should be deleted */
     private long firstValidVersionId;
+    /** recursion time of calling deletion */
+    private int recursionTime = 0;
 
     @Override
     public void run() {
@@ -272,8 +275,9 @@ public class WALNode implements IWALNode {
             costOfFlushedMemTables,
             identifier,
             config.getWalMinEffectiveInfoRatio());
-        if (snapshotOrFlushMemTable()) {
+        if (snapshotOrFlushMemTable() && recursionTime < MAX_RECURSION_TIME) {
           run();
+          recursionTime++;
         }
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -370,9 +370,9 @@ public class WALNode implements IWALNode {
     }
 
     private void flushMemTable(DataRegion dataRegion, File tsFile, IMemTable memTable) {
-      boolean shouldWait = true;
+      boolean submitted = true;
       if (memTable.getFlushStatus() == FlushStatus.WORKING) {
-        shouldWait =
+        submitted =
             dataRegion.submitAFlushTask(
                 TsFileUtils.getTimePartition(tsFile), TsFileUtils.isSequence(tsFile), memTable);
         logger.info(
@@ -384,7 +384,7 @@ public class WALNode implements IWALNode {
       }
 
       // it's fine to wait until memTable has been flushed, because deleting files is not urgent.
-      if (shouldWait) {
+      if (submitted || memTable.getFlushStatus() == FlushStatus.FLUSHING) {
         long sleepTime = 0;
         while (memTable.getFlushStatus() != FlushStatus.FLUSHED) {
           try {


### PR DESCRIPTION
1. WAL delete thread should wait when memTable flush task is submitted or memtable is flushing.
2. WAL stop recursively calling deletion when memTables are not snapshot or flushed