### PR TITLE
[IOTDB-4202]fix delete from sql IT and user-guide

### DIFF
--- a/docs/UserGuide/Write-And-Delete-Data/Delete-Data.md
+++ b/docs/UserGuide/Write-And-Delete-Data/Delete-Data.md
@@ -62,7 +62,7 @@ expressions like : time > XXX, time <= XXX, or two atomic expressions connected 
 If no "where" clause specified in a delete statement, all the data in a timeseries will be deleted.
 
 ```sql
-delete from root.ln.wf02.status
+delete from root.ln.wf02.wt02.status
 ```
 
 

--- a/docs/zh/UserGuide/Write-And-Delete-Data/Delete-Data.md
+++ b/docs/zh/UserGuide/Write-And-Delete-Data/Delete-Data.md
@@ -60,7 +60,7 @@ expressions like : time > XXX, time <= XXX, or two atomic expressions connected 
 
 如果 delete 语句中未指定 where 子句，则会删除时间序列中的所有数据。
 ```sql
-delete from root.ln.wf02.status
+delete from root.ln.wf02.wt02.status
 ```
 
 ## 多传感器时间序列值删除    

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
@@ -59,7 +59,7 @@ public class IoTDBDeletionIT {
 
   private String insertTemplate =
       "INSERT INTO root.vehicle.d0(timestamp,s0,s1,s2,s3,s4" + ") VALUES(%d,%d,%d,%f,%s,%b)";
-  private String deleteAllTemplate = "DELETE FROM root.vehicle.d0 WHERE time <= 10000";
+  private String deleteAllTemplate = "DELETE FROM root.vehicle.d0.* WHERE time <= 10000";
   private long prevPartitionInterval;
   private long size;
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedDataDeletionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedDataDeletionIT.java
@@ -55,7 +55,7 @@ public class IoTDBAlignedDataDeletionIT {
   private String insertTemplate =
       "INSERT INTO root.vehicle.d0(timestamp,s0,s1,s2,s3,s4"
           + ") ALIGNED VALUES(%d,%d,%d,%f,%s,%b)";
-  private String deleteAllTemplate = "DELETE FROM root.vehicle.d0 WHERE time <= 10000";
+  private String deleteAllTemplate = "DELETE FROM root.vehicle.d0.* WHERE time <= 10000";
   private long prevPartitionInterval;
   private long size;
 

--- a/integration/src/test/java/org/apache/iotdb/db/integration/versionadaption/IoTDBDeletionVersionAdaptionIT.java
+++ b/integration/src/test/java/org/apache/iotdb/db/integration/versionadaption/IoTDBDeletionVersionAdaptionIT.java
@@ -59,7 +59,7 @@ public class IoTDBDeletionVersionAdaptionIT {
 
   private String insertTemplate =
       "INSERT INTO root.vehicle.d0(timestamp,s0,s1,s2,s3,s4" + ") VALUES(%d,%d,%d,%f,%s,%b)";
-  private String deleteAllTemplate = "DELETE FROM root.vehicle.d0 WHERE time <= 10000";
+  private String deleteAllTemplate = "DELETE FROM root.vehicle.d0.* WHERE time <= 10000";
   private long prevPartitionInterval;
 
   @Before


### PR DESCRIPTION
After discussion, we think we should return some warn messages and still let it return success.
 
If this way works, I think we should consider some pervious error codes and let these return success but with warn message because of this rule:

"It should be noted that when the deleted path does not exist, IoTDB will not prompt that the path does not exist, but that the execution is successful, because SQL is a declarative programming method. Unless it is a syntax error, insufficient permissions and so on, it is not considered an error".

Thanks!

previous:
IoTDB> delete from root.sgcc.wf01.wt01.ts0
Msg: The statement is executed successfully.
IoTDB> delete from root.sgcc.wf01.wt01.ts0abcefg
Msg: The statement is executed successfully.


after fix:
![image](https://user-images.githubusercontent.com/17932988/186665183-91c32214-b269-426a-b8eb-f025458e8126.png)
