### PR TITLE
[IOTDB-4039] Unify thread-name of ClientPools

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/client/AsyncMultiLeaderServiceClient.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/client/AsyncMultiLeaderServiceClient.java
@@ -112,8 +112,9 @@ public class AsyncMultiLeaderServiceClient extends MultiLeaderConsensusIService.
 
     public Factory(
         ClientManager<TEndPoint, AsyncMultiLeaderServiceClient> clientManager,
-        ClientFactoryProperty clientFactoryProperty) {
-      super(clientManager, clientFactoryProperty);
+        ClientFactoryProperty clientFactoryProperty,
+        String threadName) {
+      super(clientManager, clientFactoryProperty, threadName);
     }
 
     @Override

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/client/MultiLeaderConsensusClientPool.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/client/MultiLeaderConsensusClientPool.java
@@ -37,7 +37,8 @@ public class MultiLeaderConsensusClientPool {
       implements IClientPoolFactory<TEndPoint, AsyncMultiLeaderServiceClient> {
 
     private final MultiLeaderConfig config;
-    private static final String THREAD_NAME = "MultiLeaderConsensusClientPool";
+    private static final String MULTI_LEADER_CONSENSUS_CLIENT_POOL_THREAD_NAME =
+        "MultiLeaderConsensusClientPool";
 
     public AsyncMultiLeaderServiceClientPoolFactory(MultiLeaderConfig config) {
       this.config = config;
@@ -55,7 +56,7 @@ public class MultiLeaderConsensusClientPool {
                   .setSelectorNumOfAsyncClientManager(
                       config.getRpc().getSelectorNumOfClientManager())
                   .build(),
-              THREAD_NAME),
+              MULTI_LEADER_CONSENSUS_CLIENT_POOL_THREAD_NAME),
           new ClientPoolProperty.Builder<AsyncMultiLeaderServiceClient>().build().getConfig());
     }
   }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/client/MultiLeaderConsensusClientPool.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/client/MultiLeaderConsensusClientPool.java
@@ -37,6 +37,7 @@ public class MultiLeaderConsensusClientPool {
       implements IClientPoolFactory<TEndPoint, AsyncMultiLeaderServiceClient> {
 
     private final MultiLeaderConfig config;
+    private static final String THREAD_NAME = "MultiLeaderConsensusClientPool";
 
     public AsyncMultiLeaderServiceClientPoolFactory(MultiLeaderConfig config) {
       this.config = config;
@@ -53,7 +54,8 @@ public class MultiLeaderConsensusClientPool {
                   .setRpcThriftCompressionEnabled(config.getRpc().isRpcThriftCompressionEnabled())
                   .setSelectorNumOfAsyncClientManager(
                       config.getRpc().getSelectorNumOfClientManager())
-                  .build()),
+                  .build(),
+              THREAD_NAME),
           new ClientPoolProperty.Builder<AsyncMultiLeaderServiceClient>().build().getConfig());
     }
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/AsyncBaseClientFactory.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/AsyncBaseClientFactory.java
@@ -39,15 +39,15 @@ public abstract class AsyncBaseClientFactory<K, V> extends BaseClientFactory<K, 
       ClientFactoryProperty clientFactoryProperty,
       String threadName) {
     super(clientManager, clientFactoryProperty);
-    tManagers = new TAsyncClientManager[clientFactoryProperty.getSelectorNumOfAsyncClientPool()];
-    for (int i = 0; i < tManagers.length; i++) {
-      try {
-        tManagers[i] = new TAsyncClientManager();
-      } catch (IOException e) {
-        logger.error("Cannot create Async client factory", e);
-      }
-    }
     synchronized (this) {
+      tManagers = new TAsyncClientManager[clientFactoryProperty.getSelectorNumOfAsyncClientPool()];
+      for (int i = 0; i < tManagers.length; i++) {
+        try {
+          tManagers[i] = new TAsyncClientManager();
+        } catch (IOException e) {
+          logger.error("Cannot create Async client factory", e);
+        }
+      }
       Thread.getAllStackTraces().keySet().stream()
           .filter(thread -> thread.getName().contains(THRIFT_THREAD_NAME))
           .collect(Collectors.toList())

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/AsyncBaseClientFactory.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/AsyncBaseClientFactory.java
@@ -51,7 +51,7 @@ public abstract class AsyncBaseClientFactory<K, V> extends BaseClientFactory<K, 
       Thread.getAllStackTraces().keySet().stream()
           .filter(thread -> thread.getName().contains(THRIFT_THREAD_NAME))
           .collect(Collectors.toList())
-          .forEach(thread -> thread.setName(threadName + "-" + thread.getId()));
+          .forEach(thread -> thread.setName(threadName + "-selector" + "-" + thread.getId()));
     }
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolFactory.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolFactory.java
@@ -33,6 +33,12 @@ import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 public class ClientPoolFactory {
 
   private static final CommonConfig conf = CommonDescriptor.getInstance().getConfig();
+  private static final String DATA_NODE_CLIENT_POOL_THREAD_NAME =
+      "AsyncDataNodeInternalServiceClientPool";
+  private static final String CONFIG_NODE_HEARTBEAT_CLIENT_POOL_THREAD_NAME =
+      "AsyncConfigNodeHeartbeatServiceClientPool";
+  private static final String DATA_NODE_HEARTBEAT_CLIENT_POOL_THREAD_NAME =
+      "AsyncDataNodeHeartbeatServiceClientPool";
 
   private ClientPoolFactory() {}
 
@@ -65,7 +71,8 @@ public class ClientPoolFactory {
                   .setConnectionTimeoutMs(conf.getConnectionTimeoutInMS())
                   .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnabled())
                   .setSelectorNumOfAsyncClientManager(conf.getSelectorNumOfClientManager())
-                  .build()),
+                  .build(),
+              DATA_NODE_CLIENT_POOL_THREAD_NAME),
           new ClientPoolProperty.Builder<AsyncDataNodeInternalServiceClient>().build().getConfig());
     }
   }
