### PR TITLE
[IOTDB-4072] Updated the ConfigNode Dashboard to add a display of node online and offline information and the distribution of leaders

### DIFF
--- a/grafana-metrics-example/cluster/Apache IoTDB ConfigNode Dashboard v0.14.0.json
+++ b/grafana-metrics-example/cluster/Apache IoTDB ConfigNode Dashboard v0.14.0.json
@@ -418,7 +418,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "cluster_node_status{name =~ \"EndPoint.*\"}",
+          "expr": "cluster_node_status{}",
           "legendFormat": "{{instance}}  {{type}} {{name}}",
           "range": true,
           "refId": "A"
@@ -493,7 +493,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "cluster_node_leader_count{name =~ \"EndPoint.*\"}",
+          "expr": "cluster_node_leader_count{}",
           "legendFormat": "{{name}} total leaders",
           "range": true,
           "refId": "A"

--- a/grafana-metrics-example/cluster/Apache IoTDB ConfigNode Dashboard v0.14.0.json
+++ b/grafana-metrics-example/cluster/Apache IoTDB ConfigNode Dashboard v0.14.0.json
@@ -89,7 +89,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 28,
+      "id": 38,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -169,7 +169,7 @@
       "title": "Overview",
       "type": "stat"
     },
-    {
+	{
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -177,7 +177,327 @@
         "x": 0,
         "y": 8
       },
-      "id": 40,
+      "id": 36,
+      "panels": [],
+      "title": "Node Info",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "config_node{status=\"Online\"}",
+          "legendFormat": "ConfigNode",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "data_node{status=\"Online\"}",
+          "hide": false,
+          "legendFormat": "DataNode",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Total number of online nodes",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 9
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "config_node{status=\"Unknown\"}",
+          "hide": false,
+          "legendFormat": "ConfigNode",
+          "range": true,
+          "refId": "AA"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "data_node{status=\"Unknown\"}",
+          "hide": false,
+          "legendFormat": "DataNode",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Total number of offline nodes",
+      "type": "stat"
+    },
+	{
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 2,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "cluster_node_status{name =~ \"EndPoint.*\"}",
+          "legendFormat": "{{instance}}  {{type}} {{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Select the node that you want to view",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 28,
+      "panels": [],
+      "title": "Leadership Distribution",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "cluster_node_leader_count{name =~ \"EndPoint.*\"}",
+          "legendFormat": "{{name}} total leaders",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Leadership distribution",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 24,
       "panels": [],
       "title": "Region",
       "type": "row"
@@ -233,9 +553,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 9
+        "y": 37
       },
-      "id": 38,
+      "id": 22,
       "options": {
         "legend": {
           "calcs": [],
@@ -314,9 +634,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 9
+        "y": 37
       },
-      "id": 32,
+      "id": 20,
       "options": {
         "legend": {
           "calcs": [],
@@ -395,9 +715,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 17
+        "y": 45
       },
-      "id": 35,
+      "id": 20,
       "options": {
         "legend": {
           "calcs": [],
@@ -476,9 +796,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 17
+        "y": 45
       },
-      "id": 37,
+      "id": 18,
       "options": {
         "legend": {
           "calcs": [],
@@ -512,7 +832,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 53
       },
       "id": 16,
       "panels": [],
@@ -570,7 +890,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 54
       },
       "id": 10,
       "options": {
@@ -664,7 +984,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 54
       },
       "id": 8,
       "options": {
@@ -758,7 +1078,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 62
       },
       "id": 6,
       "options": {
@@ -888,7 +1208,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 34
+        "y": 62
       },
       "id": 4,
       "options": {
@@ -969,7 +1289,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 42
+        "y": 70
       },
       "id": 2,
       "options": {
@@ -1063,7 +1383,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 70
       },
       "id": 26,
       "options": {
@@ -1147,7 +1467,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 50
+        "y": 78
       },
       "id": 42,
       "options": {
@@ -1229,7 +1549,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 50
+        "y": 78
       },
       "id": 44,
       "options": {
@@ -1324,7 +1644,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 86
       },
       "id": 46,
       "options": {

--- a/grafana-metrics-example/cluster/Apache IoTDB ConfigNode Dashboard v0.14.0.json
+++ b/grafana-metrics-example/cluster/Apache IoTDB ConfigNode Dashboard v0.14.0.json
@@ -365,13 +365,26 @@
               "mode": "off"
             }
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "index": 1,
+                  "text": "Unknown"
+                },
+                "1": {
+                  "index": 0,
+                  "text": "Online"
+                }
+              },
+              "type": "value"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -411,7 +424,7 @@
           "refId": "A"
         }
       ],
-      "title": "Select the node that you want to view",
+      "title": "The status of cluster node",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
## Description

### After
![image](https://user-images.githubusercontent.com/71131924/183562570-80c2e56d-064c-48fc-add4-9a871eeef386.png)

For the presentation of these indicators, if the leader of the confignode appears in the timeframe displayed by the graffana, the indicators may appear duplicated on the panel. At present, there is no good solution, which can only allow users to avoid the time of leader transformation when using it. Since the utility of this data is still greater than the cost of adjusting the grafana time frame operation that the user may have, I personally feel that it can be shown in this way for the time being.