### PR TITLE
[IOTDB-4275]Handle measurement when traversing for paths using template

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -271,6 +271,15 @@ public class IoTDBSchemaTemplateIT {
     statement.execute("SET SCHEMA TEMPLATE t1 TO root.sg2.d2");
     statement.execute("SET SCHEMA TEMPLATE t2 TO root.sg3.d1");
     statement.execute("SET SCHEMA TEMPLATE t2 TO root.sg3.d2");
+    statement.execute("INSERT INTO root.sg3.d2.verify(time, show) VALUES (1, 1)");
+
+    try (ResultSet resultSet = statement.executeQuery("SHOW PATHS USING SCHEMA TEMPLATE t1")) {
+      String resultRecord;
+      while (resultSet.next()) {
+        resultRecord = resultSet.getString(1);
+        Assert.assertEquals("", resultRecord);
+      }
+    }
 
     // activate schema template
     statement.execute("CREATE TIMESERIES OF SCHEMA TEMPLATE ON root.sg1.d2");

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -1360,8 +1360,9 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
           @Override
           protected boolean processFullMatchedMNode(IMNode node, int idx, int level)
               throws MetadataException {
-            // shall not traverse nodes inside template
-            if (!node.getPartialPath().equals(getCurrentPartialPath(node))) {
+            // shall not traverse nodes inside template or measurement ones
+            if (!node.getPartialPath().equals(getCurrentPartialPath(node))
+                || node.isMeasurement()) {
               return true;
             }
 
@@ -1397,8 +1398,9 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
 
           @Override
           protected boolean processFullMatchedMNode(IMNode node, int idx, int level) {
-            // shall not traverse nodes inside template
-            if (!node.getPartialPath().equals(getCurrentPartialPath(node))) {
+            // shall not traverse nodes inside template or measurement ones
+            if (!node.getPartialPath().equals(getCurrentPartialPath(node))
+                || node.isMeasurement()) {
               return true;
             }
 
@@ -1539,6 +1541,9 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
 
           @Override
           protected boolean processFullMatchedMNode(IMNode node, int idx, int level) {
+            if (node.isMeasurement()) {
+              return true;
+            }
             if (node.getSchemaTemplateId() != NON_TEMPLATE
                 && templateId != ALL_TEMPLATE
                 && node.getSchemaTemplateId() != templateId) {


### PR DESCRIPTION
When querying for paths using template, DataNode will traverse the tree of MNodes and call method `getSchemaTemplateId` on every nodes accessed ignoring whether it is a measurement, which may throw an `RuntimeException` since measurement node cannot set or using any template.

This PR handled the situation by an extra `if statement`, and fixed related methods which works in standalone mode as well.

Corresponding issue on rel/0.13 had been fixed previously.