### PR TITLE
[To rel/0.13] [IOTDB-3709] Fix a loop occurred in TsFileResourceList, causing the query to fail and oom occurs

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResourceList.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResourceList.java
@@ -47,6 +47,9 @@ public class TsFileResourceList implements List<TsFileResource> {
    * @param newNode the file to insert
    */
   public void insertBefore(TsFileResource node, TsFileResource newNode) {
+    if (newNode.equals(node)) {
+      return;
+    }
     newNode.prev = node.prev;
     newNode.next = node;
     if (node.prev == null) {
@@ -65,6 +68,9 @@ public class TsFileResourceList implements List<TsFileResource> {
    * @param newNode the file to insert
    */
   public void insertAfter(TsFileResource node, TsFileResource newNode) {
+    if (node.equals(newNode)) {
+      return;
+    }
     newNode.prev = node;
     newNode.next = node.next;
     if (node.next == null) {
@@ -135,7 +141,7 @@ public class TsFileResourceList implements List<TsFileResource> {
    * node's, the new node will be inserted to the tail of the list.
    */
   public boolean keepOrderInsert(TsFileResource newNode) throws IOException {
-    if (newNode.prev != null || newNode.next != null) {
+    if (newNode.prev != null || newNode.next != null || (count == 1 && header == newNode)) {
       // this node already in a list
       return false;
     }


### PR DESCRIPTION
See [IOTDB-3709](https://issues.apache.org/jira/browse/IOTDB-3709).

The loop occured in TsFileResourceList is because a same TsFileResource is inserted twice.