### PR TITLE
[To rel/0.13][IOTDB-3906][IOTDB-3921]Support template DDL under DoubleLive mode

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncPlanTypeUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncPlanTypeUtils.java
@@ -21,13 +21,21 @@ package org.apache.iotdb.db.doublelive;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
+import org.apache.iotdb.db.qp.physical.sys.ActivateTemplatePlan;
 import org.apache.iotdb.db.qp.physical.sys.AlterTimeSeriesPlan;
+import org.apache.iotdb.db.qp.physical.sys.AppendTemplatePlan;
 import org.apache.iotdb.db.qp.physical.sys.CreateAlignedTimeSeriesPlan;
 import org.apache.iotdb.db.qp.physical.sys.CreateMultiTimeSeriesPlan;
+import org.apache.iotdb.db.qp.physical.sys.CreateTemplatePlan;
 import org.apache.iotdb.db.qp.physical.sys.CreateTimeSeriesPlan;
+import org.apache.iotdb.db.qp.physical.sys.DeactivateTemplatePlan;
 import org.apache.iotdb.db.qp.physical.sys.DeleteStorageGroupPlan;
 import org.apache.iotdb.db.qp.physical.sys.DeleteTimeSeriesPlan;
+import org.apache.iotdb.db.qp.physical.sys.DropTemplatePlan;
+import org.apache.iotdb.db.qp.physical.sys.PruneTemplatePlan;
 import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
+import org.apache.iotdb.db.qp.physical.sys.SetTemplatePlan;
+import org.apache.iotdb.db.qp.physical.sys.UnsetTemplatePlan;
 
 public class OperationSyncPlanTypeUtils {
 
@@ -38,7 +46,15 @@ public class OperationSyncPlanTypeUtils {
         || plan instanceof CreateMultiTimeSeriesPlan
         || plan instanceof CreateAlignedTimeSeriesPlan
         || plan instanceof DeleteTimeSeriesPlan
-        || plan instanceof AlterTimeSeriesPlan) {
+        || plan instanceof AlterTimeSeriesPlan
+        || plan instanceof ActivateTemplatePlan
+        || plan instanceof AppendTemplatePlan
+        || plan instanceof CreateTemplatePlan
+        || plan instanceof DeactivateTemplatePlan
+        || plan instanceof DropTemplatePlan
+        || plan instanceof PruneTemplatePlan
+        || plan instanceof SetTemplatePlan
+        || plan instanceof UnsetTemplatePlan) {
       return OperationSyncPlanType.DDLPlan;
     } else if (plan instanceof DeletePlan || plan instanceof InsertPlan) {
       return OperationSyncPlanType.DMLPlan;


### PR DESCRIPTION
## Description
Add support for create/drop, set/unset, activate/deactivate, append/prune template operation when considering whether to invoke a double-live session during process of a DDL statement.