### PR TITLE
Thrift only generates Python and Go code for session client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1344,6 +1344,7 @@
                                     <generator>py</generator>
                                     <thriftExecutable>${thrift.exec.absolute.path}</thriftExecutable>
                                     <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
+                                    <includes>**/common.thrift,**/client.thrift</includes>
                                     <outputDirectory>${project.build.directory}/generated-sources-python/</outputDirectory>
                                 </configuration>
                             </execution>
@@ -1357,6 +1358,7 @@
                                     <generator>go</generator>
                                     <thriftExecutable>${thrift.exec.absolute.path}</thriftExecutable>
                                     <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
+                                    <includes>**/common.thrift,**/client.thrift</includes>
                                     <outputDirectory>${project.build.directory}/generated-sources-go</outputDirectory>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
## Description

After this change, thrift will generates Python and Go code for session client only.

The Python and Go code for node communication is unnecessary. 

<img width="420" alt="image" src="https://user-images.githubusercontent.com/25913899/186367313-c00b0028-f286-45c0-871f-980898fabe8e.png">
