### PR TITLE
[IOTDB-3980][Metric] Use asynchronous way to collect some predefined metrics.

### DIFF
--- a/metrics/interface/src/main/assembly/resources/conf/iotdb-metric.yml
+++ b/metrics/interface/src/main/assembly/resources/conf/iotdb-metric.yml
@@ -40,7 +40,7 @@ predefinedMetrics:
   - FILE
 
 # The period of the collection of some metrics in asynchronous way, such as tsfile size.
-asyncCollectPeriod: 5
+asyncCollectPeriodInSecond: 5
 
 # The http server's port for prometheus exporter to get metric data.
 prometheusExporterPort: 9091

--- a/metrics/interface/src/main/assembly/resources/conf/iotdb-metric.yml
+++ b/metrics/interface/src/main/assembly/resources/conf/iotdb-metric.yml
@@ -39,6 +39,9 @@ predefinedMetrics:
   - JVM
   - FILE
 
+# The period of the collection of some metrics in asynchronous way, such as tsfile size.
+asyncCollectPeriod: 5
+
 # The http server's port for prometheus exporter to get metric data.
 prometheusExporterPort: 9091
 

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/MetricService.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/MetricService.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.metrics.config.MetricConfig;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.config.ReloadLevel;
 import org.apache.iotdb.metrics.impl.DoNothingMetricManager;
+import org.apache.iotdb.metrics.predefined.IMetricSet;
 import org.apache.iotdb.metrics.reporter.CompositeReporter;
 import org.apache.iotdb.metrics.reporter.Reporter;
 import org.apache.iotdb.metrics.utils.PredefinedMetric;
