### PR TITLE
[IOTDB-3750] Fix NPE caused by SchemaQueryMergeOperator#next returning null

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryMergeOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryMergeOperator.java
@@ -51,16 +51,14 @@ public class SchemaQueryMergeOperator implements ProcessOperator {
 
   @Override
   public TsBlock next() {
-    if (children.get(currentIndex).hasNext()) {
-      return children.get(currentIndex).next();
-    } else {
-      currentIndex++;
-      return null;
-    }
+    return children.get(currentIndex).next();
   }
 
   @Override
   public boolean hasNext() {
+    while (currentIndex < children.size() && !children.get(currentIndex).hasNext()) {
+      currentIndex++;
+    }
     return currentIndex < children.size();
   }
 


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/IOTDB-3750