### PR TITLE
[IOTDB-4036] Encode aligned memory chunk in columnar format

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
@@ -38,7 +38,13 @@ import org.slf4j.LoggerFactory;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 public class AlignedWritableMemChunk implements IWritableMemChunk {
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
@@ -400,7 +400,6 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
               break;
           }
         }
-
         alignedChunkWriter.nextColumn();
       }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
@@ -38,12 +38,7 @@ import org.slf4j.LoggerFactory;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class AlignedWritableMemChunk implements IWritableMemChunk {
 
@@ -295,65 +290,92 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
   @Override
   public void encode(IChunkWriter chunkWriter) {
     AlignedChunkWriterImpl alignedChunkWriter = (AlignedChunkWriterImpl) chunkWriter;
-    List<Integer> timeDuplicateAlignedRowIndexList = null;
+
+    boolean[] timeDuplicateInfo = null;
     for (int sortedRowIndex = 0; sortedRowIndex < list.rowCount(); sortedRowIndex++) {
       long time = list.getTime(sortedRowIndex);
 
-      // skip duplicated data
-      if ((sortedRowIndex + 1 < list.rowCount() && (time == list.getTime(sortedRowIndex + 1)))) {
-        // record the time duplicated row index list for vector type
-        if (timeDuplicateAlignedRowIndexList == null) {
-          timeDuplicateAlignedRowIndexList = new ArrayList<>();
-          timeDuplicateAlignedRowIndexList.add(list.getValueIndex(sortedRowIndex));
+      if (sortedRowIndex == list.rowCount() - 1 || time != list.getTime(sortedRowIndex + 1)) {
+        alignedChunkWriter.write(time);
+      } else {
+        if (Objects.isNull(timeDuplicateInfo)) {
+          timeDuplicateInfo = new boolean[list.rowCount()];
         }
-        timeDuplicateAlignedRowIndexList.add(list.getValueIndex(sortedRowIndex + 1));
-        continue;
+        timeDuplicateInfo[sortedRowIndex] = true;
       }
-      List<TSDataType> dataTypes = list.getTsDataTypes();
-      int originRowIndex = list.getValueIndex(sortedRowIndex);
-      for (int columnIndex = 0; columnIndex < dataTypes.size(); columnIndex++) {
-        // write the time duplicated rows
-        if (timeDuplicateAlignedRowIndexList != null
-            && !timeDuplicateAlignedRowIndexList.isEmpty()) {
-          originRowIndex =
-              list.getValidRowIndexForTimeDuplicatedRows(
-                  timeDuplicateAlignedRowIndexList, columnIndex);
+    }
+
+    List<TSDataType> dataTypes = list.getTsDataTypes();
+    // value columns
+    for (int columnIndex = 0; columnIndex < dataTypes.size(); columnIndex++) {
+      // Pair of Time and Index
+      Pair<Long, Integer> lastValidPointIndexForTimeDupCheck = null;
+      if (Objects.nonNull(timeDuplicateInfo)) {
+        lastValidPointIndexForTimeDupCheck = new Pair<>(Long.MIN_VALUE, null);
+      }
+      for (int sortedRowIndex = 0; sortedRowIndex < list.rowCount(); sortedRowIndex++) {
+        // skip time duplicated rows
+        if (Objects.nonNull(timeDuplicateInfo)) {
+          if (!list.isNullValue(list.getValueIndex(sortedRowIndex), columnIndex)) {
+            lastValidPointIndexForTimeDupCheck.left = list.getTime(sortedRowIndex);
+            lastValidPointIndexForTimeDupCheck.right = list.getValueIndex(sortedRowIndex);
+          }
+          if (timeDuplicateInfo[sortedRowIndex]) {
+            continue;
+          }
+        }
+        // The part of code solves the following problem:
+        // Time: 1,2,2,3
+        // Value: 1,2,null,null
+        // When rowIndex:1, pair(min,null), timeDuplicateInfo:false, write(T:1,V:1)
+        // When rowIndex:2, pair(2,2), timeDuplicateInfo:true, skip writing value
+        // When rowIndex:3, pair(2,2), timeDuplicateInfo:false, T:2!=air.left:2, write(T:2,V:2)
+        // When rowIndex:4, pair(2,2), timeDuplicateInfo:false, T:3!=pair.left:2, write(T:3,V:null)
+        int originRowIndex;
+        long time = list.getTime(sortedRowIndex);
+        if (Objects.nonNull(lastValidPointIndexForTimeDupCheck)
+            && (time == lastValidPointIndexForTimeDupCheck.left)) {
+          originRowIndex = lastValidPointIndexForTimeDupCheck.right;
+        } else {
+          originRowIndex = list.getValueIndex(sortedRowIndex);
         }
         boolean isNull = list.isNullValue(originRowIndex, columnIndex);
         switch (dataTypes.get(columnIndex)) {
           case BOOLEAN:
-            alignedChunkWriter.write(
+            alignedChunkWriter.writeByColumn(
                 time, list.getBooleanByValueIndex(originRowIndex, columnIndex), isNull);
             break;
           case INT32:
-            alignedChunkWriter.write(
+            alignedChunkWriter.writeByColumn(
                 time, list.getIntByValueIndex(originRowIndex, columnIndex), isNull);
             break;
           case INT64:
-            alignedChunkWriter.write(
+            alignedChunkWriter.writeByColumn(
                 time, list.getLongByValueIndex(originRowIndex, columnIndex), isNull);
             break;
           case FLOAT:
-            alignedChunkWriter.write(
+            alignedChunkWriter.writeByColumn(
                 time, list.getFloatByValueIndex(originRowIndex, columnIndex), isNull);
             break;
           case DOUBLE:
-            alignedChunkWriter.write(
+            alignedChunkWriter.writeByColumn(
                 time, list.getDoubleByValueIndex(originRowIndex, columnIndex), isNull);
             break;
           case TEXT:
-            alignedChunkWriter.write(
+            alignedChunkWriter.writeByColumn(
                 time, list.getBinaryByValueIndex(originRowIndex, columnIndex), isNull);
             break;
           default:
-            LOGGER.error(
-                "AlignedWritableMemChunk does not support data type: {}",
-                dataTypes.get(columnIndex));
             break;
         }
       }
-      alignedChunkWriter.write(time);
-      timeDuplicateAlignedRowIndexList = null;
+      alignedChunkWriter.nextColumn();
+    }
+
+    for (int sortedRowIndex = 0; sortedRowIndex < list.rowCount(); sortedRowIndex++) {
+      if (Objects.isNull(timeDuplicateInfo) || !timeDuplicateInfo[sortedRowIndex]) {
+        alignedChunkWriter.write(list.getTime(sortedRowIndex));
+      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
@@ -330,7 +330,7 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
     }
 
     List<TSDataType> dataTypes = list.getTsDataTypes();
-    for (int pageNum = 0; pageNum < pageRange.size() / 2; pageNum += 2) {
+    for (int pageNum = 0; pageNum < pageRange.size() / 2; pageNum += 1) {
       for (int columnIndex = 0; columnIndex < dataTypes.size(); columnIndex++) {
         // Pair of Time and Index
         Pair<Long, Integer> lastValidPointIndexForTimeDupCheck = null;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -219,6 +219,34 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
   }
 
+  public void writeByColumn(long time, int value, boolean isNull) {
+    valueChunkWriterList.get(valueIndex).write(time, value, isNull);
+  }
+
+  public void writeByColumn(long time, long value, boolean isNull) {
+    valueChunkWriterList.get(valueIndex).write(time, value, isNull);
+  }
+
+  public void writeByColumn(long time, boolean value, boolean isNull) {
+    valueChunkWriterList.get(valueIndex).write(time, value, isNull);
+  }
+
+  public void writeByColumn(long time, float value, boolean isNull) {
+    valueChunkWriterList.get(valueIndex).write(time, value, isNull);
+  }
+
+  public void writeByColumn(long time, double value, boolean isNull) {
+    valueChunkWriterList.get(valueIndex).write(time, value, isNull);
+  }
+
+  public void writeByColumn(long time, Binary value, boolean isNull) {
+    valueChunkWriterList.get(valueIndex).write(time, value, isNull);
+  }
+
+  public void nextColumn() {
+    valueIndex++;
+  }
+
   /**
    * check occupied memory size, if it exceeds the PageSize threshold, construct a page and put it
    * to pageBuffer

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -263,7 +263,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     return false;
   }
 
-  public void writePageToPageBuffer() {
+  private void writePageToPageBuffer() {
     timeChunkWriter.writePageToPageBuffer();
     for (ValueChunkWriter valueChunkWriter : valueChunkWriterList) {
       valueChunkWriter.writePageToPageBuffer();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -263,7 +263,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     return false;
   }
 
-  private void writePageToPageBuffer() {
+  public void writePageToPageBuffer() {
     timeChunkWriter.writePageToPageBuffer();
     for (ValueChunkWriter valueChunkWriter : valueChunkWriterList) {
       valueChunkWriter.writePageToPageBuffer();


### PR DESCRIPTION
Comparative experiment before and after this PR:

- Configuration of benchmark
  - Storage_group = 10
  - DB_SWITCH=IoTDB-013-SESSION_BY_TABLET
  - Device_num = 50
  - Sensor_num = 500
  - Insert_data_type = 1:1:1:1:1:1(boolean:int:long:float:double:Text)
  - VECTOR = True

- Configuration of IoTDB Server
  - enable_seq_space_compaction=false
  - enable_unseq_space_compaction=false
  - enable_cross_space_compaction=false
  - write_read_schema_free_memory_proportion=7:1:1:1
  - flush_proportion=0.7
  - memtable_size_threshold=1073741824(default)
  - avg_series_point_number_threshold=1000/5000/10000


1. avg_series_point_number_threshold=1000
before 17578533.54 points/s
after 19968317.28 points/s

2. avg_series_point_number_threshold=5000
before 17939349.93 points/s
after 20227324.97 points/s

3. avg_series_point_number_threshold=10000
before 18184068.69 points/s
after 1947944228 points/s
