### PR TITLE
[Doc] Fix unavailable references

### DIFF
--- a/docs/Development/HowtoContributeCode.md
+++ b/docs/Development/HowtoContributeCode.md
@@ -80,7 +80,7 @@ a.Configuration file: server/src/assembly/resources/conf/iotdb-datanode.properti
 
 b. Codes: IoTDBDescriptor, IoTDBConfig
 
-c. Documentation: docs/UserGuide/Reference/Config-Manual.md
+c. Documentation: docs/UserGuide/Reference/DataNode-Config-Manual.md
 
 3.To modify configuration parameters in IT and UT, you need to modify them in the method annotated by @before and reset them in the method annotated by @after. In this way, you can avoid impact on other tests. The parameters of the compaction module are placed in the CompactionConfigRestorer file.
 

--- a/docs/UserGuide/Data-Concept/Data-Type.md
+++ b/docs/UserGuide/Data-Concept/Data-Type.md
@@ -33,7 +33,7 @@ IoTDB supports the following data types:
 * TEXT (String)
 
 
-The time series of **FLOAT** and **DOUBLE** type can specify (MAX\_POINT\_NUMBER, see [this page](../Reference/SQL-Reference.md) for more information on how to specify), which is the number of digits after the decimal point of the floating point number, if the encoding method is [RLE](Encoding.md) or [TS\_2DIFF](Encoding.md). If MAX\_POINT\_NUMBER is not specified, the system will use [float\_precision](../Reference/Config-Manual.md) in the configuration file `iotdb-datanode.properties`.
+The time series of **FLOAT** and **DOUBLE** type can specify (MAX\_POINT\_NUMBER, see [this page](../Reference/SQL-Reference.md) for more information on how to specify), which is the number of digits after the decimal point of the floating point number, if the encoding method is [RLE](Encoding.md) or [TS\_2DIFF](Encoding.md). If MAX\_POINT\_NUMBER is not specified, the system will use [float\_precision](../Reference/DataNode-Config-Manual.md) in the configuration file `iotdb-datanode.properties`.
 
 * For Float data value, The data range is (-Integer.MAX_VALUE, Integer.MAX_VALUE), rather than Float.MAX_VALUE, and the max_point_number is 19, caused by the limition of function Math.round(float) in Java.
 * For Double data value, The data range is (-Long.MAX_VALUE, Long.MAX_VALUE), rather than Double.MAX_VALUE, and the max_point_number is 19, caused by the limition of function Math.round(double) in Java (Long.MAX_VALUE=9.22E18).

--- a/docs/UserGuide/Data-Concept/Time-Partition.md
+++ b/docs/UserGuide/Data-Concept/Time-Partition.md
@@ -55,7 +55,7 @@ Enable time partition and set partition_interval to 86400 (one day), then the da
 
 ## Suggestions
 
-When enabling time partition, it is better to enable timed flush memtable, configuration params are detailed in [Config manual for timed flush](../Reference/Config-Manual.md).
+When enabling time partition, it is better to enable timed flush memtable, configuration params are detailed in [Config manual for timed flush](../Reference/DataNode-Config-Manual.md).
 
 * enable_timed_flush_unseq_memtable: Whether to enable timed flush unsequence memtable, enabled by default.
 

--- a/docs/UserGuide/Data-Modeling/DataRegion.md
+++ b/docs/UserGuide/Data-Modeling/DataRegion.md
@@ -52,4 +52,4 @@ data_region_num
 
 Recommended value is [data region number] = [CPU core number] / [user-defined storage group number]
 
-For more information, you can refer to [this page](../Reference/Config-Manual.md).
+For more information, you can refer to [this page](../Reference/DataNode-Config-Manual.md).

--- a/docs/UserGuide/QuickStart/Files.md
+++ b/docs/UserGuide/QuickStart/Files.md
@@ -27,17 +27,17 @@ The data in IoTDB is divided into three categories, namely data files, system fi
 
 ### Data Files
 
