### PR TITLE
[IOTDB-3938] Fix SeriesSlotExecutor initialization logic for insertion performance

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/Partition.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/Partition.java
@@ -23,11 +23,12 @@ import org.apache.iotdb.commons.partition.executor.SeriesPartitionExecutor;
 
 import java.util.List;
 
+// todo replace this data structure with PartitionTable
 public abstract class Partition {
   protected String seriesSlotExecutorName;
   protected int seriesPartitionSlotNum;
 
-  // todo decouple this executor with Partition and replace this data structure with PartitionTable
+  // todo decouple this executor with Partition
   private final SeriesPartitionExecutor executor;
 
   public Partition(String seriesSlotExecutorName, int seriesPartitionSlotNum) {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/Partition.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/Partition.java
@@ -27,6 +27,7 @@ public abstract class Partition {
   protected String seriesSlotExecutorName;
   protected int seriesPartitionSlotNum;
 
+  // todo decouple this executor with Partition and replace this data structure with PartitionTable
   private final SeriesPartitionExecutor executor;
 
   public Partition(String seriesSlotExecutorName, int seriesPartitionSlotNum) {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/executor/SeriesPartitionExecutor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/executor/SeriesPartitionExecutor.java
@@ -26,7 +26,7 @@ import java.lang.reflect.InvocationTargetException;
 /** All SeriesPartitionExecutors must be subclasses of SeriesPartitionExecutor */
 public abstract class SeriesPartitionExecutor {
 
-  // The param, executorName and seriesPartitionSlotNum, is global unique during system running.
+  // The params, executorName and seriesPartitionSlotNum, are global unique during system running.
   // Therefore, one executor instance is enough for usage.
   protected static SeriesPartitionExecutor EXECUTOR;
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/executor/SeriesPartitionExecutor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/executor/SeriesPartitionExecutor.java
@@ -26,6 +26,10 @@ import java.lang.reflect.InvocationTargetException;
 /** All SeriesPartitionExecutors must be subclasses of SeriesPartitionExecutor */
 public abstract class SeriesPartitionExecutor {
 
+  // The param, executorName and seriesPartitionSlotNum, is global unique during system running.
+  // Therefore, one executor instance is enough for usage.
+  protected static SeriesPartitionExecutor EXECUTOR;
+
   protected final int seriesPartitionSlotNum;
 
   public SeriesPartitionExecutor(int seriesPartitionSlotNum) {
@@ -36,17 +40,28 @@ public abstract class SeriesPartitionExecutor {
 
   public static SeriesPartitionExecutor getSeriesPartitionExecutor(
       String executorName, int seriesPartitionSlotNum) {
-    try {
-      Class<?> executor = Class.forName(executorName);
-      Constructor<?> executorConstructor = executor.getConstructor(int.class);
-      return (SeriesPartitionExecutor) executorConstructor.newInstance(seriesPartitionSlotNum);
-    } catch (ClassNotFoundException
-        | NoSuchMethodException
-        | InstantiationException
-        | IllegalAccessException
-        | InvocationTargetException e) {
-      throw new IllegalArgumentException(
-          String.format("Couldn't Constructor SeriesPartitionExecutor class: %s", executorName));
+    if (EXECUTOR == null) {
+      initStaticSeriesPartitionExecutor(executorName, seriesPartitionSlotNum);
+    }
+    return EXECUTOR;
+  }
+
+  private static synchronized void initStaticSeriesPartitionExecutor(
+      String executorName, int seriesPartitionSlotNum) {
+    if (EXECUTOR == null) {
+      try {
+        Class<?> executor = Class.forName(executorName);
+        Constructor<?> executorConstructor = executor.getConstructor(int.class);
+        EXECUTOR =
+            (SeriesPartitionExecutor) executorConstructor.newInstance(seriesPartitionSlotNum);
+      } catch (ClassNotFoundException
+          | NoSuchMethodException
+          | InstantiationException
+          | IllegalAccessException
+          | InvocationTargetException e) {
+        throw new IllegalArgumentException(
+            String.format("Couldn't Constructor SeriesPartitionExecutor class: %s", executorName));
+      }
     }
   }
 }

--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -71,7 +71,6 @@ import org.apache.iotdb.db.qp.physical.sys.UnsetTemplatePlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.ShowDevicesResult;
 import org.apache.iotdb.db.query.dataset.ShowTimeSeriesResult;
-import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.EncodingInferenceUtils;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -1898,7 +1897,7 @@ public class RSchemaRegion implements ISchemaRegion {
           measurementList[i] = nodeMap.get(i).getName();
         }
       } catch (MetadataException e) {
-        if (IoTDB.isClusterMode()) {
+        if (config.isClusterMode()) {
           logger.debug(
               "meet error when check {}.{}, message: {}",
               devicePath,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/idtable/IDTableHashmapImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/idtable/IDTableHashmapImpl.java
@@ -166,7 +166,7 @@ public class IDTableHashmapImpl implements IDTable {
           }
         }
       } catch (MetadataException e) {
-        if (IoTDB.isClusterMode()) {
+        if (config.isClusterMode()) {
           logger.debug(
               "meet error when check {}.{}, message: {}",
               devicePath,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -78,7 +78,6 @@ import org.apache.iotdb.db.qp.physical.sys.UnsetTemplatePlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.ShowDevicesResult;
 import org.apache.iotdb.db.query.dataset.ShowTimeSeriesResult;
-import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.sync.sender.manager.SchemaSyncManager;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
@@ -1603,7 +1602,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
           measurementList[i] = measurementMNode.getName();
         }
       } catch (MetadataException e) {
-        if (IoTDB.isClusterMode()) {
+        if (config.isClusterMode()) {
           logger.debug(
               "meet error when check {}.{}, message: {}",
               devicePath,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -75,7 +75,6 @@ import org.apache.iotdb.db.qp.physical.sys.UnsetTemplatePlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.ShowDevicesResult;
 import org.apache.iotdb.db.query.dataset.ShowTimeSeriesResult;
-import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.sync.sender.manager.SchemaSyncManager;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
@@ -1578,7 +1577,7 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
             measurementList[i] = measurementMNode.getName();
           }
         } catch (MetadataException e) {
-          if (IoTDB.isClusterMode()) {
+          if (config.isClusterMode()) {
             logger.debug(
                 "meet error when check {}.{}, message: {}",
                 devicePath,

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/Coordinator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/Coordinator.java
@@ -120,7 +120,7 @@ public class Coordinator {
     QueryId globalQueryId = queryIdGenerator.createNextQueryId();
     try (SetThreadName queryName = new SetThreadName(globalQueryId.getId())) {
       if (sql != null && sql.length() > 0) {
-        LOGGER.info("start executing sql: {}", sql);
+        LOGGER.debug("start executing sql: {}", sql);
       }
       MPPQueryContext queryContext =
           new MPPQueryContext(

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -138,7 +138,7 @@ public class DataNode implements DataNodeMBean {
 
   /** initialize the current node and its services */
   public boolean initLocalEngines() {
-    IoTDB.setClusterMode();
+    config.setClusterMode(true);
     return true;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -67,7 +67,6 @@ public class IoTDB implements IoTDBMBean {
   public static LocalSchemaProcessor schemaProcessor = LocalSchemaProcessor.getInstance();
   public static LocalConfigNode configManager = LocalConfigNode.getInstance();
   public static ServiceProvider serviceProvider;
-  private static boolean clusterMode = false;
 
   public static IoTDB getInstance() {
     return IoTDBHolder.INSTANCE;
@@ -94,11 +93,7 @@ public class IoTDB implements IoTDBMBean {
   }
 
   public static void setClusterMode() {
-    IoTDB.clusterMode = true;
-  }
-
-  public static boolean isClusterMode() {
-    return IoTDB.clusterMode;
+    config.setClusterMode(true);
   }
 
   public void active() {
@@ -173,7 +168,7 @@ public class IoTDB implements IoTDBMBean {
     initProtocols();
     // in cluster mode, InfluxDBMManager has been initialized, so there is no need to init again to
     // avoid wasting time.
-    if (!isClusterMode()
+    if (!config.isClusterMode()
         && IoTDBDescriptor.getInstance().getConfig().isEnableInfluxDBRpcService()) {
       initInfluxDBMManager();
     }
@@ -207,7 +202,7 @@ public class IoTDB implements IoTDBMBean {
   }
 
   private void initServiceProvider() throws QueryProcessException {
-    if (!clusterMode) {
+    if (!config.isClusterMode()) {
       serviceProvider = new StandaloneServiceProvider();
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -51,7 +51,7 @@ public class IoTDBShutdownHook extends Thread {
     }
     WALManager.getInstance().deleteOutdatedWALFiles();
 
-    if (IoTDB.isClusterMode()) {
+    if (IoTDBDescriptor.getInstance().getConfig().isClusterMode()) {
       // This setting ensures that compaction work is not discarded
       // even if there are frequent restarts
       DataRegionConsensusImpl.getInstance()


### PR DESCRIPTION
## Description

### Motivation

The initialization of SeriesSlotExecutor in Partition seriously affects the insertion performance, causing 6% performance loss in new standalone comparing with that in old standalone.

### Modification

Since the param of SeriesSlotExecutor is immutable during system running and it is stateless, the SeriesSlotExecutor is implemented as a singleton.

Remove the ```isClusterMode``` in ```IoTDB.class``` and use IoTDBConfig to store the state instead. Decouple DataNode.class from IoTDB.class