### PR TITLE
[IOTDB-4074] Allocate SchemaRegion and DataRegion seperately

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RegionBalancer.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RegionBalancer.java
@@ -72,6 +72,8 @@ public class RegionBalancer {
     List<TDataNodeConfiguration> onlineDataNodes =
         getNodeManager().filterDataNodeThroughStatus(NodeStatus.Running);
     List<TRegionReplicaSet> allocatedRegions = getPartitionManager().getAllReplicaSets();
+    allocatedRegions.removeIf(
+        allocateRegion -> allocateRegion.getRegionId().getType() != consensusGroupType);
 
     for (Map.Entry<String, Integer> entry : allotmentMap.entrySet()) {
       String storageGroup = entry.getKey();

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -78,7 +78,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -561,7 +560,7 @@ public class PartitionInfo implements SnapshotProcessor {
    * @return All Regions' RegionReplicaSet
    */
   public List<TRegionReplicaSet> getAllReplicaSets() {
-    List<TRegionReplicaSet> result = new Vector<>();
+    List<TRegionReplicaSet> result = new ArrayList<>();
     storageGroupPartitionTables
         .values()
         .forEach(


### PR DESCRIPTION
Filter the specific consensusGroupType‘s allocatedRegions so that we can focus on the specified type of region allocation.