### PR TITLE
[IOTDB-3548] Fix not enough dataNode error msg

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterPartitionFetcher.java
@@ -145,6 +145,11 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
             == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
           schemaPartition = parseSchemaPartitionResp(schemaPartitionResp);
           partitionCache.updateSchemaPartitionCache(devicePaths, schemaPartition);
+        } else {
+          throw new RuntimeException(
+              new IoTDBException(
+                  schemaPartitionResp.getStatus().getMessage(),
+                  schemaPartitionResp.getStatus().getCode()));
         }
       }
       return schemaPartition;


### PR DESCRIPTION
## Description

see [IOTDB-3548](https://issues.apache.org/jira/browse/IOTDB-3548)

The partitionCache doesn't do any exception handle while the result returned by configNode is fail. Add the related check.

1C1D，with data_replica_factor=3 and schema_replica_factor=3
![image](https://user-images.githubusercontent.com/38524330/176075057-7665154b-2533-4c02-8f88-b420641c82de.png)
