### PR TITLE
[IOTDB-4027] Guarantee atomicity for latest snapshot

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -174,7 +174,7 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
     // delete snapshotDir fully in case of last takeSnapshot() crashed
     FileUtils.deleteFully(snapshotDir);
 
-    snapshotDir.mkdir();
+    snapshotDir.mkdirs();
     if (!snapshotDir.isDirectory()) {
       logger.error("Unable to create snapshotDir at {}", snapshotDir);
       return RaftLog.INVALID_LOG_INDEX;

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -90,7 +90,21 @@ public class SnapshotStorage implements StateMachineStorage {
     if (snapshots == null || snapshots.length == 0) {
       return null;
     }
-    return snapshots[snapshots.length - 1].toFile();
+    int i = snapshots.length - 1;
+    for (; i >= 0; i--) {
+      String metafilePath =
+          getMetafilePath(snapshots[i].toFile(), snapshots[i].getFileName().toString());
+      if (new File(metafilePath).exists()) {
+        break;
+      } else {
+        try {
+          FileUtils.deleteFully(snapshots[i]);
+        } catch (IOException e) {
+          logger.warn("delete incomplete snapshot directory {} failed due to {}", snapshots[i], e);
+        }
+      }
+    }
+    return i < 0 ? null : snapshots[i].toFile();
   }
 
   private List<Path> getAllFilesUnder(File rootDir) {

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
@@ -116,6 +116,12 @@ public class SnapshotTest {
     proxy.getStateMachineStorage().cleanupOldSnapshots(null);
     Assert.assertFalse(new File(snapshotFilename).exists());
     Assert.assertTrue(new File(snapshotFilenameLatest).exists());
+
+    // delete meta file, then the proxy will consider the latest snapshotInfo incomplete
+    Assert.assertTrue(new File(getSnapshotMetaFilename("616_4217")).delete());
+    info = proxy.getLatestSnapshot();
+    Assert.assertNull(info);
+    Assert.assertFalse(new File(snapshotFilenameLatest).exists());
   }
 
   private String getSnapshotMetaFilename(String termIndexMeta) {


### PR DESCRIPTION
Currently, when fetching latest snapshot, RatisConsensus will visit snapshot directory by order and pick the largest term_index directory as the latest snapshot. However, this snapshot might be incomplete if state machine crashed during the middle of snapshotting. 
Thus, we have to decide whether a snapshot dir contains a complete snapshot by testing the existence of meta file (which is added to the snapshot dir last).