### PR TITLE
[IOTDB-3787] Multi-leader consensus follower's wal accumulates

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/client/DispatchLogHandler.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/client/DispatchLogHandler.java
@@ -57,6 +57,8 @@ public class DispatchLogHandler implements AsyncMethodCallback<TSyncLogRes> {
       sleepCorrespondingTimeAndRetryAsynchronous();
     } else {
       thread.getSyncStatus().removeBatch(batch);
+      // update safely deleted search index after current sync index is updated by removeBatch
+      thread.updateSafelyDeletedSearchIndex();
     }
   }
 

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/IndexController.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/IndexController.java
@@ -54,17 +54,6 @@ public class IndexController {
     restore();
   }
 
-  public long incrementAndGet() {
-    try {
-      lock.writeLock().lock();
-      currentIndex++;
-      checkPersist();
-      return currentIndex;
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
   public long updateAndGet(long index) {
     try {
       lock.writeLock().lock();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
@@ -201,10 +201,6 @@ public class LogDispatcher {
           syncStatus.addNextBatch(batch);
           // sends batch asynchronously and migrates the retry logic into the callback handler
           sendBatchAsync(batch, new DispatchLogHandler(this, batch));
-          // update safely deleted search index to delete outdated info,
-          // indicating that insert nodes whose search index are before this value can be deleted
-          // safely
-          reader.setSafelyDeletedSearchIndex(impl.getCurrentSafelyDeletedSearchIndex());
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -212,6 +208,13 @@ public class LogDispatcher {
         logger.error("Unexpected error in logDispatcher for peer {}", peer, e);
       }
       logger.info("{}: Dispatcher for {} exits", impl.getThisNode(), peer);
+    }
+
+    public void updateSafelyDeletedSearchIndex() {
+      // update safely deleted search index to delete outdated info,
+      // indicating that insert nodes whose search index are before this value can be deleted
+      // safely
+      reader.setSafelyDeletedSearchIndex(impl.getCurrentSafelyDeletedSearchIndex());
     }
 
     public PendingBatch getBatch() {


### PR DESCRIPTION
Fix this problem by updating safely deleted search index after current sync index is updated by removeBatch.