### PR TITLE
[IOTDB-3687] Rename config_nodes to target_config_nodes

### DIFF
--- a/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -37,7 +37,7 @@ rpc_port=22277
 consensus_port=22278
 
 
-# Used for connecting to the ConfigNodeGroup
+# At least one running ConfigNode should be set for joining the cluster
 # Format: ip:port
 # where the ip should be consistent with the target ConfigNode's confignode_rpc_address,
 # and the port should be consistent with the target ConfigNode's confignode_rpc_port.

--- a/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -41,8 +41,8 @@ consensus_port=22278
 # Format: ip:port
 # where the ip should be consistent with the target ConfigNode's confignode_rpc_address,
 # and the port should be consistent with the target ConfigNode's confignode_rpc_port.
-# For the first ConfigNode to start, config_nodes points to its own ip:port.
-# For other ConfigNodes that are started or restarted, config_nodes points to any running ConfigNode's ip:port.
+# For the first ConfigNode to start, target_config_nodes points to its own ip:port.
+# For other ConfigNodes that are started or restarted, target_config_nodes points to any running ConfigNode's ip:port.
 # Datatype: String
 target_config_nodes=0.0.0.0:22277
 

--- a/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -44,7 +44,7 @@ consensus_port=22278
 # For the first ConfigNode to start, config_nodes points to its own ip:port.
 # For other ConfigNodes that are started or restarted, config_nodes points to any running ConfigNode's ip:port.
 # Datatype: String
-config_nodes=0.0.0.0:22277
+target_config_nodes=0.0.0.0:22277
 
 
 ####################

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -115,9 +115,10 @@ public class ConfigNodeDescriptor {
           Integer.parseInt(
               properties.getProperty("consensus_port", String.valueOf(conf.getConsensusPort()))));
 
