### PR TITLE
[IOTDB-4047] Fix query NPE after change device alignment

### DIFF
--- a/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBDeleteTimeseriesIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/aligned/IoTDBDeleteTimeseriesIT.java
@@ -170,6 +170,70 @@ public class IoTDBDeleteTimeseriesIT {
   }
 
   @Test
+  public void deleteTimeseriesAndChangeDeviceAlignmentTest() throws Exception {
+    String[] retArray = new String[] {"1,1.0,2.0,"};
+    int cnt = 0;
+
+    try (Connection connection =
+            DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("INSERT INTO root.sg3.d1(timestamp,s1,s2) ALIGNED VALUES(1,1,2)");
+      statement.execute("SHOW DEVICES");
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          Assert.assertEquals("true", resultSet.getString("isAligned"));
+        }
+      }
+      cnt = 0;
+      statement.execute("DELETE timeseries root.sg3.d1.s1");
+      statement.execute("DELETE timeseries root.sg3.d1.s2");
+      statement.execute("INSERT INTO root.sg3.d1(timestamp,s1,s2) VALUES(1,1,2)");
+      statement.execute("SHOW DEVICES");
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          Assert.assertEquals("false", resultSet.getString("isAligned"));
+        }
+      }
+      boolean hasResult = statement.execute("SELECT * FROM root.sg3.d1");
+      Assert.assertTrue(hasResult);
+      try (ResultSet resultSet = statement.getResultSet()) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        while (resultSet.next()) {
+          StringBuilder builder = new StringBuilder();
+          for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+            builder.append(resultSet.getString(i)).append(",");
+          }
+          Assert.assertEquals(retArray[cnt], builder.toString());
+          cnt++;
+        }
+      }
+      cnt = 0;
+      statement.execute("DELETE timeseries root.sg3.d1.s1");
+      statement.execute("DELETE timeseries root.sg3.d1.s2");
+      statement.execute("INSERT INTO root.sg3.d1(timestamp,s1,s2) ALIGNED VALUES(1,1,2)");
+      statement.execute("SHOW DEVICES");
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          Assert.assertEquals("true", resultSet.getString("isAligned"));
+        }
+      }
+      hasResult = statement.execute("SELECT * FROM root.sg3.d1");
+      Assert.assertTrue(hasResult);
+      try (ResultSet resultSet = statement.getResultSet()) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        while (resultSet.next()) {
+          StringBuilder builder = new StringBuilder();
+          for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+            builder.append(resultSet.getString(i)).append(",");
+          }
+          Assert.assertEquals(retArray[cnt], builder.toString());
+          cnt++;
+        }
+      }
+    }
+  }
+
+  @Test
   public void deleteTimeSeriesMultiIntervalTest() {
     String[] retArray1 = new String[] {"0,0"};
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -642,6 +642,9 @@ public abstract class AbstractMemTable implements IMemTable {
       return;
     }
     totalPointsNum -= memChunkGroup.delete(originalPath, devicePath, startTimestamp, endTimestamp);
+    if (memChunkGroup.getMemChunkMap().isEmpty()) {
+      memTableMap.remove(getDeviceID(devicePath));
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description
IOTDB-4047

After fixing
```
IoTDB> insert into root.sg.d1(time,s1,s2) aligned values(1,2,3)
Msg: The statement is executed successfully.
IoTDB> show devices
+----------+---------+
|   devices|isAligned|
+----------+---------+
|root.sg.d1|     true|
+----------+---------+
Total line number = 1
It costs 0.031s
IoTDB> delete timeseries root.sg.d1.s1
Msg: The statement is executed successfully.
IoTDB> delete timeseries root.sg.d1.s2
Msg: The statement is executed successfully.
IoTDB> insert into root.sg.d1(time,s1,s2) values(1,2,3)
Msg: The statement is executed successfully.
IoTDB> show devices
+----------+---------+
|   devices|isAligned|
+----------+---------+
|root.sg.d1|    false|
+----------+---------+
Total line number = 1
It costs 0.003s
IoTDB> select * from root.**
+-----------------------------+-------------+-------------+
|                         Time|root.sg.d1.s1|root.sg.d1.s2|
+-----------------------------+-------------+-------------+
|1970-01-01T08:00:00.001+08:00|          2.0|          3.0|
+-----------------------------+-------------+-------------+
Total line number = 1
It costs 0.050s
IoTDB> delete timeseries root.sg.d1.s1
Msg: The statement is executed successfully.
IoTDB> delete timeseries root.sg.d1.s2
Msg: The statement is executed successfully.
IoTDB> show devices
+-------+---------+
|devices|isAligned|
+-------+---------+
+-------+---------+
Empty set.
It costs 0.002s
IoTDB> insert into root.sg.d1(time,s1,s2) aligned values(1,2,3)
Msg: The statement is executed successfully.
IoTDB> show devices
+----------+---------+
|   devices|isAligned|
+----------+---------+
|root.sg.d1|     true|
+----------+---------+
Total line number = 1
It costs 0.003s
IoTDB> select * from root.**
+-----------------------------+-------------+-------------+
|                         Time|root.sg.d1.s1|root.sg.d1.s2|
+-----------------------------+-------------+-------------+
|1970-01-01T08:00:00.001+08:00|          2.0|          3.0|
+-----------------------------+-------------+-------------+
Total line number = 1
It costs 0.008s
```