### PR TITLE
[To rel/0.13][IOTDB-3970]fix when session reconnect,lose verify code

### DIFF
--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -226,11 +226,13 @@ public class SessionConnection {
     TSStatus resp;
     try {
       resp = client.setTimeZone(req);
+      verifySuccessWrapper(resp);
     } catch (TException e) {
       if (reconnect()) {
         try {
           req.setSessionId(sessionId);
           resp = client.setTimeZone(req);
+          verifySuccessWrapper(resp);
         } catch (TException tException) {
           throw new IoTDBConnectionException(tException);
         }
@@ -238,7 +240,6 @@ public class SessionConnection {
         throw new IoTDBConnectionException(logForReconnectionFailure());
       }
     }
-    RpcUtils.verifySuccess(resp);
     this.zoneId = ZoneId.of(zoneId);
   }
 
@@ -373,6 +374,7 @@ public class SessionConnection {
           execReq.setSessionId(sessionId);
           execReq.setStatementId(statementId);
           execResp = client.executeQueryStatement(execReq);
+          verifySuccessWithRedirectionWrapper(execResp.getStatus());
         } catch (TException tException) {
           throw new IoTDBConnectionException(tException);
         }
@@ -380,8 +382,6 @@ public class SessionConnection {
         throw new IoTDBConnectionException(logForReconnectionFailure());
       }
     }
-
-    RpcUtils.verifySuccess(execResp.getStatus());
     return new SessionDataSet(
         sql,
         execResp.getColumns(),
@@ -434,6 +434,7 @@ public class SessionConnection {
           execReq.setSessionId(sessionId);
           execReq.setStatementId(statementId);
           execResp = client.executeRawDataQuery(execReq);
+          verifySuccessWithRedirectionWrapper(execResp.getStatus());
         } catch (TException tException) {
           throw new IoTDBConnectionException(tException);
         }
@@ -441,8 +442,6 @@ public class SessionConnection {
         throw new IoTDBConnectionException(logForReconnectionFailure());
       }
     }
-
-    RpcUtils.verifySuccess(execResp.getStatus());
     return new SessionDataSet(
         "",
         execResp.getColumns(),
@@ -472,6 +471,7 @@ public class SessionConnection {
           tsLastDataQueryReq.setSessionId(sessionId);
           tsLastDataQueryReq.setStatementId(statementId);
           tsExecuteStatementResp = client.executeLastDataQuery(tsLastDataQueryReq);
+          verifySuccessWithRedirectionWrapper(tsExecuteStatementResp.getStatus());
         } catch (TException tException) {
           throw new IoTDBConnectionException(tException);
         }
@@ -479,8 +479,6 @@ public class SessionConnection {
         throw new IoTDBConnectionException(logForReconnectionFailure());
       }
     }
-
-    RpcUtils.verifySuccess(tsExecuteStatementResp.getStatus());
     return new SessionDataSet(
         "",
         tsExecuteStatementResp.getColumns(),
@@ -929,6 +927,7 @@ public class SessionConnection {
       if (reconnect()) {
         try {
           execResp = client.querySchemaTemplate(req);
+          verifySuccessWrapper(execResp.getStatus());
         } catch (TException tException) {
           throw new IoTDBConnectionException(tException);
         }
@@ -936,8 +935,6 @@ public class SessionConnection {
         throw new IoTDBConnectionException(logForReconnectionFailure());
       }
     }
-
-    RpcUtils.verifySuccess(execResp.getStatus());
     return execResp;
   }
 


### PR DESCRIPTION
## Description
when session reconnect,some method lose verify logic.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
