### PR TITLE
Fix ConfigNode startup bug

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -212,7 +212,7 @@ public class ConfigNode implements ConfigNodeMBean {
                   .sendSyncRequestToConfigNodeWithRetry(
                       targetConfigNode, req, ConfigNodeRequestType.REGISTER_CONFIG_NODE);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-        break;
+        return;
       } else if (status.getCode() == TSStatusCode.NEED_REDIRECTION.getStatusCode()) {
         targetConfigNode = status.getRedirectNode();
         LOGGER.info("ConfigNode need redirect to  {}.", targetConfigNode);


### PR DESCRIPTION
I am very sorry that I wrote a line of code wrong in resolving the conflict of [IOTDB-3844](https://github.com/apache/iotdb/pull/6831)

The ConfigNodes can startup successfully now:

<img width="371" alt="image" src="https://user-images.githubusercontent.com/33111881/182345229-bbfeb90d-d046-4439-885d-8960b13926ed.png">
