### PR TITLE
[To rel/0.12][IOTDB-3858] IndexOutOfBoundsException: bitIndex < 0

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BloomFilter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/BloomFilter.java
@@ -138,7 +138,12 @@ public class BloomFilter {
     }
 
     public int hash(String value) {
-      return Math.abs(Murmur128Hash.hash(value, seed)) % cap;
+      int res = Murmur128Hash.hash(value, seed);
+      if (res == Integer.MIN_VALUE) {
+        res = 0;
+      }
+
+      return Math.abs(res) % cap;
     }
   }
 }


### PR DESCRIPTION
### Description
This bug is caused by Math.abs(Integer.MIN_VALUE) returning a negative number.

### Solution
Avoid using hash value Integer.MIN_VALUE and set to 0. (as same as master version)