### PR TITLE
[IOTDB-3678] Added array size adjust method for PrimitiveArrayManager.

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -305,6 +305,16 @@ public class IoTDBDescriptor {
         conf.setUnSeqTsFileSize(unSeqTsFileSize);
       }
 
+      int PrimitiveArraySize =
+          Integer.parseInt(
+              properties
+                  .getProperty("primitive_array_size", Long.toString(conf.getUnSeqTsFileSize()))
+                  .trim());
+      if (PrimitiveArraySize > 0) {
+        conf.setPrimitiveArraySize(PrimitiveArraySize);
+        PrimitiveArrayManager.changeSize(PrimitiveArraySize);
+      }
+
       long memTableSizeThreshold =
           Long.parseLong(
               properties

--- a/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
@@ -38,7 +38,7 @@ public class PrimitiveArrayManager {
 
   private static final IoTDBConfig CONFIG = IoTDBDescriptor.getInstance().getConfig();
 
-  public static final int ARRAY_SIZE = CONFIG.getPrimitiveArraySize();
+  public static int ARRAY_SIZE = CONFIG.getPrimitiveArraySize();
 
   /**
    * The actual used memory will be 50% larger than the statistic, so we need to limit the size of
@@ -143,6 +143,14 @@ public class PrimitiveArrayManager {
       array = createPrimitiveArray(dataType);
     }
     return array;
+  }
+
+  public static void changeSize(int size) {
+    synchronized (POOLED_ARRAYS) {
+      ARRAY_SIZE = size;
+      release(POOLED_ARRAYS);
+      updateLimits();
+    }
   }
 
   private static void updateLimits() {
@@ -256,6 +264,10 @@ public class PrimitiveArrayManager {
       order = TSDataType.TEXT.serialize();
     } else {
       throw new UnSupportedDataTypeException(array.getClass().toString());
+    }
+
+    if(Array.getLength(array) != ARRAY_SIZE) {
+      return;
     }
 
     synchronized (POOLED_ARRAYS[order]) {

--- a/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
@@ -266,8 +266,8 @@ public class PrimitiveArrayManager {
       throw new UnSupportedDataTypeException(array.getClass().toString());
     }
 
-    if(Array.getLength(array) != ARRAY_SIZE) {
-      return;
+    if (Array.getLength(array) != ARRAY_SIZE) {
+      return ;
     }
 
     synchronized (POOLED_ARRAYS[order]) {


### PR DESCRIPTION
Improvement: Now users can use "load configuration" command to adjust primitive_array_size while the server is in running progress.