### PR TITLE
[IOTDB-4138] Refactor consensus api and add javadoc

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
@@ -125,7 +125,7 @@ public class ConsensusManager {
     for (TConfigNodeLocation configNodeLocation : configNodeLocations) {
       peerList.add(new Peer(consensusGroupId, configNodeLocation.getConsensusEndPoint()));
     }
-    consensusImpl.addConsensusGroup(consensusGroupId, peerList);
+    consensusImpl.createPeer(consensusGroupId, peerList);
   }
 
   /**

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -465,7 +465,7 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
 
     ConsensusGroupId groupId = configManager.getConsensusManager().getConsensusGroupId();
     ConsensusGenericResponse resp =
-        configManager.getConsensusManager().getConsensusImpl().removeConsensusGroup(groupId);
+        configManager.getConsensusManager().getConsensusImpl().deletePeer(groupId);
     if (!resp.isSuccess()) {
       return new TSStatus(TSStatusCode.REMOVE_CONFIGNODE_FAILED.getStatusCode())
           .setMessage(

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -50,7 +50,8 @@ public interface IConsensus {
    * group. This node will prepare and initialize local statemachine {@link IStateMachine} and other
    * data structures. After this method returns, we can call {@link #addPeer(ConsensusGroupId,
    * Peer)} to notify original group that this new Peer is prepared to be added into the latest
-   * configuration.
+   * configuration. createPeer should be called on a node that does not contain any peer of the
+   * consensus group, to avoid one node having more than one replica.
    *
    * @param groupId the consensus group this Peer belongs
    * @param peers other known peers in this group
@@ -61,7 +62,7 @@ public interface IConsensus {
    * When the <em>local node</em> is no longer a member of the given consensus group, call this
    * method to do cleanup works. This method will close local statemachine {@link IStateMachine},
    * delete local data and do other cleanup works. Be sure this method is called after successfully
-   * removing local peer from current consensus group configuration (by calling {@link
+   * removing this peer from current consensus group configuration (by calling {@link
    * #removePeer(ConsensusGroupId, Peer)} or {@link #changePeer(ConsensusGroupId, List)}).
    *
    * @param groupId the consensus group this Peer used to belong
@@ -75,6 +76,8 @@ public interface IConsensus {
    * #createPeer(ConsensusGroupId, List)} on the new Peer before calling this method. When this
    * method returns, the group data should be already transmitted to the new Peer. That is, the new
    * peer is available to answer client requests by the time this method successfully returns.
+   * addPeer should be called on a living peer of the consensus group. For example: We'd like to add
+   * a peer D to (A, B, C) group. We need to execute addPeer in A, B or C.
    *
    * @param groupId the consensus group this peer belongs
    * @param peer the newly added peer
@@ -84,7 +87,9 @@ public interface IConsensus {
   /**
    * Tell the group to remove an active Peer. The removed peer can no longer answer group requests
    * when this method successfully returns. Call {@link #deletePeer(ConsensusGroupId)} on the
-   * removed Peer to do cleanup jobs after this method successfully returns.
+   * removed Peer to do cleanup jobs after this method successfully returns. removePeer should be
+   * called on a living peer of its consensus group. For example: a group has A, B, C. We'd like to
+   * remove C, in case C is dead, the removePeer should be sent to A or B.
    *
    * @param groupId the consensus group this peer belongs
    * @param peer the peer to be removed

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -44,15 +44,61 @@ public interface IConsensus {
   ConsensusReadResponse read(ConsensusGroupId groupId, IConsensusRequest IConsensusRequest);
 
   // multi consensus group API
-  ConsensusGenericResponse addConsensusGroup(ConsensusGroupId groupId, List<Peer> peers);
 
-  ConsensusGenericResponse removeConsensusGroup(ConsensusGroupId groupId);
+  /**
+   * Require the <em>local node</em> to create a Peer and become a member of the given consensus
+   * group. This node will prepare and initialize local statemachine {@link IStateMachine} and other
+   * data structures. After this method returns, we can call {@link #addPeer(ConsensusGroupId,
+   * Peer)} to notify original group that this new Peer is prepared to be added into the latest
+   * configuration.
+   *
+   * @param groupId the consensus group this Peer belongs
+   * @param peers other known peers in this group
+   */
+  ConsensusGenericResponse createPeer(ConsensusGroupId groupId, List<Peer> peers);
+
+  /**
+   * When the <em>local node</em> is no longer a member of the given consensus group, call this
+   * method to do cleanup works. This method will close local statemachine {@link IStateMachine},
+   * delete local data and do other cleanup works. Be sure this method is called after successfully
+   * removing local peer from current consensus group configuration (by calling {@link
+   * #removePeer(ConsensusGroupId, Peer)} or {@link #changePeer(ConsensusGroupId, List)}).
+   *
+   * @param groupId the consensus group this Peer used to belong
+   */
+  ConsensusGenericResponse deletePeer(ConsensusGroupId groupId);
 
   // single consensus group API
