### PR TITLE
[IOTDB-3254][IOTDB-3492] Fix storage group related error message

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
@@ -112,9 +112,7 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
       result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     } catch (MetadataException e) {
       LOGGER.error("Error StorageGroup name", e);
-      result
-          .setCode(e.getErrorCode())
-          .setMessage(e.getMessage());
+      result.setCode(e.getErrorCode()).setMessage(e.getMessage());
     } finally {
       storageGroupReadWriteLock.writeLock().unlock();
     }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ClusterSchemaInfo.java
@@ -113,8 +113,8 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
     } catch (MetadataException e) {
       LOGGER.error("Error StorageGroup name", e);
       result
-          .setCode(TSStatusCode.SET_STORAGE_GROUP_FAILED.getStatusCode())
-          .setMessage("Error StorageGroup name");
+          .setCode(e.getErrorCode())
+          .setMessage(e.getMessage());
     } finally {
       storageGroupReadWriteLock.writeLock().unlock();
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterPartitionFetcher.java
@@ -19,10 +19,12 @@
 package org.apache.iotdb.db.mpp.plan.analyze;
 
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.consensus.PartitionRegionId;
+import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.partition.DataPartitionQueryParam;
@@ -299,11 +301,18 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
                 storageGroupNamesNeedCreated.add(storageGroupNameNeedCreated.getFullPath());
               }
             }
+            Set<String> successFullyCreatedStorageGroup = new HashSet<>();
             for (String storageGroupName : storageGroupNamesNeedCreated) {
               TStorageGroupSchema storageGroupSchema = new TStorageGroupSchema();
               storageGroupSchema.setName(storageGroupName);
               TSetStorageGroupReq req = new TSetStorageGroupReq(storageGroupSchema);
-              client.setStorageGroup(req);
+              TSStatus tsStatus = client.setStorageGroup(req);
+              if (TSStatusCode.SUCCESS_STATUS.getStatusCode() == tsStatus.getCode()) {
+                successFullyCreatedStorageGroup.add(storageGroupName);
+              } else {
+                partitionCache.updateStorageCache(successFullyCreatedStorageGroup);
+                throw new RuntimeException(new IoTDBException(tsStatus.message, tsStatus.code));
+              }
             }
             partitionCache.updateStorageCache(storageGroupNamesNeedCreated);
             // third try to hit cache

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ConfigExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ConfigExecution.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.mpp.plan.execution.config;
 
+import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -33,6 +34,7 @@ import org.apache.iotdb.db.mpp.plan.execution.config.executor.IConfigTaskExecuto
 import org.apache.iotdb.db.mpp.plan.execution.config.executor.StandaloneConfigTaskExecutor;
 import org.apache.iotdb.db.mpp.plan.statement.Statement;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 
@@ -117,7 +119,18 @@ public class ConfigExecution implements IQueryExecution {
 
   public void fail(Throwable cause) {
     stateMachine.transitionToFailed(cause);
-    taskFuture.set(new ConfigTaskResult(TSStatusCode.INTERNAL_SERVER_ERROR));
+    ConfigTaskResult result;
+    if (cause instanceof IoTDBException) {
+      result =
+          new ConfigTaskResult(TSStatusCode.representOf(((IoTDBException) cause).getErrorCode()));
+    } else if (cause instanceof StatementExecutionException) {
+      result =
+          new ConfigTaskResult(
+              TSStatusCode.representOf(((StatementExecutionException) cause).getStatusCode()));
+    } else {
+      result = new ConfigTaskResult(TSStatusCode.INTERNAL_SERVER_ERROR);
+    }
+    taskFuture.set(result);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TFlushReq;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.consensus.PartitionRegionId;
+import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.confignode.rpc.thrift.TClusterNodeInfos;
 import org.apache.iotdb.confignode.rpc.thrift.TCountStorageGroupResp;
@@ -103,7 +104,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
             "Failed to execute set storage group {} in config node, status is {}.",
             setStorageGroupStatement.getStorageGroupPath(),
             tsStatus);
-        future.setException(new StatementExecutionException(tsStatus));
+        future.setException(new IoTDBException(tsStatus.message, tsStatus.code));
       } else {
         future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
       }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSIServiceImpl.java
@@ -564,7 +564,7 @@ public class DataNodeTSIServiceImpl implements TSIEventHandler {
 
       if (result.status.code != TSStatusCode.SUCCESS_STATUS.getStatusCode()
           && result.status.code != TSStatusCode.NEED_REDIRECTION.getStatusCode()) {
-        throw new RuntimeException("error code: " + result.status);
+        return RpcUtils.getTSExecuteStatementResp(result.status);
       }
 
       IQueryExecution queryExecution = COORDINATOR.getQueryExecution(queryId);

--- a/server/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
@@ -99,9 +99,6 @@ public class ErrorHandlingUtils {
     // ignore logging sg not ready exception
     if (rootCause instanceof StorageGroupNotReadyException) {
       return RpcUtils.getStatus(TSStatusCode.STORAGE_GROUP_NOT_READY, rootCause.getMessage());
-    } else if (rootCause instanceof IoTDBException) {
-      return RpcUtils.getStatus(
-          ((IoTDBException) rootCause).getErrorCode(), rootCause.getMessage());
     }
 
     Throwable t = e instanceof ExecutionException ? e.getCause() : e;
@@ -126,6 +123,12 @@ public class ErrorHandlingUtils {
     } else if (t instanceof SemanticException) {
       return RpcUtils.getStatus(TSStatusCode.SEMANTIC_ERROR, rootCause.getMessage());
     }
+
+    if (t instanceof RuntimeException && rootCause instanceof IoTDBException) {
+      return RpcUtils.getStatus(
+          ((IoTDBException) rootCause).getErrorCode(), rootCause.getMessage());
+    }
+
     return null;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
@@ -99,6 +99,9 @@ public class ErrorHandlingUtils {
     // ignore logging sg not ready exception
     if (rootCause instanceof StorageGroupNotReadyException) {
       return RpcUtils.getStatus(TSStatusCode.STORAGE_GROUP_NOT_READY, rootCause.getMessage());
+    } else if (rootCause instanceof IoTDBException) {
+      return RpcUtils.getStatus(
+          ((IoTDBException) rootCause).getErrorCode(), rootCause.getMessage());
     }
 
     Throwable t = e instanceof ExecutionException ? e.getCause() : e;


### PR DESCRIPTION
## Description


### Motivation

The exception handle mechanism cannot reveal the correct and clear message to client. Wrong error code and wrong message occurs.

See IOTDB-3254, IOTDB-3492

### Modification

Modify some exception handling methods to help bubbling the desired message.

Fix the auto create storage group bug in ClusterPartitionFetcher.

### Result

![image](https://user-images.githubusercontent.com/38524330/175932736-4beafea7-caea-4554-9b7a-037ba30b1dd2.png)

