### PR TITLE
Add query redirect logic in planning side when retrying

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/MPPQueryContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/MPPQueryContext.java
@@ -21,6 +21,9 @@ package org.apache.iotdb.db.mpp.common;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.db.mpp.plan.analyze.QueryType;
 
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * This class is used to record the context of a query including QueryId, query statement, session
  * info and so on
@@ -37,8 +40,11 @@ public class MPPQueryContext {
   private TEndPoint localInternalEndpoint;
   private ResultNodeContext resultNodeContext;
 
+  private final List<TEndPoint> endPointBlackList;
+
   public MPPQueryContext(QueryId queryId) {
     this.queryId = queryId;
+    this.endPointBlackList = new LinkedList<>();
   }
 
   public MPPQueryContext(
@@ -47,8 +53,8 @@ public class MPPQueryContext {
       SessionInfo session,
       TEndPoint localDataBlockEndpoint,
       TEndPoint localInternalEndpoint) {
+    this(queryId);
     this.sql = sql;
-    this.queryId = queryId;
     this.session = session;
     this.localDataBlockEndpoint = localDataBlockEndpoint;
     this.localInternalEndpoint = localInternalEndpoint;
@@ -63,11 +69,7 @@ public class MPPQueryContext {
       TEndPoint localInternalEndpoint,
       long timeOut,
       long startTime) {
-    this.sql = sql;
-    this.queryId = queryId;
-    this.session = session;
-    this.localDataBlockEndpoint = localDataBlockEndpoint;
-    this.localInternalEndpoint = localInternalEndpoint;
+    this(sql, queryId, session, localDataBlockEndpoint, localInternalEndpoint);
     this.resultNodeContext = new ResultNodeContext(queryId);
     this.timeOut = timeOut;
     this.startTime = startTime;
@@ -115,5 +117,13 @@ public class MPPQueryContext {
 
   public void setStartTime(long startTime) {
     this.startTime = startTime;
+  }
+
+  public void addFailedEndPoint(TEndPoint endPoint) {
+    this.endPointBlackList.add(endPoint);
+  }
+
+  public List<TEndPoint> getEndPointBlackList() {
+    return endPointBlackList;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/MPPQueryContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/MPPQueryContext.java
@@ -40,6 +40,9 @@ public class MPPQueryContext {
   private TEndPoint localInternalEndpoint;
   private ResultNodeContext resultNodeContext;
 
+  // When some DataNode cannot be connected, its endPoint will be put
+  // in this list. And the following retry will avoid planning fragment
+  // onto this node.
   private final List<TEndPoint> endPointBlackList;
 
   public MPPQueryContext(QueryId queryId) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
@@ -264,6 +264,7 @@ public class ExpressionAnalyzer {
       List<PartialPath> actualPaths = new ArrayList<>();
       if (rawPath.getFullPath().startsWith(SQLConstant.ROOT + TsFileConstant.PATH_SEPARATOR)) {
         actualPaths.add(rawPath);
+        patternTree.appendPathPattern(rawPath);
       } else {
         for (PartialPath prefixPath : prefixPaths) {
           PartialPath concatPath = prefixPath.concatPath(rawPath);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -90,7 +90,7 @@ public class QueryExecution implements IQueryExecution {
 
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static final int MAX_RETRY_COUNT = 3;
-  private static final long RETRY_INTERVAL_IN_MS = 10_000;
+  private static final long RETRY_INTERVAL_IN_MS = 2_000;
   private int retryCount = 0;
   private final MPPQueryContext context;
   private IScheduler scheduler;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -90,7 +90,7 @@ public class QueryExecution implements IQueryExecution {
 
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static final int MAX_RETRY_COUNT = 3;
-  private static final long RETRY_INTERVAL_IN_MS = 2000;
+  private static final long RETRY_INTERVAL_IN_MS = 10_000;
   private int retryCount = 0;
   private final MPPQueryContext context;
   private IScheduler scheduler;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -90,7 +90,7 @@ public class QueryExecution implements IQueryExecution {
 
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static final int MAX_RETRY_COUNT = 3;
-  private static final long RETRY_INTERVAL_IN_MS = 2_000;
+  private static final long RETRY_INTERVAL_IN_MS = 2000;
   private int retryCount = 0;
   private final MPPQueryContext context;
   private IScheduler scheduler;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.mpp.plan.planner.distribution;
 
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.mpp.common.MPPQueryContext;
@@ -35,8 +36,12 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.ExchangeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.sink.FragmentSinkNode;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -45,6 +50,7 @@ import java.util.Map;
  * into only one FragmentInstance.
  */
 public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
+  private static final Logger logger = LoggerFactory.getLogger(SimpleFragmentParallelPlanner.class);
 
   private SubPlan subPlan;
   private Analysis analysis;
@@ -122,16 +128,46 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
     // TODO: (Chen Rongzhao) need to make the values of ReadConsistencyLevel as static variable or
     // enums
     boolean selectRandomDataNode = "weak".equals(readConsistencyLevel);
+
+    List<TDataNodeLocation> availableDataNodes =
+        filterAvailableTDataNode(regionReplicaSet.getDataNodeLocations());
+    if (availableDataNodes.size() == 0) {
+      String errorMsg =
+          String.format(
+              "all replicas for region[%s] are not available in these DataNodes[%s]",
+              regionReplicaSet.getRegionId(), regionReplicaSet.getDataNodeLocations());
+      throw new IllegalArgumentException(errorMsg);
+    }
+    if (regionReplicaSet.getDataNodeLocationsSize() != availableDataNodes.size()) {
+      logger.info("Available replicas: " + availableDataNodes);
+    }
     int targetIndex;
     if (!selectRandomDataNode || queryContext.getSession() == null) {
       targetIndex = 0;
     } else {
-      targetIndex =
-          (int)
-              (queryContext.getSession().getSessionId()
-                  % regionReplicaSet.getDataNodeLocationsSize());
+      targetIndex = (int) (queryContext.getSession().getSessionId() % availableDataNodes.size());
     }
-    return regionReplicaSet.getDataNodeLocations().get(targetIndex);
+    return availableDataNodes.get(targetIndex);
+  }
+
+  private List<TDataNodeLocation> filterAvailableTDataNode(
+      List<TDataNodeLocation> originalDataNodeList) {
+    List<TDataNodeLocation> result = new LinkedList<>();
+    for (TDataNodeLocation dataNodeLocation : originalDataNodeList) {
+      if (isAvailableDataNode(dataNodeLocation)) {
+        result.add(dataNodeLocation);
+      }
+    }
+    return result;
+  }
+
+  private boolean isAvailableDataNode(TDataNodeLocation dataNodeLocation) {
+    for (TEndPoint endPoint : queryContext.getEndPointBlackList()) {
+      if (endPoint.getIp().equals(dataNodeLocation.internalEndPoint.getIp())) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private void calculateNodeTopologyBetweenInstance() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
@@ -129,6 +129,8 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
     // enums
     boolean selectRandomDataNode = "weak".equals(readConsistencyLevel);
 
+    // When planning fragment onto specific DataNode, the DataNode whose endPoint is in
+    // black list won't be considered because it may have connection issue now.
     List<TDataNodeLocation> availableDataNodes =
         filterAvailableTDataNode(regionReplicaSet.getDataNodeLocations());
     if (availableDataNodes.size() == 0) {
@@ -139,7 +141,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
       throw new IllegalArgumentException(errorMsg);
     }
     if (regionReplicaSet.getDataNodeLocationsSize() != availableDataNodes.size()) {
-      logger.info("Available replicas: " + availableDataNodes);
+      logger.info("available replicas: " + availableDataNodes);
     }
     int targetIndex;
     if (!selectRandomDataNode || queryContext.getSession() == null) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
@@ -76,7 +76,11 @@ public class ClusterScheduler implements IScheduler {
     this.queryType = queryType;
     this.dispatcher =
         new FragmentInstanceDispatcherImpl(
-            queryType, executor, writeOperationExecutor, internalServiceClientManager);
+            queryType,
+            queryContext,
+            executor,
+            writeOperationExecutor,
+            internalServiceClientManager);
     if (queryType == QueryType.READ) {
       this.stateTracker =
           new FixedRateFragInsStateTracker(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
@@ -87,10 +87,7 @@ public class ClusterScheduler implements IScheduler {
               stateMachine, scheduledExecutor, instances, internalServiceClientManager);
       this.queryTerminator =
           new SimpleQueryTerminator(
-              scheduledExecutor,
-              queryContext.getQueryId(),
-              instances,
-              internalServiceClientManager);
+              scheduledExecutor, queryContext, instances, internalServiceClientManager);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.db.consensus.DataRegionConsensusImpl;
 import org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl;
 import org.apache.iotdb.db.exception.mpp.FragmentInstanceDispatchException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
+import org.apache.iotdb.db.mpp.common.MPPQueryContext;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceInfo;
 import org.apache.iotdb.db.mpp.plan.analyze.QueryType;
 import org.apache.iotdb.db.mpp.plan.analyze.SchemaValidator;
@@ -66,6 +67,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
   private final ExecutorService executor;
   private final ExecutorService writeOperationExecutor;
   private final QueryType type;
+  private final MPPQueryContext queryContext;
   private final String localhostIpAddr;
   private final int localhostInternalPort;
   private final IClientManager<TEndPoint, SyncDataNodeInternalServiceClient>
@@ -73,10 +75,12 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
 
   public FragmentInstanceDispatcherImpl(
       QueryType type,
+      MPPQueryContext queryContext,
       ExecutorService executor,
       ExecutorService writeOperationExecutor,
       IClientManager<TEndPoint, SyncDataNodeInternalServiceClient> internalServiceClientManager) {
     this.type = type;
+    this.queryContext = queryContext;
     this.executor = executor;
     this.writeOperationExecutor = writeOperationExecutor;
     this.internalServiceClientManager = internalServiceClientManager;
@@ -187,6 +191,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
       TSStatus status = new TSStatus();
       status.setCode(TSStatusCode.SYNC_CONNECTION_EXCEPTION.getStatusCode());
       status.setMessage("can't connect to node {}" + endPoint);
+      queryContext.addFailedEndPoint(endPoint);
       throw new FragmentInstanceDispatchException(status);
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -191,6 +191,8 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
       TSStatus status = new TSStatus();
       status.setCode(TSStatusCode.SYNC_CONNECTION_EXCEPTION.getStatusCode());
       status.setMessage("can't connect to node {}" + endPoint);
+      // If the DataNode cannot be connected, its endPoint will be put into black list
+      // so that the following retry will avoid dispatching instance towards this DataNode.
       queryContext.addFailedEndPoint(endPoint);
       throw new FragmentInstanceDispatchException(status);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/SimpleQueryTerminator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/SimpleQueryTerminator.java
@@ -75,6 +75,11 @@ public class SimpleQueryTerminator implements IQueryTerminator {
 
   @Override
   public Future<Boolean> terminate() {
+    // For the failure dispatch, the termination should not be triggered because of connection issue
+    this.relatedHost =
+        this.relatedHost.stream()
+            .filter(endPoint -> !queryContext.getEndPointBlackList().contains(endPoint))
+            .collect(Collectors.toList());
     return scheduledExecutor.schedule(
         this::syncTerminate, TERMINATION_GRACE_PERIOD_IN_MS, TimeUnit.MILLISECONDS);
   }
@@ -98,7 +103,6 @@ public class SimpleQueryTerminator implements IQueryTerminator {
   private List<TEndPoint> getRelatedHost(List<FragmentInstance> fragmentInstances) {
     return fragmentInstances.stream()
         .map(instance -> instance.getHostDataNode().internalEndPoint)
-        .filter(endPoint -> !queryContext.getEndPointBlackList().contains(endPoint))
         .distinct()
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
## Description
Before this change, when some DataNode cannot be connected, the retry logic will re-dispatch the FragmentInstance to other DataNode according to the result from `ConfigNode`. But it is not reliable sometimes when using MultiLeaderConsensus because the leader only be changed after 20s. It is not user-friendly to make the query retry waiting more than 20s for users because we actually have some other alive DataNode replicas.

In this change, I added the redirect logic in planning side to make the request try another DataNode replica according to its query process. That is, if dispatching of FragmentInstance failed for some DataNode, it will select another one DataNode who owns the same Region replicas even if the ConfigNode's result is not changed.

On the other hand, this PR fixed a bug in `ExpressionAnalyzer`.

**Test:**
<img width="1300" alt="image" src="https://user-images.githubusercontent.com/18027703/185068055-16276296-73e2-41b1-9aaf-36b0ee57e2da.png">

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/18027703/185068225-818dbdbc-1ef1-4dee-909c-27aba98488fa.png">