+
+  /**
+   * Tell the group that a new Peer is prepared to be added into this group. Call {@link
+   * #createPeer(ConsensusGroupId, List)} on the new Peer before calling this method. When this
+   * method returns, the group data should be already transmitted to the new Peer. That is, the new
+   * peer is available to answer client requests by the time this method successfully returns.
+   *
+   * @param groupId the consensus group this peer belongs
+   * @param peer the newly added peer
+   */
   ConsensusGenericResponse addPeer(ConsensusGroupId groupId, Peer peer);
 
+  /**
+   * Tell the group to remove an active Peer. The removed peer can no longer answer group requests
+   * when this method successfully returns. Call {@link #deletePeer(ConsensusGroupId)} on the
+   * removed Peer to do cleanup jobs after this method successfully returns.
+   *
+   * @param groupId the consensus group this peer belongs
+   * @param peer the peer to be removed
+   */
   ConsensusGenericResponse removePeer(ConsensusGroupId groupId, Peer peer);
 
+  /**
+   * Change group configuration. This method allows you to add/remove multiple Peers at once. This
+   * method is similar to {@link #addPeer(ConsensusGroupId, Peer)} or {@link
+   * #removePeer(ConsensusGroupId, Peer)}
+   *
+   * @param groupId the consensus group
+   * @param newPeers the new member configuration of this group
+   */
   ConsensusGenericResponse changePeer(ConsensusGroupId groupId, List<Peer> newPeers);
 
   // management API

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderConsensus.java
@@ -152,7 +152,7 @@ public class MultiLeaderConsensus implements IConsensus {
   }
 
   @Override
