### PR TITLE
#6551

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
@@ -18,18 +18,16 @@
  */
 package org.apache.iotdb.db.rescon;
 
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.Binary;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayDeque;
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicLong;
 
 /** Manage all primitive data lists in memory, including get and release operations. */
 public class PrimitiveArrayManager {
@@ -266,7 +264,7 @@ public class PrimitiveArrayManager {
    * @return an array of primitive data arrays
    */
   public static Object createDataListsByType(TSDataType dataType, int size) {
-    int arrayNumber = (int) Math.ceil((float) size / (float) ARRAY_SIZE);
+    int arrayNumber = size / ARRAY_SIZE + 1;
     switch (dataType) {
       case BOOLEAN:
         boolean[][] booleans = new boolean[arrayNumber][];

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
@@ -18,16 +18,15 @@
  */
 package org.apache.iotdb.db.utils.datastructure;
 
+import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
+
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
 public class BooleanTVList extends TVList {
 
@@ -93,11 +92,11 @@ public class BooleanTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null || sortedTimestamps.length < size / ARRAY_SIZE + 1) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < size / ARRAY_SIZE + 1) {
       sortedValues =
           (boolean[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.BOOLEAN, size);
     }


### PR DESCRIPTION
参考bug#6551

原代码： int arrayNumber = (int) Math.ceil((float) size / (float) ARRAY_SIZE);
ARRAY_SIZE是32，size代入 1224826 * 32 +1，应该算出来1224827，实际计算为1224826。改为直接计算结果1224826 / 32 +1。
另外，sort中size判断也不合理，统一修改了。