### PR TITLE
[IOTDB-4185] Prevent RatisConsensus Start Race

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -169,6 +169,9 @@ public class ConfigManager implements IManager {
     this.procedureManager = new ProcedureManager(this, procedureInfo);
     this.udfManager = new UDFManager(this, udfInfo);
     this.loadManager = new LoadManager(this);
+
+    // ConsensusManager must be initialized last, as it would load states from disk and reinitialize
+    // above managers
     this.consensusManager = new ConsensusManager(this, stateMachine);
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
@@ -68,6 +68,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -432,14 +433,18 @@ public class NodeManager {
 
   /** loop body of the heartbeat thread */
   private void heartbeatLoopBody() {
-    if (getConsensusManager().isLeader()) {
-      // Generate HeartbeatReq
-      THeartbeatReq heartbeatReq = genHeartbeatReq();
-      // Send heartbeat requests to all the registered DataNodes
-      pingRegisteredDataNodes(heartbeatReq, getRegisteredDataNodes());
-      // Send heartbeat requests to all the registered ConfigNodes
-      pingRegisteredConfigNodes(heartbeatReq, getRegisteredConfigNodes());
-    }
+    Optional.ofNullable(getConsensusManager())
+        .ifPresent(
+            consensusManager -> {
+              if (getConsensusManager().isLeader()) {
+                // Generate HeartbeatReq
+                THeartbeatReq heartbeatReq = genHeartbeatReq();
+                // Send heartbeat requests to all the registered DataNodes
+                pingRegisteredDataNodes(heartbeatReq, getRegisteredDataNodes());
+                // Send heartbeat requests to all the registered ConfigNodes
+                pingRegisteredConfigNodes(heartbeatReq, getRegisteredConfigNodes());
+              }
+            });
   }
 
   private THeartbeatReq genHeartbeatReq() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
@@ -433,6 +433,7 @@ public class NodeManager {
 
   /** loop body of the heartbeat thread */
   private void heartbeatLoopBody() {
+    // the consensusManager of configManager may not be fully initialized at this time
     Optional.ofNullable(getConsensusManager())
         .ifPresent(
             consensusManager -> {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/PartitionManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/PartitionManager.java
@@ -497,6 +497,7 @@ public class PartitionManager {
 
   /** Called by {@link PartitionManager#regionCleaner} Delete RegionGroups periodically. */
   public void clearDeletedRegions() {
+    // the consensusManager of configManager may not be fully initialized at this time
     Optional.ofNullable(getConsensusManager())
         .ifPresent(
             consensusManager -> {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/PartitionManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/PartitionManager.java
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -496,19 +497,23 @@ public class PartitionManager {
 
   /** Called by {@link PartitionManager#regionCleaner} Delete RegionGroups periodically. */
   public void clearDeletedRegions() {
-    if (getConsensusManager().isLeader()) {
-      final Set<TRegionReplicaSet> deletedRegionSet = partitionInfo.getDeletedRegionSet();
-      if (!deletedRegionSet.isEmpty()) {
-        LOGGER.info(
-            "DELETE REGIONS {} START",
-            deletedRegionSet.stream()
-                .map(TRegionReplicaSet::getRegionId)
-                .collect(Collectors.toList()));
-        deletedRegionSet.forEach(
-            regionReplicaSet -> removeRegionGroupCache(regionReplicaSet.regionId));
-        SyncDataNodeClientPool.getInstance().deleteRegions(deletedRegionSet);
-      }
-    }
+    Optional.ofNullable(getConsensusManager())
+        .ifPresent(
+            consensusManager -> {
+              if (getConsensusManager().isLeader()) {
+                final Set<TRegionReplicaSet> deletedRegionSet = partitionInfo.getDeletedRegionSet();
+                if (!deletedRegionSet.isEmpty()) {
+                  LOGGER.info(
+                      "DELETE REGIONS {} START",
+                      deletedRegionSet.stream()
+                          .map(TRegionReplicaSet::getRegionId)
+                          .collect(Collectors.toList()));
+                  deletedRegionSet.forEach(
+                      regionReplicaSet -> removeRegionGroupCache(regionReplicaSet.regionId));
+                  SyncDataNodeClientPool.getInstance().deleteRegions(deletedRegionSet);
+                }
+              }
+            });
   }
 
   public void startRegionCleaner() {


### PR DESCRIPTION
Race condition detected as follows:
1. PartitionRegionStateMachine is initialized.
2. ConsensusManager constructor is called, but not returned.
3. Inside ConsensusManager ctor, RaftServer is initialized in ConsensusManager and start election.
4. Inside ConsensusManager ctor, RaftServer is elected and notifies PartitionRegionStateMachine.
5. PartitionRegionStateMachine starts heartbeat service, which uses ConsensusManager.
6. However, in Step5, ConsensusManager Constructor is not returned, which means the ref is null. It can cause NPE