### PR TITLE
[IOTDB-3795] Remove setting read-only when handling compaction exception

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionExceptionHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionExceptionHandler.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.db.engine.compaction;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
@@ -235,7 +234,6 @@ public class CompactionExceptionHandler {
             fullStorageGroupName,
             targetResource,
             lostSourceResources);
-        IoTDBDescriptor.getInstance().getConfig().setReadOnly(true);
         return false;
       }
     }


### PR DESCRIPTION
See [IOTDB-3795](https://issues.apache.org/jira/browse/IOTDB-3795)