### PR TITLE
[IOTDB-3670] IoTDBSyncSenderIT.testRealtimeDel failed

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/sync/IoTDBSyncSenderIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/sync/IoTDBSyncSenderIT.java
@@ -56,6 +56,8 @@ public class IoTDBSyncSenderIT {
   private boolean enableUnseqSpaceCompaction;
   private boolean enableCrossSpaceCompaction;
 
+  private static final long waitTime = 2000;
+
   private static final String pipeSinkName = "test_pipesink";
   private static final String pipeName = "test_pipe";
 
@@ -318,7 +320,7 @@ public class IoTDBSyncSenderIT {
       preparePipeAndSetMock(); // realtime
       startPipe();
 
-      Thread.sleep(1000L); // check
+      Thread.sleep(waitTime); // check
       checkInsOnlyResult(transportClient.getPipeDataList());
     } catch (Exception e) {
       e.printStackTrace();
@@ -326,7 +328,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();
@@ -343,7 +345,7 @@ public class IoTDBSyncSenderIT {
 
       preparePipeAndSetMock(); // realtime
       startPipe();
-      Thread.sleep(1000L);
+      Thread.sleep(waitTime);
       prepareIns3();
 
       Thread.sleep(1000L); // check
@@ -354,7 +356,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();
@@ -375,7 +377,7 @@ public class IoTDBSyncSenderIT {
       prepareIns3();
       startPipe();
 
-      Thread.sleep(1000L); // check
+      Thread.sleep(waitTime); // check
       checkInsOnlyResult(transportClient.getPipeDataList());
     } catch (Exception e) {
       e.printStackTrace();
@@ -383,7 +385,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();
@@ -404,7 +406,7 @@ public class IoTDBSyncSenderIT {
       prepareIns3();
       stopPipe();
 
-      Thread.sleep(1000L); // check
+      Thread.sleep(waitTime); // check
       checkInsOnlyResult(transportClient.getPipeDataList());
     } catch (Exception e) {
       e.printStackTrace();
@@ -412,7 +414,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();
@@ -434,7 +436,7 @@ public class IoTDBSyncSenderIT {
       preparePipeAndSetMock(); // realtime
       startPipe();
 
-      Thread.sleep(1000L); // check
+      Thread.sleep(waitTime); // check
       checkResult(
           Arrays.asList("schemaWithDel3InHistory", "ins1", "ins2", "ins3WithDel3InHistory"),
           transportClient.getPipeDataList());
@@ -444,7 +446,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();
@@ -469,7 +471,7 @@ public class IoTDBSyncSenderIT {
       prepareDel3();
       stopPipe();
 
-      Thread.sleep(1000L); // check
+      Thread.sleep(waitTime); // check
       checkResult(
           Arrays.asList("schema", "ins1", "ins2", "del1", "ins3", "del2", "del3"),
           transportClient.getPipeDataList());
@@ -479,7 +481,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();
@@ -499,7 +501,7 @@ public class IoTDBSyncSenderIT {
       restart();
       prepareIns3();
 
-      Thread.sleep(1000L); // check
+      Thread.sleep(waitTime); // check
       checkInsOnlyResult(transportClient.getPipeDataList());
     } catch (Exception e) {
       e.printStackTrace();
@@ -507,7 +509,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();
@@ -529,7 +531,7 @@ public class IoTDBSyncSenderIT {
       prepareIns3();
       startPipe();
 
-      Thread.sleep(1000L); // check
+      Thread.sleep(waitTime); // check
       checkInsOnlyResult(transportClient.getPipeDataList());
     } catch (Exception e) {
       e.printStackTrace();
@@ -537,7 +539,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();
@@ -564,7 +566,7 @@ public class IoTDBSyncSenderIT {
       prepareDel3();
       startPipe();
 
-      Thread.sleep(1000L); // check
+      Thread.sleep(waitTime); // check
       checkResult(
           Arrays.asList("schema", "ins1", "ins2", "del2WithoutIns3", "ins3", "del3"),
           transportClient.getPipeDataList());
@@ -574,7 +576,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();
@@ -603,7 +605,7 @@ public class IoTDBSyncSenderIT {
       startPipe();
       restart();
 
-      Thread.sleep(1000L); // check
+      Thread.sleep(waitTime); // check
       checkResult(
           Arrays.asList("schema", "ins1", "ins2", "del2WithoutIns3", "ins3", "del3", "ins4"),
           transportClient.getPipeDataList());
@@ -613,7 +615,7 @@ public class IoTDBSyncSenderIT {
     } finally {
       try {
         dropPipe();
-        Thread.sleep(1000L);
+        Thread.sleep(waitTime);
       } catch (Exception e) {
         e.printStackTrace();
         Assert.fail();


### PR DESCRIPTION
Problem:
https://github.com/apache/iotdb/runs/7076658328?check_suite_focus=true
IoTDBSyncSenderIT.testRealtimeDel:473->checkResult:301 expected:<25> but was:<15>

Solution:
This is not a stable error.
Guess problem cause by waiting time too short for IoTDB to persist tsfile