### PR TITLE
Guarantee Atomicity in Ratis InstallSnapshot RPC

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -123,7 +123,7 @@ public class SnapshotStorage implements StateMachineStorage {
         continue;
       }
       FileInfo fileInfo = new FileInfoWithDelayedMd5Computing(file);
-      if (file.toFile().getName().matches(getMetafileMatcherRegex())) {
+      if (file.toFile().getName().startsWith(META_FILE_PREFIX)) {
         metafileInfo = fileInfo;
       } else {
         fileInfos.add(fileInfo);
@@ -183,11 +183,6 @@ public class SnapshotStorage implements StateMachineStorage {
     return snapshotDir.getAbsolutePath() + File.separator + META_FILE_PREFIX + termIndexMetadata;
   }
 
-  private String getMetafileMatcherRegex() {
-    // meta file should always end with term_index
-    return META_FILE_PREFIX + "\\d+_\\d+$";
-  }
-
   /**
    * After leader InstallSnapshot to a slow follower, Ratis will put all snapshot files directly
    * under statemachineDir. We need to handle this special scenario and rearrange these files to
@@ -196,7 +191,7 @@ public class SnapshotStorage implements StateMachineStorage {
    */
   void moveSnapshotFileToSubDirectory() {
     File[] potentialMetafile =
-        stateMachineDir.listFiles((dir, name) -> name.matches(getMetafileMatcherRegex()));
+        stateMachineDir.listFiles((dir, name) -> name.startsWith(META_FILE_PREFIX));
     if (potentialMetafile == null || potentialMetafile.length == 0) {
       // the statemachine dir contains no direct metafile
       return;

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -117,13 +117,20 @@ public class SnapshotStorage implements StateMachineStorage {
     }
 
     List<FileInfo> fileInfos = new ArrayList<>();
+    FileInfo metafileInfo = null;
     for (Path file : actualSnapshotFiles) {
       if (file.endsWith(".md5")) {
         continue;
       }
       FileInfo fileInfo = new FileInfoWithDelayedMd5Computing(file);
-      fileInfos.add(fileInfo);
+      if (file.toFile().getName().matches(getMetafileMatcherRegex())) {
+        metafileInfo = fileInfo;
+      } else {
+        fileInfos.add(fileInfo);
+      }
     }
+    // metafile should be sent last for atomicity considerations
+    fileInfos.add(metafileInfo);
 
     return new FileListSnapshotInfo(
         fileInfos, snapshotTermIndex.getTerm(), snapshotTermIndex.getIndex());

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
@@ -118,6 +118,10 @@ public class SnapshotTest {
     SnapshotInfo info = proxy.getLatestSnapshot();
     Assert.assertEquals(info.getTerm(), 616);
     Assert.assertEquals(info.getIndex(), 4217);
+    // metafile must be the last file in SnapshotInfo for atomicity consideration
+    Path last = info.getFiles().get(info.getFiles().size() - 1).getPath();
+    Assert.assertEquals(
+        last.toFile().getName(), new File(getSnapshotMetaFilename("616_4217")).getName());
 
     // clean up
     proxy.getStateMachineStorage().cleanupOldSnapshots(null);
@@ -190,7 +194,7 @@ public class SnapshotTest {
     String actualSnapshotName =
         CrossDiskLinkStatemachine.ensureSnapshotFileName(testDir, "20_1005");
     File actualSnapshotFile = new File(actualSnapshotName);
-    Assert.assertEquals(proxy.getLatestSnapshot().getFiles().size(), 1);
+    Assert.assertEquals(proxy.getLatestSnapshot().getFiles().size(), 2);
     Assert.assertEquals(
         proxy.getLatestSnapshot().getFiles().get(0).getPath().toFile().getAbsolutePath(),
         actualSnapshotFile.getAbsolutePath());


### PR DESCRIPTION
Currently RatisConsensus uses a metafile to control snapshot atomicity. That is, a metafile is added to snapshot directory last, and we judge a snapshot directory's completeness by the existence of this metafile.
Therefore, we have to guarantee this order when sending snapshot directory via network. That is, the metafile must be transmitted last.