### PR TITLE
upgrade spotless to fix jvmargs issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,20 +175,6 @@ and "`antlr/target/generated-sources/antlr4`" need to be added to sources roots 
 **In IDEA, you just need to right click on the root project name and choose "`Maven->Reload Project`" after 
 you run `mvn package` successfully.**
 
-#### Spotless problem
-**NOTE**: IF you are using JDK16+, you have to create a file called `jvm.config`,
-put it under `.mvn/`, before you use `spotless:apply`. The file contains the following content:
-```
---add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-```
-
-This is [an issue of Spotless](https://github.com/diffplug/spotless/issues/834),
-Once the issue is fixed, we can remove this file.
-
 ### Configurations
 
 configuration files are under "conf" folder

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -161,19 +161,6 @@ git checkout vx.x.x
 
 **IDEA的操作方法：在上述maven命令编译好后，右键项目名称，选择"`Maven->Reload project`"，即可。**
 
-#### Spotless问题（JDK16+）
-**NOTE**: 如果你在使用 JDK16+, 并且要做`spotless:apply`或者`spotless:check`，
-那么需要在`.mvn/`文件夹下创建一个文件 `jvm.config`, 内容如下:
-```
---add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-```
-这是spotless依赖的googlecodeformat的 [问题](https://github.com/diffplug/spotless/issues/834),
-近期可能会被官方解决。
-
 ### 配置
 
 配置文件在"conf"文件夹下

--- a/docs/Development/ContributeGuide.md
+++ b/docs/Development/ContributeGuide.md
@@ -122,20 +122,6 @@ plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) together wi
 8. Before you submit codes, you can use `mvn spotless:check` to check your codes manually,
 and use `mvn spotless:apply` to format your codes.
 
-**NOTICE (if you are using JDK16+)**: IF you are using JDK16+, you have to create a file called 
-`jvm.config`, put it under `.mvn/`, before you use `spotless:apply`. 
-The file contains the following content:
-```
---add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-```
-
-This is [an issue of Spotless](https://github.com/diffplug/spotless/issues/834),
-Once the issue is fixed, we can remove this file.
-
 ## Code Sytle
 We use the [maven-checkstyle-plugin](https://checkstyle.sourceforge.io/config_filefilters.html) to make Java codes obey a consistent ruleset defined in [checkstyle.xml](https://github.com/apache/iotdb/blob/master/checkstyle.xml) under the project root.
 

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <client-cpp>false</client-cpp>
         <!-- disable enforcer by default-->
         <enforcer.skip>true</enforcer.skip>
-        <spotless.version>2.22.3</spotless.version>
+        <spotless.version>2.22.8</spotless.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
         <!-- for REST service -->


### PR DESCRIPTION
Since https://github.com/diffplug/spotless/issues/834 resolved, upgrade spotless version for suppressing jvmargs issue on JDK17+.