@@ -31,6 +32,8 @@ import org.apache.iotdb.metrics.utils.ReporterType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -44,11 +47,13 @@ public abstract class MetricService {
 
   protected MetricManager metricManager = new DoNothingMetricManager();
 
+  protected List<IMetricSet> metricSets = new ArrayList<>();
+
   protected CompositeReporter compositeReporter = new CompositeReporter();
 
   protected boolean isEnableMetric = metricConfig.getEnableMetric();
 
-  private AtomicBoolean firstInit = new AtomicBoolean(true);
+  private final AtomicBoolean firstInit = new AtomicBoolean(true);
 
   public MetricService() {}
 
@@ -79,6 +84,10 @@ public abstract class MetricService {
     compositeReporter.stopAll();
     metricManager = new DoNothingMetricManager();
     compositeReporter = new CompositeReporter();
+    for (IMetricSet metricSet : metricSets) {
+      metricSet.stopAsyncCollectedMetrics();
+    }
+    metricSets = new ArrayList<>();
   }
 
   protected void loadManager() {

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
@@ -47,7 +47,7 @@ public class MetricConfig {
   private List<PredefinedMetric> predefinedMetrics =
       Arrays.asList(PredefinedMetric.JVM, PredefinedMetric.FILE);
 
-  private Integer asyncCollectPeriod = 5;
+  private Integer asyncCollectPeriodInSecond = 5;
 
   /** the http server's port for prometheus exporter to get metric data. */
   private String prometheusExporterPort = "9091";
@@ -217,12 +217,12 @@ public class MetricConfig {
     this.predefinedMetrics = predefinedMetrics;
   }
 
-  public Integer getAsyncCollectPeriod() {
-    return asyncCollectPeriod;
+  public Integer getAsyncCollectPeriodInSecond() {
+    return asyncCollectPeriodInSecond;
   }
 
-  public void setAsyncCollectPeriod(Integer asyncCollectPeriod) {
-    this.asyncCollectPeriod = asyncCollectPeriod;
+  public void setAsyncCollectPeriodInSecond(Integer asyncCollectPeriodInSecond) {
+    this.asyncCollectPeriodInSecond = asyncCollectPeriodInSecond;
   }
 
   public String getPrometheusExporterPort() {

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
@@ -47,6 +47,8 @@ public class MetricConfig {
   private List<PredefinedMetric> predefinedMetrics =
       Arrays.asList(PredefinedMetric.JVM, PredefinedMetric.FILE);
 
+  private Integer asyncCollectPeriod = 5;
+
   /** the http server's port for prometheus exporter to get metric data. */
   private String prometheusExporterPort = "9091";
 
@@ -213,6 +215,14 @@ public class MetricConfig {
 
   public void setPredefinedMetrics(List<PredefinedMetric> predefinedMetrics) {
     this.predefinedMetrics = predefinedMetrics;
+  }
+
+  public Integer getAsyncCollectPeriod() {
+    return asyncCollectPeriod;
+  }
+
+  public void setAsyncCollectPeriod(Integer asyncCollectPeriod) {
+    this.asyncCollectPeriod = asyncCollectPeriod;
   }
 
   public String getPrometheusExporterPort() {

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
@@ -160,6 +160,7 @@ public class MetricConfig {
     metricReporterList = newMetricConfig.getMetricReporterList();
     metricLevel = newMetricConfig.getMetricLevel();
     predefinedMetrics = newMetricConfig.getPredefinedMetrics();
+    asyncCollectPeriodInSecond = newMetricConfig.getAsyncCollectPeriodInSecond();
     prometheusExporterPort = newMetricConfig.getPrometheusExporterPort();
     ioTDBReporterConfig = newMetricConfig.ioTDBReporterConfig;
   }
@@ -260,6 +261,7 @@ public class MetricConfig {
         && metricReporterList.equals(anotherMetricConfig.getMetricReporterList())
         && metricLevel.equals(anotherMetricConfig.getMetricLevel())
         && predefinedMetrics.equals(anotherMetricConfig.getPredefinedMetrics())
+        && asyncCollectPeriodInSecond.equals(anotherMetricConfig.getAsyncCollectPeriodInSecond())
         && prometheusExporterPort.equals(anotherMetricConfig.getPrometheusExporterPort())
         && ioTDBReporterConfig.equals(anotherMetricConfig.getIoTDBReporterConfig());
   }

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfigDescriptor.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfigDescriptor.java
@@ -122,9 +122,10 @@ public class MetricConfigDescriptor {
         // restart reporters or restart service
         if (!metricConfig.getMonitorType().equals(newMetricConfig.getMonitorType())
             || !metricConfig.getMetricLevel().equals(newMetricConfig.getMetricLevel())
+            || !metricConfig.getPredefinedMetrics().equals(newMetricConfig.getPredefinedMetrics())
             || !metricConfig
-                .getPredefinedMetrics()
-                .equals(newMetricConfig.getPredefinedMetrics())) {
+                .getAsyncCollectPeriodInSecond()
+                .equals(newMetricConfig.getAsyncCollectPeriodInSecond())) {
           reloadLevel = ReloadLevel.RESTART_METRIC;
         } else {
           reloadLevel = ReloadLevel.RESTART_REPORTER;

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/predefined/IMetricSet.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/predefined/IMetricSet.java
@@ -28,4 +28,10 @@ public interface IMetricSet {
 
   /** get type of metric set */
   PredefinedMetric getType();
+
+  /** start async collectd metric */
+  default void startAsyncCollectedMetrics() {}
+
+  /** stop async collectd metric */
+  default void stopAsyncCollectedMetrics() {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/MetricsService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/MetricsService.java
@@ -100,6 +100,8 @@ public class MetricsService extends MetricService implements MetricsServiceMBean
         return;
     }
     metricSet.bindTo(metricManager);
+    metricSet.startAsyncCollectedMetrics();
+    metricSets.add(metricSet);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/FileMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/FileMetrics.java
@@ -52,43 +52,43 @@ public class FileMetrics implements IMetricSet {
     metricManager.getOrCreateAutoGauge(
         Metric.FILE_SIZE.toString(),
         MetricLevel.IMPORTANT,
-        walFileTotalSize,
-        value -> value,
+        this,
+        FileMetrics::getWalFileTotalSize,
         Tag.NAME.toString(),
         "wal");
     metricManager.getOrCreateAutoGauge(
         Metric.FILE_SIZE.toString(),
         MetricLevel.IMPORTANT,
-        sequenceFileTotalSize,
-        value -> value,
+        this,
+        FileMetrics::getSequenceFileTotalSize,
         Tag.NAME.toString(),
         "seq");
     metricManager.getOrCreateAutoGauge(
         Metric.FILE_SIZE.toString(),
         MetricLevel.IMPORTANT,
-        unsequenceFileTotalSize,
-        value -> value,
+        this,
+        FileMetrics::getUnsequenceFileTotalSize,
         Tag.NAME.toString(),
         "unseq");
     metricManager.getOrCreateAutoGauge(
         Metric.FILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        walFileTotalCount,
-        value -> value,
+        this,
+        FileMetrics::getWalFileTotalCount,
         Tag.NAME.toString(),
         "wal");
     metricManager.getOrCreateAutoGauge(
         Metric.FILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        sequenceFileTotalCount,
-        value -> value,
+        this,
+        FileMetrics::getSequenceFileTotalCount,
         Tag.NAME.toString(),
         "seq");
     metricManager.getOrCreateAutoGauge(
         Metric.FILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        unsequenceFileTotalCount,
-        value -> value,
+        this,
+        FileMetrics::getUnsequenceFileTotalCount,
         Tag.NAME.toString(),
         "unseq");
   }
@@ -103,8 +103,8 @@ public class FileMetrics implements IMetricSet {
     service.scheduleAtFixedRate(
         this::collect,
         1,
-        MetricConfigDescriptor.getInstance().getMetricConfig().getAsyncCollectPeriod(),
-        TimeUnit.MILLISECONDS);
+        MetricConfigDescriptor.getInstance().getMetricConfig().getAsyncCollectPeriodInSecond(),
+        TimeUnit.SECONDS);
   }
 
   @Override
@@ -149,7 +149,7 @@ public class FileMetrics implements IMetricSet {
                   return result;
                 })
             .sum();
-    sequenceFileTotalSize =
+    sequenceFileTotalCount =
         Stream.of(dataDirs)
             .mapToLong(
                 dir -> {
@@ -179,5 +179,29 @@ public class FileMetrics implements IMetricSet {
                   }
                 })
             .sum();
+  }
+
+  public long getWalFileTotalSize() {
+    return walFileTotalSize;
+  }
+
+  public long getWalFileTotalCount() {
+    return walFileTotalCount;
+  }
+
+  public long getSequenceFileTotalSize() {
+    return sequenceFileTotalSize;
+  }
+
+  public long getSequenceFileTotalCount() {
+    return sequenceFileTotalCount;
+  }
+
+  public long getUnsequenceFileTotalSize() {
+    return unsequenceFileTotalSize;
+  }
+
+  public long getUnsequenceFileTotalCount() {
+    return unsequenceFileTotalCount;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/FileMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/FileMetrics.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.service.metrics.enums.Metric;
 import org.apache.iotdb.db.service.metrics.enums.Tag;
+import org.apache.iotdb.db.wal.WALManager;
 import org.apache.iotdb.metrics.MetricManager;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.predefined.IMetricSet;
@@ -115,7 +116,7 @@ public class FileMetrics implements IMetricSet {
   }
 
   private void collect() {
-    walFileTotalSize = Stream.of(walDirs).mapToLong(FileUtils::getDirSize).sum();
+    walFileTotalSize = WALManager.getInstance().getTotalDiskUsage();
     sequenceFileTotalSize =
         Stream.of(dataDirs)
             .mapToLong(

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/FileMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/FileMetrics.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.service.metrics.predefined;
 
+import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -100,7 +101,8 @@ public class FileMetrics implements IMetricSet {
 
   @Override
   public void startAsyncCollectedMetrics() {
-    service.scheduleAtFixedRate(
+    ScheduledExecutorUtil.safelyScheduleAtFixedRate(
+        service,
         this::collect,
         1,
         MetricConfigDescriptor.getInstance().getMetricConfig().getAsyncCollectPeriodInSecond(),

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -18,10 +18,10 @@
  */
 package org.apache.iotdb.db.service.metrics.predefined;
 
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.service.metrics.enums.Metric;
 import org.apache.iotdb.db.service.metrics.enums.Tag;
 import org.apache.iotdb.metrics.MetricManager;
+import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.predefined.IMetricSet;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.PredefinedMetric;
@@ -30,9 +30,15 @@ import com.sun.management.OperatingSystemMXBean;
 
 import java.io.File;
 import java.lang.management.ManagementFactory;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class SystemMetrics implements IMetricSet {
   private com.sun.management.OperatingSystemMXBean osMXBean;
+  private final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+  private long systemDiskTotalSpace = 0L;
+  private long systemDiskFreeSpace = 0L;
 
   public SystemMetrics() {
     osMXBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
@@ -107,35 +113,42 @@ public class SystemMetrics implements IMetricSet {
     metricManager.getOrCreateAutoGauge(
         Metric.SYS_DISK_TOTAL_SPACE.toString(),
         MetricLevel.CORE,
-        this,
-        a -> getSysDiskTotalSpace(),
+        systemDiskTotalSpace,
+        value -> value,
         Tag.NAME.toString(),
         "system");
     metricManager.getOrCreateAutoGauge(
         Metric.SYS_DISK_FREE_SPACE.toString(),
         MetricLevel.CORE,
-        this,
-        a -> getSysDickFreeSpace(),
+        systemDiskFreeSpace,
+        value -> value,
         Tag.NAME.toString(),
         "system");
-    String[] dataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();
   }
 
-  private long getSysDiskTotalSpace() {
+  @Override
+  public void startAsyncCollectedMetrics() {
+    service.scheduleAtFixedRate(
+        this::collect,
+        1,
+        MetricConfigDescriptor.getInstance().getMetricConfig().getAsyncCollectPeriod(),
+        TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public void stopAsyncCollectedMetrics() {
+    service.shutdown();
+  }
+
+  private void collect() {
     File[] files = File.listRoots();
     long sysTotalSpace = 0L;
-    for (File file : files) {
-      sysTotalSpace += file.getTotalSpace();
-    }
-    return sysTotalSpace;
-  }
-
-  private long getSysDickFreeSpace() {
-    File[] files = File.listRoots();
     long sysFreeSpace = 0L;
     for (File file : files) {
+      sysTotalSpace += file.getTotalSpace();
       sysFreeSpace += file.getFreeSpace();
     }
-    return sysFreeSpace;
+    systemDiskTotalSpace = sysTotalSpace;
+    systemDiskFreeSpace = sysFreeSpace;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.service.metrics.predefined;
 
+import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
 import org.apache.iotdb.db.service.metrics.enums.Metric;
 import org.apache.iotdb.db.service.metrics.enums.Tag;
 import org.apache.iotdb.metrics.MetricManager;
@@ -128,7 +129,8 @@ public class SystemMetrics implements IMetricSet {
 
   @Override
   public void startAsyncCollectedMetrics() {
-    service.scheduleAtFixedRate(
+    ScheduledExecutorUtil.safelyScheduleAtFixedRate(
+        service,
         this::collect,
         1,
         MetricConfigDescriptor.getInstance().getMetricConfig().getAsyncCollectPeriodInSecond(),

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -131,7 +131,7 @@ public class SystemMetrics implements IMetricSet {
     service.scheduleAtFixedRate(
         this::collect,
         1,
-        MetricConfigDescriptor.getInstance().getMetricConfig().getAsyncCollectPeriod(),
+        MetricConfigDescriptor.getInstance().getMetricConfig().getAsyncCollectPeriodInSecond(),
         TimeUnit.MILLISECONDS);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -134,7 +134,7 @@ public class SystemMetrics implements IMetricSet {
         this::collect,
         1,
         MetricConfigDescriptor.getInstance().getMetricConfig().getAsyncCollectPeriodInSecond(),
-        TimeUnit.MILLISECONDS);
+        TimeUnit.SECONDS);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -114,15 +114,15 @@ public class SystemMetrics implements IMetricSet {
     metricManager.getOrCreateAutoGauge(
         Metric.SYS_DISK_TOTAL_SPACE.toString(),
         MetricLevel.CORE,
-        systemDiskTotalSpace,
-        value -> value,
+        this,
+        SystemMetrics::getSystemDiskTotalSpace,
         Tag.NAME.toString(),
         "system");
     metricManager.getOrCreateAutoGauge(
         Metric.SYS_DISK_FREE_SPACE.toString(),
         MetricLevel.CORE,
-        systemDiskFreeSpace,
-        value -> value,
+        this,
+        SystemMetrics::getSystemDiskFreeSpace,
         Tag.NAME.toString(),
         "system");
   }
@@ -152,5 +152,21 @@ public class SystemMetrics implements IMetricSet {
     }
     systemDiskTotalSpace = sysTotalSpace;
     systemDiskFreeSpace = sysFreeSpace;
+  }
+
+  public long getSystemDiskTotalSpace() {
+    return systemDiskTotalSpace;
+  }
+
+  public void setSystemDiskTotalSpace(long systemDiskTotalSpace) {
+    this.systemDiskTotalSpace = systemDiskTotalSpace;
+  }
+
+  public long getSystemDiskFreeSpace() {
+    return systemDiskFreeSpace;
+  }
+
+  public void setSystemDiskFreeSpace(long systemDiskFreeSpace) {
+    this.systemDiskFreeSpace = systemDiskFreeSpace;
   }
 }


### PR DESCRIPTION
See more details: https://issues.apache.org/jira/browse/IOTDB-3980.

Use asynchronous way to collect some predefined metrics. they are `file_count`, `file_size`, `sys_disk_total_space`, `sys_disk_free_space`.
Also, I add `asyncCollectPeriodInSecond` param for use to control the task that updated the metrics above.