### PR TITLE
[IOTDB-4234] implicit definition of token PIPESERVER in parser

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IdentifierParser.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IdentifierParser.g4
@@ -116,7 +116,6 @@ keyWords
     | PATHS
     | PIPE
     | PIPES
-    | PIPESERVER
     | PIPESINK
     | PIPESINKS
     | PIPESINKTYPE


### PR DESCRIPTION
![5701661398067_ pic](https://user-images.githubusercontent.com/25913899/186570517-b9ef940d-ce3d-4729-8582-4c676751d851.jpg)
