### PR TITLE
Add weak read consistency policy for MPP

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/MPPQueryContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/MPPQueryContext.java
@@ -76,4 +76,8 @@ public class MPPQueryContext {
   public TEndPoint getLocalInternalEndpoint() {
     return localInternalEndpoint;
   }
+
+  public SessionInfo getSession() {
+    return session;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/SessionInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/SessionInfo.java
@@ -18,9 +18,26 @@
  */
 package org.apache.iotdb.db.mpp.common;
 
-import java.time.ZoneId;
-
 public class SessionInfo {
-  private String userName;
-  private ZoneId zoneId;
+  private final long sessionId;
+  private final String userName;
+  private final String zoneId;
+
+  public SessionInfo(long sessionId, String userName, String zoneId) {
+    this.sessionId = sessionId;
+    this.userName = userName;
+    this.zoneId = zoneId;
+  }
+
+  public long getSessionId() {
+    return sessionId;
+  }
+
+  public String getUserName() {
+    return userName;
+  }
+
+  public String getZoneId() {
+    return zoneId;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
@@ -18,7 +18,9 @@
  */
 package org.apache.iotdb.db.mpp.plan.planner.distribution;
 
+import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.mpp.common.MPPQueryContext;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.plan.analyze.Analysis;
@@ -100,9 +102,35 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
     // redirected
     // to another host when scheduling
     fragmentInstance.setDataRegionAndHost(regionReplicaSet);
+    fragmentInstance.setHostDataNode(selectTargetDataNode(regionReplicaSet));
+
     fragmentInstance.getFragment().setTypeProvider(analysis.getTypeProvider());
     instanceMap.putIfAbsent(fragment.getId(), fragmentInstance);
     fragmentInstanceList.add(fragmentInstance);
+  }
+
+  private TDataNodeLocation selectTargetDataNode(TRegionReplicaSet regionReplicaSet) {
+    if (regionReplicaSet == null
+        || regionReplicaSet.getDataNodeLocations() == null
+        || regionReplicaSet.getDataNodeLocations().size() == 0) {
+      throw new IllegalArgumentException(
+          String.format("regionReplicaSet is invalid: %s", regionReplicaSet));
+    }
+    String readConsistencyLevel =
+        IoTDBDescriptor.getInstance().getConfig().getReadConsistencyLevel();
+    // TODO: (Chen Rongzhao) need to make the values of ReadConsistencyLevel as static variable or
+    // enums
+    boolean selectRandomDataNode = "weak".equals(readConsistencyLevel);
+    int targetIndex;
+    if (!selectRandomDataNode) {
+      targetIndex = 0;
+    } else {
+      targetIndex =
+          (int)
+              (queryContext.getSession().getSessionId()
+                  % regionReplicaSet.getDataNodeLocationsSize());
+    }
+    return regionReplicaSet.getDataNodeLocations().get(targetIndex);
   }
 
   private void calculateNodeTopologyBetweenInstance() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
@@ -122,7 +122,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
     // enums
     boolean selectRandomDataNode = "weak".equals(readConsistencyLevel);
     int targetIndex;
-    if (!selectRandomDataNode) {
+    if (!selectRandomDataNode || queryContext.getSession() == null) {
       targetIndex = 0;
     } else {
       targetIndex =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/FragmentInstance.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/FragmentInstance.java
@@ -87,6 +87,12 @@ public class FragmentInstance implements IConsensusRequest {
     }
   }
 
+  // Although the HostDataNode is set in method setDataRegionAndHost(),
+  // we still keep another method for customized needs
+  public void setHostDataNode(TDataNodeLocation hostDataNode) {
+    this.hostDataNode = hostDataNode;
+  }
+
   public TRegionReplicaSet getRegionReplicaSet() {
     return regionReplicaSet;
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
@@ -229,6 +229,7 @@ public class SessionManager {
     sessionIdToUsername.put(sessionId, username);
     sessionIdToZoneId.put(sessionId, ZoneId.of(zoneId));
     sessionIdToClientVersion.put(sessionId, clientVersion);
+    sessionIdToSessionInfo.put(sessionId, new SessionInfo(sessionId, username, zoneId));
 
     return sessionId;
   }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/QueryPlannerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/QueryPlannerTest.java
@@ -74,7 +74,7 @@ public class QueryPlannerTest {
             new MPPQueryContext(
                 querySql,
                 new QueryId("query1"),
-                new SessionInfo(),
+                new SessionInfo(1L, "fakeUsername", "fakeZoneId"),
                 new TEndPoint(),
                 new TEndPoint()),
             IoTDBThreadPoolFactory.newSingleThreadExecutor("test_query"),

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/scheduler/StandaloneSchedulerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/scheduler/StandaloneSchedulerTest.java
@@ -140,7 +140,11 @@ public class StandaloneSchedulerTest {
     configNode.getBelongedSchemaRegionIdWithAutoCreate(new PartialPath("root.ln.wf01.wt01.status"));
     MPPQueryContext context =
         new MPPQueryContext(
-            "", new QueryId("query1"), new SessionInfo(), new TEndPoint(), new TEndPoint());
+            "",
+            new QueryId("query1"),
+            new SessionInfo(1L, "fakeUsername", "fakeZoneId"),
+            new TEndPoint(),
+            new TEndPoint());
     ExecutorService executor = IoTDBThreadPoolFactory.newSingleThreadExecutor("Test");
     QueryStateMachine stateMachine = new QueryStateMachine(context.getQueryId(), executor);
 
@@ -239,7 +243,11 @@ public class StandaloneSchedulerTest {
     configNode.getBelongedSchemaRegionIdWithAutoCreate(new PartialPath("root.ln.wf01.GPS"));
     MPPQueryContext context =
         new MPPQueryContext(
-            "", new QueryId("query1"), new SessionInfo(), new TEndPoint(), new TEndPoint());
+            "",
+            new QueryId("query1"),
+            new SessionInfo(1L, "fakeUsername", "fakeZoneId"),
+            new TEndPoint(),
+            new TEndPoint());
     ExecutorService executor = IoTDBThreadPoolFactory.newSingleThreadExecutor("Test");
     QueryStateMachine stateMachine = new QueryStateMachine(context.getQueryId(), executor);
 
@@ -348,7 +356,11 @@ public class StandaloneSchedulerTest {
     configNode.getBelongedSchemaRegionIdWithAutoCreate(new PartialPath("root.ln.d3"));
     MPPQueryContext context =
         new MPPQueryContext(
-            "", new QueryId("query1"), new SessionInfo(), new TEndPoint(), new TEndPoint());
+            "",
+            new QueryId("query1"),
+            new SessionInfo(1L, "fakeUsername", "fakeZoneId"),
+            new TEndPoint(),
+            new TEndPoint());
     ExecutorService executor = IoTDBThreadPoolFactory.newSingleThreadExecutor("Test");
     QueryStateMachine stateMachine = new QueryStateMachine(context.getQueryId(), executor);
 
@@ -396,7 +408,11 @@ public class StandaloneSchedulerTest {
     configNode.getBelongedDataRegionIdWithAutoCreate(new PartialPath(deviceId));
     MPPQueryContext context =
         new MPPQueryContext(
-            "", new QueryId("query1"), new SessionInfo(), new TEndPoint(), new TEndPoint());
+            "",
+            new QueryId("query1"),
+            new SessionInfo(1L, "fakeUsername", "fakeZoneId"),
+            new TEndPoint(),
+            new TEndPoint());
     ExecutorService executor = IoTDBThreadPoolFactory.newSingleThreadExecutor("Test");
     QueryStateMachine stateMachine = new QueryStateMachine(context.getQueryId(), executor);
 
@@ -473,7 +489,11 @@ public class StandaloneSchedulerTest {
     configNode.getBelongedDataRegionIdWithAutoCreate(deviceId);
     MPPQueryContext context =
         new MPPQueryContext(
-            "", new QueryId("query1"), new SessionInfo(), new TEndPoint(), new TEndPoint());
+            "",
+            new QueryId("query1"),
+            new SessionInfo(1L, "fakeUsername", "fakeZoneId"),
+            new TEndPoint(),
+            new TEndPoint());
     ExecutorService executor = IoTDBThreadPoolFactory.newSingleThreadExecutor("Test");
     QueryStateMachine stateMachine = new QueryStateMachine(context.getQueryId(), executor);
 


### PR DESCRIPTION
## Description
Add weak consistency level read policy for MPP framework.
That is, the DataNode in one ConsensusGroup will be selected randomly in weak consistency level.

And on the other hand, we will try to keep the session consistency that the selected DataNode will be same for one Region from one session.

<img width="985" alt="image" src="https://user-images.githubusercontent.com/18027703/179219648-e903ecf2-c278-4f3a-944a-cfc65f716420.png">
