### PR TITLE
Add more log to the cancellation operation of FragmentInstanceStateTracker

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FixedRateFragInsStateTracker.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FixedRateFragInsStateTracker.java
@@ -43,9 +43,13 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
 
   private static final Logger logger = LoggerFactory.getLogger(FixedRateFragInsStateTracker.class);
 
+  private static final long SAME_STATE_PRINT_RATE_IN_MS = 10 * 60 * 1000;
+
   // TODO: (xingtanzjr) consider how much Interval is OK for state tracker
   private static final long STATE_FETCH_INTERVAL_IN_MS = 500;
   private ScheduledFuture<?> trackTask;
+  private FragmentInstanceState lastState;
+  private long durationToLastPrintInMS;
 
   public FixedRateFragInsStateTracker(
       QueryStateMachine stateMachine,
@@ -69,8 +73,15 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
 
   @Override
   public void abort() {
+    logger.info("start to abort state tracker");
     if (trackTask != null) {
-      trackTask.cancel(true);
+      logger.info("start to cancel fixed rate tracking task");
+      boolean cancelResult = trackTask.cancel(true);
+      if (!cancelResult) {
+        logger.error("cancel state tracking task failed. {}", trackTask.isCancelled());
+      } else {
+        logger.info("cancellation succeeds");
+      }
     }
   }
 
@@ -78,7 +89,13 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
     for (FragmentInstance instance : instances) {
       try (SetThreadName threadName = new SetThreadName(instance.getId().getFullId())) {
         FragmentInstanceState state = fetchState(instance);
-        logger.info("State is {}", state);
+        if (needPrintState(lastState, state, durationToLastPrintInMS)) {
+          logger.info("State is {}", state);
+          lastState = state;
+          durationToLastPrintInMS = 0;
+        } else {
+          durationToLastPrintInMS += STATE_FETCH_INTERVAL_IN_MS;
+        }
 
         if (state != null) {
           stateMachine.updateFragInstanceState(instance.getId(), state);
@@ -88,5 +105,13 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
         logger.error("error happened while fetching query state", e);
       }
     }
+  }
+
+  private boolean needPrintState(
+      FragmentInstanceState previous, FragmentInstanceState current, long durationToLastPrintInMS) {
+    if (current != previous) {
+      return true;
+    }
+    return durationToLastPrintInMS >= SAME_STATE_PRINT_RATE_IN_MS;
   }
 }


### PR DESCRIPTION
## Description
During our test, we found that sometimes the FragmentInstanceStateTracker may won't be cancelled successfully after the QueryExecution finishing. And it would print lots of logs such as `State is NO_SUCH_INSTANCE`

We investigated this issue and found that the `cancel()` of FixedRateScheduleTask may failed due to some unknown reason. We have some replacement implementation here but we want to find the root cause of the cancel failure.

So we add more logs here currently and will investigate more once it appears next time.