### PR TITLE
[IOTDB-4056] Fix the problem that could not find or load main class in shell `remove-confignode.sh`

### DIFF
--- a/confignode/src/assembly/resources/sbin/remove-confignode.sh
+++ b/confignode/src/assembly/resources/sbin/remove-confignode.sh
@@ -72,7 +72,6 @@ launch_service() {
   confignode_parms="-Dlogback.configurationFile=${CONFIGNODE_CONF}/logback.xml"
   confignode_parms="$confignode_parms -DCONFIGNODE_HOME=${CONFIGNODE_HOME}"
   confignode_parms="$confignode_parms -DCONFIGNODE_CONF=${CONFIGNODE_CONF}"
-  echo "$JAVA" $illegal_access_params $confignode_parms $CONFIGNODE_JMX_OPTS -cp "$CLASSPATH" "$class" $CONF_PARAMS
   exec "$JAVA" $illegal_access_params $confignode_parms $CONFIGNODE_JMX_OPTS -cp "$CLASSPATH" "$class" $CONF_PARAMS
   return $?
 }

--- a/confignode/src/assembly/resources/sbin/remove-confignode.sh
+++ b/confignode/src/assembly/resources/sbin/remove-confignode.sh
@@ -18,20 +18,19 @@
 # under the License.
 #
 
-
 echo ----------------------------
 echo Starting to remove IoTDB ConfigNode
 echo ----------------------------
 
 if [ -z "${CONFIGNODE_HOME}" ]; then
-  export CONFIGNODE_HOME="`dirname "$0"`/.."
+  export CONFIGNODE_HOME="$(dirname "$0")/.."
 fi
 
 CONFIGNODE_CONF=${CONFIGNODE_HOME}/conf
 CONFIGNODE_LOGS=${CONFIGNODE_HOME}/logs
 
 is_conf_path=false
-for arg do
+for arg; do
   shift
   if [ "$arg" == "-c" ]; then
     is_conf_path=true
@@ -48,29 +47,34 @@ done
 CONF_PARAMS="-r "$*
 
 if [ -f "$CONFIGNODE_CONF/confignode-env.sh" ]; then
-    if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
-      . "$CONFIGNODE_CONF/confignode-env.sh" "printgc"
-    else
-        . "$CONFIGNODE_CONF/confignode-env.sh"
-    fi
+  if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
+    . "$CONFIGNODE_CONF/confignode-env.sh" "printgc"
+  else
+    . "$CONFIGNODE_CONF/confignode-env.sh"
+  fi
 else
-    echo "can't find $CONFIGNODE_CONF/confignode-env.sh"
+  echo "can't find $CONFIGNODE_CONF/confignode-env.sh"
 fi
 
