### PR TITLE
[IOTDB-4244] Optimize csv tool, add Options '-typeInfer' , '-linesPer…

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
+++ b/cli/src/main/java/org/apache/iotdb/tool/AbstractCsvTool.java
@@ -214,26 +214,74 @@ public abstract class AbstractCsvTool {
   public static Boolean writeCsvFile(
       List<String> headerNames, List<List<Object>> records, String filePath) {
     try {
-      CSVPrinter printer =
+      final CSVPrinterWrapper csvPrinterWrapper = new CSVPrinterWrapper(filePath);
+      if (headerNames != null) {
+        csvPrinterWrapper.printRecord(headerNames);
+      }
+      for (List record : records) {
+        csvPrinterWrapper.printRecord(record);
+      }
+      csvPrinterWrapper.flush();
+      csvPrinterWrapper.close();
+      return true;
+    } catch (IOException e) {
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  static class CSVPrinterWrapper {
+    private final String filePath;
+    private final CSVFormat csvFormat;
+    private CSVPrinter csvPrinter;
+
+    public CSVPrinterWrapper(String filePath) {
+      this.filePath = filePath;
+      this.csvFormat =
           CSVFormat.Builder.create(CSVFormat.DEFAULT)
               .setHeader()
               .setSkipHeaderRecord(true)
               .setEscape('\\')
               .setQuoteMode(QuoteMode.NONE)
-              .build()
-              .print(new PrintWriter(filePath));
-      if (headerNames != null) {
-        printer.printRecord(headerNames);
+              .build();
+    }
+
+    public void printRecord(final Iterable<?> values) throws IOException {
+      if (csvPrinter == null) {
+        csvPrinter = csvFormat.print(new PrintWriter(filePath));
       }
-      for (List record : records) {
-        printer.printRecord(record);
+      csvPrinter.printRecord(values);
+    }
+
+    public void print(Object value) {
+      if (csvPrinter == null) {
+        try {
+          csvPrinter = csvFormat.print(new PrintWriter(filePath));
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
       }
-      printer.flush();
-      printer.close();
-      return true;
-    } catch (IOException e) {
-      e.printStackTrace();
-      return false;
+      try {
+        csvPrinter.print(value);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    public void println() throws IOException {
+      csvPrinter.println();
+    }
+
+    public void close() throws IOException {
+      if (csvPrinter != null) {
+        csvPrinter.close();
+      }
+    }
+
+    public void flush() throws IOException {
+      if (csvPrinter != null) {
+        csvPrinter.flush();
+      }
     }
   }
 }

--- a/cross-tests/src/test/java/org/apache/iotdb/cross/tests/tools/importCsv/ExportCsvTestIT.java
+++ b/cross-tests/src/test/java/org/apache/iotdb/cross/tests/tools/importCsv/ExportCsvTestIT.java
@@ -70,7 +70,7 @@ public class ExportCsvTestIT extends AbstractScript {
     String[] params = {"-td", "target/", "-q", "select c1,c2,c3 from root.test.t1"};
     prepareData();
     testMethod(params, null);
-    CSVParser parser = readCsvFile("target/dump0.csv");
+    CSVParser parser = readCsvFile("target/dump0_0.csv");
     String[] realRecords = {
       "root.test.t1.c1,root.test.t1.c2,root.test.t1.c3", "1.0,\"\"abc\",aa\",\"abbe's\""
     };
@@ -90,7 +90,7 @@ public class ExportCsvTestIT extends AbstractScript {
     };
     prepareData();
     testMethod(params, null);
-    CSVParser parser = readCsvFile("target/dump0.csv");
+    CSVParser parser = readCsvFile("target/dump0_0.csv");
     String[] realRecords = {
       "root.test.t1.c1(FLOAT),root.test.t1.c2(TEXT),root.test.t1.c3(TEXT)",
       "1.0,\"\"abc\",aa\",\"abbe's\""
@@ -111,7 +111,7 @@ public class ExportCsvTestIT extends AbstractScript {
     };
     prepareData();
     testMethod(params, null);
-    CSVParser parser = readCsvFile("target/dump0.csv");
+    CSVParser parser = readCsvFile("target/dump0_0.csv");
     String[] realRecords = {
       "count(root.test.t1.c1),count(root.test.t1.c2),count(root.test.t1.c3)", "1,1,1"
     };

--- a/cross-tests/src/test/java/org/apache/iotdb/cross/tests/tools/importCsv/ImportCsvTestIT.java
+++ b/cross-tests/src/test/java/org/apache/iotdb/cross/tests/tools/importCsv/ImportCsvTestIT.java
@@ -309,7 +309,7 @@ public class ImportCsvTestIT extends AbstractScript {
       file.delete();
     }
     // check the failed file
-    List<CSVRecord> records = readCsvFile(CSV_FILE + ".failed").getRecords();
+    List<CSVRecord> records = readCsvFile(CSV_FILE + ".failed_0").getRecords();
     String[] realRecords = {
       "Time,root.fit.d1.s1(INT32),root.fit.d1.s2(TEXT),root.fit.d2.s1(INT32),root.fit.d2.s3(INT32),root.fit.p.s1(INT32)",
       "1,100,\"hello\",200,\"300\",400"

--- a/docs/UserGuide/Write-And-Delete-Data/CSV-Tool.md
+++ b/docs/UserGuide/Write-And-Delete-Data/CSV-Tool.md
@@ -29,10 +29,10 @@ The CSV tool can help you import data in CSV format to IoTDB or export data from
 
 ```shell
 # Unix/OS X
-> tools/export-csv.sh  -h <ip> -p <port> -u <username> -pw <password> -td <directory> [-tf <time-format> -datatype <true/false> -q <query command> -s <sql file>]
+> tools/export-csv.sh  -h <ip> -p <port> -u <username> -pw <password> -td <directory> [-tf <time-format> -datatype <true/false> -q <query command> -s <sql file> -linesPerFile <int>]
 
 # Windows
-> tools\export-csv.bat -h <ip> -p <port> -u <username> -pw <password> -td <directory> [-tf <time-format> -datatype <true/false> -q <query command> -s <sql file>]
+> tools\export-csv.bat -h <ip> -p <port> -u <username> -pw <password> -td <directory> [-tf <time-format> -datatype <true/false> -q <query command> -s <sql file> -linesPerFile <int>]
 ```
 
 Description:
@@ -50,6 +50,10 @@ Description:
 * `-tf <time-format>`:
   - specifying a time format that you want. The time format have to obey [ISO 8601](https://calendars.wikia.org/wiki/ISO_8601) standard. If you want to save the time as the timestamp, then setting `-tf timestamp`
   - example: `-tf yyyy-MM-dd\ HH:mm:ss` or `-tf timestamp`
+* `-linesPerFile <int>`:
+  - Specifying lines of each dump file, `10000` is default.
+  - example: `-linesPerFile 1`
+
 
 More, if you don't use one of `-s` and `-q`, you need to enter some queries after running the export script. The results of the different query will be saved to different CSV files.
 
@@ -66,6 +70,8 @@ More, if you don't use one of `-s` and `-q`, you need to enter some queries afte
 > tools/export-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -s sql.txt
 # Or
 > tools/export-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -tf yyyy-MM-dd\ HH:mm:ss -s sql.txt
+# Or
+> tools/export-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -tf yyyy-MM-dd\ HH:mm:ss -s sql.txt -linesPerFile 10
 
 # Windows
 > tools/export-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -td ./
@@ -77,6 +83,8 @@ More, if you don't use one of `-s` and `-q`, you need to enter some queries afte
 > tools/export-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -s sql.txt
 # Or
 > tools/export-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -tf yyyy-MM-dd\ HH:mm:ss -s sql.txt
+# Or
+> tools/export-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -tf yyyy-MM-dd\ HH:mm:ss -s sql.txt -linesPerFile 10
 ```
 
 ### Sample SQL file
@@ -174,9 +182,9 @@ Time,Device,str(TEXT),int(INT32)
 
 ```shell
 # Unix/OS X
-> tools/import-csv.sh -h <ip> -p <port> -u <username> -pw <password> -f <xxx.csv> [-fd <./failedDirectory>] [-aligned <true>] [-tp <ms/ns/us>]
+> tools/import-csv.sh -h <ip> -p <port> -u <username> -pw <password> -f <xxx.csv> [-fd <./failedDirectory>] [-aligned <true>] [-tp <ms/ns/us>] [-typeInfer <boolean=text,float=double...>]
 # Windows
-> tools\import-csv.bat -h <ip> -p <port> -u <username> -pw <password> -f <xxx.csv> [-fd <./failedDirectory>] [-aligned <true>] [-tp <ms/ns/us>]
+> tools\import-csv.bat -h <ip> -p <port> -u <username> -pw <password> -f <xxx.csv> [-fd <./failedDirectory>] [-aligned <true>] [-tp <ms/ns/us>] [-typeInfer <boolean=text,float=double...>]
 ```
 
 Description:
@@ -200,6 +208,19 @@ Description:
 * `-tp <time-precision>`:
   - specifying a time precision. Options includes `ms`(millisecond), `ns`(nanosecond), and `us`(microsecond), `ms` is default.
 
+* `-typeInfer <srcTsDataType1=dstTsDataType1,srcTsDataType2=dstTsDataType2,...>`:
+  - specifying rules of type inference. 
+  - Option `srcTsDataType` includes `boolean`,`int`,`long`,`float`,`double`,`NaN`.
+  - Option `dstTsDataType` includes `boolean`,`int`,`long`,`float`,`double`,`text`.
+  - When `srcTsDataType` is `boolean`, `dstTsDataType` should be between `boolean` and `text`.
+  - When `srcTsDataType` is `NaN`, `dstTsDataType` should be among `float`, `double` and `text`.
+  - When `srcTsDataType` is Numeric type, `dstTsDataType` precision should be greater than `srcTsDataType`.
+  - example: `-typeInfer boolean=text,float=double`
+  
+* `-linesPerFailedFile <int>`:
+  - Specifying lines of each failed file, `10000` is default.
+  - example: `-linesPerFailedFile 1`
+
 ### Example
 
 ```sh
@@ -207,12 +228,24 @@ Description:
 > tools/import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed
 # or
 > tools/import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed
+# or
+> tools\import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed -tp ns
+# or
+> tools\import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed -tp ns -typeInfer boolean=text,float=double
+# or
+> tools\import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed -tp ns -typeInfer boolean=text,float=double -linesPerFailedFile 10
+
 # Windows
 > tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv
 # or
 > tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd .\failed
 # or
 > tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd .\failed -tp ns
+# or
+> tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd .\failed -tp ns -typeInfer boolean=text,float=double
+# or
+> tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd .\failed -tp ns -typeInfer boolean=text,float=double -linesPerFailedFile 10
+
 ```
 
 ### Note

--- a/docs/zh/UserGuide/Write-And-Delete-Data/CSV-Tool.md
+++ b/docs/zh/UserGuide/Write-And-Delete-Data/CSV-Tool.md
@@ -50,6 +50,9 @@ CSV 工具可帮您将 CSV 格式的数据导入到 IoTDB 或者将数据从 IoT
 * `-tf <time-format>`:
   - 指定一个你想要得到的时间格式。时间格式必须遵守[ISO 8601](https://calendars.wikia.org/wiki/ISO_8601)标准。如果说你想要以时间戳来保存时间，那就设置为`-tf timestamp`。
   - 例如: `-tf yyyy-MM-dd\ HH:mm:ss` or `-tf timestamp`
+* `-linesPerFile <int>`:
+  - 指定导出的dump文件最大行数，默认值为`10000`。
+  - 例如： `-linesPerFile 1`
 
 除此之外，如果你没有使用`-s`和`-q`参数，在导出脚本被启动之后你需要按照程序提示输入查询语句，不同的查询结果会被保存到不同的CSV文件中。
 
@@ -66,6 +69,8 @@ CSV 工具可帮您将 CSV 格式的数据导入到 IoTDB 或者将数据从 IoT
 > tools/export-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -s sql.txt
 # Or
 > tools/export-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -tf yyyy-MM-dd\ HH:mm:ss -s sql.txt
+# Or
+> tools/export-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -tf yyyy-MM-dd\ HH:mm:ss -s sql.txt -linesPerFile 10
 
 # Windows
 > tools/export-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -td ./
@@ -77,6 +82,8 @@ CSV 工具可帮您将 CSV 格式的数据导入到 IoTDB 或者将数据从 IoT
 > tools/export-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -s sql.txt
 # Or
 > tools/export-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -tf yyyy-MM-dd\ HH:mm:ss -s sql.txt
+# Or
+> tools/export-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -tf yyyy-MM-dd\ HH:mm:ss -s sql.txt -linesPerFile 10
 ```
 
 ### SQL 文件示例
@@ -175,9 +182,9 @@ Time,Device,str(TEXT),int(INT32)
 
 ```shell
 # Unix/OS X
->tools/import-csv.sh -h <ip> -p <port> -u <username> -pw <password> -f <xxx.csv> [-fd <./failedDirectory>] [-aligned <true>] [-tp <ms/ns/us>]
+>tools/import-csv.sh -h <ip> -p <port> -u <username> -pw <password> -f <xxx.csv> [-fd <./failedDirectory>] [-aligned <true>] [-tp <ms/ns/us>] [-typeInfer <boolean=text,float=double...>] [-linesPerFailedFile <int_value>]
 # Windows
->tools\import-csv.bat -h <ip> -p <port> -u <username> -pw <password> -f <xxx.csv> [-fd <./failedDirectory>] [-aligned <true>] [-tp <ms/ns/us>]
+>tools\import-csv.bat -h <ip> -p <port> -u <username> -pw <password> -f <xxx.csv> [-fd <./failedDirectory>] [-aligned <true>] [-tp <ms/ns/us>] [-typeInfer <boolean=text,float=double...>] [-linesPerFailedFile <int_value>]
 ```
 
 参数:
@@ -201,6 +208,19 @@ Time,Device,str(TEXT),int(INT32)
 * `-tp`:
   - 用于指定时间精度，可选值包括`ms`（毫秒），`ns`（纳秒），`us`（微秒），默认值为`ms`。
 
+* `-typeInfer <srcTsDataType1=dstTsDataType1,srcTsDataType2=dstTsDataType2,...>`:
+  - 用于指定类型推断规则.
+  - `srcTsDataType` 包括 `boolean`,`int`,`long`,`float`,`double`,`NaN`.
+  - `dstTsDataType` 包括 `boolean`,`int`,`long`,`float`,`double`,`text`.
+  - 当`srcTsDataType`为`boolean`, `dstTsDataType`只能为`boolean`或`text`.
+  - 当`srcTsDataType`为`NaN`, `dstTsDataType`只能为`float`, `double`或`text`.
+  - 当`srcTsDataType`为数值类型, `dstTsDataType`的精度需要高于`srcTsDataType`.
+  - 例如:`-typeInfer boolean=text,float=double`
+
+* `-linesPerFailedFile <int>`:
+  - 用于指定每个导入失败文件写入数据的行数，默认值为10000。
+  - 例如：`-linesPerFailedFile 1`
+
 ### 运行示例
 
 ```sh
@@ -208,12 +228,22 @@ Time,Device,str(TEXT),int(INT32)
 >tools/import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed
 # or
 >tools/import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed
+# or
+> tools\import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed -tp ns
+# or
+> tools\import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed -tp ns -typeInfer boolean=text,float=double
+# or
+> tools\import-csv.sh -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd ./failed -tp ns -typeInfer boolean=text,float=double -linesPerFailedFile 10
 # Windows
 >tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv
 # or
 >tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd .\failed
 # or
 > tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd .\failed -tp ns
+# or
+> tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd .\failed -tp ns -typeInfer boolean=text,float=double
+# or
+> tools\import-csv.bat -h 127.0.0.1 -p 6667 -u root -pw root -f example-filename.csv -fd .\failed -tp ns -typeInfer boolean=text,float=double -linesPerFailedFile 10
 ```
 
 ### 注意


### PR DESCRIPTION
[PoC]

Proof of `-linesPerFile`

1. Prepare dataset
``` sql
create storage group root.ln;
create timeseries root.ln.wf01.wt01.temperature with datatype=FLOAT ,encoding=RLE;
create timeseries root.ln.wf01.wt01.status with datatype=BOOLEAN,encoding=RLE;
create timeseries root.ln.wf01.wt01.hardware with datatype=TEXT,encoding=PLAIN;
create timeseries root.ln.wf01.wt01.score with datatype=INT32,encoding=RLE;
insert into root.ln.wf01.wt01(time,status,temperature,hardware,score) values(1509525300000,TRUE,25.99,'V001',88);
insert into root.ln.wf01.wt01(time,status,temperature,hardware) values(1509525360000,TRUE,25.99,'V002');
insert into root.ln.wf01.wt01(time,status,temperature,hardware,score) values(1509525470000,TRUE,23.19,'V001',91);
insert into root.ln.wf01.wt01(time,status,temperature,hardware) values(1509525490000,FALSE,26.92,'V002');
insert into root.ln.wf01.wt01(time,status,hardware,score) values(1509580800000,FALSE,'V001',95);
insert into root.ln.wf01.wt01(time,status,temperature,score) values(1509559200000,FALSE,26.92,90);
insert into root.ln.wf01.wt01(time,status,temperature) values(1509638400000,TRUE,26.0);
insert into root.ln.wf01.wt01(time,temperature,hardware) values(1509724800000,23.29,'V001');
insert into root.ln.wf01.wt01(time,status,temperature,hardware) values(1509811200000,TRUE,24.19,'V002');
insert into root.ln.wf01.wt01(time,status,temperature,score) values(1509897600000,FALSE,20.19,88);
insert into root.ln.wf01.wt01(time,status,temperature) values(1509908400000,FALSE,20.19);
insert into root.ln.wf01.wt01(time,temperature,score) values(1509984000000,22.12,86);
insert into root.ln.wf01.wt01(time,status,temperature) values(1510069800000,FALSE,20.12);
insert into root.ln.wf01.wt01(time,status,temperature,hardware) values(1510069920000,FALSE,21.22,'V001');
insert into root.ln.wf01.wt01(time,status,temperature) values(1510070100000,TRUE,21.22);
insert into root.ln.wf01.wt01(time,status,hardware,score) values(1510070370000,TRUE,'V002',93);
insert into root.ln.wf01.wt01(time,status,temperature,hardware) values(1510070400000,TRUE,23.99,'V002');
insert into root.ln.wf01.wt01(time,temperature,hardware) values(1541174400000,20.99,'V002');
insert into root.ln.wf01.wt01(time,status,temperature,score) values(1541433600000,TRUE,25.99,89);
insert into root.ln.wf01.wt01(time,status,hardware,score) values(1572883200000,TRUE,'V002',90);
insert into root.ln.wf01.wt01(time,status,temperature,hardware) values(1573056000000,TRUE,24.19,'V001');
```
2. export with option '-linesPerFile 1'
``` shell
sh export-csv.sh -u root -pw root -h xxxx-p 6667 -q "select * from root.**" -linesPerFile 2
```
3. 21 lines export to 11 file, abc0_[0-10].csv
![image](https://user-images.githubusercontent.com/82880298/187019739-594b1e62-2f6d-4025-a8e2-787c6c212867.png)

Proof of `-typeInfer `

1. prepare csv file
![image](https://user-images.githubusercontent.com/82880298/187021024-2676638f-71d4-423c-86ee-6f58936a0dff.png)

2. import with -typeInfer boolean=text,int=double
``` shell
sh import-csv.sh -u root -pw root -h xxxx -p 6667 -typeInfer boolean=text,int=double -f dump0_0.csv 
```
3. show timeseries;
![image](https://user-images.githubusercontent.com/82880298/187020963-75a9770b-5c59-4509-b365-e9c7e7616159.png)

