### PR TITLE
[IOTDB-4150] Client output has double error code

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -70,7 +70,6 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.template.SetSchemaTemplat
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowNodesInSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowPathSetTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowSchemaTemplateStatement;
-import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import com.google.common.util.concurrent.SettableFuture;
@@ -188,7 +187,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
             udfName,
             className,
             uris);
-        future.setException(new StatementExecutionException(executionStatus));
+        future.setException(new IoTDBException(executionStatus.message, executionStatus.code));
       } else {
         future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
       }
@@ -231,7 +230,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
 
       if (TSStatusCode.SUCCESS_STATUS.getStatusCode() != executionStatus.getCode()) {
         LOGGER.error("[{}] Failed to drop function {} in config node.", executionStatus, udfName);
-        future.setException(new StatementExecutionException(executionStatus));
+        future.setException(new IoTDBException(executionStatus.message, executionStatus.code));
       } else {
         future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
       }
@@ -286,7 +285,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
     if (tsStatus.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
     } else {
-      future.setException(new StatementExecutionException(tsStatus));
+      future.setException(new IoTDBException(tsStatus.message, tsStatus.code));
     }
     return future;
   }
@@ -309,7 +308,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
     if (tsStatus.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
     } else {
-      future.setException(new StatementExecutionException(tsStatus));
+      future.setException(new IoTDBException(tsStatus.message, tsStatus.code));
     }
     return future;
   }
@@ -332,7 +331,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
     if (tsStatus.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
     } else {
-      future.setException(new StatementExecutionException(tsStatus));
+      future.setException(new IoTDBException(tsStatus.message, tsStatus.code));
     }
     return future;
   }
@@ -406,7 +405,9 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
         CONFIG_NODE_CLIENT_MANAGER.borrowClient(ConfigNodeInfo.partitionRegionId)) {
       showRegionResp = client.showRegion(showRegionReq);
       if (showRegionResp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-        future.setException(new StatementExecutionException(showRegionResp.getStatus()));
+        future.setException(
+            new IoTDBException(
+                showRegionResp.getStatus().message, showRegionResp.getStatus().code));
         return future;
       }
     } catch (TException | IOException e) {
@@ -426,7 +427,9 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
         CONFIG_NODE_CLIENT_MANAGER.borrowClient(ConfigNodeInfo.partitionRegionId)) {
       showDataNodesResp = client.showDataNodes();
       if (showDataNodesResp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-        future.setException(new StatementExecutionException(showDataNodesResp.getStatus()));
+        future.setException(
+            new IoTDBException(
+                showDataNodesResp.getStatus().message, showDataNodesResp.getStatus().code));
         return future;
       }
     } catch (TException | IOException e) {
@@ -446,7 +449,9 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
       showConfigNodesResp = client.showConfigNodes();
       if (showConfigNodesResp.getStatus().getCode()
           != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-        future.setException(new StatementExecutionException(showConfigNodesResp.getStatus()));
+        future.setException(
+            new IoTDBException(
+                showConfigNodesResp.getStatus().message, showConfigNodesResp.getStatus().code));
         return future;
       }
     } catch (TException | IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/StandaloneConfigTaskExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/StandaloneConfigTaskExecutor.java
@@ -46,8 +46,6 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.template.SetSchemaTemplat
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowNodesInSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowPathSetTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowSchemaTemplateStatement;
-import org.apache.iotdb.rpc.RpcUtils;
-import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import com.google.common.util.concurrent.SettableFuture;
@@ -154,9 +152,7 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
               udfName, className, uris, e.getMessage());
       LOGGER.error(message, e);
       future.setException(
-          new StatementExecutionException(
-              new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode())
-                  .setMessage(message)));
+          new IoTDBException(message, TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     }
     return future;
   }
@@ -202,9 +198,7 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
           String.format("Failed to drop function %s, because %s.", udfName, e.getMessage());
       LOGGER.error(message, e);
       future.setException(
-          new StatementExecutionException(
-              new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode())
-                  .setMessage(message)));
+          new IoTDBException(message, TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     }
     return future;
   }
@@ -229,7 +223,7 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
     if (tsStatus.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
     } else {
-      future.setException(new StatementExecutionException(tsStatus));
+      future.setException(new IoTDBException(tsStatus.message, tsStatus.code));
     }
     return future;
   }
@@ -241,7 +235,7 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
     if (tsStatus.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
     } else {
-      future.setException(new StatementExecutionException(tsStatus));
+      future.setException(new IoTDBException(tsStatus.message, tsStatus.code));
     }
     return future;
   }
@@ -253,7 +247,7 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
     if (tsStatus.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
     } else {
-      future.setException(new StatementExecutionException(tsStatus));
+      future.setException(new IoTDBException(tsStatus.message, tsStatus.code));
     }
     return future;
   }
