### PR TITLE
[IOTDB-4267]Add the logic to process other PlanNode besides InsertNode in MultiLeaderConsensus

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -196,8 +196,8 @@ public class DataRegionStateMachine extends BaseStateMachine {
           insertNodeWrapper.getStartSyncIndex(),
           insertNodeWrapper.getEndSyncIndex());
       List<TSStatus> subStatus = new LinkedList<>();
-      for (InsertNode insertNode : insertNodeWrapper.getInsertNodes()) {
-        subStatus.add(write(insertNode));
+      for (PlanNode planNode : insertNodeWrapper.getInsertNodes()) {
+        subStatus.add(write(planNode));
       }
       queueSortCondition.signalAll();
       return new TSStatus().setSubStatus(subStatus);
@@ -209,7 +209,7 @@ public class DataRegionStateMachine extends BaseStateMachine {
   private static class InsertNodeWrapper implements Comparable<InsertNodeWrapper> {
     private final long startSyncIndex;
     private final long endSyncIndex;
-    private final List<InsertNode> insertNodes;
+    private final List<PlanNode> insertNodes;
 
     public InsertNodeWrapper(long startSyncIndex, long endSyncIndex) {
       this.startSyncIndex = startSyncIndex;
@@ -222,7 +222,7 @@ public class DataRegionStateMachine extends BaseStateMachine {
       return Long.compare(startSyncIndex, o.startSyncIndex);
     }
 
-    public void add(InsertNode insertNode) {
+    public void add(PlanNode insertNode) {
       this.insertNodes.add(insertNode);
     }
 
@@ -234,7 +234,7 @@ public class DataRegionStateMachine extends BaseStateMachine {
       return endSyncIndex;
     }
 
-    public List<InsertNode> getInsertNodes() {
+    public List<PlanNode> getInsertNodes() {
       return insertNodes;
     }
   }
@@ -248,13 +248,23 @@ public class DataRegionStateMachine extends BaseStateMachine {
     return insertNodeWrapper;
   }
 
-  private InsertNode grabInsertNode(IndexedConsensusRequest indexedRequest) {
+  private PlanNode grabInsertNode(IndexedConsensusRequest indexedRequest) {
     List<InsertNode> insertNodes = new ArrayList<>(indexedRequest.getRequests().size());
     for (IConsensusRequest req : indexedRequest.getRequests()) {
       // PlanNode in IndexedConsensusRequest should always be InsertNode
-      InsertNode innerNode = (InsertNode) getPlanNode(req);
-      innerNode.setSearchIndex(indexedRequest.getSearchIndex());
-      insertNodes.add(innerNode);
+      PlanNode planNode = getPlanNode(req);
+      if (planNode instanceof InsertNode) {
+        InsertNode innerNode = (InsertNode) planNode;
+        innerNode.setSearchIndex(indexedRequest.getSearchIndex());
+        insertNodes.add(innerNode);
+      } else if (indexedRequest.getRequests().size() == 1) {
+        // If the planNode is not InsertNode, it is expected that the IndexedConsensusRequest only
+        // contains one request
+        return planNode;
+      } else {
+        throw new IllegalArgumentException(
+            "PlanNodes in IndexedConsensusRequest are not InsertNode and the size of requests are larger than 1");
+      }
     }
     return mergeInsertNodes(insertNodes);
   }


### PR DESCRIPTION
Fix the issue that `DeleteDataNode` is not processed when using MultiLeaderConsensus.

Besides, other PlanNode which does not belong to InsertNode won't be processed before this PR.

**Test：**
1. Execute delete operation using client when inserting data by BenchMark.
<img width="807" alt="image" src="https://user-images.githubusercontent.com/18027703/187361517-43b1d9eb-5b64-4cd0-a550-1bc98319bd63.png">

2. Finally, I verified the result for each replica
<img width="868" alt="image" src="https://user-images.githubusercontent.com/18027703/187363896-73018dc9-337b-49cb-8d45-782960e34ccd.png">
