### PR TITLE
[IOTDB-4262] Fix missing setSessionId when `showAllTemplates`

### DIFF
--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -874,6 +874,7 @@ public class SessionConnection {
   protected TSQueryTemplateResp querySchemaTemplate(TSQueryTemplateReq req)
       throws StatementExecutionException, IoTDBConnectionException {
     TSQueryTemplateResp execResp;
+    req.setSessionId(sessionId);
     try {
       execResp = client.querySchemaTemplate(req);
       RpcUtils.verifySuccess(execResp.getStatus());


### PR DESCRIPTION
There is a missing `setSessionId` in `SessionConnection` within api `querySchemaTemplate`. It does't turn out any exception since there is no authority check for `querySchemaTemplate` in 0.13.x, but throw exception under the check in 0.14. 

This PR fixed the issue mentioned above.

The pictures below show the difference between before and after the missing statement fixed.

Before:
![8a698297a1fe847591c962079a3ef25](https://user-images.githubusercontent.com/22140148/187162091-5a44bff3-7d12-48a3-99ff-30f3c17ddeca.jpg)
After:
![bc973a3ce116f27d85d08a687a1a335](https://user-images.githubusercontent.com/22140148/187162123-aecfbdbf-de19-4c93-be6f-491d9bc8e2a4.jpg)
