### PR TITLE
[IOTDB-4118] Fix SinkHandle bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/LocalSourceHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/LocalSourceHandle.java
@@ -142,7 +142,7 @@ public class LocalSourceHandle implements ISourceHandle {
       logger.info("Source handle is being aborted.");
       synchronized (queue) {
         synchronized (this) {
-          if (aborted) {
+          if (aborted || closed) {
             return;
           }
           queue.abort();
@@ -163,7 +163,7 @@ public class LocalSourceHandle implements ISourceHandle {
       logger.info("Source handle is being closed.");
       synchronized (queue) {
         synchronized (this) {
-          if (aborted) {
+          if (aborted || closed) {
             return;
           }
           queue.close();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
@@ -121,6 +121,10 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
         }
         ((SinkHandle) sinkHandles.get(e.getSourceFragmentInstanceId()))
             .acknowledgeTsBlock(e.getStartSequenceId(), e.getEndSequenceId());
+      } catch (Throwable t) {
+        logger.error(
+            "ack TsBlock [{}, {}) failed.", e.getStartSequenceId(), e.getEndSequenceId(), t);
+        throw t;
       }
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/SinkHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/SinkHandle.java
@@ -197,7 +197,7 @@ public class SinkHandle implements ISinkHandle {
   @Override
   public synchronized void setNoMoreTsBlocks() {
     logger.info("start to set no-more-tsblocks");
-    if (aborted) {
+    if (aborted || closed) {
       return;
     }
     try {
@@ -283,7 +283,7 @@ public class SinkHandle implements ISinkHandle {
   void acknowledgeTsBlock(int startSequenceId, int endSequenceId) {
     long freedBytes = 0L;
     synchronized (this) {
-      if (aborted) {
+      if (aborted || closed) {
         return;
       }
       Iterator<Entry<Integer, Pair<TsBlock, Long>>> iterator =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/SourceHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/SourceHandle.java
@@ -384,7 +384,7 @@ public class SourceHandle implements ISourceHandle {
             executorService.submit(
                 new SendAcknowledgeDataBlockEventTask(startSequenceId, endSequenceId));
             synchronized (SourceHandle.this) {
-              if (aborted) {
+              if (aborted || closed) {
                 return;
               }
               for (int i = startSequenceId; i < endSequenceId; i++) {


### PR DESCRIPTION
We should ignore all the operations after the sinkHandle is aborted or closed. The `close` state is newly added, in some places we forgot to add its judgement.