### PR TITLE
[IOTDB-4037] Change default query execute threads to cpu cores

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -357,7 +357,7 @@ timestamp_precision=ms
 
 # How many threads can concurrently execute query statement. When <= 0, use CPU core number.
 # Datatype: int
-# concurrent_query_thread=16
+# concurrent_query_thread=0
 
 # How many threads can concurrently read data for raw data query. When <= 0, use CPU core number.
 # Datatype: int

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -300,7 +300,7 @@ public class IoTDBConfig {
   private int concurrentFlushThread = Runtime.getRuntime().availableProcessors();
 
   /** How many threads can concurrently execute query statement. When <= 0, use CPU core number. */
-  private int concurrentQueryThread = 16;
+  private int concurrentQueryThread = Runtime.getRuntime().availableProcessors();
 
   /** How many queries can be concurrently executed. When <= 0, use 1000. */
   private int maxAllowedConcurrentQueries = 1000;

--- a/server/src/main/java/org/apache/iotdb/db/service/NewIoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/NewIoTDB.java
@@ -42,7 +42,6 @@ import org.apache.iotdb.db.engine.trigger.service.TriggerRegistrationService;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.localconfignode.LocalConfigNode;
 import org.apache.iotdb.db.metadata.LocalSchemaProcessor;
-import org.apache.iotdb.db.mpp.execution.exchange.MPPDataExchangeService;
 import org.apache.iotdb.db.mpp.execution.schedule.DriverScheduler;
 import org.apache.iotdb.db.protocol.mpprest.MPPRestService;
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
@@ -134,7 +133,6 @@ public class NewIoTDB implements NewIoTDBMBean {
     registerManager.register(WALManager.getInstance());
 
     registerManager.register(StorageEngineV2.getInstance());
-    registerManager.register(MPPDataExchangeService.getInstance());
     registerManager.register(DataNodeInternalRPCService.getInstance());
     registerManager.register(DriverScheduler.getInstance());
 


### PR DESCRIPTION
Change default query execute threads to cpu cores and don't set up DataExchangeService in standalone mode.