### PR TITLE
[IOTDB-3734] Set safely deleted search index directly in multi-leader

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.consensus.common.request;
 
+import org.apache.iotdb.consensus.multileader.wal.ConsensusReqReader;
+
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
@@ -31,6 +33,10 @@ public class IndexedConsensusRequest implements IConsensusRequest {
   private final long safelyDeletedSearchIndex;
 
   private final IConsensusRequest request;
+
+  public IndexedConsensusRequest(long searchIndex, IConsensusRequest request) {
+    this(searchIndex, ConsensusReqReader.DEFAULT_SAFELY_DELETED_SEARCH_INDEX, request);
+  }
 
   public IndexedConsensusRequest(
       long searchIndex, long safelyDeletedSearchIndex, IConsensusRequest request) {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderServerImpl.java
@@ -177,14 +177,12 @@ public class MultiLeaderServerImpl {
 
   public IndexedConsensusRequest buildIndexedConsensusRequestForLocalRequest(
       IConsensusRequest request) {
-    return new IndexedConsensusRequest(
-        index.incrementAndGet(), getCurrentSafelyDeletedSearchIndex(), request);
+    return new IndexedConsensusRequest(index.incrementAndGet(), request);
   }
 
   public IndexedConsensusRequest buildIndexedConsensusRequestForRemoteRequest(
       ByteBufferConsensusRequest request) {
-    return new IndexedConsensusRequest(
-        ConsensusReqReader.DEFAULT_SEARCH_INDEX, getCurrentSafelyDeletedSearchIndex(), request);
+    return new IndexedConsensusRequest(ConsensusReqReader.DEFAULT_SEARCH_INDEX, request);
   }
 
   /**

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
@@ -201,6 +201,10 @@ public class LogDispatcher {
           syncStatus.addNextBatch(batch);
           // sends batch asynchronously and migrates the retry logic into the callback handler
           sendBatchAsync(batch, new DispatchLogHandler(this, batch));
+          // update safely deleted search index to delete outdated info,
+          // indicating that insert nodes whose search index are before this value can be deleted
+          // safely
+          reader.setSafelyDeletedSearchIndex(impl.getCurrentSafelyDeletedSearchIndex());
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/wal/ConsensusReqReader.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/wal/ConsensusReqReader.java
@@ -30,7 +30,13 @@ import java.util.concurrent.TimeoutException;
 /** This interface provides search interface for consensus requests via index. */
 public interface ConsensusReqReader {
 
+  /** this insert node doesn't need to participate in multi-leader consensus */
   long DEFAULT_SEARCH_INDEX = -1;
+
+  /** multi-leader consensus cannot delete any insert nodes */
+  long DEFAULT_SAFELY_DELETED_SEARCH_INDEX = Long.MIN_VALUE;
+
+  void setSafelyDeletedSearchIndex(long safelyDeletedSearchIndex);
 
   /**
    * Gets the consensus request at the specified position.

--- a/consensus/src/test/java/org/apache/iotdb/consensus/multileader/util/FakeConsensusReqReader.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/multileader/util/FakeConsensusReqReader.java
@@ -37,6 +37,9 @@ public class FakeConsensusReqReader implements ConsensusReqReader, DataSet {
   }
 
   @Override
+  public void setSafelyDeletedSearchIndex(long safelyDeletedSearchIndex) {}
+
+  @Override
   public IConsensusRequest getReq(long index) {
     synchronized (requestSets) {
       for (IndexedConsensusRequest indexedConsensusRequest : requestSets.getRequestSet()) {

--- a/consensus/src/test/java/org/apache/iotdb/consensus/multileader/util/TestStateMachine.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/multileader/util/TestStateMachine.java
@@ -65,7 +65,6 @@ public class TestStateMachine implements IStateMachine, IStateMachine.EventApi {
         requestSets.add(
             new IndexedConsensusRequest(
                 ((IndexedConsensusRequest) request).getSearchIndex(),
-                -1,
                 new TestEntry(buffer.getInt(), Peer.deserialize(buffer))),
             false);
       } else {

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -106,9 +106,6 @@ public class DataRegionStateMachine extends BaseStateMachine {
         if (planNode instanceof InsertNode) {
           ((InsertNode) planNode)
               .setSearchIndex(((IndexedConsensusRequest) request).getSearchIndex());
-          ((InsertNode) planNode)
-              .setSafelyDeletedSearchIndex(
-                  ((IndexedConsensusRequest) request).getSafelyDeletedSearchIndex());
         }
       } else {
         planNode = getPlanNode(request);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertMultiTabletsNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertMultiTabletsNode.java
@@ -136,12 +136,6 @@ public class InsertMultiTabletsNode extends InsertNode implements BatchInsertNod
   }
 
   @Override
-  public void setSafelyDeletedSearchIndex(long index) {
-    safelyDeletedSearchIndex = index;
-    insertTabletNodeList.forEach(plan -> plan.setSafelyDeletedSearchIndex(index));
-  }
-
-  @Override
   public boolean validateAndSetSchema(SchemaTree schemaTree) {
     for (InsertTabletNode insertTabletNode : insertTabletNodeList) {
       if (!insertTabletNode.validateAndSetSchema(schemaTree)) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsNode.java
@@ -103,12 +103,6 @@ public class InsertRowsNode extends InsertNode implements BatchInsertNode {
     insertRowNodeList.forEach(plan -> plan.setSearchIndex(index));
   }
 
-  @Override
-  public void setSafelyDeletedSearchIndex(long index) {
-    safelyDeletedSearchIndex = index;
-    insertRowNodeList.forEach(plan -> plan.setSafelyDeletedSearchIndex(index));
-  }
-
   public Map<Integer, TSStatus> getResults() {
     return results;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -91,12 +91,6 @@ public class InsertRowsOfOneDeviceNode extends InsertNode implements BatchInsert
     insertRowNodeList.forEach(plan -> plan.setSearchIndex(index));
   }
 
-  @Override
-  public void setSafelyDeletedSearchIndex(long index) {
-    safelyDeletedSearchIndex = index;
-    insertRowNodeList.forEach(plan -> plan.setSafelyDeletedSearchIndex(index));
-  }
-
   public TSStatus[] getFailingStatus() {
     return StatusUtils.getFailingStatus(results, insertRowNodeList.size());
   }

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.wal.allocation;
 
 import org.apache.iotdb.commons.utils.FileUtils;
+import org.apache.iotdb.consensus.multileader.wal.ConsensusReqReader;
 import org.apache.iotdb.db.wal.node.IWALNode;
 import org.apache.iotdb.db.wal.node.WALNode;
 
@@ -52,7 +53,7 @@ public class FirstCreateStrategy extends AbstractNodeAllocationStrategy {
       IWALNode walNode = createWALNode(applicantUniqueId);
       if (walNode instanceof WALNode) {
         // avoid deletion
-        ((WALNode) walNode).setSafelyDeletedSearchIndex(Long.MIN_VALUE);
+        walNode.setSafelyDeletedSearchIndex(ConsensusReqReader.DEFAULT_SAFELY_DELETED_SEARCH_INDEX);
         identifier2Nodes.put(applicantUniqueId, (WALNode) walNode);
       }
       return walNode;
@@ -73,7 +74,7 @@ public class FirstCreateStrategy extends AbstractNodeAllocationStrategy {
           createWALNode(applicantUniqueId, logDirectory, startFileVersion, startSearchIndex);
       if (walNode instanceof WALNode) {
         // avoid deletion
-        ((WALNode) walNode).setSafelyDeletedSearchIndex(Long.MIN_VALUE);
+        walNode.setSafelyDeletedSearchIndex(ConsensusReqReader.DEFAULT_SAFELY_DELETED_SEARCH_INDEX);
         identifier2Nodes.put(applicantUniqueId, (WALNode) walNode);
       }
     } finally {

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALFakeNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALFakeNode.java
@@ -100,6 +100,11 @@ public class WALFakeNode implements IWALNode {
   }
 
   @Override
+  public void setSafelyDeletedSearchIndex(long safelyDeletedSearchIndex) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public IConsensusRequest getReq(long index) {
     throw new UnsupportedOperationException();
   }

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -687,7 +687,8 @@ public class WALNode implements IWALNode {
       if (needUpdatingFilesToSearch || filesToSearch == null) {
         updateFilesToSearch();
         if (needUpdatingFilesToSearch) {
-          logger.debug("update file to search failed, the next search index is {}", nextSearchIndex);
+          logger.debug(
+              "update file to search failed, the next search index is {}", nextSearchIndex);
           return false;
         }
       }

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -77,8 +77,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.apache.iotdb.db.mpp.plan.planner.plan.node.write.InsertNode.DEFAULT_SAFELY_DELETED_SEARCH_INDEX;
-
 /**
  * This class encapsulates {@link IWALBuffer} and {@link CheckpointManager}. If search is enabled,
  * the order of search index should be protected by the upper layer, and the value should start from
@@ -87,6 +85,8 @@ import static org.apache.iotdb.db.mpp.plan.planner.plan.node.write.InsertNode.DE
 public class WALNode implements IWALNode {
   private static final Logger logger = LoggerFactory.getLogger(WALNode.class);
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
+  /** no multi-leader consensus, all insert nodes can be safely deleted */
+  public static final long DEFAULT_SAFELY_DELETED_SEARCH_INDEX = Long.MAX_VALUE;
 
   /** unique identifier of this WALNode */
   private final String identifier;
@@ -135,9 +135,6 @@ public class WALNode implements IWALNode {
 
   @Override
   public WALFlushListener log(long memTableId, InsertRowNode insertRowNode) {
-    if (insertRowNode.getSafelyDeletedSearchIndex() != DEFAULT_SAFELY_DELETED_SEARCH_INDEX) {
-      safelyDeletedSearchIndex = insertRowNode.getSafelyDeletedSearchIndex();
-    }
     WALEntry walEntry = new WALEntry(memTableId, insertRowNode);
     return log(walEntry);
   }
@@ -152,9 +149,6 @@ public class WALNode implements IWALNode {
   @Override
   public WALFlushListener log(
       long memTableId, InsertTabletNode insertTabletNode, int start, int end) {
-    if (insertTabletNode.getSafelyDeletedSearchIndex() != DEFAULT_SAFELY_DELETED_SEARCH_INDEX) {
-      safelyDeletedSearchIndex = insertTabletNode.getSafelyDeletedSearchIndex();
-    }
     WALEntry walEntry = new WALEntry(memTableId, insertTabletNode, start, end);
     return log(walEntry);
   }
@@ -464,6 +458,7 @@ public class WALNode implements IWALNode {
   // endregion
 
   // region Search interfaces for consensus group
+  @Override
   public void setSafelyDeletedSearchIndex(long safelyDeletedSearchIndex) {
     this.safelyDeletedSearchIndex = safelyDeletedSearchIndex;
   }

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -229,7 +229,7 @@ public class WALNode implements IWALNode {
         }
       }
 
-      logger.info(
+      logger.debug(
           "Start deleting outdated wal files for wal node-{}, the first valid version id is {}, and the safely deleted search index is {}.",
           identifier,
           firstValidVersionId,
@@ -687,7 +687,7 @@ public class WALNode implements IWALNode {
       if (needUpdatingFilesToSearch || filesToSearch == null) {
         updateFilesToSearch();
         if (needUpdatingFilesToSearch) {
-          logger.warn("update file to search failed");
+          logger.debug("update file to search failed, the next search index is {}", nextSearchIndex);
           return false;
         }
       }


### PR DESCRIPTION
Set safely deleted search index directly in multi-leader to delete outdated wal files.