### PR TITLE
[IOTDB-3822]Fix cross compaction overlap bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -42,7 +42,6 @@ import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1887,7 +1886,8 @@ public class IoTDBConfig {
     return crossCompactionFileSelectionTimeBudget;
   }
 
-  void setCrossCompactionFileSelectionTimeBudget(long crossCompactionFileSelectionTimeBudget) {
+  public void setCrossCompactionFileSelectionTimeBudget(
+      long crossCompactionFileSelectionTimeBudget) {
     this.crossCompactionFileSelectionTimeBudget = crossCompactionFileSelectionTimeBudget;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -42,6 +42,7 @@ import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1886,8 +1887,7 @@ public class IoTDBConfig {
     return crossCompactionFileSelectionTimeBudget;
   }
 
-  public void setCrossCompactionFileSelectionTimeBudget(
-      long crossCompactionFileSelectionTimeBudget) {
+  void setCrossCompactionFileSelectionTimeBudget(long crossCompactionFileSelectionTimeBudget) {
     this.crossCompactionFileSelectionTimeBudget = crossCompactionFileSelectionTimeBudget;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
@@ -22,7 +22,7 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.constant.CrossCompactionSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.CrossSpaceCompactionResource;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceCompactionFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
@@ -222,7 +222,7 @@ public class CompactionUtils {
     }
   }
 
-  public static ICrossSpaceMergeFileSelector getCrossSpaceFileSelector(
+  public static ICrossSpaceCompactionFileSelector getCrossSpaceFileSelector(
       long budget, CrossSpaceCompactionResource resource) {
     CrossCompactionSelector strategy =
         IoTDBDescriptor.getInstance().getConfig().getCrossCompactionSelector();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
@@ -24,7 +24,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.cross.ICrossSpaceSelector;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceCompactionFileSelector;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.MergeException;
@@ -91,7 +91,7 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
     CrossSpaceCompactionResource compactionResource =
         new CrossSpaceCompactionResource(seqFileList, unSeqFileList, timeLowerBound);
 
-    ICrossSpaceMergeFileSelector fileSelector =
+    ICrossSpaceCompactionFileSelector fileSelector =
         CompactionUtils.getCrossSpaceFileSelector(budget, compactionResource);
     try {
       List[] mergeFiles = fileSelector.select();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/ICrossSpaceCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/ICrossSpaceCompactionFileSelector.java
@@ -27,7 +27,7 @@ import java.util.List;
  * IMergeFileSelector selects a set of files from given seqFiles and unseqFiles which can be merged
  * without exceeding given memory budget.
  */
-public interface ICrossSpaceMergeFileSelector {
+public interface ICrossSpaceCompactionFileSelector {
 
   List[] select() throws MergeException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -262,11 +262,10 @@ public class RewriteCompactionFileSelector implements ICrossSpaceCompactionFileS
         }
 
         long seqEndTime = seqFile.getEndTime(deviceId);
-        long seqStartTime = seqFile.getStartTime(deviceId);
         if (!seqFile.isClosed()) {
           // we cannot make sure whether unclosed file has overlap or not, so we just add it.
           tmpSelectedSeqFiles.add(i);
-        } else if (unseqEndTime < seqStartTime || unseqEndTime <= seqEndTime) {
+        } else if (unseqEndTime <= seqEndTime) {
           // if time range in unseq file is 10-20, seq file is 30-40, or
           // time range in unseq file is 10-20, seq file is 15-25, then select this seq file and
           // there is no more overlap later.

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.engine.compaction.cross.utils.AbstractCompactionEstim
 import org.apache.iotdb.db.engine.compaction.task.ICompactionSelector;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.MergeException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -262,19 +263,12 @@ public class RewriteCompactionFileSelector implements ICrossSpaceCompactionFileS
 
         long seqEndTime = seqFile.getEndTime(deviceId);
         long seqStartTime = seqFile.getStartTime(deviceId);
-        if (unseqEndTime < seqStartTime) {
-          // Suppose the time range in unseq file is 10-20, seq file is 30-40. If this unseq file
-          // has no overlapped seq files, then select this seq file. Otherwise, skip this seq file.
-          // There is no more overlap later.
-          // if (tmpSelectedSeqFiles.size() == 0) {
-          tmpSelectedSeqFiles.add(i);
-          // }
-          noMoreOverlap = true;
-        } else if (!seqFile.isClosed()) {
+        if (!seqFile.isClosed()) {
           // we cannot make sure whether unclosed file has overlap or not, so we just add it.
           tmpSelectedSeqFiles.add(i);
-        } else if (unseqEndTime <= seqEndTime) {
-          // if time range in unseq file is 10-20, seq file is 15-25, then select this seq file and
+        } else if (unseqEndTime < seqStartTime || unseqEndTime <= seqEndTime) {
+          // if time range in unseq file is 10-20, seq file is 30-40, or
+          // time range in unseq file is 10-20, seq file is 15-25, then select this seq file and
           // there is no more overlap later.
           tmpSelectedSeqFiles.add(i);
           noMoreOverlap = true;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -262,9 +262,12 @@ public class RewriteCompactionFileSelector implements ICrossSpaceCompactionFileS
         }
 
         long seqEndTime = seqFile.getEndTime(deviceId);
+        long seqStartTime = seqFile.getStartTime(deviceId);
         if (!seqFile.isClosed()) {
-          // we cannot make sure whether unclosed file has overlap or not, so we just add it.
-          tmpSelectedSeqFiles.add(i);
+          // for unclosed file, only select those that overlap with the unseq file
+          if (unseqEndTime >= seqStartTime) {
+            tmpSelectedSeqFiles.add(i);
+          }
         } else if (unseqEndTime <= seqEndTime) {
           // if time range in unseq file is 10-20, seq file is 30-40, or
           // time range in unseq file is 10-20, seq file is 15-25, then select this seq file and

--- a/server/src/main/java/org/apache/iotdb/db/tools/validate/TsFileValidationTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/validate/TsFileValidationTool.java
@@ -50,6 +50,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.PATH_SEPARATOR;
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
@@ -82,7 +84,7 @@ public class TsFileValidationTool {
   private static final Logger logger = LoggerFactory.getLogger(TsFileValidationTool.class);
   private static final List<File> seqDataDirList = new ArrayList<>();
   private static final List<File> fileList = new ArrayList<>();
-  private static int badFileNum = 0;
+  public static int badFileNum = 0;
 
   /**
    * The form of param is: [path of data dir or tsfile] [-pd = print details or not] [-f = path of
@@ -129,7 +131,7 @@ public class TsFileValidationTool {
           }
           // get time partition dirs and sort them
           List<File> timePartitionDirs =
-              Arrays.asList(Objects.requireNonNull(dataRegionDir.listFiles()));
+              Arrays.asList(Objects.requireNonNull(dataRegionDir.listFiles())).stream().filter(file -> Pattern.compile("[0-9]*").matcher(file.getName()).matches()).collect(Collectors.toList());
           timePartitionDirs.sort(
               (f1, f2) ->
                   Long.compareUnsigned(Long.parseLong(f1.getName()), Long.parseLong(f2.getName())));
@@ -162,7 +164,7 @@ public class TsFileValidationTool {
     }
   }
 
-  private static void findUncorrectFiles(List<File> tsFiles) {
+  public static void findUncorrectFiles(List<File> tsFiles) {
     // measurementID -> <fileName, [lastTime, endTimeInLastFile]>
     Map<String, Pair<String, long[]>> measurementLastTime = new HashMap<>();
     // deviceID -> <fileName, endTime>, the endTime of device in the last seq file
@@ -497,12 +499,19 @@ public class TsFileValidationTool {
         }
       } catch (Throwable e) {
         logger.error("Meet errors in reading file {} , skip it.", tsFile.getAbsolutePath(), e);
-        if (printDetails) {
-          printBoth(
-              "-- Meet errors in reading file "
-                  + tsFile.getAbsolutePath()
-                  + ", tsfile may be corrupted.");
+        if(!isBadFileMap.get(tsFile.getName())){
+          if (printDetails) {
+            printBoth(
+                    "-- Meet errors in reading file "
+                            + tsFile.getAbsolutePath()
+                            + ", tsfile may be corrupted.");
+          }else{
+            printBoth(tsFile.getAbsolutePath());
+          }
+          isBadFileMap.put(tsFile.getName(), true);
+          badFileNum++;
         }
+
       } finally {
         for (String msg : previousBadFileMsgs) {
           printBoth(msg);

--- a/server/src/main/java/org/apache/iotdb/db/tools/validate/TsFileValidationTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/validate/TsFileValidationTool.java
@@ -131,7 +131,9 @@ public class TsFileValidationTool {
           }
           // get time partition dirs and sort them
           List<File> timePartitionDirs =
-              Arrays.asList(Objects.requireNonNull(dataRegionDir.listFiles())).stream().filter(file -> Pattern.compile("[0-9]*").matcher(file.getName()).matches()).collect(Collectors.toList());
+              Arrays.asList(Objects.requireNonNull(dataRegionDir.listFiles())).stream()
+                  .filter(file -> Pattern.compile("[0-9]*").matcher(file.getName()).matches())
+                  .collect(Collectors.toList());
           timePartitionDirs.sort(
               (f1, f2) ->
                   Long.compareUnsigned(Long.parseLong(f1.getName()), Long.parseLong(f2.getName())));
@@ -499,13 +501,13 @@ public class TsFileValidationTool {
         }
       } catch (Throwable e) {
         logger.error("Meet errors in reading file {} , skip it.", tsFile.getAbsolutePath(), e);
-        if(!isBadFileMap.get(tsFile.getName())){
+        if (!isBadFileMap.get(tsFile.getName())) {
           if (printDetails) {
             printBoth(
-                    "-- Meet errors in reading file "
-                            + tsFile.getAbsolutePath()
-                            + ", tsfile may be corrupted.");
-          }else{
+                "-- Meet errors in reading file "
+                    + tsFile.getAbsolutePath()
+                    + ", tsfile may be corrupted.");
+          } else {
             printBoth(tsFile.getAbsolutePath());
           }
           isBadFileMap.put(tsFile.getName(), true);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -65,6 +65,9 @@ public class AbstractCompactionTest {
   private static final int oldPagePointSize =
       TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
 
+  private static final int oldMaxCrossCompactionFileNum =
+      IoTDBDescriptor.getInstance().getConfig().getMaxCrossCompactionCandidateFileNum();
+
   protected static File STORAGE_GROUP_DIR =
       new File(
           TestConstant.BASE_OUTPUT_PATH
@@ -260,6 +263,9 @@ public class AbstractCompactionTest {
     unseqResources.clear();
     IoTDB.configManager.clear();
     IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(oldTargetChunkSize);
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setMaxCrossCompactionCandidateFileNum(oldMaxCrossCompactionFileNum);
     TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(oldChunkGroupSize);
     TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(oldPagePointSize);
     EnvironmentUtils.cleanEnv();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTest.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.CrossSpaceCompactionResource;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceCompactionFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionCheckerUtils;
@@ -423,7 +423,7 @@ public class CrossSpaceCompactionTest {
           CrossSpaceCompactionResource mergeResource =
               new CrossSpaceCompactionResource(
                   seqTsFileResourceList, unseqTsFileResourceList, timeLowerBound);
-          ICrossSpaceMergeFileSelector fileSelector =
+          ICrossSpaceCompactionFileSelector fileSelector =
               new RewriteCompactionFileSelector(mergeResource, Long.MAX_VALUE);
           List[] mergeFiles = fileSelector.select();
           index++;
@@ -729,7 +729,7 @@ public class CrossSpaceCompactionTest {
           CrossSpaceCompactionResource mergeResource =
               new CrossSpaceCompactionResource(
                   seqTsFileResourceList, unseqTsFileResourceList, timeLowerBound);
-          ICrossSpaceMergeFileSelector fileSelector =
+          ICrossSpaceCompactionFileSelector fileSelector =
               new RewriteCompactionFileSelector(mergeResource, Long.MAX_VALUE);
           List[] mergeFiles = fileSelector.select();
           if (mergeFiles.length > 0) {
@@ -1033,7 +1033,7 @@ public class CrossSpaceCompactionTest {
           CrossSpaceCompactionResource mergeResource =
               new CrossSpaceCompactionResource(
                   seqTsFileResourceList, unseqTsFileResourceList, timeLowerBound);
-          ICrossSpaceMergeFileSelector fileSelector =
+          ICrossSpaceCompactionFileSelector fileSelector =
               new RewriteCompactionFileSelector(mergeResource, Long.MAX_VALUE);
           List[] mergeFiles = fileSelector.select();
           if (mergeFiles.length > 0) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
@@ -1,0 +1,269 @@
+package org.apache.iotdb.db.engine.compaction.cross;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.compaction.AbstractCompactionTest;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.CrossSpaceCompactionResource;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceCompactionFileSelector;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
+import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
+import org.apache.iotdb.db.exception.MergeException;
+import org.apache.iotdb.db.exception.StorageEngineException;
+import org.apache.iotdb.db.query.control.FileReaderManager;
+import org.apache.iotdb.db.tools.validate.TsFileValidationTool;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
+    TsFileManager tsFileManager=
+            new TsFileManager(COMPACTION_TEST_SG, "0", STORAGE_GROUP_DIR.getPath());
+
+    private final String oldThreadName = Thread.currentThread().getName();
+
+    @Before
+    public void setUp() throws IOException, WriteProcessException, MetadataException {
+        super.setUp();
+        IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(1024);
+        TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
+        Thread.currentThread().setName("pool-1-IoTDB-Compaction-1");
+        IoTDBDescriptor.getInstance().getConfig().setCrossCompactionFileSelectionTimeBudget(-1);
+    }
+
+    @After
+    public void tearDown() throws IOException, StorageEngineException {
+        super.tearDown();
+        Thread.currentThread().setName(oldThreadName);
+        FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
+    }
+
+    /**
+     * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
+     * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4200<br>
+     * Selected seq file index: 3<br>
+     * Selected unseq file index: 1, 2
+     */
+    @Test
+    public void test1() throws MetadataException, IOException, WriteProcessException, MergeException {
+        registerTimeseriesInMManger(5, 10, true);
+        createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
+        createFiles(2, 10, 10, 1000, 2100, 2100, 100, 100, true, false);
+        createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+        createFiles(1, 10, 10, 1000, 5300, 5300, 100, 100, true, true);
+        tsFileManager.addAll(seqResources,true);
+       tsFileManager.addAll(unseqResources,false);
+
+        CrossSpaceCompactionResource resource =
+                new CrossSpaceCompactionResource(seqResources, unseqResources);
+        ICrossSpaceCompactionFileSelector mergeFileSelector =
+                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+        List[] result = mergeFileSelector.select();
+        Assert.assertEquals(2,result.length);
+        Assert.assertEquals(2,result[0].size());
+        Assert.assertEquals(2,result[1].size());
+
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                result[0],
+                result[1],
+                IoTDBDescriptor.getInstance()
+                        .getConfig()
+                        .getCrossCompactionPerformer()
+                        .createInstance(),
+                new AtomicInteger(0),
+                tsFileManager.getNextCompactionTaskId()).doCompaction();
+
+        validateSeqFiles();
+
+    }
+
+    /**
+     * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
+     * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4700<br>
+     * Selected seq file index: 3<br>
+     * Selected unseq file index: 1, 2
+     */
+    @Test
+    public void test2() throws MetadataException, IOException, WriteProcessException, MergeException {
+        registerTimeseriesInMManger(5, 10, true);
+        createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
+        createFiles(1, 5, 10, 1000, 2100, 2100, 100, 100, true, false);
+        createFiles(1, 5, 10, 1500, 3200, 3200, 100, 100, true, false);
+        createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
+        tsFileManager.addAll(seqResources,true);
+        tsFileManager.addAll(unseqResources,false);
+
+        CrossSpaceCompactionResource resource =
+                new CrossSpaceCompactionResource(seqResources, unseqResources);
+        ICrossSpaceCompactionFileSelector mergeFileSelector =
+                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+        List[] result = mergeFileSelector.select();
+        Assert.assertEquals(2,result.length);
+        Assert.assertEquals(1,result[0].size());
+        Assert.assertEquals(2,result[1].size());
+
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                result[0],
+                result[1],
+                IoTDBDescriptor.getInstance()
+                        .getConfig()
+                        .getCrossCompactionPerformer()
+                        .createInstance(),
+                new AtomicInteger(0),
+                tsFileManager.getNextCompactionTaskId()).doCompaction();
+
+        validateSeqFiles();
+    }
+
+    /**
+     * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
+     * 4 Unseq files: 1500 ~ 2500, 1700 ~ 2000, 2400 ~ 3400, 3300 ~ 4500<br>
+     * Selected seq file index: 2, 3<br>
+     * Selected unseq file index: 1, 2, 3, 4
+     */
+    @Test
+    public void test3() throws MetadataException, IOException, WriteProcessException, MergeException {
+        registerTimeseriesInMManger(5, 10, true);
+        createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
+        createFiles(1, 5, 10, 1000, 1500, 1500, 100, 100, true, false);
+        createFiles(1, 5, 10, 300, 1700, 1700, 100, 100, true, false);
+        createFiles(1, 5, 10, 1000, 2400, 2400, 100, 100, true, false);
+        createFiles(1, 5, 10, 1200, 3300, 3300, 100, 100, true, false);
+        createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
+        tsFileManager.addAll(seqResources,true);
+        tsFileManager.addAll(unseqResources,false);
+
+        CrossSpaceCompactionResource resource =
+                new CrossSpaceCompactionResource(seqResources, unseqResources);
+        ICrossSpaceCompactionFileSelector mergeFileSelector =
+                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+        List[] result = mergeFileSelector.select();
+        Assert.assertEquals(2,result.length);
+        Assert.assertEquals(2,result[0].size());
+        Assert.assertEquals(4,result[1].size());
+
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                result[0],
+                result[1],
+                IoTDBDescriptor.getInstance()
+                        .getConfig()
+                        .getCrossCompactionPerformer()
+                        .createInstance(),
+                new AtomicInteger(0),
+                tsFileManager.getNextCompactionTaskId()).doCompaction();
+
+        validateSeqFiles();
+    }
+
+    /**
+     * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6500 ~ 7500<br>
+     * 5 Unseq files: 1500 ~ 2500, 1700 ~ 2000, 2400 ~ 3400, 3300 ~ 4500, 6301 ~ 7301<br>
+     * Notice: the last seq file is unsealed<br>
+     * Selected seq file index: 2, 3<br>
+     * Selected unseq file index: 1, 2, 3, 4
+     */
+    @Test
+    public void test4() throws MetadataException, IOException, WriteProcessException, MergeException {
+        registerTimeseriesInMManger(5, 10, true);
+        createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
+        createFiles(1, 5, 10, 1000, 1500, 1500, 100, 100, true, false);
+        createFiles(1, 5, 10, 300, 1700, 1700, 100, 100, true, false);
+        createFiles(1, 5, 10, 1000, 2400, 2400, 100, 100, true, false);
+        createFiles(1, 5, 10, 1200, 3300, 3300, 100, 100, true, false);
+        createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
+        createFiles(1, 5, 10, 1000, 6500, 6500, 100, 100, true, true);
+        createFiles(1, 5, 10, 1000, 6301, 6301, 100, 100, true, false);
+        seqResources.get(4).setStatus(TsFileResourceStatus.UNCLOSED);
+        tsFileManager.addAll(seqResources,true);
+        tsFileManager.addAll(unseqResources,false);
+
+        CrossSpaceCompactionResource resource =
+                new CrossSpaceCompactionResource(seqResources, unseqResources);
+        ICrossSpaceCompactionFileSelector mergeFileSelector =
+                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+        List[] result = mergeFileSelector.select();
+        Assert.assertEquals(2,result.length);
+        Assert.assertEquals(2,result[0].size());
+        Assert.assertEquals(4,result[1].size());
+
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                result[0],
+                result[1],
+                IoTDBDescriptor.getInstance()
+                        .getConfig()
+                        .getCrossCompactionPerformer()
+                        .createInstance(),
+                new AtomicInteger(0),
+                tsFileManager.getNextCompactionTaskId()).doCompaction();
+
+        validateSeqFiles();
+    }
+
+    /**
+     * 7 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400, 5500 ~ 6500, 6600 ~ 7600<br>
+     * 2 Unseq files: 2150 ~ 5450, 1150 ～ 5550<br>
+     * Selected seq file index: 2, 3, 4, 5, 6<br>
+     * Selected unseq file index: 1, 2
+     */
+    @Test
+    public void test5() throws MetadataException, IOException, WriteProcessException, MergeException {
+        registerTimeseriesInMManger(5, 10, true);
+        createFiles(7, 5, 10, 1000, 0, 0, 100, 100, true, true);
+        createFiles(1, 5, 10, 3300, 2150, 2150, 100, 100, true, false);
+        createFiles(1, 5, 10, 4400, 1150, 1150, 100, 100, true, false);
+
+        tsFileManager.addAll(seqResources,true);
+        tsFileManager.addAll(unseqResources,false);
+
+        CrossSpaceCompactionResource resource =
+                new CrossSpaceCompactionResource(seqResources, unseqResources);
+        ICrossSpaceCompactionFileSelector mergeFileSelector =
+                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+        List[] result = mergeFileSelector.select();
+        Assert.assertEquals(2,result.length);
+        Assert.assertEquals(5,result[0].size());
+        Assert.assertEquals(2,result[1].size());
+
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                result[0],
+                result[1],
+                IoTDBDescriptor.getInstance()
+                        .getConfig()
+                        .getCrossCompactionPerformer()
+                        .createInstance(),
+                new AtomicInteger(0),
+                tsFileManager.getNextCompactionTaskId()).doCompaction();
+
+        validateSeqFiles();
+    }
+
+    private void validateSeqFiles(){
+        List<File> files=new ArrayList<>();
+        for(TsFileResource resource:tsFileManager.getTsFileList(true)){
+            files.add(resource.getTsFile());
+        }
+        TsFileValidationTool.findUncorrectFiles(files);
+        Assert.assertEquals(0,TsFileValidationTool.badFileNum);
+    }
+
+}

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iotdb.db.engine.compaction.cross;
 
 import org.apache.iotdb.commons.exception.MetadataException;
@@ -15,6 +34,7 @@ import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.db.tools.validate.TsFileValidationTool;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,243 +47,1127 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
-    TsFileManager tsFileManager=
-            new TsFileManager(COMPACTION_TEST_SG, "0", STORAGE_GROUP_DIR.getPath());
+  TsFileManager tsFileManager =
+      new TsFileManager(COMPACTION_TEST_SG, "0", STORAGE_GROUP_DIR.getPath());
 
-    private final String oldThreadName = Thread.currentThread().getName();
+  private final String oldThreadName = Thread.currentThread().getName();
 
-    @Before
-    public void setUp() throws IOException, WriteProcessException, MetadataException {
-        super.setUp();
-        IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(1024);
-        TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
-        Thread.currentThread().setName("pool-1-IoTDB-Compaction-1");
-        IoTDBDescriptor.getInstance().getConfig().setCrossCompactionFileSelectionTimeBudget(-1);
+  @Before
+  public void setUp() throws IOException, WriteProcessException, MetadataException {
+    super.setUp();
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(1024);
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
+    Thread.currentThread().setName("pool-1-IoTDB-Compaction-1");
+  }
+
+  @After
+  public void tearDown() throws IOException, StorageEngineException {
+    super.tearDown();
+    Thread.currentThread().setName(oldThreadName);
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
+  }
+
+  /**
+   * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4200<br>
+   * Selected seq file index: 3<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void test1() throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(2, 10, 10, 1000, 2100, 2100, 100, 100, true, false);
+    createFiles(1, 10, 10, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 5300, 5300, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(1, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4700<br>
+   * Selected seq file index: 3<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void test2() throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 2100, 2100, 100, 100, true, false);
+    createFiles(1, 5, 10, 1500, 3200, 3200, 100, 100, true, false);
+    createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(1, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
+   * 2 Unseq files: 1500 ~ 3000, 3100 ~ 4100<br>
+   * Selected seq file index: 2, 3<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void test3() throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 10, 1500, 1500, 1500, 100, 100, true, false);
+    createFiles(1, 5, 10, 1000, 3100, 3100, 100, 100, true, false);
+    createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6500 ~ 7500<br>
+   * 5 Unseq files: 1500 ~ 2500, 1700 ~ 2000, 2400 ~ 3400, 3300 ~ 4500, 6301 ~ 7301<br>
+   * Notice: the last seq file is unsealed<br>
+   * Selected seq file index: 2, 3<br>
+   * Selected unseq file index: 1, 2, 3, 4
+   */
+  @Test
+  public void test4() throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 1500, 1500, 100, 100, true, false);
+    createFiles(1, 5, 10, 300, 1700, 1700, 100, 100, true, false);
+    createFiles(1, 5, 10, 1000, 2400, 2400, 100, 100, true, false);
+    createFiles(1, 5, 10, 1200, 3300, 3300, 100, 100, true, false);
+    createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 6500, 6500, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 6301, 6301, 100, 100, true, false);
+    seqResources.get(4).setStatus(TsFileResourceStatus.UNCLOSED);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(4, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+    Assert.assertEquals(result[1].get(2), unseqResources.get(2));
+    Assert.assertEquals(result[1].get(3), unseqResources.get(3));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 7 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400, 5500 ~ 6500, 6600 ~
+   * 7600<br>
+   * 2 Unseq files: 2150 ~ 5450, 1150 ～ 5550<br>
+   * Selected seq file index: 2, 3, 4, 5, 6<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void test5() throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(7, 5, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 10, 3300, 2150, 2150, 100, 100, true, false);
+    createFiles(1, 5, 10, 4400, 1150, 1150, 100, 100, true, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(5, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+    Assert.assertEquals(result[0].get(2), seqResources.get(3));
+    Assert.assertEquals(result[0].get(3), seqResources.get(4));
+    Assert.assertEquals(result[0].get(4), seqResources.get(5));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 4 Seq files: 0 ~ 1000, 1100 ~ 4100, 4200 ~ 5200, 5300 ~ 6300<br>
+   * 3 Unseq files: 1500 ~ 2500, 2600 ～ 3600, 2000 ~ 3000<br>
+   * Selected seq file index: 2<br>
+   * Selected unseq file index: 1, 2, 3
+   */
+  @Test
+  public void test6() throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 5, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 10, 3000, 1100, 1100, 100, 100, true, true);
+    createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(2, 5, 10, 1000, 1500, 1500, 100, 100, true, false);
+    createFiles(1, 5, 10, 1000, 2000, 2000, 100, 100, true, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(1, result[0].size());
+    Assert.assertEquals(3, result[1].size());
+    for (TsFileResource selectedResource : (List<TsFileResource>) result[0]) {
+      Assert.assertEquals(selectedResource, seqResources.get(1));
     }
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+    Assert.assertEquals(result[1].get(2), unseqResources.get(2));
 
-    @After
-    public void tearDown() throws IOException, StorageEngineException {
-        super.tearDown();
-        Thread.currentThread().setName(oldThreadName);
-        FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 4100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 3 Unseq files: 1500 ~ 2500, 2600 ～ 3600, 2000 ~ 3000, 1200 ~ 5250<br>
+   * Selected seq file index: 2, 3, 4<br>
+   * Selected unseq file index: 1, 2, 3, 4
+   */
+  @Test
+  public void test7() throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 5, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 10, 3000, 1100, 1100, 100, 100, true, true);
+    createFiles(3, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(2, 5, 10, 1000, 1500, 1500, 100, 100, true, false);
+    createFiles(1, 5, 10, 1000, 2000, 2000, 100, 100, true, false);
+    createFiles(1, 5, 10, 4050, 1200, 1200, 100, 100, true, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(4, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+    Assert.assertEquals(result[0].get(2), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+    Assert.assertEquals(result[1].get(2), unseqResources.get(2));
+    Assert.assertEquals(result[1].get(3), unseqResources.get(3));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
+   * 4 Unseq files: 1500 ~ 2500, 1700 ~ 2000, 2400 ~ 3400, 3300 ~ 4500<br>
+   * Selected seq file index: 2, 3<br>
+   * Selected unseq file index: 1, 2, 3, 4
+   */
+  @Test
+  public void test8() throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 1500, 1500, 100, 100, true, false);
+    createFiles(1, 5, 10, 300, 1700, 1700, 100, 100, true, false);
+    createFiles(1, 5, 10, 1000, 2400, 2400, 100, 100, true, false);
+    createFiles(1, 5, 10, 1200, 3300, 3300, 100, 100, true, false);
+    createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(4, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+    Assert.assertEquals(result[1].get(2), unseqResources.get(2));
+    Assert.assertEquals(result[1].get(3), unseqResources.get(3));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4200<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [10,10], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile10()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(2, 10, 10, 1000, 2100, 2100, 100, 100, true, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(2, 10, 10, 1000, 5300, 5300, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4200<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [10,5], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile11()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(2, 10, 10, 1000, 2100, 2100, 100, 100, true, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(1, 10, 5, 1000, 5300, 5300, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 6400, 6400, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 6 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400, 7500 ~ 8500<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4200<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [5,10], [10,7], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 5<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile12()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(2, 10, 10, 1000, 2100, 2100, 100, 100, true, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 5300, 5300, 100, 100, true, true);
+    createFiles(1, 10, 7, 1000, 6400, 6400, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 7500, 7500, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(4));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4700<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [10,10], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile20()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 2100, 2100, 100, 100, true, false);
+    createFiles(1, 10, 10, 1500, 3200, 3200, 100, 100, true, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(2, 10, 10, 1000, 5300, 5300, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4700<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [10,5], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile21()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 2100, 2100, 100, 100, true, false);
+    createFiles(1, 10, 10, 1500, 3200, 3200, 100, 100, true, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(1, 10, 5, 1000, 5300, 5300, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 6400, 6400, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 6 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400, 7500 ~ 8500<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4700<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [5,10], [10,7], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 5<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile22()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 2100, 2100, 100, 100, true, false);
+    createFiles(1, 10, 10, 1500, 3200, 3200, 100, 100, true, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 5300, 5300, 100, 100, true, true);
+    createFiles(1, 10, 7, 1000, 6400, 6400, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 7500, 7500, 100, 100, true, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(4));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 1500 ~ 3000, 3100 ~ 4100<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [5,5], [5,5], [5,10], [10,10], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 2, 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile30()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 1100, 1100, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(2, 10, 10, 1000, 5300, 5300, 100, 100, true, true);
+    createFiles(1, 10, 10, 1500, 1500, 1500, 100, 100, true, false);
+    createFiles(1, 10, 10, 1000, 3100, 3100, 100, 100, true, false);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+    Assert.assertEquals(result[0].get(2), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 1500 ~ 3000, 3100 ~ 4100<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [5,5], [5,5], [5,10], [10,5], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 2, 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile31()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 1100, 1100, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(1, 10, 5, 1000, 5300, 5300, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 6400, 6400, 100, 100, true, true);
+    createFiles(1, 10, 10, 1500, 1500, 1500, 100, 100, true, false);
+    createFiles(1, 10, 10, 1000, 3100, 3100, 100, 100, true, false);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+    Assert.assertEquals(result[0].get(2), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 6 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400, 7500 ~ 8500<br>
+   * 2 Unseq files: 1500 ~ 3000, 3100 ~ 4100<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [5,5], [5,5], [5,10], [10,7], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 2, 3, 5<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile32()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 1100, 1100, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 5300, 5300, 100, 100, true, true);
+    createFiles(1, 10, 7, 1000, 6400, 6400, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 7500, 7500, 100, 100, true, true);
+    createFiles(1, 10, 10, 1500, 1500, 1500, 100, 100, true, false);
+    createFiles(1, 10, 10, 1000, 3100, 3100, 100, 100, true, false);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 9 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400,......<br>
+   * 1 Unseq files: 2150 ~ 5450<br>
+   * Selected seq file index: 3, 4, 5, 6, 7<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile50()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 6, 6, 1000, 1100, 1100, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 2200, 2200, 100, 100, true, true);
+    createFiles(1, 4, 4, 1000, 3300, 3300, 100, 100, true, true);
+    createFiles(1, 3, 3, 1000, 4400, 4400, 100, 100, true, true);
+    createFiles(1, 2, 2, 1000, 5500, 5500, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 6600, 6600, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 7700, 7700, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 8800, 8800, 100, 100, true, true);
+    createFiles(1, 10, 10, 3300, 2150, 2150, 100, 100, true, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(5, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[0].get(3), seqResources.get(5));
+    Assert.assertEquals(result[0].get(4), seqResources.get(6));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 9 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400,......<br>
+   * 1 Unseq files: 2150 ~ 5450<br>
+   * Selected seq file index: 3, 4, 5, 6, 7<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile51()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 6, 6, 1000, 1100, 1100, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 2200, 2200, 100, 100, true, true);
+    createFiles(1, 4, 4, 1000, 3300, 3300, 100, 100, true, true);
+    createFiles(1, 3, 3, 1000, 4400, 4400, 100, 100, true, true);
+    createFiles(1, 2, 2, 1000, 5500, 5500, 100, 100, true, true);
+    createFiles(1, 10, 5, 1000, 6600, 6600, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 7700, 7700, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 8800, 8800, 100, 100, true, true);
+    createFiles(1, 10, 10, 3300, 2150, 2150, 100, 100, true, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(5, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[0].get(3), seqResources.get(5));
+    Assert.assertEquals(result[0].get(4), seqResources.get(6));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 9 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400,......<br>
+   * 1 Unseq files: 2150 ~ 5450<br>
+   * Selected seq file index: 3, 4, 5, 6, 7, 8<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile52()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 6, 6, 1000, 1100, 1100, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 2200, 2200, 100, 100, true, true);
+    createFiles(1, 4, 4, 1000, 3300, 3300, 100, 100, true, true);
+    createFiles(1, 3, 3, 1000, 4400, 4400, 100, 100, true, true);
+    createFiles(1, 2, 2, 1000, 5500, 5500, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 6600, 6600, 100, 100, true, true);
+    createFiles(1, 10, 7, 1000, 7700, 7700, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 8800, 8800, 100, 100, true, true);
+    createFiles(1, 10, 10, 3300, 2150, 2150, 100, 100, true, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(6, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[0].get(3), seqResources.get(5));
+    Assert.assertEquals(result[0].get(4), seqResources.get(6));
+    Assert.assertEquals(result[0].get(5), seqResources.get(7));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 9 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400,......<br>
+   * 1 Unseq files: 2150 ~ 5450<br>
+   * Selected seq file index: 3, 4, 5, 6, 8<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile53()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 6, 6, 1000, 1100, 1100, 100, 100, true, true);
+    createFiles(1, 5, 5, 1000, 2200, 2200, 100, 100, true, true);
+    createFiles(1, 4, 4, 1000, 3300, 3300, 100, 100, true, true);
+    createFiles(1, 3, 3, 1000, 4400, 4400, 100, 100, true, true);
+    createFiles(1, 5, 2, 1000, 5500, 5500, 100, 100, true, true);
+    createFiles(1, 5, 10, 1000, 6600, 6600, 100, 100, true, true);
+    createFiles(1, 10, 7, 1000, 7700, 7700, 100, 100, true, true);
+    createFiles(1, 10, 10, 1000, 8800, 8800, 100, 100, true, true);
+    createFiles(1, 10, 10, 3300, 2150, 2150, 100, 100, true, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(5, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[0].get(3), seqResources.get(5));
+    Assert.assertEquals(result[0].get(4), seqResources.get(7));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  private void validateSeqFiles() {
+    List<File> files = new ArrayList<>();
+    for (TsFileResource resource : tsFileManager.getTsFileList(true)) {
+      files.add(resource.getTsFile());
     }
-
-    /**
-     * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
-     * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4200<br>
-     * Selected seq file index: 3<br>
-     * Selected unseq file index: 1, 2
-     */
-    @Test
-    public void test1() throws MetadataException, IOException, WriteProcessException, MergeException {
-        registerTimeseriesInMManger(5, 10, true);
-        createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
-        createFiles(2, 10, 10, 1000, 2100, 2100, 100, 100, true, false);
-        createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, true, true);
-        createFiles(1, 10, 10, 1000, 5300, 5300, 100, 100, true, true);
-        tsFileManager.addAll(seqResources,true);
-       tsFileManager.addAll(unseqResources,false);
-
-        CrossSpaceCompactionResource resource =
-                new CrossSpaceCompactionResource(seqResources, unseqResources);
-        ICrossSpaceCompactionFileSelector mergeFileSelector =
-                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
-        List[] result = mergeFileSelector.select();
-        Assert.assertEquals(2,result.length);
-        Assert.assertEquals(2,result[0].size());
-        Assert.assertEquals(2,result[1].size());
-
-        new CrossSpaceCompactionTask(
-                0,
-                tsFileManager,
-                result[0],
-                result[1],
-                IoTDBDescriptor.getInstance()
-                        .getConfig()
-                        .getCrossCompactionPerformer()
-                        .createInstance(),
-                new AtomicInteger(0),
-                tsFileManager.getNextCompactionTaskId()).doCompaction();
-
-        validateSeqFiles();
-
-    }
-
-    /**
-     * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
-     * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4700<br>
-     * Selected seq file index: 3<br>
-     * Selected unseq file index: 1, 2
-     */
-    @Test
-    public void test2() throws MetadataException, IOException, WriteProcessException, MergeException {
-        registerTimeseriesInMManger(5, 10, true);
-        createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
-        createFiles(1, 5, 10, 1000, 2100, 2100, 100, 100, true, false);
-        createFiles(1, 5, 10, 1500, 3200, 3200, 100, 100, true, false);
-        createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
-        tsFileManager.addAll(seqResources,true);
-        tsFileManager.addAll(unseqResources,false);
-
-        CrossSpaceCompactionResource resource =
-                new CrossSpaceCompactionResource(seqResources, unseqResources);
-        ICrossSpaceCompactionFileSelector mergeFileSelector =
-                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
-        List[] result = mergeFileSelector.select();
-        Assert.assertEquals(2,result.length);
-        Assert.assertEquals(1,result[0].size());
-        Assert.assertEquals(2,result[1].size());
-
-        new CrossSpaceCompactionTask(
-                0,
-                tsFileManager,
-                result[0],
-                result[1],
-                IoTDBDescriptor.getInstance()
-                        .getConfig()
-                        .getCrossCompactionPerformer()
-                        .createInstance(),
-                new AtomicInteger(0),
-                tsFileManager.getNextCompactionTaskId()).doCompaction();
-
-        validateSeqFiles();
-    }
-
-    /**
-     * 4 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300<br>
-     * 4 Unseq files: 1500 ~ 2500, 1700 ~ 2000, 2400 ~ 3400, 3300 ~ 4500<br>
-     * Selected seq file index: 2, 3<br>
-     * Selected unseq file index: 1, 2, 3, 4
-     */
-    @Test
-    public void test3() throws MetadataException, IOException, WriteProcessException, MergeException {
-        registerTimeseriesInMManger(5, 10, true);
-        createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
-        createFiles(1, 5, 10, 1000, 1500, 1500, 100, 100, true, false);
-        createFiles(1, 5, 10, 300, 1700, 1700, 100, 100, true, false);
-        createFiles(1, 5, 10, 1000, 2400, 2400, 100, 100, true, false);
-        createFiles(1, 5, 10, 1200, 3300, 3300, 100, 100, true, false);
-        createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
-        tsFileManager.addAll(seqResources,true);
-        tsFileManager.addAll(unseqResources,false);
-
-        CrossSpaceCompactionResource resource =
-                new CrossSpaceCompactionResource(seqResources, unseqResources);
-        ICrossSpaceCompactionFileSelector mergeFileSelector =
-                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
-        List[] result = mergeFileSelector.select();
-        Assert.assertEquals(2,result.length);
-        Assert.assertEquals(2,result[0].size());
-        Assert.assertEquals(4,result[1].size());
-
-        new CrossSpaceCompactionTask(
-                0,
-                tsFileManager,
-                result[0],
-                result[1],
-                IoTDBDescriptor.getInstance()
-                        .getConfig()
-                        .getCrossCompactionPerformer()
-                        .createInstance(),
-                new AtomicInteger(0),
-                tsFileManager.getNextCompactionTaskId()).doCompaction();
-
-        validateSeqFiles();
-    }
-
-    /**
-     * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6500 ~ 7500<br>
-     * 5 Unseq files: 1500 ~ 2500, 1700 ~ 2000, 2400 ~ 3400, 3300 ~ 4500, 6301 ~ 7301<br>
-     * Notice: the last seq file is unsealed<br>
-     * Selected seq file index: 2, 3<br>
-     * Selected unseq file index: 1, 2, 3, 4
-     */
-    @Test
-    public void test4() throws MetadataException, IOException, WriteProcessException, MergeException {
-        registerTimeseriesInMManger(5, 10, true);
-        createFiles(2, 5, 10, 1000, 0, 0, 100, 100, true, true);
-        createFiles(1, 5, 10, 1000, 1500, 1500, 100, 100, true, false);
-        createFiles(1, 5, 10, 300, 1700, 1700, 100, 100, true, false);
-        createFiles(1, 5, 10, 1000, 2400, 2400, 100, 100, true, false);
-        createFiles(1, 5, 10, 1200, 3300, 3300, 100, 100, true, false);
-        createFiles(2, 5, 10, 1000, 4200, 4200, 100, 100, true, true);
-        createFiles(1, 5, 10, 1000, 6500, 6500, 100, 100, true, true);
-        createFiles(1, 5, 10, 1000, 6301, 6301, 100, 100, true, false);
-        seqResources.get(4).setStatus(TsFileResourceStatus.UNCLOSED);
-        tsFileManager.addAll(seqResources,true);
-        tsFileManager.addAll(unseqResources,false);
-
-        CrossSpaceCompactionResource resource =
-                new CrossSpaceCompactionResource(seqResources, unseqResources);
-        ICrossSpaceCompactionFileSelector mergeFileSelector =
-                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
-        List[] result = mergeFileSelector.select();
-        Assert.assertEquals(2,result.length);
-        Assert.assertEquals(2,result[0].size());
-        Assert.assertEquals(4,result[1].size());
-
-        new CrossSpaceCompactionTask(
-                0,
-                tsFileManager,
-                result[0],
-                result[1],
-                IoTDBDescriptor.getInstance()
-                        .getConfig()
-                        .getCrossCompactionPerformer()
-                        .createInstance(),
-                new AtomicInteger(0),
-                tsFileManager.getNextCompactionTaskId()).doCompaction();
-
-        validateSeqFiles();
-    }
-
-    /**
-     * 7 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400, 5500 ~ 6500, 6600 ~ 7600<br>
-     * 2 Unseq files: 2150 ~ 5450, 1150 ～ 5550<br>
-     * Selected seq file index: 2, 3, 4, 5, 6<br>
-     * Selected unseq file index: 1, 2
-     */
-    @Test
-    public void test5() throws MetadataException, IOException, WriteProcessException, MergeException {
-        registerTimeseriesInMManger(5, 10, true);
-        createFiles(7, 5, 10, 1000, 0, 0, 100, 100, true, true);
-        createFiles(1, 5, 10, 3300, 2150, 2150, 100, 100, true, false);
-        createFiles(1, 5, 10, 4400, 1150, 1150, 100, 100, true, false);
-
-        tsFileManager.addAll(seqResources,true);
-        tsFileManager.addAll(unseqResources,false);
-
-        CrossSpaceCompactionResource resource =
-                new CrossSpaceCompactionResource(seqResources, unseqResources);
-        ICrossSpaceCompactionFileSelector mergeFileSelector =
-                new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
-        List[] result = mergeFileSelector.select();
-        Assert.assertEquals(2,result.length);
-        Assert.assertEquals(5,result[0].size());
-        Assert.assertEquals(2,result[1].size());
-
-        new CrossSpaceCompactionTask(
-                0,
-                tsFileManager,
-                result[0],
-                result[1],
-                IoTDBDescriptor.getInstance()
-                        .getConfig()
-                        .getCrossCompactionPerformer()
-                        .createInstance(),
-                new AtomicInteger(0),
-                tsFileManager.getNextCompactionTaskId()).doCompaction();
-
-        validateSeqFiles();
-    }
-
-    private void validateSeqFiles(){
-        List<File> files=new ArrayList<>();
-        for(TsFileResource resource:tsFileManager.getTsFileList(true)){
-            files.add(resource.getTsFile());
-        }
-        TsFileValidationTool.findUncorrectFiles(files);
-        Assert.assertEquals(0,TsFileValidationTool.badFileNum);
-    }
-
+    TsFileValidationTool.findUncorrectFiles(files);
+    Assert.assertEquals(0, TsFileValidationTool.badFileNum);
+  }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
@@ -1921,8 +1921,8 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
   /**
    * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400<br>
    * 1 Unseq files: 2500 ~ 3500<br>
-   * Selected seq file index: none<br>
-   * Selected unseq file index: none
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1
    */
   @Test
   public void testWithUnclosedSeqFileAndNewSensorInUnseqFile()
@@ -1950,7 +1950,21 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
     ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
-    Assert.assertEquals(0, result.length);
+    // Assert.assertEquals(0, result.length);
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
   }
 
   /**
@@ -2011,7 +2025,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400<br>
    * 2 Unseq files: 2500 ~ 3500, 4310 ~ 4360<br>
    * Selected seq file index: 3, 4<br>
-   * Selected unseq file index: 1
+   * Selected unseq file index: 1, 2
    */
   @Test
   public void testUnseqFileOverlapWithUnclosedSeqFile2()
@@ -2040,10 +2054,11 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
     List[] result = mergeFileSelector.select();
     Assert.assertEquals(2, result.length);
     Assert.assertEquals(2, result[0].size());
-    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(2, result[1].size());
     Assert.assertEquals(result[0].get(0), seqResources.get(2));
     Assert.assertEquals(result[0].get(1), seqResources.get(3));
     Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
 
     new CrossSpaceCompactionTask(
             0,

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
@@ -1865,6 +1865,203 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
     validateSeqFiles();
   }
 
+  /**
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400<br>
+   * 1 Unseq files: 2500 ~ 3500<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithUnclosedSeqFile()
+      throws MergeException, IOException, MetadataException, WriteProcessException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(5, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 2500, 2500, 100, 100, false, false);
+
+    TsFileResource unclosedSeqResource = new TsFileResource(seqResources.get(4).getTsFile());
+    unclosedSeqResource.setStatus(TsFileResourceStatus.UNCLOSED);
+    TsFileResource lastSeqResource = seqResources.get(4);
+    for (String deviceID : lastSeqResource.getDevices()) {
+      unclosedSeqResource.updateStartTime(deviceID, lastSeqResource.getStartTime(deviceID));
+    }
+    seqResources.remove(4);
+    seqResources.add(4, unclosedSeqResource);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400<br>
+   * 1 Unseq files: 2500 ~ 3500<br>
+   * Selected seq file index: none<br>
+   * Selected unseq file index: none
+   */
+  @Test
+  public void testWithUnclosedSeqFileAndNewSensorInUnseqFile()
+      throws MergeException, IOException, MetadataException, WriteProcessException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(3, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 3300, 3300, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 4400, 4400, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 2500, 2500, 100, 100, false, false);
+
+    TsFileResource unclosedSeqResource = new TsFileResource(seqResources.get(4).getTsFile());
+    unclosedSeqResource.setStatus(TsFileResourceStatus.UNCLOSED);
+    TsFileResource lastSeqResource = seqResources.get(4);
+    for (String deviceID : lastSeqResource.getDevices()) {
+      unclosedSeqResource.updateStartTime(deviceID, lastSeqResource.getStartTime(deviceID));
+    }
+    seqResources.remove(4);
+    seqResources.add(4, unclosedSeqResource);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(0, result.length);
+  }
+
+  /**
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400<br>
+   * 2 Unseq files: 2500 ~ 3500, 1500 ~ 4500<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testUnseqFileOverlapWithUnclosedSeqFile()
+      throws MergeException, IOException, MetadataException, WriteProcessException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(5, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 2500, 2500, 100, 100, false, false);
+    createFiles(1, 5, 5, 3000, 1500, 1500, 100, 100, false, false);
+
+    TsFileResource unclosedSeqResource = new TsFileResource(seqResources.get(4).getTsFile());
+    unclosedSeqResource.setStatus(TsFileResourceStatus.UNCLOSED);
+    TsFileResource lastSeqResource = seqResources.get(4);
+    for (String deviceID : lastSeqResource.getDevices()) {
+      unclosedSeqResource.updateStartTime(deviceID, lastSeqResource.getStartTime(deviceID));
+    }
+    seqResources.remove(4);
+    seqResources.add(4, unclosedSeqResource);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400<br>
+   * 2 Unseq files: 2500 ~ 3500, 1500 ~ 4500<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithUnclosedUnSeqFile()
+      throws MergeException, IOException, MetadataException, WriteProcessException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(5, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 2500, 2500, 100, 100, false, false);
+    createFiles(1, 5, 5, 3000, 1500, 1500, 100, 100, false, false);
+
+    TsFileResource unclosedUnSeqResource = new TsFileResource(unseqResources.get(1).getTsFile());
+    unclosedUnSeqResource.setStatus(TsFileResourceStatus.UNCLOSED);
+    TsFileResource lastUnSeqResource = unseqResources.get(1);
+    for (String deviceID : lastUnSeqResource.getDevices()) {
+      unclosedUnSeqResource.updateStartTime(deviceID, lastUnSeqResource.getStartTime(deviceID));
+      unclosedUnSeqResource.updateEndTime(deviceID, lastUnSeqResource.getEndTime(deviceID));
+    }
+    unseqResources.remove(1);
+    unseqResources.add(1, unclosedUnSeqResource);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
   private void validateSeqFiles() {
     List<File> files = new ArrayList<>();
     for (TsFileResource resource : tsFileManager.getTsFileList(true)) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
@@ -267,6 +267,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    */
   @Test
   public void test5() throws MetadataException, IOException, WriteProcessException, MergeException {
+    IoTDBDescriptor.getInstance().getConfig().setMaxCrossCompactionCandidateFileNum(7);
     registerTimeseriesInMManger(5, 10, true);
     createFiles(7, 5, 10, 1000, 0, 0, 100, 100, true, true);
     createFiles(1, 5, 10, 3300, 2150, 2150, 100, 100, true, false);
@@ -471,7 +472,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1, 2
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile10()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile10()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -522,7 +523,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1, 2
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile11()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile11()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -574,7 +575,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1, 2
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile12()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile12()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -626,7 +627,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1, 2
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile20()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile20()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -678,7 +679,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1, 2
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile21()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile21()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -731,7 +732,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1, 2
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile22()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile22()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(2, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -785,7 +786,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1, 2
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile30()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile30()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -839,7 +840,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1, 2
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile31()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile31()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -894,7 +895,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1, 2
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile32()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile32()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -946,7 +947,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile50()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile50()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -1002,7 +1003,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile51()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile51()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -1058,7 +1059,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile52()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile52()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -1114,7 +1115,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
    * Selected unseq file index: 1
    */
   @Test
-  public void testWithNewDeviceAndSensorInUnseqFile53()
+  public void testWithNewAlignedDeviceAndSensorInUnseqFile53()
       throws MetadataException, IOException, WriteProcessException, MergeException {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(1, 10, 10, 1000, 0, 0, 100, 100, true, true);
@@ -1127,6 +1128,708 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
     createFiles(1, 10, 7, 1000, 7700, 7700, 100, 100, true, true);
     createFiles(1, 10, 10, 1000, 8800, 8800, 100, 100, true, true);
     createFiles(1, 10, 10, 3300, 2150, 2150, 100, 100, true, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(5, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[0].get(3), seqResources.get(5));
+    Assert.assertEquals(result[0].get(4), seqResources.get(7));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4200<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [10,10], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile10()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(2, 10, 10, 1000, 2100, 2100, 100, 100, false, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, false, true);
+    createFiles(2, 10, 10, 1000, 5300, 5300, 100, 100, false, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4200<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [10,5], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile11()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(2, 10, 10, 1000, 2100, 2100, 100, 100, false, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, false, true);
+    createFiles(1, 10, 5, 1000, 5300, 5300, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 6400, 6400, 100, 100, false, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 6 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400, 7500 ~ 8500<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4200<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [5,10], [10,7], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 5<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile12()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(2, 10, 10, 1000, 2100, 2100, 100, 100, false, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, false, true);
+    createFiles(1, 5, 10, 1000, 5300, 5300, 100, 100, false, true);
+    createFiles(1, 10, 7, 1000, 6400, 6400, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 7500, 7500, 100, 100, false, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(4));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4700<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [10,10], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile20()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 2100, 2100, 100, 100, false, false);
+    createFiles(1, 10, 10, 1500, 3200, 3200, 100, 100, false, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, false, true);
+    createFiles(2, 10, 10, 1000, 5300, 5300, 100, 100, false, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4700<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [10,5], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile21()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 2100, 2100, 100, 100, false, false);
+    createFiles(1, 10, 10, 1500, 3200, 3200, 100, 100, false, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, false, true);
+    createFiles(1, 10, 5, 1000, 5300, 5300, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 6400, 6400, 100, 100, false, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 6 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400, 7500 ~ 8500<br>
+   * 2 Unseq files: 2100 ~ 3100, 3200 ~ 4700<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [10,10], [5,5], [5,10], [10,7], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 3, 5<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile22()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(2, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 2100, 2100, 100, 100, false, false);
+    createFiles(1, 10, 10, 1500, 3200, 3200, 100, 100, false, false);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, false, true);
+    createFiles(1, 5, 10, 1000, 5300, 5300, 100, 100, false, true);
+    createFiles(1, 10, 7, 1000, 6400, 6400, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 7500, 7500, 100, 100, false, true);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(2, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(4));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 1500 ~ 3000, 3100 ~ 4100<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [5,5], [5,5], [5,10], [10,10], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 2, 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile30()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 1100, 1100, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, false, true);
+    createFiles(2, 10, 10, 1000, 5300, 5300, 100, 100, false, true);
+    createFiles(1, 10, 10, 1500, 1500, 1500, 100, 100, false, false);
+    createFiles(1, 10, 10, 1000, 3100, 3100, 100, 100, false, false);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+    Assert.assertEquals(result[0].get(2), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 5 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400<br>
+   * 2 Unseq files: 1500 ~ 3000, 3100 ~ 4100<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [5,5], [5,5], [5,10], [10,5], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 2, 3, 4<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile31()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 1100, 1100, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, false, true);
+    createFiles(1, 10, 5, 1000, 5300, 5300, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 6400, 6400, 100, 100, false, true);
+    createFiles(1, 10, 10, 1500, 1500, 1500, 100, 100, false, false);
+    createFiles(1, 10, 10, 1000, 3100, 3100, 100, 100, false, false);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+    Assert.assertEquals(result[0].get(2), seqResources.get(3));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * [Time range]:<br>
+   * 6 Seq files: 0 ~ 1000, 1100 ~ 2100, 4200 ~ 5200, 5300 ~ 6300, 6400 ~ 7400, 7500 ~ 8500<br>
+   * 2 Unseq files: 1500 ~ 3000, 3100 ~ 4100<br>
+   * [DeviceNum, SensorNum]:<br>
+   * seq files: [10,10], [5,5], [5,5], [5,10], [10,7], [10,10]<br>
+   * unseq files: [10,10], [10,10]<br>
+   * Selected seq file index: 2, 3, 5<br>
+   * Selected unseq file index: 1, 2
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile32()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 1100, 1100, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 4200, 4200, 100, 100, false, true);
+    createFiles(1, 5, 10, 1000, 5300, 5300, 100, 100, false, true);
+    createFiles(1, 10, 7, 1000, 6400, 6400, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 7500, 7500, 100, 100, false, true);
+    createFiles(1, 10, 10, 1500, 1500, 1500, 100, 100, false, false);
+    createFiles(1, 10, 10, 1000, 3100, 3100, 100, 100, false, false);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(3, result[0].size());
+    Assert.assertEquals(2, result[1].size());
+
+    Assert.assertEquals(result[0].get(0), seqResources.get(1));
+    Assert.assertEquals(result[0].get(1), seqResources.get(2));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+    Assert.assertEquals(result[1].get(1), unseqResources.get(1));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 9 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400,......<br>
+   * 1 Unseq files: 2150 ~ 5450<br>
+   * Selected seq file index: 3, 4, 5, 6, 7<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile50()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 6, 6, 1000, 1100, 1100, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 2200, 2200, 100, 100, false, true);
+    createFiles(1, 4, 4, 1000, 3300, 3300, 100, 100, false, true);
+    createFiles(1, 3, 3, 1000, 4400, 4400, 100, 100, false, true);
+    createFiles(1, 2, 2, 1000, 5500, 5500, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 6600, 6600, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 7700, 7700, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 8800, 8800, 100, 100, false, true);
+    createFiles(1, 10, 10, 3300, 2150, 2150, 100, 100, false, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(5, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[0].get(3), seqResources.get(5));
+    Assert.assertEquals(result[0].get(4), seqResources.get(6));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 9 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400,......<br>
+   * 1 Unseq files: 2150 ~ 5450<br>
+   * Selected seq file index: 3, 4, 5, 6, 7<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile51()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 6, 6, 1000, 1100, 1100, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 2200, 2200, 100, 100, false, true);
+    createFiles(1, 4, 4, 1000, 3300, 3300, 100, 100, false, true);
+    createFiles(1, 3, 3, 1000, 4400, 4400, 100, 100, false, true);
+    createFiles(1, 2, 2, 1000, 5500, 5500, 100, 100, false, true);
+    createFiles(1, 10, 5, 1000, 6600, 6600, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 7700, 7700, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 8800, 8800, 100, 100, false, true);
+    createFiles(1, 10, 10, 3300, 2150, 2150, 100, 100, false, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(5, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[0].get(3), seqResources.get(5));
+    Assert.assertEquals(result[0].get(4), seqResources.get(6));
+
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 9 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400,......<br>
+   * 1 Unseq files: 2150 ~ 5450<br>
+   * Selected seq file index: 3, 4, 5, 6, 7, 8<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile52()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 6, 6, 1000, 1100, 1100, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 2200, 2200, 100, 100, false, true);
+    createFiles(1, 4, 4, 1000, 3300, 3300, 100, 100, false, true);
+    createFiles(1, 3, 3, 1000, 4400, 4400, 100, 100, false, true);
+    createFiles(1, 2, 2, 1000, 5500, 5500, 100, 100, false, true);
+    createFiles(1, 5, 10, 1000, 6600, 6600, 100, 100, false, true);
+    createFiles(1, 10, 7, 1000, 7700, 7700, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 8800, 8800, 100, 100, false, true);
+    createFiles(1, 10, 10, 3300, 2150, 2150, 100, 100, false, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    Assert.assertEquals(2, result.length);
+    Assert.assertEquals(6, result[0].size());
+    Assert.assertEquals(1, result[1].size());
+    Assert.assertEquals(result[0].get(0), seqResources.get(2));
+    Assert.assertEquals(result[0].get(1), seqResources.get(3));
+    Assert.assertEquals(result[0].get(2), seqResources.get(4));
+    Assert.assertEquals(result[0].get(3), seqResources.get(5));
+    Assert.assertEquals(result[0].get(4), seqResources.get(6));
+    Assert.assertEquals(result[0].get(5), seqResources.get(7));
+    Assert.assertEquals(result[1].get(0), unseqResources.get(0));
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            result[0],
+            result[1],
+            IoTDBDescriptor.getInstance()
+                .getConfig()
+                .getCrossCompactionPerformer()
+                .createInstance(),
+            new AtomicInteger(0),
+            tsFileManager.getNextCompactionTaskId())
+        .doCompaction();
+
+    validateSeqFiles();
+  }
+
+  /**
+   * 9 Seq files: 0 ~ 1000, 1100 ~ 2100, 2200 ~ 3200, 3300 ~ 4300, 4400 ~ 5400,......<br>
+   * 1 Unseq files: 2150 ~ 5450<br>
+   * Selected seq file index: 3, 4, 5, 6, 8<br>
+   * Selected unseq file index: 1
+   */
+  @Test
+  public void testWithNewDeviceAndSensorInUnseqFile53()
+      throws MetadataException, IOException, WriteProcessException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(1, 10, 10, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 6, 6, 1000, 1100, 1100, 100, 100, false, true);
+    createFiles(1, 5, 5, 1000, 2200, 2200, 100, 100, false, true);
+    createFiles(1, 4, 4, 1000, 3300, 3300, 100, 100, false, true);
+    createFiles(1, 3, 3, 1000, 4400, 4400, 100, 100, false, true);
+    createFiles(1, 5, 2, 1000, 5500, 5500, 100, 100, false, true);
+    createFiles(1, 5, 10, 1000, 6600, 6600, 100, 100, false, true);
+    createFiles(1, 10, 7, 1000, 7700, 7700, 100, 100, false, true);
+    createFiles(1, 10, 10, 1000, 8800, 8800, 100, 100, false, true);
+    createFiles(1, 10, 10, 3300, 2150, 2150, 100, 100, false, false);
 
     tsFileManager.addAll(seqResources, true);
     tsFileManager.addAll(unseqResources, false);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.CrossSpaceCompactionResource;
-import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceCompactionFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
@@ -61,7 +61,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
   public void testFullSelection() throws MergeException, IOException {
     CrossSpaceCompactionResource resource =
         new CrossSpaceCompactionResource(seqResources, unseqResources);
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
     List<TsFileResource> seqSelected = result[0];
@@ -90,7 +90,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
   public void testWithFewMemoryBudgeSelection() throws MergeException, IOException {
     CrossSpaceCompactionResource resource =
         new CrossSpaceCompactionResource(seqResources, unseqResources);
-    ICrossSpaceMergeFileSelector mergeFileSelector = new RewriteCompactionFileSelector(resource, 1);
+    ICrossSpaceCompactionFileSelector mergeFileSelector = new RewriteCompactionFileSelector(resource, 1);
     List[] result = mergeFileSelector.select();
     assertEquals(2, result.length);
   }
@@ -99,7 +99,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
   public void testRestrictedSelection() throws MergeException, IOException {
     CrossSpaceCompactionResource resource =
         new CrossSpaceCompactionResource(seqResources, unseqResources);
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, 400000);
     List[] result = mergeFileSelector.select();
     List<TsFileResource> seqSelected = result[0];
@@ -156,7 +156,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     newUnseqResources.add(largeUnseqTsFileResource);
     CrossSpaceCompactionResource resource =
         new CrossSpaceCompactionResource(seqResources, newUnseqResources);
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
     assertEquals(0, result.length);
@@ -246,7 +246,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
     CrossSpaceCompactionResource resource =
         new CrossSpaceCompactionResource(seqResources, unseqResources);
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
     assertEquals(2, result[0].size());
@@ -304,7 +304,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
       CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
       // the budget is enough to select unseq0 and unseq2, but not unseq1
       // the first selection should only contain seq0 and unseq0
-      ICrossSpaceMergeFileSelector mergeFileSelector =
+      ICrossSpaceCompactionFileSelector mergeFileSelector =
           new RewriteCompactionFileSelector(resource, 29000);
       List[] result = mergeFileSelector.select();
       assertEquals(1, result[0].size());
@@ -380,7 +380,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(10, resource.getUnseqFiles().size());
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, 500 * 1024 * 1024);
     List[] result = mergeFileSelector.select();
     Assert.assertEquals(2, result.length);
@@ -443,7 +443,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(1, resource.getUnseqFiles().size());
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, 500 * 1024 * 1024);
     List[] result = mergeFileSelector.select();
     Assert.assertEquals(2, result.length);
@@ -506,7 +506,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(2, resource.getUnseqFiles().size());
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, 500 * 1024 * 1024);
     List[] result = mergeFileSelector.select();
     Assert.assertEquals(2, result.length);
@@ -572,7 +572,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(4, resource.getUnseqFiles().size());
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, 500 * 1024 * 1024);
     List[] result = mergeFileSelector.select();
     Assert.assertEquals(2, result.length);
@@ -641,7 +641,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     CrossSpaceCompactionResource resource = new CrossSpaceCompactionResource(seqList, unseqList);
     Assert.assertEquals(5, resource.getSeqFiles().size());
     Assert.assertEquals(4, resource.getUnseqFiles().size());
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, 500 * 1024 * 1024);
     List[] result = mergeFileSelector.select();
     Assert.assertEquals(2, result.length);
@@ -877,7 +877,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     IoTDBDescriptor.getInstance().getConfig().setMaxCrossCompactionCandidateFileNum(5);
     CrossSpaceCompactionResource resource =
         new CrossSpaceCompactionResource(seqResources, unseqResources);
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
     assertEquals(2, result.length);
@@ -899,7 +899,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
 
     CrossSpaceCompactionResource resource =
         new CrossSpaceCompactionResource(seqResources, unseqResources);
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     List[] result = mergeFileSelector.select();
     List<TsFileResource> seqSelected = result[0];
@@ -916,7 +916,7 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
   public void testDeleteInSelection() throws Exception {
     CrossSpaceCompactionResource resource =
         new CrossSpaceCompactionResource(seqResources, unseqResources);
-    ICrossSpaceMergeFileSelector mergeFileSelector =
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
         new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
     AtomicBoolean fail = new AtomicBoolean(false);
     Thread thread1 =

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -90,7 +90,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
   public void testWithFewMemoryBudgeSelection() throws MergeException, IOException {
     CrossSpaceCompactionResource resource =
         new CrossSpaceCompactionResource(seqResources, unseqResources);
-    ICrossSpaceCompactionFileSelector mergeFileSelector = new RewriteCompactionFileSelector(resource, 1);
+    ICrossSpaceCompactionFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, 1);
     List[] result = mergeFileSelector.select();
     assertEquals(2, result.length);
   }


### PR DESCRIPTION
**Bug description:**
timeseries overlap within one page
timeseries overlap between pages
timeseries overlap between files
device overlap between files

**Reason**
The reason for the problem is that there are bugs in the process of selecting files in cross space compaction. For example, there are seq files 1 2 and unseq files 1. The timestamps of the unseq file is both smaller than those of seq files 1 2. When unseq file 1 has d1, d2 , while seq file 1 has d2 and seq file 2 has d1, d2. If seq file 2 is selected first, then file 1 will be skipped. So solution is to select both of the seq files 1 and 2.
