### PR TITLE
[IOTDB-3814] Fix insert rows by sql with wrong data type NPE

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
@@ -292,4 +292,20 @@ public class IoTDBInsertAlignedValuesIT {
           e.getMessage().contains("Insertion contains duplicated measurement: status"));
     }
   }
+
+  @Test
+  public void testInsertMultiRows() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          "insert into root.sg1.d1(time, s1, s2) aligned values(10, 2, 2), (11, 3, '3'), (12,12.11,false);");
+      fail();
+    } catch (SQLException e) {
+      assertTrue(
+          e.getMessage(),
+          e.getMessage()
+              .contains(
+                  "failed to insert measurements [s2] caused by data type is not consistent"));
+    }
+  }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
@@ -301,11 +301,7 @@ public class IoTDBInsertAlignedValuesIT {
           "insert into root.sg1.d1(time, s1, s2) aligned values(10, 2, 2), (11, 3, '3'), (12,12.11,false);");
       fail();
     } catch (SQLException e) {
-      assertTrue(
-          e.getMessage(),
-          e.getMessage()
-              .contains(
-                  "failed to insert measurements [s2] caused by data type is not consistent"));
+      assertTrue(e.getMessage(), e.getMessage().contains("data type is not consistent"));
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -862,15 +862,15 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     insertStatement.semanticCheck();
     long[] timeArray = insertStatement.getTimes();
     PartialPath devicePath = insertStatement.getDevice();
-    String[] measurements = insertStatement.getMeasurementList();
+    String[] measurementList = insertStatement.getMeasurementList();
     if (timeArray.length == 1) {
       // construct insert row statement
       InsertRowStatement insertRowStatement = new InsertRowStatement();
       insertRowStatement.setDevicePath(devicePath);
       insertRowStatement.setTime(timeArray[0]);
-      insertRowStatement.setMeasurements(measurements);
-      insertRowStatement.setDataTypes(new TSDataType[insertStatement.getMeasurementList().length]);
-      Object[] values = new Object[insertStatement.getMeasurementList().length];
+      insertRowStatement.setMeasurements(measurementList);
+      insertRowStatement.setDataTypes(new TSDataType[measurementList.length]);
+      Object[] values = new Object[measurementList.length];
       System.arraycopy(insertStatement.getValuesList().get(0), 0, values, 0, values.length);
       insertRowStatement.setValues(values);
       insertRowStatement.setNeedInferType(true);
@@ -884,10 +884,12 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       for (int i = 0; i < timeArray.length; i++) {
         InsertRowStatement statement = new InsertRowStatement();
         statement.setDevicePath(devicePath);
+        String[] measurements = new String[measurementList.length];
+        System.arraycopy(measurementList, 0, measurements, 0, measurements.length);
         statement.setMeasurements(measurements);
         statement.setTime(timeArray[i]);
-        statement.setDataTypes(new TSDataType[insertStatement.getMeasurementList().length]);
-        Object[] values = new Object[insertStatement.getMeasurementList().length];
+        statement.setDataTypes(new TSDataType[measurementList.length]);
+        Object[] values = new Object[measurementList.length];
         System.arraycopy(insertStatement.getValuesList().get(i), 0, values, 0, values.length);
         statement.setValues(values);
         statement.setAligned(insertStatement.isAligned());

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertMultiTabletsNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertMultiTabletsNode.java
@@ -141,6 +141,9 @@ public class InsertMultiTabletsNode extends InsertNode implements BatchInsertNod
       if (!insertTabletNode.validateAndSetSchema(schemaTree)) {
         return false;
       }
+      if (!this.hasFailedMeasurements() && insertTabletNode.hasFailedMeasurements()) {
+        this.failedMeasurementIndex2Info = insertTabletNode.failedMeasurementIndex2Info;
+      }
     }
     return true;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowNode.java
@@ -179,10 +179,13 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
         deviceSchemaInfo.getMeasurementSchemaList().toArray(new MeasurementSchema[0]);
 
     // transfer data types from string values when necessary
-    try {
-      transferType();
-    } catch (QueryProcessException e) {
-      return false;
+    if (isNeedInferType) {
+      try {
+        transferType();
+        return true;
+      } catch (QueryProcessException e) {
+        return false;
+      }
     }
 
     // validate whether data types are matched
@@ -195,9 +198,6 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
    */
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   private void transferType() throws QueryProcessException {
-    if (!isNeedInferType) {
-      return;
-    }
 
     for (int i = 0; i < measurementSchemas.length; i++) {
       // null when time series doesn't exist

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsNode.java
@@ -125,6 +125,9 @@ public class InsertRowsNode extends InsertNode implements BatchInsertNode {
       if (!insertRowNode.validateAndSetSchema(schemaTree)) {
         return false;
       }
+      if (!this.hasFailedMeasurements() && insertRowNode.hasFailedMeasurements()) {
+        this.failedMeasurementIndex2Info = insertRowNode.failedMeasurementIndex2Info;
+      }
     }
     return true;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -148,6 +148,9 @@ public class InsertRowsOfOneDeviceNode extends InsertNode implements BatchInsert
       if (!insertRowNode.validateAndSetSchema(schemaTree)) {
         return false;
       }
+      if (!this.hasFailedMeasurements() && insertRowNode.hasFailedMeasurements()) {
+        this.failedMeasurementIndex2Info = insertRowNode.failedMeasurementIndex2Info;
+      }
     }
     storeMeasurementsAndDataType();
     return true;


### PR DESCRIPTION
## Description

See IOTDB-3814.

After fixing
```
IoTDB> insert into root.sg1.d1(time, s1, s2) aligned values(10, 2, 2), (11, 3, '3'), (12,12.11,false);
Msg: 411: failed to insert measurements [s2] caused by data type is not consistent, input '3', registered FLOAT
IoTDB> select ** from root
+-----------------------------+--------------+--------------+
|                         Time|root.sg1.d1.s1|root.sg1.d1.s2|
+-----------------------------+--------------+--------------+
|1970-01-01T08:00:00.010+08:00|           2.0|           2.0|
|1970-01-01T08:00:00.011+08:00|           3.0|          null|
|1970-01-01T08:00:00.012+08:00|         12.11|          null|
+-----------------------------+--------------+--------------+
Total line number = 3
It costs 0.107s
```
