### PR TITLE
[IOTDB-3747] Fix log bug

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/DataNodeConfigurationResp.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/DataNodeConfigurationResp.java
@@ -59,13 +59,17 @@ public class DataNodeConfigurationResp implements DataSet {
     this.globalConfig = globalConfig;
   }
 
-  public void convertToRpcDataNodeRegisterResp(TDataNodeRegisterResp resp) {
+  public TDataNodeRegisterResp convertToRpcDataNodeRegisterResp() {
+    TDataNodeRegisterResp resp = new TDataNodeRegisterResp();
     resp.setStatus(status);
     resp.setConfigNodeList(configNodeList);
+
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()
         || status.getCode() == TSStatusCode.DATANODE_ALREADY_REGISTERED.getStatusCode()) {
       resp.setDataNodeId(dataNodeId);
       resp.setGlobalConfig(globalConfig);
     }
+
+    return resp;
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
@@ -136,6 +136,7 @@ public class NodeManager {
       getConsensusManager().write(activateDataNodePlan);
       // Adjust the maximum RegionGroup number of each StorageGroup
       getClusterSchemaManager().adjustMaxRegionGroupCount();
+      status.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
       status.setMessage("activateDataNode success.");
     }
     return status;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
@@ -43,7 +43,6 @@ import org.apache.iotdb.confignode.rpc.thrift.TGlobalConfig;
 import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.common.response.ConsensusGenericResponse;
-import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.slf4j.Logger;
@@ -94,25 +93,29 @@ public class NodeManager {
   /**
    * Register DataNode
    *
-   * @param req RegisterDataNodeReq
+   * @param registerDataNodePlan RegisterDataNodeReq
    * @return DataNodeConfigurationDataSet. The TSStatus will be set to SUCCESS_STATUS when register
    *     success, and DATANODE_ALREADY_REGISTERED when the DataNode is already exist.
    */
-  public DataSet registerDataNode(RegisterDataNodePlan req) {
+  public DataSet registerDataNode(RegisterDataNodePlan registerDataNodePlan) {
     DataNodeConfigurationResp dataSet = new DataNodeConfigurationResp();
-    TSStatus status = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
-    status.setMessage("registerDataNode success.");
-    if (nodeInfo.isRegisteredDataNode(req.getInfo().getLocation())) {
+    TSStatus status = new TSStatus();
+
+    if (nodeInfo.isRegisteredDataNode(registerDataNodePlan.getInfo().getLocation())) {
       status.setCode(TSStatusCode.DATANODE_ALREADY_REGISTERED.getStatusCode());
       status.setMessage("DataNode already registered.");
-    } else if (req.getInfo().getLocation().getDataNodeId() < 0) {
-      // only when new dataNode is registered, generate new dataNodeId
-      req.getInfo().getLocation().setDataNodeId(nodeInfo.generateNextNodeId());
-      status = getConsensusManager().write(req).getStatus();
+    } else if (registerDataNodePlan.getInfo().getLocation().getDataNodeId() < 0) {
+      // Generating a new dataNodeId only when current DataNode doesn't exist yet
+      registerDataNodePlan.getInfo().getLocation().setDataNodeId(nodeInfo.generateNextNodeId());
+      getConsensusManager().write(registerDataNodePlan);
+
+      status.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
+      status.setMessage("registerDataNode success.");
     }
+
     dataSet.setStatus(status);
-    dataSet.setDataNodeId(req.getInfo().getLocation().getDataNodeId());
-    dataSet.setConfigNodeList(nodeInfo.getRegisteredConfigNodes());
+    dataSet.setDataNodeId(registerDataNodePlan.getInfo().getLocation().getDataNodeId());
+    dataSet.setConfigNodeList(getRegisteredConfigNodes());
     setGlobalConfig(dataSet);
     return dataSet;
   }
@@ -120,20 +123,20 @@ public class NodeManager {
   /**
    * Active DataNode
    *
-   * @param req ActiveDataNodeReq
+   * @param activateDataNodePlan ActiveDataNodeReq
    * @return TSStatus The TSStatus will be set to SUCCESS_STATUS when active success, and
    *     DATANODE_ALREADY_REGISTERED when the DataNode is already exist.
    */
-  public TSStatus activateDataNode(ActivateDataNodePlan req) {
+  public TSStatus activateDataNode(ActivateDataNodePlan activateDataNodePlan) {
     TSStatus status = new TSStatus();
-    if (nodeInfo.isRegisteredDataNode(req.getInfo().getLocation())) {
+    if (nodeInfo.isRegisteredDataNode(activateDataNodePlan.getInfo().getLocation())) {
       status.setCode(TSStatusCode.DATANODE_ALREADY_ACTIVATED.getStatusCode());
       status.setMessage("DataNode already activated.");
     } else {
-      ConsensusWriteResponse resp = getConsensusManager().write(req);
-      status = resp.getStatus();
+      getConsensusManager().write(activateDataNodePlan);
       // Adjust the maximum RegionGroup number of each StorageGroup
       getClusterSchemaManager().adjustMaxRegionGroupCount();
+      status.setMessage("activateDataNode success.");
     }
     return status;
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
@@ -125,11 +125,16 @@ public class NodeInfo implements SnapshotProcessor {
     }
   }
 
-  /** @return true if the specific DataNode is registered */
+  /**
+   * Only leader use this interface
+   *
+   * @return True if the specific DataNode already registered, false otherwise
+   */
   public boolean isRegisteredDataNode(TDataNodeLocation dataNodeLocation) {
     boolean result = false;
-    dataNodeInfoReadWriteLock.readLock().lock();
+
     int originalDataNodeId = dataNodeLocation.getDataNodeId();
+    dataNodeInfoReadWriteLock.readLock().lock();
     try {
       for (Map.Entry<Integer, TDataNodeInfo> entry : registeredDataNodes.entrySet()) {
         dataNodeLocation.setDataNodeId(entry.getKey());
@@ -137,11 +142,11 @@ public class NodeInfo implements SnapshotProcessor {
           result = true;
           break;
         }
-        dataNodeLocation.setDataNodeId(originalDataNodeId);
       }
     } finally {
       dataNodeInfoReadWriteLock.readLock().unlock();
     }
+    dataNodeLocation.setDataNodeId(originalDataNodeId);
 
     return result;
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -129,12 +129,10 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
 
   @Override
   public TDataNodeRegisterResp registerDataNode(TDataNodeRegisterReq req) throws TException {
-    RegisterDataNodePlan registerReq = new RegisterDataNodePlan(req.getDataNodeInfo());
-    DataNodeConfigurationResp registerResp =
-        (DataNodeConfigurationResp) configManager.registerDataNode(registerReq);
-
-    TDataNodeRegisterResp resp = new TDataNodeRegisterResp();
-    registerResp.convertToRpcDataNodeRegisterResp(resp);
+    TDataNodeRegisterResp resp =
+        ((DataNodeConfigurationResp)
+                configManager.registerDataNode(new RegisterDataNodePlan(req.getDataNodeInfo())))
+            .convertToRpcDataNodeRegisterResp();
 
     // Print log to record the ConfigNode that performs the RegisterDatanodeRequest
     LOGGER.info("Execute RegisterDatanodeRequest {} with result {}", req, resp);


### PR DESCRIPTION
Follow the following process for IoTDB cluster startup test:

1. Start 3C3D, Datanodes may be redirected during registration, but they always succeed
![image](https://user-images.githubusercontent.com/33111881/177706322-77a40a2f-ba97-4d04-bebb-f7006c5ae147.png)
![image](https://user-images.githubusercontent.com/33111881/177706511-c4c48a91-d409-4a1a-ac01-60e5c10d9173.png)
2. Shutdown DataNodes and restart, success
![image](https://user-images.githubusercontent.com/33111881/177706866-2895df39-6908-45dc-9958-6ccff2ed90a5.png)


Then I check the logs in DataNodes:

1. For the registration:
![image](https://user-images.githubusercontent.com/33111881/177707661-4900514e-0825-4c5e-93f8-6925a3fc2887.png)
![image](https://user-images.githubusercontent.com/33111881/177707787-c70e25ef-26fd-4151-ab03-32ed7f439f6b.png)

2. For the activation:
![image](https://user-images.githubusercontent.com/33111881/177707541-cd6e2038-7edb-4063-b97a-f7ed371bb857.png)
