### PR TITLE
[IOTDB-3685] Create parameter schema_region_per_data_node and data_region_per_processor in ConfigNode

### DIFF
--- a/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -48,13 +48,26 @@ config_nodes=0.0.0.0:22277
 
 
 ####################
-### Consensus protocol configuration
+### Region configuration
 ####################
 
-# All parameters in Consensus protocol configuration is unmodifiable after ConfigNode starts for the first time.
-# And these parameters should be consistent within the ConfigNodeGroup.
 
-# DataRegion consensus protocol type
+# SchemaRegion consensus protocol type.
+# This parameter is unmodifiable after ConfigNode starts for the first time.
+# These consensus protocols are currently supported:
+# 1. org.apache.iotdb.consensus.standalone.StandAloneConsensus(Consensus patterns optimized specifically for single replica)
+# 2. org.apache.iotdb.consensus.ratis.RatisConsensus(Raft protocol)
+# Datatype: String
+# schema_region_consensus_protocol_class=org.apache.iotdb.consensus.standalone.StandAloneConsensus
+
+# The maximum number of SchemaRegion expected to be managed by each DataNode.
+# Notice: Since each StorageGroup requires at least one SchemaRegion to manage it's schema,
+# this parameter doesn't limit the number of SchemaRegions when there are too many StorageGroups.
+# Datatype: Double
+# schema_region_per_data_node=1.0
+
+# DataRegion consensus protocol type.
+# This parameter is unmodifiable after ConfigNode starts for the first time.
 # These consensus protocols are currently supported:
 # 1. org.apache.iotdb.consensus.standalone.StandAloneConsensus(Consensus patterns optimized specifically for single replica)
 # 2. org.apache.iotdb.consensus.multileader.MultiLeaderConsensus(weak consistency, high performance)
@@ -62,12 +75,11 @@ config_nodes=0.0.0.0:22277
 # Datatype: String
 # data_region_consensus_protocol_class=org.apache.iotdb.consensus.standalone.StandAloneConsensus
 
