### PR TITLE
[IOTDB-3992] After the restart, previous storage groups are not marked as Metrics

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -74,12 +74,11 @@ public class ConfigNode implements ConfigNodeMBean {
     LOGGER.info("Activating {}...", ConfigNodeConstant.GLOBAL_NAME);
 
     try {
-      // Init ConfigManager
-      initConfigManager();
       // Set up internal services
       setUpInternalServices();
-      // Add some Metrics for configManager
-      configManager.addMetrics();
+      // Init ConfigManager
+      initConfigManager();
+
       /* Restart */
       if (SystemPropertiesUtils.isRestarted()) {
         setUpRPCService();
@@ -141,6 +140,8 @@ public class ConfigNode implements ConfigNodeMBean {
       }
       System.exit(-1);
     }
+    // Add some Metrics for configManager
+    configManager.addMetrics();
     LOGGER.info("Successfully initialize ConfigManager.");
   }
 


### PR DESCRIPTION
## This reason is asynchronous StorageGroupPartitionTable recovery after startup ConsensusManager, then MetricsSerive has not been registered.


#### 1、Register internal servers ahead of Manager loading.

#### 2、Before，the ConfigManager instance was previously required by ‘setUpInternalServices()’（execute ‘configManager.getDataNodeRemoveManager().start()’;，It has been modified in version 1ffe93cb270ae9d8152a9507bb80acb95ceb6ee6），So put ‘manager.addmetrics ()’ under ‘active () ’then, but you don't need to do that now.

### Test
#### After
![image](https://user-images.githubusercontent.com/71131924/181670470-571492fa-1b1e-47ee-bd75-255524773217.png)

