### PR TITLE
[To rel/0.13][ISSUE-6937]Add alignment flag for single measurement template

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
+++ b/integration/src/test/java/org/apache/iotdb/session/template/TemplateUT.java
@@ -41,6 +41,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -647,6 +648,63 @@ public class TemplateUT {
       fail();
     } catch (Exception e) {
       assertEquals("326: Template is in use on root.sg.v1.d1", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testSingleMeasurementTemplateAlignment() throws IoTDBConnectionException {
+    try {
+      List<String> str_list = new ArrayList<>();
+      str_list.add("at1");
+      List<TSDataType> type_list = new ArrayList<>();
+      type_list.add(TSDataType.FLOAT);
+      List<TSEncoding> encoding_list = new ArrayList<>();
+      encoding_list.add(TSEncoding.GORILLA);
+      List<CompressionType> compression_type_list = new ArrayList<>();
+      compression_type_list.add(CompressionType.SNAPPY);
+      session.createSchemaTemplate(
+          "t1", str_list, type_list, encoding_list, compression_type_list, true);
+      session.addAlignedMeasurementInTemplate(
+          "t1", "at2", TSDataType.FLOAT, TSEncoding.GORILLA, CompressionType.SNAPPY);
+      session.addAlignedMeasurementInTemplate(
+          "t1", "at3", TSDataType.FLOAT, TSEncoding.GORILLA, CompressionType.SNAPPY);
+
+      session.executeNonQueryStatement("set template t1 to root.SG1");
+      session.executeNonQueryStatement("create timeseries of schema template on root.SG1.a");
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail();
+    } finally {
+      if (session != null) {
+        session.close();
+      }
+    }
+
+    try {
+      EnvironmentUtils.restartDaemon();
+    } catch (Exception e) {
+      Assert.fail();
+    }
+
+    try {
+      session = new Session("127.0.0.1", 6667, "root", "root", 16);
+      session.open();
+
+      SessionDataSet res = session.executeQueryStatement("show devices");
+      if (res.hasNext()) {
+        Assert.assertEquals("true", res.next().getFields().get(1).toString());
+      }
+
+      res = session.executeQueryStatement("show timeseries");
+      int cnt = 0;
+      while (res.hasNext()) {
+        cnt++;
+        res.next();
+      }
+      assertEquals(3, cnt);
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail();
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
@@ -89,7 +89,7 @@ public class Template {
         isAlign = true;
       } else {
         // If sublist of measurements has only one item,
-        // but it share prefix with other aligned sublist, it will be aligned too
+        // but it shares prefix with other aligned sublist, it will be aligned too
         String[] thisMeasurement =
             MetaUtils.splitPathToDetachedPath(plan.getMeasurements().get(i).get(0));
         String thisPrefix =


### PR DESCRIPTION
The root cause of #6937 is that the information of whether the template which has only one measurement inside is directly aligned is indeed regrettably lost within the former version of MLog. At the very begining, this information is supposed to be deduced by the structure of nested lists indicating measurement hierarchy, and the template with only one measurement was considered as a trivial case which  however occurs the issue today.

This PR added an extra constant flag `DIR_ALI_FLG` to indicate to indicate whether the template is directly aligned. The flag reuses bits which are used to indicate `schemaNames` are deprecated.  Considering the reason above and that the template with only one measurement is not that prevalent, the fix affects only few classes, while leaving other files untouched.