### PR TITLE
[IOTDB-4298] Fix schema memory allocate for cluster

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -963,6 +963,8 @@ public class IoTDBConfig {
   /** ThreadPool size for write operation in coordinator */
   private int coordinatorWriteExecutorSize = 50;
 
+  private boolean isDefaultSchemaMemoryConfig = true;
+
   /** Memory allocated for schemaRegion */
   private long allocateMemoryForSchemaRegion = allocateMemoryForSchema * 8 / 10;
 
@@ -3067,6 +3069,14 @@ public class IoTDBConfig {
 
   public TEndPoint getAddressAndPort() {
     return new TEndPoint(rpcAddress, rpcPort);
+  }
+
+  boolean isDefaultSchemaMemoryConfig() {
+    return isDefaultSchemaMemoryConfig;
+  }
+
+  void setDefaultSchemaMemoryConfig(boolean defaultSchemaMemoryConfig) {
+    isDefaultSchemaMemoryConfig = defaultSchemaMemoryConfig;
   }
 
   public long getAllocateMemoryForSchemaRegion() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -963,6 +963,10 @@ public class IoTDBConfig {
   /** ThreadPool size for write operation in coordinator */
   private int coordinatorWriteExecutorSize = 50;
 
+  /**
+   * Whether the schema memory allocation is default config. Used for cluster mode initialization
+   * judgement
+   */
   private boolean isDefaultSchemaMemoryConfig = true;
 
   /** Memory allocated for schemaRegion */

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -190,6 +190,7 @@ public class DataNode implements DataNodeMBean {
             config.setDataNodeId(dataNodeID);
           }
           IoTDBDescriptor.getInstance().loadGlobalConfig(dataNodeRegisterResp.globalConfig);
+          IoTDBDescriptor.getInstance().initClusterSchemaMemoryAllocate();
 
           if (!IoTDBStartCheck.getInstance()
               .checkConsensusProtocolExists(TConsensusGroupType.DataRegion)) {


### PR DESCRIPTION
## Description


### Cause
The init of IoTDBConfig is always before the DataNode cluster mode init, which results in the schema memory is always allocated  as the default config for standalone mode, 8:1:0:1 for schema region, schema cache, partition cache and last cache.

### Solution
Recheck and update schema memory allocation when DataNode init the cluster config.

### Result

![image](https://user-images.githubusercontent.com/38524330/187825059-d3b958e9-c940-40d1-954e-e1ec8046f808.png)

