### PR TITLE
[To rel/0.13] [IOTDB-4194] Fix IOException happened in Compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
@@ -316,7 +316,7 @@ public class CompactionUtils {
       TsFileResource resource, TsFileSequenceReader reader, String device, String measurement)
       throws IllegalPathException, IOException {
     List<ChunkMetadata> chunkMetadata =
-        reader.getChunkMetadataList(new PartialPath(device, measurement));
+        reader.getChunkMetadataList(new PartialPath(device, measurement), true);
     if (chunkMetadata.size() > 0) {
       chunkMetadata.get(0).setFilePath(resource.getTsFilePath());
       Chunk chunk = ChunkCache.getInstance().get(chunkMetadata.get(0));


### PR DESCRIPTION
While ITimeIndex degrading from DeviceIndex to FileIndex, `tsFileResource.mayContainsDevice(device)` may return true even if this tsfile doesn't contain this `device`