### PR TITLE
[IoTDB-4118] leverage client RPC to do the retry logic rather than threadPool

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryState.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryState.java
@@ -28,7 +28,7 @@ public enum QueryState {
   QUEUED(false),
   PLANNED(false),
   DISPATCHING(false),
-  RETRYING(false),
+  PENDING_RETRY(false),
   RUNNING(false),
   FINISHED(true),
   CANCELED(true),

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/QueryStateMachine.java
@@ -92,6 +92,10 @@ public class QueryStateMachine {
     return queryState.get();
   }
 
+  public void transitionToQueued() {
+    queryState.set(QueryState.QUEUED);
+  }
+
   public void transitionToPlanned() {
     queryState.set(QueryState.PLANNED);
   }
@@ -100,12 +104,12 @@ public class QueryStateMachine {
     queryState.set(QueryState.DISPATCHING);
   }
 
-  public void transitionToRetrying(TSStatus failureStatus) {
+  public void transitionToPendingRetry(TSStatus failureStatus) {
     if (queryState.get().isDone()) {
       return;
     }
     this.failureStatus = failureStatus;
-    queryState.set(QueryState.RETRYING);
+    queryState.set(QueryState.PENDING_RETRY);
   }
 
   public void transitionToRunning() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -144,10 +144,6 @@ public class QueryExecution implements IQueryExecution {
     stateMachine.addStateChangeListener(
         state -> {
           try (SetThreadName queryName = new SetThreadName(context.getQueryId().getId())) {
-            if (state == QueryState.RETRYING) {
-              retry();
-              return;
-            }
             if (!state.isDone()) {
               return;
             }
@@ -179,17 +175,18 @@ public class QueryExecution implements IQueryExecution {
 
     doLogicalPlan();
     doDistributedPlan();
+    stateMachine.transitionToPlanned();
     if (context.getQueryType() == QueryType.READ) {
       initResultHandle();
     }
     schedule();
   }
 
-  private void retry() {
+  private ExecutionResult retry() {
     if (retryCount >= MAX_RETRY_COUNT) {
       logger.error("reach max retry count. transit query to failed");
       stateMachine.transitionToFailed();
-      return;
+      return getStatus();
     }
     logger.warn("error when executing query. {}", stateMachine.getFailureMessage());
     // stop and clean up resources the QueryExecution used
@@ -203,13 +200,14 @@ public class QueryExecution implements IQueryExecution {
     }
     retryCount++;
     logger.info("start to retry. Retry count is: {}", retryCount);
-
+    stateMachine.transitionToQueued();
     // force invalid PartitionCache
     partitionFetcher.invalidAllCache();
     // re-analyze the query
     this.analysis = analyze(rawStatement, context, partitionFetcher, schemaFetcher);
     // re-start the QueryExecution
     this.start();
+    return getStatus();
   }
 
   private boolean skipExecute() {
@@ -407,11 +405,20 @@ public class QueryExecution implements IQueryExecution {
       SettableFuture<QueryState> future = SettableFuture.create();
       stateMachine.addStateChangeListener(
           state -> {
-            if (state == QueryState.RUNNING || state.isDone()) {
+            if (state == QueryState.RUNNING
+                || state.isDone()
+                || state == QueryState.PENDING_RETRY) {
               future.set(state);
             }
           });
       QueryState state = future.get();
+      if (state == QueryState.PENDING_RETRY) {
+        // That we put retry() here is aimed to leverage the ClientRPC thread rather than
+        // create another new thread to do the retry() logic.
+        // This way will lead to recursive call because retry() calls getStatus() inside.
+        // The max depths of recursive call is equal to the max retry count.
+        return retry();
+      }
       // TODO: (xingtanzjr) use more TSStatusCode if the QueryState isn't FINISHED
       return getExecutionResult(state);
     } catch (InterruptedException | ExecutionException e) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
@@ -106,7 +106,7 @@ public class ClusterScheduler implements IScheduler {
       FragInstanceDispatchResult result = dispatchResultFuture.get();
       if (!result.isSuccessful()) {
         if (needRetry(result.getFailureStatus())) {
-          stateMachine.transitionToRetrying(result.getFailureStatus());
+          stateMachine.transitionToPendingRetry(result.getFailureStatus());
         } else {
           stateMachine.transitionToFailed(result.getFailureStatus());
         }


### PR DESCRIPTION
## Description
Before this change, we use `exeuctor` threadPool to execute the `retry()` logic. retry() will submit another dispatcher task which is also need to run by `executor` threadPool, which will lead to deadlock if so many retry() from different queries are triggered together.

In this PR, we leverage the ClientRPC thread to do the retry logic and it won't lead to the deadlock in above scenario

By the way, we change the `RETRYING` to `PENDING_RETRY` to make the state more concrete.