### PR TITLE
[IOTDB-3718] Unify retry logic of SyncClientPool in ConfigNode

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/ConfigNodeRequestType.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/ConfigNodeRequestType.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.client;
+
+public enum ConfigNodeRequestType {
+  deleteRegions,
+  invalidatePartitionCache,
+  invalidatePermissionCache,
+  invalidateSchemaCache,
+
+  addConsensusGroup,
+  notifyRegisterSuccess,
+  registerConfigNode,
+  removeConfigNode,
+  stopConfigNode;
+}

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/DataNodeRequestType.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/DataNodeRequestType.java
@@ -19,10 +19,9 @@
 
 package org.apache.iotdb.confignode.client;
 
-public enum ConfigNodeRequestType {
-  addConsensusGroup,
-  notifyRegisterSuccess,
-  registerConfigNode,
-  removeConfigNode,
-  stopConfigNode;
+public enum DataNodeRequestType {
+  deleteRegions,
+  invalidatePartitionCache,
+  invalidatePermissionCache,
+  invalidateSchemaCache;
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncConfigNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncConfigNodeClientPool.java
@@ -27,11 +27,14 @@ import org.apache.iotdb.commons.utils.StatusUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterResp;
 import org.apache.iotdb.db.client.DataNodeClientPoolFactory;
+import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
+import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -62,118 +65,74 @@ public class SyncConfigNodeClientPool {
     }
   }
 
-  /** Only use registerConfigNode when the ConfigNode is first startup. */
-  public TConfigNodeRegisterResp registerConfigNode(
-      TEndPoint endPoint, TConfigNodeRegisterReq req) {
-    // TODO: Unified retry logic
+  public Object sendSyncRequestToConfigNode(
+      TEndPoint endPoint, Object req, ConfigNodeRequestType requestType) {
     Throwable lastException = null;
     for (int retry = 0; retry < retryNum; retry++) {
       try (SyncConfigNodeIServiceClient client = clientManager.borrowClient(endPoint)) {
-        return client.registerConfigNode(req);
-      } catch (Exception e) {
-        lastException = e;
-        LOGGER.warn("Register ConfigNode failed because {}, retrying {}...", e.getMessage(), retry);
-        doRetryWait(retry);
-      }
-    }
-    LOGGER.error("Register ConfigNode failed", lastException);
-    return new TConfigNodeRegisterResp()
-        .setStatus(
-            new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
-                .setMessage("All retry failed due to " + lastException.getMessage()));
-  }
-
-  public void addConsensusGroup(TEndPoint endPoint, List<TConfigNodeLocation> configNodeLocation)
-      throws Exception {
-    // TODO: Unified retry logic
-    Exception lastException = null;
-    for (int retry = 0; retry < retryNum; retry++) {
-      try (SyncConfigNodeIServiceClient client = clientManager.borrowClient(endPoint)) {
-        TConfigNodeRegisterResp registerResp = new TConfigNodeRegisterResp();
-        registerResp.setConfigNodeList(configNodeLocation);
-        registerResp.setStatus(StatusUtils.OK);
-        client.addConsensusGroup(registerResp);
-        return;
-      } catch (Exception e) {
+        switch (requestType) {
+          case registerConfigNode:
+            // Only use registerConfigNode when the ConfigNode is first startup.
+            return client.registerConfigNode((TConfigNodeRegisterReq) req);
+          case addConsensusGroup:
+            addConsensusGroup((List<TConfigNodeLocation>) req, client);
+            return null;
+          case notifyRegisterSuccess:
+            client.notifyRegisterSuccess();
+            return null;
+          case removeConfigNode:
+            return removeConfigNode((TConfigNodeLocation) req, client);
+          case stopConfigNode:
+            // Only use stopConfigNode when the ConfigNode is removed.
+            return client.stopConfigNode((TConfigNodeLocation) req);
+          default:
+            return RpcUtils.getStatus(
+                TSStatusCode.EXECUTE_STATEMENT_ERROR, "Unknown request type: " + requestType);
+        }
+      } catch (Throwable e) {
         lastException = e;
         LOGGER.warn(
-            "Add Consensus Group failed because {}, retrying {} ...", e.getMessage(), retry);
+            requestType + " failed on ConfigNode {}, because {}, retrying {}...",
+            endPoint,
+            e.getMessage(),
+            retry);
         doRetryWait(retry);
       }
     }
-
-    throw lastException;
+    LOGGER.error(requestType + " failed on ConfigNode {}", endPoint, lastException);
+    return new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
+        .setMessage("All retry failed due to" + lastException.getMessage());
   }
 
-  public void notifyRegisterSuccess(TEndPoint endPoint) {
-    // TODO: Unified retry logic
-    for (int retry = 0; retry < retryNum; retry++) {
-      try (SyncConfigNodeIServiceClient client = clientManager.borrowClient(endPoint)) {
-        client.notifyRegisterSuccess();
-        return;
-      } catch (Exception e) {
-        LOGGER.warn("Notify register failed because {}, retrying {} ...", e.getMessage(), retry);
-        doRetryWait(retry);
-      }
-    }
+  public void addConsensusGroup(
+      List<TConfigNodeLocation> configNodeLocation, SyncConfigNodeIServiceClient client)
+      throws TException {
+    TConfigNodeRegisterResp registerResp = new TConfigNodeRegisterResp();
+    registerResp.setConfigNodeList(configNodeLocation);
+    registerResp.setStatus(StatusUtils.OK);
+    client.addConsensusGroup(registerResp);
+    return;
   }
 
   /**
    * ConfigNode Leader stop any ConfigNode in the cluster
    *
-   * @param configNodeLocations target_config_nodes of confignode-system.properties
    * @param configNodeLocation To be removed ConfigNode
    * @return SUCCESS_STATUS: remove ConfigNode success, other status remove failed
    */
   public TSStatus removeConfigNode(
-      List<TConfigNodeLocation> configNodeLocations, TConfigNodeLocation configNodeLocation) {
-    // TODO: Unified retry logic
-    Throwable lastException = null;
-    for (TConfigNodeLocation nodeLocation : configNodeLocations) {
-      for (int retry = 0; retry < retryNum; retry++) {
-        try (SyncConfigNodeIServiceClient client =
-            clientManager.borrowClient(nodeLocation.getInternalEndPoint())) {
-          TSStatus status = client.removeConfigNode(configNodeLocation);
-          while (status.getCode() == TSStatusCode.NEED_REDIRECTION.getStatusCode()) {
-            TimeUnit.MILLISECONDS.sleep(2000);
-            updateConfigNodeLeader(status);
-            try (SyncConfigNodeIServiceClient clientLeader =
-                clientManager.borrowClient(configNodeLeader)) {
-              status = clientLeader.removeConfigNode(configNodeLocation);
-            }
-          }
-          return status;
-        } catch (Throwable e) {
-          lastException = e;
-          LOGGER.warn(
-              "Remove ConfigNode failed because {}, retrying {} ...", e.getMessage(), retry);
-          doRetryWait(retry);
-        }
+      TConfigNodeLocation configNodeLocation, SyncConfigNodeIServiceClient client)
+      throws TException, IOException, InterruptedException {
+    TSStatus status = client.removeConfigNode(configNodeLocation);
+    while (status.getCode() == TSStatusCode.NEED_REDIRECTION.getStatusCode()) {
+      TimeUnit.MILLISECONDS.sleep(2000);
+      updateConfigNodeLeader(status);
+      try (SyncConfigNodeIServiceClient clientLeader =
+          clientManager.borrowClient(configNodeLeader)) {
+        status = clientLeader.removeConfigNode(configNodeLocation);
       }
     }
-
-    LOGGER.error("Remove ConfigNode failed", lastException);
-    return new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
-        .setMessage("All retry failed due to " + lastException.getMessage());
-  }
-
-  /** Only use stopConfigNode when the ConfigNode is removed. */
-  public TSStatus stopConfigNode(TConfigNodeLocation configNodeLocation) {
-    // TODO: Unified retry logic
-    Throwable lastException = null;
-    for (int retry = 0; retry < retryNum; retry++) {
-      try (SyncConfigNodeIServiceClient client =
-          clientManager.borrowClient(configNodeLocation.getInternalEndPoint())) {
-        return client.stopConfigNode(configNodeLocation);
-      } catch (Exception e) {
-        lastException = e;
-        LOGGER.warn("Stop ConfigNode failed because {}, retrying {}...", e.getMessage(), retry);
-        doRetryWait(retry);
-      }
-    }
-    LOGGER.error("Stop ConfigNode failed", lastException);
-    return new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
-        .setMessage("All retry failed due to" + lastException.getMessage());
+    return status;
   }
 
   private void doRetryWait(int retryNum) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncConfigNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncConfigNodeClientPool.java
@@ -92,14 +92,15 @@ public class SyncConfigNodeClientPool {
       } catch (Throwable e) {
         lastException = e;
         LOGGER.warn(
-            requestType + " failed on ConfigNode {}, because {}, retrying {}...",
+            "{} failed on ConfigNode {}, because {}, retrying {}...",
+            requestType,
             endPoint,
             e.getMessage(),
             retry);
         doRetryWait(retry);
       }
     }
-    LOGGER.error(requestType + " failed on ConfigNode {}", endPoint, lastException);
+    LOGGER.error("{} failed on ConfigNode {}", requestType, endPoint, lastException);
     return new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
         .setMessage("All retry failed due to" + lastException.getMessage());
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncDataNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncDataNodeClientPool.java
@@ -59,7 +59,7 @@ public class SyncDataNodeClientPool {
   }
 
   public TSStatus sendSyncRequestToDataNode(
-      TEndPoint endPoint, Object req, ConfigNodeRequestType requestType) {
+      TEndPoint endPoint, Object req, DataNodeRequestType requestType) {
     Throwable lastException = null;
     for (int retry = 0; retry < retryNum; retry++) {
       try (SyncDataNodeInternalServiceClient client = clientManager.borrowClient(endPoint)) {
@@ -115,7 +115,7 @@ public class SyncDataNodeClientPool {
     for (TConsensusGroupId regionId : regionIds) {
       LOGGER.debug("Delete region {} ", regionId);
       final TSStatus status =
-          sendSyncRequestToDataNode(endPoint, regionId, ConfigNodeRequestType.deleteRegions);
+          sendSyncRequestToDataNode(endPoint, regionId, DataNodeRequestType.deleteRegions);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         LOGGER.info("DELETE Region {} successfully", regionId);
         deletedRegionSet.removeIf(k -> k.getRegionId().equals(regionId));

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncDataNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncDataNodeClientPool.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.sync.SyncDataNodeInternalServiceClient;
 import org.apache.iotdb.mpp.rpc.thrift.TInvalidateCacheReq;
 import org.apache.iotdb.mpp.rpc.thrift.TInvalidatePermissionCacheReq;
+import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.thrift.TException;
@@ -39,11 +40,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /** Synchronously send RPC requests to DataNodes. See mpp.thrift for more details. */
 public class SyncDataNodeClientPool {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SyncDataNodeClientPool.class);
+
+  private static final int retryNum = 6;
 
   private final IClientManager<TEndPoint, SyncDataNodeInternalServiceClient> clientManager;
 
@@ -54,35 +58,37 @@ public class SyncDataNodeClientPool {
                 new ConfigNodeClientPoolFactory.SyncDataNodeInternalServiceClientPoolFactory());
   }
 
-  public TSStatus invalidatePartitionCache(
-      TEndPoint endPoint, TInvalidateCacheReq invalidateCacheReq) {
-    TSStatus status;
-    try (SyncDataNodeInternalServiceClient client = clientManager.borrowClient(endPoint)) {
-      status = client.invalidatePartitionCache(invalidateCacheReq);
-      LOGGER.info("Invalid Schema Cache {} successfully", invalidateCacheReq);
-    } catch (IOException e) {
-      LOGGER.error("Can't connect to DataNode {}", endPoint, e);
-      status = new TSStatus(TSStatusCode.TIME_OUT.getStatusCode());
-    } catch (TException e) {
-      LOGGER.error("Invalid Schema Cache on DataNode {} failed", endPoint, e);
-      status = new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode());
+  public Object sendSyncRequestToDataNode(
+      TEndPoint endPoint, Object req, ConfigNodeRequestType requestType) {
+    Throwable lastException = null;
+    for (int retry = 0; retry < retryNum; retry++) {
+      try (SyncDataNodeInternalServiceClient client = clientManager.borrowClient(endPoint)) {
+        switch (requestType) {
+          case invalidatePartitionCache:
+            return client.invalidatePartitionCache((TInvalidateCacheReq) req);
+          case invalidateSchemaCache:
+            return client.invalidateSchemaCache((TInvalidateCacheReq) req);
+          case deleteRegions:
+            return client.deleteRegion((TConsensusGroupId) req);
+          case invalidatePermissionCache:
+            return client.invalidatePermissionCache((TInvalidatePermissionCacheReq) req);
+          default:
+            return RpcUtils.getStatus(
+                TSStatusCode.EXECUTE_STATEMENT_ERROR, "Unknown request type: " + requestType);
+        }
+      } catch (TException | IOException e) {
+        lastException = e;
+        LOGGER.warn(
+            requestType + " failed on DataNode {}, because {}, retrying {}...",
+            endPoint,
+            e.getMessage(),
+            retry);
+        doRetryWait(retry);
+      }
     }
-    return status;
-  }
-
-  public TSStatus invalidateSchemaCache(
-      TEndPoint endPoint, TInvalidateCacheReq invalidateCacheReq) {
-    TSStatus status;
-    try (SyncDataNodeInternalServiceClient client = clientManager.borrowClient(endPoint)) {
-      status = client.invalidateSchemaCache(invalidateCacheReq);
-    } catch (IOException e) {
-      LOGGER.error("Can't connect to DataNode {}", endPoint, e);
-      status = new TSStatus(TSStatusCode.TIME_OUT.getStatusCode());
-    } catch (TException e) {
-      LOGGER.error("Invalid Schema Cache on DataNode {} failed", endPoint, e);
-      status = new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode());
-    }
-    return status;
+    LOGGER.error(requestType + " failed on DataNode {}", endPoint, lastException);
+    return new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
+        .setMessage("All retry failed due to" + lastException.getMessage());
   }
 
   public void deleteRegions(Set<TRegionReplicaSet> deletedRegionSet) {
@@ -105,35 +111,24 @@ public class SyncDataNodeClientPool {
       TEndPoint endPoint,
       List<TConsensusGroupId> regionIds,
       Set<TRegionReplicaSet> deletedRegionSet) {
-    try (SyncDataNodeInternalServiceClient client = clientManager.borrowClient(endPoint)) {
-      for (TConsensusGroupId regionId : regionIds) {
-        LOGGER.debug("Delete region {} ", regionId);
-        final TSStatus status = client.deleteRegion(regionId);
-        if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-          LOGGER.info("DELETE Region {} successfully", regionId);
-          deletedRegionSet.removeIf(k -> k.getRegionId().equals(regionId));
-        }
+    for (TConsensusGroupId regionId : regionIds) {
+      LOGGER.debug("Delete region {} ", regionId);
+      final TSStatus status =
+          (TSStatus)
+              sendSyncRequestToDataNode(endPoint, regionId, ConfigNodeRequestType.deleteRegions);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        LOGGER.info("DELETE Region {} successfully", regionId);
+        deletedRegionSet.removeIf(k -> k.getRegionId().equals(regionId));
       }
-    } catch (IOException e) {
-      LOGGER.error("Can't connect to DataNode {}", endPoint, e);
-    } catch (TException e) {
-      LOGGER.error("Delete Region on DataNode {} failed", endPoint, e);
     }
   }
 
-  public TSStatus invalidatePermissionCache(
-      TEndPoint endPoint, TInvalidatePermissionCacheReq invalidatePermissionCacheReq) {
-    TSStatus status;
-    try (SyncDataNodeInternalServiceClient client = clientManager.borrowClient(endPoint)) {
-      status = client.invalidatePermissionCache(invalidatePermissionCacheReq);
-    } catch (IOException e) {
-      LOGGER.error("Can't connect to DataNode {}", endPoint, e);
-      status = new TSStatus(TSStatusCode.TIME_OUT.getStatusCode());
-    } catch (TException e) {
-      LOGGER.error("Invalid Permission Cache on DataNode {} failed", endPoint, e);
-      status = new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode());
+  private void doRetryWait(int retryNum) {
+    try {
+      TimeUnit.MILLISECONDS.sleep(100L * (long) Math.pow(2, retryNum));
+    } catch (InterruptedException e) {
+      LOGGER.error("Retry wait failed.", e);
     }
-    return status;
   }
 
   // TODO: Is the ClientPool must be a singleton?

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncDataNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/SyncDataNodeClientPool.java
@@ -58,7 +58,7 @@ public class SyncDataNodeClientPool {
                 new ConfigNodeClientPoolFactory.SyncDataNodeInternalServiceClientPoolFactory());
   }
 
-  public Object sendSyncRequestToDataNode(
+  public TSStatus sendSyncRequestToDataNode(
       TEndPoint endPoint, Object req, ConfigNodeRequestType requestType) {
     Throwable lastException = null;
     for (int retry = 0; retry < retryNum; retry++) {
@@ -79,14 +79,15 @@ public class SyncDataNodeClientPool {
       } catch (TException | IOException e) {
         lastException = e;
         LOGGER.warn(
-            requestType + " failed on DataNode {}, because {}, retrying {}...",
+            "{} failed on DataNode {}, because {}, retrying {}...",
+            requestType,
             endPoint,
             e.getMessage(),
             retry);
         doRetryWait(retry);
       }
     }
-    LOGGER.error(requestType + " failed on DataNode {}", endPoint, lastException);
+    LOGGER.error("{} failed on DataNode {}", requestType, endPoint, lastException);
     return new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
         .setMessage("All retry failed due to" + lastException.getMessage());
   }
@@ -114,8 +115,7 @@ public class SyncDataNodeClientPool {
     for (TConsensusGroupId regionId : regionIds) {
       LOGGER.debug("Delete region {} ", regionId);
       final TSStatus status =
-          (TSStatus)
-              sendSyncRequestToDataNode(endPoint, regionId, ConfigNodeRequestType.deleteRegions);
+          sendSyncRequestToDataNode(endPoint, regionId, ConfigNodeRequestType.deleteRegions);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         LOGGER.info("DELETE Region {} successfully", regionId);
         deletedRegionSet.removeIf(k -> k.getRegionId().equals(regionId));

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
@@ -90,7 +90,7 @@ public class ConfigNodeRemoveCheck {
     }
   }
 
-  /** target_config_nodes of confignode-system.properties **/
+  /** target_config_nodes of confignode-system.properties * */
   public List<TConfigNodeLocation> getConfigNodeList() throws BadNodeUrlException {
     return NodeUrlUtils.parseTConfigNodeUrls(
         systemProperties.getProperty(IoTDBConstant.TARGET_CONFIG_NODES));

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.BadNodeUrlException;
 import org.apache.iotdb.commons.utils.NodeUrlUtils;
+import org.apache.iotdb.confignode.client.ConfigNodeRequestType;
 import org.apache.iotdb.confignode.client.SyncConfigNodeClientPool;
 import org.apache.iotdb.rpc.TSStatusCode;
 
@@ -72,14 +73,24 @@ public class ConfigNodeRemoveCheck {
 
   public void removeConfigNode(TConfigNodeLocation nodeLocation)
       throws BadNodeUrlException, IOException {
-    TSStatus status =
-        SyncConfigNodeClientPool.getInstance().removeConfigNode(getConfigNodeList(), nodeLocation);
+    TSStatus status = new TSStatus();
+    for (TConfigNodeLocation configNodeLocation : getConfigNodeList()) {
+      status =
+          (TSStatus)
+              SyncConfigNodeClientPool.getInstance()
+                  .sendSyncRequestToConfigNode(
+                      configNodeLocation.getInternalEndPoint(),
+                      nodeLocation,
+                      ConfigNodeRequestType.removeConfigNode);
+      break;
+    }
     if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       LOGGER.error(status.getMessage());
       throw new IOException("Remove ConfigNode failed:");
     }
   }
 
+  /** target_config_nodes of confignode-system.properties * */
   public List<TConfigNodeLocation> getConfigNodeList() throws BadNodeUrlException {
     return NodeUrlUtils.parseTConfigNodeUrls(
         systemProperties.getProperty(IoTDBConstant.TARGET_CONFIG_NODES));

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
@@ -90,7 +90,7 @@ public class ConfigNodeRemoveCheck {
     }
   }
 
-  /** target_config_nodes of confignode-system.properties * */
+  /** target_config_nodes of confignode-system.properties **/
   public List<TConfigNodeLocation> getConfigNodeList() throws BadNodeUrlException {
     return NodeUrlUtils.parseTConfigNodeUrls(
         systemProperties.getProperty(IoTDBConstant.TARGET_CONFIG_NODES));

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
@@ -82,7 +82,9 @@ public class ConfigNodeRemoveCheck {
                       configNodeLocation.getInternalEndPoint(),
                       nodeLocation,
                       ConfigNodeRequestType.removeConfigNode);
-      break;
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        break;
+      }
     }
     if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       LOGGER.error(status.getMessage());
@@ -90,7 +92,7 @@ public class ConfigNodeRemoveCheck {
     }
   }
 
-  /** target_config_nodes of confignode-system.properties * */
+  /** target_config_nodes of confignode-system.properties */
   public List<TConfigNodeLocation> getConfigNodeList() throws BadNodeUrlException {
     return NodeUrlUtils.parseTConfigNodeUrls(
         systemProperties.getProperty(IoTDBConstant.TARGET_CONFIG_NODES));

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/PermissionManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/PermissionManager.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.confignode.manager;
 
 import org.apache.iotdb.common.rpc.thrift.TDataNodeInfo;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.confignode.client.ConfigNodeRequestType;
 import org.apache.iotdb.confignode.client.SyncDataNodeClientPool;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
 import org.apache.iotdb.confignode.consensus.request.auth.AuthorPlan;
@@ -105,8 +106,12 @@ public class PermissionManager {
     req.setRoleName(roleName);
     for (TDataNodeInfo dataNodeInfo : allDataNodes) {
       status =
-          SyncDataNodeClientPool.getInstance()
-              .invalidatePermissionCache(dataNodeInfo.getLocation().getInternalEndPoint(), req);
+          (TSStatus)
+              SyncDataNodeClientPool.getInstance()
+                  .sendSyncRequestToDataNode(
+                      dataNodeInfo.getLocation().getInternalEndPoint(),
+                      req,
+                      ConfigNodeRequestType.invalidatePermissionCache);
       if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/PermissionManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/PermissionManager.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.confignode.manager;
 
 import org.apache.iotdb.common.rpc.thrift.TDataNodeInfo;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.confignode.client.ConfigNodeRequestType;
+import org.apache.iotdb.confignode.client.DataNodeRequestType;
 import org.apache.iotdb.confignode.client.SyncDataNodeClientPool;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
 import org.apache.iotdb.confignode.consensus.request.auth.AuthorPlan;
@@ -110,7 +110,7 @@ public class PermissionManager {
               .sendSyncRequestToDataNode(
                   dataNodeInfo.getLocation().getInternalEndPoint(),
                   req,
-                  ConfigNodeRequestType.invalidatePermissionCache);
+                  DataNodeRequestType.invalidatePermissionCache);
       if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/PermissionManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/PermissionManager.java
@@ -106,12 +106,11 @@ public class PermissionManager {
     req.setRoleName(roleName);
     for (TDataNodeInfo dataNodeInfo : allDataNodes) {
       status =
-          (TSStatus)
-              SyncDataNodeClientPool.getInstance()
-                  .sendSyncRequestToDataNode(
-                      dataNodeInfo.getLocation().getInternalEndPoint(),
-                      req,
-                      ConfigNodeRequestType.invalidatePermissionCache);
+          SyncDataNodeClientPool.getInstance()
+              .sendSyncRequestToDataNode(
+                  dataNodeInfo.getLocation().getInternalEndPoint(),
+                  req,
+                  ConfigNodeRequestType.invalidatePermissionCache);
       if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -113,19 +113,17 @@ public class ConfigNodeProcedureEnv {
     invalidateCacheReq.setFullPath(storageGroupName);
     for (TDataNodeInfo dataNodeInfo : allDataNodes) {
       final TSStatus invalidateSchemaStatus =
-          (TSStatus)
-              SyncDataNodeClientPool.getInstance()
-                  .sendSyncRequestToDataNode(
-                      dataNodeInfo.getLocation().getInternalEndPoint(),
-                      invalidateCacheReq,
-                      ConfigNodeRequestType.invalidateSchemaCache);
+          SyncDataNodeClientPool.getInstance()
+              .sendSyncRequestToDataNode(
+                  dataNodeInfo.getLocation().getInternalEndPoint(),
+                  invalidateCacheReq,
+                  ConfigNodeRequestType.invalidateSchemaCache);
       final TSStatus invalidatePartitionStatus =
-          (TSStatus)
-              SyncDataNodeClientPool.getInstance()
-                  .sendSyncRequestToDataNode(
-                      dataNodeInfo.getLocation().getInternalEndPoint(),
-                      invalidateCacheReq,
-                      ConfigNodeRequestType.invalidatePartitionCache);
+          SyncDataNodeClientPool.getInstance()
+              .sendSyncRequestToDataNode(
+                  dataNodeInfo.getLocation().getInternalEndPoint(),
+                  invalidateCacheReq,
+                  ConfigNodeRequestType.invalidatePartitionCache);
       if (!verifySucceed(invalidatePartitionStatus, invalidateSchemaStatus)) {
         LOG.error(
             "Invalidate cache failed, invalidate partition cache status is {}， invalidate schema cache status is {}",

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.confignode.procedure.env;
 import org.apache.iotdb.common.rpc.thrift.TConfigNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeInfo;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.confignode.client.ConfigNodeRequestType;
 import org.apache.iotdb.confignode.client.SyncConfigNodeClientPool;
 import org.apache.iotdb.confignode.client.SyncDataNodeClientPool;
 import org.apache.iotdb.confignode.consensus.request.write.DeleteStorageGroupPlan;
@@ -112,13 +113,19 @@ public class ConfigNodeProcedureEnv {
     invalidateCacheReq.setFullPath(storageGroupName);
     for (TDataNodeInfo dataNodeInfo : allDataNodes) {
       final TSStatus invalidateSchemaStatus =
-          SyncDataNodeClientPool.getInstance()
-              .invalidateSchemaCache(
-                  dataNodeInfo.getLocation().getInternalEndPoint(), invalidateCacheReq);
+          (TSStatus)
+              SyncDataNodeClientPool.getInstance()
+                  .sendSyncRequestToDataNode(
+                      dataNodeInfo.getLocation().getInternalEndPoint(),
+                      invalidateCacheReq,
+                      ConfigNodeRequestType.invalidateSchemaCache);
       final TSStatus invalidatePartitionStatus =
-          SyncDataNodeClientPool.getInstance()
-              .invalidatePartitionCache(
-                  dataNodeInfo.getLocation().getInternalEndPoint(), invalidateCacheReq);
+          (TSStatus)
+              SyncDataNodeClientPool.getInstance()
+                  .sendSyncRequestToDataNode(
+                      dataNodeInfo.getLocation().getInternalEndPoint(),
+                      invalidateCacheReq,
+                      ConfigNodeRequestType.invalidatePartitionCache);
       if (!verifySucceed(invalidatePartitionStatus, invalidateSchemaStatus)) {
         LOG.error(
             "Invalidate cache failed, invalidate partition cache status is {}， invalidate schema cache status is {}",
@@ -145,7 +152,10 @@ public class ConfigNodeProcedureEnv {
         new ArrayList<>(configManager.getNodeManager().getRegisteredConfigNodes());
     configNodeLocations.add(tConfigNodeLocation);
     SyncConfigNodeClientPool.getInstance()
-        .addConsensusGroup(tConfigNodeLocation.getInternalEndPoint(), configNodeLocations);
+        .sendSyncRequestToConfigNode(
+            tConfigNodeLocation.getInternalEndPoint(),
+            configNodeLocations,
+            ConfigNodeRequestType.addConsensusGroup);
   }
 
   /**
@@ -174,7 +184,10 @@ public class ConfigNodeProcedureEnv {
    */
   public void notifyRegisterSuccess(TConfigNodeLocation configNodeLocation) {
     SyncConfigNodeClientPool.getInstance()
-        .notifyRegisterSuccess(configNodeLocation.getInternalEndPoint());
+        .sendSyncRequestToConfigNode(
+            configNodeLocation.getInternalEndPoint(),
+            null,
+            ConfigNodeRequestType.notifyRegisterSuccess);
   }
 
   public ReentrantLock getAddConfigNodeLock() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TConfigNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeInfo;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.confignode.client.ConfigNodeRequestType;
+import org.apache.iotdb.confignode.client.DataNodeRequestType;
 import org.apache.iotdb.confignode.client.SyncConfigNodeClientPool;
 import org.apache.iotdb.confignode.client.SyncDataNodeClientPool;
 import org.apache.iotdb.confignode.consensus.request.write.DeleteStorageGroupPlan;
@@ -117,13 +118,13 @@ public class ConfigNodeProcedureEnv {
               .sendSyncRequestToDataNode(
                   dataNodeInfo.getLocation().getInternalEndPoint(),
                   invalidateCacheReq,
-                  ConfigNodeRequestType.invalidateSchemaCache);
+                  DataNodeRequestType.invalidateSchemaCache);
       final TSStatus invalidatePartitionStatus =
           SyncDataNodeClientPool.getInstance()
               .sendSyncRequestToDataNode(
                   dataNodeInfo.getLocation().getInternalEndPoint(),
                   invalidateCacheReq,
-                  ConfigNodeRequestType.invalidatePartitionCache);
+                  DataNodeRequestType.invalidatePartitionCache);
       if (!verifySucceed(invalidatePartitionStatus, invalidateSchemaStatus)) {
         LOG.error(
             "Invalidate cache failed, invalidate partition cache status is {}， invalidate schema cache status is {}",

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.commons.udf.service.UDFClassLoaderManager;
 import org.apache.iotdb.commons.udf.service.UDFExecutableManager;
 import org.apache.iotdb.commons.udf.service.UDFRegistrationService;
 import org.apache.iotdb.commons.utils.NodeUrlUtils;
+import org.apache.iotdb.confignode.client.ConfigNodeRequestType;
 import org.apache.iotdb.confignode.client.SyncConfigNodeClientPool;
 import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
 import org.apache.iotdb.confignode.conf.ConfigNodeConstant;
@@ -187,7 +188,10 @@ public class ConfigNode implements ConfigNodeMBean {
     TEndPoint targetConfigNode = conf.getTargetConfigNode();
     while (true) {
       TConfigNodeRegisterResp resp =
-          SyncConfigNodeClientPool.getInstance().registerConfigNode(targetConfigNode, req);
+          (TConfigNodeRegisterResp)
+              SyncConfigNodeClientPool.getInstance()
+                  .sendSyncRequestToConfigNode(
+                      targetConfigNode, req, ConfigNodeRequestType.registerConfigNode);
       if (resp.getStatus().getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         conf.setPartitionRegionId(resp.getPartitionRegionId().getId());
         break;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.StatusUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.confignode.client.ConfigNodeRequestType;
 import org.apache.iotdb.confignode.client.SyncConfigNodeClientPool;
 import org.apache.iotdb.confignode.conf.ConfigNodeConstant;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
@@ -395,7 +396,13 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
 
     TSStatus status = configManager.removeConfigNode(removeConfigNodePlan);
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      status = SyncConfigNodeClientPool.getInstance().stopConfigNode(configNodeLocation);
+      status =
+          (TSStatus)
+              SyncConfigNodeClientPool.getInstance()
+                  .sendSyncRequestToConfigNode(
+                      configNodeLocation.getInternalEndPoint(),
+                      configNodeLocation,
+                      ConfigNodeRequestType.stopConfigNode);
     }
 
     // Print log to record the ConfigNode that performs the RemoveConfigNodeRequest


### PR DESCRIPTION
Unify retry logic of SyncClientPool in ConfigNode
see details : https://issues.apache.org/jira/browse/IOTDB-3718