### PR TITLE
IOTDB-4043 Unify ClientPool Factory

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/async/confignode/AsyncConfigNodeHeartbeatClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/async/confignode/AsyncConfigNodeHeartbeatClientPool.java
@@ -19,9 +19,9 @@
 package org.apache.iotdb.confignode.client.async.confignode;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+import org.apache.iotdb.commons.client.ClientPoolFactory;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.async.AsyncConfigNodeHeartbeatServiceClient;
-import org.apache.iotdb.confignode.client.ConfigNodeClientPoolFactory;
 import org.apache.iotdb.confignode.client.async.handlers.ConfigNodeHeartbeatHandler;
 
 public class AsyncConfigNodeHeartbeatClientPool {
@@ -32,7 +32,7 @@ public class AsyncConfigNodeHeartbeatClientPool {
     clientManager =
         new IClientManager.Factory<TEndPoint, AsyncConfigNodeHeartbeatServiceClient>()
             .createClientManager(
-                new ConfigNodeClientPoolFactory.AsyncConfigNodeHeartbeatServiceClientPoolFactory());
+                new ClientPoolFactory.AsyncConfigNodeHeartbeatServiceClientPoolFactory());
   }
 
   /**

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/async/datanode/AsyncDataNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/async/datanode/AsyncDataNodeClientPool.java
@@ -25,9 +25,9 @@ import org.apache.iotdb.common.rpc.thrift.TFlushReq;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSetTTLReq;
+import org.apache.iotdb.commons.client.ClientPoolFactory;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.async.AsyncDataNodeInternalServiceClient;
-import org.apache.iotdb.confignode.client.ConfigNodeClientPoolFactory;
 import org.apache.iotdb.confignode.client.DataNodeRequestType;
 import org.apache.iotdb.confignode.client.async.handlers.AbstractRetryHandler;
 import org.apache.iotdb.confignode.client.async.handlers.ClearCacheHandler;
@@ -67,7 +67,7 @@ public class AsyncDataNodeClientPool {
     clientManager =
         new IClientManager.Factory<TEndPoint, AsyncDataNodeInternalServiceClient>()
             .createClientManager(
-                new ConfigNodeClientPoolFactory.AsyncDataNodeInternalServiceClientPoolFactory());
+                new ClientPoolFactory.AsyncDataNodeInternalServiceClientPoolFactory());
   }
 
   /**

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/async/datanode/AsyncDataNodeHeartbeatClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/async/datanode/AsyncDataNodeHeartbeatClientPool.java
@@ -19,9 +19,9 @@
 package org.apache.iotdb.confignode.client.async.datanode;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+import org.apache.iotdb.commons.client.ClientPoolFactory;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.async.AsyncDataNodeHeartbeatServiceClient;
-import org.apache.iotdb.confignode.client.ConfigNodeClientPoolFactory;
 import org.apache.iotdb.confignode.client.async.handlers.DataNodeHeartbeatHandler;
 import org.apache.iotdb.mpp.rpc.thrift.THeartbeatReq;
 
@@ -34,7 +34,7 @@ public class AsyncDataNodeHeartbeatClientPool {
     clientManager =
         new IClientManager.Factory<TEndPoint, AsyncDataNodeHeartbeatServiceClient>()
             .createClientManager(
-                new ConfigNodeClientPoolFactory.AsyncDataNodeHeartbeatServiceClientPoolFactory());
+                new ClientPoolFactory.AsyncDataNodeHeartbeatServiceClientPoolFactory());
   }
 
   /**

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/sync/datanode/SyncDataNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/sync/datanode/SyncDataNodeClientPool.java
@@ -23,9 +23,9 @@ import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.client.ClientPoolFactory;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.sync.SyncDataNodeInternalServiceClient;
-import org.apache.iotdb.confignode.client.ConfigNodeClientPoolFactory;
 import org.apache.iotdb.confignode.client.DataNodeRequestType;
 import org.apache.iotdb.mpp.rpc.thrift.TAddConsensusGroup;
 import org.apache.iotdb.mpp.rpc.thrift.TDisableDataNodeReq;
@@ -62,7 +62,7 @@ public class SyncDataNodeClientPool {
     clientManager =
         new IClientManager.Factory<TEndPoint, SyncDataNodeInternalServiceClient>()
             .createClientManager(
-                new ConfigNodeClientPoolFactory.SyncDataNodeInternalServiceClientPoolFactory());
+                new ClientPoolFactory.SyncDataNodeInternalServiceClientPoolFactory());
   }
 
   public TSStatus sendSyncRequestToDataNodeWithRetry(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.rpc.RpcUtils;
 
 import java.io.File;
-import java.util.concurrent.TimeUnit;
 
 public class ConfigNodeConfig {
 
@@ -44,9 +43,6 @@ public class ConfigNodeConfig {
 
   // TODO: Read from iotdb-confignode.properties
   private int partitionRegionId = 0;
-
-  /** Thrift socket and connection timeout between nodes */
-  private int connectionTimeoutInMS = (int) TimeUnit.SECONDS.toMillis(20);
 
   /** ConfigNodeGroup consensus protocol */
   private String configNodeConsensusProtocolClass = ConsensusFactory.RatisConsensus;
