### PR TITLE
[IOTDB-4271] Fix heartbeat error after setting a DataNode's status to Read-Only

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/heartbeat/ConfigNodeHeartbeatCache.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/heartbeat/ConfigNodeHeartbeatCache.java
@@ -80,6 +80,6 @@ public class ConfigNodeHeartbeatCache extends BaseNodeCache {
   @Override
   public NodeStatus getNodeStatus() {
     // Return a copy of status
-    return NodeStatus.valueOf(status.getStatus());
+    return NodeStatus.parse(status.getStatus());
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/heartbeat/DataNodeHeartbeatCache.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/heartbeat/DataNodeHeartbeatCache.java
@@ -77,7 +77,7 @@ public class DataNodeHeartbeatCache extends BaseNodeCache {
     }
 
     return NodeStatus.isNormalStatus(status)
-        != NodeStatus.isNormalStatus(NodeStatus.valueOf(originStatus));
+        != NodeStatus.isNormalStatus(NodeStatus.parse(originStatus));
   }
 
   @Override
@@ -97,6 +97,6 @@ public class DataNodeHeartbeatCache extends BaseNodeCache {
     }
 
     // Return a copy of status
-    return NodeStatus.valueOf(status.getStatus());
+    return NodeStatus.parse(status.getStatus());
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/heartbeat/NodeHeartbeatSample.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/heartbeat/NodeHeartbeatSample.java
@@ -41,7 +41,7 @@ public class NodeHeartbeatSample {
   public NodeHeartbeatSample(THeartbeatResp heartbeatResp, long receiveTimestamp) {
     this.sendTimestamp = heartbeatResp.getHeartbeatTimestamp();
     this.receiveTimestamp = receiveTimestamp;
-    this.status = NodeStatus.valueOf(heartbeatResp.getStatus());
+    this.status = NodeStatus.parse(heartbeatResp.getStatus());
     this.cpu = heartbeatResp.getCpu();
     this.memory = heartbeatResp.getMemory();
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/cluster/NodeStatus.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/cluster/NodeStatus.java
@@ -30,7 +30,7 @@ public enum NodeStatus {
   Removing("Removing"),
 
   /** Only query statements are permitted */
-  ReadOnly("Read-Only"),
+  ReadOnly("ReadOnly"),
 
   /**
    * Unrecoverable errors occur, system will be read-only or exit according to the param


### PR DESCRIPTION
The reason why cause this bug is that, I use NodeStatus.valueOf to parse the NodeStatus code, which is incorrect. I also tested the validity of show cluster and leader shifting after one DataNode's status is changed: 

1. I started a 1C3D cluster on my local machine, where the consensus protocol of DataRegion is MultiLeader:
![image](https://user-images.githubusercontent.com/33111881/187225238-3e03c27d-fa9c-442a-b13d-cab3b59fe085.png)

2. I inserted some data in three different StorageGroups in order to ensure that each DataNode has exactly one leader of DataRegion:
![image](https://user-images.githubusercontent.com/33111881/187225752-4582d1f2-2500-42f5-8da0-d16d4faa8d43.png)


3. I changed one DataNode's status into Read-Only, and the result of show cluster is correct:
![image](https://user-images.githubusercontent.com/33111881/187225941-d0522163-bd43-4f60-a13b-6fcef0bed347.png)


4. ConfigNode shifted DataRegion's leader and broadcasted the latest RegionRouteMap immediately:
![image](https://user-images.githubusercontent.com/33111881/187226230-5434d04d-0696-4d8c-8cd8-36fd26f043d2.png)

