### PR TITLE
[IOTDB-3937] Fix the initialization of IoTDB Reporter in metric framework.

### DIFF
--- a/metrics/dropwizard-metrics/src/main/java/org/apache/iotdb/metrics/dropwizard/reporter/IoTDBReporter.java
+++ b/metrics/dropwizard-metrics/src/main/java/org/apache/iotdb/metrics/dropwizard/reporter/IoTDBReporter.java
@@ -80,7 +80,7 @@ public class IoTDBReporter extends ScheduledReporter {
             ioTDBReporterConfig.getUsername(),
             ioTDBReporterConfig.getPassword(),
             ioTDBReporterConfig.getMaxConnectionNumber());
-    IoTDBMetricsUtils.checkAndCreateStorageGroup(sessionPool);
+    IoTDBMetricsUtils.checkOrCreateStorageGroup(sessionPool);
   }
 
   @Override

--- a/metrics/dropwizard-metrics/src/main/java/org/apache/iotdb/metrics/dropwizard/reporter/IoTDBReporter.java
+++ b/metrics/dropwizard-metrics/src/main/java/org/apache/iotdb/metrics/dropwizard/reporter/IoTDBReporter.java
@@ -22,7 +22,7 @@ package org.apache.iotdb.metrics.dropwizard.reporter;
 import org.apache.iotdb.metrics.config.MetricConfig;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.dropwizard.MetricName;
-import org.apache.iotdb.metrics.utils.MetricsUtils;
+import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.pool.SessionPool;
@@ -80,6 +80,7 @@ public class IoTDBReporter extends ScheduledReporter {
             ioTDBReporterConfig.getUsername(),
             ioTDBReporterConfig.getPassword(),
             ioTDBReporterConfig.getMaxConnectionNumber());
+    IoTDBMetricsUtils.checkAndCreateStorageGroup(sessionPool);
   }
 
   @Override
@@ -232,7 +233,7 @@ public class IoTDBReporter extends ScheduledReporter {
 
   private void updateValue(String name, Map<String, String> labels, Object value) {
     if (value != null) {
-      String deviceId = MetricsUtils.generatePath(name, labels);
+      String deviceId = IoTDBMetricsUtils.generatePath(name, labels);
       List<String> sensors = Collections.singletonList("value");
 
       List<TSDataType> dataTypes = new ArrayList<>();

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
@@ -63,15 +63,16 @@ public class IoTDBMetricsUtils {
     return stringBuilder.toString();
   }
 
-  public static void checkAndCreateStorageGroup(SessionPool session) {
-    try {
-      SessionDataSetWrapper result =
-          session.executeQueryStatement("show storage group " + STORAGE_GROUP);
-      if (0 == result.getBatchSize()) {
+  public static void checkOrCreateStorageGroup(SessionPool session) {
+    try (SessionDataSetWrapper result =
+        session.executeQueryStatement("show storage group " + STORAGE_GROUP)) {
+      if (!result.hasNext()) {
         session.setStorageGroup(STORAGE_GROUP);
       }
-    } catch (StatementExecutionException | IoTDBConnectionException e) {
-      logger.error("CheckAndCreateStorageGroup failed", e);
+    } catch (IoTDBConnectionException e) {
+      logger.error("CheckOrCreateStorageGroup failed because ", e);
+    } catch (StatementExecutionException e) {
+      // do nothing
     }
   }
 }

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
@@ -21,18 +21,27 @@ package org.apache.iotdb.metrics.utils;
 
 import org.apache.iotdb.metrics.config.MetricConfig;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.session.pool.SessionDataSetWrapper;
+import org.apache.iotdb.session.pool.SessionPool;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-public class MetricsUtils {
+public class IoTDBMetricsUtils {
+  private static final Logger logger = LoggerFactory.getLogger(IoTDBMetricsUtils.class);
   private static final MetricConfig metricConfig =
       MetricConfigDescriptor.getInstance().getMetricConfig();
+  private static final String STORAGE_GROUP =
+      "root." + metricConfig.getIoTDBReporterConfig().getDatabase();
 
   public static String generatePath(String name, Map<String, String> labels) {
     StringBuilder stringBuilder = new StringBuilder();
     stringBuilder
-        .append("root.")
-        .append(metricConfig.getIoTDBReporterConfig().getDatabase())
+        .append(STORAGE_GROUP)
         .append(".`")
         .append(metricConfig.getRpcAddress())
         .append(":")
@@ -52,5 +61,17 @@ public class MetricsUtils {
           .append("`");
     }
     return stringBuilder.toString();
+  }
+
+  public static void checkAndCreateStorageGroup(SessionPool session) {
+    try {
+      SessionDataSetWrapper result =
+          session.executeQueryStatement("show storage group " + STORAGE_GROUP);
+      if (0 == result.getBatchSize()) {
+        session.setStorageGroup(STORAGE_GROUP);
+      }
+    } catch (StatementExecutionException | IoTDBConnectionException e) {
+      logger.error("CheckAndCreateStorageGroup failed", e);
+    }
   }
 }

--- a/metrics/micrometer-metrics/src/main/java/org/apache/iotdb/metrics/micrometer/reporter/IoTDBMeterRegistry.java
+++ b/metrics/micrometer-metrics/src/main/java/org/apache/iotdb/metrics/micrometer/reporter/IoTDBMeterRegistry.java
@@ -57,7 +57,7 @@ public class IoTDBMeterRegistry extends StepMeterRegistry {
             ioTDBReporterConfig.getUsername(),
             ioTDBReporterConfig.getPassword(),
             ioTDBReporterConfig.getMaxConnectionNumber());
-    IoTDBMetricsUtils.checkAndCreateStorageGroup(sessionPool);
+    IoTDBMetricsUtils.checkOrCreateStorageGroup(sessionPool);
   }
 
   @Override

--- a/metrics/micrometer-metrics/src/main/java/org/apache/iotdb/metrics/micrometer/reporter/IoTDBMeterRegistry.java
+++ b/metrics/micrometer-metrics/src/main/java/org/apache/iotdb/metrics/micrometer/reporter/IoTDBMeterRegistry.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.metrics.micrometer.reporter;
 
 import org.apache.iotdb.metrics.config.MetricConfig;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
-import org.apache.iotdb.metrics.utils.MetricsUtils;
+import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.pool.SessionPool;
@@ -57,6 +57,7 @@ public class IoTDBMeterRegistry extends StepMeterRegistry {
             ioTDBReporterConfig.getUsername(),
             ioTDBReporterConfig.getPassword(),
             ioTDBReporterConfig.getMaxConnectionNumber());
+    IoTDBMetricsUtils.checkAndCreateStorageGroup(sessionPool);
   }
 
   @Override
@@ -128,7 +129,7 @@ public class IoTDBMeterRegistry extends StepMeterRegistry {
 
   private void updateValue(String name, Map<String, String> labels, Double value, Long time) {
     if (value != null) {
-      String deviceId = MetricsUtils.generatePath(name, labels);
+      String deviceId = IoTDBMetricsUtils.generatePath(name, labels);
       List<String> sensors = Collections.singletonList("value");
       List<TSDataType> dataTypes = Collections.singletonList(TSDataType.DOUBLE);
       List<Object> values = Collections.singletonList(value);


### PR DESCRIPTION
In the initialization, IoTDB Reporter need to check the existence of storage group and create if not exists.
See: https://issues.apache.org/jira/browse/IOTDB-3937