### PR TITLE
[IOTDB-4100] remove and modify some methods in ConfigNodeRPCServiceProcessor and ConfigManager.

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/DataPartitionResp.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/DataPartitionResp.java
@@ -20,19 +20,16 @@
 package org.apache.iotdb.confignode.consensus.response;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
-import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.partition.DataPartitionTable;
-import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionTableResp;
 import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class DataPartitionResp implements DataSet {
@@ -60,52 +57,6 @@ public class DataPartitionResp implements DataSet {
 
   public boolean isAllPartitionsExist() {
     return allPartitionsExist;
-  }
-
-  public TDataPartitionResp convertToTDataPartitionResp(
-      Map<TConsensusGroupId, TRegionReplicaSet> replicaSetMap) {
-    TDataPartitionResp resp = new TDataPartitionResp();
-    resp.setStatus(status);
-
-    if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>>
-          dataPartitionMap = new ConcurrentHashMap<>();
-
-      dataPartition.forEach(
-          (storageGroup, dataPartitionTable) -> {
-            Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>
-                seriesPartitionSlotMap = new ConcurrentHashMap<>();
-
-            dataPartitionTable
-                .getDataPartitionMap()
-                .forEach(
-                    (seriesPartitionSlot, seriesPartitionTable) -> {
-                      Map<TTimePartitionSlot, List<TRegionReplicaSet>> timePartitionSlotMap =
-                          new ConcurrentHashMap<>();
-
-                      seriesPartitionTable
-                          .getSeriesPartitionMap()
-                          .forEach(
-                              (timePartitionSlot, consensusGroupIds) -> {
-                                List<TRegionReplicaSet> regionReplicaSets = new Vector<>();
-
-                                consensusGroupIds.forEach(
-                                    consensusGroupId ->
-                                        regionReplicaSets.add(replicaSetMap.get(consensusGroupId)));
-
-                                timePartitionSlotMap.put(timePartitionSlot, regionReplicaSets);
-                              });
-
-                      seriesPartitionSlotMap.put(seriesPartitionSlot, timePartitionSlotMap);
-                    });
-
-            dataPartitionMap.put(storageGroup, seriesPartitionSlotMap);
-          });
-
-      resp.setDataPartitionMap(dataPartitionMap);
-    }
-
-    return resp;
   }
 
   public TDataPartitionTableResp convertToTDataPartitionTableResp() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/SchemaPartitionResp.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/SchemaPartitionResp.java
@@ -20,11 +20,9 @@
 package org.apache.iotdb.confignode.consensus.response;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
-import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
 import org.apache.iotdb.commons.partition.SchemaPartitionTable;
-import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionTableResp;
 import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -61,36 +59,6 @@ public class SchemaPartitionResp implements DataSet {
 
   public boolean isAllPartitionsExist() {
     return allPartitionsExist;
-  }
-
-  public TSchemaPartitionResp convertToRpcSchemaPartitionResp(
-      Map<TConsensusGroupId, TRegionReplicaSet> replicaSetMap) {
-    TSchemaPartitionResp resp = new TSchemaPartitionResp();
-    resp.setStatus(status);
-
-    if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      Map<String, Map<TSeriesPartitionSlot, TRegionReplicaSet>> schemaPartitionMap =
-          new ConcurrentHashMap<>();
-
-      schemaPartition.forEach(
-          (storageGroup, schemaPartitionTable) -> {
-            Map<TSeriesPartitionSlot, TRegionReplicaSet> seriesPartitionSlotMap =
-                new ConcurrentHashMap<>();
-
-            schemaPartitionTable
-                .getSchemaPartitionMap()
-                .forEach(
-                    (seriesPartitionSlot, consensusGroupId) ->
-                        seriesPartitionSlotMap.put(
-                            seriesPartitionSlot, replicaSetMap.get(consensusGroupId)));
-
-            schemaPartitionMap.put(storageGroup, seriesPartitionSlotMap);
-          });
-
-      resp.setSchemaRegionMap(schemaPartitionMap);
-    }
-
-    return resp;
   }
 
   public TSchemaPartitionTableResp convertToRpcSchemaPartitionTableResp() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -78,7 +78,6 @@ import org.apache.iotdb.confignode.persistence.schema.ClusterSchemaInfo;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TCreateSchemaTemplateReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeInfo;
-import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TGetAllTemplatesResp;
 import org.apache.iotdb.confignode.rpc.thrift.TGetPathsSetTemplatesResp;
@@ -88,7 +87,6 @@ import org.apache.iotdb.confignode.rpc.thrift.TRegionInfo;
 import org.apache.iotdb.confignode.rpc.thrift.TRegionMigrateResultReportReq;
 import org.apache.iotdb.confignode.rpc.thrift.TRegionRouteMapResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementResp;
-import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSetSchemaTemplateReq;
 import org.apache.iotdb.confignode.rpc.thrift.TShowClusterResp;
@@ -370,143 +368,105 @@ public class ConfigManager implements IManager {
   }
 
   @Override
-  public Object getSchemaPartition(PathPatternTree patternTree, boolean isContainedReplicaSet) {
-    // Construct empty response from parameter isContainedReplicaSet
-    Object resp;
-    if (isContainedReplicaSet) {
-      resp = new TSchemaPartitionResp();
-    } else {
-      resp = new TSchemaPartitionTableResp();
-    }
+  public TSchemaPartitionTableResp getSchemaPartition(PathPatternTree patternTree) {
+    // Construct empty response
+    TSchemaPartitionTableResp resp = new TSchemaPartitionTableResp();
 
     TSStatus status = confirmLeader();
-    if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      // Build GetSchemaPartitionPlan
-      Map<String, Set<TSeriesPartitionSlot>> partitionSlotsMap = new HashMap<>();
-      List<PartialPath> relatedPaths = patternTree.getAllPathPatterns();
-      List<String> allStorageGroups = getClusterSchemaManager().getStorageGroupNames();
-      Map<String, Boolean> scanAllRegions = new HashMap<>();
-      for (PartialPath path : relatedPaths) {
-        for (String storageGroup : allStorageGroups) {
-          try {
-            PartialPath storageGroupPath = new PartialPath(storageGroup);
-            if (path.overlapWith(storageGroupPath.concatNode(MULTI_LEVEL_PATH_WILDCARD))
-                && !scanAllRegions.containsKey(storageGroup)) {
-              List<TSeriesPartitionSlot> relatedSlot = calculateRelatedSlot(path, storageGroupPath);
-              if (relatedSlot.isEmpty()) {
-                scanAllRegions.put(storageGroup, true);
-                partitionSlotsMap.put(storageGroup, new HashSet<>());
-              } else {
-                partitionSlotsMap
-                    .computeIfAbsent(storageGroup, k -> new HashSet<>())
-                    .addAll(relatedSlot);
-              }
+    if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+      return resp.setStatus(status);
+    }
+
+    // Build GetSchemaPartitionPlan
+    Map<String, Set<TSeriesPartitionSlot>> partitionSlotsMap = new HashMap<>();
+    List<PartialPath> relatedPaths = patternTree.getAllPathPatterns();
+    List<String> allStorageGroups = getClusterSchemaManager().getStorageGroupNames();
+    Map<String, Boolean> scanAllRegions = new HashMap<>();
+    for (PartialPath path : relatedPaths) {
+      for (String storageGroup : allStorageGroups) {
+        try {
+          PartialPath storageGroupPath = new PartialPath(storageGroup);
+          if (path.overlapWith(storageGroupPath.concatNode(MULTI_LEVEL_PATH_WILDCARD))
+              && !scanAllRegions.containsKey(storageGroup)) {
+            List<TSeriesPartitionSlot> relatedSlot = calculateRelatedSlot(path, storageGroupPath);
+            if (relatedSlot.isEmpty()) {
+              scanAllRegions.put(storageGroup, true);
+              partitionSlotsMap.put(storageGroup, new HashSet<>());
+            } else {
+              partitionSlotsMap
+                  .computeIfAbsent(storageGroup, k -> new HashSet<>())
+                  .addAll(relatedSlot);
             }
-          } catch (IllegalPathException e) {
-            // this line won't be reached in general
-            throw new RuntimeException(e);
           }
+        } catch (IllegalPathException e) {
+          // this line won't be reached in general
+          throw new RuntimeException(e);
         }
-      }
-
-      // Return empty resp if the partitionSlotsMap is empty
-      if (partitionSlotsMap.isEmpty()) {
-        if (isContainedReplicaSet) {
-          return ((TSchemaPartitionResp) resp)
-              .setStatus(StatusUtils.OK)
-              .setSchemaRegionMap(new HashMap<>());
-        } else {
-          return ((TSchemaPartitionTableResp) resp)
-              .setStatus(StatusUtils.OK)
-              .setSchemaPartitionTable(new HashMap<>());
-        }
-      }
-
-      GetSchemaPartitionPlan getSchemaPartitionPlan =
-          new GetSchemaPartitionPlan(
-              partitionSlotsMap.entrySet().stream()
-                  .collect(
-                      Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue()))));
-      SchemaPartitionResp queryResult =
-          (SchemaPartitionResp) partitionManager.getSchemaPartition(getSchemaPartitionPlan);
-      if (isContainedReplicaSet) {
-        resp =
-            queryResult.convertToRpcSchemaPartitionResp(getLoadManager().genLatestRegionRouteMap());
-      } else {
-        resp = queryResult.convertToRpcSchemaPartitionTableResp();
-      }
-
-      // TODO: Delete or hide this LOGGER before officially release.
-      LOGGER.info("GetSchemaPartition receive paths: {}, return: {}", relatedPaths, resp);
-
-      return resp;
-    } else {
-      if (isContainedReplicaSet) {
-        return ((TSchemaPartitionResp) resp).setStatus(status);
-      } else {
-        return ((TSchemaPartitionTableResp) resp).setStatus(status);
       }
     }
+
+    // Return empty resp if the partitionSlotsMap is empty
+    if (partitionSlotsMap.isEmpty()) {
+      return resp.setStatus(StatusUtils.OK).setSchemaPartitionTable(new HashMap<>());
+    }
+
+    GetSchemaPartitionPlan getSchemaPartitionPlan =
+        new GetSchemaPartitionPlan(
+            partitionSlotsMap.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue()))));
+    SchemaPartitionResp queryResult =
+        (SchemaPartitionResp) partitionManager.getSchemaPartition(getSchemaPartitionPlan);
+    resp = queryResult.convertToRpcSchemaPartitionTableResp();
+
+    // TODO: Delete or hide this LOGGER before officially release.
+    LOGGER.info("GetSchemaPartition receive paths: {}, return: {}", relatedPaths, resp);
+
+    return resp;
   }
 
   @Override
