### PR TITLE
[IOTDB-3636] Fix delete non existing sg error msg

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -84,6 +84,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -268,6 +269,11 @@ public class ConfigManager implements IManager {
       // remove wild
       Map<String, TStorageGroupSchema> deleteStorageSchemaMap =
           getClusterSchemaManager().getMatchedStorageGroupSchemasByName(deletedPaths);
+      if (deleteStorageSchemaMap.isEmpty()) {
+        return RpcUtils.getStatus(
+            TSStatusCode.TIMESERIES_NOT_EXIST.getStatusCode(),
+            String.format("Path %s does not exist", Arrays.toString(deletedPaths.toArray())));
+      }
       ArrayList<TStorageGroupSchema> parsedDeleteStorageGroups =
           new ArrayList<>(deleteStorageSchemaMap.values());
       return procedureManager.deleteStorageGroups(parsedDeleteStorageGroups);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -194,7 +194,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
             "Failed to execute delete storage group {} in config node, status is {}.",
             deleteStorageGroupStatement.getPrefixPath(),
             tsStatus);
-        future.setException(new StatementExecutionException(tsStatus));
+        future.setException(new IoTDBException(tsStatus.getMessage(), tsStatus.getCode()));
       } else {
         future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
       }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/StandaloneConfigTaskExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/StandaloneConfigTaskExecutor.java
@@ -173,6 +173,7 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
                     "Path %s does not exist",
                     Arrays.toString(deleteStorageGroupStatement.getPrefixPath().toArray())),
                 TSStatusCode.TIMESERIES_NOT_EXIST.getStatusCode()));
+        return future;
       } else {
         LocalConfigNode.getInstance().deleteStorageGroups(deletePathList);
       }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/StandaloneConfigTaskExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/StandaloneConfigTaskExecutor.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.mpp.plan.execution.config.executor;
 
 import org.apache.iotdb.common.rpc.thrift.TFlushReq;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.udf.service.UDFExecutableManager;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -164,9 +166,19 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
         deletePathList.addAll(
             LocalConfigNode.getInstance().getMatchedStorageGroups(prefixPath, false));
       }
-      LocalConfigNode.getInstance().deleteStorageGroups(deletePathList);
+      if (deletePathList.isEmpty()) {
+        future.setException(
+            new IoTDBException(
+                String.format(
+                    "Path %s does not exist",
+                    Arrays.toString(deleteStorageGroupStatement.getPrefixPath().toArray())),
+                TSStatusCode.TIMESERIES_NOT_EXIST.getStatusCode()));
+      } else {
+        LocalConfigNode.getInstance().deleteStorageGroups(deletePathList);
+      }
     } catch (MetadataException e) {
       future.setException(e);
+      return future;
     }
     future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
     return future;


### PR DESCRIPTION
## Description

To stick with 0.13. While trying to delete non existing storage group, in other words the input path patterns doesn't match any existing storage group, message like "path not exists" should be returned.

Result 
![image](https://user-images.githubusercontent.com/38524330/176083855-0c0fce5f-f552-4b63-b253-5e4e1656f49e.png)