### PR TITLE
[IOTDB-4028] Npe in updateNodeLoadStatistic of LoadManager when cluster first starts.

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
@@ -184,6 +184,15 @@ public class NodeManager {
   /**
    * Only leader use this interface
    *
+   * @return The number of registered TotalNodes
+   */
+  public int getRegisteredNodeCount() {
+    return nodeInfo.getRegisteredNodeCount();
+  }
+
+  /**
+   * Only leader use this interface
+   *
    * @return The number of total cpu cores in online DataNodes
    */
   public int getTotalCpuCoreCount() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
@@ -292,7 +292,9 @@ public class LoadManager {
     if (isNeedBroadcast.get()) {
       broadcastLatestRegionRouteMap();
     }
-    addMetrics();
+    if (nodeCacheMap.size() == getNodeManager().getRegisteredNodeCount()) {
+      addMetrics();
+    }
   }
 
   private void broadcastLatestRegionRouteMap() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
@@ -269,7 +269,7 @@ public class NodeInfo implements SnapshotProcessor {
     return result;
   }
 
-  /** Return the number of registered ConfigNodes */
+  /** Return the number of registered Nodes */
   public int getRegisteredNodeCount() {
     int result;
     configNodeInfoReadWriteLock.readLock().lock();

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
@@ -268,6 +268,21 @@ public class NodeInfo implements SnapshotProcessor {
     }
     return result;
   }
+
+  /** Return the number of registered ConfigNodes */
+  public int getRegisteredNodeCount() {
+    int result;
+    configNodeInfoReadWriteLock.readLock().lock();
+    dataNodeInfoReadWriteLock.readLock().lock();
+    try {
+      result = registeredConfigNodes.size() + registeredDataNodes.size();
+    } finally {
+      dataNodeInfoReadWriteLock.readLock().unlock();
+      configNodeInfoReadWriteLock.readLock().unlock();
+    }
+    return result;
+  }
+
   /** Return the number of total cpu cores in online DataNodes */
   public int getTotalCpuCoreCount() {
     int result = 0;


### PR DESCRIPTION
###  When registering node metrics, the first asynchronous heartbeat has not finished. As a result, the nodeCacheMap is empty, and NPE exception occurs.


### Now, a judgment is added to determine whether the length of nodeCacheMap and the number of registered nodes are equal. If the length is equal, indicators are registered; if not, metrics are prohibited from being registered.

### After the modification, the system restarts without exception.


