### PR TITLE
[IOTDB-4119] Fix concurrency problem when auto create schemaCacheEntry in updateLastCache method.

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
@@ -151,11 +151,16 @@ public class DataNodeSchemaCache {
     PartialPath seriesPath = measurementPath.transformToPartialPath();
     SchemaCacheEntry entry = cache.getIfPresent(seriesPath);
     if (null == entry) {
-      entry =
-          new SchemaCacheEntry(
-              (MeasurementSchema) measurementPath.getMeasurementSchema(),
-              measurementPath.isUnderAlignedEntity());
-      cache.put(seriesPath, entry);
+      synchronized (cache) {
+        entry = cache.getIfPresent(seriesPath);
+        if (null == entry) {
+          entry =
+              new SchemaCacheEntry(
+                  (MeasurementSchema) measurementPath.getMeasurementSchema(),
+                  measurementPath.isUnderAlignedEntity());
+          cache.put(seriesPath, entry);
+        }
+      }
     }
 
     DataNodeLastCacheManager.updateLastCache(


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/IOTDB-4119