### PR TITLE
[To rel/0.13][IOTDB-3879] Modify document about the Programming-Cpp-Native-API

### DIFF
--- a/docs/UserGuide/API/Programming-Cpp-Native-API.md
+++ b/docs/UserGuide/API/Programming-Cpp-Native-API.md
@@ -306,9 +306,9 @@ void insertTablets(std::unordered_map<std::string, Tablet *> &tablets);
 ```cpp
 void insertRecord(const std::string &deviceId, 
                   int64_t time, 
-				  const std::vector<std::string> &measurements,
+                  const std::vector<std::string> &measurements,
                   const std::vector<TSDataType::TSDataType> &types, 
-				  const std::vector<char *> &values);
+                  const std::vector<char *> &values);
 ```
 
 - Insert multiple Records
@@ -336,7 +336,7 @@ Without type information, server has to do type inference, which may cost some t
 ```cpp
 void insertRecord(const std::string &deviceId, 
                   int64_t time, 
-				  const std::vector<std::string> &measurements,
+                  const std::vector<std::string> &measurements,
                   const std::vector<std::string> &values);
 
 

--- a/docs/UserGuide/API/Programming-Cpp-Native-API.md
+++ b/docs/UserGuide/API/Programming-Cpp-Native-API.md
@@ -304,11 +304,8 @@ void insertTablets(std::unordered_map<std::string, Tablet *> &tablets);
 
 - Insert a Record, which contains multiple measurement value of a device at a timestamp
 ```cpp
-void insertRecord(const std::string &deviceId, 
-                  int64_t time, 
-                  const std::vector<std::string> &measurements,
-                  const std::vector<TSDataType::TSDataType> &types, 
-                  const std::vector<char *> &values);
+void insertRecord(const std::string &deviceId, int64_t time, const std::vector<std::string> &measurements,
+                  const std::vector<TSDataType::TSDataType> &types, const std::vector<char *> &values);
 ```
 
 - Insert multiple Records
@@ -334,9 +331,7 @@ void insertRecordsOfOneDevice(const std::string &deviceId,
 Without type information, server has to do type inference, which may cost some time.
 
 ```cpp
