### PR TITLE
[IOTDB-4034] Fix throwing compaction exception when shutting down IoTDB

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.consensus.DataRegionConsensusImpl;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.StorageEngineV2;
-import org.apache.iotdb.db.engine.compaction.CompactionTaskManager;
 import org.apache.iotdb.db.metadata.schemaregion.SchemaEngineMode;
 import org.apache.iotdb.db.utils.MemUtils;
 import org.apache.iotdb.db.wal.WALManager;
@@ -36,7 +35,6 @@ public class IoTDBShutdownHook extends Thread {
 
   @Override
   public void run() {
-    CompactionTaskManager.getInstance().stop();
     // close rocksdb if possible to avoid lose data
     if (SchemaEngineMode.valueOf(IoTDBDescriptor.getInstance().getConfig().getSchemaEngineMode())
         .equals(SchemaEngineMode.Rocksdb_based)) {


### PR DESCRIPTION
See [IOTDB-4034](https://issues.apache.org/jira/browse/IOTDB-4034).
The reason for this bug is the same as [PR-6788](https://github.com/apache/iotdb/pull/6788).
