### PR TITLE
[IOTDB-3823] Optimize leader routing policy

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/heartbeat/RegionGroupCache.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/heartbeat/RegionGroupCache.java
@@ -68,6 +68,7 @@ public class RegionGroupCache implements IRegionGroupCache {
   public boolean updateLoadStatistic() {
     long updateVersion = Long.MIN_VALUE;
     int updateLeaderDataNodeId = -1;
+    int originLeaderDataNodeId = leaderDataNodeId.get();
 
     synchronized (slidingWindow) {
       for (LinkedList<RegionHeartbeatSample> samples : slidingWindow.values()) {
@@ -82,11 +83,12 @@ public class RegionGroupCache implements IRegionGroupCache {
     }
 
     if (updateVersion > versionTimestamp.get()) {
+      // Only update when the leadership information is latest
       versionTimestamp.set(updateVersion);
       leaderDataNodeId.set(updateLeaderDataNodeId);
-      return true;
     }
-    return false;
+
+    return !(originLeaderDataNodeId == leaderDataNodeId.get());
   }
 
   @Override


### PR DESCRIPTION
Now the leader policy will broadcast RegionRouteMap only if the leadership has changed. However, if we use MultiLeader protocol, the ConfigNode-leader still broadcast RegionRouteMap continually since each Region always takes of itself as the leader.