-void insertRecord(const std::string &deviceId, 
-                  int64_t time, 
-                  const std::vector<std::string> &measurements,
+void insertRecord(const std::string &deviceId, int64_t time, const std::vector<std::string> &measurements,
                   const std::vector<std::string> &values);
 
 
@@ -349,7 +344,7 @@ void insertRecords(const std::vector<std::string> &deviceIds,
 void insertRecordsOfOneDevice(const std::string &deviceId,
                               std::vector<int64_t> &times,
                               std::vector<std::vector<std::string>> &measurementsList,
-                              std::vector<std::vector<char *>> &valuesList);
+                              const std::vector<std::vector<std::string>> &valuesList);
 ```
 
 #### Insert data into Aligned Timeseries

--- a/docs/UserGuide/API/Programming-Cpp-Native-API.md
+++ b/docs/UserGuide/API/Programming-Cpp-Native-API.md
@@ -304,8 +304,11 @@ void insertTablets(std::unordered_map<std::string, Tablet *> &tablets);
 
 - Insert a Record, which contains multiple measurement value of a device at a timestamp
 ```cpp
-void insertRecord(const std::string &deviceId, int64_t time, const std::vector<std::string> &measurements,
-                  const std::vector<std::string> &values);
+void insertRecord(const std::string &deviceId, 
+                  int64_t time, 
+				  const std::vector<std::string> &measurements,
+                  const std::vector<TSDataType::TSDataType> &types, 
+				  const std::vector<char *> &values);
 ```
 
 - Insert multiple Records
@@ -313,7 +316,8 @@ void insertRecord(const std::string &deviceId, int64_t time, const std::vector<s
 void insertRecords(const std::vector<std::string> &deviceIds,
                    const std::vector<int64_t> &times,
                    const std::vector<std::vector<std::string>> &measurementsList,
-                   const std::vector<std::vector<std::string>> &valuesList);
+                   const std::vector<std::vector<TSDataType::TSDataType>> &typesList,
+                   const std::vector<std::vector<char *>> &valuesList);
 ```
 
 - Insert multiple Records that belong to the same device. With type info the server has no need to do type inference, which leads a better performance
@@ -321,6 +325,7 @@ void insertRecords(const std::vector<std::string> &deviceIds,
 void insertRecordsOfOneDevice(const std::string &deviceId,
                               std::vector<int64_t> &times,
                               std::vector<std::vector<std::string>> &measurementsList,
+                              std::vector<std::vector<TSDataType::TSDataType>> &typesList,
                               std::vector<std::vector<char *>> &valuesList);
 ```
 
@@ -329,21 +334,21 @@ void insertRecordsOfOneDevice(const std::string &deviceId,
 Without type information, server has to do type inference, which may cost some time.
 
 ```cpp
-void insertRecord(const std::string &deviceId, int64_t time, const std::vector<std::string> &measurements,
-                  const std::vector<TSDataType::TSDataType> &types, const std::vector<char *> &values);
+void insertRecord(const std::string &deviceId, 
+                  int64_t time, 
+				  const std::vector<std::string> &measurements,
+                  const std::vector<std::string> &values);
 
 
 void insertRecords(const std::vector<std::string> &deviceIds,
                    const std::vector<int64_t> &times,
                    const std::vector<std::vector<std::string>> &measurementsList,
-                   const std::vector<std::vector<TSDataType::TSDataType>> &typesList,
-                   const std::vector<std::vector<char *>> &valuesList);
+                   const std::vector<std::vector<std::string>> &valuesList);
 
 
 void insertRecordsOfOneDevice(const std::string &deviceId,
                               std::vector<int64_t> &times,
                               std::vector<std::vector<std::string>> &measurementsList,
-                              std::vector<std::vector<TSDataType::TSDataType>> &typesList,
                               std::vector<std::vector<char *>> &valuesList);
 ```
 

--- a/docs/zh/UserGuide/API/Programming-Cpp-Native-API.md
+++ b/docs/zh/UserGuide/API/Programming-Cpp-Native-API.md
@@ -299,11 +299,8 @@ void insertTablets(std::unordered_map<std::string, Tablet *> &tablets);
 
 - 插入一个 Record，一个 Record 是一个设备一个时间戳下多个测点的数据
 ```cpp
-void insertRecord(const std::string &deviceId, 
-                  int64_t time, 
-                  const std::vector<std::string> &measurements,
-                  const std::vector<TSDataType::TSDataType> &types, 
-                  const std::vector<char *> &values);
+void insertRecord(const std::string &deviceId, int64_t time, const std::vector<std::string> &measurements,
+                  const std::vector<TSDataType::TSDataType> &types, const std::vector<char *> &values);
 ```
 
 - 插入多个 Record
@@ -329,9 +326,7 @@ void insertRecordsOfOneDevice(const std::string &deviceId,
 服务器需要做类型推断，可能会有额外耗时，速度较无需类型推断的写入慢。
 
 ```cpp
-void insertRecord(const std::string &deviceId, 
-                  int64_t time, 
-                  const std::vector<std::string> &measurements,
+void insertRecord(const std::string &deviceId, int64_t time, const std::vector<std::string> &measurements,
                   const std::vector<std::string> &values);
 
 
@@ -344,7 +339,7 @@ void insertRecords(const std::vector<std::string> &deviceIds,
 void insertRecordsOfOneDevice(const std::string &deviceId,
                               std::vector<int64_t> &times,
                               std::vector<std::vector<std::string>> &measurementsList,
-                              std::vector<std::vector<char *>> &valuesList);
+                              const std::vector<std::vector<std::string>> &valuesList);
 ```
 
 #### 对齐时间序列写入

--- a/docs/zh/UserGuide/API/Programming-Cpp-Native-API.md
+++ b/docs/zh/UserGuide/API/Programming-Cpp-Native-API.md
@@ -303,7 +303,7 @@ void insertRecord(const std::string &deviceId,
                   int64_t time, 
                   const std::vector<std::string> &measurements,
                   const std::vector<TSDataType::TSDataType> &types, 
-				  const std::vector<char *> &values);
+                  const std::vector<char *> &values);
 ```
 
 - 插入多个 Record
@@ -331,7 +331,7 @@ void insertRecordsOfOneDevice(const std::string &deviceId,
 ```cpp
 void insertRecord(const std::string &deviceId, 
                   int64_t time, 
-				  const std::vector<std::string> &measurements,
+                  const std::vector<std::string> &measurements,
                   const std::vector<std::string> &values);
 
 

--- a/docs/zh/UserGuide/API/Programming-Cpp-Native-API.md
+++ b/docs/zh/UserGuide/API/Programming-Cpp-Native-API.md
@@ -299,8 +299,11 @@ void insertTablets(std::unordered_map<std::string, Tablet *> &tablets);
 
 - 插入一个 Record，一个 Record 是一个设备一个时间戳下多个测点的数据
 ```cpp
-void insertRecord(const std::string &deviceId, int64_t time, const std::vector<std::string> &measurements,
-                  const std::vector<std::string> &values);
+void insertRecord(const std::string &deviceId, 
+                  int64_t time, 
+                  const std::vector<std::string> &measurements,
+                  const std::vector<TSDataType::TSDataType> &types, 
+				  const std::vector<char *> &values);
 ```
 
 - 插入多个 Record
@@ -308,7 +311,8 @@ void insertRecord(const std::string &deviceId, int64_t time, const std::vector<s
 void insertRecords(const std::vector<std::string> &deviceIds,
                    const std::vector<int64_t> &times,
                    const std::vector<std::vector<std::string>> &measurementsList,
-                   const std::vector<std::vector<std::string>> &valuesList);
+                   const std::vector<std::vector<TSDataType::TSDataType>> &typesList,
+                   const std::vector<std::vector<char *>> &valuesList);
 ```
 
 - 插入同属于一个 device 的多个 Record
@@ -316,6 +320,7 @@ void insertRecords(const std::vector<std::string> &deviceIds,
 void insertRecordsOfOneDevice(const std::string &deviceId,
                               std::vector<int64_t> &times,
                               std::vector<std::vector<std::string>> &measurementsList,
+                              std::vector<std::vector<TSDataType::TSDataType>> &typesList,
                               std::vector<std::vector<char *>> &valuesList);
 ```
 
@@ -324,21 +329,21 @@ void insertRecordsOfOneDevice(const std::string &deviceId,
 服务器需要做类型推断，可能会有额外耗时，速度较无需类型推断的写入慢。
 
 ```cpp
-void insertRecord(const std::string &deviceId, int64_t time, const std::vector<std::string> &measurements,
-                  const std::vector<TSDataType::TSDataType> &types, const std::vector<char *> &values);
+void insertRecord(const std::string &deviceId, 
+                  int64_t time, 
+				  const std::vector<std::string> &measurements,
+                  const std::vector<std::string> &values);
 
 
 void insertRecords(const std::vector<std::string> &deviceIds,
                    const std::vector<int64_t> &times,
                    const std::vector<std::vector<std::string>> &measurementsList,
-                   const std::vector<std::vector<TSDataType::TSDataType>> &typesList,
-                   const std::vector<std::vector<char *>> &valuesList);
+                   const std::vector<std::vector<std::string>> &valuesList);
 
 
 void insertRecordsOfOneDevice(const std::string &deviceId,
                               std::vector<int64_t> &times,
                               std::vector<std::vector<std::string>> &measurementsList,
-                              std::vector<std::vector<TSDataType::TSDataType>> &typesList,
                               std::vector<std::vector<char *>> &valuesList);
 ```
 


### PR DESCRIPTION
C + + interface descriptions about insertRecord/insertRecords/insertRecordsOfOneDevice errors.
The interface about Data Manipulation Interface and the interface about Insert with type inference description information is upside down.