-  public Object getOrCreateSchemaPartition(
-      PathPatternTree patternTree, boolean isContainedReplicaSet) {
-    // Construct empty response from parameter isContainedReplicaSet
-    Object resp;
-    if (isContainedReplicaSet) {
-      resp = new TSchemaPartitionResp();
-    } else {
-      resp = new TSchemaPartitionTableResp();
-    }
+  public TSchemaPartitionTableResp getOrCreateSchemaPartition(PathPatternTree patternTree) {
+    // Construct empty response
+    TSchemaPartitionTableResp resp = new TSchemaPartitionTableResp();
 
     TSStatus status = confirmLeader();
-    if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      List<String> devicePaths = patternTree.getAllDevicePatterns();
-      List<String> storageGroups = getClusterSchemaManager().getStorageGroupNames();
+    if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+      return resp.setStatus(status);
+    }
 
-      // Build GetOrCreateSchemaPartitionPlan
-      Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap = new HashMap<>();
-      for (String devicePath : devicePaths) {
-        if (!devicePath.contains("*")) {
-          // Only check devicePaths that without "*"
-          for (String storageGroup : storageGroups) {
-            if (PathUtils.isStartWith(devicePath, storageGroup)) {
-              partitionSlotsMap
-                  .computeIfAbsent(storageGroup, key -> new ArrayList<>())
-                  .add(getPartitionManager().getSeriesPartitionSlot(devicePath));
-              break;
-            }
+    List<String> devicePaths = patternTree.getAllDevicePatterns();
+    List<String> storageGroups = getClusterSchemaManager().getStorageGroupNames();
+
+    // Build GetOrCreateSchemaPartitionPlan
+    Map<String, List<TSeriesPartitionSlot>> partitionSlotsMap = new HashMap<>();
+    for (String devicePath : devicePaths) {
+      if (!devicePath.contains("*")) {
+        // Only check devicePaths that without "*"
+        for (String storageGroup : storageGroups) {
+          if (PathUtils.isStartWith(devicePath, storageGroup)) {
+            partitionSlotsMap
+                .computeIfAbsent(storageGroup, key -> new ArrayList<>())
+                .add(getPartitionManager().getSeriesPartitionSlot(devicePath));
+            break;
           }
         }
       }
-      GetOrCreateSchemaPartitionPlan getOrCreateSchemaPartitionPlan =
-          new GetOrCreateSchemaPartitionPlan(partitionSlotsMap);
-
-      SchemaPartitionResp queryResult =
-          (SchemaPartitionResp)
-              partitionManager.getOrCreateSchemaPartition(getOrCreateSchemaPartitionPlan);
-      if (isContainedReplicaSet) {
-        resp =
-            queryResult.convertToRpcSchemaPartitionResp(getLoadManager().genLatestRegionRouteMap());
-      } else {
-        resp = queryResult.convertToRpcSchemaPartitionTableResp();
-      }
-
-      // TODO: Delete or hide this LOGGER before officially release.
-      LOGGER.info(
-          "GetOrCreateSchemaPartition receive devicePaths: {}, return TSchemaPartitionResp: {}",
-          devicePaths,
-          resp);
-
-      return resp;
-    } else {
-      if (isContainedReplicaSet) {
-        return ((TSchemaPartitionResp) resp).setStatus(status);
-      } else {
-        return ((TSchemaPartitionTableResp) resp).setStatus(status);
-      }
     }
+    GetOrCreateSchemaPartitionPlan getOrCreateSchemaPartitionPlan =
+        new GetOrCreateSchemaPartitionPlan(partitionSlotsMap);
+
+    SchemaPartitionResp queryResult =
+        (SchemaPartitionResp)
+            partitionManager.getOrCreateSchemaPartition(getOrCreateSchemaPartitionPlan);
+    resp = queryResult.convertToRpcSchemaPartitionTableResp();
+
+    // TODO: Delete or hide this LOGGER before officially release.
+    LOGGER.info(
+        "GetOrCreateSchemaPartition receive devicePaths: {}, return TSchemaPartitionResp: {}",
+        devicePaths,
+        resp);
+
+    return resp;
   }
 
   @Override
@@ -539,80 +499,51 @@ public class ConfigManager implements IManager {
   }
 
   @Override
-  public Object getDataPartition(
-      GetDataPartitionPlan getDataPartitionPlan, boolean isContainedReplicaSet) {
-    // Construct empty response from parameter isContainedReplicaSet
-    Object resp;
-    if (isContainedReplicaSet) {
-      resp = new TDataPartitionResp();
-    } else {
-      resp = new TDataPartitionTableResp();
-    }
+  public TDataPartitionTableResp getDataPartition(GetDataPartitionPlan getDataPartitionPlan) {
+    // Construct empty response
+    TDataPartitionTableResp resp = new TDataPartitionTableResp();
 
     TSStatus status = confirmLeader();
-    if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      DataPartitionResp queryResult =
-          (DataPartitionResp) partitionManager.getDataPartition(getDataPartitionPlan);
-
-      if (isContainedReplicaSet) {
-        resp = queryResult.convertToTDataPartitionResp(getLoadManager().genLatestRegionRouteMap());
-      } else {
-        resp = queryResult.convertToTDataPartitionTableResp();
-      }
-
-      // TODO: Delete or hide this LOGGER before officially release.
-      LOGGER.info(
-          "GetDataPartition interface receive PartitionSlotsMap: {}, return: {}",
-          getDataPartitionPlan.getPartitionSlotsMap(),
-          resp);
-
-      return resp;
-    } else {
-      if (isContainedReplicaSet) {
-        return ((TDataPartitionResp) resp).setStatus(status);
-      } else {
-        return ((TDataPartitionTableResp) resp).setStatus(status);
-      }
+    if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+      return resp.setStatus(status);
     }
+    DataPartitionResp queryResult =
+        (DataPartitionResp) partitionManager.getDataPartition(getDataPartitionPlan);
+
+    resp = queryResult.convertToTDataPartitionTableResp();
+
+    // TODO: Delete or hide this LOGGER before officially release.
+    LOGGER.info(
+        "GetDataPartition interface receive PartitionSlotsMap: {}, return: {}",
+        getDataPartitionPlan.getPartitionSlotsMap(),
+        resp);
+
+    return resp;
   }
 
   @Override
-  public Object getOrCreateDataPartition(
-      GetOrCreateDataPartitionPlan getOrCreateDataPartitionReq, boolean isContainedReplicaSet) {
-    // Construct empty response from parameter isContainedReplicaSet
-    Object resp;
-    if (isContainedReplicaSet) {
-      resp = new TDataPartitionResp();
-    } else {
-      resp = new TDataPartitionTableResp();
-    }
+  public TDataPartitionTableResp getOrCreateDataPartition(
+      GetOrCreateDataPartitionPlan getOrCreateDataPartitionReq) {
+    // Construct empty response
+    TDataPartitionTableResp resp = new TDataPartitionTableResp();
 
     TSStatus status = confirmLeader();
-    if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      DataPartitionResp queryResult =
-          (DataPartitionResp)
-              partitionManager.getOrCreateDataPartition(getOrCreateDataPartitionReq);
-
-      if (isContainedReplicaSet) {
-        resp = queryResult.convertToTDataPartitionResp(getLoadManager().genLatestRegionRouteMap());
-      } else {
-        resp = queryResult.convertToTDataPartitionTableResp();
-      }
-
-      // TODO: Delete or hide this LOGGER before officially release.
-      LOGGER.info(
-          "GetOrCreateDataPartition success. receive PartitionSlotsMap: {}, return: {}",
-          getOrCreateDataPartitionReq.getPartitionSlotsMap(),
-          resp);
-
-      return resp;
-    } else {
-      if (isContainedReplicaSet) {
-        return ((TDataPartitionResp) resp).setStatus(status);
-      } else {
-        return ((TDataPartitionTableResp) resp).setStatus(status);
-      }
+    if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+      return resp.setStatus(status);
     }
+
+    DataPartitionResp queryResult =
+        (DataPartitionResp) partitionManager.getOrCreateDataPartition(getOrCreateDataPartitionReq);
+
+    resp = queryResult.convertToTDataPartitionTableResp();
+
+    // TODO: Delete or hide this LOGGER before officially release.
+    LOGGER.info(
+        "GetOrCreateDataPartition success. receive PartitionSlotsMap: {}, return: {}",
+        getOrCreateDataPartitionReq.getPartitionSlotsMap(),
+        resp);
+
+    return resp;
   }
 
   private TSStatus confirmLeader() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/IManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/IManager.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.confignode.consensus.request.write.SetTimePartitionInter
 import org.apache.iotdb.confignode.manager.load.LoadManager;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TCreateSchemaTemplateReq;
+import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TGetAllTemplatesResp;
 import org.apache.iotdb.confignode.rpc.thrift.TGetPathsSetTemplatesResp;
 import org.apache.iotdb.confignode.rpc.thrift.TGetTemplateResp;
@@ -47,6 +48,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TPermissionInfoResp;
 import org.apache.iotdb.confignode.rpc.thrift.TRegionMigrateResultReportReq;
 import org.apache.iotdb.confignode.rpc.thrift.TRegionRouteMapResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementResp;
+import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSetSchemaTemplateReq;
 import org.apache.iotdb.confignode.rpc.thrift.TShowClusterResp;
 import org.apache.iotdb.confignode.rpc.thrift.TShowConfigNodesResp;
@@ -190,20 +192,16 @@ public interface IManager {
   /**
    * Get SchemaPartition
    *
-   * @param isContainedReplicaSet The last map level of result will contain TRegionReplicaSet if
-   *     true, otherwise the last level will be TConsensusGroupId
    * @return TSchemaPartitionResp
    */
-  Object getSchemaPartition(PathPatternTree patternTree, boolean isContainedReplicaSet);
+  TSchemaPartitionTableResp getSchemaPartition(PathPatternTree patternTree);
 
   /**
    * Get or create SchemaPartition
    *
-   * @param isContainedReplicaSet The last map level of result will contain TRegionReplicaSet if
-   *     true, otherwise the last level will be TConsensusGroupId
    * @return TSchemaPartitionResp
    */
-  Object getOrCreateSchemaPartition(PathPatternTree patternTree, boolean isContainedReplicaSet);
+  TSchemaPartitionTableResp getOrCreateSchemaPartition(PathPatternTree patternTree);
 
   /**
    * create SchemaNodeManagementPartition for child paths node management
@@ -215,21 +213,17 @@ public interface IManager {
   /**
    * Get DataPartition
    *
-   * @param isContainedReplicaSet The last map level of result will contain TRegionReplicaSet if
-   *     true, otherwise the last level will be TConsensusGroupId
    * @return TDataPartitionResp
    */
-  Object getDataPartition(GetDataPartitionPlan getDataPartitionPlan, boolean isContainedReplicaSet);
+  TDataPartitionTableResp getDataPartition(GetDataPartitionPlan getDataPartitionPlan);
 
   /**
    * Get or create DataPartition
    *
-   * @param isContainedReplicaSet The last map level of result will contain TRegionReplicaSet if
-   *     true, otherwise the last level will be TConsensusGroupId
    * @return TDataPartitionResp
    */
-  Object getOrCreateDataPartition(
-      GetOrCreateDataPartitionPlan getOrCreateDataPartitionPlan, boolean isContainedReplicaSet);
+  TDataPartitionTableResp getOrCreateDataPartition(
+      GetOrCreateDataPartitionPlan getOrCreateDataPartitionPlan);
 
   /**
    * Operate Permission

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -72,7 +72,6 @@ import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRemoveReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRemoveResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionReq;
-import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDeleteStorageGroupReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDeleteStorageGroupsReq;
@@ -87,7 +86,6 @@ import org.apache.iotdb.confignode.rpc.thrift.TRegionRouteMapResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionReq;
-import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSetDataReplicationFactorReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSetSchemaReplicationFactorReq;
@@ -282,26 +280,11 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
   }
 
   @Override
-  public TSchemaPartitionResp getSchemaPartition(TSchemaPartitionReq req) throws TException {
-    PathPatternTree patternTree =
-        PathPatternTree.deserialize(ByteBuffer.wrap(req.getPathPatternTree()));
-    return (TSchemaPartitionResp) configManager.getSchemaPartition(patternTree, true);
-  }
-
-  @Override
   public TSchemaPartitionTableResp getSchemaPartitionTable(TSchemaPartitionReq req)
       throws TException {
     PathPatternTree patternTree =
         PathPatternTree.deserialize(ByteBuffer.wrap(req.getPathPatternTree()));
-    return (TSchemaPartitionTableResp) configManager.getSchemaPartition(patternTree, false);
-  }
-
-  @Override
-  public TSchemaPartitionResp getOrCreateSchemaPartition(TSchemaPartitionReq req)
-      throws TException {
-    PathPatternTree patternTree =
-        PathPatternTree.deserialize(ByteBuffer.wrap(req.getPathPatternTree()));
-    return (TSchemaPartitionResp) configManager.getOrCreateSchemaPartition(patternTree, true);
+    return configManager.getSchemaPartition(patternTree);
   }
 
   @Override
@@ -309,7 +292,7 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
       throws TException {
     PathPatternTree patternTree =
         PathPatternTree.deserialize(ByteBuffer.wrap(req.getPathPatternTree()));
-    return (TSchemaPartitionTableResp) configManager.getOrCreateSchemaPartition(patternTree, false);
+    return configManager.getOrCreateSchemaPartition(patternTree);
   }
 
   @Override
@@ -322,25 +305,10 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
   }
 
   @Override
-  public TDataPartitionResp getDataPartition(TDataPartitionReq req) throws TException {
-    GetDataPartitionPlan getDataPartitionPlan =
-        GetDataPartitionPlan.convertFromRpcTDataPartitionReq(req);
-    return (TDataPartitionResp) configManager.getDataPartition(getDataPartitionPlan, true);
-  }
-
-  @Override
   public TDataPartitionTableResp getDataPartitionTable(TDataPartitionReq req) throws TException {
     GetDataPartitionPlan getDataPartitionPlan =
         GetDataPartitionPlan.convertFromRpcTDataPartitionReq(req);
-    return (TDataPartitionTableResp) configManager.getDataPartition(getDataPartitionPlan, false);
-  }
-
-  @Override
-  public TDataPartitionResp getOrCreateDataPartition(TDataPartitionReq req) throws TException {
-    GetOrCreateDataPartitionPlan getOrCreateDataPartitionReq =
-        GetOrCreateDataPartitionPlan.convertFromRpcTDataPartitionReq(req);
-    return (TDataPartitionResp)
-        configManager.getOrCreateDataPartition(getOrCreateDataPartitionReq, true);
+    return configManager.getDataPartition(getDataPartitionPlan);
   }
 
   @Override
@@ -348,8 +316,7 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
       throws TException {
     GetOrCreateDataPartitionPlan getOrCreateDataPartitionReq =
         GetOrCreateDataPartitionPlan.convertFromRpcTDataPartitionReq(req);
-    return (TDataPartitionTableResp)
-        configManager.getOrCreateDataPartition(getOrCreateDataPartitionReq, false);
+    return configManager.getOrCreateDataPartition(getOrCreateDataPartitionReq);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
@@ -47,7 +47,6 @@ import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRemoveReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRemoveResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionReq;
-import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDeleteStorageGroupReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDeleteStorageGroupsReq;
@@ -62,7 +61,6 @@ import org.apache.iotdb.confignode.rpc.thrift.TRegionRouteMapResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaNodeManagementResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionReq;
-import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSchemaPartitionTableResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSetDataReplicationFactorReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSetSchemaReplicationFactorReq;
@@ -490,44 +488,11 @@ public class ConfigNodeClient
   }
 
   @Override
-  public TSchemaPartitionResp getSchemaPartition(TSchemaPartitionReq req) throws TException {
-    for (int i = 0; i < RETRY_NUM; i++) {
-      try {
-        TSchemaPartitionResp resp = client.getSchemaPartition(req);
-        if (!updateConfigNodeLeader(resp.status)) {
-          return resp;
-        }
-      } catch (TException e) {
-        configLeader = null;
-      }
-      reconnect();
-    }
-    throw new TException(MSG_RECONNECTION_FAIL);
-  }
-
-  @Override
   public TSchemaPartitionTableResp getSchemaPartitionTable(TSchemaPartitionReq req)
       throws TException {
     for (int i = 0; i < RETRY_NUM; i++) {
       try {
         TSchemaPartitionTableResp resp = client.getSchemaPartitionTable(req);
-        if (!updateConfigNodeLeader(resp.status)) {
-          return resp;
-        }
-      } catch (TException e) {
-        configLeader = null;
-      }
-      reconnect();
-    }
-    throw new TException(MSG_RECONNECTION_FAIL);
-  }
-
-  @Override
-  public TSchemaPartitionResp getOrCreateSchemaPartition(TSchemaPartitionReq req)
-      throws TException {
-    for (int i = 0; i < RETRY_NUM; i++) {
-      try {
-        TSchemaPartitionResp resp = client.getOrCreateSchemaPartition(req);
         if (!updateConfigNodeLeader(resp.status)) {
           return resp;
         }
@@ -574,42 +539,10 @@ public class ConfigNodeClient
   }
 
   @Override
-  public TDataPartitionResp getDataPartition(TDataPartitionReq req) throws TException {
-    for (int i = 0; i < RETRY_NUM; i++) {
-      try {
-        TDataPartitionResp resp = client.getDataPartition(req);
-        if (!updateConfigNodeLeader(resp.status)) {
-          return resp;
-        }
-      } catch (TException e) {
-        configLeader = null;
-      }
-      reconnect();
-    }
-    throw new TException(MSG_RECONNECTION_FAIL);
-  }
-
-  @Override
   public TDataPartitionTableResp getDataPartitionTable(TDataPartitionReq req) throws TException {
     for (int i = 0; i < RETRY_NUM; i++) {
       try {
         TDataPartitionTableResp resp = client.getDataPartitionTable(req);
-        if (!updateConfigNodeLeader(resp.status)) {
-          return resp;
-        }
-      } catch (TException e) {
-        configLeader = null;
-      }
-      reconnect();
-    }
-    throw new TException(MSG_RECONNECTION_FAIL);
-  }
-
-  @Override
-  public TDataPartitionResp getOrCreateDataPartition(TDataPartitionReq req) throws TException {
-    for (int i = 0; i < RETRY_NUM; i++) {
-      try {
-        TDataPartitionResp resp = client.getOrCreateDataPartition(req);
         if (!updateConfigNodeLeader(resp.status)) {
           return resp;
         }

--- a/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/thrift-confignode/src/main/thrift/confignode.thrift
@@ -121,13 +121,6 @@ struct TSchemaPartitionReq {
   1: required binary pathPatternTree
 }
 
-// TODO: Replace this by TSchemaPartitionTableResp
-struct TSchemaPartitionResp {
-  1: required common.TSStatus status
-  // map<StorageGroupName, map<TSeriesPartitionSlot, TRegionReplicaSet>>
-  2: optional map<string, map<common.TSeriesPartitionSlot, common.TRegionReplicaSet>> schemaRegionMap
-}
-
 struct TSchemaPartitionTableResp {
   1: required common.TSStatus status
   // map<StorageGroupName, map<TSeriesPartitionSlot, TConsensusGroupId>>
@@ -151,13 +144,6 @@ struct TSchemaNodeManagementResp {
 struct TDataPartitionReq {
   // map<StorageGroupName, map<TSeriesPartitionSlot, list<TTimePartitionSlot>>>
   1: required map<string, map<common.TSeriesPartitionSlot, list<common.TTimePartitionSlot>>> partitionSlotsMap
-}
-
-// TODO: Replace this by TDataPartitionTableResp
-struct TDataPartitionResp {
-  1: required common.TSStatus status
-  // map<StorageGroupName, map<TSeriesPartitionSlot, map<TTimePartitionSlot, list<TRegionReplicaSet>>>>
-  2: optional map<string, map<common.TSeriesPartitionSlot, map<common.TTimePartitionSlot, list<common.TRegionReplicaSet>>>> dataPartitionMap
 }
 
 struct TDataPartitionTableResp {
@@ -429,18 +415,12 @@ service IConfigNodeRPCService {
   // SchemaPartition
   // ======================================================
 
-  // TODO: Replace this by getSchemaPartitionTable
-  TSchemaPartitionResp getSchemaPartition(TSchemaPartitionReq req)
-
   /**
    * Get SchemaPartitionTable by specific PathPatternTree,
    * the returned SchemaPartitionTable will not contain the unallocated SeriesPartitionSlots
    * See https://apache-iotdb.feishu.cn/docs/doccnqe3PLPEKwsCX1xadXQ2JOg for detailed matching rules
    */
   TSchemaPartitionTableResp getSchemaPartitionTable(TSchemaPartitionReq req)
-
-  // TODO: Replace this by getOrCreateSchemaPartitionTable
-  TSchemaPartitionResp getOrCreateSchemaPartition(TSchemaPartitionReq req)
 
   /**
    * Get or create SchemaPartitionTable by specific PathPatternTree,
@@ -463,17 +443,11 @@ service IConfigNodeRPCService {
   // DataPartition
   // ======================================================
 
-  // TODO: Replace this by getDataPartitionTable
-  TDataPartitionResp getDataPartition(TDataPartitionReq req)
-
   /**
    * Get DataPartitionTable by specific PartitionSlotsMap,
    * the returned DataPartitionTable will not contain the unallocated SeriesPartitionSlots and TimePartitionSlots
    */
   TDataPartitionTableResp getDataPartitionTable(TDataPartitionReq req)
-
-  // TODO: Replace this by getOrCreateDataPartitionTable
-  TDataPartitionResp getOrCreateDataPartition(TDataPartitionReq req)
 
   /**
    * Get or create DataPartitionTable by specific PartitionSlotsMap,


### PR DESCRIPTION
1. remove `getSchemaPartition`, `getOrCreateSchemaPartition`, `getDataPartition`, `getOrCreateDataPartition` methods in  ConfigNodeRPCServiceProcessor.
2. modify `getSchemaPartition`, `getOrCreateSchemaPartition`, `getDataPartition`, `getOrCreateDataPartition` methods in  ConfigManager: modify the type of response of methods, remove `isContainedReplicaSet` parameter.

See more details: https://issues.apache.org/jira/browse/IOTDB-4100.