### PR TITLE
[IOTDB-3938] Optimize Standalone schema fetch performance

### DIFF
--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -55,6 +55,7 @@ import org.apache.iotdb.db.metadata.schemaregion.rocksdb.mnode.RMNodeValueType;
 import org.apache.iotdb.db.metadata.schemaregion.rocksdb.mnode.RMeasurementMNode;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.utils.MetaFormatUtils;
+import org.apache.iotdb.db.mpp.common.schematree.DeviceSchemaInfo;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertTabletPlan;
@@ -1919,6 +1920,13 @@ public class RSchemaRegion implements ISchemaRegion {
       }
     }
     return deviceMNode;
+  }
+
+  @Override
+  public DeviceSchemaInfo getDeviceSchemaInfoWithAutoCreate(
+      PartialPath devicePath, String[] measurements, TSDataType[] tsDataTypes, boolean aligned)
+      throws MetadataException {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
 import org.apache.iotdb.db.metadata.path.MeasurementPath;
 import org.apache.iotdb.db.metadata.template.Template;
+import org.apache.iotdb.db.mpp.common.schematree.DeviceSchemaInfo;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
 import org.apache.iotdb.db.qp.physical.sys.ActivateTemplateInClusterPlan;
 import org.apache.iotdb.db.qp.physical.sys.ActivateTemplatePlan;
@@ -42,6 +43,7 @@ import org.apache.iotdb.db.qp.physical.sys.UnsetTemplatePlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.ShowDevicesResult;
 import org.apache.iotdb.db.query.dataset.ShowTimeSeriesResult;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.io.File;
@@ -354,6 +356,10 @@ public interface ISchemaRegion {
   // region Interfaces for InsertPlan process
   /** get schema for device. Attention!!! Only support insertPlan */
   IMNode getSeriesSchemasAndReadLockDevice(InsertPlan plan) throws MetadataException, IOException;
+
+  DeviceSchemaInfo getDeviceSchemaInfoWithAutoCreate(
+      PartialPath devicePath, String[] measurements, TSDataType[] tsDataTypes, boolean aligned)
+      throws MetadataException;
   // endregion
 
   // region Interfaces for Template operations

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -56,6 +56,8 @@ import org.apache.iotdb.db.metadata.rescon.TimeseriesStatistics;
 import org.apache.iotdb.db.metadata.tag.TagManager;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.template.TemplateManager;
+import org.apache.iotdb.db.mpp.common.schematree.DeviceSchemaInfo;
+import org.apache.iotdb.db.mpp.common.schematree.MeasurementSchemaInfo;
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
@@ -85,6 +87,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -1742,6 +1745,48 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       compressors.add(TSFileDescriptor.getInstance().getConfig().getCompressor());
     }
     createAlignedTimeSeries(prefixPath, measurements, dataTypes, encodings, compressors);
+  }
+
+  @Override
+  public DeviceSchemaInfo getDeviceSchemaInfoWithAutoCreate(
+      PartialPath devicePath, String[] measurements, TSDataType[] tsDataTypes, boolean aligned)
+      throws MetadataException {
+    try {
+      List<MeasurementSchemaInfo> measurementSchemaInfoList = new ArrayList<>(measurements.length);
+      IMNode deviceMNode = getDeviceNodeWithAutoCreate(devicePath);
+      IMeasurementMNode measurementMNode;
+      for (int i = 0; i < measurements.length; i++) {
+        measurementMNode = getMeasurementMNode(deviceMNode, measurements[i]);
+        if (measurementMNode == null) {
+          if (config.isAutoCreateSchemaEnabled()) {
+            if (aligned) {
+              internalAlignedCreateTimeseries(
+                  devicePath,
+                  Collections.singletonList(measurements[i]),
+                  Collections.singletonList(tsDataTypes[i]));
+
+            } else {
+              internalCreateTimeseries(devicePath.concatNode(measurements[i]), tsDataTypes[i]);
+            }
+            // after creating timeseries, the deviceMNode has been replaced by a new entityMNode
+            deviceMNode = mtree.getNodeByPath(devicePath);
+            measurementMNode = getMeasurementMNode(deviceMNode, measurements[i]);
+          } else {
+            throw new PathNotExistException(devicePath + PATH_SEPARATOR + measurements[i]);
+          }
+        }
+        measurementSchemaInfoList.add(
+            new MeasurementSchemaInfo(
+                measurementMNode.getName(),
+                (MeasurementSchema) measurementMNode.getSchema(),
+                measurementMNode.getAlias()));
+      }
+
+      return new DeviceSchemaInfo(
+          devicePath, deviceMNode.getAsEntityMNode().isAligned(), measurementSchemaInfoList);
+    } catch (IOException e) {
+      throw new MetadataException(e);
+    }
   }
 
   // endregion

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -54,6 +54,7 @@ import org.apache.iotdb.db.metadata.rescon.TimeseriesStatistics;
 import org.apache.iotdb.db.metadata.tag.TagManager;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.template.TemplateManager;
