### PR TITLE
add dockerfile to compile docker with multi-platform

### DIFF
--- a/docker/src/main/Dockerfile-0.13.1-node-multi-platform
+++ b/docker/src/main/Dockerfile-0.13.1-node-multi-platform
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM --platform=$TARGETPLATFORM eclipse-temurin:11-jre-focal
+RUN apt update \
+  # procps is for `free` command
+  && apt install wget unzip lsof procps -y \
+  && wget https://downloads.apache.org/iotdb/0.13.1/apache-iotdb-0.13.1-server-bin.zip \
+  # if you are in China, use the following URL
+  #&& wget https://mirrors.tuna.tsinghua.edu.cn/apache/iotdb/0.13.1/apache-iotdb-0.13.1-server-bin.zip \
+  && unzip apache-iotdb-0.13.1-server-bin.zip \
+  && rm apache-iotdb-0.13.1-server-bin.zip \
+  && mv apache-iotdb-0.13.1-server-bin /iotdb \
+  && apt remove wget unzip -y \
+  && apt autoremove -y \
+  && apt purge --auto-remove -y \
+  && apt clean -y
+# rpc port
+EXPOSE 6667
+# JMX port
+EXPOSE 31999
+# sync port
+EXPOSE 5555
+# monitor port
+EXPOSE 8181
+VOLUME /iotdb/data
+VOLUME /iotdb/logs
+ENV PATH="/iotdb/sbin/:/iotdb/tools/:${PATH}"
+ENTRYPOINT ["/iotdb/sbin/start-server.sh"]


### PR DESCRIPTION
use docker-buildx to  compile docker images for multi-platform

docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 -t apache/iotdb:0.13.1-node -f Dockerfile-0.13.1-node-multi-platform . --push