### PR TITLE
[IOTDB-3767] Add getPartitionTable and getOrCreatePartitionTable interfaces

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/read/GetOrCreateDataPartitionPlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/read/GetOrCreateDataPartitionPlan.java
@@ -18,11 +18,35 @@
  */
 package org.apache.iotdb.confignode.consensus.request.read;
 
+import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
+import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
+import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionReq;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class GetOrCreateDataPartitionPlan extends GetDataPartitionPlan {
 
   public GetOrCreateDataPartitionPlan() {
     super(ConfigPhysicalPlanType.GetOrCreateDataPartition);
+  }
+
+  public GetOrCreateDataPartitionPlan(
+      Map<String, Map<TSeriesPartitionSlot, List<TTimePartitionSlot>>> partitionSlotsMap) {
+    this();
+    this.partitionSlotsMap = partitionSlotsMap;
+  }
+
+  /**
+   * Convert TDataPartitionReq to GetOrCreateDataPartitionPlan
+   *
+   * @param req TDataPartitionReq
+   * @return GetOrCreateDataPartitionPlan
+   */
+  public static GetOrCreateDataPartitionPlan convertFromRpcTDataPartitionReq(
+      TDataPartitionReq req) {
+    return new GetOrCreateDataPartitionPlan(new ConcurrentHashMap<>(req.getPartitionSlotsMap()));
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/read/GetOrCreateSchemaPartitionPlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/read/GetOrCreateSchemaPartitionPlan.java
@@ -18,11 +18,20 @@
  */
 package org.apache.iotdb.confignode.consensus.request.read;
 
+import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
+
+import java.util.List;
+import java.util.Map;
 
 public class GetOrCreateSchemaPartitionPlan extends GetSchemaPartitionPlan {
 
   public GetOrCreateSchemaPartitionPlan() {
     super(ConfigPhysicalPlanType.GetOrCreateSchemaPartition);
+  }
+
+  public GetOrCreateSchemaPartitionPlan(Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap) {
+    this();
+    this.partitionSlotsMap = partitionSlotsMap;
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/read/GetSchemaPartitionPlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/read/GetSchemaPartitionPlan.java
@@ -40,7 +40,7 @@ public class GetSchemaPartitionPlan extends ConfigPhysicalPlan {
   // Map<StorageGroup, List<SeriesPartitionSlot>>
   // Get all SchemaPartitions when the partitionSlotsMap is empty
   // Get all exists SchemaPartitions in one StorageGroup when the SeriesPartitionSlot is empty
-  private Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap;
+  protected Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap;
 
   public GetSchemaPartitionPlan() {
     super(ConfigPhysicalPlanType.GetSchemaPartition);
@@ -50,7 +50,8 @@ public class GetSchemaPartitionPlan extends ConfigPhysicalPlan {
     super(configPhysicalPlanType);
   }
 
-  public void setPartitionSlotsMap(Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap) {
+  public GetSchemaPartitionPlan(Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap) {
+    this();
     this.partitionSlotsMap = partitionSlotsMap;
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/SchemaPartitionResp.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/SchemaPartitionResp.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
 import org.apache.iotdb.commons.partition.SchemaPartitionTable;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
+import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionTableResp;
 import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.rpc.TSStatusCode;
 
@@ -87,6 +88,24 @@ public class SchemaPartitionResp implements DataSet {
           });
 
       resp.setSchemaRegionMap(schemaPartitionMap);
+    }
+
+    return resp;
+  }
+
+  public TSchemaPartitionTableResp convertToRpcSchemaPartitionTableResp() {
+    TSchemaPartitionTableResp resp = new TSchemaPartitionTableResp();
+    resp.setStatus(status);
+
+    if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+      Map<String, Map<TSeriesPartitionSlot, TConsensusGroupId>> schemaPartitionMap =
+          new ConcurrentHashMap<>();
+
+      schemaPartition.forEach(
+          (storageGroup, schemaPartitionTable) ->
+              schemaPartitionMap.put(storageGroup, schemaPartitionTable.getSchemaPartitionMap()));
+
+      resp.setSchemaPartitionTable(schemaPartitionMap);
     }
 
     return resp;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -77,10 +77,12 @@ import org.apache.iotdb.confignode.rpc.thrift.TClusterNodeInfos;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionResp;
+import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TPermissionInfoResp;
 import org.apache.iotdb.confignode.rpc.thrift.TRegionRouteMapResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
+import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TStorageGroupSchema;
 import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.db.mpp.common.schematree.PathPatternTree;
@@ -344,10 +346,18 @@ public class ConfigManager implements IManager {
   }
 
   @Override
-  public TSchemaPartitionResp getSchemaPartition(PathPatternTree patternTree) {
+  public Object getSchemaPartition(PathPatternTree patternTree, boolean isContainedReplicaSet) {
+    // Construct empty response from parameter isContainedReplicaSet
+    Object resp;
+    if (isContainedReplicaSet) {
+      resp = new TSchemaPartitionResp();
+    } else {
+      resp = new TSchemaPartitionTableResp();
+    }
+
     TSStatus status = confirmLeader();
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      GetSchemaPartitionPlan getSchemaPartitionPlan = new GetSchemaPartitionPlan();
+      // Build GetSchemaPartitionPlan
       Map<String, Set<TSeriesPartitionSlot>> partitionSlotsMap = new HashMap<>();
       List<PartialPath> relatedPaths = patternTree.getAllPathPatterns();
       List<String> allStorageGroups = getClusterSchemaManager().getStorageGroupNames();
@@ -375,44 +385,64 @@ public class ConfigManager implements IManager {
         }
       }
 
-      // return empty partition
+      // Return empty resp if the partitionSlotsMap is empty
       if (partitionSlotsMap.isEmpty()) {
-        TSchemaPartitionResp resp = new TSchemaPartitionResp();
-        resp.setStatus(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
-        resp.setSchemaRegionMap(new HashMap<>());
-        return resp;
+        if (isContainedReplicaSet) {
+          return ((TSchemaPartitionResp) resp)
+              .setStatus(StatusUtils.OK)
+              .setSchemaRegionMap(new HashMap<>());
+        } else {
+          return ((TSchemaPartitionTableResp) resp)
+              .setStatus(StatusUtils.OK)
+              .setSchemaPartitionTable(new HashMap<>());
+        }
       }
 
-      getSchemaPartitionPlan.setPartitionSlotsMap(
-          partitionSlotsMap.entrySet().stream()
-              .collect(Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue()))));
-
-      SchemaPartitionResp resp =
+      GetSchemaPartitionPlan getSchemaPartitionPlan =
+          new GetSchemaPartitionPlan(
+              partitionSlotsMap.entrySet().stream()
+                  .collect(
+                      Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue()))));
+      SchemaPartitionResp queryResult =
           (SchemaPartitionResp) partitionManager.getSchemaPartition(getSchemaPartitionPlan);
-      TSchemaPartitionResp result =
-          resp.convertToRpcSchemaPartitionResp(getLoadManager().genRealTimeRoutingPolicy());
+      if (isContainedReplicaSet) {
+        resp =
+            queryResult.convertToRpcSchemaPartitionResp(
+                getLoadManager().genRealTimeRoutingPolicy());
+      } else {
+        resp = queryResult.convertToRpcSchemaPartitionTableResp();
+      }
 
       // TODO: Delete or hide this LOGGER before officially release.
-      LOGGER.info(
-          "GetSchemaPartition receive paths: {}, return TSchemaPartitionResp: {}",
-          relatedPaths,
-          result);
+      LOGGER.info("GetSchemaPartition receive paths: {}, return: {}", relatedPaths, resp);
 
-      return result;
+      return resp;
     } else {
-      return new TSchemaPartitionResp().setStatus(status);
+      if (isContainedReplicaSet) {
+        return ((TSchemaPartitionResp) resp).setStatus(status);
+      } else {
+        return ((TSchemaPartitionTableResp) resp).setStatus(status);
+      }
     }
   }
 
   @Override
-  public TSchemaPartitionResp getOrCreateSchemaPartition(PathPatternTree patternTree) {
+  public Object getOrCreateSchemaPartition(
+      PathPatternTree patternTree, boolean isContainedReplicaSet) {
+    // Construct empty response from parameter isContainedReplicaSet
+    Object resp;
+    if (isContainedReplicaSet) {
+      resp = new TSchemaPartitionResp();
+    } else {
+      resp = new TSchemaPartitionTableResp();
+    }
+
     TSStatus status = confirmLeader();
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       List<String> devicePaths = patternTree.getAllDevicePatterns();
       List<String> storageGroups = getClusterSchemaManager().getStorageGroupNames();
 
-      GetOrCreateSchemaPartitionPlan getOrCreateSchemaPartitionPlan =
-          new GetOrCreateSchemaPartitionPlan();
+      // Build GetOrCreateSchemaPartitionPlan
       Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap = new HashMap<>();
       for (String devicePath : devicePaths) {
         if (!devicePath.contains("*")) {
@@ -427,23 +457,33 @@ public class ConfigManager implements IManager {
           }
         }
       }
-      getOrCreateSchemaPartitionPlan.setPartitionSlotsMap(partitionSlotsMap);
+      GetOrCreateSchemaPartitionPlan getOrCreateSchemaPartitionPlan =
+          new GetOrCreateSchemaPartitionPlan(partitionSlotsMap);
 
-      SchemaPartitionResp resp =
+      SchemaPartitionResp queryResult =
           (SchemaPartitionResp)
               partitionManager.getOrCreateSchemaPartition(getOrCreateSchemaPartitionPlan);
-      TSchemaPartitionResp result =
-          resp.convertToRpcSchemaPartitionResp(getLoadManager().genRealTimeRoutingPolicy());
+      if (isContainedReplicaSet) {
+        resp =
+            queryResult.convertToRpcSchemaPartitionResp(
+                getLoadManager().genRealTimeRoutingPolicy());
+      } else {
+        resp = queryResult.convertToRpcSchemaPartitionTableResp();
+      }
 
       // TODO: Delete or hide this LOGGER before officially release.
       LOGGER.info(
           "GetOrCreateSchemaPartition receive devicePaths: {}, return TSchemaPartitionResp: {}",
           devicePaths,
-          result);
+          resp);
 
-      return result;
+      return resp;
     } else {
-      return new TSchemaPartitionResp().setStatus(status);
+      if (isContainedReplicaSet) {
+        return ((TSchemaPartitionResp) resp).setStatus(status);
+      } else {
+        return ((TSchemaPartitionTableResp) resp).setStatus(status);
+      }
     }
   }
 
