### PR TITLE
[IOTDB-3994] Fix the format of COMPACTION_TASK_COUNT metric.

### DIFF
--- a/docs/UserGuide/Maintenance-Tools/Metric-Tool.md
+++ b/docs/UserGuide/Maintenance-Tools/Metric-Tool.md
@@ -78,14 +78,14 @@ Next, we will choose Prometheus format data as samples to describe each kind of 
 
 #### 4.3.1. API
 
-| Metric              | Tag                   | level     | Description                              | Sample                                       |
-| ------------------- | --------------------- | --------- | ---------------------------------------- | -------------------------------------------- |
-| entry_seconds_count | name="{{interface}}" | important | The total request count of the interface | entry_seconds_count{name="openSession",} 1.0 |
-| entry_seconds_sum   | name="{{interface}}" | important | The total cost seconds of the interface  | entry_seconds_sum{name="openSession",} 0.024 |
-| entry_seconds_max   | name="{{interface}}" | important | The max latency of the interface         | entry_seconds_max{name="openSession",} 0.024 |
-| quantity_total      | name="pointsIn"       | important | The total points inserted into IoTDB     | quantity_total{name="pointsIn",} 1.0         |
-| thrift_connections  | name="{{thriftService}}" | core | current number of thrift connections | thrift_connections{name="RPC",} 1.0 |
-| thrift_active_threads | name="{{thriftThread}}" | core | current number if thrift worker threads | thrift_active_threads{name="RPC",} 1.0 |
+| Metric                | Tag                      | level     | Description                              | Sample                                       |
+| --------------------- | ------------------------ | --------- | ---------------------------------------- | -------------------------------------------- |
+| entry_seconds_count   | name="{{interface}}"     | important | The total request count of the interface | entry_seconds_count{name="openSession",} 1.0 |
+| entry_seconds_sum     | name="{{interface}}"     | important | The total cost seconds of the interface  | entry_seconds_sum{name="openSession",} 0.024 |
+| entry_seconds_max     | name="{{interface}}"     | important | The max latency of the interface         | entry_seconds_max{name="openSession",} 0.024 |
+| quantity_total        | name="pointsIn"          | important | The total points inserted into IoTDB     | quantity_total{name="pointsIn",} 1.0         |
+| thrift_connections    | name="{{thriftService}}" | core      | current number of thrift connections     | thrift_connections{name="RPC",} 1.0          |
+| thrift_active_threads | name="{{thriftThread}}"  | core      | current number if thrift worker threads  | thrift_active_threads{name="RPC",} 1.0       |
 
 #### 4.3.2. Task
 | Metric                  | Tag                                                                           | level     | Description                                              | Sample                                                                                  |
@@ -96,6 +96,7 @@ Next, we will choose Prometheus format data as samples to describe each kind of 
 | cost_task_seconds_sum   | name="inner_compaction/cross_compaction/flush"                                | important | The total cost seconds of all tasks till now             | cost_task_seconds_sum{name="flush",} 0.363                                              |
 | data_written            | name="compaction", <br />type="aligned/not-aligned/total"                     | important | The size of data written in compaction                   | data_written{name="compaction",type="total",} 10240                                     |
 | data_read               | name="compaction"                                                             | important | The size of data read in compaction                      | data_read={name="compaction",} 10240                                                    |
+| compaction_task_count   | name = "inner_compaction/cross_compaction", type="sequence/unsequence/total"  | important | The number of compaction task                            | compaction_task_count{name="inner_compaction",type="sequence",} 1                       |
 
 #### 4.3.3. Memory Usage
 

--- a/docs/zh/UserGuide/Maintenance-Tools/Metric-Tool.md
+++ b/docs/zh/UserGuide/Maintenance-Tools/Metric-Tool.md
@@ -76,14 +76,14 @@ IoTDB对外提供JMX和Prometheus格式的监控指标，对于JMX，可以通�
 
 #### 4.3.1. 接入层
 
