### PR TITLE
[To rel/0.12][IOTDB-3730][ISSUE-6551] ArrayIndexOutOfBounds when flushing a memtable

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
@@ -266,7 +266,7 @@ public class PrimitiveArrayManager {
    * @return an array of primitive data arrays
    */
   public static Object createDataListsByType(TSDataType dataType, int size) {
-    int arrayNumber = (int) Math.ceil((float) size / (float) ARRAY_SIZE);
+    int arrayNumber = getRowCount(size);
     switch (dataType) {
       case BOOLEAN:
         boolean[][] booleans = new boolean[arrayNumber][];
@@ -307,5 +307,9 @@ public class PrimitiveArrayManager {
       default:
         throw new UnSupportedDataTypeException(dataType.name());
     }
+  }
+
+  public static int getRowCount(int size) {
+    return size / ARRAY_SIZE + size % ARRAY_SIZE == 0 ? 0 : 1;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
@@ -266,7 +266,7 @@ public class PrimitiveArrayManager {
    * @return an array of primitive data arrays
    */
   public static Object createDataListsByType(TSDataType dataType, int size) {
-    int arrayNumber = getRowCount(size);
+    int arrayNumber = getArrayRowCount(size);
     switch (dataType) {
       case BOOLEAN:
         boolean[][] booleans = new boolean[arrayNumber][];
@@ -309,7 +309,7 @@ public class PrimitiveArrayManager {
     }
   }
 
-  public static int getRowCount(int size) {
-    return size / ARRAY_SIZE + size % ARRAY_SIZE == 0 ? 0 : 1;
+  public static int getArrayRowCount(int size) {
+    return size / ARRAY_SIZE + (size % ARRAY_SIZE == 0 ? 0 : 1);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
@@ -96,11 +96,12 @@ public class BinaryTVList extends TVList {
   @Override
   public void sort() {
     if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedValues =
           (Binary[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.TEXT, size);
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
@@ -95,11 +95,12 @@ public class BinaryTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedValues =
           (Binary[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.TEXT, size);
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
@@ -95,11 +95,12 @@ public class BooleanTVList extends TVList {
   @Override
   public void sort() {
     if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedValues =
           (boolean[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.BOOLEAN, size);
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
@@ -94,11 +94,12 @@ public class BooleanTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedValues =
           (boolean[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.BOOLEAN, size);
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
@@ -96,11 +96,12 @@ public class DoubleTVList extends TVList {
   @Override
   public void sort() {
     if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedValues =
           (double[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.DOUBLE, size);
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
@@ -95,11 +95,12 @@ public class DoubleTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedValues =
           (double[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.DOUBLE, size);
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
@@ -96,11 +96,12 @@ public class FloatTVList extends TVList {
   @Override
   public void sort() {
     if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedValues =
           (float[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.FLOAT, size);
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
@@ -95,11 +95,12 @@ public class FloatTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedValues =
           (float[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.FLOAT, size);
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
@@ -95,11 +95,12 @@ public class IntTVList extends TVList {
   @Override
   public void sort() {
     if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedValues = (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, size);
     }
     sort(0, size);

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
@@ -94,11 +94,12 @@ public class IntTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedValues = (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, size);
     }
     sort(0, size);

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
@@ -95,11 +95,12 @@ public class LongTVList extends TVList {
   @Override
   public void sort() {
     if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(size)) {
       sortedValues = (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
     sort(0, size);

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
@@ -94,11 +94,12 @@ public class LongTVList extends TVList {
 
   @Override
   public void sort() {
-    if (sortedTimestamps == null || sortedTimestamps.length < size) {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedTimestamps =
           (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
-    if (sortedValues == null || sortedValues.length < size) {
+    if (sortedValues == null || sortedValues.length < PrimitiveArrayManager.getRowCount(size)) {
       sortedValues = (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, size);
     }
     sort(0, size);

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/PrimitiveArrayManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/PrimitiveArrayManagerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils.datastructure;
+
+import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PrimitiveArrayManagerTest {
+  @Test
+  public void testGetArrayRowCount() {
+    Assert.assertEquals(1224827, PrimitiveArrayManager.getArrayRowCount(1224826 * 32 + 1));
+    Assert.assertEquals(1224826, PrimitiveArrayManager.getArrayRowCount(1224826 * 32));
+    Assert.assertEquals(1, PrimitiveArrayManager.getArrayRowCount(32));
+    Assert.assertEquals(1, PrimitiveArrayManager.getArrayRowCount(5));
+    Assert.assertEquals(2, PrimitiveArrayManager.getArrayRowCount(33));
+  }
+}


### PR DESCRIPTION
The problem is caused by a loss of precision in converting integers to floating point numbers