### PR TITLE
[IOTDB-4258]Replace StorageGroupNode inside cache member if setToEntity

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -325,7 +325,6 @@ public class IoTDBSchemaTemplateIT {
     while (resultSet.next()) {
       Assert.assertEquals(2L, resultSet.getLong("COUNT(root.test.sg_satosg.s1)"));
     }
-    System.out.println(resultSet);
   }
 
   private void prepareTemplate() throws SQLException {

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -302,6 +302,32 @@ public class IoTDBSchemaTemplateIT {
     Assert.assertFalse(resultSet.next());
   }
 
+  @Test
+  public void testSetAndActivateTemplateOnSGNode() throws SQLException {
+    statement.execute("CREATE STORAGE GROUP root.test.sg_satosg");
+    statement.execute("SET SCHEMA TEMPLATE t1 TO root.test.sg_satosg");
+    statement.execute("INSERT INTO root.test.sg_satosg(time, s1) VALUES (1, 1)");
+    statement.execute("INSERT INTO root.test.sg_satosg(time, s1) VALUES (2, 2)");
+    ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.test.sg_satosg.**");
+
+    Set<String> expRes =
+        new HashSet<>(
+            Arrays.asList(new String[] {"root.test.sg_satosg.s1", "root.test.sg_satosg.s2"}));
+    int resCnt = 0;
+    while (resultSet.next()) {
+      resCnt++;
+      expRes.remove(resultSet.getString("timeseries"));
+    }
+    Assert.assertEquals(2, resCnt);
+    Assert.assertTrue(expRes.isEmpty());
+
+    resultSet = statement.executeQuery("SELECT COUNT(s1) from root.test.sg_satosg");
+    while (resultSet.next()) {
+      Assert.assertEquals(2L, resultSet.getLong("COUNT(root.test.sg_satosg.s1)"));
+    }
+    System.out.println(resultSet);
+  }
+
   private void prepareTemplate() throws SQLException {
     // create storage group
     statement.execute("CREATE STORAGE GROUP root.sg1");

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -39,7 +39,6 @@ import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
 import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
 import org.apache.iotdb.db.metadata.mnode.InternalMNode;
-import org.apache.iotdb.db.metadata.mnode.MNodeUtils;
 import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
 import org.apache.iotdb.db.metadata.mnode.iterator.IMNodeIterator;
 import org.apache.iotdb.db.metadata.mtree.store.MemMTreeStore;
@@ -1482,7 +1481,10 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
       if (cur.isEntity()) {
         entityMNode = cur.getAsEntityMNode();
       } else {
-        entityMNode = MNodeUtils.setToEntity(cur);
+        entityMNode = store.setToEntity(cur);
+        if (entityMNode.isStorageGroup()) {
+          this.storageGroupMNode = entityMNode.getAsStorageGroupMNode();
+        }
       }
     }
 
@@ -1507,7 +1509,10 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
     if (cur.isEntity()) {
       entityMNode = cur.getAsEntityMNode();
     } else {
-      entityMNode = MNodeUtils.setToEntity(cur);
+      entityMNode = store.setToEntity(cur);
+      if (entityMNode.isStorageGroup()) {
+        this.storageGroupMNode = entityMNode.getAsStorageGroupMNode();
+      }
     }
 
     if (!entityMNode.isAligned()) {


### PR DESCRIPTION
If a `StroageGroupNode` being set to `StorageGroupEntityNode`, it shall be replaced by some methods. 

Before this PR, although the local variable of the node has been replaced, but the member field  `storageGroupMNode` and `store` within `MTreeBelowSGMemoryImpl` has not been updated, which turned out that some insert seemed to be lost.

This PR fixed the issue, and corresponding IT has been added.