### PR TITLE
[To rel/0.13]Fix mLogParser and mLogTxtWriter

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogTxtWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/logfile/MLogTxtWriter.java
@@ -419,7 +419,9 @@ public class MLogTxtWriter implements AutoCloseable {
     // OperationType,templateName,isAlign[,measurementPath,dataType,encoding,compressor]
     StringBuilder buf = new StringBuilder();
     buf.append(MetadataOperationType.APPEND_TEMPLATE);
+    buf.append(",");
     buf.append(plan.getName());
+    buf.append(",");
     buf.append(plan.isAligned());
     for (int i = 0; i < plan.getMeasurements().size(); i++) {
       buf.append(
@@ -441,8 +443,10 @@ public class MLogTxtWriter implements AutoCloseable {
     // OperationType,templateName[,measurementPath]
     StringBuilder buf = new StringBuilder();
     buf.append(MetadataOperationType.PRUNE_TEMPLATE);
+    buf.append(",");
     buf.append(plan.getName());
     for (int i = 0; i < plan.getPrunedMeasurements().size(); i++) {
+      buf.append(",");
       buf.append(plan.getPrunedMeasurements().get(i));
     }
     buf.append(LINE_SEPARATOR);

--- a/server/src/main/java/org/apache/iotdb/db/tools/mlog/MLogParser.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/mlog/MLogParser.java
@@ -227,6 +227,7 @@ public class MLogParser {
             break;
           case PRUNE_TEMPLATE:
             mLogTxtWriter.pruneTemplate((PruneTemplatePlan) plan);
+            break;
           case SET_TEMPLATE:
             mLogTxtWriter.setTemplate((SetTemplatePlan) plan);
             break;


### PR DESCRIPTION
## Description
A missing `break` produce an exception when parsing a mlog.bin while not corrupting correctness of the log. This PR fix this problem and add more `,` in `mLogTxtWrite` to make output file more human-friendly.