-  public ConsensusGenericResponse addConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
+  public ConsensusGenericResponse createPeer(ConsensusGroupId groupId, List<Peer> peers) {
     int consensusGroupSize = peers.size();
     if (consensusGroupSize == 0) {
       return ConsensusGenericResponse.newBuilder()
@@ -194,7 +194,7 @@ public class MultiLeaderConsensus implements IConsensus {
   }
 
   @Override
-  public ConsensusGenericResponse removeConsensusGroup(ConsensusGroupId groupId) {
+  public ConsensusGenericResponse deletePeer(ConsensusGroupId groupId) {
     AtomicBoolean exist = new AtomicBoolean(false);
     stateMachineMap.computeIfPresent(
         groupId,

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -250,7 +250,7 @@ class RatisConsensus implements IConsensus {
    * register self to the RaftGroup
    */
   @Override
-  public ConsensusGenericResponse addConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
+  public ConsensusGenericResponse createPeer(ConsensusGroupId groupId, List<Peer> peers) {
     RaftGroup group = buildRaftGroup(groupId, peers);
     // pre-conditions: myself in this new group
     if (!group.getPeers().contains(myself)) {
@@ -285,7 +285,7 @@ class RatisConsensus implements IConsensus {
    * clean up
    */
   @Override
-  public ConsensusGenericResponse removeConsensusGroup(ConsensusGroupId groupId) {
+  public ConsensusGenericResponse deletePeer(ConsensusGroupId groupId) {
     RaftGroupId raftGroupId = Utils.fromConsensusGroupIdToRaftGroupId(groupId);
     RaftGroup raftGroup = getGroupInfo(raftGroupId);
 

--- a/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/standalone/StandAloneConsensus.java
@@ -126,7 +126,7 @@ class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public ConsensusGenericResponse addConsensusGroup(ConsensusGroupId groupId, List<Peer> peers) {
+  public ConsensusGenericResponse createPeer(ConsensusGroupId groupId, List<Peer> peers) {
     int consensusGroupSize = peers.size();
     if (consensusGroupSize != 1) {
       return ConsensusGenericResponse.newBuilder()
@@ -162,7 +162,7 @@ class StandAloneConsensus implements IConsensus {
   }
 
   @Override
-  public ConsensusGenericResponse removeConsensusGroup(ConsensusGroupId groupId) {
+  public ConsensusGenericResponse deletePeer(ConsensusGroupId groupId) {
     AtomicBoolean exist = new AtomicBoolean(false);
     stateMachineMap.computeIfPresent(
         groupId,

--- a/consensus/src/test/java/org/apache/iotdb/consensus/multileader/MultiLeaderConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/multileader/MultiLeaderConsensusTest.java
@@ -116,9 +116,9 @@ public class MultiLeaderConsensusTest {
   @Test
   public void ReplicateUsingQueueTest() throws IOException, InterruptedException {
     logger.info("Start ReplicateUsingQueueTest");
-    servers.get(0).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(1).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(2).addConsensusGroup(group.getGroupId(), group.getPeers());
+    servers.get(0).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(1).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(2).createPeer(group.getGroupId(), group.getPeers());
 
     Assert.assertEquals(0, servers.get(0).getImpl(gid).getIndex());
     Assert.assertEquals(0, servers.get(1).getImpl(gid).getIndex());
@@ -205,8 +205,8 @@ public class MultiLeaderConsensusTest {
   @Test
   public void ReplicateUsingWALTest() throws IOException, InterruptedException {
     logger.info("Start ReplicateUsingWALTest");
-    servers.get(0).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(1).addConsensusGroup(group.getGroupId(), group.getPeers());
+    servers.get(0).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(1).createPeer(group.getGroupId(), group.getPeers());
 
     Assert.assertEquals(0, servers.get(0).getImpl(gid).getIndex());
     Assert.assertEquals(0, servers.get(1).getImpl(gid).getIndex());
@@ -224,7 +224,7 @@ public class MultiLeaderConsensusTest {
     stopServer();
     initServer();
 
-    servers.get(2).addConsensusGroup(group.getGroupId(), group.getPeers());
+    servers.get(2).createPeer(group.getGroupId(), group.getPeers());
 
     Assert.assertEquals(peers, servers.get(0).getImpl(gid).getConfiguration());
     Assert.assertEquals(peers, servers.get(1).getImpl(gid).getConfiguration());

--- a/consensus/src/test/java/org/apache/iotdb/consensus/multileader/RecoveryTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/multileader/RecoveryTest.java
@@ -75,11 +75,11 @@ public class RecoveryTest {
 
   @Test
   public void recoveryTest() throws Exception {
-    consensusImpl.addConsensusGroup(
+    consensusImpl.createPeer(
         schemaRegionId,
         Collections.singletonList(new Peer(schemaRegionId, new TEndPoint("0.0.0.0", 9000))));
 
-    consensusImpl.removeConsensusGroup(schemaRegionId);
+    consensusImpl.deletePeer(schemaRegionId);
 
     consensusImpl.stop();
     consensusImpl = null;
@@ -87,7 +87,7 @@ public class RecoveryTest {
     constructConsensus();
 
     ConsensusGenericResponse response =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             schemaRegionId,
             Collections.singletonList(new Peer(schemaRegionId, new TEndPoint("0.0.0.0", 9000))));
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -122,9 +122,9 @@ public class RatisConsensusTest {
 
   @Test
   public void basicConsensus3Copy() throws Exception {
-    servers.get(0).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(1).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(2).addConsensusGroup(group.getGroupId(), group.getPeers());
+    servers.get(0).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(1).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(2).createPeer(group.getGroupId(), group.getPeers());
 
     doConsensus(servers.get(0), group.getGroupId(), 10, 10);
   }
@@ -133,14 +133,14 @@ public class RatisConsensusTest {
   public void addMemberToGroup() throws Exception {
     List<Peer> original = peers.subList(0, 1);
 
-    servers.get(0).addConsensusGroup(group.getGroupId(), original);
+    servers.get(0).createPeer(group.getGroupId(), original);
     doConsensus(servers.get(0), group.getGroupId(), 10, 10);
 
     // add 2 members
-    servers.get(1).addConsensusGroup(group.getGroupId(), peers);
+    servers.get(1).createPeer(group.getGroupId(), peers);
     servers.get(0).addPeer(group.getGroupId(), peers.get(1));
 
-    servers.get(2).addConsensusGroup(group.getGroupId(), peers);
+    servers.get(2).createPeer(group.getGroupId(), peers);
     servers.get(0).changePeer(group.getGroupId(), peers);
 
     Assert.assertEquals(stateMachines.get(0).getConfiguration().size(), 3);
@@ -149,26 +149,26 @@ public class RatisConsensusTest {
 
   @Test
   public void removeMemberFromGroup() throws Exception {
-    servers.get(0).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(1).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(2).addConsensusGroup(group.getGroupId(), group.getPeers());
+    servers.get(0).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(1).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(2).createPeer(group.getGroupId(), group.getPeers());
 
     doConsensus(servers.get(0), group.getGroupId(), 10, 10);
 
     servers.get(0).transferLeader(gid, peers.get(0));
     servers.get(0).removePeer(gid, peers.get(1));
-    servers.get(1).removeConsensusGroup(gid);
+    servers.get(1).deletePeer(gid);
     servers.get(0).removePeer(gid, peers.get(2));
-    servers.get(2).removeConsensusGroup(gid);
+    servers.get(2).deletePeer(gid);
 
     doConsensus(servers.get(0), group.getGroupId(), 10, 20);
   }
 
   @Test
   public void crashAndStart() throws Exception {
-    servers.get(0).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(1).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(2).addConsensusGroup(group.getGroupId(), group.getPeers());
+    servers.get(0).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(1).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(2).createPeer(group.getGroupId(), group.getPeers());
 
     // 200 operation will trigger snapshot & purge
     doConsensus(servers.get(0), group.getGroupId(), 200, 200);
@@ -179,9 +179,9 @@ public class RatisConsensusTest {
     servers.clear();
 
     makeServers();
-    servers.get(0).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(1).addConsensusGroup(group.getGroupId(), group.getPeers());
-    servers.get(2).addConsensusGroup(group.getGroupId(), group.getPeers());
+    servers.get(0).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(1).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(2).createPeer(group.getGroupId(), group.getPeers());
     doConsensus(servers.get(0), gid, 10, 210);
   }
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/standalone/RecoveryTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/standalone/RecoveryTest.java
@@ -74,7 +74,7 @@ public class RecoveryTest {
 
   @Test
   public void recoveryTest() throws Exception {
-    consensusImpl.addConsensusGroup(
+    consensusImpl.createPeer(
         schemaRegionId,
         Collections.singletonList(new Peer(schemaRegionId, new TEndPoint("0.0.0.0", 9000))));
 
@@ -84,7 +84,7 @@ public class RecoveryTest {
     constructConsensus();
 
     ConsensusGenericResponse response =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             schemaRegionId,
             Collections.singletonList(new Peer(schemaRegionId, new TEndPoint("0.0.0.0", 9000))));
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/standalone/StandAloneConsensusTest.java
@@ -158,21 +158,21 @@ public class StandAloneConsensusTest {
   @Test
   public void addConsensusGroup() {
     ConsensusGenericResponse response1 =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new TEndPoint("0.0.0.0", 6667))));
     assertTrue(response1.isSuccess());
     assertNull(response1.getException());
 
     ConsensusGenericResponse response2 =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new TEndPoint("0.0.0.0", 6667))));
     assertFalse(response2.isSuccess());
     assertTrue(response2.getException() instanceof ConsensusGroupAlreadyExistException);
 
     ConsensusGenericResponse response3 =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             dataRegionId,
             Arrays.asList(
                 new Peer(dataRegionId, new TEndPoint("0.0.0.0", 6667)),
@@ -181,14 +181,14 @@ public class StandAloneConsensusTest {
     assertTrue(response3.getException() instanceof IllegalPeerNumException);
 
     ConsensusGenericResponse response4 =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new TEndPoint("0.0.0.1", 6667))));
     assertFalse(response4.isSuccess());
     assertTrue(response4.getException() instanceof IllegalPeerEndpointException);
 
     ConsensusGenericResponse response5 =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             schemaRegionId,
             Collections.singletonList(new Peer(schemaRegionId, new TEndPoint("0.0.0.0", 6667))));
     assertTrue(response5.isSuccess());
@@ -197,18 +197,18 @@ public class StandAloneConsensusTest {
 
   @Test
   public void removeConsensusGroup() {
-    ConsensusGenericResponse response1 = consensusImpl.removeConsensusGroup(dataRegionId);
+    ConsensusGenericResponse response1 = consensusImpl.deletePeer(dataRegionId);
     assertFalse(response1.isSuccess());
     assertTrue(response1.getException() instanceof ConsensusGroupNotExistException);
 
     ConsensusGenericResponse response2 =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new TEndPoint("0.0.0.0", 6667))));
     assertTrue(response2.isSuccess());
     assertNull(response2.getException());
 
-    ConsensusGenericResponse response3 = consensusImpl.removeConsensusGroup(dataRegionId);
+    ConsensusGenericResponse response3 = consensusImpl.deletePeer(dataRegionId);
     assertTrue(response3.isSuccess());
     assertNull(response3.getException());
   }
@@ -254,21 +254,21 @@ public class StandAloneConsensusTest {
   @Test
   public void write() {
     ConsensusGenericResponse response1 =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             dataRegionId,
             Collections.singletonList(new Peer(dataRegionId, new TEndPoint("0.0.0.0", 6667))));
     assertTrue(response1.isSuccess());
     assertNull(response1.getException());
 
     ConsensusGenericResponse response2 =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             schemaRegionId,
             Collections.singletonList(new Peer(schemaRegionId, new TEndPoint("0.0.0.0", 6667))));
     assertTrue(response2.isSuccess());
     assertNull(response2.getException());
 
     ConsensusGenericResponse response3 =
-        consensusImpl.addConsensusGroup(
+        consensusImpl.createPeer(
             configId,
             Collections.singletonList(new Peer(configId, new TEndPoint("0.0.0.0", 6667))));
     assertTrue(response3.isSuccess());

--- a/server/src/main/java/org/apache/iotdb/db/service/RegionMigrateService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/RegionMigrateService.java
@@ -488,9 +488,9 @@ public class RegionMigrateService implements IService {
       ConsensusGenericResponse resp;
       try {
         if (regionId instanceof DataRegionId) {
-          resp = DataRegionConsensusImpl.getInstance().removeConsensusGroup(regionId);
+          resp = DataRegionConsensusImpl.getInstance().deletePeer(regionId);
         } else {
-          resp = SchemaRegionConsensusImpl.getInstance().removeConsensusGroup(regionId);
+          resp = SchemaRegionConsensusImpl.getInstance().deletePeer(regionId);
         }
       } catch (Throwable e) {
         taskLogger.error("remove region {} consensus group error", regionId, e);

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -314,7 +314,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
         peers.add(new Peer(schemaRegionId, endpoint));
       }
       ConsensusGenericResponse consensusGenericResponse =
-          SchemaRegionConsensusImpl.getInstance().addConsensusGroup(schemaRegionId, peers);
+          SchemaRegionConsensusImpl.getInstance().createPeer(schemaRegionId, peers);
       if (consensusGenericResponse.isSuccess()) {
         tsStatus = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
       } else {
@@ -352,7 +352,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
         peers.add(new Peer(dataRegionId, endpoint));
       }
       ConsensusGenericResponse consensusGenericResponse =
-          DataRegionConsensusImpl.getInstance().addConsensusGroup(dataRegionId, peers);
+          DataRegionConsensusImpl.getInstance().createPeer(dataRegionId, peers);
       if (consensusGenericResponse.isSuccess()) {
         tsStatus = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
       } else {
@@ -541,7 +541,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
         ConsensusGroupId.Factory.createFromTConsensusGroupId(tconsensusGroupId);
     if (consensusGroupId instanceof DataRegionId) {
       ConsensusGenericResponse response =
-          DataRegionConsensusImpl.getInstance().removeConsensusGroup(consensusGroupId);
+          DataRegionConsensusImpl.getInstance().deletePeer(consensusGroupId);
       if (!response.isSuccess()
           && !(response.getException() instanceof PeerNotInConsensusGroupException)) {
         return RpcUtils.getStatus(
@@ -550,7 +550,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
       StorageEngineV2.getInstance().deleteDataRegion((DataRegionId) consensusGroupId);
     } else {
       ConsensusGenericResponse response =
-          SchemaRegionConsensusImpl.getInstance().removeConsensusGroup(consensusGroupId);
+          SchemaRegionConsensusImpl.getInstance().deletePeer(consensusGroupId);
       if (!response.isSuccess()
           && !(response.getException() instanceof PeerNotInConsensusGroupException)) {
         return RpcUtils.getStatus(
@@ -752,9 +752,9 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
     TSStatus status = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     ConsensusGenericResponse resp;
     if (regionId instanceof DataRegionId) {
-      resp = DataRegionConsensusImpl.getInstance().addConsensusGroup(regionId, peers);
+      resp = DataRegionConsensusImpl.getInstance().createPeer(regionId, peers);
     } else {
-      resp = SchemaRegionConsensusImpl.getInstance().addConsensusGroup(regionId, peers);
+      resp = SchemaRegionConsensusImpl.getInstance().createPeer(regionId, peers);
     }
     if (!resp.isSuccess()) {
       LOGGER.error(

--- a/server/src/test/java/org/apache/iotdb/db/service/DataNodeInternalRPCServiceImplTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/service/DataNodeInternalRPCServiceImplTest.java
@@ -82,7 +82,7 @@ public class DataNodeInternalRPCServiceImplTest {
   public void setUp() throws Exception {
     TRegionReplicaSet regionReplicaSet = genRegionReplicaSet();
     SchemaRegionConsensusImpl.getInstance()
-        .addConsensusGroup(
+        .createPeer(
             ConsensusGroupId.Factory.createFromTConsensusGroupId(regionReplicaSet.getRegionId()),
             genSchemaRegionPeerList(regionReplicaSet));
     dataNodeInternalRPCServiceImpl = new DataNodeInternalRPCServiceImpl();
@@ -92,7 +92,7 @@ public class DataNodeInternalRPCServiceImplTest {
   public void tearDown() throws Exception {
     TRegionReplicaSet regionReplicaSet = genRegionReplicaSet();
     SchemaRegionConsensusImpl.getInstance()
-        .removeConsensusGroup(
+        .deletePeer(
             ConsensusGroupId.Factory.createFromTConsensusGroupId(regionReplicaSet.getRegionId()));
     FileUtils.deleteFully(new File(conf.getConsensusDir()));
   }


### PR DESCRIPTION
Currently in IConsensus, addConsensusGroup and removeConsensusGroup is  ambiguous and often cause misunderstandings. We should change its name and add a javadoc to describe its usage and implementations. 
see https://issues.apache.org/jira/browse/IOTDB-4138