### PR TITLE
[IOTDB-3702] Use thread pool to recover broken tsfiles without wal

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/WALRecoverManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/WALRecoverManager.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.DataRegionException;
+import org.apache.iotdb.db.exception.runtime.StorageEngineFailureException;
 import org.apache.iotdb.db.wal.exception.WALRecoverException;
 import org.apache.iotdb.db.wal.recover.file.UnsealedTsFileRecoverPerformer;
 import org.apache.iotdb.db.wal.utils.listener.WALRecoverListener;
@@ -37,9 +38,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 /** First set allVsgScannedLatch, then call recover method. */
 public class WALRecoverManager {
@@ -103,25 +107,7 @@ public class WALRecoverManager {
         }
       }
       // deal with remaining TsFiles which don't have wal
-      for (UnsealedTsFileRecoverPerformer recoverPerformer :
-          absolutePath2RecoverPerformer.values()) {
-        recoverThreadPool.submit(
-            () -> {
-              try {
-                recoverPerformer.startRecovery();
-                // skip redo logs because it doesn't belong to any wal node
-                recoverPerformer.endRecovery();
-                recoverPerformer.getRecoverListener().succeed();
-              } catch (DataRegionException | IOException | WALRecoverException e) {
-                logger.error(
-                    "Fail to recover unsealed TsFile {}, skip it.",
-                    recoverPerformer.getTsFileAbsolutePath(),
-                    e);
-                recoverPerformer.getRecoverListener().fail(e);
-              }
-            });
-      }
-      absolutePath2RecoverPerformer.clear();
+      asyncRecoverLeftTsFiles();
     } catch (Exception e) {
       for (UnsealedTsFileRecoverPerformer recoverPerformer :
           absolutePath2RecoverPerformer.values()) {
@@ -141,6 +127,49 @@ public class WALRecoverManager {
       stop();
     }
     logger.info("Successfully recover all wal nodes.");
+  }
+
+  private void asyncRecoverLeftTsFiles() {
+    if (absolutePath2RecoverPerformer.isEmpty()) {
+      return;
+    }
+
+    List<Future<Void>> futures = new ArrayList<>();
+    ExecutorService recoverTsFilesThreadPool =
+        IoTDBThreadPoolFactory.newFixedThreadPool(
+            Runtime.getRuntime().availableProcessors(), "TsFile-Recover");
+    // async recover
+    for (UnsealedTsFileRecoverPerformer recoverPerformer : absolutePath2RecoverPerformer.values()) {
+      Callable<Void> recoverTsFileTask =
+          () -> {
+            try {
+              recoverPerformer.startRecovery();
+              // skip redo logs because it doesn't belong to any wal node
+              recoverPerformer.endRecovery();
+              recoverPerformer.getRecoverListener().succeed();
+            } catch (DataRegionException | IOException | WALRecoverException e) {
+              logger.error(
+                  "Fail to recover unsealed TsFile {}, skip it.",
+                  recoverPerformer.getTsFileAbsolutePath(),
+                  e);
+              recoverPerformer.getRecoverListener().fail(e);
+            }
+            return null;
+          };
+      futures.add(recoverTsFilesThreadPool.submit(recoverTsFileTask));
+    }
+    // wait until all tasks done
+    for (Future<Void> future : futures) {
+      try {
+        future.get();
+      } catch (ExecutionException e) {
+        throw new StorageEngineFailureException("StorageEngine failed to recover.", e);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new StorageEngineFailureException("StorageEngine failed to recover.", e);
+      }
+    }
+    recoverTsFilesThreadPool.shutdown();
   }
 
   public WALRecoverListener addRecoverPerformer(UnsealedTsFileRecoverPerformer recoverPerformer) {


### PR DESCRIPTION
To accelerate recovery , use thread pool to recover broken tsfiles without wal.