### PR TITLE
Add Authorization parameters to confignode.properties

### DIFF
--- a/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -306,3 +306,30 @@ target_config_nodes=0.0.0.0:22277
 # 2. weak(Read from a random replica)
 # Datatype: string
 # read_consistency_level=strong
+
+
+####################
+### Authorization Configuration
+####################
+
+
+# which class to serve for authorization. By default, it is LocalFileAuthorizer.
+# Another choice is org.apache.iotdb.db.auth.authorizer.OpenIdAuthorizer
+# authorizer_provider_class=org.apache.iotdb.commons.auth.authorizer.LocalFileAuthorizer
+
+# If OpenIdAuthorizer is enabled, then openID_url must be set.
+# openID_url=
+
+# admin username, default is root
+# Datatype: string
+# admin_name=root
+
+# encryption provider class
+# iotdb_server_encrypt_decrypt_provider=org.apache.iotdb.commons.security.encrypt.MessageDigestEncrypt
+
+# encryption provided class parameter
+# iotdb_server_encrypt_decrypt_provider_parameter=
+
+# admin password, default is root
+# Datatype: string
+# admin_password=root

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -862,14 +862,26 @@ timestamp_precision=ms
 ### Authorization Configuration
 ####################
 
-#which class to serve for authorization. By default, it is LocalFileAuthorizer.
-#Another choice is org.apache.iotdb.db.auth.authorizer.OpenIdAuthorizer
+# which class to serve for authorization. By default, it is LocalFileAuthorizer.
+# Another choice is org.apache.iotdb.db.auth.authorizer.OpenIdAuthorizer
 # authorizer_provider_class=org.apache.iotdb.commons.auth.authorizer.LocalFileAuthorizer
 
+# If OpenIdAuthorizer is enabled, then openID_url must be set.
+# openID_url=
 
-#If OpenIdAuthorizer is enabled, then openID_url must be set.
+# admin username, default is root
+# Datatype: string
+# admin_name=root
 
-#openID_url=
+# encryption provider class
+# iotdb_server_encrypt_decrypt_provider=org.apache.iotdb.commons.security.encrypt.MessageDigestEncrypt
+
+# encryption provided class parameter
+# iotdb_server_encrypt_decrypt_provider_parameter=
+
+# admin password, default is root
+# Datatype: string
+# admin_password=root
 
 # Cache size of user and role
 # Datatype: int
@@ -1014,14 +1026,6 @@ timestamp_precision=ms
 # time range for partitioning data inside each storage group, the unit is second
 # Datatype: long
 # partition_interval=604800
-
-# admin username, default is root
-# Datatype: string
-# admin_name=root
-
-# admin password, default is root
-# Datatype: string
-# admin_password=root
 
 ####################
 ### Influx DB RPC Service Configuration


### PR DESCRIPTION
Authorization configuration parameters should also use in confignode.properties.