### PR TITLE
[To rel/0.13][IOTDB-3904]fix set/unset, drop, and deactivate template api in sessionPool

### DIFF
--- a/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -2097,6 +2097,7 @@ public class SessionPool {
       try {
         session.setSchemaTemplate(templateName, prefixPath);
         putBack(session);
+        return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
         logger.warn(
@@ -2116,6 +2117,7 @@ public class SessionPool {
       try {
         session.unsetSchemaTemplate(prefixPath, templateName);
         putBack(session);
+        return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
         logger.warn(
@@ -2135,6 +2137,7 @@ public class SessionPool {
       try {
         session.createTimeseriesOfTemplateOnPath(path);
         putBack(session);
+        return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
         logger.warn(String.format("create timeseries of template on [%s] failed", path), e);
@@ -2153,6 +2156,7 @@ public class SessionPool {
       try {
         session.deactivateTemplateOn(templateName, prefixPath);
         putBack(session);
+        return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
         logger.warn(
@@ -2172,6 +2176,7 @@ public class SessionPool {
       try {
         session.dropSchemaTemplate(templateName);
         putBack(session);
+        return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
         logger.warn(String.format("dropSchemaTemplate [%s] failed", templateName), e);


### PR DESCRIPTION
## Description
There is a missing `return` in the interface about template set/unset, drop, deactivate and activate within `sessionPool`, which may produce duplicated operation and unexpected exception.
This PR has fixed the issue in the title, along with issue IOTDB-3905 and IOTDB-3907.