### PR TITLE
Enable partition cache and change default size to 10000

### DIFF
--- a/consensus/src/test/java/org/apache/iotdb/consensus/multileader/MultiLeaderConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/multileader/MultiLeaderConsensusTest.java
@@ -55,6 +55,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MultiLeaderConsensusTest {
 
@@ -346,7 +347,7 @@ public class MultiLeaderConsensusTest {
 
   private static class TestStateMachine implements IStateMachine, IStateMachine.EventApi {
 
-    private final Set<IndexedConsensusRequest> requestSet = new HashSet<>();
+    private final Set<IndexedConsensusRequest> requestSet = ConcurrentHashMap.newKeySet();
 
     public Set<IndexedConsensusRequest> getRequestSet() {
       return requestSet;

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -1031,7 +1031,7 @@ timestamp_precision=ms
 # cache size for partition.
 # This cache is used to improve partition fetch from config node.
 # Datatype: int
-# partition_cache_size=0
+# partition_cache_size=10000
 
 ####################
 ### Schema File Configuration

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -1031,7 +1031,7 @@ timestamp_precision=ms
 # cache size for partition.
 # This cache is used to improve partition fetch from config node.
 # Datatype: int
-# partition_cache_size=10000
+# partition_cache_size=100000
 
 ####################
 ### Schema File Configuration

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -896,7 +896,7 @@ public class IoTDBConfig {
    * Cache size of partition cache in {@link
    * org.apache.iotdb.db.mpp.plan.analyze.ClusterPartitionFetcher}
    */
-  private int partitionCacheSize = 0;
+  private int partitionCacheSize = 10000;
 
   /** Cache size of user and role */
   private int authorCacheSize = 100;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -896,7 +896,7 @@ public class IoTDBConfig {
    * Cache size of partition cache in {@link
    * org.apache.iotdb.db.mpp.plan.analyze.ClusterPartitionFetcher}
    */
-  private int partitionCacheSize = 10000;
+  private int partitionCacheSize = 100000;
 
   /** Cache size of user and role */
   private int authorCacheSize = 100;


### PR DESCRIPTION
## Description
1. After the fix from @SpriCoder for PartitionCache, let's enable the partition cache