### PR TITLE
[IOTDB-4195]improve error message of NPE from schema partition

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/SchemaPartition.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/SchemaPartition.java
@@ -20,7 +20,9 @@ package org.apache.iotdb.commons.partition;
 
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
+import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.utils.PathUtils;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -65,6 +67,11 @@ public class SchemaPartition extends Partition {
     // TODO return the latest dataRegionReplicaSet for each time partition
     String storageGroup = getStorageGroupByDevice(deviceName);
     TSeriesPartitionSlot seriesPartitionSlot = calculateDeviceGroupId(deviceName);
+    if (schemaPartitionMap.get(storageGroup) == null) {
+      throw new RuntimeException(
+          new IoTDBException(
+              "Path does not exist. ", TSStatusCode.PATH_NOT_EXIST_ERROR.getStatusCode()));
+    }
     return schemaPartitionMap.get(storageGroup).get(seriesPartitionSlot);
   }
 


### PR DESCRIPTION
When alter not exist timeseries path it will occurs internal server error message:

Msg: 500: [INTERNAL_SERVER_ERROR(500)] Exception occurred: "ALTER timeseries root.turbine.d1.s1 RENAME tag1 TO newTag1". executeStatement failed. null

actually, it just need to tell us paths not exist and that will be clear.

After fix：
![image](https://user-images.githubusercontent.com/17932988/185735617-8c2de987-60a4-49b8-95fd-c9fb53eec615.png)
