### PR TITLE
[IOTDB-3837] Exclude md5 file when get latest snapshot

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -143,6 +143,9 @@ public class SnapshotStorage implements StateMachineStorage {
 
     List<FileInfo> fileInfos = new ArrayList<>();
     for (Path file : getAllFilesUnder(latestSnapshotDir)) {
+      if (file.endsWith(".md5")) {
+        continue;
+      }
       FileInfo fileInfo = new FileInfoWithDelayedMd5Computing(file);
       fileInfos.add(fileInfo);
     }


### PR DESCRIPTION
Ratis requires to send snapshot file together with its md5 digest. We decide to calculate it once and store md5 in file under the snapshot dir. However, when send snapshot second time, ratis will consider these md5 file also one part of the snapshot. So we have to exclude the md5 file when fetching the latest snapshot.