### PR TITLE
[IOTDB-3859] Fix wrong isBlocked() method implementation in AggregationOperator

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/AggregationOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/AggregationOperatorTest.java
@@ -46,6 +46,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
 import org.junit.After;
 import org.junit.Before;
@@ -108,8 +109,18 @@ public class AggregationOperatorTest {
     AggregationOperator aggregationOperator =
         initAggregationOperator(aggregationTypes, null, inputLocations);
     int count = 0;
-    while (aggregationOperator.hasNext()) {
+    while (true) {
+      ListenableFuture<?> blocked = aggregationOperator.isBlocked();
+      if (!blocked.isDone()) {
+        continue;
+      }
+      if (!aggregationOperator.hasNext()) {
+        break;
+      }
       TsBlock resultTsBlock = aggregationOperator.next();
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       assertEquals(6524750.0, resultTsBlock.getColumn(1).getDouble(0), 0.0001);
       assertEquals(0, resultTsBlock.getColumn(2).getLong(0));
@@ -140,8 +151,18 @@ public class AggregationOperatorTest {
     AggregationOperator aggregationOperator =
         initAggregationOperator(aggregationTypes, null, inputLocations);
     int count = 0;
-    while (aggregationOperator.hasNext()) {
+    while (true) {
+      ListenableFuture<?> blocked = aggregationOperator.isBlocked();
+      if (!blocked.isDone()) {
+        continue;
+      }
+      if (!aggregationOperator.hasNext()) {
+        break;
+      }
       TsBlock resultTsBlock = aggregationOperator.next();
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(13049.5, resultTsBlock.getColumn(0).getDouble(0), 0.001);
       assertEquals(20000, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(10499, resultTsBlock.getColumn(2).getInt(0));
@@ -179,8 +200,18 @@ public class AggregationOperatorTest {
     AggregationOperator aggregationOperator =
         initAggregationOperator(aggregationTypes, groupByTimeParameter, inputLocations);
     int count = 0;
-    while (aggregationOperator.hasNext()) {
+    while (true) {
+      ListenableFuture<?> blocked = aggregationOperator.isBlocked();
+      if (!blocked.isDone()) {
+        continue;
+      }
+      if (!aggregationOperator.hasNext()) {
+        break;
+      }
       TsBlock resultTsBlock = aggregationOperator.next();
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -221,8 +252,18 @@ public class AggregationOperatorTest {
     AggregationOperator aggregationOperator =
         initAggregationOperator(aggregationTypes, groupByTimeParameter, inputLocations);
     int count = 0;
-    while (aggregationOperator.hasNext()) {
+    while (true) {
+      ListenableFuture<?> blocked = aggregationOperator.isBlocked();
+      if (!blocked.isDone()) {
+        continue;
+      }
+      if (!aggregationOperator.hasNext()) {
+        break;
+      }
       TsBlock resultTsBlock = aggregationOperator.next();
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/AggregationOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/AggregationOperatorTest.java
@@ -56,6 +56,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -91,7 +92,8 @@ public class AggregationOperatorTest {
 
   /** Try to aggregate unary intermediate result of one time series without group by interval. */
   @Test
-  public void testAggregateIntermediateResult1() throws IllegalPathException {
+  public void testAggregateIntermediateResult1()
+      throws IllegalPathException, ExecutionException, InterruptedException {
     List<AggregationType> aggregationTypes = new ArrayList<>();
     aggregationTypes.add(AggregationType.COUNT);
     aggregationTypes.add(AggregationType.SUM);
@@ -111,9 +113,7 @@ public class AggregationOperatorTest {
     int count = 0;
     while (true) {
       ListenableFuture<?> blocked = aggregationOperator.isBlocked();
-      if (!blocked.isDone()) {
-        continue;
-      }
+      blocked.get();
       if (!aggregationOperator.hasNext()) {
         break;
       }
@@ -134,7 +134,8 @@ public class AggregationOperatorTest {
 
   /** Try to aggregate binary intermediate result of one time series without group by interval. */
   @Test
-  public void testAggregateIntermediateResult2() throws IllegalPathException {
+  public void testAggregateIntermediateResult2()
+      throws IllegalPathException, ExecutionException, InterruptedException {
     List<AggregationType> aggregationTypes = new ArrayList<>();
     aggregationTypes.add(AggregationType.AVG);
     aggregationTypes.add(AggregationType.FIRST_VALUE);
@@ -153,9 +154,7 @@ public class AggregationOperatorTest {
     int count = 0;
     while (true) {
       ListenableFuture<?> blocked = aggregationOperator.isBlocked();
-      if (!blocked.isDone()) {
-        continue;
-      }
+      blocked.get();
       if (!aggregationOperator.hasNext()) {
         break;
       }
@@ -172,7 +171,8 @@ public class AggregationOperatorTest {
   }
 
   @Test
-  public void testGroupByIntermediateResult1() throws IllegalPathException {
+  public void testGroupByIntermediateResult1()
+      throws IllegalPathException, ExecutionException, InterruptedException {
     int[][] result =
         new int[][] {
           {100, 100, 100, 99},
@@ -202,9 +202,7 @@ public class AggregationOperatorTest {
     int count = 0;
     while (true) {
       ListenableFuture<?> blocked = aggregationOperator.isBlocked();
-      if (!blocked.isDone()) {
-        continue;
-      }
+      blocked.get();
       if (!aggregationOperator.hasNext()) {
         break;
       }
@@ -228,7 +226,8 @@ public class AggregationOperatorTest {
   }
 
   @Test
-  public void testGroupByIntermediateResult2() throws IllegalPathException {
+  public void testGroupByIntermediateResult2()
+      throws IllegalPathException, ExecutionException, InterruptedException {
     double[][] result =
         new double[][] {
           {20049.5, 20149.5, 6249.5, 8429.808},
@@ -254,9 +253,7 @@ public class AggregationOperatorTest {
     int count = 0;
     while (true) {
       ListenableFuture<?> blocked = aggregationOperator.isBlocked();
-      if (!blocked.isDone()) {
-        continue;
-      }
+      blocked.get();
       if (!aggregationOperator.hasNext()) {
         break;
       }


### PR DESCRIPTION
see IOTDB-3859

In the previous implementation, we only wait for the first blocked child operator to end blocking. But there may be other child operators still blocked. We need to wait for all child operators to end blocking.