### PR TITLE
[IOTDB-3927]Fix incorrect cross compaction selector log

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
@@ -96,13 +96,6 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
     try {
       List[] mergeFiles = fileSelector.select();
       if (mergeFiles.length == 0) {
-        if (compactionResource.getUnseqFiles().size() > 0) {
-          // still have unseq files but cannot be selected
-          LOGGER.warn(
-              "{} cannot select merge candidates under the budget {}",
-              logicalStorageGroupName,
-              budget);
-        }
         return Collections.emptyList();
       }
       LOGGER.info(


### PR DESCRIPTION
See details in [IOTDB-3927](https://issues.apache.org/jira/secure/RapidBoard.jspa?rapidView=492&projectKey=IOTDB&view=detail&selectedIssue=IOTDB-3927&quickFilter=2202).
When no files can be selected in the cross space compaction, it is not because the memory exceeds the threshold, but the seq files or unseen files are being occupied by other compaction tasks. 
In addition, even if the memory exceeds the threshold, at least one group of unseq file and its overlapping seq files will be selected.