@@ -477,48 +517,79 @@ public class ConfigManager implements IManager {
   }
 
   @Override
-  public TDataPartitionResp getDataPartition(GetDataPartitionPlan getDataPartitionPlan) {
+  public Object getDataPartition(
+      GetDataPartitionPlan getDataPartitionPlan, boolean isContainedReplicaSet) {
+    // Construct empty response from parameter isContainedReplicaSet
+    Object resp;
+    if (isContainedReplicaSet) {
+      resp = new TDataPartitionResp();
+    } else {
+      resp = new TDataPartitionTableResp();
+    }
+
     TSStatus status = confirmLeader();
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      DataPartitionResp resp =
+      DataPartitionResp queryResult =
           (DataPartitionResp) partitionManager.getDataPartition(getDataPartitionPlan);
 
-      TDataPartitionResp result =
-          resp.convertToTDataPartitionResp(getLoadManager().genRealTimeRoutingPolicy());
+      if (isContainedReplicaSet) {
+        resp = queryResult.convertToTDataPartitionResp(getLoadManager().genRealTimeRoutingPolicy());
+      } else {
+        resp = queryResult.convertToTDataPartitionTableResp();
+      }
 
       // TODO: Delete or hide this LOGGER before officially release.
       LOGGER.info(
-          "GetDataPartition interface receive PartitionSlotsMap: {}, return TDataPartitionResp: {}",
+          "GetDataPartition interface receive PartitionSlotsMap: {}, return: {}",
           getDataPartitionPlan.getPartitionSlotsMap(),
-          result);
+          resp);
 
-      return result;
+      return resp;
     } else {
-      return new TDataPartitionResp().setStatus(status);
+      if (isContainedReplicaSet) {
+        return ((TDataPartitionResp) resp).setStatus(status);
+      } else {
+        return ((TDataPartitionTableResp) resp).setStatus(status);
+      }
     }
   }
 
   @Override
