### PR TITLE
[To rel/0.12] [IOTDB-3738] Fix ArrayIndexOutOfBoundException in recovering cross space compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeFileInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/recover/MergeFileInfo.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.engine.merge.recover;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.exception.compaction.InvalidCompactionLogException;
 
 import java.io.File;
 
@@ -60,10 +61,15 @@ public class MergeFileInfo {
         paths[pathLength - 5].equals("sequence"));
   }
 
-  public static MergeFileInfo getFileInfoFromString(String infoString) {
+  public static MergeFileInfo getFileInfoFromString(String infoString)
+      throws InvalidCompactionLogException {
     if (!infoString.contains(File.separator)) {
       // the info string records info of merge files
       String[] splits = infoString.split(" ");
+      if (splits.length != 5) {
+        throw new InvalidCompactionLogException("Invalid file info string " + infoString);
+      }
+
       return new MergeFileInfo(
           splits[0],
           splits[1],

--- a/server/src/main/java/org/apache/iotdb/db/exception/compaction/CompactionException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/compaction/CompactionException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.exception.compaction;
+
+public class CompactionException extends Exception {
+  public CompactionException(String message) {
+    super(message);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/exception/compaction/InvalidCompactionLogException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/compaction/InvalidCompactionLogException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.exception.compaction;
+
+public class InvalidCompactionLogException extends CompactionException {
+  public InvalidCompactionLogException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
See [IOTDB-3738](https://issues.apache.org/jira/browse/IOTDB-3738).
The exception occurs because we didn't make MergeLogAnalyzer compatible with old version merge log which contains the info of merge progress.