### PR TITLE
[IOTDB-3877] Fix DataNodeInternalRPCServiceImplTest NullPointerException

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -104,9 +104,15 @@ public class EnvironmentUtils {
 
     // deregister all user defined classes
     try {
-      UDFRegistrationService.getInstance().deregisterAll();
-      TriggerRegistrationService.getInstance().deregisterAll();
-      ContinuousQueryService.getInstance().deregisterAll();
+      if (UDFRegistrationService.getInstance() != null) {
+        UDFRegistrationService.getInstance().deregisterAll();
+      }
+      if (TriggerRegistrationService.getInstance() != null) {
+        TriggerRegistrationService.getInstance().deregisterAll();
+      }
+      if (ContinuousQueryService.getInstance() != null) {
+        ContinuousQueryService.getInstance().deregisterAll();
+      }
     } catch (UDFRegistrationException | TriggerManagementException | ContinuousQueryException e) {
       fail(e.getMessage());
     }


### PR DESCRIPTION
When I run the test class  DataNodeInternalRPCServiceImplTest 

it will occur NullPointerException at tearDownAfterClass() method
