### PR TITLE
[IOTDB-3684] Fail to read wal from wal file caused by FileNotFoundException

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/io/WALWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/io/WALWriter.java
@@ -19,13 +19,26 @@
 package org.apache.iotdb.db.wal.io;
 
 import org.apache.iotdb.db.wal.buffer.WALEntry;
+import org.apache.iotdb.db.wal.utils.WALFileStatus;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 
 /** WALWriter writes the binary {@link WALEntry} into .wal file. */
 public class WALWriter extends LogWriter {
+  private WALFileStatus walFileStatus = WALFileStatus.CONTAINS_NONE_SEARCH_INDEX;
+
   public WALWriter(File logFile) throws FileNotFoundException {
     super(logFile);
+  }
+
+  public void updateFileStatus(WALFileStatus walFileStatus) {
+    if (walFileStatus == WALFileStatus.CONTAINS_SEARCH_INDEX) {
+      this.walFileStatus = WALFileStatus.CONTAINS_SEARCH_INDEX;
+    }
+  }
+
+  public WALFileStatus getWalFileStatus() {
+    return walFileStatus;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
@@ -36,11 +36,11 @@ public class WALFileUtils {
    * versionId is a self-incremented id number, helping to maintain the order of wal files.
    * startSearchIndex is the valid search index of last flushed wal entry. statusCode is the. For
    * example: <br>
-   * _0-0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
-   * _1-5-1.wal: -1, -1, -1, -1 <br>
-   * _2-5-0.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
-   * _3-12-0.wal: 12, 12, 12, 12, 12 <br>
-   * _4-12-0.wal: 12, 13, 14, 15, 16, -1 <br>
+   * _0-0-1.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
+   * _1-5-0.wal: -1, -1, -1, -1 <br>
+   * _2-5-1.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
+   * _3-12-1.wal: 12, 12, 12, 12, 12 <br>
+   * _4-12-1.wal: 12, 13, 14, 15, 16, -1 <br>
    */
   public static final Pattern WAL_FILE_NAME_PATTERN =
       Pattern.compile(
@@ -105,13 +105,13 @@ public class WALFileUtils {
 
   /**
    * Find index of the file which probably contains target insert plan. <br>
-   * Given wal files [ _0-0-0.wal, _1-5-1.wal, _2-5-0.wal, _3-12-0.wal, _4-12-0.wal ], details as
+   * Given wal files [ _0-0-1.wal, _1-5-0.wal, _2-5-1.wal, _3-12-1.wal, _4-12-1.wal ], details as
    * below: <br>
-   * _0-0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
-   * _1-5-1.wal: -1, -1, -1, -1 <br>
-   * _2-5-0.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
-   * _3-12-0.wal: 12, 12, 12, 12, 12 <br>
-   * _4-12-0.wal: 12, 13, 14, 15, 16, -1 <br>
+   * _0-0-1.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
+   * _1-5-0.wal: -1, -1, -1, -1 <br>
+   * _2-5-1.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
+   * _3-12-1.wal: 12, 12, 12, 12, 12 <br>
+   * _4-12-1.wal: 12, 13, 14, 15, 16, -1 <br>
    * searching [1, 5] will return 0, searching [6, 12] will return 1, search [13, infinity) will
    * return 3， others will return -1
    *

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
@@ -74,57 +74,57 @@ public class ConsensusReqReaderTest {
 
   /**
    * Generate wal files as below: <br>
-   * _0-0-0.wal: 1,-1 <br>
-   * _1-1-0.wal: 2,2,2 <br>
-   * _2-2-0.wal: 3,3 <br>
-   * _3-3-0.wal: 3,4 <br>
-   * _4-4-0.wal: 4 <br>
-   * _5-4-0.wal: 4,4,5 <br>
-   * _6-5-0.wal: 6 <br>
+   * _0-0-1.wal: 1,-1 <br>
+   * _1-1-1.wal: 2,2,2 <br>
+   * _2-2-1.wal: 3,3 <br>
+   * _3-3-1.wal: 3,4 <br>
+   * _4-4-1.wal: 4 <br>
+   * _5-4-1.wal: 4,4,5 <br>
+   * _6-5-1.wal: 6 <br>
    * 1 - InsertRowNode, 2 - InsertRowsOfOneDeviceNode, 3 - InsertRowsNode, 4 -
    * InsertMultiTabletsNode, 5 - InsertTabletNode, 6 - InsertRowNode
    */
   private void simulateFileScenario01() throws IllegalPathException {
     InsertTabletNode insertTabletNode;
     InsertRowNode insertRowNode;
-    // _0-0-0.wal
+    // _0-0-1.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(1);
     walNode.log(0, insertRowNode); // 1
     insertTabletNode = getInsertTabletNode(devicePath, new long[] {2});
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // -1
     walNode.rollWALFile();
-    // _1-1-0.wal
+    // _1-1-1.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(2);
     walNode.log(0, insertRowNode); // 2
     walNode.log(0, insertRowNode); // 2
     walNode.log(0, insertRowNode); // 2
     walNode.rollWALFile();
-    // _2-2-0.wal
+    // _2-2-1.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(3);
     walNode.log(0, insertRowNode); // 3
     walNode.log(0, insertRowNode); // 3
     walNode.rollWALFile();
-    // _3-3-0.wal
+    // _3-3-1.wal
     insertRowNode.setDevicePath(new PartialPath(devicePath + "test"));
     walNode.log(0, insertRowNode); // 3
     insertTabletNode = getInsertTabletNode(devicePath, new long[] {4});
     insertTabletNode.setSearchIndex(4);
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     walNode.rollWALFile();
-    // _4-4-0.wal
+    // _4-4-1.wal
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     walNode.rollWALFile();
-    // _5-4-0.wal
+    // _5-4-1.wal
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     insertTabletNode = getInsertTabletNode(devicePath, new long[] {5});
     insertTabletNode.setSearchIndex(5);
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 5
     walNode.rollWALFile();
-    // _6-5-0.wal
+    // _6-5-1.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(6);
     WALFlushListener walFlushListener = walNode.log(0, insertRowNode); // 6

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
@@ -259,7 +259,7 @@ public class WALNodeTest {
     }
     walNode.onMemTableFlushed(memTable);
     walNode.onMemTableCreated(new PrimitiveMemTable(), tsFilePath);
-    // check existence of _0-0-0.wal file
+    // check existence of _0-0-0.wal file and _1-0-1.wal file
     assertTrue(
         new File(
                 logDirectory
@@ -270,7 +270,7 @@ public class WALNodeTest {
         new File(
                 logDirectory
                     + File.separator
-                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_NONE_SEARCH_INDEX))
+                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_SEARCH_INDEX))
             .exists());
     walNode.deleteOutdatedFiles();
     assertFalse(
@@ -283,7 +283,7 @@ public class WALNodeTest {
         new File(
                 logDirectory
                     + File.separator
-                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_NONE_SEARCH_INDEX))
+                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_SEARCH_INDEX))
             .exists());
     // check flush listeners
     try {


### PR DESCRIPTION
Some outdated wal files doesn't contains search index are deleted by wal-delete thread, so FileNotFoundException may occur when searching. Fix it by searching again.