-Data files store all the data that the user wrote to IoTDB, which contains TsFile and other files. TsFile storage directory can be configured with the `data_dirs` configuration item (see [file layer](../Reference/Config-Manual.md) for details). Other files can be configured through [data_dirs](../Reference/Config-Manual.md) configuration item (see [Engine Layer](../Reference/Config-Manual.md) for details).
+Data files store all the data that the user wrote to IoTDB, which contains TsFile and other files. TsFile storage directory can be configured with the `data_dirs` configuration item (see [file layer](../Reference/DataNode-Config-Manual.md) for details). Other files can be configured through [data_dirs](../Reference/DataNode-Config-Manual.md) configuration item (see [Engine Layer](../Reference/DataNode-Config-Manual.md) for details).
 
-In order to support users' storage requirements such as disk space expansion better, IoTDB supports multiple file directories storage methods for TsFile storage configuration. Users can set multiple storage paths as data storage locations( see [data_dirs](../Reference/Config-Manual.md) configuration item), and you can specify or customize the directory selection strategy (see [multi_dir_strategy](../Reference/Config-Manual.md) configuration item for details).
+In order to support users' storage requirements such as disk space expansion better, IoTDB supports multiple file directories storage methods for TsFile storage configuration. Users can set multiple storage paths as data storage locations( see [data_dirs](../Reference/DataNode-Config-Manual.md) configuration item), and you can specify or customize the directory selection strategy (see [multi_dir_strategy](../Reference/DataNode-Config-Manual.md) configuration item for details).
 
 ### System files
 
-System files include schema files, which store metadata information of data in IoTDB. It can be configured through the `base_dir` configuration item (see [System Layer](../Reference/Config-Manual.md) for details).
+System files include schema files, which store metadata information of data in IoTDB. It can be configured through the `base_dir` configuration item (see [System Layer](../Reference/DataNode-Config-Manual.md) for details).
 
 ### Pre-write Log Files
 
-Pre-write log files store WAL files. It can be configured through the `wal_dir` configuration item (see [System Layer](../Reference/Config-Manual.md) for details).
+Pre-write log files store WAL files. It can be configured through the `wal_dir` configuration item (see [System Layer](../Reference/DataNode-Config-Manual.md) for details).
 
 ### Example of Setting Data storage Directory
 

--- a/docs/UserGuide/QuickStart/QuickStart.md
+++ b/docs/UserGuide/QuickStart/QuickStart.md
@@ -52,7 +52,7 @@ configuration files are under "conf" folder
   * system config module (`iotdb-datanode.properties`)
   * log config module (`logback.xml`). 
 
-For more, see [Config](../Reference/Config-Manual.md) in detail.
+For more, see [Config](../Reference/DataNode-Config-Manual.md) in detail.
 
 ## Start
 

--- a/docs/zh/Development/HowtoContributeCode.md
+++ b/docs/zh/Development/HowtoContributeCode.md
@@ -77,7 +77,7 @@ iotdb-datanode.properties 和 IoTDBConfig 默认值需要保持一致。
 如果需要对配置参数进行改动。以下文件需要同时修改：
   1. 配置文件：server/src/assembly/resources/conf/iotdb-datanode.properties
   2. 代码：IoTDBDescriptor、IoTDBConfig
-  3. 文档：docs/UserGuide/Reference/Config-Manual.md、docs/zh/UserGuide/Reference/Config-Manual.md
+  3. 文档：docs/UserGuide/Reference/DataNode-Config-Manual.md、docs/zh/UserGuide/Reference/DataNode-Config-Manual.md
 
 如果你想要在 IT 和 UT 文件中对配置参数进行修改，你需要在 @Before 修饰的方法里修改，并且在 @After 修饰的方法里重置，来避免对其他测试的影响。合并模块的参数统一放在CompactionConfigRestorer 文件里。
 

--- a/docs/zh/UserGuide/Data-Concept/Data-Type.md
+++ b/docs/zh/UserGuide/Data-Concept/Data-Type.md
@@ -34,7 +34,7 @@ IoTDB 支持：
 
 一共六种数据类型。
 
-其中 **FLOAT** 与 **DOUBLE** 类型的序列，如果编码方式采用 [RLE](Encoding.md) 或 [TS_2DIFF](Encoding.md) 可以指定 MAX_POINT_NUMBER，该项为浮点数的小数点后位数，若不指定则系统会根据配置文件`iotdb-datanode.properties`文件中的 [float_precision 项](../Reference/Config-Manual.md) 配置。
+其中 **FLOAT** 与 **DOUBLE** 类型的序列，如果编码方式采用 [RLE](Encoding.md) 或 [TS_2DIFF](Encoding.md) 可以指定 MAX_POINT_NUMBER，该项为浮点数的小数点后位数，若不指定则系统会根据配置文件`iotdb-datanode.properties`文件中的 [float_precision 项](../Reference/DataNode-Config-Manual.md) 配置。
 
 当系统中用户输入的数据类型与该时间序列的数据类型不对应时，系统会提醒类型错误，如下所示，二阶差分编码不支持布尔类型：
 