@@ -82,7 +89,8 @@ public class ClientPoolFactory {
                   .setConnectionTimeoutMs(conf.getConnectionTimeoutInMS())
                   .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnabled())
                   .setSelectorNumOfAsyncClientManager(conf.getSelectorNumOfClientManager())
-                  .build()),
+                  .build(),
+              CONFIG_NODE_HEARTBEAT_CLIENT_POOL_THREAD_NAME),
           new ClientPoolProperty.Builder<AsyncConfigNodeHeartbeatServiceClient>()
               .build()
               .getConfig());
@@ -101,7 +109,8 @@ public class ClientPoolFactory {
                   .setConnectionTimeoutMs(conf.getConnectionTimeoutInMS())
                   .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnabled())
                   .setSelectorNumOfAsyncClientManager(conf.getSelectorNumOfClientManager())
-                  .build()),
+                  .build(),
+              DATA_NODE_HEARTBEAT_CLIENT_POOL_THREAD_NAME),
           new ClientPoolProperty.Builder<AsyncDataNodeHeartbeatServiceClient>()
               .build()
               .getConfig());

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncConfigNodeHeartbeatServiceClient.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncConfigNodeHeartbeatServiceClient.java
@@ -107,8 +107,9 @@ public class AsyncConfigNodeHeartbeatServiceClient extends IConfigNodeRPCService
 
     public Factory(
         ClientManager<TEndPoint, AsyncConfigNodeHeartbeatServiceClient> clientManager,
-        ClientFactoryProperty clientFactoryProperty) {
-      super(clientManager, clientFactoryProperty);
+        ClientFactoryProperty clientFactoryProperty,
+        String threadName) {
+      super(clientManager, clientFactoryProperty, threadName);
     }
 
     @Override

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncConfigNodeIServiceClient.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncConfigNodeIServiceClient.java
@@ -112,8 +112,9 @@ public class AsyncConfigNodeIServiceClient extends IConfigNodeRPCService.AsyncCl
 
     public Factory(
         ClientManager<TEndPoint, AsyncConfigNodeIServiceClient> clientManager,
-        ClientFactoryProperty clientFactoryProperty) {
-      super(clientManager, clientFactoryProperty);
+        ClientFactoryProperty clientFactoryProperty,
+        String threadName) {
+      super(clientManager, clientFactoryProperty, threadName);
     }
 
     @Override

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeHeartbeatServiceClient.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeHeartbeatServiceClient.java
@@ -107,8 +107,9 @@ public class AsyncDataNodeHeartbeatServiceClient extends IDataNodeRPCService.Asy
 
     public Factory(
         ClientManager<TEndPoint, AsyncDataNodeHeartbeatServiceClient> clientManager,
-        ClientFactoryProperty clientFactoryProperty) {
-      super(clientManager, clientFactoryProperty);
+        ClientFactoryProperty clientFactoryProperty,
+        String threadName) {
+      super(clientManager, clientFactoryProperty, threadName);
     }
 
     @Override

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeInternalServiceClient.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeInternalServiceClient.java
@@ -124,8 +124,9 @@ public class AsyncDataNodeInternalServiceClient extends IDataNodeRPCService.Asyn
 
     public Factory(
         ClientManager<TEndPoint, AsyncDataNodeInternalServiceClient> clientManager,
-        ClientFactoryProperty clientFactoryProperty) {
-      super(clientManager, clientFactoryProperty);
+        ClientFactoryProperty clientFactoryProperty,
+        String threadName) {
+      super(clientManager, clientFactoryProperty, threadName);
     }
 
     @Override

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeMPPDataExchangeServiceClient.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeMPPDataExchangeServiceClient.java
@@ -113,8 +113,9 @@ public class AsyncDataNodeMPPDataExchangeServiceClient extends MPPDataExchangeSe
 
     public Factory(
         ClientManager<TEndPoint, AsyncDataNodeMPPDataExchangeServiceClient> clientManager,
-        ClientFactoryProperty clientFactoryProperty) {
-      super(clientManager, clientFactoryProperty);
+        ClientFactoryProperty clientFactoryProperty,
+        String threadName) {
+      super(clientManager, clientFactoryProperty, threadName);
     }
 
     @Override