-CLASSPATH=""
-for f in ${CONFIGNODE_HOME}/lib/*.jar; do
+if [ -d ${CONFIGNODE_HOME}/lib ]; then
+  LIB_PATH=${CONFIGNODE_HOME}/lib
+else
+  LIB_PATH=${CONFIGNODE_HOME}/../lib
+fi
+
+for f in ${LIB_PATH}/*.jar; do
   CLASSPATH=${CLASSPATH}":"$f
 done
 classname=org.apache.iotdb.confignode.service.ConfigNode
 
-launch_service()
-{
-	class="$1"
-	confignode_parms="-Dlogback.configurationFile=${CONFIGNODE_CONF}/logback.xml"
-	confignode_parms="$confignode_parms -DCONFIGNODE_HOME=${CONFIGNODE_HOME}"
-	confignode_parms="$confignode_parms -DCONFIGNODE_CONF=${CONFIGNODE_CONF}"
-	exec "$JAVA" $illegal_access_params $confignode_parms $CONFIGNODE_JMX_OPTS -cp "$CLASSPATH" "$class" $CONF_PARAMS
-	return $?
+launch_service() {
+  class="$1"
+  confignode_parms="-Dlogback.configurationFile=${CONFIGNODE_CONF}/logback.xml"
+  confignode_parms="$confignode_parms -DCONFIGNODE_HOME=${CONFIGNODE_HOME}"
+  confignode_parms="$confignode_parms -DCONFIGNODE_CONF=${CONFIGNODE_CONF}"
+  echo "$JAVA" $illegal_access_params $confignode_parms $CONFIGNODE_JMX_OPTS -cp "$CLASSPATH" "$class" $CONF_PARAMS
+  exec "$JAVA" $illegal_access_params $confignode_parms $CONFIGNODE_JMX_OPTS -cp "$CLASSPATH" "$class" $CONF_PARAMS
+  return $?
 }
 
 # Start up the service

--- a/confignode/src/assembly/resources/sbin/remove-confignode.sh
+++ b/confignode/src/assembly/resources/sbin/remove-confignode.sh
@@ -62,6 +62,7 @@ else
   LIB_PATH=${CONFIGNODE_HOME}/../lib
 fi
 
+CLASSPATH=""
 for f in ${LIB_PATH}/*.jar; do
   CLASSPATH=${CLASSPATH}":"$f
 done

--- a/confignode/src/assembly/resources/sbin/start-confignode.sh
+++ b/confignode/src/assembly/resources/sbin/start-confignode.sh
@@ -18,20 +18,19 @@
 # under the License.
 #
 
-
 echo ----------------------------
 echo Starting IoTDB ConfigNode
 echo ----------------------------
 
 if [ -z "${CONFIGNODE_HOME}" ]; then
-  export CONFIGNODE_HOME="`dirname "$0"`/.."
+  export CONFIGNODE_HOME="$(dirname "$0")/.."
 fi
 
 CONFIGNODE_CONF=${CONFIGNODE_HOME}/conf
 CONFIGNODE_LOGS=${CONFIGNODE_HOME}/logs
 
 is_conf_path=false
-for arg do
+for arg; do
   shift
   if [ "$arg" == "-c" ]; then
     is_conf_path=true
@@ -48,19 +47,19 @@ done
 CONF_PARAMS="-s "$*
 
 if [ -f "$CONFIGNODE_CONF/confignode-env.sh" ]; then
-    if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
-      . "$CONFIGNODE_CONF/confignode-env.sh" "printgc"
-    else
-        . "$CONFIGNODE_CONF/confignode-env.sh"
-    fi
+  if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
+    . "$CONFIGNODE_CONF/confignode-env.sh" "printgc"
+  else
+    . "$CONFIGNODE_CONF/confignode-env.sh"
+  fi
 else
-    echo "can't find $CONFIGNODE_CONF/confignode-env.sh"
+  echo "can't find $CONFIGNODE_CONF/confignode-env.sh"
 fi
 
 if [ -d ${CONFIGNODE_HOME}/lib ]; then
-LIB_PATH=${CONFIGNODE_HOME}/lib
+  LIB_PATH=${CONFIGNODE_HOME}/lib
 else
-LIB_PATH=${CONFIGNODE_HOME}/../lib
+  LIB_PATH=${CONFIGNODE_HOME}/../lib
 fi
 
 CLASSPATH=""
@@ -69,14 +68,13 @@ for f in ${LIB_PATH}/*.jar; do
 done
 classname=org.apache.iotdb.confignode.service.ConfigNode
 
-launch_service()
-{
-	class="$1"
-	confignode_parms="-Dlogback.configurationFile=${CONFIGNODE_CONF}/logback.xml"
-	confignode_parms="$confignode_parms -DCONFIGNODE_HOME=${CONFIGNODE_HOME}"
-	confignode_parms="$confignode_parms -DCONFIGNODE_CONF=${CONFIGNODE_CONF}"
-	exec "$JAVA" $illegal_access_params $confignode_parms $CONFIGNODE_JMX_OPTS -cp "$CLASSPATH" "$class" $CONF_PARAMS
-	return $?
+launch_service() {
+  class="$1"
+  confignode_parms="-Dlogback.configurationFile=${CONFIGNODE_CONF}/logback.xml"
+  confignode_parms="$confignode_parms -DCONFIGNODE_HOME=${CONFIGNODE_HOME}"
+  confignode_parms="$confignode_parms -DCONFIGNODE_CONF=${CONFIGNODE_CONF}"
+  exec "$JAVA" $illegal_access_params $confignode_parms $CONFIGNODE_JMX_OPTS -cp "$CLASSPATH" "$class" $CONF_PARAMS
+  return $?
 }
 
 # Start up the service

--- a/confignode/src/assembly/resources/sbin/stop-confignode.sh
+++ b/confignode/src/assembly/resources/sbin/stop-confignode.sh
@@ -18,14 +18,13 @@
 # under the License.
 #
 
+CONFIGNODE_CONF="$(dirname "$0")/../conf"
+internal_port=$(sed '/^internal_port=/!d;s/.*=//' ${CONFIGNODE_CONF}/iotdb-confignode.properties)
 
-CONFIGNODE_CONF="`dirname "$0"`/../conf"
-internal_port=`sed '/^internal_port=/!d;s/.*=//' ${CONFIGNODE_CONF}/iotdb-confignode.properties`
-
-if  type lsof > /dev/null 2>&1 ; then
+if type lsof >/dev/null 2>&1; then
   PID=$(lsof -t -i:${internal_port} -sTCP:LISTEN)
-elif type netstat > /dev/null 2>&1 ; then
-  PID=$(netstat -anp 2>/dev/null | grep ":${internal_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g" )
+elif type netstat >/dev/null 2>&1; then
+  PID=$(netstat -anp 2>/dev/null | grep ":${internal_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g")
 else
   echo ""
   echo " Error: No necessary tool."


### PR DESCRIPTION
## Description

see details in https://issues.apache.org/jira/browse/IOTDB-4056

The problem is that the conf and lib directory is different in `confignode` and `distribution`.

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/6756545/183419820-20f45d9b-e2f4-490a-add6-9e6770adfebf.png">

![image](https://user-images.githubusercontent.com/6756545/183419937-5dc7fc41-edfd-4985-b53c-eaa061d66f0e.png)


change codes are shown as below
<img width="866" alt="image" src="https://user-images.githubusercontent.com/6756545/183422406-911d9e0e-ec81-45c2-ba4f-056533ef56fc.png">
---

- 1.1 start-confignode in confignode directory
<img width="1047" alt="image" src="https://user-images.githubusercontent.com/6756545/183558037-9eb7f040-f949-4915-a8e6-736c7cba4674.png">

- 1.2 remove-confignode in confignode directory
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/6756545/183558194-ce13ac37-758d-45bd-bf82-7c8adaf8fc1a.png">

- 1.3 stop-confignode in confignode directory
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/6756545/183558631-eedd82ee-6d80-456a-b257-7881c86230e2.png">

- 2.1 start-confignode in distribution directory
<img width="1047" alt="image" src="https://user-images.githubusercontent.com/6756545/183558889-11329a44-58ba-43ee-9bf4-8c6044168aa4.png">

- 2.2 remove-confignode in distribution directory
<img width="1047" alt="image" src="https://user-images.githubusercontent.com/6756545/183559003-f67184ec-c311-422c-9a9b-3c53904cef9d.png">

- 2.3 stop-confignode in distribution directory
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/6756545/183559091-b00b52c8-b66c-411b-9d7d-7c3e36760754.png">

