### PR TITLE
[To rel/0.13][IOTDB-2525] Modify last cache value mechanism

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.integration;
 
-import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.service.IoTDB;
@@ -302,10 +301,6 @@ public class IoTDBLastIT {
       PartialPath path = new PartialPath("root.ln.wf01.wt02.temperature");
       IoTDB.metaManager.resetLastCache(path);
 
-      IMeasurementMNode node;
-      node = IoTDB.metaManager.getMeasurementMNode(path);
-      Assert.assertTrue(node.getLastCacheContainer().isEmptyContainer());
-
       boolean hasResultSet =
           statement.execute("select last temperature,status,id from root.ln.wf01.wt02");
 
@@ -585,17 +580,17 @@ public class IoTDBLastIT {
   @Test
   public void lastWithEmptyContainer() {
     String[] retArray =
-            new String[] {
-                    "500,root.ln.wf01.wt02.temperature,15.7,DOUBLE",
-                    "500,root.ln.wf01.wt02.status,false,BOOLEAN",
-                    "500,root.ln.wf01.wt02.id,9,INT32",
-                    "600,root.ln.wf01.wt02.temperature,10.2,DOUBLE",
-                    "600,root.ln.wf01.wt02.status,false,BOOLEAN",
-                    "600,root.ln.wf01.wt02.id,6,INT32"
-            };
+        new String[] {
+          "500,root.ln.wf01.wt02.temperature,15.7,DOUBLE",
+          "500,root.ln.wf01.wt02.status,false,BOOLEAN",
+          "500,root.ln.wf01.wt02.id,9,INT32",
+          "600,root.ln.wf01.wt02.temperature,10.2,DOUBLE",
+          "600,root.ln.wf01.wt02.status,false,BOOLEAN",
+          "600,root.ln.wf01.wt02.id,6,INT32"
+        };
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
 
       PartialPath path = new PartialPath("root.ln.wf01.wt02.temperature");
       IoTDB.metaManager.resetLastCache(path);
@@ -605,12 +600,12 @@ public class IoTDBLastIT {
       Assert.assertTrue(node.getLastCacheContainer().isEmptyContainer());
 
       boolean hasResultSet =
-              statement.execute("select last temperature,status,id from root.ln.wf01.wt02");
+          statement.execute("select last temperature,status,id from root.ln.wf01.wt02");
 
       assertTrue(hasResultSet);
     } catch (Exception e) {
-    e.printStackTrace();
-    fail(e.getMessage());
+      e.printStackTrace();
+      fail(e.getMessage());
     }
     try {
       EnvironmentUtils.restartDaemon();
@@ -619,14 +614,14 @@ public class IoTDBLastIT {
     }
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
 
       PartialPath path = new PartialPath("root.ln.wf01.wt02.temperature");
       IMeasurementMNode node;
       node = IoTDB.metaManager.getMeasurementMNode(path);
       Assert.assertNull(node.getLastCacheContainer().getCachedLast());
       boolean hasResultSet =
-              statement.execute("select last temperature,status,id from root.ln.wf01.wt02");
+          statement.execute("select last temperature,status,id from root.ln.wf01.wt02");
       node = IoTDB.metaManager.getMeasurementMNode(path);
       Assert.assertFalse(node.getLastCacheContainer().isEmptyContainer());
       assertTrue(hasResultSet);
@@ -642,12 +637,12 @@ public class IoTDBLastIT {
     }
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
 
       PartialPath path = new PartialPath("root.ln.wf01.wt02.temperature");
       IMeasurementMNode node;
       boolean hasResultSet =
-              statement.execute("select last temperature,status,id from root.ln.wf01.wt02");
+          statement.execute("select last temperature,status,id from root.ln.wf01.wt02");
       node = IoTDB.metaManager.getMeasurementMNode(path);
       Assert.assertFalse(node.getLastCacheContainer().isEmptyContainer());
       assertTrue(hasResultSet);
@@ -656,11 +651,7 @@ public class IoTDBLastIT {
       e.printStackTrace();
       fail(e.getMessage());
     }
-
-
   }
-
-
 
   private void prepareData() {
     try (Connection connection = EnvFactory.getEnv().getConnection();

--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
@@ -577,6 +577,7 @@ public class IoTDBLastIT {
     }
   }
 
+  // test cases that empty container would be created
   @Test
   public void lastWithEmptyContainer() {
     String[] retArray =

--- a/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
@@ -603,6 +603,21 @@ public class IoTDBLastIT {
           statement.execute("select last temperature,status,id from root.ln.wf01.wt02");
 
       assertTrue(hasResultSet);
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans =
+              resultSet.getString(TIMESTAMP_STR)
+                  + ","
+                  + resultSet.getString(TIMESEIRES_STR)
+                  + ","
+                  + resultSet.getString(VALUE_STR)
+                  + ","
+                  + resultSet.getString(DATA_TYPE_STR);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+      }
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());
@@ -625,6 +640,21 @@ public class IoTDBLastIT {
       node = IoTDB.metaManager.getMeasurementMNode(path);
       Assert.assertFalse(node.getLastCacheContainer().isEmptyContainer());
       assertTrue(hasResultSet);
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans =
+              resultSet.getString(TIMESTAMP_STR)
+                  + ","
+                  + resultSet.getString(TIMESEIRES_STR)
+                  + ","
+                  + resultSet.getString(VALUE_STR)
+                  + ","
+                  + resultSet.getString(DATA_TYPE_STR);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+      }
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());
@@ -646,6 +676,21 @@ public class IoTDBLastIT {
       node = IoTDB.metaManager.getMeasurementMNode(path);
       Assert.assertFalse(node.getLastCacheContainer().isEmptyContainer());
       assertTrue(hasResultSet);
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans =
+              resultSet.getString(TIMESTAMP_STR)
+                  + ","
+                  + resultSet.getString(TIMESEIRES_STR)
+                  + ","
+                  + resultSet.getString(VALUE_STR)
+                  + ","
+                  + resultSet.getString(DATA_TYPE_STR);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+      }
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -1869,10 +1869,11 @@ public class MManager {
 
   /**
    * Reset the last cache value of time series of given seriesPath. MManager will use the seriesPath
-   * to search the node.
+   * to search the node.The LastCacheContainer will be set as the EmptyLastCacheContainer.
    *
    * @param seriesPath the PartialPath of full path from root to Measurement
    */
+  @TestOnly
   public void resetLastCache(PartialPath seriesPath) {
     IMeasurementMNode node;
     try {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/idtable/entry/SchemaEntry.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/idtable/entry/SchemaEntry.java
@@ -218,6 +218,4 @@ public class SchemaEntry implements ILastCacheContainer {
   public boolean isEmptyContainer() {
     return false;
   };
-
-
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/idtable/entry/SchemaEntry.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/idtable/entry/SchemaEntry.java
@@ -213,4 +213,11 @@ public class SchemaEntry implements ILastCacheContainer {
     return Objects.hash(schema);
   }
   // endregion
+
+  @Override
+  public boolean isEmptyContainer() {
+    return false;
+  };
+
+
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
@@ -21,7 +21,9 @@ package org.apache.iotdb.db.metadata.lastCache;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
+import org.apache.iotdb.db.metadata.lastCache.container.EmptyLastCacheContainer;
 import org.apache.iotdb.db.metadata.lastCache.container.ILastCacheContainer;
+import org.apache.iotdb.db.metadata.lastCache.container.LastCacheContainer;
 import org.apache.iotdb.db.metadata.mnode.IEntityMNode;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
@@ -85,6 +87,10 @@ public class LastCacheManager {
     checkIsTemplateLastCacheAndSetIfAbsent(node);
 
     ILastCacheContainer lastCacheContainer = node.getLastCacheContainer();
+    if(lastCacheContainer.isEmptyContainer()){
+      lastCacheContainer = new LastCacheContainer();
+      node.setLastCacheContainer(lastCacheContainer);
+    }
     lastCacheContainer.updateCachedLast(timeValuePair, highPriorityUpdate, latestFlushedTime);
   }
 
@@ -101,9 +107,13 @@ public class LastCacheManager {
 
     checkIsTemplateLastCacheAndSetIfAbsent(node);
 
-    ILastCacheContainer lastCacheContainer = node.getLastCacheContainer();
-    lastCacheContainer.resetLastCache();
+//    ILastCacheContainer lastCacheContainer = node.getLastCacheContainer();
+//    lastCacheContainer.resetLastCache();
+    node.setLastCacheContainer(new EmptyLastCacheContainer());
+
   }
+
+
 
   private static void checkIsTemplateLastCacheAndSetIfAbsent(IMeasurementMNode node) {
     IEntityMNode entityMNode = node.getParent();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
@@ -109,7 +109,8 @@ public class LastCacheManager {
 
 //    ILastCacheContainer lastCacheContainer = node.getLastCacheContainer();
 //    lastCacheContainer.resetLastCache();
-    node.setLastCacheContainer(new EmptyLastCacheContainer());
+    // 单例模式
+    node.setLastCacheContainer(EmptyLastCacheContainer.getInstance());
 
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
@@ -87,7 +87,7 @@ public class LastCacheManager {
     checkIsTemplateLastCacheAndSetIfAbsent(node);
 
     ILastCacheContainer lastCacheContainer = node.getLastCacheContainer();
-    if(lastCacheContainer.isEmptyContainer()){
+    if (lastCacheContainer.isEmptyContainer()) {
       lastCacheContainer = new LastCacheContainer();
       node.setLastCacheContainer(lastCacheContainer);
     }
@@ -95,7 +95,7 @@ public class LastCacheManager {
   }
 
   /**
-   * reset the last cache value of time series of given seriesPath
+   * reset the LastCacheContainer to the EmptyLastCacheContainer
    *
    * @param node the measurementMNode holding the lastCache When invoker only has the target
    *     seriesPath, the node could be null and MManager will search the node
@@ -107,14 +107,8 @@ public class LastCacheManager {
 
     checkIsTemplateLastCacheAndSetIfAbsent(node);
 
-//    ILastCacheContainer lastCacheContainer = node.getLastCacheContainer();
-//    lastCacheContainer.resetLastCache();
-    // 单例模式
     node.setLastCacheContainer(EmptyLastCacheContainer.getInstance());
-
   }
-
-
 
   private static void checkIsTemplateLastCacheAndSetIfAbsent(IMeasurementMNode node) {
     IEntityMNode entityMNode = node.getParent();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
@@ -105,7 +105,6 @@ public class LastCacheManager {
    * @param node the measurementMNode holding the lastCache When invoker only has the target
    *     seriesPath, the node could be null and MManager will search the node
    */
-  @TestOnly
   public static void resetLastCache(IMeasurementMNode node) {
     if (node == null) {
       return;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
@@ -89,7 +89,7 @@ public class LastCacheManager {
 
     ILastCacheContainer lastCacheContainer = node.getLastCacheContainer();
     if (lastCacheContainer.isEmptyContainer()) {
-      synchronized (LastCacheManager.class){
+      synchronized (node){
         if (lastCacheContainer.isEmptyContainer()){
           lastCacheContainer = new LastCacheContainer();
           node.setLastCacheContainer(lastCacheContainer);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/LastCacheManager.java
@@ -89,8 +89,8 @@ public class LastCacheManager {
 
     ILastCacheContainer lastCacheContainer = node.getLastCacheContainer();
     if (lastCacheContainer.isEmptyContainer()) {
-      synchronized (node){
-        if (lastCacheContainer.isEmptyContainer()){
+      synchronized (node) {
+        if (lastCacheContainer.isEmptyContainer()) {
           lastCacheContainer = new LastCacheContainer();
           node.setLastCacheContainer(lastCacheContainer);
         }
@@ -105,6 +105,7 @@ public class LastCacheManager {
    * @param node the measurementMNode holding the lastCache When invoker only has the target
    *     seriesPath, the node could be null and MManager will search the node
    */
+  @TestOnly
   public static void resetLastCache(IMeasurementMNode node) {
     if (node == null) {
       return;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/EmptyLastCacheContainer.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/EmptyLastCacheContainer.java
@@ -19,49 +19,46 @@
 
 package org.apache.iotdb.db.metadata.lastCache.container;
 
-import org.apache.iotdb.db.engine.StorageEngine;
-import org.apache.iotdb.db.metadata.lastCache.container.value.ILastCacheValue;
-import org.apache.iotdb.db.service.SettleService;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
-import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
+
 public class EmptyLastCacheContainer implements ILastCacheContainer {
 
-    private EmptyLastCacheContainer() {}
+  private EmptyLastCacheContainer() {}
 
-    public static EmptyLastCacheContainer getInstance() {
-        return InstanceHolder.INSTANCE;
+  public static EmptyLastCacheContainer getInstance() {
+    return InstanceHolder.INSTANCE;
+  }
+
+  @Override
+  public TimeValuePair getCachedLast() {
+    return null;
+  };
+
+  @Override
+  public void updateCachedLast(
+      TimeValuePair timeValuePair, boolean highPriorityUpdate, Long latestFlushedTime) {};
+
+  @Override
+  public synchronized void resetLastCache() {
+    return;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return true;
+  };
+
+  @Override
+  public boolean isEmptyContainer() {
+    return true;
+  }
+
+  static class InstanceHolder {
+
+    private static final EmptyLastCacheContainer INSTANCE = new EmptyLastCacheContainer();
+
+    private InstanceHolder() {
+      // forbidding instantiation
     }
-    @Override
-    public TimeValuePair getCachedLast(){
-        return null;
-    };
-
-    @Override
-    public void updateCachedLast(
-            TimeValuePair timeValuePair, boolean highPriorityUpdate, Long latestFlushedTime){
-
-    };
-
-    @Override
-    public synchronized void resetLastCache() {
-        return;
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return true;
-    };
-
-    @Override
-    public boolean isEmptyContainer() {return true;}
-
-    static class InstanceHolder {
-
-        private static final EmptyLastCacheContainer INSTANCE = new EmptyLastCacheContainer();
-
-        private InstanceHolder() {
-            // forbidding instantiation
-        }
-    }
-
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/EmptyLastCacheContainer.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/EmptyLastCacheContainer.java
@@ -19,13 +19,18 @@
 
 package org.apache.iotdb.db.metadata.lastCache.container;
 
+import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.metadata.lastCache.container.value.ILastCacheValue;
+import org.apache.iotdb.db.service.SettleService;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 public class EmptyLastCacheContainer implements ILastCacheContainer {
 
-    ILastCacheValue lastCacheValue = null;
+    private EmptyLastCacheContainer() {}
 
+    public static EmptyLastCacheContainer getInstance() {
+        return InstanceHolder.INSTANCE;
+    }
     @Override
     public TimeValuePair getCachedLast(){
         return null;
@@ -39,7 +44,7 @@ public class EmptyLastCacheContainer implements ILastCacheContainer {
 
     @Override
     public synchronized void resetLastCache() {
-        lastCacheValue = null;
+        return;
     }
 
     @Override
@@ -48,6 +53,15 @@ public class EmptyLastCacheContainer implements ILastCacheContainer {
     };
 
     @Override
-    public boolean isEmptyContainer() {return false;}
+    public boolean isEmptyContainer() {return true;}
+
+    static class InstanceHolder {
+
+        private static final EmptyLastCacheContainer INSTANCE = new EmptyLastCacheContainer();
+
+        private InstanceHolder() {
+            // forbidding instantiation
+        }
+    }
 
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/EmptyLastCacheContainer.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/EmptyLastCacheContainer.java
@@ -19,30 +19,35 @@
 
 package org.apache.iotdb.db.metadata.lastCache.container;
 
+import org.apache.iotdb.db.metadata.lastCache.container.value.ILastCacheValue;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
+import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
+public class EmptyLastCacheContainer implements ILastCacheContainer {
 
-/** this interface declares the operations of LastCache data */
-public interface ILastCacheContainer {
+    ILastCacheValue lastCacheValue = null;
 
-  // get lastCache of monad timseries
-  TimeValuePair getCachedLast();
+    @Override
+    public TimeValuePair getCachedLast(){
+        return null;
+    };
 
-  /**
-   * update last point cache
-   *
-   * @param timeValuePair last point
-   * @param highPriorityUpdate whether it's a high priority update
-   * @param latestFlushedTime latest flushed time
-   */
-  void updateCachedLast(
-      TimeValuePair timeValuePair, boolean highPriorityUpdate, Long latestFlushedTime);
+    @Override
+    public void updateCachedLast(
+            TimeValuePair timeValuePair, boolean highPriorityUpdate, Long latestFlushedTime){
 
-  // reset all lastCache data of one timeseries(monad or vector)
-  void resetLastCache();
+    };
 
-  // whether the entry contains lastCache Value.
-  boolean isEmpty();
+    @Override
+    public synchronized void resetLastCache() {
+        lastCacheValue = null;
+    }
 
-  // whether the instance is empty container
-  boolean isEmptyContainer();
+    @Override
+    public boolean isEmpty() {
+        return true;
+    };
+
+    @Override
+    public boolean isEmptyContainer() {return false;}
+
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/LastCacheContainer.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/LastCacheContainer.java
@@ -67,4 +67,7 @@ public class LastCacheContainer implements ILastCacheContainer {
   public boolean isEmpty() {
     return lastCacheValue == null;
   }
+
+  @Override
+  public boolean isEmptyContainer() {return false;}
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/LastCacheContainer.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/lastCache/container/LastCacheContainer.java
@@ -69,5 +69,7 @@ public class LastCacheContainer implements ILastCacheContainer {
   }
 
   @Override
-  public boolean isEmptyContainer() {return false;}
+  public boolean isEmptyContainer() {
+    return false;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -257,7 +257,7 @@ public class LastQueryExecutor {
     }
 
     for (int i = 0; i < cacheAccessors.size(); i++) {
-      if(cacheAccessors.get(i).checkEmptyContainer()){
+      if (cacheAccessors.get(i).checkEmptyContainer()) {
         resultContainer.add(new Pair<>(true, null));
         continue;
       }
@@ -296,8 +296,6 @@ public class LastQueryExecutor {
     boolean checkEmptyContainer();
 
     void markEmpty();
-
-
   }
 
   private static class MManagerLastCacheAccessor implements LastCacheAccessor {
@@ -336,19 +334,20 @@ public class LastQueryExecutor {
       }
     }
 
-    public boolean checkEmptyContainer(){
-      if (node == null){
+    public boolean checkEmptyContainer() {
+      if (node == null) {
         return false;
       } else {
         return node.getLastCacheContainer().isEmptyContainer();
       }
     }
 
-    public void markEmpty(){
-      if (node == null){
+    public void markEmpty() {
+      if (node == null) {
         return;
       } else {
-        node.setLastCacheContainer(EmptyLastCacheContainer.getInstance());;
+        node.setLastCacheContainer(EmptyLastCacheContainer.getInstance());
+        ;
       }
     }
   }
@@ -385,11 +384,11 @@ public class LastQueryExecutor {
       }
     }
 
-    public boolean checkEmptyContainer(){
+    public boolean checkEmptyContainer() {
       return false;
     }
 
-    public void markEmpty(){
+    public void markEmpty() {
       return;
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -230,6 +230,7 @@ public class LastQueryExecutor {
           }
         } else {
           resultContainer.get(i).left = true;
+          // set empty container when the system restart and container is initialized as null
           cacheAccessors.get(i).markEmpty();
         }
       }
@@ -256,7 +257,9 @@ public class LastQueryExecutor {
       }
     }
 
+
     for (int i = 0; i < cacheAccessors.size(); i++) {
+      // if empty container, then it means no data, query results return null
       if (cacheAccessors.get(i).checkEmptyContainer()) {
         resultContainer.add(new Pair<>(true, null));
         continue;

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -257,7 +257,6 @@ public class LastQueryExecutor {
       }
     }
 
-
     for (int i = 0; i < cacheAccessors.size(); i++) {
       // if empty container, then it means no data, query results return null
       if (cacheAccessors.get(i).checkEmptyContainer()) {


### PR DESCRIPTION
**[Issue](https://issues.apache.org/jira/browse/IOTDB-2525)**
Currently, if a time series has no data written before, the last cache will be null, which we still need to read the disk.

**Solution**
Add a EmptyLastCacheContainer class to indicate that this timeseries has no data.