### PR TITLE
[To rel/0.13][IOTDB-3894]Fix last cache with template

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
@@ -1406,6 +1406,14 @@ public class MTree implements Serializable {
           throw new PathNotExistException(path.getFullPath(), true);
         }
         next = upperTemplate.getDirectNode(nodes[i]);
+        if (next.isMeasurement()) {
+          next =
+              MeasurementMNode.getMeasurementMNode(
+                  cur.getAsEntityMNode(),
+                  next.getName(),
+                  next.getAsMeasurementMNode().getSchema(),
+                  null);
+        }
       }
       cur = next;
     }


### PR DESCRIPTION
## Description


### Problem

see IOTDB-3894

### Cause

The last value was cached in the measurementMNode inside template, which means different timeseries represented by one template shared the same measurementMNode instance and this mistakes the last cache value.

### Solution

Since the template is only used as one level, the measurementMNode instance will be cloned and returned for last query and last cache execution.

