### PR TITLE
[IOTDB-3781] Reinforce the regionCleaner task's startup logic

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
@@ -139,12 +139,16 @@ public class PartitionRegionStateMachine implements IStateMachine, IStateMachine
   @Override
   public void notifyLeaderChanged(ConsensusGroupId groupId, TEndPoint newLeader) {
     if (currentNode.equals(newLeader)) {
-      LOGGER.info("Current node {} is Leader, start procedure manager.", newLeader);
+      LOGGER.info("Current node {} becomes Leader", newLeader);
       configManager.getProcedureManager().shiftExecutor(true);
       configManager.getLoadManager().start();
+      configManager.getPartitionManager().startRegionCleaner();
     } else {
+      LOGGER.info(
+          "Current node {} is not longer the leader, the new leader is {}", currentNode, newLeader);
       configManager.getProcedureManager().shiftExecutor(false);
       configManager.getLoadManager().stop();
+      configManager.getPartitionManager().stopRegionCleaner();
     }
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/PartitionManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/PartitionManager.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -73,23 +74,22 @@ public class PartitionManager {
 
   private final IManager configManager;
   private final PartitionInfo partitionInfo;
-  private static final int REGION_CLEANER_WORK_INTERVAL = 300;
-  private static final int REGION_CLEANER_WORK_INITIAL_DELAY = 10;
 
   private SeriesPartitionExecutor executor;
+
+  /** Region cleaner */
+  // Monitor for leadership change
+  private final Object scheduleMonitor = new Object();
+  // Try to delete Regions in every 10s
+  private static final int REGION_CLEANER_WORK_INTERVAL = 10;
   private final ScheduledExecutorService regionCleaner;
+  private Future<?> currentRegionCleanerFuture;
 
   public PartitionManager(IManager configManager, PartitionInfo partitionInfo) {
     this.configManager = configManager;
     this.partitionInfo = partitionInfo;
     this.regionCleaner =
         IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor("IoTDB-Region-Cleaner");
-    ScheduledExecutorUtil.safelyScheduleAtFixedRate(
-        regionCleaner,
-        this::clearDeletedRegions,
-        REGION_CLEANER_WORK_INITIAL_DELAY,
-        REGION_CLEANER_WORK_INTERVAL,
-        TimeUnit.SECONDS);
     setSeriesPartitionExecutor();
   }
 
@@ -397,24 +397,6 @@ public class PartitionManager {
     getConsensusManager().write(preDeleteStorageGroupPlan);
   }
 
-  /**
-   * Called by {@link PartitionManager#regionCleaner} Delete regions of logical deleted storage
-   * groups periodically.
-   */
-  public void clearDeletedRegions() {
-    if (getConsensusManager().isLeader()) {
-      final Set<TRegionReplicaSet> deletedRegionSet = partitionInfo.getDeletedRegionSet();
-      if (!deletedRegionSet.isEmpty()) {
-        LOGGER.info(
-            "DELETE REGIONS {} START",
-            deletedRegionSet.stream()
-                .map(TRegionReplicaSet::getRegionId)
-                .collect(Collectors.toList()));
-        SyncDataNodeClientPool.getInstance().deleteRegions(deletedRegionSet);
-      }
-    }
-  }
-
   public void addMetrics() {
     partitionInfo.addMetrics();
   }
@@ -451,6 +433,51 @@ public class PartitionManager {
    */
   public String getRegionStorageGroup(TConsensusGroupId regionId) {
     return partitionInfo.getRegionStorageGroup(regionId);
+  }
+
+  /**
+   * Called by {@link PartitionManager#regionCleaner} Delete regions of logical deleted storage
+   * groups periodically.
+   */
+  public void clearDeletedRegions() {
+    if (getConsensusManager().isLeader()) {
+      final Set<TRegionReplicaSet> deletedRegionSet = partitionInfo.getDeletedRegionSet();
+      if (!deletedRegionSet.isEmpty()) {
+        LOGGER.info(
+            "DELETE REGIONS {} START",
+            deletedRegionSet.stream()
+                .map(TRegionReplicaSet::getRegionId)
+                .collect(Collectors.toList()));
+        SyncDataNodeClientPool.getInstance().deleteRegions(deletedRegionSet);
+      }
+    }
+  }
+
+  public void startRegionCleaner() {
+    synchronized (scheduleMonitor) {
+      if (currentRegionCleanerFuture == null) {
+        /* Start the RegionCleaner service */
+        currentRegionCleanerFuture =
+            ScheduledExecutorUtil.safelyScheduleAtFixedRate(
+                regionCleaner,
+                this::clearDeletedRegions,
+                0,
+                REGION_CLEANER_WORK_INTERVAL,
+                TimeUnit.SECONDS);
+        LOGGER.info("RegionCleaner is started successfully.");
+      }
+    }
+  }
+
+  public void stopRegionCleaner() {
+    synchronized (scheduleMonitor) {
+      if (currentRegionCleanerFuture != null) {
+        /* Stop the RegionCleaner service */
+        currentRegionCleanerFuture.cancel(false);
+        currentRegionCleanerFuture = null;
+        LOGGER.info("RegionCleaner is stopped successfully.");
+      }
+    }
   }
 
   public ScheduledExecutorService getRegionCleaner() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -83,6 +83,7 @@ public class ProcedureManager {
             CONFIG_NODE_CONFIG.getProcedureCompletedCleanInterval(),
             CONFIG_NODE_CONFIG.getProcedureCompletedEvictTTL());
         store.start();
+        LOGGER.info("ProcedureManager is started successfully.");
       }
     } else {
       if (executor.isRunning()) {
@@ -90,6 +91,7 @@ public class ProcedureManager {
         if (!executor.isRunning()) {
           executor.join();
           store.stop();
+          LOGGER.info("ProcedureManager is stopped successfully.");
         }
       }
     }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
@@ -225,6 +225,7 @@ public class LoadManager {
                 0,
                 heartbeatInterval,
                 TimeUnit.MILLISECONDS);
+        LOGGER.info("Heartbeat service is started successfully.");
       }
 
       /* Start the load balancing service */
@@ -236,6 +237,7 @@ public class LoadManager {
                 0,
                 heartbeatInterval,
                 TimeUnit.MILLISECONDS);
+        LOGGER.info("LoadBalancing service is started successfully.");
       }
     }
   }
@@ -247,8 +249,10 @@ public class LoadManager {
       if (currentHeartbeatFuture != null) {
         currentHeartbeatFuture.cancel(false);
         currentHeartbeatFuture = null;
+        LOGGER.info("Heartbeat service is stopped successfully.");
         currentLoadBalancingFuture.cancel(false);
         currentLoadBalancingFuture = null;
+        LOGGER.info("LoadBalancing service is stopped successfully.");
       }
     }
   }


### PR DESCRIPTION
The regionCleaner task in ConfigNode's PartitionManager will start as soon as the PartitionManager is initialized, which is unsafe however. Ever interior ScheduledExecutor should not be started until the current ConfigNode confirms it's leadership. And these inner ScheduleExecutor should be shutdown immediatly when the current ConfigNode loses it's leadership.

Test result, all ScheduledExecutor started after the current ConfigNode becomes leader:

![image](https://user-images.githubusercontent.com/33111881/181195354-480bb8a5-f980-443c-9eb6-39ac2121b27a.png)

