### PR TITLE
[IOTDB-4177][IOTDB-4152] Fix INSERT Failed when using SESSION_BY_RECORDS

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
@@ -977,8 +977,8 @@ public class LocalConfigNode {
         // use an empty dataPartitionMap to init DataPartition
         if (dataRegionId != null) {
           Map<TTimePartitionSlot, List<TRegionReplicaSet>> timePartitionToRegionsMap =
-              new HashMap<>();
-
+              deviceToRegionsMap.getOrDefault(
+                  executor.getSeriesPartitionSlot(deviceId), new HashMap<>());
           timePartitionToRegionsMap.put(
               new TTimePartitionSlot(STANDALONE_MOCK_TIME_SLOT_START_TIME),
               Collections.singletonList(
@@ -1031,7 +1031,8 @@ public class LocalConfigNode {
         DataRegionId dataRegionId =
             getBelongedDataRegionIdWithAutoCreate(new PartialPath(deviceId));
         Map<TTimePartitionSlot, List<TRegionReplicaSet>> timePartitionToRegionsMap =
-            new HashMap<>();
+            deviceToRegionsMap.getOrDefault(
+                executor.getSeriesPartitionSlot(deviceId), new HashMap<>());
         for (TTimePartitionSlot timePartitionSlot :
             dataPartitionQueryParam.getTimePartitionSlotList()) {
           // for each time partition


### PR DESCRIPTION
## Description

If a batch insert have timestamps in two time partition slots, this bug would cause all data be inserted into the last time partition slot.

IOTDB-4152 is caused by the same reason.