### PR TITLE
[IoTDB-3674] Fix the issue that TransformNode is not considered in ExchangeNodeAddr

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/ExchangeNodeAdder.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/ExchangeNodeAdder.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.LastQueryMergeNode
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MultiChildNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggregationNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TimeJoinNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TransformNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedLastQueryScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedSeriesAggregationScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedSeriesScanNode;
@@ -210,6 +211,11 @@ public class ExchangeNodeAdder extends PlanVisitor<PlanNode, NodeGroupContext> {
   @Override
   public PlanNode visitGroupByLevel(GroupByLevelNode node, NodeGroupContext context) {
     return processMultiChildNode(node, context);
+  }
+
+  @Override
+  public PlanNode visitTransform(TransformNode node, NodeGroupContext context) {
+    return processOneChildNode(node, context);
   }
 
   private PlanNode processMultiChildNode(MultiChildNode node, NodeGroupContext context) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/process/TransformNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/process/TransformNode.java
@@ -168,6 +168,11 @@ public class TransformNode extends ProcessNode {
   }
 
   @Override
+  public String toString() {
+    return "TransformNode-" + this.getPlanNodeId();
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;


### PR DESCRIPTION
## Description
The TransformNode is not considered in ExchangeNodeAddr, which will lead to some planning error if the plan contains TransformNode and will be distributed in several regions.

See the test here:
<img width="570" alt="image" src="https://user-images.githubusercontent.com/18027703/178678445-be5c61db-f99f-40fa-9724-b6e7bbd967cd.png">
