### PR TITLE
[IOTDB-4253] Modify the jdbc query time column to be empty

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
@@ -205,6 +205,7 @@ public class IoTDBNonAlignJDBCResultSet extends AbstractIoTDBJDBCResultSet {
 
   @Override
   protected void constructOneRow() {
+    ioTDBRpcDataSet.lastReadWasNull = false;
     for (int i = 0; i < tsQueryNonAlignDataSet.timeList.size(); i++) {
       times[i] = null;
       ioTDBRpcDataSet.values[i] = null;

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBJDBCDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBJDBCDataSet.java
@@ -368,6 +368,7 @@ public class IoTDBJDBCDataSet {
   }
 
   public void constructOneRow() {
+    lastReadWasNull = false;
     tsQueryDataSet.time.get(time);
     for (int i = 0; i < tsQueryDataSet.bitmapList.size(); i++) {
       ByteBuffer bitmapBuffer = tsQueryDataSet.bitmapList.get(i);


### PR DESCRIPTION
When the query statement is executed with jdbc, when the last column of the previous row is empty, the next row last Read Was Null will still be true, resulting in the Timestamp column not displaying time information