-| Metric              | Tag             | level     | 说明             | 示例                                         |
-| ------------------- | --------------- | --------- | ---------------- | -------------------------------------------- |
-| entry_seconds_count | name="{{interface}}"   | important | 接口累计访问次数 | entry_seconds_count{name="openSession",} 1.0 |
-| entry_seconds_sum   | name="{{interface}}"   | important | 接口累计耗时(s)  | entry_seconds_sum{name="openSession",} 0.024 |
-| entry_seconds_max   | name="{{interface}}"   | important | 接口最大耗时(s)  | entry_seconds_max{name="openSession",} 0.024 |
-| quantity_total      | name="pointsIn" | important | 系统累计写入点数 | quantity_total{name="pointsIn",} 1.0         |
-| thrift_connections  | name="{{thriftService}}" | core | thrift当前连接数 | thrift_connections{name="RPC",} 1.0 |
-| thrift_active_threads | name="{{thriftThread}}" | core | thrift worker线程数 | thrift_active_threads{name="RPC",} 1.0 |
+| Metric                | Tag                      | level     | 说明                | 示例                                         |
+| --------------------- | ------------------------ | --------- | ------------------- | -------------------------------------------- |
+| entry_seconds_count   | name="{{interface}}"     | important | 接口累计访问次数    | entry_seconds_count{name="openSession",} 1.0 |
+| entry_seconds_sum     | name="{{interface}}"     | important | 接口累计耗时(s)     | entry_seconds_sum{name="openSession",} 0.024 |
+| entry_seconds_max     | name="{{interface}}"     | important | 接口最大耗时(s)     | entry_seconds_max{name="openSession",} 0.024 |
+| quantity_total        | name="pointsIn"          | important | 系统累计写入点数    | quantity_total{name="pointsIn",} 1.0         |
+| thrift_connections    | name="{{thriftService}}" | core      | thrift当前连接数    | thrift_connections{name="RPC",} 1.0          |
+| thrift_active_threads | name="{{thriftThread}}"  | core      | thrift worker线程数 | thrift_active_threads{name="RPC",} 1.0       |
 
 #### 4.3.2. Task
 
@@ -95,6 +95,7 @@ IoTDB对外提供JMX和Prometheus格式的监控指标，对于JMX，可以通�
 | cost_task_seconds_sum   | name="inner_compaction/cross_compaction/flush"                                | important | 任务累计耗时(s)                 | cost_task_seconds_sum{name="flush",} 0.363                                                         |
 | data_written            | name="compaction", <br />type="aligned/not-aligned/total"                     | important | 合并文件时写入量                | data_written{name="compaction",type="total",} 10240                                                |
 | data_read               | name="compaction"                                                             | important | 合并文件时的读取量              | data_read={name="compaction",} 10240                                                               |
+| compaction_task_count   | name = "inner_compaction/cross_compaction", type="sequence/unsequence/total"  | important | 合并任务个数                    | compaction_task_count{name="inner_compaction",type="sequence",} 1                                  |
 
 #### 4.3.3. 内存占用
 

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/CompactionMetricsRecorder.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/CompactionMetricsRecorder.java
@@ -153,7 +153,7 @@ public class CompactionMetricsRecorder {
                   Metric.COMPACTION_TASK_COUNT.toString(),
                   MetricLevel.IMPORTANT,
                   Tag.NAME.toString(),
-                  "inner_compaction_count",
+                  "inner_compaction",
                   Tag.TYPE.toString(),
                   ((InnerSpaceCompactionTask) task).isSequence() ? "sequence" : "unsequence");
         } else {
@@ -164,7 +164,9 @@ public class CompactionMetricsRecorder {
                   Metric.COMPACTION_TASK_COUNT.toString(),
                   MetricLevel.IMPORTANT,
                   Tag.NAME.toString(),
-                  "cross_compaction_count");
+                  "cross_compaction",
+                  Tag.TYPE.toString(),
+                  "total");
         }
         break;
       default:


### PR DESCRIPTION
In Prometheus, all meters with the same name need to have the same set of tag keys.

The description of problem: https://issues.apache.org/jira/browse/IOTDB-3994