### PR TITLE
[IOTDB-3795] Remove setting read-only when handling compaction exception

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionExceptionHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionExceptionHandler.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.db.engine.compaction.task;
 
 import org.apache.iotdb.db.conf.IoTDBConstant;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.CompactionUtils;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
@@ -239,7 +238,6 @@ public class CompactionExceptionHandler {
             fullStorageGroupName,
             targetResource,
             lostSourceResources);
-        IoTDBDescriptor.getInstance().getConfig().setReadOnly(true);
         return false;
       }
     }


### PR DESCRIPTION
See [IOTDB-3795](https://issues.apache.org/jira/browse/IOTDB-3795)