### PR TITLE
Refine the Retry logic for QueryExecution because of Execption changed.

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryStateMachine.java
@@ -100,12 +100,12 @@ public class QueryStateMachine {
     queryState.set(QueryState.DISPATCHING);
   }
 
-  public void transitionToRetrying(Throwable throwable) {
+  public void transitionToRetrying(TSStatus failureStatus) {
     if (queryState.get().isDone()) {
       return;
     }
+    this.failureStatus = failureStatus;
     queryState.set(QueryState.RETRYING);
-    this.failureException = throwable;
   }
 
   public void transitionToRunning() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -454,7 +454,9 @@ public class QueryExecution implements IQueryExecution {
 
     TSStatus tsstatus = RpcUtils.getStatus(statusCode, stateMachine.getFailureMessage());
 
-    if (stateMachine.getFailureStatus() != null) {
+    // If RETRYING is triggered by this QueryExecution, the stateMachine.getFailureStatus()
+    // is also not null. And in this situation, we should return the failure status.
+    if (state.isDone() && stateMachine.getFailureStatus() != null) {
       tsstatus = stateMachine.getFailureStatus();
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -454,8 +454,8 @@ public class QueryExecution implements IQueryExecution {
 
     TSStatus tsstatus = RpcUtils.getStatus(statusCode, stateMachine.getFailureMessage());
 
-    // If RETRYING is triggered by this QueryExecution, the stateMachine.getFailureStatus()
-    // is also not null. And in this situation, we should return the failure status.
+    // If RETRYING is triggered by this QueryExecution, the stateMachine.getFailureStatus() is also
+    // not null. We should only return the failure status when QueryExecution is in Done state.
     if (state.isDone() && stateMachine.getFailureStatus() != null) {
       tsstatus = stateMachine.getFailureStatus();
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.mpp.plan.scheduler;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.sync.SyncDataNodeInternalServiceClient;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
@@ -29,6 +30,7 @@ import org.apache.iotdb.db.mpp.execution.fragment.FragmentInfo;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceState;
 import org.apache.iotdb.db.mpp.plan.analyze.QueryType;
 import org.apache.iotdb.db.mpp.plan.planner.plan.FragmentInstance;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import io.airlift.units.Duration;
 import org.slf4j.Logger;
@@ -89,6 +91,11 @@ public class ClusterScheduler implements IScheduler {
     }
   }
 
+  private boolean needRetry(TSStatus failureStatus) {
+    return failureStatus != null
+        && failureStatus.getCode() == TSStatusCode.SYNC_CONNECTION_EXCEPTION.getStatusCode();
+  }
+
   @Override
   public void start() {
     stateMachine.transitionToDispatching();
@@ -99,12 +106,10 @@ public class ClusterScheduler implements IScheduler {
     try {
       FragInstanceDispatchResult result = dispatchResultFuture.get();
       if (!result.isSuccessful()) {
-        if (result.getFailureStatus() != null) {
-          stateMachine.transitionToFailed(result.getFailureStatus());
+        if (needRetry(result.getFailureStatus())) {
+          stateMachine.transitionToRetrying(result.getFailureStatus());
         } else {
-          // won't get into here
-          stateMachine.transitionToFailed(
-              new IllegalStateException("Fragment cannot be dispatched"));
+          stateMachine.transitionToFailed(result.getFailureStatus());
         }
         return;
       }
@@ -113,7 +118,7 @@ public class ClusterScheduler implements IScheduler {
       if (e instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
-      stateMachine.transitionToRetrying(e);
+      stateMachine.transitionToFailed(e);
       return;
     }
 


### PR DESCRIPTION
## Description
During recent change, we add more detailed error message when dispatching. And in this PR, we will only make the QueryExecution's retry triggered when the failure status is `SYNC_CONNECTION_EXCEPTION`