### PR TITLE
[To rel/0.12]Avoid serializing resource file and adding mods to file that don't contain the device when deleting data

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.engine.storagegroup;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.concurrent.ThreadName;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -80,6 +79,8 @@ import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
+
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1827,6 +1828,7 @@ public class StorageGroupProcessor {
       }
 
       if (deleteEnd >= tsFileResource.getStartTime(deviceId) && deleteStart <= endTime) {
+        // time range of device has overlap with the deletion
         return false;
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1821,13 +1821,13 @@ public class StorageGroupProcessor {
     }
     for (PartialPath device : devicePaths) {
       String deviceId = device.getFullPath();
-      long endTime = tsFileResource.getEndTime(deviceId);
       if (!tsFileResource.getDevices().contains(deviceId)) {
         // resource does not contain this device
         continue;
       }
 
-      if (deleteEnd >= tsFileResource.getStartTime(deviceId) && deleteStart <= endTime) {
+      if (deleteEnd >= tsFileResource.getStartTime(deviceId)
+          && deleteStart <= tsFileResource.getEndTime(deviceId)) {
         // time range of device has overlap with the deletion
         return false;
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -42,6 +42,7 @@ import org.apache.iotdb.tsfile.fileSystem.fsFactory.FSFactory;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.FilePathUtils;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -825,7 +826,7 @@ public class TsFileResource {
     if (planIndex < minPlanIndex || planIndex > maxPlanIndex) {
       maxPlanIndex = Math.max(maxPlanIndex, planIndex);
       minPlanIndex = Math.min(minPlanIndex, planIndex);
-      if (isClosed()) {
+      if (closed) {
         try {
           serialize();
         } catch (IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -42,7 +42,6 @@ import org.apache.iotdb.tsfile.fileSystem.fsFactory.FSFactory;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.FilePathUtils;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -823,17 +822,19 @@ public class TsFileResource {
     if (planIndex == Long.MIN_VALUE || planIndex == Long.MAX_VALUE) {
       return;
     }
-    maxPlanIndex = Math.max(maxPlanIndex, planIndex);
-    minPlanIndex = Math.min(minPlanIndex, planIndex);
-    if (closed) {
-      try {
-        serialize();
-      } catch (IOException e) {
-        LOGGER.error(
-            "Cannot serialize TsFileResource {} when updating plan index {}-{}",
-            this,
-            maxPlanIndex,
-            planIndex);
+    if (planIndex < minPlanIndex || planIndex > maxPlanIndex) {
+      maxPlanIndex = Math.max(maxPlanIndex, planIndex);
+      minPlanIndex = Math.min(minPlanIndex, planIndex);
+      if (isClosed()) {
+        try {
+          serialize();
+        } catch (IOException e) {
+          LOGGER.error(
+              "Cannot serialize TsFileResource {} when updating plan index {}-{}",
+              this,
+              maxPlanIndex,
+              planIndex);
+        }
       }
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
@@ -49,6 +49,7 @@ import org.apache.iotdb.tsfile.read.reader.IPointReader;
 import org.apache.iotdb.tsfile.write.record.TSRecord;
 import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -867,13 +868,6 @@ public class StorageGroupProcessorTest {
       } else {
         Assert.assertFalse(resource.getModFile().exists());
       }
-    }
-
-    StorageEngine.getInstance().deleteStorageGroup(new PartialPath(storageGroup));
-    Thread.sleep(500);
-
-    for (TsFileResource resource : processor.getSequenceFileTreeSet()) {
-      Assert.assertFalse(resource.getTsFile().exists());
     }
   }
 


### PR DESCRIPTION
**Description**

The resource file will be reserialized every time data is deleted
When there is no device corresponding to the timeseries to be deleted in the tsfile, there will still be mods records.

**Solution**
Reserialize resource file only when `planIndex` is less then `minPlanIndex` or larger then `maxPlanIndex`.
When the device of the timeseries to be deleted is not in the tsfile, skip it and do not add mods to it.