### PR TITLE
[IOTDB-4219] Add system.exit(0) for the stop method of datanode

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/DataNodeServerCommandLine.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNodeServerCommandLine.java
@@ -92,7 +92,7 @@ public class DataNodeServerCommandLine extends ServerCommandLine {
 
     // we start IoTDB kernel first. then we start the cluster module.
     if (MODE_START.equals(mode)) {
-      dataNode.doAddNode(args);
+      dataNode.doAddNode();
     } else if (MODE_REMOVE.equals(mode)) {
       doRemoveNode(args);
     } else {


### PR DESCRIPTION
## Description

Datanode PID can't be shut down completely when execute remove-datanode.sh. Now we add `System.exit(0);` in the stop method of DataNode.

```java
  public void stop() {
    deactivate();

    try {
      MetricService.getInstance().stop();
      SchemaRegionConsensusImpl.getInstance().stop();
      DataRegionConsensusImpl.getInstance().stop();
    } catch (Exception e) {
      logger.error("stop data node error", e);
    }

    // kill the datanode process 5 seconds later
    // if remove this step, datanode process will still alive
    new Thread(
            () -> {
              try {
                TimeUnit.SECONDS.sleep(5);
              } catch (InterruptedException e) {
                logger.error("Meets InterruptedException in stop method of DataNode");
              } finally {
                System.exit(0);
              }
            })
        .start();
  }
```

## Test results

before executed remove-datanode.sh
![image](https://user-images.githubusercontent.com/6756545/187639669-2fac3606-77ad-41ac-ae33-97770abeeb7f.png)

after executed remove-datanode.sh
![image](https://user-images.githubusercontent.com/6756545/187639728-ee88c895-18bc-419f-83ee-2f446ba720e8.png)

the logs on removed datanode, and the interrupted exceptions will be dealed later
![image](https://user-images.githubusercontent.com/6756545/187639842-727e7176-b08b-4f88-86d2-50b38c013273.png)


