### PR TITLE
[IOTDB-4179] Clear iotdb-thrift-sync in pom file

### DIFF
--- a/node-commons/pom.xml
+++ b/node-commons/pom.xml
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
-            <artifactId>iotdb-thrift-sync</artifactId>
+            <artifactId>iotdb-thrift</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -67,11 +67,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
-            <artifactId>iotdb-thrift-sync</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iotdb</groupId>
             <artifactId>influxdb-thrift</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
#7004 removed modules `iotdb-thrift-sync` but forgot to clear `iotdb-thrift-sync` from the pom file.