### PR TITLE
[IOTDB-3689][To rel/0.12]Select at least one unseq file in cross space compaction 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1319,7 +1319,7 @@ public class IoTDBConfig {
     return mergeMemoryBudget;
   }
 
-  void setMergeMemoryBudget(long mergeMemoryBudget) {
+  public void setMergeMemoryBudget(long mergeMemoryBudget) {
     this.mergeMemoryBudget = mergeMemoryBudget;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
@@ -49,7 +49,7 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
   MergeResource resource;
 
   long totalCost;
-  private long memoryBudget;
+  private final long memoryBudget;
   private long maxSeqFileCost;
 
   // the number of timeseries being queried at the same time
@@ -187,7 +187,7 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
   }
 
   private boolean updateSelectedFiles(long newCost, TsFileResource unseqFile) {
-    if (totalCost + newCost < memoryBudget) {
+    if (selectedUnseqFiles.size() == 0 || totalCost + newCost < memoryBudget) {
       selectedUnseqFiles.add(unseqFile);
       maxSeqFileCost = tempMaxSeqFileCost;
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxFileMergeFileSelectorTest.java
@@ -83,8 +83,9 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
   public void testNonSelection() throws MergeException, IOException {
     MergeResource resource = new MergeResource(seqResources, unseqResources);
     IMergeFileSelector mergeFileSelector = new MaxFileMergeFileSelector(resource, 1);
+    // at least one unseq file will be selected
     List[] result = mergeFileSelector.select();
-    assertEquals(0, result.length);
+    assertEquals(2, result.length);
     resource.clear();
   }
 
@@ -306,10 +307,10 @@ public class MaxFileMergeFileSelectorTest extends MergeTest {
       resource =
           new MergeResource(
               seqList.subList(1, seqList.size()), unseqList.subList(1, unseqList.size()));
-      // the second selection should be empty
+      // the second selection should select at least one unseq file
       mergeFileSelector = new MaxFileMergeFileSelector(resource, 29000);
       result = mergeFileSelector.select();
-      assertEquals(0, result.length);
+      assertEquals(2, result.length);
       resource.clear();
     } finally {
       removeFiles(seqList, unseqList);

--- a/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxSeriesMergeFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/merge/MaxSeriesMergeFileSelectorTest.java
@@ -71,12 +71,11 @@ public class MaxSeriesMergeFileSelectorTest extends MergeTest {
   }
 
   @Test
-  public void testNonSelection() throws MergeException, IOException {
+  public void testSelectAtLeastOneUnseqFile() throws MergeException, IOException {
     MergeResource resource = new MergeResource(seqResources, unseqResources);
     MaxSeriesMergeFileSelector mergeFileSelector = new MaxSeriesMergeFileSelector(resource, 1);
     List[] result = mergeFileSelector.select();
-    assertEquals(0, result.length);
-    assertEquals(0, mergeFileSelector.getConcurrentMergeNum());
+    assertEquals(2, result.length);
     resource.clear();
   }
 


### PR DESCRIPTION
Regardless of whether the estimated memory exceeds the threshold, at least one unseq file should be selected for cross space compaction.