### PR TITLE
[IOTDB-3958] Add error logging in thread pool

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/WrappedCallable.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/WrappedCallable.java
@@ -20,28 +20,30 @@ package org.apache.iotdb.commons.concurrent;
 
 import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
 
-/** A wrapper for {@link Runnable} logging errors when uncaught exception is thrown. */
-public abstract class WrappedRunnable implements Runnable {
+import java.util.concurrent.Callable;
+
+/** A wrapper for {@link Callable} logging errors when uncaught exception is thrown. */
+public abstract class WrappedCallable<V> implements Callable<V> {
 
   @Override
-  public final void run() {
+  public final V call() {
     try {
-      runMayThrow();
+      return callMayThrow();
     } catch (Exception e) {
       throw ScheduledExecutorUtil.propagate(e);
     }
   }
 
-  public abstract void runMayThrow() throws Exception;
+  public abstract V callMayThrow() throws Exception;
 
-  public static Runnable wrap(Runnable runnable) {
-    if (runnable instanceof WrappedRunnable) {
-      return runnable;
+  public static <V> Callable<V> wrap(Callable<V> callable) {
+    if (callable instanceof WrappedCallable) {
+      return callable;
     }
-    return new WrappedRunnable() {
+    return new WrappedCallable<V>() {
       @Override
-      public void runMayThrow() {
-        runnable.run();
+      public V callMayThrow() throws Exception {
+        return callable.call();
       }
     };
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/ScheduledExecutorUtil.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/ScheduledExecutorUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.commons.concurrent.threadpool;
 
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -184,5 +185,11 @@ public class ScheduledExecutorUtil {
         initialDelay,
         delay,
         unit);
+  }
+
+  public static RuntimeException propagate(Throwable throwable) {
+    logger.error("Run thread failed", throwable);
+    Throwables.throwIfUnchecked(throwable);
+    throw new RuntimeException(throwable);
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/WrappedScheduledExecutorService.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/WrappedScheduledExecutorService.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.commons.concurrent.threadpool;
 
+import org.apache.iotdb.commons.concurrent.WrappedCallable;
+import org.apache.iotdb.commons.concurrent.WrappedRunnable;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.service.JMXService;
 
@@ -33,6 +35,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 public class WrappedScheduledExecutorService
     implements ScheduledExecutorService, WrappedScheduledExecutorServiceMBean {
@@ -49,26 +52,26 @@ public class WrappedScheduledExecutorService
 
   @Override
   public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-    return service.schedule(command, delay, unit);
+    return service.schedule(WrappedRunnable.wrap(command), delay, unit);
   }
 
   @Override
   public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-    return service.schedule(callable, delay, unit);
+    return service.schedule(WrappedCallable.wrap(callable), delay, unit);
   }
 
   @Override
   @SuppressWarnings("unsafeThreadSchedule")
   public ScheduledFuture<?> scheduleAtFixedRate(
       Runnable command, long initialDelay, long period, TimeUnit unit) {
-    return service.scheduleAtFixedRate(command, initialDelay, period, unit);
+    return service.scheduleAtFixedRate(WrappedRunnable.wrap(command), initialDelay, period, unit);
   }
 
   @Override
   @SuppressWarnings("unsafeThreadSchedule")
   public ScheduledFuture<?> scheduleWithFixedDelay(
       Runnable command, long initialDelay, long delay, TimeUnit unit) {
-    return service.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    return service.scheduleWithFixedDelay(WrappedRunnable.wrap(command), initialDelay, delay, unit);
   }
 
   @Override
@@ -100,47 +103,51 @@ public class WrappedScheduledExecutorService
 
   @Override
   public <T> Future<T> submit(Callable<T> task) {
-    return service.submit(task);
+    return service.submit(WrappedCallable.wrap(task));
   }
 
   @Override
   public <T> Future<T> submit(Runnable task, T result) {
-    return service.submit(task, result);
+    return service.submit(WrappedRunnable.wrap(task), result);
   }
 
   @Override
   public Future<?> submit(Runnable task) {
-    return service.submit(task);
+    return service.submit(WrappedRunnable.wrap(task));
   }
 
   @Override
   public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
       throws InterruptedException {
-    return service.invokeAll(tasks);
+    return service.invokeAll(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()));
   }
 
   @Override
   public <T> List<Future<T>> invokeAll(
       Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
       throws InterruptedException {
-    return service.invokeAll(tasks, timeout, unit);
+    return service.invokeAll(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()), timeout, unit);
   }
 
   @Override
   public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
       throws InterruptedException, ExecutionException {
-    return service.invokeAny(tasks);
+    return service.invokeAny(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()));
   }
 
   @Override
   public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return service.invokeAny(tasks, timeout, unit);
+    return service.invokeAny(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()), timeout, unit);
   }
 
   @Override
   public void execute(Runnable command) {
-    service.execute(command);
+    service.execute(WrappedRunnable.wrap(command));
   }
 
   @Override

--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/WrappedSingleThreadExecutorService.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/WrappedSingleThreadExecutorService.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.commons.concurrent.threadpool;
 
+import org.apache.iotdb.commons.concurrent.WrappedCallable;
+import org.apache.iotdb.commons.concurrent.WrappedRunnable;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.service.JMXService;
 
@@ -30,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 public class WrappedSingleThreadExecutorService
     implements ExecutorService, WrappedSingleThreadExecutorServiceMBean {
@@ -74,46 +77,50 @@ public class WrappedSingleThreadExecutorService
 
   @Override
   public <T> Future<T> submit(Callable<T> task) {
-    return service.submit(task);
+    return service.submit(WrappedCallable.wrap(task));
   }
 
   @Override
   public <T> Future<T> submit(Runnable task, T result) {
-    return service.submit(task, result);
+    return service.submit(WrappedRunnable.wrap(task), result);
   }
 
   @Override
   public Future<?> submit(Runnable task) {
-    return service.submit(task);
+    return service.submit(WrappedRunnable.wrap(task));
   }
 
   @Override
   public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
       throws InterruptedException {
-    return service.invokeAll(tasks);
+    return service.invokeAll(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()));
   }
 
   @Override
   public <T> List<Future<T>> invokeAll(
       Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
       throws InterruptedException {
-    return service.invokeAll(tasks, timeout, unit);
+    return service.invokeAll(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()), timeout, unit);
   }
 
   @Override
   public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
       throws InterruptedException, ExecutionException {
-    return service.invokeAny(tasks);
+    return service.invokeAny(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()));
   }
 
   @Override
   public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return service.invokeAny(tasks, timeout, unit);
+    return service.invokeAny(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()), timeout, unit);
   }
 
   @Override
   public void execute(Runnable command) {
-    service.execute(command);
+    service.execute(WrappedRunnable.wrap(command));
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/WrappedSingleThreadScheduledExecutor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/WrappedSingleThreadScheduledExecutor.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.commons.concurrent.threadpool;
 
+import org.apache.iotdb.commons.concurrent.WrappedCallable;
+import org.apache.iotdb.commons.concurrent.WrappedRunnable;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.service.JMXService;
 
@@ -31,6 +33,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 public class WrappedSingleThreadScheduledExecutor
     implements ScheduledExecutorService, WrappedSingleThreadScheduledExecutorMBean {
@@ -47,26 +50,26 @@ public class WrappedSingleThreadScheduledExecutor
 
   @Override
   public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-    return service.schedule(command, delay, unit);
+    return service.schedule(WrappedRunnable.wrap(command), delay, unit);
   }
 
   @Override
   public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-    return service.schedule(callable, delay, unit);
+    return service.schedule(WrappedCallable.wrap(callable), delay, unit);
   }
 
   @Override
   @SuppressWarnings("unsafeThreadSchedule")
   public ScheduledFuture<?> scheduleAtFixedRate(
       Runnable command, long initialDelay, long period, TimeUnit unit) {
-    return service.scheduleAtFixedRate(command, initialDelay, period, unit);
+    return service.scheduleAtFixedRate(WrappedRunnable.wrap(command), initialDelay, period, unit);
   }
 
   @Override
   @SuppressWarnings("unsafeThreadSchedule")
   public ScheduledFuture<?> scheduleWithFixedDelay(
       Runnable command, long initialDelay, long delay, TimeUnit unit) {
-    return service.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    return service.scheduleWithFixedDelay(WrappedRunnable.wrap(command), initialDelay, delay, unit);
   }
 
   @Override
