### PR TITLE
Rename mppDataExchangeEndPoint to mPPDataExchangeEndPoint in common.thrift

### DIFF
--- a/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigRequestSerDeTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigRequestSerDeTest.java
@@ -83,7 +83,7 @@ public class ConfigRequestSerDeTest {
     dataNodeLocation.setDataNodeId(1);
     dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667));
     dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003));
-    dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
+    dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
     dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010));
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010));
 
@@ -199,7 +199,7 @@ public class ConfigRequestSerDeTest {
     dataNodeLocation.setDataNodeId(0);
     dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667));
     dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003));
-    dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
+    dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
     dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010));
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010));
 
@@ -236,7 +236,7 @@ public class ConfigRequestSerDeTest {
     dataNodeLocation.setDataNodeId(0);
     dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667));
     dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003));
-    dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
+    dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
     dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010));
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010));
 
@@ -292,7 +292,7 @@ public class ConfigRequestSerDeTest {
     dataNodeLocation.setDataNodeId(0);
     dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667));
     dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003));
-    dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
+    dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
     dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010));
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010));
 

--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
@@ -220,7 +220,7 @@ public class PartitionInfoTest {
       tDataNodeLocation.setDataNodeId(i);
       tDataNodeLocation.setExternalEndPoint(new TEndPoint("127.0.0.1", 6000 + i));
       tDataNodeLocation.setInternalEndPoint(new TEndPoint("127.0.0.1", 7000 + i));
-      tDataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("127.0.0.1", 8000 + i));
+      tDataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("127.0.0.1", 8000 + i));
       tDataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("127.0.0.1", 9000 + i));
       tDataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("127.0.0.1", 10000 + i));
       dataNodeLocations.add(tDataNodeLocation);

--- a/confignode/src/test/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessorTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessorTest.java
@@ -148,7 +148,7 @@ public class ConfigNodeRPCServiceProcessorTest {
       TDataNodeLocation dataNodeLocation = new TDataNodeLocation();
       dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667 + i));
       dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003 + i));
-      dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777 + i));
+      dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777 + i));
       dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010 + i));
       dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010 + i));
 
@@ -174,7 +174,7 @@ public class ConfigNodeRPCServiceProcessorTest {
     TDataNodeLocation dataNodeLocation = new TDataNodeLocation();
     dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6668));
     dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9004));
-    dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8778));
+    dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8778));
     dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40011));
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50011));
 
@@ -202,7 +202,7 @@ public class ConfigNodeRPCServiceProcessorTest {
       dataNodeLocation.setDataNodeId(i + 1);
       dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667 + i));
       dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003 + i));
-      dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777 + i));
+      dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777 + i));
       dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010 + i));
       dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010 + i));
       Assert.assertEquals(dataNodeLocation, infoList.get(i).getValue().getLocation());
@@ -217,7 +217,7 @@ public class ConfigNodeRPCServiceProcessorTest {
     dataNodeLocation.setDataNodeId(1);
     dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667));
     dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003));
-    dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
+    dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
     dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010));
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010));
     Assert.assertEquals(dataNodeLocation, infoMap.get(1).getLocation());
@@ -243,7 +243,7 @@ public class ConfigNodeRPCServiceProcessorTest {
       dataNodeLocation.setDataNodeId(i + 1);
       dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667 + i));
       dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003 + i));
-      dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777 + i));
+      dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777 + i));
       dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010 + i));
       dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010 + i));
       Assert.assertEquals(dataNodeLocation, dataNodeInfos.get(i));

--- a/node-commons/src/test/java/org/apache/iotdb/commons/partition/SerializeTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/partition/SerializeTest.java
@@ -67,7 +67,7 @@ public abstract class SerializeTest {
       tDataNodeLocation.setDataNodeId(i);
       tDataNodeLocation.setExternalEndPoint(new TEndPoint("127.0.0.1", 6000 + i));
       tDataNodeLocation.setInternalEndPoint(new TEndPoint("127.0.0.1", 7000 + i));
-      tDataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("127.0.0.1", 8000 + i));
+      tDataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("127.0.0.1", 8000 + i));
       tDataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("127.0.0.1", 9000 + i));
       tDataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("127.0.0.1", 10000 + i));
       dataNodeLocations.add(tDataNodeLocation);