--- a/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
@@ -447,7 +447,9 @@ public class ClientManagerTest {
         ClientManager<TEndPoint, AsyncDataNodeInternalServiceClient> manager) {
       return new GenericKeyedObjectPool<>(
           new AsyncDataNodeInternalServiceClient.Factory(
-              manager, new ClientFactoryProperty.Builder().build()),
+              manager,
+              new ClientFactoryProperty.Builder().build(),
+              "AsyncDataNodeInternalServiceClientPool"),
           new ClientPoolProperty.Builder<AsyncDataNodeInternalServiceClient>().build().getConfig());
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/client/DataNodeClientPoolFactory.java
+++ b/server/src/main/java/org/apache/iotdb/db/client/DataNodeClientPoolFactory.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.commons.client.ClientManager;
 import org.apache.iotdb.commons.client.ClientPoolProperty;
 import org.apache.iotdb.commons.client.IClientPoolFactory;
 import org.apache.iotdb.commons.client.async.AsyncConfigNodeIServiceClient;
-import org.apache.iotdb.commons.client.async.AsyncDataNodeInternalServiceClient;
 import org.apache.iotdb.commons.client.async.AsyncDataNodeMPPDataExchangeServiceClient;
 import org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient;
 import org.apache.iotdb.commons.client.sync.SyncDataNodeInternalServiceClient;
@@ -40,6 +39,10 @@ import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 public class DataNodeClientPoolFactory {
 
   private static final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
+  private static final String CONFIG_NODE_CLIENT_POOL_THREAD_NAME =
+      "AsyncConfigNodeIServiceClientPool";
+  private static final String DATA_NODE_MPP_DATA_EXCHANGE_CLIENT_POOL_THREAD_NAME =
+      "AsyncDataNodeMPPDataExchangeServiceClientPool";
 
   private DataNodeClientPoolFactory() {}
 
@@ -72,7 +75,8 @@ public class DataNodeClientPoolFactory {
                   .setConnectionTimeoutMs(conf.getConnectionTimeoutInMS())
                   .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnable())
                   .setSelectorNumOfAsyncClientManager(conf.getSelectorNumOfClientManager())
-                  .build()),
+                  .build(),
+              CONFIG_NODE_CLIENT_POOL_THREAD_NAME),
           new ClientPoolProperty.Builder<AsyncConfigNodeIServiceClient>().build().getConfig());
     }
   }
@@ -91,23 +95,6 @@ public class DataNodeClientPoolFactory {
                   .setSelectorNumOfAsyncClientManager(conf.getSelectorNumOfClientManager())
                   .build()),
           new ClientPoolProperty.Builder<SyncDataNodeInternalServiceClient>().build().getConfig());
-    }
-  }
-
-  public static class AsyncDataNodeInternalServiceClientPoolFactory
-      implements IClientPoolFactory<TEndPoint, AsyncDataNodeInternalServiceClient> {
-    @Override
-    public KeyedObjectPool<TEndPoint, AsyncDataNodeInternalServiceClient> createClientPool(
-        ClientManager<TEndPoint, AsyncDataNodeInternalServiceClient> manager) {
-      return new GenericKeyedObjectPool<>(
-          new AsyncDataNodeInternalServiceClient.Factory(
-              manager,
-              new ClientFactoryProperty.Builder()
-                  .setConnectionTimeoutMs(conf.getConnectionTimeoutInMS())
-                  .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnable())
-                  .setSelectorNumOfAsyncClientManager(conf.getSelectorNumOfClientManager())
-                  .build()),
-          new ClientPoolProperty.Builder<AsyncDataNodeInternalServiceClient>().build().getConfig());
     }
   }
 
@@ -142,7 +129,8 @@ public class DataNodeClientPoolFactory {
                   .setConnectionTimeoutMs(conf.getConnectionTimeoutInMS())
                   .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnable())
                   .setSelectorNumOfAsyncClientManager(conf.getSelectorNumOfClientManager())
-                  .build()),
+                  .build(),
+              DATA_NODE_MPP_DATA_EXCHANGE_CLIENT_POOL_THREAD_NAME),
           new ClientPoolProperty.Builder<AsyncDataNodeMPPDataExchangeServiceClient>()
               .build()
               .getConfig());


### PR DESCRIPTION
1、We can view online threads：
Example：

![图片](https://user-images.githubusercontent.com/79885238/183575707-06e64f11-3305-4773-89e3-5088be9143cd.png)
![图片](https://user-images.githubusercontent.com/79885238/183575737-a88504f8-2839-43ef-a993-c35c87c6cd28.png)
![图片](https://user-images.githubusercontent.com/79885238/183575766-79e1cf65-7ffa-4215-a8b6-c7271b5cc55a.png)


meanwhile
![图片](https://user-images.githubusercontent.com/79885238/183576054-c2b21dc9-f069-477c-ae04-28391db7eb7b.png)

2、Delete a duplicate class
AsyncDataNodeInternalServiceClientPoolFactory
