### PR TITLE
[IOTDB-4027] Ratis snapshot atomicity: Reorder

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -181,22 +181,31 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
     }
 
     boolean applicationTakeSnapshotSuccess = applicationStateMachine.takeSnapshot(snapshotDir);
-    boolean addTermIndexMetafileSuccess =
-        snapshotStorage.addTermIndexMetaFile(snapshotDir, metadata);
-
-    if (!applicationTakeSnapshotSuccess || !addTermIndexMetafileSuccess) {
-      // this takeSnapshot failed, clean up files and directories
-      // statemachine is supposed to clear snapshotDir on failure
-      boolean isEmpty = snapshotDir.delete();
-      if (!isEmpty) {
-        logger.warn(
-            "StateMachine take snapshot failed but leave unexpected remaining files at "
-                + snapshotDir.getAbsolutePath());
-        FileUtils.deleteFully(snapshotDir);
-      }
+    if (!applicationTakeSnapshotSuccess) {
+      deleteIncompleteSnapshot(snapshotDir);
       return RaftLog.INVALID_LOG_INDEX;
     }
+
+    boolean addTermIndexMetafileSuccess =
+        snapshotStorage.addTermIndexMetaFile(snapshotDir, metadata);
+    if (!addTermIndexMetafileSuccess) {
+      deleteIncompleteSnapshot(snapshotDir);
+      return RaftLog.INVALID_LOG_INDEX;
+    }
+
     return lastApplied.getIndex();
+  }
+
+  private void deleteIncompleteSnapshot(File snapshotDir) throws IOException {
+    // this takeSnapshot failed, clean up files and directories
+    // statemachine is supposed to clear snapshotDir on failure
+    boolean isEmpty = snapshotDir.delete();
+    if (!isEmpty) {
+      logger.warn(
+          "StateMachine take snapshot failed but leave unexpected remaining files at "
+              + snapshotDir.getAbsolutePath());
+      FileUtils.deleteFully(snapshotDir);
+    }
   }
 
   private void loadSnapshot(File latestSnapshotDir) {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -201,9 +201,7 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
     // statemachine is supposed to clear snapshotDir on failure
     boolean isEmpty = snapshotDir.delete();
     if (!isEmpty) {
-      logger.warn(
-          "StateMachine take snapshot failed but leave unexpected remaining files at "
-              + snapshotDir.getAbsolutePath());
+      logger.info("Snapshot directory is incomplete, deleting " + snapshotDir.getAbsolutePath());
       FileUtils.deleteFully(snapshotDir);
     }
   }


### PR DESCRIPTION
Previous code 
1. create metafile
2. judge snapshotSuccess & metafileSuccess at same time.
If the program crashes when 1 completes but 2 fails, than atomicity is affected.