@@ -67,15 +63,6 @@ public class ConfigNodeConfig {
   private RegionBalancer.RegionAllocateStrategy regionAllocateStrategy =
       RegionBalancer.RegionAllocateStrategy.GREEDY;
 
-  /**
-   * ClientManager will have so many selector threads (TAsyncClientManager) to distribute to its
-   * clients.
-   */
-  private int selectorNumOfClientManager =
-      Runtime.getRuntime().availableProcessors() / 4 > 0
-          ? Runtime.getRuntime().availableProcessors() / 4
-          : 1;
-
   /** Number of SeriesPartitionSlots per StorageGroup */
   private int seriesPartitionSlotNum = 10000;
 
@@ -85,9 +72,6 @@ public class ConfigNodeConfig {
 
   /** Max concurrent client number */
   private int rpcMaxConcurrentClientNum = 65535;
-
-  /** whether to use thrift compression. */
-  private boolean isRpcThriftCompressionEnabled = false;
 
   /** whether to use Snappy compression before sending data through the network */
   private boolean rpcAdvancedCompressionEnable = false;
@@ -231,10 +215,6 @@ public class ConfigNodeConfig {
     this.seriesPartitionExecutorClass = seriesPartitionExecutorClass;
   }
 
-  public int getSelectorNumOfClientManager() {
-    return selectorNumOfClientManager;
-  }
-
   public long getTimePartitionInterval() {
     return timePartitionInterval;
   }
@@ -249,14 +229,6 @@ public class ConfigNodeConfig {
 
   public void setRpcMaxConcurrentClientNum(int rpcMaxConcurrentClientNum) {
     this.rpcMaxConcurrentClientNum = rpcMaxConcurrentClientNum;
-  }
-
-  public boolean isRpcThriftCompressionEnabled() {
-    return isRpcThriftCompressionEnabled;
-  }
-
-  public void setRpcThriftCompressionEnabled(boolean rpcThriftCompressionEnabled) {
-    isRpcThriftCompressionEnabled = rpcThriftCompressionEnabled;
   }
 
   public boolean isRpcAdvancedCompressionEnable() {
@@ -281,19 +253,6 @@ public class ConfigNodeConfig {
 
   public void setThriftDefaultBufferSize(int thriftDefaultBufferSize) {
     this.thriftDefaultBufferSize = thriftDefaultBufferSize;
-  }
-
-  public int getConnectionTimeoutInMS() {
-    return connectionTimeoutInMS;
-  }
-
-  public ConfigNodeConfig setConnectionTimeoutInMS(int connectionTimeoutInMS) {
-    this.connectionTimeoutInMS = connectionTimeoutInMS;
-    return this;
-  }
-
-  public void setSelectorNumOfClientManager(int selectorNumOfClientManager) {
-    this.selectorNumOfClientManager = selectorNumOfClientManager;
   }
 
   public String getConsensusDir() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -177,12 +177,6 @@ public class ConfigNodeDescriptor {
                   "rpc_advanced_compression_enable",
                   String.valueOf(conf.isRpcAdvancedCompressionEnable()))));
 
-      conf.setRpcThriftCompressionEnabled(
-          Boolean.parseBoolean(
-              properties.getProperty(
-                  "rpc_thrift_compression_enable",
-                  String.valueOf(conf.isRpcThriftCompressionEnabled()))));
-
       conf.setRpcMaxConcurrentClientNum(
           Integer.parseInt(
               properties.getProperty(
@@ -198,17 +192,6 @@ public class ConfigNodeDescriptor {
           Integer.parseInt(
               properties.getProperty(
                   "thrift_max_frame_size", String.valueOf(conf.getThriftMaxFrameSize()))));
-
-      conf.setConnectionTimeoutInMS(
-          Integer.parseInt(
-              properties.getProperty(
-                  "connection_timeout_ms", String.valueOf(conf.getConnectionTimeoutInMS()))));
-
-      conf.setSelectorNumOfClientManager(
-          Integer.parseInt(
-              properties.getProperty(
-                  "selector_thread_nums_of_client_manager",
-                  String.valueOf(conf.getSelectorNumOfClientManager()))));
 
       conf.setSystemDir(properties.getProperty("system_dir", conf.getSystemDir()));
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCService.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCService.java
@@ -19,6 +19,8 @@
 package org.apache.iotdb.confignode.service.thrift;
 
 import org.apache.iotdb.commons.concurrent.ThreadName;
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.runtime.RPCServiceException;
 import org.apache.iotdb.commons.service.AbstractThriftServiceThread;
@@ -36,7 +38,8 @@ import org.apache.iotdb.metrics.utils.MetricLevel;
 /** ConfigNodeRPCServer exposes the interface that interacts with the DataNode */
 public class ConfigNodeRPCService extends ThriftService implements ConfigNodeRPCServiceMBean {
 
-  private static final ConfigNodeConfig conf = ConfigNodeDescriptor.getInstance().getConf();
+  private static final ConfigNodeConfig configConf = ConfigNodeDescriptor.getInstance().getConf();
+  private static final CommonConfig commonConfig = CommonDescriptor.getInstance().getConfig();
 
   private ConfigNodeRPCServiceProcessor configNodeRPCServiceProcessor;
 
@@ -72,10 +75,10 @@ public class ConfigNodeRPCService extends ThriftService implements ConfigNodeRPC
               ThreadName.CONFIG_NODE_RPC_CLIENT.getName(),
               getBindIP(),
               getBindPort(),
-              conf.getRpcMaxConcurrentClientNum(),
-              conf.getThriftServerAwaitTimeForStopService(),
+              configConf.getRpcMaxConcurrentClientNum(),
+              configConf.getThriftServerAwaitTimeForStopService(),
               new ConfigNodeRPCServiceHandler(configNodeRPCServiceProcessor),
-              conf.isRpcThriftCompressionEnabled());
+              commonConfig.isRpcThriftCompressionEnabled());
     } catch (RPCServiceException e) {
       throw new IllegalAccessException(e.getMessage());
     }
@@ -93,11 +96,11 @@ public class ConfigNodeRPCService extends ThriftService implements ConfigNodeRPC
 
   @Override
   public String getBindIP() {
-    return conf.getInternalAddress();
+    return configConf.getInternalAddress();
   }
 
   @Override
   public int getBindPort() {
-    return conf.getInternalPort();
+    return configConf.getInternalPort();
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolFactory.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolFactory.java
@@ -17,28 +17,24 @@
  * under the License.
  */
 
-package org.apache.iotdb.confignode.client;
+package org.apache.iotdb.commons.client;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
-import org.apache.iotdb.commons.client.ClientFactoryProperty;
-import org.apache.iotdb.commons.client.ClientManager;
-import org.apache.iotdb.commons.client.ClientPoolProperty;
-import org.apache.iotdb.commons.client.IClientPoolFactory;
 import org.apache.iotdb.commons.client.async.AsyncConfigNodeHeartbeatServiceClient;
 import org.apache.iotdb.commons.client.async.AsyncDataNodeHeartbeatServiceClient;
 import org.apache.iotdb.commons.client.async.AsyncDataNodeInternalServiceClient;
 import org.apache.iotdb.commons.client.sync.SyncDataNodeInternalServiceClient;
-import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
-import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 
 import org.apache.commons.pool2.KeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 
-public class ConfigNodeClientPoolFactory {
+public class ClientPoolFactory {
 
-  private static final ConfigNodeConfig conf = ConfigNodeDescriptor.getInstance().getConf();
+  private static final CommonConfig conf = CommonDescriptor.getInstance().getConfig();
 
-  private ConfigNodeClientPoolFactory() {}
+  private ClientPoolFactory() {}
 
   public static class SyncDataNodeInternalServiceClientPoolFactory
       implements IClientPoolFactory<TEndPoint, SyncDataNodeInternalServiceClient> {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.commons.conf;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
 
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 public class CommonConfig {
 
@@ -73,6 +74,21 @@ public class CommonConfig {
    * will also be affected. Unit: millisecond
    */
   private long defaultTTL = Long.MAX_VALUE;
+
+  /** Thrift socket and connection timeout between data node and config node. */
+  private int connectionTimeoutInMS = (int) TimeUnit.SECONDS.toMillis(20);
+
+  /**
+   * ClientManager will have so many selector threads (TAsyncClientManager) to distribute to its
+   * clients.
+   */
+  private int selectorNumOfClientManager =
+      Runtime.getRuntime().availableProcessors() / 4 > 0
+          ? Runtime.getRuntime().availableProcessors() / 4
+          : 1;
+
+  /** whether to use thrift compression. */
+  private boolean isRpcThriftCompressionEnabled = false;
 
   CommonConfig() {}
 
@@ -179,5 +195,29 @@ public class CommonConfig {
 
   public void setDefaultTTL(long defaultTTL) {
     this.defaultTTL = defaultTTL;
+  }
+
+  public int getConnectionTimeoutInMS() {
+    return connectionTimeoutInMS;
+  }
+
+  public void setConnectionTimeoutInMS(int connectionTimeoutInMS) {
+    this.connectionTimeoutInMS = connectionTimeoutInMS;
+  }
+
+  public int getSelectorNumOfClientManager() {
+    return selectorNumOfClientManager;
+  }
+
+  public void setSelectorNumOfClientManager(int selectorNumOfClientManager) {
+    this.selectorNumOfClientManager = selectorNumOfClientManager;
+  }
+
+  public boolean isRpcThriftCompressionEnabled() {
+    return isRpcThriftCompressionEnabled;
+  }
+
+  public void setRpcThriftCompressionEnabled(boolean rpcThriftCompressionEnabled) {
+    isRpcThriftCompressionEnabled = rpcThriftCompressionEnabled;
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -77,5 +77,22 @@ public class CommonDescriptor {
     config.setDefaultTTL(
         Long.parseLong(
             properties.getProperty("default_ttl", String.valueOf(config.getDefaultTTL()))));
+
+    config.setRpcThriftCompressionEnabled(
+        Boolean.parseBoolean(
+            properties.getProperty(
+                "rpc_thrift_compression_enable",
+                String.valueOf(config.isRpcThriftCompressionEnabled()))));
+
+    config.setConnectionTimeoutInMS(
+        Integer.parseInt(
+            properties.getProperty(
+                "connection_timeout_ms", String.valueOf(config.getConnectionTimeoutInMS()))));
+
+    config.setSelectorNumOfClientManager(
+        Integer.parseInt(
+            properties.getProperty(
+                "selector_thread_nums_of_client_manager",
+                String.valueOf(config.getSelectorNumOfClientManager()))));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.commons.client.ClientManager;
 import org.apache.iotdb.commons.client.ClientPoolProperty;
 import org.apache.iotdb.commons.client.sync.SyncThriftClient;
 import org.apache.iotdb.commons.client.sync.SyncThriftClientWithErrorHandler;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.PartitionRegionId;
 import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
 import org.apache.iotdb.confignode.rpc.thrift.TAddConsensusGroupReq;
@@ -131,7 +132,7 @@ public class ConfigNodeClient
     // Read config nodes from configuration
     configNodes = ConfigNodeInfo.getInstance().getLatestConfigNodes();
     protocolFactory =
-        IoTDBDescriptor.getInstance().getConfig().isRpcThriftCompressionEnable()
+        CommonDescriptor.getInstance().getConfig().isRpcThriftCompressionEnabled()
             ? new TCompactProtocol.Factory()
             : new TBinaryProtocol.Factory();
 


### PR DESCRIPTION
moveConfigNodeClientPoolFactory to commons

This is to move confignodeclientpoolfactory to Commons. An optimization of renaming clientpoolfactory. Datanodeclientpoolfactory contains a special confignodeclient. It has not been decided whether to migrate
