### PR TITLE
[IOTDB-4020] Use canonical path when recovering wal

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/WALNodeRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/WALNodeRecoverTask.java
@@ -199,9 +199,8 @@ public class WALNodeRecoverTask implements Runnable {
     for (MemTableInfo memTableInfo : memTableId2Info.values()) {
       firstValidVersionId = Math.min(firstValidVersionId, memTableInfo.getFirstFileVersionId());
 
-      File tsFile = new File(memTableInfo.getTsFilePath());
       UnsealedTsFileRecoverPerformer recoverPerformer =
-          walRecoverManger.removeRecoverPerformer(tsFile.getAbsolutePath());
+          walRecoverManger.removeRecoverPerformer(new File(memTableInfo.getTsFilePath()));
       if (recoverPerformer != null) {
         memTableId2RecoverPerformer.put(memTableInfo.getMemTableId(), recoverPerformer);
       }

--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/WALRecoverManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/WALRecoverManager.java
@@ -176,13 +176,27 @@ public class WALRecoverManager {
     if (hasStarted) {
       logger.error("Cannot recover tsfile from wal because wal recovery has already started");
     } else {
-      absolutePath2RecoverPerformer.put(recoverPerformer.getTsFileAbsolutePath(), recoverPerformer);
+      try {
+        String canonicalPath = recoverPerformer.getTsFileResource().getTsFile().getCanonicalPath();
+        absolutePath2RecoverPerformer.put(canonicalPath, recoverPerformer);
+      } catch (IOException e) {
+        logger.error(
+            "Fail to add recover performer for file {}",
+            recoverPerformer.getTsFileAbsolutePath(),
+            e);
+      }
     }
     return recoverPerformer.getRecoverListener();
   }
 
-  UnsealedTsFileRecoverPerformer removeRecoverPerformer(String absolutePath) {
-    return absolutePath2RecoverPerformer.remove(absolutePath);
+  UnsealedTsFileRecoverPerformer removeRecoverPerformer(File file) {
+    try {
+      String canonicalPath = file.getCanonicalPath();
+      return absolutePath2RecoverPerformer.remove(canonicalPath);
+    } catch (IOException e) {
+      logger.error("Fail to remove recover performer for file {}", file, e);
+    }
+    return null;
   }
 
   public CountDownLatch getAllDataRegionScannedLatch() {


### PR DESCRIPTION
This error is caused by using absolute path because it contains "." and "..", making it not unique.