### PR TITLE
[To rel/0.13][IOTDB-4222] Create data region repeatedly when concurrently deleting and creating storage groups

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/StorageGroupManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/StorageGroupManager.java
@@ -156,7 +156,6 @@ public class StorageGroupManager {
    * @return virtual storage group processor
    */
   @SuppressWarnings("java:S2445")
-  // actually storageGroupMNode is a unique object on the mtree, synchronize it is reasonable
   public VirtualStorageGroupProcessor getProcessor(
       PartialPath partialPath, IStorageGroupMNode storageGroupMNode)
       throws StorageGroupProcessorException, StorageEngineException {
@@ -166,7 +165,9 @@ public class StorageGroupManager {
     if (processor == null) {
       // if finish recover
       if (isVsgReady[loc].get()) {
-        synchronized (storageGroupMNode) {
+        // it's unsafe to synchronize MNode here because
+        // concurrent deletions and creates will create a new MNode
+        synchronized (isVsgReady[loc]) {
           processor = virtualStorageGroupProcessor[loc];
           if (processor == null) {
             processor =

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/StorageGroupManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/virtualSg/StorageGroupManager.java
@@ -166,7 +166,7 @@ public class StorageGroupManager {
       // if finish recover
       if (isVsgReady[loc].get()) {
         // it's unsafe to synchronize MNode here because
-        // concurrent deletions and creates will create a new MNode
+        // concurrent deletions and creations will create a new MNode
         synchronized (isVsgReady[loc]) {
           processor = virtualStorageGroupProcessor[loc];
           if (processor == null) {


### PR DESCRIPTION
Synchronize ready condition rather than MNode.