### PR TITLE
Optimize ml WAL limitation for MultiLeader

### DIFF
--- a/confignode/src/test/resources/confignode1conf/iotdb-confignode.properties
+++ b/confignode/src/test/resources/confignode1conf/iotdb-confignode.properties
@@ -1,3 +1,4 @@
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/consensus/src/main/java/org/apache/iotdb/consensus/config/MultiLeaderConfig.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/config/MultiLeaderConfig.java
@@ -202,8 +202,7 @@ public class MultiLeaderConfig {
     private final int maxWaitingTimeForAccumulatingBatchInMs;
     private final long basicRetryWaitTimeMs;
     private final long maxRetryWaitTimeMs;
-    private final long throttleDownThreshold;
-    private final long throttleUpThreshold;
+    private final long walThrottleThreshold;
     private final long throttleTimeOutMs;
 
     private Replication(
@@ -213,8 +212,7 @@ public class MultiLeaderConfig {
         int maxWaitingTimeForAccumulatingBatchInMs,
         long basicRetryWaitTimeMs,
         long maxRetryWaitTimeMs,
-        long throttleDownThreshold,
-        long throttleUpThreshold,
+        long walThrottleThreshold,
         long throttleTimeOutMs) {
       this.maxPendingRequestNumPerNode = maxPendingRequestNumPerNode;
       this.maxRequestPerBatch = maxRequestPerBatch;
@@ -222,8 +220,7 @@ public class MultiLeaderConfig {
       this.maxWaitingTimeForAccumulatingBatchInMs = maxWaitingTimeForAccumulatingBatchInMs;
       this.basicRetryWaitTimeMs = basicRetryWaitTimeMs;
       this.maxRetryWaitTimeMs = maxRetryWaitTimeMs;
-      this.throttleDownThreshold = throttleDownThreshold;
-      this.throttleUpThreshold = throttleUpThreshold;
+      this.walThrottleThreshold = walThrottleThreshold;
       this.throttleTimeOutMs = throttleTimeOutMs;
     }
 
@@ -251,12 +248,8 @@ public class MultiLeaderConfig {
       return maxRetryWaitTimeMs;
     }
 
-    public long getThrottleDownThreshold() {
-      return throttleDownThreshold;
-    }
-
-    public long getThrottleUpThreshold() {
-      return throttleUpThreshold;
+    public long getWalThrottleThreshold() {
+      return walThrottleThreshold;
     }
 
     public long getThrottleTimeOutMs() {
@@ -276,8 +269,7 @@ public class MultiLeaderConfig {
       private int maxWaitingTimeForAccumulatingBatchInMs = 500;
       private long basicRetryWaitTimeMs = TimeUnit.MILLISECONDS.toMillis(100);
       private long maxRetryWaitTimeMs = TimeUnit.SECONDS.toMillis(20);
-      private long throttleDownThreshold = 50 * 1024 * 1024 * 1024L;
-      private long throttleUpThreshold = 1024 * 1024 * 1024L;
+      private long walThrottleThreshold = 50 * 1024 * 1024 * 1024L;
       private long throttleTimeOutMs = TimeUnit.SECONDS.toMillis(30);
 
       public Replication.Builder setMaxPendingRequestNumPerNode(int maxPendingRequestNumPerNode) {
@@ -311,13 +303,8 @@ public class MultiLeaderConfig {
         return this;
       }
 
-      public Replication.Builder setThrottleDownThreshold(long throttleDownThreshold) {
-        this.throttleDownThreshold = throttleDownThreshold;
-        return this;
-      }
-
-      public Replication.Builder setThrottleUpThreshold(long throttleUpThreshold) {
-        this.throttleUpThreshold = throttleUpThreshold;
+      public Replication.Builder setWalThrottleThreshold(long walThrottleThreshold) {
+        this.walThrottleThreshold = walThrottleThreshold;
         return this;
       }
 
@@ -334,8 +321,7 @@ public class MultiLeaderConfig {
             maxWaitingTimeForAccumulatingBatchInMs,
             basicRetryWaitTimeMs,
             maxRetryWaitTimeMs,
-            throttleDownThreshold,
-            throttleUpThreshold,
+            walThrottleThreshold,
             throttleTimeOutMs);
       }
     }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderServerImpl.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.consensus.multileader.client.AsyncMultiLeaderServiceClie
 import org.apache.iotdb.consensus.multileader.logdispatcher.LogDispatcher;
 import org.apache.iotdb.consensus.multileader.wal.ConsensusReqReader;
 import org.apache.iotdb.consensus.multileader.wal.GetConsensusReqReaderPlan;
+import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.tsfile.utils.PublicBAOS;
 
@@ -46,7 +47,11 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class MultiLeaderServerImpl {
 
@@ -56,6 +61,8 @@ public class MultiLeaderServerImpl {
 
   private final Peer thisNode;
   private final IStateMachine stateMachine;
+  private final Lock stateMachineLock = new ReentrantLock();
+  private final Condition stateMachineCondition = stateMachineLock.newCondition();
   private final String storageDir;
   private final List<Peer> configuration;
   private final AtomicLong index;
@@ -108,14 +115,20 @@ public class MultiLeaderServerImpl {
    * records the index of the log and writes locally, and then asynchronous replication is performed
    */
   public TSStatus write(IConsensusRequest request) {
-    synchronized (stateMachine) {
+    stateMachineLock.lock();
+    try {
       if (needToThrottleDown()) {
         logger.info(
             "[Throttle Down] index:{}, safeIndex:{}",
             getIndex(),
             getCurrentSafelyDeletedSearchIndex());
         try {
-          stateMachine.wait(config.getReplication().getThrottleTimeOutMs());
+          boolean timeout =
+              !stateMachineCondition.await(
+                  config.getReplication().getThrottleTimeOutMs(), TimeUnit.MILLISECONDS);
+          if (timeout) {
+            return RpcUtils.getStatus(TSStatusCode.READ_ONLY_SYSTEM_ERROR);
+          }
         } catch (InterruptedException e) {
           logger.error("Failed to throttle down because ", e);
           Thread.currentThread().interrupt();
@@ -151,6 +164,8 @@ public class MultiLeaderServerImpl {
             result.getCode());
       }
       return result;
+    } finally {
+      stateMachineLock.unlock();
     }
   }
 
@@ -238,13 +253,20 @@ public class MultiLeaderServerImpl {
   }
 
   public boolean needToThrottleDown() {
-    return reader.getTotalSize() > config.getReplication().getThrottleDownThreshold();
+    return reader.getTotalSize() > config.getReplication().getWalThrottleThreshold();
   }
 
   public boolean needToThrottleUp() {
-    return reader.getTotalSize()
-        < config.getReplication().getThrottleDownThreshold()
-            - config.getReplication().getThrottleUpThreshold();
+    return reader.getTotalSize() < config.getReplication().getWalThrottleThreshold();
+  }
+
+  public void signal() {
+    stateMachineLock.lock();
+    try {
+      stateMachineCondition.signalAll();
+    } finally {
+      stateMachineLock.unlock();
+    }
   }
 
   public AtomicLong getIndexObject() {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/MultiLeaderServerImpl.java
@@ -117,7 +117,7 @@ public class MultiLeaderServerImpl {
   public TSStatus write(IConsensusRequest request) {
     stateMachineLock.lock();
     try {
-      if (needToThrottleDown()) {
+      if (needBlockWrite()) {
         logger.info(
             "[Throttle Down] index:{}, safeIndex:{}",
             getIndex(),
@@ -252,11 +252,11 @@ public class MultiLeaderServerImpl {
     return config;
   }
 
-  public boolean needToThrottleDown() {
+  public boolean needBlockWrite() {
     return reader.getTotalSize() > config.getReplication().getWalThrottleThreshold();
   }
 
-  public boolean needToThrottleUp() {
+  public boolean unblockWrite() {
     return reader.getTotalSize() < config.getReplication().getWalThrottleThreshold();
   }
 

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
@@ -224,9 +224,7 @@ public class LogDispatcher {
       reader.setSafelyDeletedSearchIndex(impl.getCurrentSafelyDeletedSearchIndex());
       // notify
       if (impl.needToThrottleUp()) {
-        synchronized (impl.getStateMachine()) {
-          impl.getStateMachine().notifyAll();
-        }
+        impl.signal();
       }
     }
 

--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
@@ -223,7 +223,7 @@ public class LogDispatcher {
       // safely
       reader.setSafelyDeletedSearchIndex(impl.getCurrentSafelyDeletedSearchIndex());
       // notify
-      if (impl.needToThrottleUp()) {
+      if (impl.unblockWrite()) {
         impl.signal();
       }
     }

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -181,7 +181,7 @@ target_config_nodes=127.0.0.1:22277
 # The minimum size of wal files when throttle down in MultiLeader consensus
 # If it's a value smaller than 0, use the default value 50 * 1024 * 1024 * 1024 bytes (50GB).
 # Datatype: long
-# multi_leader_throttle_down_threshold_in_byte=53687091200
+# multi_leader_throttle_threshold_in_byte=53687091200
 
 ####################
 ### Directory Configuration

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -949,7 +949,7 @@ public class IoTDBConfig {
   private int driverTaskExecutionTimeSliceInMs = 100;
 
   /** Maximum size of wal buffer used in MultiLeader consensus. Unit: byte */
-  private long throttleDownThreshold = 50 * 1024 * 1024 * 1024L;
+  private long throttleThreshold = 50 * 1024 * 1024 * 1024L;
 
   IoTDBConfig() {}
 
@@ -3020,11 +3020,11 @@ public class IoTDBConfig {
     this.driverTaskExecutionTimeSliceInMs = driverTaskExecutionTimeSliceInMs;
   }
 
-  public long getThrottleDownThreshold() {
-    return throttleDownThreshold;
+  public long getThrottleThreshold() {
+    return throttleThreshold;
   }
 
-  public void setThrottleDownThreshold(long throttleDownThreshold) {
-    this.throttleDownThreshold = throttleDownThreshold;
+  public void setThrottleThreshold(long throttleThreshold) {
+    this.throttleThreshold = throttleThreshold;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1077,10 +1077,10 @@ public class IoTDBDescriptor {
     long throttleDownThresholdInByte =
         Long.parseLong(
             properties.getProperty(
-                "multi_leader_throttle_down_threshold_in_byte",
-                Long.toString(conf.getThrottleDownThreshold())));
+                "multi_leader_throttle_threshold_in_byte",
+                Long.toString(conf.getThrottleThreshold())));
     if (throttleDownThresholdInByte > 0) {
-      conf.setThrottleDownThreshold(throttleDownThresholdInByte);
+      conf.setThrottleThreshold(throttleDownThresholdInByte);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -79,7 +79,7 @@ public class DataRegionConsensusImpl {
                                       .build())
                               .setReplication(
                                   MultiLeaderConfig.Replication.newBuilder()
-                                      .setThrottleDownThreshold(conf.getThrottleDownThreshold())
+                                      .setWalThrottleThreshold(conf.getThrottleThreshold())
                                       .build())
                               .build())
                       .setRatisConfig(


### PR DESCRIPTION
## Description
Use a simple parameter to throttle the write when WAL size reaches the threshold when using MultiLeaderConsensus

