### PR TITLE
Fix transport open bug

### DIFF
--- a/influxdb-protocol/src/main/java/org/apache/iotdb/influxdb/session/InfluxDBSession.java
+++ b/influxdb-protocol/src/main/java/org/apache/iotdb/influxdb/session/InfluxDBSession.java
@@ -128,7 +128,9 @@ public class InfluxDBSession {
           RpcTransportFactory.INSTANCE.getTransport(
               // as there is a try-catch already, we do not need to use TSocket.wrap
               defaultEndPoint.getIp(), defaultEndPoint.getPort(), connectionTimeoutInMs);
-      transport.open();
+      if (!transport.isOpen()) {
+        transport.open();
+      }
     } catch (TTransportException e) {
       throw new IoTDBConnectionException(e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
@@ -159,7 +159,9 @@ public class ConfigNodeClient
           RpcTransportFactory.INSTANCE.getTransport(
               // as there is a try-catch already, we do not need to use TSocket.wrap
               endpoint.getIp(), endpoint.getPort(), (int) connectionTimeout);
-      transport.open();
+      if (!transport.isOpen()) {
+        transport.open();
+      }
       configNode = endpoint;
     } catch (TTransportException e) {
       throw new TException(e);

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -117,7 +117,9 @@ public class SessionConnection {
           RpcTransportFactory.INSTANCE.getTransport(
               // as there is a try-catch already, we do not need to use TSocket.wrap
               endPoint.getIp(), endPoint.getPort(), session.connectionTimeoutInMs);
-      transport.open();
+      if (!transport.isOpen()) {
+        transport.open();
+      }
     } catch (TTransportException e) {
       throw new IoTDBConnectionException(e);
     }


### PR DESCRIPTION
We have written an SSL transport, which risks being opened repeatedly. The judgment is made in jdbconnection, and no problem occurs.