### PR TITLE
Take memTableMap into account for memory control

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -74,12 +74,7 @@ public abstract class AbstractMemTable implements IMemTable {
   /** DeviceId -> chunkGroup(MeasurementId -> chunk) */
   private final Map<IDeviceID, IWritableMemChunkGroup> memTableMap;
 
-  /**
-   * Parameters for slightly small estimate to control memory of {@link #memTableMap}, if consider
-   * {@link RamUsageEstimator} as accurate one.
-   *
-   * <p>todo: implement reflection to be more accurate
-   */
+  /** Parameters for quick estimating increment of {@link #memTableMap} */
   private static final long WRITABLE_CHUNK_GROUP_SHALLOW_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(WritableMemChunkGroup.class);
 
@@ -89,8 +84,12 @@ public abstract class AbstractMemTable implements IMemTable {
       RamUsageEstimator.shallowSizeOfInstance(WritableMemChunk.class);
   private static final long ALIGNED_CHUNK_SHALLOW_SIZE =
       RamUsageEstimator.shallowSizeOf(AlignedWritableMemChunk.class);
-  private static final long MAP_ENTRY_SIZE = 40L;
+
+  /** Shallow size of map and entry based on {@link HashMap}, todo better accuracy by reflection */
   private static final long MAP_BASE_SIZE = 128L;
+
+  private static final long MAP_ENTRY_SIZE = 40L;
+
   private static final long INTEGER_SIZE = 16L;
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -601,7 +601,7 @@ public abstract class AbstractMemTable implements IMemTable {
   }
 
   @Override
-  public boolean ifChunkGroupExist(IDeviceID deviceID) {
+  public boolean isChunkGroupExist(IDeviceID deviceID) {
     return null != memTableMap.get(deviceID);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
@@ -84,6 +84,15 @@ public interface IMemTable extends WALEntryValue {
   /** only used when mem control enabled */
   long getTVListsRamCost();
 
+  /** only used when mem control enabled */
+  void addMemTableMapRamCost(long cost);
+
+  /** only used when mem control enabled */
+  void releaseMemTableMapRamCost(long cost);
+
+  /** only used when mem control enabled */
+  long getMemTableMapRamCost();
+
   /**
    * only used when mem control enabled
    *
@@ -167,6 +176,9 @@ public interface IMemTable extends WALEntryValue {
 
   /** must guarantee the device exists in the work memtable only used when mem control enabled */
   boolean checkIfChunkDoesNotExist(IDeviceID deviceId, String measurement);
+
+  /** assist to estimate increment of map of memTable */
+  boolean ifChunkGroupExist(IDeviceID deviceID);
 
   /** only used when mem control enabled */
   long getCurrentTVListSize(IDeviceID deviceId, String measurement);

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
@@ -178,7 +178,7 @@ public interface IMemTable extends WALEntryValue {
   boolean checkIfChunkDoesNotExist(IDeviceID deviceId, String measurement);
 
   /** assist to estimate increment of map of memTable */
-  boolean ifChunkGroupExist(IDeviceID deviceID);
+  boolean isChunkGroupExist(IDeviceID deviceID);
 
   /** only used when mem control enabled */
   long getCurrentTVListSize(IDeviceID deviceId, String measurement);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -539,7 +539,7 @@ public class TsFileProcessor {
       throw new WriteProcessException(e);
     }
 
-    if (!workMemTable.ifChunkGroupExist(deviceID)) {
+    if (!workMemTable.isChunkGroupExist(deviceID)) {
       memTableMapIncrement += AbstractMemTable.calculateMemTableMapIncrement(deviceID);
     }
 
@@ -657,7 +657,7 @@ public class TsFileProcessor {
       throw new WriteProcessException(e);
     }
 
-    if (!workMemTable.ifChunkGroupExist(deviceID)) {
+    if (!workMemTable.isChunkGroupExist(deviceID)) {
       memIncrements[3] += AbstractMemTable.calculateMemTableMapIncrement(deviceID);
     }
 
@@ -698,7 +698,7 @@ public class TsFileProcessor {
       throw new WriteProcessException(e);
     }
 
-    if (!workMemTable.ifChunkGroupExist(deviceID)) {
+    if (!workMemTable.isChunkGroupExist(deviceID)) {
       memIncrements[3] +=
           AbstractMemTable.calculateAlignedMemTableMapIncrement(deviceID, measurements);
     }

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.engine.MetadataManagerHelper;
 import org.apache.iotdb.db.engine.memtable.AlignedWritableMemChunk;
 import org.apache.iotdb.db.engine.memtable.IMemTable;
-import org.apache.iotdb.db.engine.memtable.WritableMemChunkGroup;
 import org.apache.iotdb.db.engine.querycontext.ReadOnlyMemChunk;
 import org.apache.iotdb.db.exception.TsFileProcessorException;
 import org.apache.iotdb.db.exception.WriteProcessException;
@@ -354,9 +353,6 @@ public class TsFileProcessorTest {
         memTable.getMemTableMapRamCost());
 
     // try to compare with accurate value, assert within 0.85 accuracy
-    java.lang.reflect.Field memChunkMap =
-        WritableMemChunkGroup.class.getDeclaredField("memChunkMap");
-    memChunkMap.setAccessible(true);
     AtomicLong actualRamCost = new AtomicLong(0);
     actualRamCost.addAndGet(128); // map base size
     memTable.getMemTableMap().entrySet().stream()

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
@@ -66,8 +66,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TsFileProcessorTest {
 


### PR DESCRIPTION
When `memory_control` for memTables enabled, memory overhead of `memTableMap` might be non-negligible if there is a massive amount measurement. 

This PR take the `memTableMap` into accont while controling amount memory overhead, help to deal with situation of massive measurements.