### PR TITLE
[IOTDB-3938]Fix measurements check of batch insertion

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/PathUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/PathUtils.java
@@ -65,7 +65,7 @@ public class PathUtils {
       return;
     }
     for (List<String> measurements : measurementLists) {
-      isLegalMeasurements(measurements);
+      isLegalSingleMeasurements(measurements);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -725,7 +725,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      for (List<String> measurements : req.getMeasurementsList()) {
+        PathUtils.isLegalSingleMeasurements(measurements);
+      }
 
       // Step 1: TODO(INSERT) transfer from TSInsertTabletsReq to Statement
       InsertRowsStatement statement = (InsertRowsStatement) StatementGenerator.createStatement(req);
@@ -775,7 +777,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      for (List<String> measurements : req.getMeasurementsList()) {
+        PathUtils.isLegalSingleMeasurements(measurements);
+      }
 
       // Step 1: TODO(INSERT) transfer from TSInsertTabletsReq to Statement
       InsertRowsOfOneDeviceStatement statement =
@@ -826,7 +830,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      for (List<String> measurements : req.getMeasurementsList()) {
+        PathUtils.isLegalSingleMeasurements(measurements);
+      }
 
       // Step 1: TODO(INSERT) transfer from TSInsertTabletsReq to Statement
       InsertRowsOfOneDeviceStatement statement =
@@ -917,7 +923,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
         return getNotLoggedInStatus();
       }
 
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      for (List<String> measurements : req.getMeasurementsList()) {
+        PathUtils.isLegalSingleMeasurements(measurements);
+      }
 
       // Step 1: TODO(INSERT) transfer from TSInsertTabletsReq to Statement
       InsertMultiTabletsStatement statement =
@@ -1010,7 +1018,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      for (List<String> measurements : req.getMeasurementsList()) {
+        PathUtils.isLegalSingleMeasurements(measurements);
+      }
 
       InsertRowsStatement statement = (InsertRowsStatement) StatementGenerator.createStatement(req);
 

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -725,9 +725,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      for (List<String> measurements : req.getMeasurementsList()) {
-        PathUtils.isLegalSingleMeasurements(measurements);
-      }
+      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
 
       // Step 1: TODO(INSERT) transfer from TSInsertTabletsReq to Statement
       InsertRowsStatement statement = (InsertRowsStatement) StatementGenerator.createStatement(req);
@@ -777,9 +775,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      for (List<String> measurements : req.getMeasurementsList()) {
-        PathUtils.isLegalSingleMeasurements(measurements);
-      }
+      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
 
       // Step 1: TODO(INSERT) transfer from TSInsertTabletsReq to Statement
       InsertRowsOfOneDeviceStatement statement =
@@ -830,9 +826,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      for (List<String> measurements : req.getMeasurementsList()) {
-        PathUtils.isLegalSingleMeasurements(measurements);
-      }
+      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
 
       // Step 1: TODO(INSERT) transfer from TSInsertTabletsReq to Statement
       InsertRowsOfOneDeviceStatement statement =
@@ -923,9 +917,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
         return getNotLoggedInStatus();
       }
 
-      for (List<String> measurements : req.getMeasurementsList()) {
-        PathUtils.isLegalSingleMeasurements(measurements);
-      }
+      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
 
       // Step 1: TODO(INSERT) transfer from TSInsertTabletsReq to Statement
       InsertMultiTabletsStatement statement =
@@ -1018,9 +1010,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      for (List<String> measurements : req.getMeasurementsList()) {
-        PathUtils.isLegalSingleMeasurements(measurements);
-      }
+      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
 
       InsertRowsStatement statement = (InsertRowsStatement) StatementGenerator.createStatement(req);
 


### PR DESCRIPTION
## Description


### Motivation

The wrong use of measurements check results serious performance loss in new standalone, only 50% of that of old standalone.
The wrong method causes redundant and unnecessary path split. 

### Modification

Fix the measurements check methods.

### Results

#### Before fix
![image](https://user-images.githubusercontent.com/38524330/184865810-6da0e492-b01e-43aa-831b-3aa1d9d03fa2.png)

#### After fix
![image](https://user-images.githubusercontent.com/38524330/184865967-01b66353-a86c-4732-b227-82fe4e9bfb3f.png)
