### PR TITLE
[IOTDB-4225] Fix QueryContext occupies too much memory

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/context/QueryContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/context/QueryContext.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.db.query.control.QueryTimeManager;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +91,10 @@ public class QueryContext {
    * them from 'modFile' and put then into the cache.
    */
   public List<Modification> getPathModifications(ModificationFile modFile, PartialPath path) {
+    // if the mods file does not exist, do not add it to the cache
+    if (!modFile.exists()) {
+      return Collections.emptyList();
+    }
     Map<String, List<Modification>> fileModifications =
         filePathModCache.computeIfAbsent(modFile.getFilePath(), k -> new ConcurrentHashMap<>());
     return fileModifications.computeIfAbsent(


### PR DESCRIPTION
See [IOTDB-4225](https://issues.apache.org/jira/browse/IOTDB-4225).

It's the same as [PR-7113](https://github.com/apache/iotdb/pull/7113)