### PR TITLE
[To rel/0.13][IOTDB-4087] Fix load tsfile

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -1034,8 +1034,7 @@ public class StorageEngine implements IService {
     }
     String device = deviceSet.iterator().next();
     PartialPath devicePath = new PartialPath(device);
-    PartialPath storageGroupPath = IoTDB.metaManager.getBelongedStorageGroup(devicePath);
-    getProcessorDirectly(storageGroupPath).loadNewTsFile(newTsFileResource);
+    getProcessorDirectly(devicePath).loadNewTsFile(newTsFileResource);
   }
 
   public boolean deleteTsfileForSync(File deletedTsfile)

--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -571,7 +571,7 @@ public class StorageEngine implements IService {
     try {
       IStorageGroupMNode storageGroupMNode = IoTDB.metaManager.getStorageGroupNodeByPath(path);
       storageGroupPath = storageGroupMNode.getPartialPath();
-      return getStorageGroupProcessorByPath(storageGroupPath, storageGroupMNode);
+      return getStorageGroupProcessorByPath(path, storageGroupMNode);
     } catch (StorageGroupProcessorException | MetadataException e) {
       throw new StorageEngineException(e);
     }


### PR DESCRIPTION
load tsfile功能：现在是根据存储组路径取哈希值对虚拟存储组的数量取模，单虚拟存储组没有问题，多虚拟存储组下与虚拟存储组分配冲突。改为根据tsfile第一个设备路径对虚拟存储组的数量取模