### PR TITLE
[To rel/0.13][IOTDB-3775][IOTDB-3776]Avoid serializing resource file and adding mods to file that don't contain the device when deleting data

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1448,4 +1448,9 @@ public class TsFileProcessor {
   public IMemTable getWorkMemTable() {
     return workMemTable;
   }
+
+  @TestOnly
+  public ConcurrentLinkedDeque<IMemTable> getFlushingMemTable() {
+    return flushingMemTables;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -870,17 +870,19 @@ public class TsFileResource {
     if (planIndex == Long.MIN_VALUE || planIndex == Long.MAX_VALUE) {
       return;
     }
-    maxPlanIndex = Math.max(maxPlanIndex, planIndex);
-    minPlanIndex = Math.min(minPlanIndex, planIndex);
-    if (isClosed()) {
-      try {
-        serialize();
-      } catch (IOException e) {
-        LOGGER.error(
-            "Cannot serialize TsFileResource {} when updating plan index {}-{}",
-            this,
-            maxPlanIndex,
-            planIndex);
+    if (planIndex < minPlanIndex || planIndex > maxPlanIndex) {
+      maxPlanIndex = Math.max(maxPlanIndex, planIndex);
+      minPlanIndex = Math.min(minPlanIndex, planIndex);
+      if (isClosed()) {
+        try {
+          serialize();
+        } catch (IOException e) {
+          LOGGER.error(
+              "Cannot serialize TsFileResource {} when updating plan index {}-{}",
+              this,
+              maxPlanIndex,
+              planIndex);
+        }
       }
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCrossSpaceCompactionTest.java
@@ -630,21 +630,25 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
     for (int i = 0; i < seqResources.size(); i++) {
       TsFileResource resource = seqResources.get(i);
       resource.resetModFile();
-      Assert.assertTrue(resource.getCompactionModFile().exists());
-      Assert.assertEquals(1, resource.getCompactionModFile().getModifications().size());
-      Assert.assertTrue(resource.getModFile().exists());
-      if (i == 3) {
-        Assert.assertEquals(1, resource.getModFile().getModifications().size());
-      } else {
+      if (i < 2) {
+        Assert.assertFalse(resource.getCompactionModFile().exists());
+        Assert.assertFalse(resource.getModFile().exists());
+      } else if (i == 2) {
+        Assert.assertTrue(resource.getCompactionModFile().exists());
+        Assert.assertTrue(resource.getModFile().exists());
         Assert.assertEquals(2, resource.getModFile().getModifications().size());
+        Assert.assertEquals(1, resource.getCompactionModFile().getModifications().size());
+      } else {
+        Assert.assertTrue(resource.getCompactionModFile().exists());
+        Assert.assertTrue(resource.getModFile().exists());
+        Assert.assertEquals(1, resource.getModFile().getModifications().size());
+        Assert.assertEquals(1, resource.getCompactionModFile().getModifications().size());
       }
     }
     for (TsFileResource resource : unseqResources) {
       resource.resetModFile();
-      Assert.assertTrue(resource.getCompactionModFile().exists());
-      Assert.assertEquals(1, resource.getCompactionModFile().getModifications().size());
-      Assert.assertTrue(resource.getModFile().exists());
-      Assert.assertEquals(2, resource.getModFile().getModifications().size());
+      Assert.assertFalse(resource.getCompactionModFile().exists());
+      Assert.assertFalse(resource.getModFile().exists());
     }
     rewriteCrossSpaceCompactionTask.call();
     for (TsFileResource resource : seqResources) {
@@ -657,13 +661,19 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
       Assert.assertFalse(resource.getModFile().exists());
       Assert.assertFalse(resource.getCompactionModFile().exists());
     }
-    for (TsFileResource seqResource : seqResources) {
+    for (int i = 0; i < seqResources.size(); i++) {
+      TsFileResource seqResource = seqResources.get(i);
       TsFileResource resource =
           new TsFileResource(
               TsFileNameGenerator.increaseCrossCompactionCnt(seqResource.getTsFile()));
-      Assert.assertTrue(resource.getModFile().exists());
-      Assert.assertEquals(6, resource.getModFile().getModifications().size());
-      Assert.assertFalse(resource.getCompactionModFile().exists());
+      if (i < 2) {
+        Assert.assertFalse(resource.getCompactionModFile().exists());
+        Assert.assertFalse(resource.getModFile().exists());
+      } else {
+        Assert.assertFalse(resource.getCompactionModFile().exists());
+        Assert.assertTrue(resource.getModFile().exists());
+        Assert.assertEquals(1, resource.getModFile().getModifications().size());
+      }
     }
   }
 
@@ -752,21 +762,25 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
     for (int i = 0; i < seqResources.size(); i++) {
       TsFileResource resource = seqResources.get(i);
       resource.resetModFile();
-      Assert.assertTrue(resource.getCompactionModFile().exists());
-      Assert.assertEquals(2, resource.getCompactionModFile().getModifications().size());
-      Assert.assertTrue(resource.getModFile().exists());
-      if (i == 3) {
-        Assert.assertEquals(2, resource.getModFile().getModifications().size());
-      } else {
+      if (i < 2) {
+        Assert.assertFalse(resource.getCompactionModFile().exists());
+        Assert.assertFalse(resource.getModFile().exists());
+      } else if (i == 2) {
+        Assert.assertTrue(resource.getCompactionModFile().exists());
+        Assert.assertTrue(resource.getModFile().exists());
         Assert.assertEquals(3, resource.getModFile().getModifications().size());
+        Assert.assertEquals(2, resource.getCompactionModFile().getModifications().size());
+      } else {
+        Assert.assertTrue(resource.getCompactionModFile().exists());
+        Assert.assertTrue(resource.getModFile().exists());
+        Assert.assertEquals(2, resource.getModFile().getModifications().size());
+        Assert.assertEquals(2, resource.getCompactionModFile().getModifications().size());
       }
     }
     for (TsFileResource resource : unseqResources) {
       resource.resetModFile();
-      Assert.assertTrue(resource.getCompactionModFile().exists());
-      Assert.assertEquals(2, resource.getCompactionModFile().getModifications().size());
-      Assert.assertTrue(resource.getModFile().exists());
-      Assert.assertEquals(3, resource.getModFile().getModifications().size());
+      Assert.assertFalse(resource.getCompactionModFile().exists());
+      Assert.assertFalse(resource.getModFile().exists());
     }
     rewriteCrossSpaceCompactionTask.call();
     for (TsFileResource resource : seqResources) {
@@ -779,13 +793,19 @@ public class RewriteCrossSpaceCompactionTest extends AbstractCompactionTest {
       Assert.assertFalse(resource.getModFile().exists());
       Assert.assertFalse(resource.getCompactionModFile().exists());
     }
-    for (TsFileResource seqResource : seqResources) {
+    for (int i = 0; i < seqResources.size(); i++) {
+      TsFileResource seqResource = seqResources.get(i);
       TsFileResource resource =
           new TsFileResource(
               TsFileNameGenerator.increaseCrossCompactionCnt(seqResource.getTsFile()));
-      Assert.assertTrue(resource.getModFile().exists());
-      Assert.assertEquals(12, resource.getModFile().getModifications().size());
-      Assert.assertFalse(resource.getCompactionModFile().exists());
+      if (i < 2) {
+        Assert.assertFalse(resource.getCompactionModFile().exists());
+        Assert.assertFalse(resource.getModFile().exists());
+      } else {
+        Assert.assertFalse(resource.getCompactionModFile().exists());
+        Assert.assertTrue(resource.getModFile().exists());
+        Assert.assertEquals(2, resource.getModFile().getModifications().size());
+      }
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessorTest.java
@@ -871,6 +871,82 @@ public class StorageGroupProcessorTest {
     config.setCloseTsFileIntervalAfterFlushing(prevCloseTsFileInterval);
   }
 
+  /**
+   * Totally 5 tsfiles<br>
+   * file 0, file 2 and file 4 has d0 ~ d1, time range is 0 ~ 99, 200 ~ 299, 400 ~ 499<br>
+   * file 1, file 3 has d0 ~ d2, time range is 100 ~ 199, 300 ~ 399<br>
+   * delete d2 in time range 50 ~ 150 and 150 ~ 450. Therefore, only file 1 and file 3 has mods.
+   */
+  @Test
+  public void testDeleteDataNotInFile()
+      throws IllegalPathException, WriteProcessException, TriggerExecutionException,
+          InterruptedException, IOException {
+    for (int i = 0; i < 5; i++) {
+      if (i % 2 == 0) {
+        for (int d = 0; d < 2; d++) {
+          for (int count = i * 100; count < i * 100 + 100; count++) {
+            TSRecord record = new TSRecord(count, "root.vehicle.d" + d);
+            record.addTuple(
+                DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(count)));
+            processor.insert(new InsertRowPlan(record));
+          }
+        }
+      } else {
+        for (int d = 0; d < 3; d++) {
+          for (int count = i * 100; count < i * 100 + 100; count++) {
+            TSRecord record = new TSRecord(count, "root.vehicle.d" + d);
+            record.addTuple(
+                DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(count)));
+            processor.insert(new InsertRowPlan(record));
+          }
+        }
+      }
+      processor.syncCloseAllWorkingTsFileProcessors();
+    }
+
+    // delete root.vehicle.d2.s0 data in the second file
+    processor.delete(new PartialPath("root.vehicle.d2.s0"), 50, 150, 0, null);
+
+    // delete root.vehicle.d2.s0 data in the third file
+    processor.delete(new PartialPath("root.vehicle.d2.s0"), 150, 450, 0, null);
+
+    for (int i = 0; i < processor.getTsFileResourceManager().getTsFileList(true).size(); i++) {
+      TsFileResource resource = processor.getTsFileResourceManager().getTsFileList(true).get(i);
+      if (i == 1) {
+        Assert.assertTrue(resource.getModFile().exists());
+        Assert.assertEquals(2, resource.getModFile().getModifications().size());
+      } else if (i == 3) {
+        Assert.assertTrue(resource.getModFile().exists());
+        Assert.assertEquals(1, resource.getModFile().getModifications().size());
+      } else {
+        Assert.assertFalse(resource.getModFile().exists());
+      }
+    }
+  }
+
+  @Test
+  public void testDeleteDataInFlushingMemtable()
+      throws IllegalPathException, WriteProcessException, TriggerExecutionException, IOException {
+    for (int j = 0; j < 100; j++) {
+      TSRecord record = new TSRecord(j, deviceId);
+      record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(j)));
+      processor.insert(new InsertRowPlan(record));
+    }
+    TsFileResource tsFileResource = processor.getTsFileResourceManager().getTsFileList(true).get(0);
+    TsFileProcessor tsFileProcessor = tsFileResource.getProcessor();
+    tsFileProcessor.getFlushingMemTable().addLast(tsFileProcessor.getWorkMemTable());
+
+    // delete data which is in memtable
+    processor.delete(new PartialPath("root.vehicle.d2.s0"), 50, 70, 0, null);
+
+    // delete data which is not in memtable
+    processor.delete(new PartialPath("root.vehicle.d200.s0"), 50, 70, 0, null);
+
+    processor.syncCloseAllWorkingTsFileProcessors();
+    Assert.assertTrue(tsFileResource.getModFile().exists());
+    Assert.assertEquals(2, tsFileResource.getModFile().getModifications().size());
+  }
+
   class DummySGP extends VirtualStorageGroupProcessor {
 
     DummySGP(String systemInfoDir, String storageGroupName) throws StorageGroupProcessorException {


### PR DESCRIPTION
**Description**
1. The resource file will be reserialized every time data is deleted
2. When there is no device corresponding to the timeseries to be deleted in the tsfile, there will still be mods records.
3. For unsealed files, add records to the mods file regardless of whether the conditions are met.

**Improvements**
1. Do not reserialize the resource file, because `planIndex` will be discard in the future.
2. When the device of the timeseries to be deleted is not in the tsfile, skip it and do not add mods to it.
4. For unsealed files, the data in the work memtable will be deleted, and no records will be added to the mods file. When there is flushing memtable, it will always add deletion records to the mods file.

See more details in doc https://apache-iotdb.feishu.cn/docs/doccnMqwBpAYTqkUAj3xaehsXJf?from=from_copylink.