### PR TITLE
[IOTDB-4246]select last query without schema data only return time column

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBResultSetIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBResultSetIT.java
@@ -183,4 +183,18 @@ public class IoTDBResultSetIT {
         ColumnHeaderConstant.COLUMN_DEVICES + "," + ColumnHeaderConstant.COLUMN_IS_ALIGNED + ",";
     resultSetEqualTest("show devices root.sg1.**", expectedHeader, emptyResultSet);
   }
+
+  @Test
+  public void emptyLastQueryTest() {
+    String expectedHeader =
+        ColumnHeaderConstant.COLUMN_TIME
+            + ","
+            + ColumnHeaderConstant.COLUMN_TIMESERIES
+            + ","
+            + ColumnHeaderConstant.COLUMN_VALUE
+            + ","
+            + ColumnHeaderConstant.COLUMN_TIMESERIES_DATATYPE
+            + ",";
+    resultSetEqualTest("select last s1 from root.sg.d1", expectedHeader, emptyResultSet);
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -179,6 +179,9 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       logger.info("{} fetch schema done", getLogHeader());
       // If there is no leaf node in the schema tree, the query should be completed immediately
       if (schemaTree.isEmpty()) {
+        if (queryStatement.isLastQuery()) {
+          analysis.setRespDatasetHeader(DatasetHeaderFactory.getLastQueryHeader());
+        }
         analysis.setFinishQueryAfterAnalyze(true);
         return analysis;
       }


### PR DESCRIPTION
After fix:
![image](https://user-images.githubusercontent.com/17932988/187063595-b49b9ab0-26e4-44ff-9dc6-cb08fed1a93c.png)

Keep table head the same in new cluster mode.
