### PR TITLE
for the Chinese version of User Guide，delete an extra symbol

### DIFF
--- a/docs/zh/UserGuide/QuickStart/QuickStart.md
+++ b/docs/zh/UserGuide/QuickStart/QuickStart.md
@@ -245,13 +245,13 @@ IoTDB> exit
 Linux 系统与 MacOS 系统停止命令如下：
 
 ```
-> $sbin/stop-server.sh
+> sbin/stop-server.sh
 ```
 
 Windows 系统停止命令如下：
 
 ```
-> $sbin\stop-server.bat
+> sbin\stop-server.bat
 ```
 
 ## 基础配置


### PR DESCRIPTION
I have deleted a redundant symbol in the Chinese version. Copying will report an error if not removed, and the English version is correct without this symbol.