### PR TITLE
[IOTDB-3871] purge log instantly when take a snapshot

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
@@ -518,7 +518,7 @@ public class RatisConfig {
       private int queueElementLimit = 4096;
       private SizeInBytes queueByteLimit = SizeInBytes.valueOf("64MB");
       private int purgeGap = 1024;
-      private boolean purgeUptoSnapshotIndex = false;
+      private boolean purgeUptoSnapshotIndex = true;
       private SizeInBytes segmentSizeMax = SizeInBytes.valueOf("24MB");
       private int segmentCacheNumMax = 2;
       private SizeInBytes segmentCacheSizeMax = SizeInBytes.valueOf("200MB");


### PR DESCRIPTION
# What changes proposed in this PR?
Currently, when leader takes a snapshot, it can purge the logs included in the snapshot. However, by default, if group contains a slow follower, leader will preserve all the raft logs this slow follower doesn't have. This will cause the log in leader accumulate and take a lot of disk space.