-  public TDataPartitionResp getOrCreateDataPartition(
-      GetOrCreateDataPartitionPlan getOrCreateDataPartitionReq) {
+  public Object getOrCreateDataPartition(
+      GetOrCreateDataPartitionPlan getOrCreateDataPartitionReq, boolean isContainedReplicaSet) {
+    // Construct empty response from parameter isContainedReplicaSet
+    Object resp;
+    if (isContainedReplicaSet) {
+      resp = new TDataPartitionResp();
+    } else {
+      resp = new TDataPartitionTableResp();
+    }
+
     TSStatus status = confirmLeader();
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      DataPartitionResp resp =
+      DataPartitionResp queryResult =
           (DataPartitionResp)
               partitionManager.getOrCreateDataPartition(getOrCreateDataPartitionReq);
 
-      TDataPartitionResp result =
-          resp.convertToTDataPartitionResp(getLoadManager().genRealTimeRoutingPolicy());
+      if (isContainedReplicaSet) {
+        resp = queryResult.convertToTDataPartitionResp(getLoadManager().genRealTimeRoutingPolicy());
+      } else {
+        resp = queryResult.convertToTDataPartitionTableResp();
+      }
 
       // TODO: Delete or hide this LOGGER before officially release.
       LOGGER.info(
-          "GetOrCreateDataPartition success. receive PartitionSlotsMap: {}, return TDataPartitionResp: {}",
+          "GetOrCreateDataPartition success. receive PartitionSlotsMap: {}, return: {}",
           getOrCreateDataPartitionReq.getPartitionSlotsMap(),
-          result);
+          resp);
 
-      return result;
+      return resp;
     } else {
-      return new TDataPartitionResp().setStatus(status);
+      if (isContainedReplicaSet) {
+        return ((TDataPartitionResp) resp).setStatus(status);
+      } else {
+        return ((TDataPartitionTableResp) resp).setStatus(status);
+      }
     }
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/IManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/IManager.java
@@ -41,11 +41,9 @@ import org.apache.iotdb.confignode.manager.load.LoadManager;
 import org.apache.iotdb.confignode.rpc.thrift.TClusterNodeInfos;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterResp;
