### PR TITLE
[IOTDB-3778] Use SeriesScanUtil in compaction for point reader

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
@@ -29,6 +29,8 @@ import org.apache.iotdb.db.engine.compaction.cross.rewrite.task.ReadPointPerform
 import org.apache.iotdb.db.engine.compaction.inner.utils.MultiTsFileDeviceIterator;
 import org.apache.iotdb.db.engine.compaction.performer.ICrossCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.performer.IUnseqCompactionPerformer;
+import org.apache.iotdb.db.engine.compaction.reader.IDataBlockReader;
+import org.apache.iotdb.db.engine.compaction.reader.SeriesDataBlockReader;
 import org.apache.iotdb.db.engine.compaction.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.writer.AbstractCompactionWriter;
 import org.apache.iotdb.db.engine.compaction.writer.CrossSpaceCompactionWriter;
@@ -39,19 +41,19 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.metadata.path.AlignedPath;
 import org.apache.iotdb.db.metadata.path.MeasurementPath;
-import org.apache.iotdb.db.query.context.QueryContext;
+import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
-import org.apache.iotdb.db.query.reader.series.SeriesRawDataBatchReader;
 import org.apache.iotdb.db.utils.QueryUtils;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
-import org.apache.iotdb.tsfile.read.common.BatchData;
 import org.apache.iotdb.tsfile.read.common.Chunk;
-import org.apache.iotdb.tsfile.read.reader.IBatchReader;
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.read.reader.IPointReader;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
@@ -106,7 +108,8 @@ public class ReadPointCompactionPerformer
   public void perform()
       throws IOException, MetadataException, StorageEngineException, InterruptedException {
     long queryId = QueryResourceManager.getInstance().assignCompactionQueryId();
-    QueryContext queryContext = new QueryContext(queryId);
+    FragmentInstanceContext fragmentInstanceContext =
+        FragmentInstanceContext.createFragmentInstanceContextForCompaction(queryId);
     QueryDataSource queryDataSource = new QueryDataSource(seqFiles, unseqFiles);
     QueryResourceManager.getInstance()
         .getQueryFileManager()
@@ -126,10 +129,10 @@ public class ReadPointCompactionPerformer
 
         if (isAligned) {
           compactAlignedSeries(
-              device, deviceIterator, compactionWriter, queryContext, queryDataSource);
+              device, deviceIterator, compactionWriter, fragmentInstanceContext, queryDataSource);
         } else {
           compactNonAlignedSeries(
-              device, deviceIterator, compactionWriter, queryContext, queryDataSource);
+              device, deviceIterator, compactionWriter, fragmentInstanceContext, queryDataSource);
         }
       }
 
@@ -156,7 +159,7 @@ public class ReadPointCompactionPerformer
       String device,
       MultiTsFileDeviceIterator deviceIterator,
       AbstractCompactionWriter compactionWriter,
