### PR TITLE
[IOTDB-3664] Modify python client test code

### DIFF
--- a/client-py/tests/test_template.py
+++ b/client-py/tests/test_template.py
@@ -185,9 +185,10 @@ def test_set_template():
         session.create_schema_template(template)
 
         session.set_schema_template(template_name, "root.python.GPS")
+        session.execute_non_query_statement("create timeseries of schema template on root.python.GPS")
 
         assert session.show_paths_template_set_on(template_name) == ["root.python.GPS"]
-        assert session.show_paths_template_using_on(template_name) == []
+        assert session.show_paths_template_using_on(template_name) == ["root.python.GPS"]
 
         session.unset_schema_template(template_name, "root.python.GPS")
         session.drop_schema_template(template_name)


### PR DESCRIPTION
[IOTDB-3664](https://issues.apache.org/jira/browse/IOTDB-3664) In python-client, test_template.py incidental occur the bug: “storage group is not set for current seriesPath”,  now through manual create timeseries of schema template to avoid this issue.