### PR TITLE
[IOTDB-3665] Serialize consensus protocol type to system.properties

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1712,9 +1712,6 @@ public class IoTDBDescriptor {
   // These configurations are received from config node when registering
   public void loadGlobalConfig(TGlobalConfig globalConfig) {
     conf.setSeriesPartitionExecutorClass(globalConfig.getSeriesPartitionExecutorClass());
-    conf.setDataRegionConsensusProtocolClass(globalConfig.getDataRegionConsensusProtocolClass());
-    conf.setSchemaRegionConsensusProtocolClass(
-        globalConfig.getSchemaRegionConsensusProtocolClass());
     conf.setSeriesPartitionSlotNum(globalConfig.getSeriesPartitionSlotNum());
     conf.setPartitionInterval(globalConfig.timePartitionInterval);
   }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.conf;
 
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.ConfigurationException;
 import org.apache.iotdb.commons.file.SystemFileFactory;
@@ -108,6 +109,9 @@ public class IoTDBStartCheck {
 
   private static final String DATA_NODE_ID = "data_node_id";
 
+  private static final String SCHEMA_REGION_CONSENSUS_PROTOCOL = "schema_region_consensus_protocol";
+
+  private static final String DATA_REGION_CONSENSUS_PROTOCOL = "data_region_consensus_protocol";
   private static final String IOTDB_VERSION_STRING = "iotdb_version";
 
   public static IoTDBStartCheck getInstance() {
@@ -377,9 +381,19 @@ public class IoTDBStartCheck {
       throwException(SCHEMA_ENGINE_MODE, schemaEngineMode);
     }
 
-    // properties contain DATA_NODE_ID only when start as Data node
+    // load configuration from system properties only when start as Data node
     if (properties.containsKey(DATA_NODE_ID)) {
       config.setDataNodeId(Integer.parseInt(properties.getProperty(DATA_NODE_ID)));
+    }
+
+    if (properties.containsKey(SCHEMA_REGION_CONSENSUS_PROTOCOL)) {
+      config.setSchemaRegionConsensusProtocolClass(
+          properties.getProperty(SCHEMA_REGION_CONSENSUS_PROTOCOL));
+    }
+
+    if (properties.containsKey(DATA_REGION_CONSENSUS_PROTOCOL)) {
+      config.setDataRegionConsensusProtocolClass(
+          properties.getProperty(DATA_REGION_CONSENSUS_PROTOCOL));
     }
   }
 
@@ -419,5 +433,45 @@ public class IoTDBStartCheck {
     }
     // rename system.properties.tmp to system.properties
     FileUtils.moveFile(tmpPropertiesFile, propertiesFile);
+  }
+
+  /** call this method to serialize consensus protocol */
+  public void serializeConsensusProtocol(String regionConsensusProtocol, TConsensusGroupType type)
+      throws IOException {
+    // create an empty tmpPropertiesFile
+    if (tmpPropertiesFile.createNewFile()) {
+      logger.info("Create system.properties.tmp {}.", tmpPropertiesFile);
+    } else {
+      logger.error("Create system.properties.tmp {} failed.", tmpPropertiesFile);
+      System.exit(-1);
+    }
+
+    reloadProperties();
+
+    try (FileOutputStream tmpFOS = new FileOutputStream(tmpPropertiesFile.toString())) {
+      if (type == TConsensusGroupType.DataRegion) {
+        properties.setProperty(DATA_REGION_CONSENSUS_PROTOCOL, regionConsensusProtocol);
+      } else if (type == TConsensusGroupType.SchemaRegion) {
+        properties.setProperty(SCHEMA_REGION_CONSENSUS_PROTOCOL, regionConsensusProtocol);
+      }
+      properties.store(tmpFOS, SYSTEM_PROPERTIES_STRING);
+      // serialize finished, delete old system.properties file
+      if (propertiesFile.exists()) {
+        Files.delete(propertiesFile.toPath());
+      }
+    }
+    // rename system.properties.tmp to system.properties
+    FileUtils.moveFile(tmpPropertiesFile, propertiesFile);
+  }
+
+  public boolean checkConsensusProtocolExists(TConsensusGroupType type) {
+    if (type == TConsensusGroupType.DataRegion) {
+      return properties.containsKey(DATA_REGION_CONSENSUS_PROTOCOL);
+    } else if (type == TConsensusGroupType.SchemaRegion) {
+      return properties.containsKey(SCHEMA_REGION_CONSENSUS_PROTOCOL);
+    }
+
+    logger.error("Unexpected consensus group type");
+    return false;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.service;
 
 import org.apache.iotdb.common.rpc.thrift.TConfigNodeLocation;
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeInfo;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
@@ -215,6 +216,26 @@ public class DataNode implements DataNodeMBean {
             config.setDataNodeId(dataNodeID);
           }
           IoTDBDescriptor.getInstance().loadGlobalConfig(dataNodeRegisterResp.globalConfig);
+
+          if (!IoTDBStartCheck.getInstance()
+              .checkConsensusProtocolExists(TConsensusGroupType.DataRegion)) {
+            config.setDataRegionConsensusProtocolClass(
+                dataNodeRegisterResp.globalConfig.getDataRegionConsensusProtocolClass());
+            IoTDBStartCheck.getInstance()
+                .serializeConsensusProtocol(
+                    dataNodeRegisterResp.globalConfig.getDataRegionConsensusProtocolClass(),
+                    TConsensusGroupType.DataRegion);
+          }
+
+          if (IoTDBStartCheck.getInstance()
+              .checkConsensusProtocolExists(TConsensusGroupType.SchemaRegion)) {
+            config.setSchemaRegionConsensusProtocolClass(
+                dataNodeRegisterResp.globalConfig.getSchemaRegionConsensusProtocolClass());
+            IoTDBStartCheck.getInstance()
+                .serializeConsensusProtocol(
+                    dataNodeRegisterResp.globalConfig.getSchemaRegionConsensusProtocolClass(),
+                    TConsensusGroupType.SchemaRegion);
+          }
           logger.info("Register to the cluster successfully");
           return;
         }


### PR DESCRIPTION
Optimization of datanode start-up process:

- If system.properties has data_region_consensus_protocol and schema_region_consensus_protocol, using these protocol types. This will occur when datanode restarts.
- If datanode joins into the cluster firstly, it receives the consensus protocol configuration from config node and serialize the configuration to the system.properties for restarting or recovering.