### PR TITLE
Optimize StateTracker for query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceManager.java
@@ -102,7 +102,7 @@ public class FragmentInstanceManager {
                 try {
                   DataDriver driver =
                       planner.plan(
-                          instance.getFragment().getRoot(),
+                          instance.getFragment().getPlanNodeTree(),
                           instance.getFragment().getTypeProvider(),
                           context,
                           instance.getTimeFilter(),
@@ -144,7 +144,7 @@ public class FragmentInstanceManager {
 
               try {
                 SchemaDriver driver =
-                    planner.plan(instance.getFragment().getRoot(), context, schemaRegion);
+                    planner.plan(instance.getFragment().getPlanNodeTree(), context, schemaRegion);
                 return createFragmentInstanceExecution(
                     scheduler,
                     instanceId,

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -368,6 +368,9 @@ public class QueryExecution implements IQueryExecution {
         stateMachine.transitionToFailed(e);
         Thread.currentThread().interrupt();
         throw new IoTDBException(e, TSStatusCode.QUERY_PROCESS_ERROR.getStatusCode());
+      } catch (Throwable t) {
+        stateMachine.transitionToFailed(t);
+        throw t;
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/DistributionPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/DistributionPlanner.java
@@ -73,6 +73,8 @@ public class DistributionPlanner {
           .setColumnToTsBlockIndexMap(rootWithExchange.getOutputColumnNames());
     }
     SubPlan subPlan = splitFragment(rootWithExchange);
+    // Mark the root Fragment of root SubPlan as `root`
+    subPlan.getPlanFragment().setRoot(true);
     List<FragmentInstance> fragmentInstances = planFragmentInstances(subPlan);
     // Only execute this step for READ operation
     if (context.getQueryType() == QueryType.READ) {
@@ -111,14 +113,14 @@ public class DistributionPlanner {
         context.getLocalDataBlockEndpoint(),
         context.getResultNodeContext().getVirtualFragmentInstanceId(),
         context.getResultNodeContext().getVirtualResultNodeId());
-    sinkNode.setChild(rootInstance.getFragment().getRoot());
+    sinkNode.setChild(rootInstance.getFragment().getPlanNodeTree());
     context
         .getResultNodeContext()
         .setUpStream(
             rootInstance.getHostDataNode().mPPDataExchangeEndPoint,
             rootInstance.getId(),
             sinkNode.getPlanNodeId());
-    rootInstance.getFragment().setRoot(sinkNode);
+    rootInstance.getFragment().setPlanNodeTree(sinkNode);
   }
 
   private PlanFragmentId getNextFragmentId() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
@@ -82,7 +82,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
   private void prepare() {
     List<PlanFragment> fragments = subPlan.getPlanFragmentList();
     for (PlanFragment fragment : fragments) {
-      recordPlanNodeRelation(fragment.getRoot(), fragment.getId());
+      recordPlanNodeRelation(fragment.getPlanNodeTree(), fragment.getId());
       produceFragmentInstance(fragment);
     }
   }
@@ -90,7 +90,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
   private void produceFragmentInstance(PlanFragment fragment) {
     // If one PlanFragment will produce several FragmentInstance, the instanceIdx will be increased
     // one by one
-    PlanNode rootCopy = PlanNodeUtil.deepCopy(fragment.getRoot());
+    PlanNode rootCopy = PlanNodeUtil.deepCopy(fragment.getPlanNodeTree());
     Filter timeFilter = analysis.getGlobalTimeFilter();
     FragmentInstance fragmentInstance =
         new FragmentInstance(
@@ -98,7 +98,8 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
             fragment.getId().genFragmentInstanceId(),
             timeFilter,
             queryContext.getQueryType(),
-            queryContext.getTimeOut());
+            queryContext.getTimeOut(),
+            fragment.isRoot());
 
     // Get the target region for origin PlanFragment, then its instance will be distributed one
     // of them.
@@ -174,7 +175,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
 
   private void calculateNodeTopologyBetweenInstance() {
     for (FragmentInstance instance : fragmentInstanceList) {
-      PlanNode rootNode = instance.getFragment().getRoot();
+      PlanNode rootNode = instance.getFragment().getPlanNodeTree();
       if (rootNode instanceof FragmentSinkNode) {
         // Set target Endpoint for FragmentSinkNode
         FragmentSinkNode sinkNode = (FragmentSinkNode) rootNode;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/WriteFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/WriteFragmentParallelPlanner.java
@@ -49,7 +49,7 @@ public class WriteFragmentParallelPlanner implements IFragmentParallelPlaner {
   public List<FragmentInstance> parallelPlan() {
     PlanFragment fragment = subPlan.getPlanFragment();
     Filter timeFilter = analysis.getGlobalTimeFilter();
-    PlanNode node = fragment.getRoot();
+    PlanNode node = fragment.getPlanNodeTree();
     if (!(node instanceof WritePlanNode)) {
       throw new IllegalArgumentException("PlanNode should be IWritePlanNode in WRITE operation");
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/FragmentInstance.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/FragmentInstance.java
@@ -63,6 +63,8 @@ public class FragmentInstance implements IConsensusRequest {
 
   private final long timeOut;
 
+  private boolean isRoot;
+
   // We can add some more params for a specific FragmentInstance
   // So that we can make different FragmentInstance owns different data range.
 
@@ -77,6 +79,18 @@ public class FragmentInstance implements IConsensusRequest {
     this.id = id;
     this.type = type;
     this.timeOut = timeOut > 0 ? timeOut : config.getQueryTimeoutThreshold();
+    this.isRoot = false;
+  }
+
+  public FragmentInstance(
+      PlanFragment fragment,
+      FragmentInstanceId id,
+      Filter timeFilter,
+      QueryType type,
+      long timeOut,
+      boolean isRoot) {
+    this(fragment, id, timeFilter, type, timeOut);
+    this.isRoot = isRoot;
   }
 
   public TRegionReplicaSet getDataRegionId() {
@@ -119,8 +133,12 @@ public class FragmentInstance implements IConsensusRequest {
     return id;
   }
 
+  public boolean isRoot() {
+    return isRoot;
+  }
+
   public String getDownstreamInfo() {
-    PlanNode root = getFragment().getRoot();
+    PlanNode root = getFragment().getPlanNodeTree();
     if (root instanceof FragmentSinkNode) {
       FragmentSinkNode sink = (FragmentSinkNode) root;
       return String.format(
@@ -158,7 +176,7 @@ public class FragmentInstance implements IConsensusRequest {
             "Region: %s ",
             getRegionReplicaSet() == null ? "Not set" : getRegionReplicaSet().getRegionId()));
     ret.append("\n---- Plan Node Tree ----\n");
-    ret.append(PlanNodeUtil.nodeToString(getFragment().getRoot()));
+    ret.append(PlanNodeUtil.nodeToString(getFragment().getPlanNodeTree()));
     ret.append(String.format("timeOut-%s:", getTimeOut()));
     return ret.toString();
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/PlanFragment.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/PlanFragment.java
@@ -69,10 +69,6 @@ public class PlanFragment {
     this.typeProvider = typeProvider;
   }
 
-  public void setId(PlanFragmentId id) {
-    this.id = id;
-  }
-
   public boolean isRoot() {
     return isRoot;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/PlanFragment.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/PlanFragment.java
@@ -37,24 +37,28 @@ import java.util.Objects;
 public class PlanFragment {
   // TODO once you add field for this class you need to change the serialize and deserialize methods
   private PlanFragmentId id;
-  private PlanNode root;
+  private PlanNode planNodeTree;
   private TypeProvider typeProvider;
 
-  public PlanFragment(PlanFragmentId id, PlanNode root) {
+  // indicate whether this PlanFragment is the root of the whole Fragment-Plan-Tree or not
+  private boolean isRoot;
+
+  public PlanFragment(PlanFragmentId id, PlanNode planNodeTree) {
     this.id = id;
-    this.root = root;
+    this.planNodeTree = planNodeTree;
+    this.isRoot = false;
   }
 
   public PlanFragmentId getId() {
     return id;
   }
 
-  public PlanNode getRoot() {
-    return root;
+  public PlanNode getPlanNodeTree() {
+    return planNodeTree;
   }
 
-  public void setRoot(PlanNode root) {
-    this.root = root;
+  public void setPlanNodeTree(PlanNode planNodeTree) {
+    this.planNodeTree = planNodeTree;
   }
 
   public TypeProvider getTypeProvider() {
@@ -63,6 +67,18 @@ public class PlanFragment {
 
   public void setTypeProvider(TypeProvider typeProvider) {
     this.typeProvider = typeProvider;
+  }
+
+  public void setId(PlanFragmentId id) {
+    this.id = id;
+  }
+
+  public boolean isRoot() {
+    return isRoot;
+  }
+
+  public void setRoot(boolean root) {
+    isRoot = root;
   }
 
   @Override
@@ -76,7 +92,7 @@ public class PlanFragment {
   // and the DataRegions of all SourceNodes should be same in one PlanFragment.
   // So we can use the DataRegion of one SourceNode as the PlanFragment's DataRegion.
   public TRegionReplicaSet getTargetRegion() {
-    return getNodeRegion(root);
+    return getNodeRegion(planNodeTree);
   }
 
   private TRegionReplicaSet getNodeRegion(PlanNode root) {
@@ -93,7 +109,7 @@ public class PlanFragment {
   }
 
   public PlanNode getPlanNodeById(PlanNodeId nodeId) {
-    return getPlanNodeById(root, nodeId);
+    return getPlanNodeById(planNodeTree, nodeId);
   }
 
   private PlanNode getPlanNodeById(PlanNode root, PlanNodeId nodeId) {
@@ -111,7 +127,7 @@ public class PlanFragment {
 
   public void serialize(ByteBuffer byteBuffer) {
     id.serialize(byteBuffer);
-    root.serialize(byteBuffer);
+    planNodeTree.serialize(byteBuffer);
     if (typeProvider == null) {
       ReadWriteIOUtils.write((byte) 0, byteBuffer);
     } else {
@@ -122,7 +138,7 @@ public class PlanFragment {
 
   public void serialize(DataOutputStream stream) throws IOException {
     id.serialize(stream);
-    root.serialize(stream);
+    planNodeTree.serialize(stream);
     if (typeProvider == null) {
       ReadWriteIOUtils.write((byte) 0, stream);
     } else {
@@ -160,11 +176,11 @@ public class PlanFragment {
       return false;
     }
     PlanFragment that = (PlanFragment) o;
-    return Objects.equals(id, that.id) && Objects.equals(root, that.root);
+    return Objects.equals(id, that.id) && Objects.equals(planNodeTree, that.planNodeTree);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, root);
+    return Objects.hash(id, planNodeTree);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/SubPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/SubPlan.java
@@ -44,7 +44,7 @@ public class SubPlan {
     result.append(
         String.format(
             "SubPlan-%s. RootNodeId: %s\n",
-            planFragment.getId(), planFragment.getRoot().getPlanNodeId()));
+            planFragment.getId(), planFragment.getPlanNodeTree().getPlanNodeId()));
     children.forEach(result::append);
     return result.toString();
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.db.mpp.common.MPPQueryContext;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.execution.QueryStateMachine;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInfo;
-import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceState;
 import org.apache.iotdb.db.mpp.plan.analyze.QueryType;
 import org.apache.iotdb.db.mpp.plan.planner.plan.FragmentInstance;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -131,10 +130,6 @@ public class ClusterScheduler implements IScheduler {
     // The FragmentInstances has been dispatched successfully to corresponding host, we mark the
     // QueryState to Running
     stateMachine.transitionToRunning();
-    instances.forEach(
-        instance -> {
-          stateMachine.initialFragInstanceState(instance.getId(), FragmentInstanceState.RUNNING);
-        });
 
     // TODO: (xingtanzjr) start the stateFetcher/heartbeat for each fragment instance
     this.stateTracker.start();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -172,7 +172,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
         case WRITE:
           TSendPlanNodeReq sendPlanNodeReq =
               new TSendPlanNodeReq(
-                  new TPlanNode(instance.getFragment().getRoot().serializeToByteBuffer()),
+                  new TPlanNode(instance.getFragment().getPlanNodeTree().serializeToByteBuffer()),
                   instance.getRegionReplicaSet().getRegionId());
           TSendPlanNodeResp sendPlanNodeResp = client.sendPlanNode(sendPlanNodeReq);
           if (!sendPlanNodeResp.accepted) {
@@ -256,7 +256,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
         }
         break;
       case WRITE:
-        PlanNode planNode = instance.getFragment().getRoot();
+        PlanNode planNode = instance.getFragment().getPlanNodeTree();
         boolean hasFailedMeasurement = false;
         String partialInsertMessage = null;
         if (planNode instanceof InsertNode) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/StandaloneScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/StandaloneScheduler.java
@@ -37,7 +37,6 @@ import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.execution.QueryStateMachine;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInfo;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceManager;
-import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceState;
 import org.apache.iotdb.db.mpp.plan.analyze.QueryType;
 import org.apache.iotdb.db.mpp.plan.analyze.SchemaValidator;
 import org.apache.iotdb.db.mpp.plan.planner.plan.FragmentInstance;
@@ -116,10 +115,6 @@ public class StandaloneScheduler implements IScheduler {
         // The FragmentInstances has been dispatched successfully to corresponding host, we mark the
         stateMachine.transitionToRunning();
         LOGGER.info("{} transit to RUNNING", getLogHeader());
-        instances.forEach(
-            instance ->
-                stateMachine.initialFragInstanceState(
-                    instance.getId(), FragmentInstanceState.RUNNING));
         this.stateTracker.start();
         LOGGER.info("{} state tracker starts", getLogHeader());
         break;
@@ -133,7 +128,7 @@ public class StandaloneScheduler implements IScheduler {
         }
         try {
           for (FragmentInstance fragmentInstance : instances) {
-            PlanNode planNode = fragmentInstance.getFragment().getRoot();
+            PlanNode planNode = fragmentInstance.getFragment().getPlanNodeTree();
             ConsensusGroupId groupId =
                 ConsensusGroupId.Factory.createFromTConsensusGroupId(
                     fragmentInstance.getRegionReplicaSet().getRegionId());

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -271,7 +271,6 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
   @Override
   public TCancelResp cancelQuery(TCancelQueryReq req) {
     try (SetThreadName threadName = new SetThreadName(req.getQueryId())) {
-      LOGGER.info("start cancelling query.");
       List<FragmentInstanceId> taskIds =
           req.getFragmentInstanceIds().stream()
               .map(FragmentInstanceId::fromThrift)
@@ -279,7 +278,6 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
       for (FragmentInstanceId taskId : taskIds) {
         FragmentInstanceManager.getInstance().cancelTask(taskId);
       }
-      LOGGER.info("finish cancelling query.");
       return new TCancelResp(true);
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/QueryStateMachineTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/QueryStateMachineTest.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.common.QueryId;
-import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceState;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -58,30 +57,6 @@ public class QueryStateMachineTest {
     stateMachine = genQueryStateMachine();
     stateMachine.transitionToFinished();
     Assert.assertEquals(stateMachine.getState(), QueryState.FINISHED);
-  }
-
-  @Test
-  public void TestFragmentInstanceToFinished() {
-    List<FragmentInstanceId> instanceIds = genFragmentInstanceIdList();
-    QueryStateMachine stateMachine = genQueryStateMachine();
-    for (FragmentInstanceId id : instanceIds) {
-      stateMachine.initialFragInstanceState(id, FragmentInstanceState.RUNNING);
-    }
-    for (FragmentInstanceId id : instanceIds) {
-      stateMachine.updateFragInstanceState(id, FragmentInstanceState.FINISHED);
-    }
-    Assert.assertEquals(stateMachine.getState(), QueryState.FINISHED);
-  }
-
-  @Test
-  public void TestFragmentInstanceToTerminalState() {
-    List<FragmentInstanceId> instanceIds = genFragmentInstanceIdList();
-    QueryStateMachine stateMachine = genQueryStateMachine();
-    for (FragmentInstanceId id : instanceIds) {
-      stateMachine.initialFragInstanceState(id, FragmentInstanceState.RUNNING);
-    }
-    stateMachine.updateFragInstanceState(instanceIds.get(0), FragmentInstanceState.FAILED);
-    Assert.assertEquals(stateMachine.getState(), QueryState.FAILED);
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/AggregationDistributionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/AggregationDistributionTest.java
@@ -88,7 +88,8 @@ public class AggregationDistributionTest {
     expectedStep.put(d1s1Path, AggregationStep.PARTIAL);
     expectedStep.put(d2s1Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
   }
 
   private void verifyAggregationStep(Map<String, AggregationStep> expected, PlanNode root) {
@@ -138,13 +139,14 @@ public class AggregationDistributionTest {
     expectedStep.put(d1s1Path, AggregationStep.PARTIAL);
     expectedStep.put(d3s1Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
     AggregationNode aggregationNode =
         (AggregationNode)
             fragmentInstances
                 .get(0)
                 .getFragment()
-                .getRoot()
+                .getPlanNodeTree()
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -175,7 +177,8 @@ public class AggregationDistributionTest {
     expectedStep.put(d1s1Path, AggregationStep.PARTIAL);
     expectedStep.put(d3s1Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
   }
 
   @Test
@@ -198,7 +201,8 @@ public class AggregationDistributionTest {
     expectedStep.put(d3s1Path, AggregationStep.PARTIAL);
     expectedStep.put(d4s1Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
   }
 
   @Test
@@ -235,7 +239,8 @@ public class AggregationDistributionTest {
     expectedStep.put(d1s1Path, AggregationStep.PARTIAL);
     expectedStep.put(d2s1Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
   }
 
   @Test
@@ -272,19 +277,22 @@ public class AggregationDistributionTest {
     expectedStep.put(d3s1Path, AggregationStep.PARTIAL);
     expectedStep.put(d4s1Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
 
     Map<String, List<String>> expectedDescriptorValue = new HashMap<>();
     expectedDescriptorValue.put(groupedPath, Arrays.asList(groupedPath, d3s1Path, d4s1Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue,
-        (GroupByLevelNode) fragmentInstances.get(0).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(0).getFragment().getPlanNodeTree().getChildren().get(0));
 
     Map<String, List<String>> expectedDescriptorValue2 = new HashMap<>();
     expectedDescriptorValue2.put(groupedPath, Arrays.asList(d3s1Path, d4s1Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue2,
-        (GroupByLevelNode) fragmentInstances.get(1).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(1).getFragment().getPlanNodeTree().getChildren().get(0));
   }
 
   @Test
@@ -332,19 +340,22 @@ public class AggregationDistributionTest {
     expectedStep.put(d3s1Path, AggregationStep.PARTIAL);
     expectedStep.put(d4s1Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
 
     Map<String, List<String>> expectedDescriptorValue = new HashMap<>();
     expectedDescriptorValue.put(groupedPath, Arrays.asList(groupedPath, d3s1Path, d4s1Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue,
-        (GroupByLevelNode) fragmentInstances.get(0).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(0).getFragment().getPlanNodeTree().getChildren().get(0));
 
     Map<String, List<String>> expectedDescriptorValue2 = new HashMap<>();
     expectedDescriptorValue2.put(groupedPath, Arrays.asList(d3s1Path, d4s1Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue2,
-        (GroupByLevelNode) fragmentInstances.get(1).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(1).getFragment().getPlanNodeTree().getChildren().get(0));
 
     verifySlidingWindowDescriptor(
         Arrays.asList(d3s1Path, d4s1Path),
@@ -352,7 +363,7 @@ public class AggregationDistributionTest {
             fragmentInstances
                 .get(0)
                 .getFragment()
-                .getRoot()
+                .getPlanNodeTree()
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -363,7 +374,7 @@ public class AggregationDistributionTest {
             fragmentInstances
                 .get(1)
                 .getFragment()
-                .getRoot()
+                .getPlanNodeTree()
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -408,21 +419,24 @@ public class AggregationDistributionTest {
     expectedStep.put(d1s1Path, AggregationStep.PARTIAL);
     expectedStep.put(d1s2Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
 
     Map<String, List<String>> expectedDescriptorValue = new HashMap<>();
     expectedDescriptorValue.put(groupedPathS1, Arrays.asList(groupedPathS1, d1s1Path));
     expectedDescriptorValue.put(groupedPathS2, Arrays.asList(groupedPathS2, d1s2Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue,
-        (GroupByLevelNode) fragmentInstances.get(0).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(0).getFragment().getPlanNodeTree().getChildren().get(0));
 
     Map<String, List<String>> expectedDescriptorValue2 = new HashMap<>();
     expectedDescriptorValue2.put(groupedPathS1, Collections.singletonList(d1s1Path));
     expectedDescriptorValue2.put(groupedPathS2, Collections.singletonList(d1s2Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue2,
-        (GroupByLevelNode) fragmentInstances.get(1).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(1).getFragment().getPlanNodeTree().getChildren().get(0));
   }
 
   @Test
@@ -468,21 +482,24 @@ public class AggregationDistributionTest {
     expectedStep.put(d1s2Path, AggregationStep.PARTIAL);
     expectedStep.put(d2s1Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
 
     Map<String, List<String>> expectedDescriptorValue = new HashMap<>();
     expectedDescriptorValue.put(groupedPathS1, Arrays.asList(groupedPathS1, d1s1Path, d2s1Path));
     expectedDescriptorValue.put(groupedPathS2, Arrays.asList(groupedPathS2, d1s2Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue,
-        (GroupByLevelNode) fragmentInstances.get(0).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(0).getFragment().getPlanNodeTree().getChildren().get(0));
 
     Map<String, List<String>> expectedDescriptorValue2 = new HashMap<>();
     expectedDescriptorValue2.put(groupedPathS1, Collections.singletonList(d1s1Path));
     expectedDescriptorValue2.put(groupedPathS2, Collections.singletonList(d1s2Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue2,
-        (GroupByLevelNode) fragmentInstances.get(2).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(2).getFragment().getPlanNodeTree().getChildren().get(0));
   }
 
   @Test
@@ -540,27 +557,31 @@ public class AggregationDistributionTest {
     expectedStep.put(d1s2Path, AggregationStep.PARTIAL);
     expectedStep.put(d2s1Path, AggregationStep.PARTIAL);
     List<FragmentInstance> fragmentInstances = plan.getInstances();
-    fragmentInstances.forEach(f -> verifyAggregationStep(expectedStep, f.getFragment().getRoot()));
+    fragmentInstances.forEach(
+        f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
 
     Map<String, List<String>> expectedDescriptorValue = new HashMap<>();
     expectedDescriptorValue.put(groupedPathS1, Arrays.asList(groupedPathS1, d1s1Path));
     expectedDescriptorValue.put(groupedPathS2, Arrays.asList(groupedPathS2, d1s2Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue,
-        (GroupByLevelNode) fragmentInstances.get(0).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(0).getFragment().getPlanNodeTree().getChildren().get(0));
 
     Map<String, List<String>> expectedDescriptorValue2 = new HashMap<>();
     expectedDescriptorValue2.put(groupedPathS1, Collections.singletonList(d2s1Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue2,
-        (GroupByLevelNode) fragmentInstances.get(1).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(1).getFragment().getPlanNodeTree().getChildren().get(0));
 
     Map<String, List<String>> expectedDescriptorValue3 = new HashMap<>();
     expectedDescriptorValue3.put(groupedPathS1, Collections.singletonList(d1s1Path));
     expectedDescriptorValue3.put(groupedPathS2, Collections.singletonList(d1s2Path));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue3,
-        (GroupByLevelNode) fragmentInstances.get(2).getFragment().getRoot().getChildren().get(0));
+        (GroupByLevelNode)
+            fragmentInstances.get(2).getFragment().getPlanNodeTree().getChildren().get(0));
 
     verifySlidingWindowDescriptor(
         Arrays.asList(d1s1Path, d1s2Path),
@@ -568,7 +589,7 @@ public class AggregationDistributionTest {
             fragmentInstances
                 .get(0)
                 .getFragment()
-                .getRoot()
+                .getPlanNodeTree()
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -579,7 +600,7 @@ public class AggregationDistributionTest {
             fragmentInstances
                 .get(1)
                 .getFragment()
-                .getRoot()
+                .getPlanNodeTree()
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -590,7 +611,7 @@ public class AggregationDistributionTest {
             fragmentInstances
                 .get(2)
                 .getFragment()
-                .getRoot()
+                .getPlanNodeTree()
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -610,7 +631,8 @@ public class AggregationDistributionTest {
         new DistributionPlanner(analysis, new LogicalQueryPlan(context, root));
     DistributedQueryPlan plan = planner.planFragments();
     assertEquals(1, plan.getInstances().size());
-    assertEquals(root, plan.getInstances().get(0).getFragment().getRoot().getChildren().get(0));
+    assertEquals(
+        root, plan.getInstances().get(0).getFragment().getPlanNodeTree().getChildren().get(0));
   }
 
   private void verifyGroupByLevelDescriptor(

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/LastQueryTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/LastQueryTest.java
@@ -62,7 +62,13 @@ public class LastQueryTest {
     DistributedQueryPlan distributedQueryPlan = planner.planFragments();
     Assert.assertEquals(1, distributedQueryPlan.getInstances().size());
     Assert.assertTrue(
-        distributedQueryPlan.getInstances().get(0).getFragment().getRoot().getChildren().get(0)
+        distributedQueryPlan
+                .getInstances()
+                .get(0)
+                .getFragment()
+                .getPlanNodeTree()
+                .getChildren()
+                .get(0)
             instanceof LastQueryNode);
   }
 
@@ -80,7 +86,13 @@ public class LastQueryTest {
     DistributedQueryPlan distributedQueryPlan = planner.planFragments();
     Assert.assertEquals(2, distributedQueryPlan.getInstances().size());
     PlanNode rootNode =
-        distributedQueryPlan.getInstances().get(0).getFragment().getRoot().getChildren().get(0);
+        distributedQueryPlan
+            .getInstances()
+            .get(0)
+            .getFragment()
+            .getPlanNodeTree()
+            .getChildren()
+            .get(0);
     Assert.assertTrue(rootNode instanceof LastQueryMergeNode);
     rootNode
         .getChildren()
@@ -104,7 +116,13 @@ public class LastQueryTest {
     DistributedQueryPlan distributedQueryPlan = planner.planFragments();
     Assert.assertEquals(3, distributedQueryPlan.getInstances().size());
     PlanNode rootNode =
-        distributedQueryPlan.getInstances().get(0).getFragment().getRoot().getChildren().get(0);
+        distributedQueryPlan
+            .getInstances()
+            .get(0)
+            .getFragment()
+            .getPlanNodeTree()
+            .getChildren()
+            .get(0);
     Assert.assertTrue(rootNode instanceof LastQueryMergeNode);
     rootNode
         .getChildren()
@@ -128,7 +146,13 @@ public class LastQueryTest {
     DistributedQueryPlan distributedQueryPlan = planner.planFragments();
     Assert.assertEquals(2, distributedQueryPlan.getInstances().size());
     PlanNode rootNode =
-        distributedQueryPlan.getInstances().get(0).getFragment().getRoot().getChildren().get(0);
+        distributedQueryPlan
+            .getInstances()
+            .get(0)
+            .getFragment()
+            .getPlanNodeTree()
+            .getChildren()
+            .get(0);
     Assert.assertTrue(rootNode instanceof LastQueryMergeNode);
     rootNode
         .getChildren()
@@ -156,7 +180,13 @@ public class LastQueryTest {
     DistributedQueryPlan distributedQueryPlan = planner.planFragments();
     Assert.assertEquals(2, distributedQueryPlan.getInstances().size());
     PlanNode rootNode =
-        distributedQueryPlan.getInstances().get(0).getFragment().getRoot().getChildren().get(0);
+        distributedQueryPlan
+            .getInstances()
+            .get(0)
+            .getFragment()
+            .getPlanNodeTree()
+            .getChildren()
+            .get(0);
     Assert.assertTrue(rootNode instanceof LastQueryCollectNode);
     rootNode
         .getChildren()


### PR DESCRIPTION
## Description
1. Fix the bug that the state of FragmentInstance is always printed when fetched.
2. Add the logic of FINISH judgement of Query. That is, if all the `root` instance are finished, the query can be transited to FINISHED instead of judging all the FragmentInstances.
3. Transit query into `Failed` state when some unexpected exception occurs during waiting the batch result to unblock client RPC.
4. Rename `root` to `planNodeTree` in `PlanFragment`

**Basic Test**：
<img width="944" alt="image" src="https://user-images.githubusercontent.com/18027703/185875888-3f06e5b6-973e-48a6-9999-1cd51b6fb1f7.png">