@@ -98,46 +101,50 @@ public class WrappedSingleThreadScheduledExecutor
 
   @Override
   public <T> Future<T> submit(Callable<T> task) {
-    return service.submit(task);
+    return service.submit(WrappedCallable.wrap(task));
   }
 
   @Override
   public <T> Future<T> submit(Runnable task, T result) {
-    return service.submit(task, result);
+    return service.submit(WrappedRunnable.wrap(task), result);
   }
 
   @Override
   public Future<?> submit(Runnable task) {
-    return service.submit(task);
+    return service.submit(WrappedRunnable.wrap(task));
   }
 
   @Override
   public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
       throws InterruptedException {
-    return service.invokeAll(tasks);
+    return service.invokeAll(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()));
   }
 
   @Override
   public <T> List<Future<T>> invokeAll(
       Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
       throws InterruptedException {
-    return service.invokeAll(tasks, timeout, unit);
+    return service.invokeAll(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()), timeout, unit);
   }
 
   @Override
   public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
       throws InterruptedException, ExecutionException {
-    return service.invokeAny(tasks);
+    return service.invokeAny(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()));
   }
 
   @Override
   public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return service.invokeAny(tasks, timeout, unit);
+    return service.invokeAny(
+        tasks.stream().map(WrappedCallable::wrap).collect(Collectors.toList()), timeout, unit);
   }
 
   @Override
   public void execute(Runnable command) {
-    service.execute(command);
+    service.execute(WrappedRunnable.wrap(command));
   }
 }


### PR DESCRIPTION
See JIRA: https://issues.apache.org/jira/browse/IOTDB-3958 .
I refactor the WrappedCallable to make sure every task submitted to thread pool will log any uncaught exceptions.