### PR TITLE
[IOTDB-4218] Print Ratis Request Exception full stack

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/exception/ConsensusException.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/exception/ConsensusException.java
@@ -28,4 +28,8 @@ public class ConsensusException extends Exception {
   public ConsensusException(String message, Throwable cause) {
     super(message, cause);
   }
+
+  public ConsensusException(Throwable cause) {
+    super(cause);
+  }
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/exception/RatisRequestFailedException.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/exception/RatisRequestFailedException.java
@@ -21,6 +21,6 @@ package org.apache.iotdb.consensus.exception;
 public class RatisRequestFailedException extends ConsensusException {
 
   public RatisRequestFailedException(Exception cause) {
-    super("Ratis request failed", cause);
+    super(cause);
   }
 }


### PR DESCRIPTION
Current constructor in RatisRequestFailedException uses (message, cause) as parameters. According to `Exception` class, when a message is given, cause will not be printed. I delete the message to enable a full stack of cause.
 