### PR TITLE
[To rel/0.13][IOTDB-3742]Fix count nodes

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
@@ -1245,8 +1245,8 @@ public class MTree implements Serializable {
   /** Get all paths from root to the given level */
   public List<PartialPath> getNodesListInGivenLevel(
       PartialPath pathPattern, int nodeLevel, StorageGroupFilter filter) throws MetadataException {
-    MNodeCollector<List<PartialPath>> collector =
-        new MNodeCollector<List<PartialPath>>(root, pathPattern) {
+    MNodeCollector<Set<PartialPath>> collector =
+        new MNodeCollector<Set<PartialPath>>(root, pathPattern) {
           @Override
           protected void transferToResult(IMNode node) {
             try {
@@ -1256,11 +1256,11 @@ public class MTree implements Serializable {
             }
           }
         };
-    collector.setResultSet(new LinkedList<>());
+    collector.setResultSet(new TreeSet<>());
     collector.setTargetLevel(nodeLevel);
     collector.setStorageGroupFilter(filter);
     collector.traverse();
-    return collector.getResult();
+    return new ArrayList<>(collector.getResult());
   }
   // endregion
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -51,8 +51,8 @@ public abstract class Traverser {
   // to construct full path or find mounted node on MTree when traverse into template
   protected Deque<IMNode> traverseContext;
 
-  // if isMeasurementTraverser, measurement in template should be processed
-  protected boolean isMeasurementTraverser = false;
+  // if true, measurement in template should be processed
+  protected boolean shouldTraverseTemplate = false;
 
   // default false means fullPath pattern match
   protected boolean isPrefixMatch = false;
@@ -159,6 +159,10 @@ public abstract class Traverser {
     }
     traverseContext.pop();
 
+    if (!shouldTraverseTemplate) {
+      return;
+    }
+
     if (!node.isUseTemplate()) {
       return;
     }
@@ -197,6 +201,10 @@ public abstract class Traverser {
         traverse(child, idx, level + 1);
       }
       traverseContext.pop();
+    }
+
+    if (!shouldTraverseTemplate) {
+      return;
     }
 
     if (!node.isUseTemplate()) {
@@ -239,6 +247,10 @@ public abstract class Traverser {
         traverse(child, idx, level + 1);
       }
       traverseContext.pop();
+    }
+
+    if (!shouldTraverseTemplate) {
+      return;
     }
 
     if (!node.isUseTemplate()) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/EntityCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/EntityCollector.java
@@ -28,11 +28,13 @@ public abstract class EntityCollector<T> extends CollectorTraverser<T> {
 
   public EntityCollector(IMNode startNode, PartialPath path) throws MetadataException {
     super(startNode, path);
+    shouldTraverseTemplate = true;
   }
 
   public EntityCollector(IMNode startNode, PartialPath path, int limit, int offset)
       throws MetadataException {
     super(startNode, path, limit, offset);
+    shouldTraverseTemplate = true;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MNodeCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MNodeCollector.java
@@ -23,9 +23,6 @@ import org.apache.iotdb.db.metadata.MManager.StorageGroupFilter;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * This class defines any node in MTree as potential target node. On finding a path matching the
  * given pattern, if a level is specified and the path is longer than the specified level,
@@ -39,8 +36,6 @@ public abstract class MNodeCollector<T> extends CollectorTraverser<T> {
 
   // level query option
   protected int targetLevel = -1;
-
-  private Set<IMNode> processedNodes = new HashSet<>();
 
   public MNodeCollector(IMNode startNode, PartialPath path) throws MetadataException {
     super(startNode, path);
@@ -72,11 +67,8 @@ public abstract class MNodeCollector<T> extends CollectorTraverser<T> {
         node = node.getParent();
         level--;
       }
-      // record processed node so they will not be processed twice
-      if (!processedNodes.contains(node)) {
-        processedNodes.add(node);
-        processResult(node);
-      }
+
+      processResult(node);
       return true;
     } else {
       processResult(node);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MeasurementCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MeasurementCollector.java
@@ -32,13 +32,13 @@ public abstract class MeasurementCollector<T> extends CollectorTraverser<T> {
 
   public MeasurementCollector(IMNode startNode, PartialPath path) throws MetadataException {
     super(startNode, path);
-    isMeasurementTraverser = true;
+    shouldTraverseTemplate = true;
   }
 
   public MeasurementCollector(IMNode startNode, PartialPath path, int limit, int offset)
       throws MetadataException {
     super(startNode, path, limit, offset);
-    isMeasurementTraverser = true;
+    shouldTraverseTemplate = true;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/EntityCounter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/EntityCounter.java
@@ -27,6 +27,7 @@ public class EntityCounter extends CounterTraverser {
 
   public EntityCounter(IMNode startNode, PartialPath path) throws MetadataException {
     super(startNode, path);
+    shouldTraverseTemplate = true;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MeasurementCounter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MeasurementCounter.java
@@ -28,7 +28,7 @@ public class MeasurementCounter extends CounterTraverser {
 
   public MeasurementCounter(IMNode startNode, PartialPath path) throws MetadataException {
     super(startNode, path);
-    isMeasurementTraverser = true;
+    shouldTraverseTemplate = true;
   }
 
   @Override


### PR DESCRIPTION
## Description

see IOTDB-3742

The node management feature is to help manage the instantiated nodes on MTree, excluding the nodes inside template. 
Since there's memory protection on schema storage, the node info won't be a heavy load to system.

Therefore, remove the node traversal logic inside template.

