### PR TITLE
[To rel/0.13][IOTDB-3969]Fix timeseries statistic bug

### DIFF
--- a/docs/UserGuide/Maintenance-Tools/Metric-Tool.md
+++ b/docs/UserGuide/Maintenance-Tools/Metric-Tool.md
@@ -111,7 +111,7 @@ Next, we will choose Prometheus format data as samples to describe each kind of 
 
 | Metric   | Tag                                   | level     | Description                                                   | Sample                           |
 | -------- | ------------------------------------- | --------- | ------------------------------------------------------------- | -------------------------------- |
-| quantity | name="timeSeries/storageGroup/device" | important | The current count of timeSeries/storageGroup/devices in IoTDB | quantity{name="timeSeries",} 1.0 |
+| quantity | name="storageGroup/device";<br/>name="timeSeries", type="normal/template" | important | The current count of timeSeries/storageGroup/devices in IoTDB | quantity{name="timeSeries",type="normal"} 1.0 |
 
 #### 4.3.6. Cluster
 

--- a/docs/zh/UserGuide/Maintenance-Tools/Metric-Tool.md
+++ b/docs/zh/UserGuide/Maintenance-Tools/Metric-Tool.md
@@ -110,7 +110,7 @@ IoTDB对外提供JMX和Prometheus格式的监控指标，对于JMX，可以通�
 
 | Metric   | Tag                                   | level     | 说明                                         | 示例                             |
 | -------- | ------------------------------------- | --------- | -------------------------------------------- | -------------------------------- |
-| quantity | name="timeSeries/storageGroup/device" | important | 当前时间timeSeries/storageGroup/device的数量 | quantity{name="timeSeries",} 1.0 |
+| quantity | name="timeSeries/storageGroup/device";<br/>name="timeSeries", type="normal/template"  | important | 当前时间timeSeries/storageGroup/device的数量 | quantity{name="timeSeries",type="normal"} 1.0 |
 
 #### 4.3.6. 集群
 

--- a/integration/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
+++ b/integration/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
@@ -1339,9 +1339,7 @@ public class IoTDBSessionSimpleIT {
       session.deleteTimeseries("root.sg.loc1.sector.x");
       fail();
     } catch (StatementExecutionException e) {
-      assertTrue(
-          e.getMessage()
-              .contains("Cannot delete a timeseries inside a template: root.sg.loc1.sector.x;"));
+      assertTrue(e.getMessage().contains("506: root.sg.loc1.sector.x;"));
     }
 
     session.close();

--- a/integration/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
+++ b/integration/src/test/java/org/apache/iotdb/session/IoTDBSessionSimpleIT.java
@@ -1339,7 +1339,9 @@ public class IoTDBSessionSimpleIT {
       session.deleteTimeseries("root.sg.loc1.sector.x");
       fail();
     } catch (StatementExecutionException e) {
-      assertTrue(e.getMessage().contains("506: root.sg.loc1.sector.x;"));
+      assertTrue(
+          e.getMessage()
+              .contains("Cannot delete a timeseries inside a template: root.sg.loc1.sector.x;"));
     }
 
     session.close();

--- a/server/src/main/java/org/apache/iotdb/db/exception/metadata/MeasurementInsideTemplateException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/metadata/MeasurementInsideTemplateException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.exception.metadata;
+
+public class MeasurementInsideTemplateException extends MetadataException {
+
+  private String path;
+
+  public MeasurementInsideTemplateException(String path) {
+    super(String.format("Cannot delete a timeseries inside a template: %s", path));
+    this.path = path;
+  }
+
+  public String getPath() {
+    return path;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -324,7 +324,9 @@ public class MManager {
             totalNormalSeriesNumber,
             AtomicLong::get,
             Tag.NAME.toString(),
-            "normal-timeSeries");
+            "timeSeries",
+            Tag.TYPE.toString(),
+            "normal");
 
     MetricsService.getInstance()
         .getMetricManager()
@@ -334,7 +336,9 @@ public class MManager {
             totalTemplateSeriesNumber,
             AtomicLong::get,
             Tag.NAME.toString(),
-            "template-timeSeries");
+            "timeSeries",
+            Tag.TYPE.toString(),
+            "template");
 
     MetricsService.getInstance()
         .getMetricManager()

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -807,7 +807,7 @@ public class MManager {
         logWriter.deleteTimeseries(deleteTimeSeriesPlan);
       }
     } catch (MeasurementInsideTemplateException e) {
-      failedNames.add(e.getPath());
+      failedNames.add(e.getMessage());
     } catch (DeleteFailedException e) {
       failedNames.add(e.getName());
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTree.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.exception.metadata.AliasAlreadyExistException;
 import org.apache.iotdb.db.exception.metadata.AlignedTimeseriesException;
 import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.MNodeTypeMismatchException;
+import org.apache.iotdb.db.exception.metadata.MeasurementInsideTemplateException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.metadata.PathAlreadyExistException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
@@ -540,8 +541,7 @@ public class MTree implements Serializable {
     }
 
     if (isPathExistsWithinTemplate(path)) {
-      throw new MetadataException(
-          "Cannot delete a timeseries inside a template: " + path.toString());
+      throw new MeasurementInsideTemplateException(path.getFullPath());
     }
 
     IMeasurementMNode deletedNode = getMeasurementMNode(path);
@@ -1272,9 +1272,11 @@ public class MTree implements Serializable {
    *
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
-  public int getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
+  public int getAllTimeseriesCount(
+      PartialPath pathPattern, boolean isPrefixMatch, boolean traverseTemplate)
       throws MetadataException {
     CounterTraverser counter = new MeasurementCounter(root, pathPattern);
+    counter.setShouldTraverseTemplate(traverseTemplate);
     counter.setPrefixMatch(isPrefixMatch);
     counter.traverse();
     return counter.getCount();
@@ -1286,7 +1288,7 @@ public class MTree implements Serializable {
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
   public int getAllTimeseriesCount(PartialPath pathPattern) throws MetadataException {
-    return getAllTimeseriesCount(pathPattern, false);
+    return getAllTimeseriesCount(pathPattern, false, true);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -279,6 +279,10 @@ public abstract class Traverser {
     this.isPrefixMatch = isPrefixMatch;
   }
 
+  public void setShouldTraverseTemplate(boolean shouldTraverseTemplate) {
+    this.shouldTraverseTemplate = shouldTraverseTemplate;
+  }
+
   /**
    * @param currentNode the node need to get the full path of
    * @return full path from traverse start node to the current node


### PR DESCRIPTION
## Description

### Problem
When delete storage group, the timeseries represent by template will be counted and the result will be used to update the timeseries statistic number. The number doesn't update when activate template. Thus the number will be negative.

### Solution
Use two number to statistic template series and normal series separately.