-      QueryContext queryContext,
+      FragmentInstanceContext fragmentInstanceContext,
       QueryDataSource queryDataSource)
       throws IOException, MetadataException {
     MultiTsFileDeviceIterator.AlignedMeasurementIterator alignedMeasurementIterator =
@@ -171,21 +174,21 @@ public class ReadPointCompactionPerformer
         measurementSchemas.stream()
             .map(IMeasurementSchema::getMeasurementId)
             .collect(Collectors.toList());
-    IBatchReader dataBatchReader =
+    IDataBlockReader dataBlockReader =
         constructReader(
             device,
             existedMeasurements,
             measurementSchemas,
             allMeasurements,
-            queryContext,
+            fragmentInstanceContext,
             queryDataSource,
             true);
 
-    if (dataBatchReader.hasNextBatch()) {
+    if (dataBlockReader.hasNextBatch()) {
       // chunkgroup is serialized only when at least one timeseries under this device has data
       compactionWriter.startChunkGroup(device, true);
       compactionWriter.startMeasurement(measurementSchemas, 0);
-      writeWithReader(compactionWriter, dataBatchReader, 0);
+      writeWithReader(compactionWriter, dataBlockReader, 0, true);
       compactionWriter.endMeasurement(0);
       compactionWriter.endChunkGroup();
     }
@@ -195,7 +198,7 @@ public class ReadPointCompactionPerformer
       String device,
       MultiTsFileDeviceIterator deviceIterator,
       AbstractCompactionWriter compactionWriter,
-      QueryContext queryContext,
+      FragmentInstanceContext fragmentInstanceContext,
       QueryDataSource queryDataSource)
       throws IOException, InterruptedException, IllegalPathException {
     MultiTsFileDeviceIterator.MeasurementIterator measurementIterator =
@@ -224,7 +227,7 @@ public class ReadPointCompactionPerformer
                   new ReadPointPerformerSubTask(
                       device,
                       measurementsForEachSubTask[i],
-                      queryContext,
+                      fragmentInstanceContext,
                       queryDataSource,
                       compactionWriter,
                       schemaMap,
@@ -341,12 +344,12 @@ public class ReadPointCompactionPerformer
    * @param measurementIds if device is aligned, then measurementIds contain all measurements. If
    *     device is not aligned, then measurementIds only contain one measurement.
    */
-  public static IBatchReader constructReader(
+  public static IDataBlockReader constructReader(
       String deviceId,
       List<String> measurementIds,
       List<IMeasurementSchema> measurementSchemas,
       Set<String> allSensors,
-      QueryContext queryContext,
+      FragmentInstanceContext fragmentInstanceContext,
       QueryDataSource queryDataSource,
       boolean isAlign)
       throws IllegalPathException {
@@ -359,17 +362,33 @@ public class ReadPointCompactionPerformer
       seriesPath = new MeasurementPath(deviceId, measurementIds.get(0), measurementSchemas.get(0));
       tsDataType = measurementSchemas.get(0).getType();
     }
-    return new SeriesRawDataBatchReader(
-        seriesPath, allSensors, tsDataType, queryContext, queryDataSource, null, null, null, true);
+    return new SeriesDataBlockReader(
+        seriesPath,
+        allSensors,
+        tsDataType,
+        fragmentInstanceContext,
+        queryDataSource,
+        null,
+        null,
+        true);
   }
 
   public static void writeWithReader(
-      AbstractCompactionWriter writer, IBatchReader reader, int subTaskId) throws IOException {
+      AbstractCompactionWriter writer, IDataBlockReader reader, int subTaskId, boolean isAligned)
+      throws IOException {
     while (reader.hasNextBatch()) {
-      BatchData batchData = reader.nextBatch();
-      while (batchData.hasCurrent()) {
-        writer.write(batchData.currentTime(), batchData.currentValue(), subTaskId);
-        batchData.next();
+      TsBlock tsBlock = reader.nextBatch();
+      //      TsBlock.TsBlockSingleColumnIterator tsBlockIterator =
+      // tsBlock.getTsBlockSingleColumnIterator();
+      IPointReader pointReader;
+      if (isAligned) {
+        pointReader = tsBlock.getTsBlockAlignedRowIterator();
+      } else {
+        pointReader = tsBlock.getTsBlockSingleColumnIterator();
+      }
+      while (!pointReader.hasNextTimeValuePair()) {
+        TimeValuePair timeValuePair = pointReader.nextTimeValuePair();
+        writer.write(timeValuePair.getTimestamp(), timeValuePair.getValue(), subTaskId);
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
@@ -363,14 +363,7 @@ public class ReadPointCompactionPerformer
       tsDataType = measurementSchemas.get(0).getType();
     }
     return new SeriesDataBlockReader(
-        seriesPath,
-        allSensors,
-        tsDataType,
-        fragmentInstanceContext,
-        queryDataSource,
-        null,
-        null,
-        true);
+        seriesPath, allSensors, tsDataType, fragmentInstanceContext, queryDataSource, true);
   }
 
   public static void writeWithReader(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
@@ -378,17 +378,15 @@ public class ReadPointCompactionPerformer
       throws IOException {
     while (reader.hasNextBatch()) {
       TsBlock tsBlock = reader.nextBatch();
-      //      TsBlock.TsBlockSingleColumnIterator tsBlockIterator =
-      // tsBlock.getTsBlockSingleColumnIterator();
       IPointReader pointReader;
       if (isAligned) {
         pointReader = tsBlock.getTsBlockAlignedRowIterator();
       } else {
         pointReader = tsBlock.getTsBlockSingleColumnIterator();
       }
-      while (!pointReader.hasNextTimeValuePair()) {
+      while (pointReader.hasNextTimeValuePair()) {
         TimeValuePair timeValuePair = pointReader.nextTimeValuePair();
-        writer.write(timeValuePair.getTimestamp(), timeValuePair.getValue(), subTaskId);
+        writer.write(timeValuePair.getTimestamp(), timeValuePair.getValue().getValue(), subTaskId);
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/reader/IDataBlockReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/reader/IDataBlockReader.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.engine.compaction.reader;
+
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+
+import java.io.IOException;
+
+public interface IDataBlockReader {
+  boolean hasNextBatch() throws IOException;
+
+  TsBlock nextBatch() throws IOException;
+
+  void close() throws IOException;
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/reader/SeriesDataBlockReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/reader/SeriesDataBlockReader.java
@@ -23,12 +23,12 @@ import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.metadata.path.AlignedPath;
+import org.apache.iotdb.db.metadata.path.MeasurementPath;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext;
 import org.apache.iotdb.db.mpp.execution.operator.source.AlignedSeriesScanUtil;
 import org.apache.iotdb.db.mpp.execution.operator.source.SeriesScanUtil;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
-import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -49,17 +49,15 @@ public class SeriesDataBlockReader implements IDataBlockReader {
       TSDataType dataType,
       FragmentInstanceContext context,
       QueryDataSource dataSource,
-      Filter timeFilter,
-      Filter valueFilter,
       boolean ascending) {
     if (seriesPath instanceof AlignedPath) {
       this.seriesScanUtil =
-          new AlignedSeriesScanUtil(
-              seriesPath, allSensors, context, timeFilter, valueFilter, ascending);
-    } else {
+          new AlignedSeriesScanUtil(seriesPath, allSensors, context, null, null, ascending);
+    } else if (seriesPath instanceof MeasurementPath) {
       this.seriesScanUtil =
-          new SeriesScanUtil(
-              seriesPath, allSensors, dataType, context, timeFilter, valueFilter, ascending);
+          new SeriesScanUtil(seriesPath, allSensors, dataType, context, null, null, ascending);
+    } else {
+      throw new IllegalArgumentException("Should call exact sub class!");
     }
     this.seriesScanUtil.initQueryDataSource(dataSource);
   }
@@ -71,19 +69,15 @@ public class SeriesDataBlockReader implements IDataBlockReader {
       FragmentInstanceContext context,
       List<TsFileResource> seqFileResource,
       List<TsFileResource> unseqFileResource,
-      Filter timeFilter,
-      Filter valueFilter,
       boolean ascending) {
     Set<String> allSensors = new HashSet<>();
     if (seriesPath instanceof AlignedPath) {
       this.seriesScanUtil =
-          new AlignedSeriesScanUtil(
-              seriesPath, allSensors, context, timeFilter, valueFilter, ascending);
+          new AlignedSeriesScanUtil(seriesPath, allSensors, context, null, null, ascending);
     } else {
       allSensors.add(seriesPath.getMeasurement());
       this.seriesScanUtil =
-          new SeriesScanUtil(
-              seriesPath, allSensors, dataType, context, timeFilter, valueFilter, ascending);
+          new SeriesScanUtil(seriesPath, allSensors, dataType, context, null, null, ascending);
     }
     seriesScanUtil.initQueryDataSource(seqFileResource, unseqFileResource);
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/reader/SeriesDataBlockReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/reader/SeriesDataBlockReader.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.engine.compaction.reader;
+
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
+import org.apache.iotdb.db.metadata.path.AlignedPath;
+import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext;
+import org.apache.iotdb.db.mpp.execution.operator.source.AlignedSeriesScanUtil;
+import org.apache.iotdb.db.mpp.execution.operator.source.SeriesScanUtil;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.read.filter.basic.Filter;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class SeriesDataBlockReader implements IDataBlockReader {
+
+  private final SeriesScanUtil seriesScanUtil;
+
+  private TsBlock tsBlock;
+
+  private boolean hasCachedBatchData = false;
+
+  public SeriesDataBlockReader(
+      PartialPath seriesPath,
+      Set<String> allSensors,
+      TSDataType dataType,
+      FragmentInstanceContext context,
+      QueryDataSource dataSource,
+      Filter timeFilter,
+      Filter valueFilter,
+      boolean ascending) {
+    if (seriesPath instanceof AlignedPath) {
+      this.seriesScanUtil =
+          new AlignedSeriesScanUtil(
+              seriesPath, allSensors, context, timeFilter, valueFilter, ascending);
+    } else {
+      this.seriesScanUtil =
+          new SeriesScanUtil(
+              seriesPath, allSensors, dataType, context, timeFilter, valueFilter, ascending);
+    }
+    this.seriesScanUtil.initQueryDataSource(dataSource);
+  }
+
+  @Override
+  public boolean hasNextBatch() throws IOException {
+
+    if (hasCachedBatchData) {
+      return true;
+    }
+
+    /*
+     * consume page data firstly
+     */
+    if (readPageData()) {
+      hasCachedBatchData = true;
+      return true;
+    }
+
+    /*
+     * consume chunk data secondly
+     */
+    if (readChunkData()) {
+      hasCachedBatchData = true;
+      return true;
+    }
+
+    /*
+     * consume next file finally
+     */
+    while (seriesScanUtil.hasNextFile()) {
+      if (readChunkData()) {
+        hasCachedBatchData = true;
+        return true;
+      }
+    }
+    return hasCachedBatchData;
+  }
+
+  @Override
+  public TsBlock nextBatch() throws IOException {
+    if (hasCachedBatchData || hasNextBatch()) {
+      hasCachedBatchData = false;
+      return tsBlock;
+    }
+    throw new IOException("no next block");
+  }
+
+  @Override
+  public void close() throws IOException {
+    // no resources need to close
+  }
+
+  private boolean readChunkData() throws IOException {
+    while (seriesScanUtil.hasNextChunk()) {
+      if (readPageData()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean readPageData() throws IOException {
+    while (seriesScanUtil.hasNextPage()) {
+      tsBlock = seriesScanUtil.nextPage();
+      if (!isEmpty(tsBlock)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isEmpty(TsBlock tsBlock) {
+    return tsBlock == null || tsBlock.isEmpty();
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceContext.java
@@ -72,11 +72,22 @@ public class FragmentInstanceContext extends QueryContext {
     return instanceContext;
   }
 
+  public static FragmentInstanceContext createFragmentInstanceContextForCompaction(long queryId) {
+    return new FragmentInstanceContext(queryId);
+  }
+
   private FragmentInstanceContext(
       FragmentInstanceId id, FragmentInstanceStateMachine stateMachine) {
     this.id = id;
     this.stateMachine = stateMachine;
     this.executionEndTime.set(END_TIME_INITIAL_VALUE);
+  }
+
+  // used for compaction
+  private FragmentInstanceContext(long queryId) {
+    this.queryId = queryId;
+    this.id = null;
+    this.stateMachine = null;
   }
 
   public void start() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanUtil.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanUtil.java
@@ -401,9 +401,8 @@ public class SeriesScanUtil {
    * overlapped pages are consumed
    */
   @SuppressWarnings("squid:S3776")
-  public
   // Suppress high Cognitive Complexity warning
-  boolean hasNextPage() throws IOException {
+  public boolean hasNextPage() throws IOException {
 
     /*
      * has overlapped data before

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanUtil.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanUtil.java
@@ -175,7 +175,7 @@ public class SeriesScanUtil {
     return !(hasNextPage() || hasNextChunk() || hasNextFile());
   }
 
-  boolean hasNextFile() throws IOException {
+  public boolean hasNextFile() throws IOException {
 
     if (!unSeqPageReaders.isEmpty()
         || firstPageReader != null
@@ -255,7 +255,7 @@ public class SeriesScanUtil {
    * This method should be called after hasNextFile() until no next chunk, make sure that all
    * overlapped chunks are consumed
    */
-  boolean hasNextChunk() throws IOException {
+  public boolean hasNextChunk() throws IOException {
 
     if (!unSeqPageReaders.isEmpty()
         || firstPageReader != null
@@ -392,6 +392,7 @@ public class SeriesScanUtil {
    * overlapped pages are consumed
    */
   @SuppressWarnings("squid:S3776")
+  public
   // Suppress high Cognitive Complexity warning
   boolean hasNextPage() throws IOException {
 
@@ -622,7 +623,7 @@ public class SeriesScanUtil {
   }
 
   /** This method should only be used when the method isPageOverlapped() return true. */
-  TsBlock nextPage() throws IOException {
+  public TsBlock nextPage() throws IOException {
 
     if (hasCachedNextOverlappedPage) {
       hasCachedNextOverlappedPage = false;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanUtil.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanUtil.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.mpp.execution.operator.source;
 
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.metadata.idtable.IDTable;
@@ -160,6 +161,14 @@ public class SeriesScanUtil {
   public void initQueryDataSource(QueryDataSource dataSource) {
     QueryUtils.fillOrderIndexes(dataSource, seriesPath.getDevice(), orderUtils.getAscending());
     this.dataSource = dataSource;
+    orderUtils.setCurSeqFileIndex(dataSource);
+  }
+
+  @TestOnly
+  public void initQueryDataSource(
+      List<TsFileResource> seqFileResource, List<TsFileResource> unseqFileResource) {
+    dataSource = new QueryDataSource(seqFileResource, unseqFileResource);
+    QueryUtils.fillOrderIndexes(dataSource, seriesPath.getDevice(), orderUtils.getAscending());
     orderUtils.setCurSeqFileIndex(dataSource);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/context/QueryContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/context/QueryContext.java
@@ -48,7 +48,7 @@ public class QueryContext {
    */
   private final Map<String, List<Modification>> fileModCache = new HashMap<>();
 
-  private long queryId;
+  protected long queryId;
 
   private long queryTimeLowerBound = Long.MIN_VALUE;
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointCompactionPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointCompactionPerformerTest.java
@@ -109,8 +109,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             seqResources,
             unseqResources,
-            null,
-            null,
             true);
     int count = 0;
     while (tsBlockReader.hasNextBatch()) {
@@ -142,8 +140,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             targetResources,
             new ArrayList<>(),
-            null,
-            null,
             true);
 
     count = 0;
@@ -192,8 +188,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -260,8 +254,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -313,8 +305,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -354,8 +344,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -407,8 +395,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -467,8 +453,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -554,8 +538,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -609,8 +591,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -686,8 +666,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -741,8 +719,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -820,8 +796,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -859,8 +833,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -904,8 +876,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
 
         int count = 0;
@@ -951,8 +921,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1008,8 +976,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1066,8 +1032,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1133,8 +1097,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1191,8 +1153,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 false);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1259,8 +1219,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1322,8 +1280,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1434,8 +1390,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1502,8 +1456,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1598,8 +1550,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1663,8 +1613,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1730,8 +1678,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1776,8 +1722,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -1828,8 +1772,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             seqResources,
             unseqResources,
-            null,
-            null,
             true);
     int count = 0;
     while (tsBlockReader.hasNextBatch()) {
@@ -1865,8 +1807,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             targetResources,
             new ArrayList<>(),
-            null,
-            null,
             true);
     count = 0;
     while (tsBlockReader.hasNextBatch()) {
@@ -1928,8 +1868,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2025,8 +1963,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2127,8 +2063,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2225,8 +2159,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2329,8 +2261,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2421,8 +2351,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2523,8 +2451,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2598,8 +2524,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2692,8 +2616,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2804,8 +2726,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -2889,8 +2809,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             seqResources,
             unseqResources,
-            null,
-            null,
             true);
     int count = 0;
     while (tsBlockReader.hasNextBatch()) {
@@ -2929,8 +2847,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             targetResources,
             new ArrayList<>(),
-            null,
-            null,
             true);
     count = 0;
     while (tsBlockReader.hasNextBatch()) {
@@ -3000,8 +2916,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -3074,8 +2988,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -3202,8 +3114,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -3310,8 +3220,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -3444,8 +3352,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -3523,8 +3429,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -3661,8 +3565,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -3740,8 +3642,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                     EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
-                null,
-                null,
                 true);
         int count = 0;
         while (tsBlockReader.hasNextBatch()) {
@@ -3928,8 +3828,6 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                       EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                   targetResources,
                   new ArrayList<>(),
-                  null,
-                  null,
                   true);
           int count = 0;
           while (tsBlockReader.hasNextBatch()) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointCompactionPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointCompactionPerformerTest.java
@@ -24,14 +24,16 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.performer.impl.ReadPointCompactionPerformer;
+import org.apache.iotdb.db.engine.compaction.reader.IDataBlockReader;
+import org.apache.iotdb.db.engine.compaction.reader.SeriesDataBlockReader;
 import org.apache.iotdb.db.engine.compaction.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.metadata.path.AlignedPath;
 import org.apache.iotdb.db.metadata.path.MeasurementPath;
+import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext;
 import org.apache.iotdb.db.query.control.FileReaderManager;
-import org.apache.iotdb.db.query.reader.series.SeriesRawDataBatchReader;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
@@ -41,8 +43,8 @@ import org.apache.iotdb.tsfile.file.header.ChunkGroupHeader;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
-import org.apache.iotdb.tsfile.read.common.BatchData;
-import org.apache.iotdb.tsfile.read.reader.IBatchReader;
+import org.apache.iotdb.tsfile.read.common.IBatchDataIterator;
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.TsFileGeneratorUtils;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
@@ -99,26 +101,29 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
             COMPACTION_TEST_SG + PATH_SEPARATOR + "d1",
             "s1",
             new MeasurementSchema("s1", TSDataType.INT64));
-    IBatchReader tsFilesReader =
-        new SeriesRawDataBatchReader(
+    IDataBlockReader tsBlockReader =
+        new SeriesDataBlockReader(
             path,
             TSDataType.INT64,
-            EnvironmentUtils.TEST_QUERY_CONTEXT,
+            FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             seqResources,
             unseqResources,
             null,
             null,
             true);
     int count = 0;
-    while (tsFilesReader.hasNextBatch()) {
-      BatchData batchData = tsFilesReader.nextBatch();
-      while (batchData.hasCurrent()) {
-        assertEquals(batchData.currentTime(), batchData.currentValue());
+    while (tsBlockReader.hasNextBatch()) {
+      TsBlock block = tsBlockReader.nextBatch();
+      IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+      while (iterator.hasNext()) {
+        assertEquals(iterator.currentTime(), iterator.currentValue());
         count++;
-        batchData.next();
+        iterator.next();
       }
     }
-    tsFilesReader.close();
+
+    tsBlockReader.close();
     assertEquals(500, count);
 
     List<TsFileResource> targetResources =
@@ -129,26 +134,30 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
     performer.perform();
     CompactionUtils.moveTargetFile(targetResources, true, COMPACTION_TEST_SG);
 
-    tsFilesReader =
-        new SeriesRawDataBatchReader(
+    tsBlockReader =
+        new SeriesDataBlockReader(
             path,
             TSDataType.INT64,
-            EnvironmentUtils.TEST_QUERY_CONTEXT,
+            FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             targetResources,
             new ArrayList<>(),
             null,
             null,
             true);
+
     count = 0;
-    while (tsFilesReader.hasNextBatch()) {
-      BatchData batchData = tsFilesReader.nextBatch();
-      while (batchData.hasCurrent()) {
-        assertEquals(batchData.currentTime(), batchData.currentValue());
+    while (tsBlockReader.hasNextBatch()) {
+      TsBlock block = tsBlockReader.nextBatch();
+      IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+      while (iterator.hasNext()) {
+        assertEquals(iterator.currentTime(), iterator.currentValue());
         count++;
-        batchData.next();
+        iterator.next();
       }
     }
-    tsFilesReader.close();
+
+    tsBlockReader.close();
     assertEquals(500, count);
   }
 
@@ -175,30 +184,33 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() >= 600) {
-              assertEquals(batchData.currentTime() + 200, batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() >= 600) {
+              assertEquals(iterator.currentTime() + 200, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+
+        tsBlockReader.close();
         if (i < 2 && j < 3) {
           assertEquals(400, count);
         } else if (i < 3) {
@@ -240,30 +252,33 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() >= 600) {
-              assertEquals(batchData.currentTime() + 200, batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() >= 600) {
+              assertEquals(iterator.currentTime() + 200, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < 2 && j < 3) {
           assertEquals(400, count);
         } else if (i < 3 && j < 5) {
@@ -290,26 +305,28 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s1",
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            assertEquals(batchData.currentTime(), batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            assertEquals(iterator.currentTime(), iterator.currentValue());
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         assertEquals(500, count);
       }
     }
@@ -329,26 +346,28 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s1",
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            assertEquals(batchData.currentTime(), batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            assertEquals(iterator.currentTime(), iterator.currentValue());
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         assertEquals(500, count);
       }
     }
@@ -380,34 +399,36 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if ((100 <= batchData.currentTime() && batchData.currentTime() < 170)
-                || (270 <= batchData.currentTime() && batchData.currentTime() < 340)) {
-              assertEquals(batchData.currentTime() + 200, batchData.currentValue());
-            } else if ((200 <= batchData.currentTime() && batchData.currentTime() < 270)
-                || (370 <= batchData.currentTime() && batchData.currentTime() < 440)) {
-              assertEquals(batchData.currentTime() + 100, batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            if ((100 <= iterator.currentTime() && iterator.currentTime() < 170)
+                || (270 <= iterator.currentTime() && iterator.currentTime() < 340)) {
+              assertEquals(iterator.currentTime() + 200, iterator.currentValue());
+            } else if ((200 <= iterator.currentTime() && iterator.currentTime() < 270)
+                || (370 <= iterator.currentTime() && iterator.currentTime() < 440)) {
+              assertEquals(iterator.currentTime() + 100, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < 2 && j < 3) {
           assertEquals(410, count);
         } else if (i < 3 && j < 5) {
@@ -437,34 +458,37 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if ((100 <= batchData.currentTime() && batchData.currentTime() < 170)
-                || (270 <= batchData.currentTime() && batchData.currentTime() < 340)) {
-              assertEquals(batchData.currentTime() + 200, batchData.currentValue());
-            } else if ((200 <= batchData.currentTime() && batchData.currentTime() < 270)
-                || (370 <= batchData.currentTime() && batchData.currentTime() < 440)) {
-              assertEquals(batchData.currentTime() + 100, batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            if ((100 <= iterator.currentTime() && iterator.currentTime() < 170)
+                || (270 <= iterator.currentTime() && iterator.currentTime() < 340)) {
+              assertEquals(iterator.currentTime() + 200, iterator.currentValue());
+            } else if ((200 <= iterator.currentTime() && iterator.currentTime() < 270)
+                || (370 <= iterator.currentTime() && iterator.currentTime() < 440)) {
+              assertEquals(iterator.currentTime() + 100, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < 2 && j < 3) {
           assertEquals(410, count);
         } else if (i < 3 && j < 5) {
@@ -522,33 +546,35 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
-            } else if (batchData.currentTime() < 850) {
-              assertEquals(batchData.currentTime() + 100, batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
+              assertEquals(iterator.currentTime(), iterator.currentValue());
+            } else if (iterator.currentTime() < 850) {
+              assertEquals(iterator.currentTime() + 100, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime() + 200, batchData.currentValue());
+              assertEquals(iterator.currentTime() + 200, iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if ((i == 0 && j == 0) || (i == 0 && j == 1) || (i == 2 && j == 4) || (i == 3 && j == 5)) {
           assertEquals(0, count);
         } else if (i < 2 && j < 3) {
@@ -575,33 +601,35 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
-            } else if (batchData.currentTime() < 850) {
-              assertEquals(batchData.currentTime() + 100, batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
+              assertEquals(iterator.currentTime(), iterator.currentValue());
+            } else if (iterator.currentTime() < 850) {
+              assertEquals(iterator.currentTime() + 100, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime() + 200, batchData.currentValue());
+              assertEquals(iterator.currentTime() + 200, iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if ((i == 0 && j == 0) || (i == 0 && j == 1) || (i == 2 && j == 4) || (i == 3 && j == 5)) {
           assertEquals(0, count);
         } else if (i < 2 && j < 3) {
@@ -650,33 +678,35 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
-            } else if (batchData.currentTime() < 850) {
-              assertEquals(batchData.currentTime() + 100, batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
+              assertEquals(iterator.currentTime(), iterator.currentValue());
+            } else if (iterator.currentTime() < 850) {
+              assertEquals(iterator.currentTime() + 100, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime() + 200, batchData.currentValue());
+              assertEquals(iterator.currentTime() + 200, iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0) {
           assertEquals(0, count);
         } else if (i < 2 && j < 3) {
@@ -703,33 +733,35 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
-            } else if (batchData.currentTime() < 850) {
-              assertEquals(batchData.currentTime() + 100, batchData.currentValue());
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
+              assertEquals(iterator.currentTime(), iterator.currentValue());
+            } else if (iterator.currentTime() < 850) {
+              assertEquals(iterator.currentTime() + 100, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime() + 200, batchData.currentValue());
+              assertEquals(iterator.currentTime() + 200, iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0) {
           assertEquals(0, count);
         } else if (i < 2 && j < 3) {
@@ -780,25 +812,27 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         assertEquals(0, count);
       }
     }
@@ -817,25 +851,27 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         assertEquals(0, count);
       }
     }
@@ -860,28 +896,31 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
+
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             assertEquals(
-                batchData.currentTime(),
-                ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                iterator.currentTime(),
+                ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         assertEquals(500, count);
       }
     }
@@ -904,28 +943,30 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             assertEquals(
-                batchData.currentTime(),
-                ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                iterator.currentTime(),
+                ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         assertEquals(500, count);
       }
     }
@@ -959,34 +1000,36 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() >= 600) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() >= 600) {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
           assertEquals(400, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 5) {
@@ -1015,34 +1058,36 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() >= 600) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() >= 600) {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
           assertEquals(400, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 5) {
@@ -1080,34 +1125,36 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() >= 600) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() >= 600) {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
           assertEquals(400, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 5) {
@@ -1136,34 +1183,36 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 false);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() >= 600) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() >= 600) {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
           assertEquals(400, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 5) {
@@ -1202,39 +1251,41 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
-            } else if (batchData.currentTime() < 850) {
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
+            } else if (iterator.currentTime() < 850) {
               assertEquals(
-                  batchData.currentTime() + 100,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 100,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
           assertEquals(1450, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 5) {
@@ -1263,39 +1314,41 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
-            } else if (batchData.currentTime() < 850) {
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
+            } else if (iterator.currentTime() < 850) {
               assertEquals(
-                  batchData.currentTime() + 100,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 100,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
           assertEquals(1450, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 5) {
@@ -1373,39 +1426,41 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
-            } else if (batchData.currentTime() < 850) {
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
+            } else if (iterator.currentTime() < 850) {
               assertEquals(
-                  batchData.currentTime() + 100,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 100,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if ((i == TsFileGeneratorUtils.getAlignDeviceOffset() && j == 0)
             || (i == TsFileGeneratorUtils.getAlignDeviceOffset() && j == 1)
             || (i == TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j == 4)
@@ -1439,39 +1494,41 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
-            } else if (batchData.currentTime() < 850) {
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
+            } else if (iterator.currentTime() < 850) {
               assertEquals(
-                  batchData.currentTime() + 100,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 100,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if ((i == TsFileGeneratorUtils.getAlignDeviceOffset() && j == 0)
             || (i == TsFileGeneratorUtils.getAlignDeviceOffset() && j == 1)
             || (i == TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j == 4)
@@ -1533,39 +1590,41 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
-            } else if (batchData.currentTime() < 850) {
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
+            } else if (iterator.currentTime() < 850) {
               assertEquals(
-                  batchData.currentTime() + 100,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 100,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == TsFileGeneratorUtils.getAlignDeviceOffset()) {
           assertEquals(0, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
@@ -1596,39 +1655,41 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
-            if (batchData.currentTime() < 200
-                || (batchData.currentTime() < 550 && batchData.currentTime() >= 500)) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
+            if (iterator.currentTime() < 200
+                || (iterator.currentTime() < 550 && iterator.currentTime() >= 500)) {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
-            } else if (batchData.currentTime() < 850) {
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
+            } else if (iterator.currentTime() < 850) {
               assertEquals(
-                  batchData.currentTime() + 100,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 100,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime() + 200,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 200,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == TsFileGeneratorUtils.getAlignDeviceOffset()) {
           assertEquals(0, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
@@ -1661,28 +1722,30 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             assertEquals(
-                batchData.currentTime(),
-                ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                iterator.currentTime(),
+                ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         assertEquals(500, count);
       }
     }
@@ -1705,28 +1768,30 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 new ArrayList<>(),
                 targetResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             assertEquals(
-                batchData.currentTime(),
-                ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                iterator.currentTime(),
+                ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         assertEquals(500, count);
       }
     }
@@ -1755,31 +1820,33 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
             COMPACTION_TEST_SG + PATH_SEPARATOR + "d1",
             "s1",
             new MeasurementSchema("s1", TSDataType.INT64));
-    IBatchReader tsFilesReader =
-        new SeriesRawDataBatchReader(
+    IDataBlockReader tsBlockReader =
+        new SeriesDataBlockReader(
             path,
             TSDataType.INT64,
-            EnvironmentUtils.TEST_QUERY_CONTEXT,
+            FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             seqResources,
             unseqResources,
             null,
             null,
             true);
     int count = 0;
-    while (tsFilesReader.hasNextBatch()) {
-      BatchData batchData = tsFilesReader.nextBatch();
-      while (batchData.hasCurrent()) {
-        if (batchData.currentTime() % 100 < 50) {
-          assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+    while (tsBlockReader.hasNextBatch()) {
+      TsBlock block = tsBlockReader.nextBatch();
+      IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+      while (iterator.hasNext()) {
+        if (iterator.currentTime() % 100 < 50) {
+          assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
         } else {
-          assertEquals(batchData.currentTime(), batchData.currentValue());
+          assertEquals(iterator.currentTime(), iterator.currentValue());
         }
 
         count++;
-        batchData.next();
+        iterator.next();
       }
     }
-    tsFilesReader.close();
+    tsBlockReader.close();
     assertEquals(500, count);
 
     List<TsFileResource> targetResources =
@@ -1790,31 +1857,33 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
     performer.perform();
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
-    tsFilesReader =
-        new SeriesRawDataBatchReader(
+    tsBlockReader =
+        new SeriesDataBlockReader(
             path,
             TSDataType.INT64,
-            EnvironmentUtils.TEST_QUERY_CONTEXT,
+            FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             targetResources,
             new ArrayList<>(),
             null,
             null,
             true);
     count = 0;
-    while (tsFilesReader.hasNextBatch()) {
-      BatchData batchData = tsFilesReader.nextBatch();
-      while (batchData.hasCurrent()) {
-        if (batchData.currentTime() % 100 < 50) {
-          assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+    while (tsBlockReader.hasNextBatch()) {
+      TsBlock block = tsBlockReader.nextBatch();
+      IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+      while (iterator.hasNext()) {
+        if (iterator.currentTime() % 100 < 50) {
+          assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
         } else {
-          assertEquals(batchData.currentTime(), batchData.currentValue());
+          assertEquals(iterator.currentTime(), iterator.currentValue());
         }
 
         count++;
-        batchData.next();
+        iterator.next();
       }
     }
-    tsFilesReader.close();
+    tsBlockReader.close();
     assertEquals(500, count);
   }
 
@@ -1851,37 +1920,39 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < 2 && j < 3) {
           assertEquals(1280, count);
         } else if (i < 1 && j < 4) {
@@ -1946,45 +2017,47 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (measurementMaxTime.get(
                     COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j)
-                >= batchData.currentTime()) {
+                >= iterator.currentTime()) {
               Assert.fail();
             }
             measurementMaxTime.put(
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
-                batchData.currentTime());
+                iterator.currentTime());
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < 2 && j < 3) {
           assertEquals(1280, count);
         } else if (i < 1 && j < 4) {
@@ -2046,37 +2119,39 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if ((i == 0 && j == 0) || (i == 0 && j == 1) || (i == 2 && j == 4) || (i == 3 && j == 4)) {
           assertEquals(0, count);
         } else if (i < 2 && j < 3) {
@@ -2142,45 +2217,47 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (measurementMaxTime.get(
                     COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j)
-                >= batchData.currentTime()) {
+                >= iterator.currentTime()) {
               Assert.fail();
             }
             measurementMaxTime.put(
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
-                batchData.currentTime());
+                iterator.currentTime());
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if ((i == 0 && j == 0) || (i == 0 && j == 1) || (i == 2 && j == 4) || (i == 3 && j == 4)) {
           assertEquals(0, count);
         } else if (i < 2 && j < 3) {
@@ -2244,37 +2321,39 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0 || i == 2) {
           assertEquals(0, count);
         } else if (i < 2 && j < 3) {
@@ -2334,45 +2413,47 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (measurementMaxTime.get(
                     COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j)
-                >= batchData.currentTime()) {
+                >= iterator.currentTime()) {
               Assert.fail();
             }
             measurementMaxTime.put(
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
-                batchData.currentTime());
+                iterator.currentTime());
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0 || i == 2) {
           assertEquals(0, count);
         } else if (i < 2 && j < 3) {
@@ -2434,37 +2515,39 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0 || i == 1 || i == 2) {
           assertEquals(0, count);
         } else {
@@ -2507,45 +2590,47 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (measurementMaxTime.get(
                     COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j)
-                >= batchData.currentTime()) {
+                >= iterator.currentTime()) {
               Assert.fail();
             }
             measurementMaxTime.put(
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
-                batchData.currentTime());
+                iterator.currentTime());
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0 || i == 1 || i == 2) {
           assertEquals(0, count);
         } else {
@@ -2599,37 +2684,39 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < 1) {
           if (j < 4) {
             assertEquals(630, count);
@@ -2709,45 +2796,47 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 "s" + j,
                 new MeasurementSchema("s" + j, TSDataType.INT64));
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.INT64,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
             if (measurementMaxTime.get(
                     COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j)
-                >= batchData.currentTime()) {
+                >= iterator.currentTime()) {
               Assert.fail();
             }
             measurementMaxTime.put(
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
-                batchData.currentTime());
+                iterator.currentTime());
             if (i == 0
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
-              assertEquals(batchData.currentTime() + 20000, batchData.currentValue());
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
             } else if ((i < 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
-              assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
             } else {
-              assertEquals(batchData.currentTime(), batchData.currentValue());
+              assertEquals(iterator.currentTime(), iterator.currentValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < 1) {
           if (j < 4) {
             assertEquals(630, count);
@@ -2792,34 +2881,36 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
             COMPACTION_TEST_SG + PATH_SEPARATOR + "d10000",
             Collections.singletonList("s1"),
             schemas);
-    IBatchReader tsFilesReader =
-        new SeriesRawDataBatchReader(
+    IDataBlockReader tsBlockReader =
+        new SeriesDataBlockReader(
             path,
             TSDataType.VECTOR,
-            EnvironmentUtils.TEST_QUERY_CONTEXT,
+            FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             seqResources,
             unseqResources,
             null,
             null,
             true);
     int count = 0;
-    while (tsFilesReader.hasNextBatch()) {
-      BatchData batchData = tsFilesReader.nextBatch();
-      while (batchData.hasCurrent()) {
-        if (batchData.currentTime() % 100 < 50) {
+    while (tsBlockReader.hasNextBatch()) {
+      TsBlock block = tsBlockReader.nextBatch();
+      IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+      while (iterator.hasNext()) {
+        if (iterator.currentTime() % 100 < 50) {
           assertEquals(
-              batchData.currentTime() + 10000,
-              ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+              iterator.currentTime() + 10000,
+              ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
         } else {
           assertEquals(
-              batchData.currentTime(),
-              ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+              iterator.currentTime(),
+              ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
         }
         count++;
-        batchData.next();
+        iterator.next();
       }
     }
-    tsFilesReader.close();
+    tsBlockReader.close();
     assertEquals(500, count);
 
     List<TsFileResource> targetResources =
@@ -2830,35 +2921,37 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
     performer.perform();
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
-    tsFilesReader =
-        new SeriesRawDataBatchReader(
+    tsBlockReader =
+        new SeriesDataBlockReader(
             path,
             TSDataType.INT64,
-            EnvironmentUtils.TEST_QUERY_CONTEXT,
+            FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
             targetResources,
             new ArrayList<>(),
             null,
             null,
             true);
     count = 0;
-    while (tsFilesReader.hasNextBatch()) {
-      BatchData batchData = tsFilesReader.nextBatch();
-      while (batchData.hasCurrent()) {
-        if (batchData.currentTime() % 100 < 50) {
+    while (tsBlockReader.hasNextBatch()) {
+      TsBlock block = tsBlockReader.nextBatch();
+      IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+      while (iterator.hasNext()) {
+        if (iterator.currentTime() % 100 < 50) {
           assertEquals(
-              batchData.currentTime() + 10000,
-              ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+              iterator.currentTime() + 10000,
+              ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
         } else {
           assertEquals(
-              batchData.currentTime(),
-              ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+              iterator.currentTime(),
+              ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
         }
 
         count++;
-        batchData.next();
+        iterator.next();
       }
     }
-    tsFilesReader.close();
+    tsBlockReader.close();
     assertEquals(500, count);
   }
 
@@ -2899,43 +2992,45 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
               assertEquals(
-                  batchData.currentTime() + 20000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
               assertEquals(
-                  batchData.currentTime() + 10000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
           assertEquals(1280, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 1 && j < 4) {
@@ -2971,43 +3066,45 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
               assertEquals(
-                  batchData.currentTime() + 20000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
               assertEquals(
-                  batchData.currentTime() + 10000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j < 3) {
           assertEquals(1280, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 1 && j < 4) {
@@ -3097,43 +3194,45 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
               assertEquals(
-                  batchData.currentTime() + 20000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
               assertEquals(
-                  batchData.currentTime() + 10000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if ((i == TsFileGeneratorUtils.getAlignDeviceOffset() && j == 0)
             || (i == TsFileGeneratorUtils.getAlignDeviceOffset() && j == 1)
             || (i == TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j == 4)
@@ -3203,43 +3302,45 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
               assertEquals(
-                  batchData.currentTime() + 20000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
               assertEquals(
-                  batchData.currentTime() + 10000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if ((i == TsFileGeneratorUtils.getAlignDeviceOffset() && j == 0)
             || (i == TsFileGeneratorUtils.getAlignDeviceOffset() && j == 1)
             || (i == TsFileGeneratorUtils.getAlignDeviceOffset() + 2 && j == 4)
@@ -3335,43 +3436,45 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
               assertEquals(
-                  batchData.currentTime() + 20000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
               assertEquals(
-                  batchData.currentTime() + 10000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0 || i == 1 || i == 2) {
           assertEquals(0, count);
         }
@@ -3412,43 +3515,45 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
               assertEquals(
-                  batchData.currentTime() + 20000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
               assertEquals(
-                  batchData.currentTime() + 10000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0 || i == 1 || i == 2) {
           assertEquals(0, count);
         }
@@ -3548,43 +3653,45 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 seqResources,
                 unseqResources,
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
               assertEquals(
-                  batchData.currentTime() + 20000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
               assertEquals(
-                  batchData.currentTime() + 10000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0 || i == 1 || i == 2) {
           assertEquals(0, count);
         }
@@ -3625,43 +3732,45 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                 COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                 Collections.singletonList("s" + j),
                 schemas);
-        IBatchReader tsFilesReader =
-            new SeriesRawDataBatchReader(
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
                 path,
                 TSDataType.VECTOR,
-                EnvironmentUtils.TEST_QUERY_CONTEXT,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                 targetResources,
                 new ArrayList<>(),
                 null,
                 null,
                 true);
         int count = 0;
-        while (tsFilesReader.hasNextBatch()) {
-          BatchData batchData = tsFilesReader.nextBatch();
-          while (batchData.hasCurrent()) {
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
+          while (iterator.hasNext()) {
             if (i == TsFileGeneratorUtils.getAlignDeviceOffset()
-                && ((450 <= batchData.currentTime() && batchData.currentTime() < 550)
-                    || (550 <= batchData.currentTime() && batchData.currentTime() < 650))) {
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
               assertEquals(
-                  batchData.currentTime() + 20000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 20000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else if ((i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4)
-                && ((20 <= batchData.currentTime() && batchData.currentTime() < 220)
-                    || (250 <= batchData.currentTime() && batchData.currentTime() < 450)
-                    || (480 <= batchData.currentTime() && batchData.currentTime() < 680))) {
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
               assertEquals(
-                  batchData.currentTime() + 10000,
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime() + 10000,
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             } else {
               assertEquals(
-                  batchData.currentTime(),
-                  ((TsPrimitiveType[]) (batchData.currentValue()))[0].getValue());
+                  iterator.currentTime(),
+                  ((TsPrimitiveType[]) (iterator.currentValue()))[0].getValue());
             }
             count++;
-            batchData.next();
+            iterator.next();
           }
         }
-        tsFilesReader.close();
+        tsBlockReader.close();
         if (i == 0 || i == 1 || i == 2) {
           assertEquals(0, count);
         }
@@ -3811,30 +3920,32 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
                   COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
                   "s" + j,
                   new MeasurementSchema("s" + j, TSDataType.INT64));
-          IBatchReader tsFilesReader =
-              new SeriesRawDataBatchReader(
+          IDataBlockReader tsBlockReader =
+              new SeriesDataBlockReader(
                   path,
                   TSDataType.INT64,
-                  EnvironmentUtils.TEST_QUERY_CONTEXT,
+                  FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                      EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
                   targetResources,
                   new ArrayList<>(),
                   null,
                   null,
                   true);
           int count = 0;
-          while (tsFilesReader.hasNextBatch()) {
-            BatchData batchData = tsFilesReader.nextBatch();
-            while (batchData.hasCurrent()) {
-              if (batchData.currentTime() < 20) {
-                assertEquals(batchData.currentTime(), batchData.currentValue());
+          while (tsBlockReader.hasNextBatch()) {
+            TsBlock block = tsBlockReader.nextBatch();
+            IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+            while (iterator.hasNext()) {
+              if (iterator.currentTime() < 20) {
+                assertEquals(iterator.currentTime(), iterator.currentValue());
               } else {
-                assertEquals(batchData.currentTime() + 10000, batchData.currentValue());
+                assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
               }
               count++;
-              batchData.next();
+              iterator.next();
             }
           }
-          tsFilesReader.close();
+          tsBlockReader.close();
           if (i < 2 && j < 3) {
             assertEquals(920, count);
           } else {


### PR DESCRIPTION
In new MPP query framework, we create a new scan util called SeriesScanUtil and the old SeriesReader will be removed together with old standalone IoTDB.
However, current compaction still depends on the SeriesReader, we need to change it to depend on SeriesScanUtil instead.