### PR TITLE
[IOTDB-4155] StackOverflowError occurs when deleting wal files

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -270,8 +270,8 @@ public class WALNode implements IWALNode {
           if (safelyDeletedSearchIndex != DEFAULT_SAFELY_DELETED_SEARCH_INDEX) {
             return;
           }
-          run();
           recursionTime++;
+          run();
         }
       }
     }


### PR DESCRIPTION
Add recursionTime before recursively calling deletion method. Otherwise, this method may crash because of StackOverflowError.