--- a/node-commons/src/test/java/org/apache/iotdb/commons/utils/ThriftCommonsSerDeUtilsTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/utils/ThriftCommonsSerDeUtilsTest.java
@@ -65,7 +65,7 @@ public class ThriftCommonsSerDeUtilsTest {
     dataNodeLocation0.setDataNodeId(0);
     dataNodeLocation0.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667));
     dataNodeLocation0.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003));
-    dataNodeLocation0.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
+    dataNodeLocation0.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
     dataNodeLocation0.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010));
     dataNodeLocation0.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010));
 
@@ -129,7 +129,7 @@ public class ThriftCommonsSerDeUtilsTest {
       dataNodeLocation.setDataNodeId(i);
       dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667 + i));
       dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003 + i));
-      dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777 + i));
+      dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777 + i));
       dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010 + i));
       dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010 + i));
       regionReplicaSet0.getDataNodeLocations().add(dataNodeLocation);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/DistributionPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/DistributionPlanner.java
@@ -115,7 +115,7 @@ public class DistributionPlanner {
     context
         .getResultNodeContext()
         .setUpStream(
-            rootInstance.getHostDataNode().mppDataExchangeEndPoint,
+            rootInstance.getHostDataNode().mPPDataExchangeEndPoint,
             rootInstance.getId(),
             sinkNode.getPlanNodeId());
     rootInstance.getFragment().setRoot(sinkNode);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
@@ -114,7 +114,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
         PlanNodeId downStreamNodeId = sinkNode.getDownStreamPlanNodeId();
         FragmentInstance downStreamInstance = findDownStreamInstance(downStreamNodeId);
         sinkNode.setDownStream(
-            downStreamInstance.getHostDataNode().getMppDataExchangeEndPoint(),
+            downStreamInstance.getHostDataNode().getMPPDataExchangeEndPoint(),
             downStreamInstance.getId(),
             downStreamNodeId);
 
@@ -123,7 +123,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
             downStreamInstance.getFragment().getPlanNodeById(downStreamNodeId);
         ((ExchangeNode) downStreamExchangeNode)
             .setUpstream(
-                instance.getHostDataNode().getMppDataExchangeEndPoint(),
+                instance.getHostDataNode().getMPPDataExchangeEndPoint(),
                 instance.getId(),
                 sinkNode.getPlanNodeId());
       }

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -180,7 +180,7 @@ public class DataNode implements DataNodeMBean {
         location.setExternalEndPoint(new TEndPoint(config.getRpcAddress(), config.getRpcPort()));
         location.setInternalEndPoint(
             new TEndPoint(config.getInternalIp(), config.getInternalPort()));
-        location.setMppDataExchangeEndPoint(
+        location.setMPPDataExchangeEndPoint(
             new TEndPoint(config.getInternalIp(), config.getMppDataExchangePort()));
         location.setDataRegionConsensusEndPoint(
             new TEndPoint(config.getInternalIp(), config.getDataRegionConsensusPort()));
@@ -338,7 +338,7 @@ public class DataNode implements DataNodeMBean {
         location.setExternalEndPoint(new TEndPoint(config.getRpcAddress(), config.getRpcPort()));
         location.setInternalEndPoint(
             new TEndPoint(config.getInternalIp(), config.getInternalPort()));
-        location.setMppDataExchangeEndPoint(
+        location.setMPPDataExchangeEndPoint(
             new TEndPoint(config.getInternalIp(), config.getMppDataExchangePort()));
         location.setDataRegionConsensusEndPoint(
             new TEndPoint(config.getInternalIp(), config.getDataRegionConsensusPort()));

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/FragmentInstanceSerdeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/FragmentInstanceSerdeTest.java
@@ -57,7 +57,7 @@ public class FragmentInstanceSerdeTest {
     dataNodeLocation.setDataNodeId(0);
     dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667));
     dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003));
-    dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
+    dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
     dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010));
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010));
 
