### PR TITLE
Modified the processing of metrics for collecting the number of storage groups

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -120,7 +120,7 @@ public class PartitionInfo implements SnapshotProcessor {
               Metric.STORAGE_GROUP.toString(),
               MetricLevel.CORE,
               storageGroupPartitionTables,
-              o -> o.size() / 2,
+              o -> o.size(),
               Tag.NAME.toString(),
               "number");
       MetricsService.getInstance()


### PR DESCRIPTION
## Description


### storageGroupPartitionTables.size()  is the number of storage groups, not divided by two.

### Test
#### set storage group root.sg1 ~root.sg10
![image](https://user-images.githubusercontent.com/71131924/180351708-600a6810-c938-4e71-a5ea-492f2d3e5492.png)
![image](https://user-images.githubusercontent.com/71131924/180351847-4041b865-9699-43f4-a35b-aa11c4070330.png)
![image](https://user-images.githubusercontent.com/71131924/180351890-1e1f260a-7211-4614-a486-d127da9e4618.png)

#### Before
![image](https://user-images.githubusercontent.com/71131924/180352248-adcdd4e8-8ed3-4bbf-aaa5-0298494cdd51.png)

#### After
![image](https://user-images.githubusercontent.com/71131924/180351566-b88ab6c0-8aa8-4860-a9dd-564a272e7d9c.png)
