### PR TITLE
Fix the NPE error when write failed using Ratis

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusWriteResponse.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/response/ConsensusWriteResponse.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.consensus.common.response;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.consensus.exception.ConsensusException;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 public class ConsensusWriteResponse extends ConsensusResponse {
 
@@ -38,6 +39,22 @@ public class ConsensusWriteResponse extends ConsensusResponse {
   @Override
   public String toString() {
     return "ConsensusWriteResponse{" + "status=" + status + "} " + super.toString();
+  }
+
+  public boolean isSuccessful() {
+    return status != null && status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode();
+  }
+
+  public String getErrorMessage() {
+    if (status != null && status.message != null && status.message.length() > 0) {
+      return status.message;
+    }
+    if (exception != null
+        && exception.getMessage() != null
+        && exception.getMessage().length() > 0) {
+      return exception.getMessage();
+    }
+    return "unknown error message";
   }
 
   public static ConsensusWriteResponse.Builder newBuilder() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -275,9 +275,14 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           writeResponse = SchemaRegionConsensusImpl.getInstance().write(groupId, planNode);
         }
 
-        if (writeResponse.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-          logger.error(writeResponse.getStatus().message);
-          throw new FragmentInstanceDispatchException(writeResponse.getStatus());
+        if (!writeResponse.isSuccessful()) {
+          logger.error(writeResponse.getErrorMessage());
+          TSStatus failureStatus =
+              writeResponse.getStatus() != null
+                  ? writeResponse.getStatus()
+                  : RpcUtils.getStatus(
+                      TSStatusCode.EXECUTE_STATEMENT_ERROR, writeResponse.getErrorMessage());
+          throw new FragmentInstanceDispatchException(failureStatus);
         } else if (hasFailedMeasurement) {
           throw new FragmentInstanceDispatchException(
               RpcUtils.getStatus(


### PR DESCRIPTION
## Description
Before this change, the FragmentDispatcher may encounter NPE error when processing `writeResponse` because of TSStatus lack in the Object. 

This PR gives a check for the null variables in ConsensusWriteResponse to avoid NPE from its dependents.

**We need to refine the ConsensusWriteResponse later in the Consensus write method for each implementations to avoid null variable** 