-      String targetConfigNode = properties.getProperty("config_nodes", null);
-      if (targetConfigNode != null) {
-        conf.setTargetConfigNode(NodeUrlUtils.parseTEndPointUrl(targetConfigNode));
+      // TODO: Enable multiple target_config_nodes
+      String targetConfigNodes = properties.getProperty("target_config_nodes", null);
+      if (targetConfigNodes != null) {
+        conf.setTargetConfigNode(NodeUrlUtils.parseTEndPointUrl(targetConfigNodes));
       }
 
       conf.setSeriesPartitionSlotNum(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -83,12 +83,12 @@ public class ConfigNodeStartupCheck {
   /** Check whether the global configuration of the cluster is correct */
   private void checkGlobalConfig() throws ConfigurationException {
     // When the ConfigNode consensus protocol is set to StandAlone,
-    // the config_nodes needs to point to itself
+    // the target_config_nodes needs to point to itself
     if (conf.getConfigNodeConsensusProtocolClass().equals(ConsensusFactory.StandAloneConsensus)
         && (!conf.getRpcAddress().equals(conf.getTargetConfigNode().getIp())
             || conf.getRpcPort() != conf.getTargetConfigNode().getPort())) {
       throw new ConfigurationException(
-          "config_nodes",
+          "target_config_nodes",
           conf.getTargetConfigNode().getIp() + ":" + conf.getTargetConfigNode().getPort(),
           conf.getRpcAddress() + ":" + conf.getRpcPort());
     }
@@ -160,7 +160,7 @@ public class ConfigNodeStartupCheck {
    * Check if the current ConfigNode is SeedConfigNode. If true, do the SeedConfigNode configuration
    * as well.
    *
-   * @return True if the config_nodes points to itself
+   * @return True if the target_config_nodes points to itself
    */
   private boolean isSeedConfigNode() {
     boolean result =

--- a/confignode/src/test/resources/confignode1conf/iotdb-confignode.properties
+++ b/confignode/src/test/resources/confignode1conf/iotdb-confignode.properties
@@ -20,7 +20,7 @@
 rpc_address=0.0.0.0
 rpc_port=22277
 consensus_port=22278
-config_nodes=0.0.0.0:22277
+target_config_nodes=0.0.0.0:22277
 config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 data_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus

--- a/confignode/src/test/resources/confignode2conf/iotdb-confignode.properties
+++ b/confignode/src/test/resources/confignode2conf/iotdb-confignode.properties
@@ -20,7 +20,7 @@
 rpc_address=0.0.0.0
 rpc_port=22279
 consensus_port=22280
-config_nodes=0.0.0.0:22277
+target_config_nodes=0.0.0.0:22277
 config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 data_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus

--- a/confignode/src/test/resources/confignode3conf/iotdb-confignode.properties
+++ b/confignode/src/test/resources/confignode3conf/iotdb-confignode.properties
@@ -20,7 +20,7 @@
 rpc_address=0.0.0.0
 rpc_port=22281
 consensus_port=22282
-config_nodes=0.0.0.0:22277
+target_config_nodes=0.0.0.0:22277
 config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 data_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus

--- a/docs/UserGuide/Cluster/Cluster-Setup.md
+++ b/docs/UserGuide/Cluster/Cluster-Setup.md
@@ -89,7 +89,7 @@ Important parameters in iotdb-confignode.properties:
 | rpc\_address    | Internal rpc service address of ConfigNode          |
 | rpc\_port    | Internal rpc service address of ConfigNode       |
 | consensus\_port    | ConfigNode replication consensus protocol communication port    |
-| config\_nodes    | Target ConfigNode address, if the current is the first ConfigNode, then set its address:port    |
+| target\_config\_nodes    | Target ConfigNode address, if the current is the first ConfigNode, then set its address:port    |
 | data\_replication\_factor  | Data replication factor, no more than DataNode number        |
 | data\_region\_consensus\_protocol\_class | Consensus protocol of data replicas |
 | schema\_replication\_factor  | Schema replication factor, no more than DataNode number       |
@@ -116,6 +116,6 @@ Important parameters in iotdb-datanode.properties
 | mpp\_data\_exchange\_port    | Data flow port of DataNode inside cluster           |
 | data\_region\_consensus\_port    | Data replicas communication port for consensus     |
 | schema\_region\_consensus\_port    | Schema replicas communication port for consensus          |
-| config\_nodes    | Running ConfigNode of the Cluster      |
+| target\_config\_nodes    | Running ConfigNode of the Cluster      |
 
 More details [DataNode Configurations](https://iotdb.apache.org/UserGuide/Master/Reference/DataNode-Config-Manual.html)

--- a/docs/UserGuide/Reference/ConfigNode-Config-Manual.md
+++ b/docs/UserGuide/Reference/ConfigNode-Config-Manual.md
@@ -85,9 +85,9 @@ IoTDB Cluster configuration is in ConfigNode.
 |Default| 6667 |
 |Effective|After restarting system|
 
-* config\_nodes
+* target\_config\_nodes
 
-|Name| config\_nodes |
+|Name| target\_config\_nodes |
 |:---:|:---|
 |Description| Target ConfigNode address, for current ConfigNode to join the cluster |
 |Type| String |

--- a/docs/UserGuide/Reference/DataNode-Config-Manual.md
+++ b/docs/UserGuide/Reference/DataNode-Config-Manual.md
@@ -247,9 +247,9 @@ The permission definitions are in ${IOTDB\_CONF}/conf/jmx.access.
 |Default| 50010 |
 |Effective|After restarting system|
 
-* config\_nodes
+* target\_config\_nodes
 
-|Name| config\_nodes |
+|Name| target\_config\_nodes |
 |:---:|:---|
 |Description| ConfigNode Address for DataNode to join cluster |
 |Type| String |

--- a/docs/zh/UserGuide/Cluster/Cluster-Setup.md
+++ b/docs/zh/UserGuide/Cluster/Cluster-Setup.md
@@ -89,7 +89,7 @@ mvn clean package -pl distribution -am -DskipTests
 | rpc\_address    | ConfigNode 在集群内部通讯使用的地址          |
 | rpc\_port    | ConfigNode 在集群内部通讯使用的端口           |
 | consensus\_port    | ConfigNode 副本组共识协议通信使用的端口         |
-| config\_nodes    | 种子 ConfigNode 地址，第一个 ConfigNode 配置自己的 address:port        |
+| target\_config\_nodes    | 种子 ConfigNode 地址，第一个 ConfigNode 配置自己的 address:port        |
 | data\_replication\_factor  | 数据副本数，DataNode 数量不应少于此数目        |
 | data\_region\_consensus\_protocol\_class |  数据副本组的共识协议 |
 | schema\_replication\_factor  | 元数据副本数，DataNode 数量不应少于此数目       |
@@ -116,6 +116,6 @@ iotdb-datanode.properties 中的重要配置如下
 | mpp\_data\_exchange\_port    | DataNode 在集群内部接收数据流使用的端口           |
 | data\_region\_consensus\_port    | DataNode 的数据副本间共识协议通信的端口           |
 | schema\_region\_consensus\_port    | DataNode 的元数据副本间共识协议通信的端口           |
-| config\_nodes    | 集群中正在运行的 ConfigNode 地址       |
+| target\_config\_nodes    | 集群中正在运行的 ConfigNode 地址       |
 
 具体参考 [DataNode配置参数](https://iotdb.apache.org/zh/UserGuide/Master/Reference/DataNode-Config-Manual.html)

--- a/docs/zh/UserGuide/Reference/ConfigNode-Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/ConfigNode-Config-Manual.md
@@ -83,9 +83,9 @@ IoTDB 集群的全局配置通过 ConfigNode 配置。
 |默认值| 6667 |
 |改后生效方式|重启服务生效|
 
-* config\_nodes
+* target\_config\_nodes
 
-|名字| config\_nodes |
+|名字| target\_config\_nodes |
 |:---:|:---|
 |描述| 目标 ConfigNode 地址，ConfigNode 通过此地址加入集群 |
 |类型| String |

--- a/docs/zh/UserGuide/Reference/DataNode-Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/DataNode-Config-Manual.md
@@ -229,9 +229,9 @@ IoTDB DataNode 与 Standalone 模式共用一套配置文件，均位于 IoTDB �
 |默认值| 50010 |
 |改后生效方式|重启服务生效|
 
-* config\_nodes
+* target\_config\_nodes
 
-|名字| config\_nodes |
+|名字| target\_config\_nodes |
 |:---:|:---|
 |描述| ConfigNode 地址，DataNode 启动时通过此地址加入集群 |
 |类型| String |

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/ConfigNodeWrapper.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/ConfigNodeWrapper.java
@@ -50,7 +50,7 @@ public class ConfigNodeWrapper extends AbstractNodeWrapper {
     properties.setProperty("rpc_address", super.getIp());
     properties.setProperty("rpc_port", String.valueOf(getPort()));
     properties.setProperty("consensus_port", String.valueOf(this.consensusPort));
-    properties.setProperty("config_nodes", this.targetConfigNode);
+    properties.setProperty("target_config_nodes", this.targetConfigNode);
     properties.setProperty(
         "config_node_consensus_protocol_class",
         "org.apache.iotdb.consensus.standalone.StandAloneConsensus");

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/DataNodeWrapper.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/DataNodeWrapper.java
@@ -54,7 +54,7 @@ public class DataNodeWrapper extends AbstractNodeWrapper {
         "schema_region_consensus_port", String.valueOf(this.schemaRegionConsensusPort));
     properties.setProperty("connection_timeout_ms", "30000");
     if (this.targetConfigNode != null) {
-      properties.setProperty("config_nodes", this.targetConfigNode);
+      properties.setProperty("target_config_nodes", this.targetConfigNode);
     }
   }
 

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -63,7 +63,7 @@ schema_region_consensus_port=50010
 # Data nodes store config nodes ip and port to communicate with config nodes.
 # Several nodes will be picked randomly to send the request, the number of nodes
 # picked depends on the number of retries.
-config_nodes=127.0.0.1:22277
+target_config_nodes=127.0.0.1:22277
 
 # Datatype: boolean
 # rpc_thrift_compression_enable=false

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1645,7 +1645,7 @@ public class IoTDBDescriptor {
   }
 
   public void loadClusterProps(Properties properties) {
-    String configNodeUrls = properties.getProperty("config_nodes");
+    String configNodeUrls = properties.getProperty("target_config_nodes");
     if (configNodeUrls != null) {
       try {
         conf.setConfigNodeList(NodeUrlUtils.parseTEndPointUrls(configNodeUrls));

--- a/server/src/test/resources/datanode1conf/iotdb-datanode.properties
+++ b/server/src/test/resources/datanode1conf/iotdb-datanode.properties
@@ -26,7 +26,7 @@ internal_port=9003
 data_region_consensus_port=40010
 schema_region_consensus_port=50030
 
-config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
+target_config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
 
 system_dir=target/datanode1/system
 data_dirs=target/datanode1/data

--- a/server/src/test/resources/datanode2conf/iotdb-datanode.properties
+++ b/server/src/test/resources/datanode2conf/iotdb-datanode.properties
@@ -26,7 +26,7 @@ internal_port=9005
 data_region_consensus_port=40012
 schema_region_consensus_port=50032
 
-config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
+target_config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
 
 system_dir=target/datanode2/system
 data_dirs=target/datanode2/data

--- a/server/src/test/resources/datanode3conf/iotdb-datanode.properties
+++ b/server/src/test/resources/datanode3conf/iotdb-datanode.properties
@@ -26,7 +26,7 @@ internal_port=9007
 data_region_consensus_port=40014
 schema_region_consensus_port=50034
 
-config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
+target_config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
 
 system_dir=target/datanode3/system
 data_dirs=target/datanode3/data


### PR DESCRIPTION
The current name config_nodes is misleading. This pair of parameters represent only one or more target ConfigNodes that can communicate with when the node needs to join the cluster during startup. Furthermore, the modification of ConfigNode list caused by the cluster capacity expansion are controlled by internal logic. We don't need to change these parameters every time.