@@ -89,7 +89,7 @@ public class FragmentInstanceSerdeTest {
     dataNodeLocation.setDataNodeId(0);
     dataNodeLocation.setExternalEndPoint(new TEndPoint("0.0.0.0", 6667));
     dataNodeLocation.setInternalEndPoint(new TEndPoint("0.0.0.0", 9003));
-    dataNodeLocation.setMppDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
+    dataNodeLocation.setMPPDataExchangeEndPoint(new TEndPoint("0.0.0.0", 8777));
     dataNodeLocation.setDataRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 40010));
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 50010));
 

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/Util.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/Util.java
@@ -185,7 +185,7 @@ public class Util {
     return new TDataNodeLocation()
         .setDataNodeId(dataNodeId)
         .setExternalEndPoint(new TEndPoint(ip, 9000))
-        .setMppDataExchangeEndPoint(new TEndPoint(ip, 9001))
+        .setMPPDataExchangeEndPoint(new TEndPoint(ip, 9001))
         .setInternalEndPoint(new TEndPoint(ip, 9002));
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/scheduler/StandaloneSchedulerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/scheduler/StandaloneSchedulerTest.java
@@ -505,7 +505,7 @@ public class StandaloneSchedulerTest {
         new TDataNodeLocation()
             .setExternalEndPoint(new TEndPoint(conf.getRpcAddress(), conf.getRpcPort()))
             .setInternalEndPoint(new TEndPoint(conf.getInternalIp(), conf.getInternalPort()))
-            .setMppDataExchangeEndPoint(
+            .setMPPDataExchangeEndPoint(
                 new TEndPoint(conf.getInternalIp(), conf.getMppDataExchangePort()))
             .setDataRegionConsensusEndPoint(
                 new TEndPoint(conf.getInternalIp(), conf.getDataRegionConsensusPort()))

--- a/server/src/test/java/org/apache/iotdb/db/service/InternalServiceImplTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/service/InternalServiceImplTest.java
@@ -320,7 +320,7 @@ public class InternalServiceImplTest {
         new TDataNodeLocation()
             .setExternalEndPoint(new TEndPoint(conf.getRpcAddress(), conf.getRpcPort()))
             .setInternalEndPoint(new TEndPoint(conf.getInternalIp(), conf.getInternalPort()))
-            .setMppDataExchangeEndPoint(
+            .setMPPDataExchangeEndPoint(
                 new TEndPoint(conf.getInternalIp(), conf.getMppDataExchangePort()))
             .setDataRegionConsensusEndPoint(
                 new TEndPoint(conf.getInternalIp(), conf.getDataRegionConsensusPort()))

--- a/thrift-commons/src/main/thrift/common.thrift
+++ b/thrift-commons/src/main/thrift/common.thrift
@@ -70,7 +70,7 @@ struct TDataNodeLocation {
   // TEndPoint for DataNode's internal rpc
   3: required TEndPoint internalEndPoint
   // TEndPoint for exchange data between DataNodes
-  4: required TEndPoint mppDataExchangeEndPoint
+  4: required TEndPoint mPPDataExchangeEndPoint
   // TEndPoint for DataNode's dataRegion consensus protocol
   5: required TEndPoint dataRegionConsensusEndPoint
   // TEndPoint for DataNode's schemaRegion consensus protocol


### PR DESCRIPTION
By renaming mppDataExchangeEndPoint to mPPDataExchangeEndPoint.
We could use setMPPDataExchangeEndPoint and getMPPDataExchangeEndPoint.