### PR TITLE
[IOTDB-4090] Add getLatestSnapshotFiles interface in consensus

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -79,7 +79,8 @@ public interface IStateMachine {
    * paths.
    *
    * @param latestSnapshotRootDir dir where the latest snapshot sits
-   * @return List of real snapshot files
+   * @return List of real snapshot files. If the returned list is null, consensus implementations
+   * will visit and add all files under this give latestSnapshotRootDir.
    */
   default List<File> getSnapshotFiles(File latestSnapshotRootDir) {
     return null;

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -74,13 +74,13 @@ public interface IStateMachine {
   /**
    * given a snapshot dir, ask statemachine to provide all snapshot files.
    *
-   * <p>DataRegion may take snapshot at a different disk and only store a log file containing only
-   * file paths. So statemachine is required to read the log file and give the real snapshot file
+   * <p>DataRegion may take snapshot at a different disk and only store a log file containing file
+   * paths. So statemachine is required to read the log file and provide the real snapshot file
    * paths.
    *
    * @param latestSnapshotRootDir dir where the latest snapshot sits
    * @return List of real snapshot files. If the returned list is null, consensus implementations
-   * will visit and add all files under this give latestSnapshotRootDir.
+   *     will visit and add all files under this give latestSnapshotRootDir.
    */
   default List<File> getSnapshotFiles(File latestSnapshotRootDir) {
     return null;

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -71,6 +71,20 @@ public interface IStateMachine {
    */
   void loadSnapshot(File latestSnapshotRootDir);
 
+  /**
+   * given a snapshot dir, ask statemachine to provide all snapshot files.
+   *
+   * <p>DataRegion may take snapshot at a different disk and only store a log file containing only
+   * file paths. So statemachine is required to read the log file and give the real snapshot file
+   * paths.
+   *
+   * @param latestSnapshotRootDir dir where the latest snapshot sits
+   * @return List of real snapshot files
+   */
+  default List<File> getSnapshotFiles(File latestSnapshotRootDir) {
+    return null;
+  }
+
   /** An optional API for event notifications. */
   interface EventApi {
     /**

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -105,6 +105,12 @@ public class DataRegionStateMachine extends BaseStateMachine {
   }
 
   @Override
+  public List<File> getSnapshotFiles(File latestSnapshotRootDir) {
+    // TODO: implement this method
+    return super.getSnapshotFiles(latestSnapshotRootDir);
+  }
+
+  @Override
   public TSStatus write(IConsensusRequest request) {
     PlanNode planNode;
     try {


### PR DESCRIPTION
## Description

DataRegionStateMachine has cross-disk snapshot, using a single log file to record all file paths in another disk. Under this situation, we cannot directly use this log file as snapshot and transfer to other peers. So I propose to add a interface, which can let state machine decide which files are really contained in a given snapshot.