@@ -262,10 +256,9 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
   public SettableFuture<ConfigTaskResult> showCluster() {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     future.setException(
-        new StatementExecutionException(
-            RpcUtils.getStatus(
-                TSStatusCode.EXECUTE_STATEMENT_ERROR,
-                "Executing show cluster in standalone mode is not supported")));
+        new IoTDBException(
+            "Executing show cluster in standalone mode is not supported",
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     return future;
   }
 
@@ -308,10 +301,9 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
   public SettableFuture<ConfigTaskResult> showRegion(ShowRegionStatement showRegionStatement) {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     future.setException(
-        new StatementExecutionException(
-            RpcUtils.getStatus(
-                TSStatusCode.EXECUTE_STATEMENT_ERROR,
-                "Executing show regions in standalone mode is not supported")));
+        new IoTDBException(
+            "Executing show regions in standalone mode is not supported",
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     return future;
   }
 
@@ -320,10 +312,9 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
       ShowDataNodesStatement showDataNodesStatement) {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     future.setException(
-        new StatementExecutionException(
-            RpcUtils.getStatus(
-                TSStatusCode.EXECUTE_STATEMENT_ERROR,
-                "Executing show datanodes in standalone mode is not supported")));
+        new IoTDBException(
+            "Executing show datanodes in standalone mode is not supported",
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     return future;
   }
 
@@ -331,10 +322,9 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
   public SettableFuture<ConfigTaskResult> showConfigNodes() {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     future.setException(
-        new StatementExecutionException(
-            RpcUtils.getStatus(
-                TSStatusCode.EXECUTE_STATEMENT_ERROR,
-                "Executing show confignodes in standalone mode is not supported")));
+        new IoTDBException(
+            "Executing show confignodes in standalone mode is not supported",
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     return future;
   }
 
@@ -343,10 +333,9 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
       CreateSchemaTemplateStatement createSchemaTemplateStatement) {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     future.setException(
-        new StatementExecutionException(
-            RpcUtils.getStatus(
-                TSStatusCode.EXECUTE_STATEMENT_ERROR,
-                "Executing create schema template is not supported")));
+        new IoTDBException(
+            "Executing create schema template is not supported",
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     return future;
   }
 
@@ -355,10 +344,9 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
       ShowSchemaTemplateStatement showSchemaTemplateStatement) {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     future.setException(
-        new StatementExecutionException(
-            RpcUtils.getStatus(
-                TSStatusCode.EXECUTE_STATEMENT_ERROR,
-                "Executing show schema template is not supported")));
+        new IoTDBException(
+            "Executing show schema template is not supported",
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     return future;
   }
 
@@ -367,10 +355,9 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
       ShowNodesInSchemaTemplateStatement showNodesInSchemaTemplateStatement) {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     future.setException(
-        new StatementExecutionException(
-            RpcUtils.getStatus(
-                TSStatusCode.EXECUTE_STATEMENT_ERROR,
-                "Executing show nodes in schema template is not supported")));
+        new IoTDBException(
+            "Executing show nodes in schema template is not supported",
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     return future;
   }
 
@@ -379,10 +366,9 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
       SetSchemaTemplateStatement setSchemaTemplateStatement) {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     future.setException(
-        new StatementExecutionException(
-            RpcUtils.getStatus(
-                TSStatusCode.EXECUTE_STATEMENT_ERROR,
-                "Executing set schema template is not supported")));
+        new IoTDBException(
+            "Executing set schema template is not supported",
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     return future;
   }
 
@@ -391,10 +377,9 @@ public class StandaloneConfigTaskExecutor implements IConfigTaskExecutor {
       ShowPathSetTemplateStatement showPathSetTemplateStatement) {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     future.setException(
-        new StatementExecutionException(
-            RpcUtils.getStatus(
-                TSStatusCode.EXECUTE_STATEMENT_ERROR,
-                "Executing show path set template is not supported")));
+        new IoTDBException(
+            "Executing show path set template is not supported",
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()));
     return future;
   }
 }


### PR DESCRIPTION
[IOTDB-4150](https://issues.apache.org/jira/browse/IOTDB-4150)
If use StatementExecutionException in future.setException(), it will combine message and code as a new message, when client end outputs the exception, the client will use StatementExecutionException again so there are two error codes have been combined.
Before fix:
![image](https://user-images.githubusercontent.com/17932988/184851230-23f1f2e8-b68d-4d35-8c77-9523dc2099f9.png)

After fix:
![image](https://user-images.githubusercontent.com/17932988/184831814-e5cb67f1-9dc3-401a-a101-777801f61338.png)
