### PR TITLE
[IOTDB-3975]refactoring cache from authorityFetcher

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/auth/AuthorizerManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/AuthorizerManager.java
@@ -63,9 +63,9 @@ public class AuthorizerManager implements IAuthorizer {
       iAuthorizer = BasicAuthorizer.getInstance();
       authReadWriteLock = new ReentrantReadWriteLock();
       if (conf.getConfig().isClusterMode()) {
-        authorityFetcher = ClusterAuthorityFetcher.getInstance();
+        authorityFetcher = new ClusterAuthorityFetcher(new BasicAuthorityCache());
       } else {
-        authorityFetcher = StandaloneAuthorityFetcher.getInstance();
+        authorityFetcher = new StandaloneAuthorityFetcher();
       }
     } catch (AuthException e) {
       logger.error(e.getMessage());
@@ -384,7 +384,7 @@ public class AuthorizerManager implements IAuthorizer {
   }
 
   public boolean invalidateCache(String username, String roleName) {
-    return ClusterAuthorityFetcher.getInstance().invalidateCache(username, roleName);
+    return authorityFetcher.getAuthorCache().invalidateCache(username, roleName);
   }
 
   public SettableFuture<ConfigTaskResult> queryPermission(AuthorStatement authorStatement) {

--- a/server/src/main/java/org/apache/iotdb/db/auth/BasicAuthorityCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/BasicAuthorityCache.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.auth;
+
+import org.apache.iotdb.commons.auth.entity.Role;
+import org.apache.iotdb.commons.auth.entity.User;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class BasicAuthorityCache implements IAuthorCache {
+  private static final Logger logger = LoggerFactory.getLogger(BasicAuthorityCache.class);
+
+  private IoTDBDescriptor conf = IoTDBDescriptor.getInstance();
+
+  private Cache<String, User> userCache =
+      Caffeine.newBuilder()
+          .maximumSize(conf.getConfig().getAuthorCacheSize())
+          .expireAfterAccess(conf.getConfig().getAuthorCacheExpireTime(), TimeUnit.MINUTES)
+          .build();
+
+  private Cache<String, Role> roleCache =
+      Caffeine.newBuilder()
+          .maximumSize(conf.getConfig().getAuthorCacheSize())
+          .expireAfterAccess(conf.getConfig().getAuthorCacheExpireTime(), TimeUnit.MINUTES)
+          .build();
+
+  @Override
+  public User getUserCache(String userName) {
+    return userCache.getIfPresent(userName);
+  }
+
+  @Override
+  public Role getRoleCache(String roleName) {
+    return roleCache.getIfPresent(roleName);
+  }
+
+  @Override
+  public void putUserCache(String userName, User user) {
+    userCache.put(userName, user);
+  }
+
+  @Override
+  public void putRoleCache(String roleName, Role role) {
+    roleCache.put(roleName, role);
+  }
+
+  /**
+   * Initialize user and role cache information.
+   *
+   * <p>If the permission information of the role changes, only the role cache information is
+   * cleared. During permission checking, if the role belongs to a user, the user will be
+   * initialized.
+   */
+  @Override
+  public boolean invalidateCache(String userName, String roleName) {
+    if (userName != null) {
+      if (userCache.getIfPresent(userName) != null) {
+        List<String> roleList = userCache.getIfPresent(userName).getRoleList();
+        if (!roleList.isEmpty()) {
+          roleCache.invalidateAll(roleList);
+        }
+        userCache.invalidate(userName);
+      }
+      if (userCache.getIfPresent(userName) != null) {
+        logger.error("datanode cache initialization failed");
+        return false;
+      }
+    }
+    if (roleName != null) {
+      if (roleCache.getIfPresent(roleName) != null) {
+        roleCache.invalidate(roleName);
+      }
+      if (roleCache.getIfPresent(roleName) != null) {
+        logger.error("datanode cache initialization failed");
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/auth/IAuthorCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/IAuthorCache.java
@@ -19,23 +19,17 @@
 
 package org.apache.iotdb.db.auth;
 
-import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.db.mpp.plan.execution.config.ConfigTaskResult;
-import org.apache.iotdb.db.mpp.plan.statement.sys.AuthorStatement;
+import org.apache.iotdb.commons.auth.entity.Role;
+import org.apache.iotdb.commons.auth.entity.User;
 
-import com.google.common.util.concurrent.SettableFuture;
+public interface IAuthorCache {
+  User getUserCache(String userName);
 
-import java.util.List;
+  Role getRoleCache(String roleName);
 
-public interface IAuthorityFetcher {
+  void putUserCache(String userName, User user);
 
-  TSStatus checkUser(String username, String password);
+  void putRoleCache(String roleName, Role role);
 
-  TSStatus checkUserPrivileges(String username, List<String> allPath, int permission);
-
-  SettableFuture<ConfigTaskResult> operatePermission(AuthorStatement authorStatement);
-
-  SettableFuture<ConfigTaskResult> queryPermission(AuthorStatement authorStatement);
-
-  IAuthorCache getAuthorCache();
+  boolean invalidateCache(String userName, String roleName);
 }

--- a/server/src/main/java/org/apache/iotdb/db/auth/StandaloneAuthorityFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/StandaloneAuthorityFetcher.java
@@ -41,16 +41,6 @@ public class StandaloneAuthorityFetcher implements IAuthorityFetcher {
 
   private LocalConfigNode localConfigNode = LocalConfigNode.getInstance();
 
-  private static final class StandaloneAuthorityFetcherHolder {
-    private static final StandaloneAuthorityFetcher INSTANCE = new StandaloneAuthorityFetcher();
-
-    private StandaloneAuthorityFetcherHolder() {}
-  }
-
-  public static StandaloneAuthorityFetcher getInstance() {
-    return StandaloneAuthorityFetcher.StandaloneAuthorityFetcherHolder.INSTANCE;
-  }
-
   @Override
   public TSStatus checkUser(String username, String password) {
     try {
@@ -127,5 +117,10 @@ public class StandaloneAuthorityFetcher implements IAuthorityFetcher {
       future.setException(e);
     }
     return future;
+  }
+
+  @Override
+  public IAuthorCache getAuthorCache() {
+    throw new UnsupportedOperationException("AuthorCache in Standalone is not supported.");
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/auth/AuthorizerManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/auth/AuthorizerManagerTest.java
@@ -41,7 +41,7 @@ import java.util.Set;
 
 public class AuthorizerManagerTest {
 
-  ClusterAuthorityFetcher authorityFetcher = ClusterAuthorityFetcher.getInstance();
+  ClusterAuthorityFetcher authorityFetcher = new ClusterAuthorityFetcher(new BasicAuthorityCache());
 
   @Test
   public void permissionCacheTest() {
@@ -90,8 +90,10 @@ public class AuthorizerManagerTest {
     result.setRoleInfo(new HashMap<>());
 
     // User authentication permission without role
-    authorityFetcher.getUserCache().put(user.getName(), authorityFetcher.cacheUser(result));
-    User user1 = authorityFetcher.getUserCache().getIfPresent(user.getName());
+    authorityFetcher
+        .getAuthorCache()
+        .putUserCache(user.getName(), authorityFetcher.cacheUser(result));
+    User user1 = authorityFetcher.getAuthorCache().getUserCache(user.getName());
     assert user1 != null;
     Assert.assertEquals(user.getName(), user1.getName());
     Assert.assertEquals(user.getPassword(), user1.getPassword());
@@ -113,7 +115,7 @@ public class AuthorizerManagerTest {
             .getCode());
 
     // Authenticate users with roles
-    authorityFetcher.invalidateCache(user.getName(), "");
+    authorityFetcher.getAuthorCache().invalidateCache(user.getName(), "");
     tUserResp.setPrivilegeList(new ArrayList<>());
     tUserResp.setRoleList(user.getRoleList());
 
@@ -131,8 +133,10 @@ public class AuthorizerManagerTest {
       tRoleRespMap.put(role.getName(), tRoleResp);
     }
     result.setRoleInfo(tRoleRespMap);
-    authorityFetcher.getUserCache().put(user.getName(), authorityFetcher.cacheUser(result));
-    Role role3 = authorityFetcher.getRoleCache().getIfPresent(role1.getName());
+    authorityFetcher
+        .getAuthorCache()
+        .putUserCache(user.getName(), authorityFetcher.cacheUser(result));
+    Role role3 = authorityFetcher.getAuthorCache().getRoleCache(role1.getName());
     Assert.assertEquals(role1.getName(), role3.getName());
     Assert.assertEquals(role1.getPrivilegeList(), role3.getPrivilegeList());
 
@@ -151,10 +155,10 @@ public class AuthorizerManagerTest {
                 "user", Collections.singletonList("root.ln"), PrivilegeType.CREATE_USER.ordinal())
             .getCode());
 
-    authorityFetcher.invalidateCache(user.getName(), "");
+    authorityFetcher.getAuthorCache().invalidateCache(user.getName(), "");
 
-    user1 = authorityFetcher.getUserCache().getIfPresent(user.getName());
-    role1 = authorityFetcher.getRoleCache().getIfPresent(role1.getName());
+    user1 = authorityFetcher.getAuthorCache().getUserCache(user.getName());
+    role1 = authorityFetcher.getAuthorCache().getRoleCache(role1.getName());
 
     Assert.assertNull(user1);
     Assert.assertNull(role1);


### PR DESCRIPTION
## Description
1、AuthorityFetcher class is not necessary to use Singleton pattern because AuthorizerManager is already a singleton.
2、Extract the cache from the ClusterAuthorityFetcher, people can implement their cache class in their own permission model.
3、Add getAuthorCache() to IAuthorityFetcher interface, because I think every authorityFetcher should has an author cache even a standalone mode, it will avoid unnecessary I/O to the authority file.

### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