--- a/docs/zh/UserGuide/Data-Concept/Time-Partition.md
+++ b/docs/zh/UserGuide/Data-Concept/Time-Partition.md
@@ -55,7 +55,7 @@
 
 ## 使用建议
 
-使用时间分区功能时，建议同时打开 Memtable 的定时刷盘功能和 TsFileProcessor 的定时关闭功能，共 9 个相关配置参数（详情见 [timed_flush与timed_close配置项](../Reference/Config-Manual.md)）。
+使用时间分区功能时，建议同时打开 Memtable 的定时刷盘功能和 TsFileProcessor 的定时关闭功能，共 9 个相关配置参数（详情见 [timed_flush与timed_close配置项](../Reference/DataNode-Config-Manual.md)）。
 
 * enable_timed_flush_unseq_memtable: 是否开启乱序 Memtable 的定时刷盘，默认打开。
 

--- a/docs/zh/UserGuide/Data-Modeling/DataRegion.md
+++ b/docs/zh/UserGuide/Data-Modeling/DataRegion.md
@@ -50,4 +50,4 @@ data_region_num
 
 推荐值为[data region number] = [CPU core number] / [user-defined storage group number]
 
-参考[配置手册](../Reference/Config-Manual.md)以获取更多信息。
+参考[配置手册](../Reference/DataNode-Config-Manual.md)以获取更多信息。

--- a/docs/zh/UserGuide/QuickStart/Files.md
+++ b/docs/zh/UserGuide/QuickStart/Files.md
@@ -27,17 +27,17 @@ IoTDB 需要存储的数据分为三类，分别为数据文件、系统文件�
 
 ### 数据文件
 
-数据文件存储了用户写入 IoTDB 系统的所有数据。包含 TsFile 文件和其他文件，可通过 [data_dirs 配置项](../Reference/Config-Manual.md) 进行配置。
+数据文件存储了用户写入 IoTDB 系统的所有数据。包含 TsFile 文件和其他文件，可通过 [data_dirs 配置项](../Reference/DataNode-Config-Manual.md) 进行配置。
 
-为了更好的支持用户对于磁盘空间扩展等存储需求，IoTDB 为 TsFile 的存储配置增加了多文件目录的存储方式，用户可自主配置多个存储路径作为数据的持久化位置（详情见 [data_dirs 配置项](../Reference/Config-Manual.md)），并可以指定或自定义目录选择策略（详情见 [multi_dir_strategy 配置项](../Reference/Config-Manual.md)）。
+为了更好的支持用户对于磁盘空间扩展等存储需求，IoTDB 为 TsFile 的存储配置增加了多文件目录的存储方式，用户可自主配置多个存储路径作为数据的持久化位置（详情见 [data_dirs 配置项](../Reference/DataNode-Config-Manual.md)），并可以指定或自定义目录选择策略（详情见 [multi_dir_strategy 配置项](../Reference/DataNode-Config-Manual.md)）。
 
 ### 系统文件
 
-系统 Schema 文件，存储了数据文件的元数据信息。可通过 system_dir 配置项进行配置（详情见 [system_dir 配置项](../Reference/Config-Manual.md)）。
+系统 Schema 文件，存储了数据文件的元数据信息。可通过 system_dir 配置项进行配置（详情见 [system_dir 配置项](../Reference/DataNode-Config-Manual.md)）。
 
 ### 写前日志文件
 
-写前日志文件存储了系统的写前日志。可通过`wal_dir`配置项进行配置（详情见 [wal_dir 配置项](../Reference/Config-Manual.md)）。
+写前日志文件存储了系统的写前日志。可通过`wal_dir`配置项进行配置（详情见 [wal_dir 配置项](../Reference/DataNode-Config-Manual.md)）。
 
 ### 数据存储目录设置举例
 


### PR DESCRIPTION
In #6460 Config-Manual.md was renamed DataNode-Config-Manual.md. This makes Config-Manual.md unavailable.