-# SchemaRegion consensus protocol type
-# These consensus protocols are currently supported:
-# 1. org.apache.iotdb.consensus.standalone.StandAloneConsensus(Consensus patterns optimized specifically for single replica)
-# 2. org.apache.iotdb.consensus.ratis.RatisConsensus(Raft protocol)
-# Datatype: String
-# schema_region_consensus_protocol_class=org.apache.iotdb.consensus.standalone.StandAloneConsensus
+# The maximum number of SchemaRegion expected to be managed by each processor.
+# Notice: Since each StorageGroup requires at least two DataRegions to manage it's data,
+# this parameter doesn't limit the number of DataRegions when there are too many StorageGroups.
+# Datatype: Double
+# data_region_per_processor=0.5
 
 ####################
 ### PartitionSlot configuration

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -58,11 +58,17 @@ public class ConfigNodeConfig {
   /** ConfigNodeGroup consensus protocol */
   private String configNodeConsensusProtocolClass = ConsensusFactory.RatisConsensus;
 
+  /** DataNode schema region consensus protocol */
+  private String schemaRegionConsensusProtocolClass = ConsensusFactory.StandAloneConsensus;
+
+  /** The maximum number of SchemaRegion expected to be managed by each DataNode. */
+  private double schemaRegionPerDataNode = 1.0;
+
   /** DataNode data region consensus protocol */
   private String dataRegionConsensusProtocolClass = ConsensusFactory.StandAloneConsensus;
 
-  /** DataNode schema region consensus protocol */
-  private String schemaRegionConsensusProtocolClass = ConsensusFactory.StandAloneConsensus;
+  /** The maximum number of SchemaRegion expected to be managed by each DataNode. */
+  private double dataRegionPerProcessor = 0.5;
 
   /**
    * ClientManager will have so many selector threads (TAsyncClientManager) to distribute to its
@@ -320,6 +326,22 @@ public class ConfigNodeConfig {
     this.configNodeConsensusProtocolClass = configNodeConsensusProtocolClass;
   }
 
+  public String getSchemaRegionConsensusProtocolClass() {
+    return schemaRegionConsensusProtocolClass;
+  }
+
+  public void setSchemaRegionConsensusProtocolClass(String schemaRegionConsensusProtocolClass) {
+    this.schemaRegionConsensusProtocolClass = schemaRegionConsensusProtocolClass;
+  }
+
+  public double getSchemaRegionPerDataNode() {
+    return schemaRegionPerDataNode;
+  }
+
+  public void setSchemaRegionPerDataNode(double schemaRegionPerDataNode) {
+    this.schemaRegionPerDataNode = schemaRegionPerDataNode;
+  }
+
   public String getDataRegionConsensusProtocolClass() {
     return dataRegionConsensusProtocolClass;
   }
@@ -328,12 +350,12 @@ public class ConfigNodeConfig {
     this.dataRegionConsensusProtocolClass = dataRegionConsensusProtocolClass;
   }
 
-  public String getSchemaRegionConsensusProtocolClass() {
-    return schemaRegionConsensusProtocolClass;
+  public double getDataRegionPerProcessor() {
+    return dataRegionPerProcessor;
   }
 
-  public void setSchemaRegionConsensusProtocolClass(String schemaRegionConsensusProtocolClass) {
-    this.schemaRegionConsensusProtocolClass = schemaRegionConsensusProtocolClass;
+  public void setDataRegionPerProcessor(double dataRegionPerProcessor) {
+    this.dataRegionPerProcessor = dataRegionPerProcessor;
   }
 
   public int getThriftServerAwaitTimeForStopService() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -139,7 +139,7 @@ public class ConfigNodeDescriptor {
               conf.getSchemaRegionConsensusProtocolClass()));
 
       conf.setSchemaRegionPerDataNode(
-          Integer.parseInt(
+          Double.parseDouble(
               properties.getProperty(
                   "schema_region_per_data_node",
                   String.valueOf(conf.getSchemaRegionPerDataNode()))));
@@ -149,7 +149,7 @@ public class ConfigNodeDescriptor {
               "data_region_consensus_protocol_class", conf.getDataRegionConsensusProtocolClass()));
 
       conf.setDataRegionPerProcessor(
-          Integer.parseInt(
+          Double.parseDouble(
               properties.getProperty(
                   "data_region_per_processor", String.valueOf(conf.getDataRegionPerProcessor()))));
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -133,14 +133,25 @@ public class ConfigNodeDescriptor {
           properties.getProperty(
               "config_node_consensus_protocol_class", conf.getConfigNodeConsensusProtocolClass()));
 
-      conf.setDataRegionConsensusProtocolClass(
-          properties.getProperty(
-              "data_region_consensus_protocol_class", conf.getDataRegionConsensusProtocolClass()));
-
       conf.setSchemaRegionConsensusProtocolClass(
           properties.getProperty(
               "schema_region_consensus_protocol_class",
               conf.getSchemaRegionConsensusProtocolClass()));
+
+      conf.setSchemaRegionPerDataNode(
+          Integer.parseInt(
+              properties.getProperty(
+                  "schema_region_per_data_node",
+                  String.valueOf(conf.getSchemaRegionPerDataNode()))));
+
+      conf.setDataRegionConsensusProtocolClass(
+          properties.getProperty(
+              "data_region_consensus_protocol_class", conf.getDataRegionConsensusProtocolClass()));
+
+      conf.setDataRegionPerProcessor(
+          Integer.parseInt(
+              properties.getProperty(
+                  "data_region_per_processor", String.valueOf(conf.getDataRegionPerProcessor()))));
 
       conf.setRpcAdvancedCompressionEnable(
           Boolean.parseBoolean(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -193,7 +193,9 @@ public class ConfigNodeStartupCheck {
             CommonDescriptor.getInstance().getConfig().getDefaultTTL(),
             conf.getTimePartitionInterval(),
             conf.getSchemaReplicationFactor(),
-            conf.getDataReplicationFactor());
+            conf.getSchemaRegionPerDataNode(),
+            conf.getDataReplicationFactor(),
+            conf.getDataRegionPerProcessor());
 
     TEndPoint targetConfigNode = conf.getTargetConfigNode();
     while (true) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.read.CountStorageGroupReq;
 import org.apache.iotdb.confignode.consensus.request.read.GetStorageGroupReq;
 import org.apache.iotdb.confignode.consensus.request.write.AdjustMaxRegionGroupCountReq;
@@ -48,6 +49,11 @@ import java.util.Map;
 public class ClusterSchemaManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusterSchemaManager.class);
+
+  private static final double schemaRegionPerDataNode =
+      ConfigNodeDescriptor.getInstance().getConf().getSchemaRegionPerDataNode();
+  private static final double dataRegionPerProcessor =
+      ConfigNodeDescriptor.getInstance().getConf().getDataRegionPerProcessor();
 
   private final IManager configManager;
   private final ClusterSchemaInfo clusterSchemaInfo;
@@ -164,8 +170,12 @@ public class ClusterSchemaManager {
             Math.max(
                 1,
                 Math.max(
-                    dataNodeNum
-                        / (storageGroupNum * storageGroupSchema.getSchemaReplicationFactor()),
+                    (int)
+                        (schemaRegionPerDataNode
+                            * dataNodeNum
+                            / (double)
+                                (storageGroupNum
+                                    * storageGroupSchema.getSchemaReplicationFactor())),
                     allocatedSchemaRegionGroupCount));
 
         // Adjust maxDataRegionGroupCount.
@@ -178,8 +188,11 @@ public class ClusterSchemaManager {
             Math.max(
                 2,
                 Math.max(
-                    totalCpuCoreNum
-                        / (3 * storageGroupNum * storageGroupSchema.getDataReplicationFactor()),
+                    (int)
+                        (dataRegionPerProcessor
+                            * totalCpuCoreNum
+                            / (double)
+                                (storageGroupNum * storageGroupSchema.getDataReplicationFactor())),
                     allocatedDataRegionGroupCount));
 
         adjustMaxRegionGroupCountReq.putEntry(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -665,11 +665,25 @@ public class ConfigManager implements IManager {
               "Reject register, please ensure that the schema_replication_factor are consistent.");
       return errorResp;
     }
+    if (req.getSchemaRegionPerDataNode() != conf.getSchemaRegionPerDataNode()) {
+      errorResp
+          .getStatus()
+          .setMessage(
+              "Reject register, please ensure that the schema_region_per_data_node are consistent.");
+      return errorResp;
+    }
     if (req.getDataReplicationFactor() != conf.getDataReplicationFactor()) {
       errorResp
           .getStatus()
           .setMessage(
               "Reject register, please ensure that the data_replication_factor are consistent.");
+      return errorResp;
+    }
+    if (req.getDataRegionPerProcessor() != conf.getDataRegionPerProcessor()) {
+      errorResp
+          .getStatus()
+          .setMessage(
+              "Reject register, please ensure that the data_region_per_processor are consistent.");
       return errorResp;
     }
     return null;

--- a/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/thrift-confignode/src/main/thrift/confignode.thrift
@@ -202,7 +202,9 @@ struct TConfigNodeRegisterReq {
   6: required i64 defaultTTL
   7: required i64 timePartitionInterval
   8: required i32 schemaReplicationFactor
-  9: required i32 dataReplicationFactor
+  9: required double schemaRegionPerDataNode
+  10: required i32 dataReplicationFactor
+  11: required double dataRegionPerProcessor
 }
 
 struct TConfigNodeRegisterResp {


### PR DESCRIPTION
We add two parameters schema_region_per_data_node and  data_region_per_processor which makes the maxRegionCount configurable