### PR TITLE
[IOTDB-3900] start-confignode ，Failed to execute system command

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/sync/confignode/SyncConfigNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/sync/confignode/SyncConfigNodeClientPool.java
@@ -104,6 +104,11 @@ public class SyncConfigNodeClientPool {
       }
     }
     LOGGER.error("{} failed on ConfigNode {}", requestType, endPoint, lastException);
+    if (requestType == ConfigNodeRequestType.REGISTER_CONFIG_NODE) {
+      return new TConfigNodeRegisterResp(
+          new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
+              .setMessage("All retry failed due to" + lastException.getMessage()));
+    }
     return new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
         .setMessage("All retry failed due to" + lastException.getMessage());
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/sync/confignode/SyncConfigNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/sync/confignode/SyncConfigNodeClientPool.java
@@ -104,13 +104,16 @@ public class SyncConfigNodeClientPool {
       }
     }
     LOGGER.error("{} failed on ConfigNode {}", requestType, endPoint, lastException);
-    if (requestType == ConfigNodeRequestType.REGISTER_CONFIG_NODE) {
-      return new TConfigNodeRegisterResp(
-          new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
-              .setMessage("All retry failed due to" + lastException.getMessage()));
+    switch (requestType) {
+      case REGISTER_CONFIG_NODE:
+        return new TConfigNodeRegisterResp(
+            RpcUtils.getStatus(
+                TSStatusCode.ALL_RETRY_FAILED,
+                "All retry failed due to" + lastException.getMessage()));
+      default:
+        return RpcUtils.getStatus(
+            TSStatusCode.ALL_RETRY_FAILED, "All retry failed due to" + lastException.getMessage());
     }
-    return new TSStatus(TSStatusCode.ALL_RETRY_FAILED.getStatusCode())
-        .setMessage("All retry failed due to" + lastException.getMessage());
   }
 
   public void addConsensusGroup(


### PR DESCRIPTION
## 顺序启动3个confignode，不是每次必现，遇到3次，ip4 的confignode报错：
2022-07-20 15:22:39,073 [main] ERROR o.a.i.c.c.s.c.SyncConfigNodeClientPool:106 - REGISTER_CONFIG_NODE failed on ConfigNode TEndPoint(ip:192.168.130.3, port:22277)
java.io.IOException: Borrow client from pool for node TEndPoint(ip:192.168.130.3, port:22277) failed.
at org.apache.iotdb.commons.client.ClientManager.borrowClient(ClientManager.java:61)
at org.apache.iotdb.confignode.client.sync.confignode.SyncConfigNodeClientPool.sendSyncRequestToConfigNodeWithRetry(SyncConfigNodeClientPool.java:73)
at org.apache.iotdb.confignode.service.ConfigNode.registerConfigNode(ConfigNode.java:195)
at org.apache.iotdb.confignode.service.ConfigNode.active(ConfigNode.java:117)
at org.apache.iotdb.confignode.service.ConfigNodeCommandLine.run(ConfigNodeCommandLine.java:75)
at org.apache.iotdb.commons.ServerCommandLine.doMain(ServerCommandLine.java:58)
at org.apache.iotdb.confignode.service.ConfigNode.main(ConfigNode.java:73)
Caused by: net.sf.cglib.core.CodeGenerationException: org.apache.thrift.transport.TTransportException-->java.net.ConnectException: Connection refused (Connection refused)
at net.sf.cglib.core.ReflectUtils.newInstance(ReflectUtils.java:235)
at net.sf.cglib.core.ReflectUtils.newInstance(ReflectUtils.java:220)
at net.sf.cglib.proxy.Enhancer.createUsingReflection(Enhancer.java:639)
at net.sf.cglib.proxy.Enhancer.firstInstance(Enhancer.java:538)
at net.sf.cglib.core.AbstractClassGenerator.create(AbstractClassGenerator.java:231)
at net.sf.cglib.proxy.Enhancer.createHelper(Enhancer.java:377)
at net.sf.cglib.proxy.Enhancer.create(Enhancer.java:304)
at org.apache.iotdb.commons.client.sync.SyncThriftClientWithErrorHandler.newErrorHandler(SyncThriftClientWithErrorHandler.java:48)
at org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient$Factory.makeObject(SyncConfigNodeIServiceClient.java:115)
at org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient$Factory.makeObject(SyncConfigNodeIServiceClient.java:94)
at org.apache.commons.pool2.impl.GenericKeyedObjectPool.create(GenericKeyedObjectPool.java:780)
at org.apache.commons.pool2.impl.GenericKeyedObjectPool.borrowObject(GenericKeyedObjectPool.java:439)
at org.apache.commons.pool2.impl.GenericKeyedObjectPool.borrowObject(GenericKeyedObjectPool.java:350)
at org.apache.iotdb.commons.client.ClientManager.borrowClient(ClientManager.java:50)
... 6 common frames omitted
Caused by: org.apache.thrift.transport.TTransportException: java.net.ConnectException: Connection refused (Connection refused)
at org.apache.thrift.transport.TSocket.open(TSocket.java:243)
at org.apache.iotdb.rpc.TElasticFramedTransport.open(TElasticFramedTransport.java:91)
at org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient.<init>(SyncConfigNodeIServiceClient.java:62)
at org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient$$EnhancerByCGLIB$$ff60ca51.<init>(<generated>)
at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
at net.sf.cglib.core.ReflectUtils.newInstance(ReflectUtils.java:228)
... 19 common frames omitted
Caused by: java.net.ConnectException: Connection refused (Connection refused)
at java.net.PlainSocketImpl.socketConnect(Native Method)
at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:476)
at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:218)
at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:200)
at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:394)
at java.net.Socket.connect(Socket.java:606)
at org.apache.thrift.transport.TSocket.open(TSocket.java:238)
... 27 common frames omitted
2022-07-20 15:22:39,079 [main] ERROR o.a.i.c.ServerCommandLine:63 -* Failed to execute system command
java.lang.ClassCastException: org.apache.iotdb.common.rpc.thrift.TSStatus cannot be cast to org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterResp*
at org.apache.iotdb.confignode.service.ConfigNode.registerConfigNode(ConfigNode.java:195)
at org.apache.iotdb.confignode.service.ConfigNode.active(ConfigNode.java:117)
at org.apache.iotdb.confignode.service.ConfigNodeCommandLine.run(ConfigNodeCommandLine.java:75)
at org.apache.iotdb.commons.ServerCommandLine.doMain(ServerCommandLine.java:58)
at org.apache.iotdb.confignode.service.ConfigNode.main(ConfigNode.java:73)


### test result on condition: two configNodes, one dataNode
* start one configNode and one dataNode;
* start another one configNode, modify target_config_nodes in iotdb-confignode.properties to a wrong ip
![1](https://user-images.githubusercontent.com/39719966/181222306-01d4d750-1773-4677-88c0-cc121c3097cf.png)
![2](https://user-images.githubusercontent.com/39719966/181222335-5e1976cc-3fb7-43b4-96e1-ce41eb3b77f3.png)
