### PR TITLE
[IOTDB-4235] Fix deadlock in cancel query and timeout detect thread

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskThread.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskThread.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.mpp.execution.schedule;
 
+import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.mpp.execution.driver.IDriver;
 import org.apache.iotdb.db.mpp.execution.schedule.queue.IndexedBlockingQueue;
@@ -25,7 +26,6 @@ import org.apache.iotdb.db.mpp.execution.schedule.task.DriverTask;
 import org.apache.iotdb.db.utils.stats.CpuTimer;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import io.airlift.concurrent.SetThreadName;
 import io.airlift.units.Duration;
 
@@ -40,8 +40,9 @@ public class DriverTaskThread extends AbstractDriverThread {
           IoTDBDescriptor.getInstance().getConfig().getDriverTaskExecutionTimeSliceInMs(),
           TimeUnit.MILLISECONDS);
 
-  // As the callback is lightweight enough, there's no need to use another one thread to execute.
-  private static final Executor listeningExecutor = MoreExecutors.directExecutor();
+  // we manage thread pool size directly, so create an unlimited pool
+  private static final Executor listeningExecutor =
+      IoTDBThreadPoolFactory.newCachedThreadPool("scheduler-notification");
 
   public DriverTaskThread(
       String workerId,

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskTimeoutSentinelThreadTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskTimeoutSentinelThreadTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mockito;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 public class DriverTaskTimeoutSentinelThreadTest {
 
@@ -218,6 +219,7 @@ public class DriverTaskTimeoutSentinelThreadTest {
     Mockito.verify(mockScheduler, Mockito.never()).runningToReady(Mockito.any(), Mockito.any());
     Mockito.verify(mockScheduler, Mockito.times(1)).runningToBlocked(Mockito.any(), Mockito.any());
     Mockito.verify(mockScheduler, Mockito.never()).runningToFinished(Mockito.any(), Mockito.any());
+    TimeUnit.MILLISECONDS.sleep(500);
     Mockito.verify(mockScheduler, Mockito.times(1)).blockedToReady(Mockito.any());
   }
 


### PR DESCRIPTION
details can be seen in this [feishu](https://apache-iotdb.feishu.cn/docx/doxcnbUyfLosIQhnjn6kQAOceCe) doc