+import org.apache.iotdb.db.mpp.common.schematree.DeviceSchemaInfo;
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
@@ -1604,6 +1605,13 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
     }
 
     return deviceMNode;
+  }
+
+  @Override
+  public DeviceSchemaInfo getDeviceSchemaInfoWithAutoCreate(
+      PartialPath devicePath, String[] measurements, TSDataType[] tsDataTypes, boolean aligned)
+      throws MetadataException {
+    throw new UnsupportedOperationException();
   }
 
   private IMNode getDeviceInTemplateIfUsingTemplate(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTree.java
@@ -128,18 +128,25 @@ public class ClusterSchemaTree implements ISchemaTree {
       return null;
     }
 
-    List<SchemaMeasurementNode> measurementNodeList = new ArrayList<>();
+    List<MeasurementSchemaInfo> measurementSchemaInfoList = new ArrayList<>();
     SchemaNode node;
+    SchemaMeasurementNode measurementNode;
     for (String measurement : measurements) {
       node = cur.getChild(measurement);
       if (node == null) {
-        measurementNodeList.add(null);
+        measurementSchemaInfoList.add(null);
       } else {
-        measurementNodeList.add(node.getAsMeasurementNode());
+        measurementNode = node.getAsMeasurementNode();
+        measurementSchemaInfoList.add(
+            new MeasurementSchemaInfo(
+                measurementNode.getName(),
+                measurementNode.getSchema(),
+                measurementNode.getAlias()));
       }
     }
 
-    return new DeviceSchemaInfo(devicePath, cur.getAsEntityNode().isAligned(), measurementNodeList);
+    return new DeviceSchemaInfo(
+        devicePath, cur.getAsEntityNode().isAligned(), measurementSchemaInfoList);
   }
 
   public void appendMeasurementPaths(List<MeasurementPath> measurementPathList) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/DeviceGroupSchemaTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/DeviceGroupSchemaTree.java
@@ -47,6 +47,10 @@ public class DeviceGroupSchemaTree implements ISchemaTree {
     return deviceSchemaInfoMap.isEmpty();
   }
 