-import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TPermissionInfoResp;
 import org.apache.iotdb.confignode.rpc.thrift.TRegionRouteMapResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementResp;
-import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
 import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.db.mpp.common.schematree.PathPatternTree;
 
@@ -170,16 +168,20 @@ public interface IManager {
   /**
    * Get SchemaPartition
    *
+   * @param isContainedReplicaSet The last map level of result will contain TRegionReplicaSet if
+   *     true, otherwise the last level will be TConsensusGroupId
    * @return TSchemaPartitionResp
    */
-  TSchemaPartitionResp getSchemaPartition(PathPatternTree patternTree);
+  Object getSchemaPartition(PathPatternTree patternTree, boolean isContainedReplicaSet);
 
   /**
    * Get or create SchemaPartition
    *
+   * @param isContainedReplicaSet The last map level of result will contain TRegionReplicaSet if
+   *     true, otherwise the last level will be TConsensusGroupId
    * @return TSchemaPartitionResp
    */
-  TSchemaPartitionResp getOrCreateSchemaPartition(PathPatternTree patternTree);
+  Object getOrCreateSchemaPartition(PathPatternTree patternTree, boolean isContainedReplicaSet);
 
   /**
    * create SchemaNodeManagementPartition for child paths node management
@@ -191,17 +193,21 @@ public interface IManager {
   /**
    * Get DataPartition
    *
+   * @param isContainedReplicaSet The last map level of result will contain TRegionReplicaSet if
+   *     true, otherwise the last level will be TConsensusGroupId
    * @return TDataPartitionResp
    */
-  TDataPartitionResp getDataPartition(GetDataPartitionPlan getDataPartitionPlan);
+  Object getDataPartition(GetDataPartitionPlan getDataPartitionPlan, boolean isContainedReplicaSet);
 
   /**
    * Get or create DataPartition
    *
+   * @param isContainedReplicaSet The last map level of result will contain TRegionReplicaSet if
+   *     true, otherwise the last level will be TConsensusGroupId
    * @return TDataPartitionResp
    */
-  TDataPartitionResp getOrCreateDataPartition(
-      GetOrCreateDataPartitionPlan getOrCreateDataPartitionPlan);
+  Object getOrCreateDataPartition(
+      GetOrCreateDataPartitionPlan getOrCreateDataPartitionPlan, boolean isContainedReplicaSet);
 
   /**
    * Operate Permission

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -71,6 +71,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionResp;
+import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDeleteStorageGroupReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDeleteStorageGroupsReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDropFunctionReq;
@@ -81,6 +82,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
+import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSetDataReplicationFactorReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSetSchemaReplicationFactorReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSetStorageGroupReq;
@@ -262,7 +264,15 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
   public TSchemaPartitionResp getSchemaPartition(TSchemaPartitionReq req) throws TException {
     PathPatternTree patternTree =
         PathPatternTree.deserialize(ByteBuffer.wrap(req.getPathPatternTree()));
-    return configManager.getSchemaPartition(patternTree);
+    return (TSchemaPartitionResp) configManager.getSchemaPartition(patternTree, true);
+  }
+
+  @Override
+  public TSchemaPartitionTableResp getSchemaPartitionTable(TSchemaPartitionReq req)
+      throws TException {
+    PathPatternTree patternTree =
+        PathPatternTree.deserialize(ByteBuffer.wrap(req.getPathPatternTree()));
+    return (TSchemaPartitionTableResp) configManager.getSchemaPartition(patternTree, false);
   }
 
   @Override
@@ -270,7 +280,15 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
       throws TException {
     PathPatternTree patternTree =
         PathPatternTree.deserialize(ByteBuffer.wrap(req.getPathPatternTree()));
-    return configManager.getOrCreateSchemaPartition(patternTree);
+    return (TSchemaPartitionResp) configManager.getOrCreateSchemaPartition(patternTree, true);
+  }
+
+  @Override
+  public TSchemaPartitionTableResp getOrCreateSchemaPartitionTable(TSchemaPartitionReq req)
+      throws TException {
+    PathPatternTree patternTree =
+        PathPatternTree.deserialize(ByteBuffer.wrap(req.getPathPatternTree()));
+    return (TSchemaPartitionTableResp) configManager.getOrCreateSchemaPartition(patternTree, false);
   }
 
   @Override
@@ -284,16 +302,33 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
 
   @Override
   public TDataPartitionResp getDataPartition(TDataPartitionReq req) throws TException {
-    GetDataPartitionPlan getDataPartitionPlan = new GetDataPartitionPlan();
-    getDataPartitionPlan.convertFromRpcTDataPartitionReq(req);
-    return configManager.getDataPartition(getDataPartitionPlan);
+    GetDataPartitionPlan getDataPartitionPlan =
+        GetDataPartitionPlan.convertFromRpcTDataPartitionReq(req);
+    return (TDataPartitionResp) configManager.getDataPartition(getDataPartitionPlan, true);
+  }
+
+  @Override
+  public TDataPartitionTableResp getDataPartitionTable(TDataPartitionReq req) throws TException {
+    GetDataPartitionPlan getDataPartitionPlan =
+        GetDataPartitionPlan.convertFromRpcTDataPartitionReq(req);
+    return (TDataPartitionTableResp) configManager.getDataPartition(getDataPartitionPlan, false);
   }
 
   @Override
   public TDataPartitionResp getOrCreateDataPartition(TDataPartitionReq req) throws TException {
-    GetOrCreateDataPartitionPlan getOrCreateDataPartitionReq = new GetOrCreateDataPartitionPlan();
-    getOrCreateDataPartitionReq.convertFromRpcTDataPartitionReq(req);
-    return configManager.getOrCreateDataPartition(getOrCreateDataPartitionReq);
+    GetOrCreateDataPartitionPlan getOrCreateDataPartitionReq =
+        GetOrCreateDataPartitionPlan.convertFromRpcTDataPartitionReq(req);
+    return (TDataPartitionResp)
+        configManager.getOrCreateDataPartition(getOrCreateDataPartitionReq, true);
+  }
+
+  @Override
+  public TDataPartitionTableResp getOrCreateDataPartitionTable(TDataPartitionReq req)
+      throws TException {
+    GetOrCreateDataPartitionPlan getOrCreateDataPartitionReq =
+        GetOrCreateDataPartitionPlan.convertFromRpcTDataPartitionReq(req);
+    return (TDataPartitionTableResp)
+        configManager.getOrCreateDataPartition(getOrCreateDataPartitionReq, false);
   }
 
   @Override

--- a/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
@@ -286,8 +286,7 @@ public class ConfigPhysicalPlanSerDeTest {
     Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap = new HashMap<>();
     partitionSlotsMap.put(storageGroup, Collections.singletonList(seriesPartitionSlot));
 
-    GetSchemaPartitionPlan req0 = new GetSchemaPartitionPlan();
-    req0.setPartitionSlotsMap(partitionSlotsMap);
+    GetSchemaPartitionPlan req0 = new GetSchemaPartitionPlan(partitionSlotsMap);
     GetSchemaPartitionPlan req1 =
         (GetSchemaPartitionPlan) ConfigPhysicalPlan.Factory.create(req0.serializeToByteBuffer());
     Assert.assertEquals(req0, req1);
@@ -301,8 +300,7 @@ public class ConfigPhysicalPlanSerDeTest {
     Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap = new HashMap<>();
     partitionSlotsMap.put(storageGroup, Collections.singletonList(seriesPartitionSlot));
 
-    GetOrCreateSchemaPartitionPlan req0 = new GetOrCreateSchemaPartitionPlan();
-    req0.setPartitionSlotsMap(partitionSlotsMap);
+    GetOrCreateSchemaPartitionPlan req0 = new GetOrCreateSchemaPartitionPlan(partitionSlotsMap);
     GetOrCreateSchemaPartitionPlan req1 =
         (GetOrCreateSchemaPartitionPlan)
             ConfigPhysicalPlan.Factory.create(req0.serializeToByteBuffer());
@@ -355,8 +353,7 @@ public class ConfigPhysicalPlanSerDeTest {
     partitionSlotsMap.get(storageGroup).put(seriesPartitionSlot, new ArrayList<>());
     partitionSlotsMap.get(storageGroup).get(seriesPartitionSlot).add(timePartitionSlot);
 
-    GetDataPartitionPlan req0 = new GetDataPartitionPlan();
-    req0.setPartitionSlotsMap(partitionSlotsMap);
+    GetDataPartitionPlan req0 = new GetDataPartitionPlan(partitionSlotsMap);
     GetDataPartitionPlan req1 =
         (GetDataPartitionPlan) ConfigPhysicalPlan.Factory.create(req0.serializeToByteBuffer());
     Assert.assertEquals(req0, req1);
@@ -374,8 +371,7 @@ public class ConfigPhysicalPlanSerDeTest {
     partitionSlotsMap.get(storageGroup).put(seriesPartitionSlot, new ArrayList<>());
     partitionSlotsMap.get(storageGroup).get(seriesPartitionSlot).add(timePartitionSlot);
 
-    GetOrCreateDataPartitionPlan req0 = new GetOrCreateDataPartitionPlan();
-    req0.setPartitionSlotsMap(partitionSlotsMap);
+    GetOrCreateDataPartitionPlan req0 = new GetOrCreateDataPartitionPlan(partitionSlotsMap);
     GetOrCreateDataPartitionPlan req1 =
         (GetOrCreateDataPartitionPlan)
             ConfigPhysicalPlan.Factory.create(req0.serializeToByteBuffer());

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartitionTable.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartitionTable.java
@@ -137,6 +137,20 @@ public class DataPartitionTable {
     return result;
   }
 
+  public static DataPartitionTable convertFromPlainMap(
+      Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TConsensusGroupId>>>
+          dataPartitionMap) {
+    DataPartitionTable result = new DataPartitionTable();
+
+    dataPartitionMap.forEach(
+        (seriesPartitionSlot, seriesPartitionMap) ->
+            result
+                .getDataPartitionMap()
+                .put(seriesPartitionSlot, new SeriesPartitionTable(seriesPartitionMap)));
+
+    return result;
+  }
+
   public void serialize(OutputStream outputStream, TProtocol protocol)
       throws IOException, TException {
     ReadWriteIOUtils.write(dataPartitionMap.size(), outputStream);

--- a/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
@@ -46,6 +46,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionResp;
+import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDeleteStorageGroupReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDeleteStorageGroupsReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDropFunctionReq;
@@ -56,6 +57,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
+import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSetDataReplicationFactorReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSetSchemaReplicationFactorReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSetStorageGroupReq;
@@ -479,11 +481,45 @@ public class ConfigNodeClient
   }
 
   @Override
+  public TSchemaPartitionTableResp getSchemaPartitionTable(TSchemaPartitionReq req)
+      throws TException {
+    for (int i = 0; i < RETRY_NUM; i++) {
+      try {
+        TSchemaPartitionTableResp resp = client.getSchemaPartitionTable(req);
+        if (!updateConfigNodeLeader(resp.status)) {
+          return resp;
+        }
+      } catch (TException e) {
+        configLeader = null;
+      }
+      reconnect();
+    }
+    throw new TException(MSG_RECONNECTION_FAIL);
+  }
+
+  @Override
   public TSchemaPartitionResp getOrCreateSchemaPartition(TSchemaPartitionReq req)
       throws TException {
     for (int i = 0; i < RETRY_NUM; i++) {
       try {
         TSchemaPartitionResp resp = client.getOrCreateSchemaPartition(req);
+        if (!updateConfigNodeLeader(resp.status)) {
+          return resp;
+        }
+      } catch (TException e) {
+        configLeader = null;
+      }
+      reconnect();
+    }
+    throw new TException(MSG_RECONNECTION_FAIL);
+  }
+
+  @Override
+  public TSchemaPartitionTableResp getOrCreateSchemaPartitionTable(TSchemaPartitionReq req)
+      throws TException {
+    for (int i = 0; i < RETRY_NUM; i++) {
+      try {
+        TSchemaPartitionTableResp resp = client.getOrCreateSchemaPartitionTable(req);
         if (!updateConfigNodeLeader(resp.status)) {
           return resp;
         }
@@ -529,10 +565,43 @@ public class ConfigNodeClient
   }
 
   @Override
+  public TDataPartitionTableResp getDataPartitionTable(TDataPartitionReq req) throws TException {
+    for (int i = 0; i < RETRY_NUM; i++) {
+      try {
+        TDataPartitionTableResp resp = client.getDataPartitionTable(req);
+        if (!updateConfigNodeLeader(resp.status)) {
+          return resp;
+        }
+      } catch (TException e) {
+        configLeader = null;
+      }
+      reconnect();
+    }
+    throw new TException(MSG_RECONNECTION_FAIL);
+  }
+
+  @Override
   public TDataPartitionResp getOrCreateDataPartition(TDataPartitionReq req) throws TException {
     for (int i = 0; i < RETRY_NUM; i++) {
       try {
         TDataPartitionResp resp = client.getOrCreateDataPartition(req);
+        if (!updateConfigNodeLeader(resp.status)) {
+          return resp;
+        }
+      } catch (TException e) {
+        configLeader = null;
+      }
+      reconnect();
+    }
+    throw new TException(MSG_RECONNECTION_FAIL);
+  }
+
+  @Override
+  public TDataPartitionTableResp getOrCreateDataPartitionTable(TDataPartitionReq req)
+      throws TException {
+    for (int i = 0; i < RETRY_NUM; i++) {
+      try {
+        TDataPartitionTableResp resp = client.getOrCreateDataPartitionTable(req);
         if (!updateConfigNodeLeader(resp.status)) {
           return resp;
         }

--- a/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/thrift-confignode/src/main/thrift/confignode.thrift
@@ -108,10 +108,17 @@ struct TSchemaPartitionReq {
   1: required binary pathPatternTree
 }
 
+// TODO: Replace this by TSchemaPartitionTableResp
 struct TSchemaPartitionResp {
   1: required common.TSStatus status
   // map<StorageGroupName, map<TSeriesPartitionSlot, TRegionReplicaSet>>
   2: optional map<string, map<common.TSeriesPartitionSlot, common.TRegionReplicaSet>> schemaRegionMap
+}
+
+struct TSchemaPartitionTableResp {
+  1: required common.TSStatus status
+  // map<StorageGroupName, map<TSeriesPartitionSlot, TConsensusGroupId>>
+  2: optional map<string, map<common.TSeriesPartitionSlot, common.TConsensusGroupId>> schemaPartitionTable
 }
 
 // Node Management
@@ -134,10 +141,17 @@ struct TDataPartitionReq {
   1: required map<string, map<common.TSeriesPartitionSlot, list<common.TTimePartitionSlot>>> partitionSlotsMap
 }
 
+// TODO: Replace this by TDataPartitionTableResp
 struct TDataPartitionResp {
   1: required common.TSStatus status
   // map<StorageGroupName, map<TSeriesPartitionSlot, map<TTimePartitionSlot, list<TRegionReplicaSet>>>>
   2: optional map<string, map<common.TSeriesPartitionSlot, map<common.TTimePartitionSlot, list<common.TRegionReplicaSet>>>> dataPartitionMap
+}
+
+struct TDataPartitionTableResp {
+  1: required common.TSStatus status
+  // map<StorageGroupName, map<TSeriesPartitionSlot, map<TTimePartitionSlot, list<TConsensusGroupId>>>>
+  2: optional map<string, map<common.TSeriesPartitionSlot, map<common.TTimePartitionSlot, list<common.TConsensusGroupId>>>> dataPartitionTable
 }
 
 // Authorize
@@ -285,9 +299,15 @@ service IConfigNodeRPCService {
 
   /* Schema */
 
+  // TODO: Replace this by getSchemaPartitionTable
   TSchemaPartitionResp getSchemaPartition(TSchemaPartitionReq req)
 
+  TSchemaPartitionTableResp getSchemaPartitionTable(TSchemaPartitionReq req)
+
+  // TODO: Replace this by getOrCreateSchemaPartitionTable
   TSchemaPartitionResp getOrCreateSchemaPartition(TSchemaPartitionReq req)
+
+  TSchemaPartitionTableResp getOrCreateSchemaPartitionTable(TSchemaPartitionReq req)
 
   /* Node Management */
 
@@ -295,9 +315,15 @@ service IConfigNodeRPCService {
 
   /* Data */
 
+  // TODO: Replace this by getDataPartitionTable
   TDataPartitionResp getDataPartition(TDataPartitionReq req)
 
+  TDataPartitionTableResp getDataPartitionTable(TDataPartitionReq req)
+
   TDataPartitionResp getOrCreateDataPartition(TDataPartitionReq req)
+
+  // TODO: Replace this by getOrCreateDataPartitionTable
+  TDataPartitionTableResp getOrCreateDataPartitionTable(TDataPartitionReq req)
 
   /* Authorize */
 


### PR DESCRIPTION
We've created SchemaPartitionTable and DataPartitionTable whose last level points to the TConsensusGroupId rather than a specific TRegionReplicaSet, in order to reduce the memory overhead for PartitionTable in both ConfigNode and DataNode. Therefore we should add getPartitionTable and getOrCreatePartitionTable interfaces to correspond these updates. And these interfaces will eventually take the place of getPartition and getOrCreatePartition.