### PR TITLE
[IOTDB-4114] Add safety check for createPeer

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -38,6 +38,7 @@ import org.apache.iotdb.consensus.common.response.ConsensusReadResponse;
 import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
 import org.apache.iotdb.consensus.config.ConsensusConfig;
 import org.apache.iotdb.consensus.exception.ConsensusException;
+import org.apache.iotdb.consensus.exception.ConsensusGroupAlreadyExistException;
 import org.apache.iotdb.consensus.exception.ConsensusGroupNotExistException;
 import org.apache.iotdb.consensus.exception.PeerAlreadyInConsensusGroupException;
 import org.apache.iotdb.consensus.exception.PeerNotInConsensusGroupException;
@@ -255,6 +256,12 @@ class RatisConsensus implements IConsensus {
     // pre-conditions: myself in this new group
     if (!group.getPeers().contains(myself)) {
       return failed(new ConsensusGroupNotExistException(groupId));
+    }
+    RaftGroupId raftGroupId = Utils.fromConsensusGroupIdToRaftGroupId(groupId);
+    RaftGroup existGroup = getGroupInfo(raftGroupId);
+    // pre-conditions: the new group not exists
+    if (existGroup != null) {
+      return failed(new ConsensusGroupAlreadyExistException(groupId));
     }
 
     // add RaftPeer myself to this RaftGroup

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -26,10 +26,12 @@ import org.apache.iotdb.consensus.IConsensus;
 import org.apache.iotdb.consensus.common.ConsensusGroup;
 import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.common.request.ByteBufferConsensusRequest;
+import org.apache.iotdb.consensus.common.response.ConsensusGenericResponse;
 import org.apache.iotdb.consensus.common.response.ConsensusReadResponse;
 import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
 import org.apache.iotdb.consensus.config.ConsensusConfig;
 import org.apache.iotdb.consensus.config.RatisConfig;
+import org.apache.iotdb.consensus.exception.ConsensusGroupAlreadyExistException;
 
 import org.apache.ratis.util.FileUtils;
 import org.junit.After;
@@ -183,6 +185,18 @@ public class RatisConsensusTest {
     servers.get(1).createPeer(group.getGroupId(), group.getPeers());
     servers.get(2).createPeer(group.getGroupId(), group.getPeers());
     doConsensus(servers.get(0), gid, 10, 210);
+  }
+
+  @Test
+  public void createPeerMultipleTimes() {
+    List<Peer> singleMemberGroup = peers.subList(0, 1);
+
+    ConsensusGenericResponse resp = servers.get(0).createPeer(gid, singleMemberGroup);
+    Assert.assertTrue(resp.isSuccess());
+
+    ConsensusGenericResponse addAgainResp = servers.get(0).createPeer(gid, singleMemberGroup);
+    Assert.assertFalse(addAgainResp.isSuccess());
+    Assert.assertTrue(addAgainResp.getException() instanceof ConsensusGroupAlreadyExistException);
   }
 
   private void doConsensus(IConsensus consensus, ConsensusGroupId gid, int count, int target)


### PR DESCRIPTION
When ConfigNode or DataNode calls `Consensus.createPeer` twice with exact groupID, `RatisConsensus` will allow the second `createPeer` to be executed. This will cause unexpected errors, as overlapping files could interfere each other.
In this PR I propose to add a pre-condition check in `createPeer` so that the same Peer will not be created twice on one node.