+  public void addDeviceInfo(DeviceSchemaInfo deviceSchemaInfo) {
+    deviceSchemaInfoMap.put(deviceSchemaInfo.getDevicePath(), deviceSchemaInfo);
+  }
+
   public void merge(DeviceGroupSchemaTree schemaTree) {
     deviceSchemaInfoMap.putAll(schemaTree.deviceSchemaInfoMap);
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/DeviceGroupSchemaTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/DeviceGroupSchemaTree.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.common.schematree;
+
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.metadata.path.MeasurementPath;
+import org.apache.iotdb.tsfile.utils.Pair;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is specifically for standalone schema validation during data insertion. Since the
+ * schema fetch is mainly based on device path, the schema is directly grouped by device rater than
+ * organized as a trie.
+ */
+public class DeviceGroupSchemaTree implements ISchemaTree {
+
+  private final Map<PartialPath, DeviceSchemaInfo> deviceSchemaInfoMap = new HashMap<>();
+
+  @Override
+  public DeviceSchemaInfo searchDeviceSchemaInfo(
+      PartialPath devicePath, List<String> measurements) {
+    return deviceSchemaInfoMap.get(devicePath).getSubDeviceSchemaInfo(measurements);
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return deviceSchemaInfoMap.isEmpty();
+  }
+
+  public void merge(DeviceGroupSchemaTree schemaTree) {
+    deviceSchemaInfoMap.putAll(schemaTree.deviceSchemaInfoMap);
+  }
+
+  @Override
+  public Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(
+      PartialPath pathPattern, int slimit, int soffset, boolean isPrefixMatch) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(PartialPath pathPattern) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<MeasurementPath> getAllMeasurement() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<DeviceSchemaInfo> getMatchedDevices(PartialPath pathPattern, boolean isPrefixMatch) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<DeviceSchemaInfo> getMatchedDevices(PartialPath pathPattern) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getBelongedStorageGroup(String pathName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getBelongedStorageGroup(PartialPath path) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<String> getStorageGroups() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/MeasurementSchemaInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/MeasurementSchemaInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.common.schematree;
+
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+
+public class MeasurementSchemaInfo {
+
+  private final String name;
+  private final String alias;
+  private final MeasurementSchema schema;
+
+  public MeasurementSchemaInfo(String name, MeasurementSchema schema, String alias) {
+    this.name = name;
+    this.schema = schema;
+    this.alias = alias;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public MeasurementSchema getSchema() {
+    return schema;
+  }
+
+  public String getAlias() {
+    return alias;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/MeasurementSchemaInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/MeasurementSchemaInfo.java
@@ -21,6 +21,12 @@ package org.apache.iotdb.db.mpp.common.schematree;
 
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
+/**
+ * This class acts as common measurement schema format during system module interactions, mainly in
+ * analyzer and SchemaFetcher. Currently, this class cooperates with DeviceSchemaInfo and wraps
+ * measurement name, alias and MeasurementSchema, which are necessary to construct schemaTree for
+ * Query and Insertion.
+ */
 public class MeasurementSchemaInfo {
 
   private final String name;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeDeviceVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeDeviceVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.mpp.common.schematree.visitor;
 
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.mpp.common.schematree.DeviceSchemaInfo;
+import org.apache.iotdb.db.mpp.common.schematree.MeasurementSchemaInfo;
 import org.apache.iotdb.db.mpp.common.schematree.node.SchemaMeasurementNode;
 import org.apache.iotdb.db.mpp.common.schematree.node.SchemaNode;
 
@@ -50,17 +51,23 @@ public class SchemaTreeDeviceVisitor extends SchemaTreeVisitor<DeviceSchemaInfo>
   @Override
   protected DeviceSchemaInfo generateResult() {
     PartialPath path = new PartialPath(generateFullPathNodes(nextMatchedNode));
-    List<SchemaMeasurementNode> measurementNodeList = new ArrayList<>();
+    List<MeasurementSchemaInfo> measurementSchemaInfoList = new ArrayList<>();
     Iterator<SchemaNode> iterator = getChildrenIterator(nextMatchedNode);
     SchemaNode node;
+    SchemaMeasurementNode measurementNode;
     while (iterator.hasNext()) {
       node = iterator.next();
       if (node.isMeasurement()) {
-        measurementNodeList.add(node.getAsMeasurementNode());
+        measurementNode = node.getAsMeasurementNode();
+        measurementSchemaInfoList.add(
+            new MeasurementSchemaInfo(
+                measurementNode.getName(),
+                measurementNode.getSchema(),
+                measurementNode.getAlias()));
       }
     }
 
     return new DeviceSchemaInfo(
-        path, nextMatchedNode.getAsEntityNode().isAligned(), measurementNodeList);
+        path, nextMatchedNode.getAsEntityNode().isAligned(), measurementSchemaInfoList);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/StandaloneSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/StandaloneSchemaFetcher.java
@@ -23,31 +23,25 @@ import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.exception.sql.StatementAnalyzeException;
 import org.apache.iotdb.db.localconfignode.LocalConfigNode;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.metadata.schemaregion.SchemaEngine;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.mpp.common.schematree.ClusterSchemaTree;
+import org.apache.iotdb.db.mpp.common.schematree.DeviceGroupSchemaTree;
 import org.apache.iotdb.db.mpp.common.schematree.DeviceSchemaInfo;
 import org.apache.iotdb.db.mpp.common.schematree.ISchemaTree;
 import org.apache.iotdb.db.mpp.common.schematree.PathPatternTree;
-import org.apache.iotdb.db.qp.physical.sys.CreateAlignedTimeSeriesPlan;
-import org.apache.iotdb.db.qp.physical.sys.CreateTimeSeriesPlan;
-import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
-import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.utils.Pair;
-import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.apache.iotdb.db.utils.EncodingInferenceUtils.getDefaultEncoding;
 
 public class StandaloneSchemaFetcher implements ISchemaFetcher {
 
@@ -88,35 +82,23 @@ public class StandaloneSchemaFetcher implements ISchemaFetcher {
   @Override
   public ISchemaTree fetchSchemaWithAutoCreate(
       PartialPath devicePath, String[] measurements, TSDataType[] tsDataTypes, boolean aligned) {
-    ClusterSchemaTree schemaTree = new ClusterSchemaTree();
-
-    PathPatternTree patternTree = new PathPatternTree();
-    for (String measurement : measurements) {
-      patternTree.appendFullPath(devicePath, measurement);
-    }
-
-    if (patternTree.isEmpty()) {
-      return schemaTree;
-    }
-
-    ClusterSchemaTree fetchedSchemaTree;
-
-    if (!config.isAutoCreateSchemaEnabled()) {
-      fetchedSchemaTree = fetchSchema(patternTree);
-      schemaTree.mergeSchemaTree(fetchedSchemaTree);
-      return schemaTree;
-    }
-
-    fetchedSchemaTree = fetchSchema(patternTree);
-    schemaTree.mergeSchemaTree(fetchedSchemaTree);
-
-    ClusterSchemaTree missingSchemaTree =
-        checkAndAutoCreateMissingMeasurements(
-            fetchedSchemaTree, devicePath, measurements, tsDataTypes, aligned);
-
-    schemaTree.mergeSchemaTree(missingSchemaTree);
-
+    DeviceSchemaInfo deviceSchemaInfo =
+        getDeviceSchemaInfoWithAutoCreate(devicePath, measurements, tsDataTypes, aligned);
+    DeviceGroupSchemaTree schemaTree = new DeviceGroupSchemaTree();
+    schemaTree.addDeviceInfo(deviceSchemaInfo);
     return schemaTree;
+  }
+
+  private DeviceSchemaInfo getDeviceSchemaInfoWithAutoCreate(
+      PartialPath devicePath, String[] measurements, TSDataType[] tsDataTypes, boolean aligned) {
+    try {
+      SchemaRegionId schemaRegionId = localConfigNode.getBelongedSchemaRegionId(devicePath);
+      ISchemaRegion schemaRegion = schemaEngine.getSchemaRegion(schemaRegionId);
+      return schemaRegion.getDeviceSchemaInfoWithAutoCreate(
+          devicePath, measurements, tsDataTypes, aligned);
+    } catch (MetadataException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
@@ -125,40 +107,44 @@ public class StandaloneSchemaFetcher implements ISchemaFetcher {
       List<String[]> measurementsList,
       List<TSDataType[]> tsDataTypesList,
       List<Boolean> isAlignedList) {
-    ClusterSchemaTree schemaTree = new ClusterSchemaTree();
-    PathPatternTree patternTree = new PathPatternTree();
-    for (int i = 0; i < devicePathList.size(); i++) {
-      for (String measurement : measurementsList.get(i)) {
-        patternTree.appendFullPath(devicePathList.get(i), measurement);
+    Map<PartialPath, List<Integer>> deviceMap = new HashMap<>();
+    for (int i = 0, size = devicePathList.size(); i < size; i++) {
+      deviceMap.computeIfAbsent(devicePathList.get(i), k -> new ArrayList<>()).add(i);
+    }
+
+    DeviceGroupSchemaTree schemaTree = new DeviceGroupSchemaTree();
+
+    for (Map.Entry<PartialPath, List<Integer>> entry : deviceMap.entrySet()) {
+      int totalSize = 0;
+      boolean isAligned = isAlignedList.get(entry.getValue().get(0));
+      for (int index : entry.getValue()) {
+        if (isAlignedList.get(entry.getValue().get(index)) != isAligned) {
+          throw new StatementAnalyzeException(
+              String.format("Inconsistent device alignment of %s in insert plan.", entry.getKey()));
+        }
+        totalSize += measurementsList.get(index).length;
       }
+
+      String[] measurements = new String[totalSize];
+      TSDataType[] tsDataTypes = new TSDataType[totalSize];
+
+      int curPos = 0;
+      for (int index : entry.getValue()) {
+        System.arraycopy(
+            measurementsList.get(index),
+            0,
+            measurements,
+            curPos,
+            measurementsList.get(index).length);
+        System.arraycopy(
+            tsDataTypesList.get(index), 0, tsDataTypes, curPos, tsDataTypesList.get(index).length);
+        curPos += measurementsList.get(index).length;
+      }
+
+      schemaTree.addDeviceInfo(
+          getDeviceSchemaInfoWithAutoCreate(entry.getKey(), measurements, tsDataTypes, isAligned));
     }
 
-    if (patternTree.isEmpty()) {
-      return schemaTree;
-    }
-
-    ClusterSchemaTree fetchedSchemaTree;
-
-    if (!config.isAutoCreateSchemaEnabled()) {
-      fetchedSchemaTree = fetchSchema(patternTree);
-      schemaTree.mergeSchemaTree(fetchedSchemaTree);
-      return schemaTree;
-    }
-
-    fetchedSchemaTree = fetchSchema(patternTree);
-    schemaTree.mergeSchemaTree(fetchedSchemaTree);
-
-    ClusterSchemaTree missingSchemaTree;
-    for (int i = 0; i < devicePathList.size(); i++) {
-      missingSchemaTree =
-          checkAndAutoCreateMissingMeasurements(
-              schemaTree,
-              devicePathList.get(i),
-              measurementsList.get(i),
-              tsDataTypesList.get(i),
-              isAlignedList.get(i));
-      schemaTree.mergeSchemaTree(missingSchemaTree);
-    }
     return schemaTree;
   }
 
@@ -179,121 +165,4 @@ public class StandaloneSchemaFetcher implements ISchemaFetcher {
 
   @Override
   public void invalidAllCache() {}
-
-  private Pair<List<String>, List<TSDataType>> checkMissingMeasurements(
-      ISchemaTree schemaTree,
-      PartialPath devicePath,
-      String[] measurements,
-      TSDataType[] tsDataTypes) {
-    DeviceSchemaInfo deviceSchemaInfo =
-        schemaTree.searchDeviceSchemaInfo(devicePath, Arrays.asList(measurements));
-    if (deviceSchemaInfo == null) {
-      return new Pair<>(Arrays.asList(measurements), Arrays.asList(tsDataTypes));
-    }
-
-    List<String> missingMeasurements = new ArrayList<>();
-    List<TSDataType> dataTypesOfMissingMeasurement = new ArrayList<>();
-    List<MeasurementSchema> schemaList = deviceSchemaInfo.getMeasurementSchemaList();
-    for (int i = 0; i < measurements.length; i++) {
-      if (schemaList.get(i) == null) {
-        missingMeasurements.add(measurements[i]);
-        dataTypesOfMissingMeasurement.add(tsDataTypes[i]);
-      }
-    }
-
-    return new Pair<>(missingMeasurements, dataTypesOfMissingMeasurement);
-  }
-
-  private ClusterSchemaTree checkAndAutoCreateMissingMeasurements(
-      ISchemaTree schemaTree,
-      PartialPath devicePath,
-      String[] measurements,
-      TSDataType[] tsDataTypes,
-      boolean isAligned) {
-
-    Pair<List<String>, List<TSDataType>> checkResult =
-        checkMissingMeasurements(schemaTree, devicePath, measurements, tsDataTypes);
-
-    List<String> missingMeasurements = checkResult.left;
-    List<TSDataType> dataTypesOfMissingMeasurement = checkResult.right;
-
-    if (missingMeasurements.isEmpty()) {
-      return new ClusterSchemaTree();
-    }
-
-    internalCreateTimeseries(
-        devicePath, missingMeasurements, dataTypesOfMissingMeasurement, isAligned);
-
-    PathPatternTree patternTree = new PathPatternTree();
-    for (String measurement : missingMeasurements) {
-      patternTree.appendFullPath(devicePath, measurement);
-    }
-    ClusterSchemaTree reFetchSchemaTree = fetchSchema(patternTree);
-
-    Pair<List<String>, List<TSDataType>> recheckResult =
-        checkMissingMeasurements(
-            reFetchSchemaTree,
-            devicePath,
-            missingMeasurements.toArray(new String[0]),
-            dataTypesOfMissingMeasurement.toArray(new TSDataType[0]));
-
-    missingMeasurements = recheckResult.left;
-    if (!missingMeasurements.isEmpty()) {
-      StringBuilder stringBuilder = new StringBuilder();
-      stringBuilder.append("(");
-      for (String missingMeasurement : missingMeasurements) {
-        stringBuilder.append(missingMeasurement).append(" ");
-      }
-      stringBuilder.append(")");
-      throw new RuntimeException(
-          String.format(
-              "Failed to auto create schema, devicePath: %s, measurements: %s",
-              devicePath.getFullPath(), stringBuilder));
-    }
-
-    return reFetchSchemaTree;
-  }
-
-  private void internalCreateTimeseries(
-      PartialPath devicePath,
-      List<String> measurements,
-      List<TSDataType> tsDataTypes,
-      boolean isAligned) {
-    try {
-      if (isAligned) {
-        CreateAlignedTimeSeriesPlan createAlignedTimeSeriesPlan = new CreateAlignedTimeSeriesPlan();
-        createAlignedTimeSeriesPlan.setPrefixPath(devicePath);
-        createAlignedTimeSeriesPlan.setMeasurements(measurements);
-        createAlignedTimeSeriesPlan.setDataTypes(tsDataTypes);
-        List<TSEncoding> encodings = new ArrayList<>();
-        List<CompressionType> compressors = new ArrayList<>();
-        for (TSDataType dataType : tsDataTypes) {
-          encodings.add(getDefaultEncoding(dataType));
-          compressors.add(TSFileDescriptor.getInstance().getConfig().getCompressor());
-        }
-        createAlignedTimeSeriesPlan.setEncodings(encodings);
-        createAlignedTimeSeriesPlan.setCompressors(compressors);
-        SchemaRegionId schemaRegionId =
-            localConfigNode.getBelongedSchemaRegionIdWithAutoCreate(devicePath);
-        ISchemaRegion schemaRegion = schemaEngine.getSchemaRegion(schemaRegionId);
-        schemaRegion.createAlignedTimeSeries(createAlignedTimeSeriesPlan);
-      } else {
-        for (int i = 0; i < measurements.size(); i++) {
-          CreateTimeSeriesPlan createTimeSeriesPlan = new CreateTimeSeriesPlan();
-          createTimeSeriesPlan.setPath(
-              new PartialPath(devicePath.getFullPath(), measurements.get(i)));
-          createTimeSeriesPlan.setDataType(tsDataTypes.get(i));
-          createTimeSeriesPlan.setEncoding(getDefaultEncoding(tsDataTypes.get(i)));
-          createTimeSeriesPlan.setCompressor(
-              TSFileDescriptor.getInstance().getConfig().getCompressor());
-          SchemaRegionId schemaRegionId =
-              localConfigNode.getBelongedSchemaRegionIdWithAutoCreate(devicePath);
-          ISchemaRegion schemaRegion = schemaEngine.getSchemaRegion(schemaRegionId);
-          schemaRegion.createTimeseries(createTimeSeriesPlan, -1);
-        }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("cannot auto create schema ", e);
-    }
-  }
 }


### PR DESCRIPTION
## Description


### Motivation
The mechanism of schema fetch in cluster mode is not that efficient in standalone mode, comparing with that of old standalone. The main cause is the redundant process on pattern tree and schema tree.

### Modification
1. Set up a data insertion specified ```DeviceGroupSchemaTree```, which only serves standalone data insertion.
2. Add an interface in schemaRegion to implement deviceInfo fetch and auto create.

The final cpu sample result is illustrated in following picture. The time consumption of schema validation decreased from 20% to only 2%.

![image](https://user-images.githubusercontent.com/38524330/183840912-9d28e4db-07ad-481d-9a4e-ce88dbebe175.png)

