### PR TITLE
[IOTDB-4191]delete and insert data sql do not has permission

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/DeleteDataStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/DeleteDataStatement.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.mpp.plan.statement.crud;
 
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.mpp.plan.constant.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.Statement;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
@@ -31,6 +32,11 @@ public class DeleteDataStatement extends Statement {
   private List<PartialPath> pathList;
   private long deleteStartTime;
   private long deleteEndTime;
+
+  public DeleteDataStatement() {
+    super();
+    statementType = StatementType.DELETE;
+  }
 
   @Override
   public List<? extends PartialPath> getPaths() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertMultiTabletsStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertMultiTabletsStatement.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.engine.StorageEngineV2;
+import org.apache.iotdb.db.mpp.plan.constant.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
@@ -34,6 +35,11 @@ public class InsertMultiTabletsStatement extends InsertBaseStatement {
 
   /** the InsertTabletStatement list */
   List<InsertTabletStatement> insertTabletStatementList;
+
+  public InsertMultiTabletsStatement() {
+    super();
+    statementType = StatementType.MULTI_BATCH_INSERT;
+  }
 
   public List<InsertTabletStatement> getInsertTabletStatementList() {
     return insertTabletStatementList;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsOfOneDeviceStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsOfOneDeviceStatement.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.engine.StorageEngineV2;
+import org.apache.iotdb.db.mpp.plan.constant.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
@@ -37,6 +38,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class InsertRowsOfOneDeviceStatement extends InsertBaseStatement {
+
+  public InsertRowsOfOneDeviceStatement() {
+    super();
+    statementType = StatementType.BATCH_INSERT_ONE_DEVICE;
+  }
 
   /** the InsertRowsStatement list */
   private List<InsertRowStatement> insertRowStatementList;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsStatement.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.engine.StorageEngineV2;
+import org.apache.iotdb.db.mpp.plan.constant.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
@@ -34,6 +35,11 @@ public class InsertRowsStatement extends InsertBaseStatement {
 
   /** the InsertRowsStatement list */
   private List<InsertRowStatement> insertRowStatementList;
+
+  public InsertRowsStatement() {
+    super();
+    statementType = StatementType.BATCH_INSERT_ROWS;
+  }
 
   public List<PartialPath> getDevicePaths() {
     List<PartialPath> partialPaths = new ArrayList<>();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertTabletStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertTabletStatement.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.engine.StorageEngineV2;
+import org.apache.iotdb.db.mpp.plan.constant.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
 import org.apache.iotdb.tsfile.utils.BitMap;
 
@@ -38,6 +39,11 @@ public class InsertTabletStatement extends InsertBaseStatement {
   private Object[] columns;
 
   private int rowCount = 0;
+
+  public InsertTabletStatement() {
+    super();
+    statementType = StatementType.BATCH_INSERT;
+  }
 
   public int getRowCount() {
     return rowCount;


### PR DESCRIPTION
When give root.wf01.wt01 path delete_timeseries privileges, but run below sql, error occurs:

IoTDB> delete from root.ln.wf01.wt01 where time >= 1;
delete from root.ln.wf01.wt01 where time >= 1;
Msg: 602: No permissions for this operation NULL

After fix:
IoTDB> delete from root.ln.wf01.wt01 where time >= 1;
delete from root.ln.wf01.wt01 where time >= 1;
Msg: The statement is executed successfully.

Also find cannot import csv data when giving read and insert privileges, so fix it together.
