### PR TITLE
[IOTDB-4027] Support cross disk link in RatisConsensus

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.consensus.common.request.IConsensusRequest;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Function;
 
@@ -87,7 +88,7 @@ public interface IStateMachine {
    * @param latestSnapshotRootDir dir where the latest snapshot sits
    * @return List of real snapshot files.
    */
-  default List<File> getSnapshotFiles(File latestSnapshotRootDir) {
+  default List<Path> getSnapshotFiles(File latestSnapshotRootDir) {
     return Utils.listAllRegularFilesRecursively(latestSnapshotRootDir);
   }
 

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.consensus.common.Peer;
+import org.apache.iotdb.consensus.common.Utils;
 import org.apache.iotdb.consensus.common.request.IConsensusRequest;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -76,18 +77,18 @@ public interface IStateMachine {
   void loadSnapshot(File latestSnapshotRootDir);
 
   /**
-   * given a snapshot dir, ask statemachine to provide all snapshot files.
+   * given a snapshot dir, ask statemachine to provide all snapshot files. By default, it will list
+   * all files recursively under latestSnapshotDir
    *
    * <p>DataRegion may take snapshot at a different disk and only store a log file containing file
    * paths. So statemachine is required to read the log file and provide the real snapshot file
    * paths.
    *
    * @param latestSnapshotRootDir dir where the latest snapshot sits
-   * @return List of real snapshot files. If the returned list is null, consensus implementations
-   *     will visit and add all files under this give latestSnapshotRootDir.
+   * @return List of real snapshot files.
    */
   default List<File> getSnapshotFiles(File latestSnapshotRootDir) {
-    return null;
+    return Utils.listAllRegularFilesRecursively(latestSnapshotRootDir);
   }
 
   /** An optional API for event notifications. */

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/Utils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.consensus.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Utils {
+  private static final Logger logger = LoggerFactory.getLogger(Utils.class);
+
+  public static List<File> listAllRegularFilesRecursively(File rootDir) {
+    List<File> allFiles = new ArrayList<>();
+    try {
+      Files.walkFileTree(
+          rootDir.toPath(),
+          new FileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                throws IOException {
+              return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                throws IOException {
+              if (attrs.isRegularFile()) {
+                allFiles.add(file.toFile());
+              }
+              return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+              logger.info("visit file {} failed due to {}", file.toAbsolutePath(), exc);
+              return FileVisitResult.TERMINATE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                throws IOException {
+              return FileVisitResult.CONTINUE;
+            }
+          });
+    } catch (IOException ioException) {
+      logger.error("IOException occurred during listing snapshot directory: ", ioException);
+      return Collections.emptyList();
+    }
+    return allFiles;
+  }
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/Utils.java
@@ -35,8 +35,8 @@ import java.util.List;
 public class Utils {
   private static final Logger logger = LoggerFactory.getLogger(Utils.class);
 
-  public static List<File> listAllRegularFilesRecursively(File rootDir) {
-    List<File> allFiles = new ArrayList<>();
+  public static List<Path> listAllRegularFilesRecursively(File rootDir) {
+    List<Path> allFiles = new ArrayList<>();
     try {
       Files.walkFileTree(
           rootDir.toPath(),
@@ -51,7 +51,7 @@ public class Utils {
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                 throws IOException {
               if (attrs.isRegularFile()) {
-                allFiles.add(file.toFile());
+                allFiles.add(file);
               }
               return FileVisitResult.CONTINUE;
             }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class SnapshotStorage implements StateMachineStorage {
   private final Logger logger = LoggerFactory.getLogger(SnapshotStorage.class);
@@ -141,8 +142,14 @@ public class SnapshotStorage implements StateMachineStorage {
     }
     TermIndex snapshotTermIndex = Utils.getTermIndexFromDir(latestSnapshotDir);
 
+    List<File> actualSnapshotFiles = applicationStateMachine.getSnapshotFiles(latestSnapshotDir);
+    List<Path> filesIncludedInSnapshot =
+        actualSnapshotFiles != null
+            ? actualSnapshotFiles.stream().map(File::toPath).collect(Collectors.toList())
+            : getAllFilesUnder(latestSnapshotDir);
+
     List<FileInfo> fileInfos = new ArrayList<>();
-    for (Path file : getAllFilesUnder(latestSnapshotDir)) {
+    for (Path file : filesIncludedInSnapshot) {
       if (file.endsWith(".md5")) {
         continue;
       }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -97,17 +97,17 @@ public class SnapshotStorage implements StateMachineStorage {
     }
     TermIndex snapshotTermIndex = Utils.getTermIndexFromDir(latestSnapshotDir);
 
-    List<File> actualSnapshotFiles = applicationStateMachine.getSnapshotFiles(latestSnapshotDir);
+    List<Path> actualSnapshotFiles = applicationStateMachine.getSnapshotFiles(latestSnapshotDir);
     if (actualSnapshotFiles == null) {
       return null;
     }
 
     List<FileInfo> fileInfos = new ArrayList<>();
-    for (File file : actualSnapshotFiles) {
-      if (file.toPath().endsWith(".md5")) {
+    for (Path file : actualSnapshotFiles) {
+      if (file.endsWith(".md5")) {
         continue;
       }
-      FileInfo fileInfo = new FileInfoWithDelayedMd5Computing(file.toPath());
+      FileInfo fileInfo = new FileInfoWithDelayedMd5Computing(file);
       fileInfos.add(fileInfo);
     }
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
@@ -33,6 +33,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Scanner;
@@ -153,7 +155,7 @@ public class SnapshotTest {
     }
 
     @Override
-    public List<File> getSnapshotFiles(File latestSnapshotRootDir) {
+    public List<Path> getSnapshotFiles(File latestSnapshotRootDir) {
       File log = new File(latestSnapshotRootDir.getAbsolutePath() + File.separator + "record");
       Assert.assertTrue(log.exists());
       Scanner scanner = null;
@@ -167,7 +169,7 @@ public class SnapshotTest {
       }
       Assert.assertNotNull(scanner);
 
-      return Collections.singletonList(new File(actualSnapshotPath));
+      return Collections.singletonList(Paths.get(actualSnapshotPath));
     }
   }
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
@@ -30,7 +30,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
 
 public class SnapshotTest {
 
@@ -125,5 +130,58 @@ public class SnapshotTest {
         + File.separator
         + ".ratis_meta."
         + termIndexMeta;
+  }
+
+  static class CrossDiskLinkStatemachine extends TestUtils.IntegerCounter {
+    @Override
+    public boolean takeSnapshot(File snapshotDir) {
+      /*
+       * Simulate the cross disk link snapshot
+       * create a real snapshot file and a log file recording real snapshot file path
+       */
+      File snapshotRaw = new File(snapshotDir.getAbsolutePath() + File.separator + "snapshot");
+      File snapshotRecord = new File(snapshotDir.getAbsolutePath() + File.separator  + "record");
+      try {
+        Assert.assertTrue(snapshotRaw.createNewFile());
+        FileWriter writer = new FileWriter(snapshotRecord);
+        writer.write(snapshotRaw.getAbsolutePath());
+        writer.close();
+      } catch (IOException ioException) {
+        ioException.printStackTrace();
+      }
+      return true;
+    }
+
+    @Override
+    public List<File> getSnapshotFiles(File latestSnapshotRootDir) {
+      File log = new File(latestSnapshotRootDir.getAbsolutePath() + File.separator  + "record");
+      Assert.assertTrue(log.exists());
+      Scanner scanner = null;
+      try {
+        scanner = new Scanner(log);
+      } catch (FileNotFoundException e) {
+        e.printStackTrace();
+      }
+      Assert.assertNotNull(scanner);
+      String actualSnapshotPath = scanner.nextLine();
+      return Collections.singletonList(new File(actualSnapshotPath));
+    }
+  }
+
+  @Test
+  public void testCrossDiskLinkSnapshot() throws Exception {
+    ApplicationStateMachineProxy proxy =
+        new ApplicationStateMachineProxy(new CrossDiskLinkStatemachine(), null);
+
+    proxy.initialize(null, null, new EmptyStorageWithOnlySMDir());
+    proxy.notifyTermIndexUpdated(20, 1005);
+    proxy.takeSnapshot();
+    String actualSnapshotName = CrossDiskLinkStatemachine.ensureSnapshotFileName(testDir, "20_1005");
+    File actualSnapshotFile = new File(actualSnapshotName);
+    Assert.assertEquals(proxy.getLatestSnapshot().getFiles().size(), 1);
+    Assert.assertEquals(
+        proxy.getLatestSnapshot().getFiles().get(0).getPath().toFile().getAbsolutePath(),
+        actualSnapshotFile.getAbsolutePath()
+    );
   }
 }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
@@ -140,7 +140,7 @@ public class SnapshotTest {
        * create a real snapshot file and a log file recording real snapshot file path
        */
       File snapshotRaw = new File(snapshotDir.getAbsolutePath() + File.separator + "snapshot");
-      File snapshotRecord = new File(snapshotDir.getAbsolutePath() + File.separator  + "record");
+      File snapshotRecord = new File(snapshotDir.getAbsolutePath() + File.separator + "record");
       try {
         Assert.assertTrue(snapshotRaw.createNewFile());
         FileWriter writer = new FileWriter(snapshotRecord);
@@ -154,7 +154,7 @@ public class SnapshotTest {
 
     @Override
     public List<File> getSnapshotFiles(File latestSnapshotRootDir) {
-      File log = new File(latestSnapshotRootDir.getAbsolutePath() + File.separator  + "record");
+      File log = new File(latestSnapshotRootDir.getAbsolutePath() + File.separator + "record");
       Assert.assertTrue(log.exists());
       Scanner scanner = null;
       try {
@@ -176,12 +176,12 @@ public class SnapshotTest {
     proxy.initialize(null, null, new EmptyStorageWithOnlySMDir());
     proxy.notifyTermIndexUpdated(20, 1005);
     proxy.takeSnapshot();
-    String actualSnapshotName = CrossDiskLinkStatemachine.ensureSnapshotFileName(testDir, "20_1005");
+    String actualSnapshotName =
+        CrossDiskLinkStatemachine.ensureSnapshotFileName(testDir, "20_1005");
     File actualSnapshotFile = new File(actualSnapshotName);
     Assert.assertEquals(proxy.getLatestSnapshot().getFiles().size(), 1);
     Assert.assertEquals(
         proxy.getLatestSnapshot().getFiles().get(0).getPath().toFile().getAbsolutePath(),
-        actualSnapshotFile.getAbsolutePath()
-    );
+        actualSnapshotFile.getAbsolutePath());
   }
 }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
@@ -157,13 +157,16 @@ public class SnapshotTest {
       File log = new File(latestSnapshotRootDir.getAbsolutePath() + File.separator + "record");
       Assert.assertTrue(log.exists());
       Scanner scanner = null;
+      String actualSnapshotPath = null;
       try {
         scanner = new Scanner(log);
+        actualSnapshotPath = scanner.nextLine();
+        scanner.close();
       } catch (FileNotFoundException e) {
         e.printStackTrace();
       }
       Assert.assertNotNull(scanner);
-      String actualSnapshotPath = scanner.nextLine();
+
       return Collections.singletonList(new File(actualSnapshotPath));
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -57,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 public class DataRegionStateMachine extends BaseStateMachine {
 
@@ -258,13 +260,13 @@ public class DataRegionStateMachine extends BaseStateMachine {
   }
 
   @Override
-  public List<File> getSnapshotFiles(File latestSnapshotRootDir) {
+  public List<Path> getSnapshotFiles(File latestSnapshotRootDir) {
     try {
       return new SnapshotLoader(
               latestSnapshotRootDir.getAbsolutePath(),
               region.getStorageGroupName(),
               region.getDataRegionId())
-          .getSnapshotFileInfo();
+          .getSnapshotFileInfo().stream().map(File::toPath).collect(Collectors.toList());
     } catch (IOException e) {
       logger.error(
           "Meets error when getting snapshot files for {}-{}",


### PR DESCRIPTION
## Background
DataRegionStateMachine sometimes create cross disk snapshots by recording all link paths in another disk.
Please refer to jira https://issues.apache.org/jira/browse/IOTDB-3771 and PR https://github.com/apache/iotdb/pull/6782 for more details.
## Changes
I propose to support cross disk snapshots in RatisConsensus. 
Currently, Ratis list all files under given snapshot root dir and take them all as snapshot files. Now Ratis will first call `IStateMachine.getSnapshotFiles` to let statemachine decides which files should be included in the actual snapshot.  If this method returns null, Ratis will still follow the old way.