### PR TITLE
[IOTDB-3642] Enable larger queue size

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
@@ -515,8 +515,8 @@ public class RatisConfig {
 
     public static class Builder {
       private boolean useMemory = false;
-      private int queueElementLimit = 4096;
-      private SizeInBytes queueByteLimit = SizeInBytes.valueOf("64MB");
+      private int queueElementLimit = 8192;
+      private SizeInBytes queueByteLimit = SizeInBytes.valueOf("96MB");
       private int purgeGap = 1024;
       private boolean purgeUptoSnapshotIndex = true;
       private SizeInBytes segmentSizeMax = SizeInBytes.valueOf("24MB");


### PR DESCRIPTION
Sometimes RatisConsensus.write would return failure if too much previous requests are pending. I enlarged the max queueing requests and max queueing bytes to reduce the probability of failure. Besides, **upper layers should adopt backoff retry mechanism to 100% guarantee requests be written**.