### PR TITLE
[IOTDB-4137] Reject write when Peer in ReadOnly state in RatisConsensus

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/exception/NodeReadOnlyException.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/exception/NodeReadOnlyException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.consensus.exception;
+
+import org.apache.ratis.protocol.RaftPeer;
+
+public class NodeReadOnlyException extends ConsensusException {
+  public NodeReadOnlyException(RaftPeer peer) {
+    super(
+        String.format(
+            "Current Peer %s in Address %s is in Read Only State",
+            peer.getId(), peer.getAddress()));
+  }
+}


### PR DESCRIPTION
When receiving a write request from upper layer, RatisConsensus should see whether current Peer
1. is in ReadOnly state.
2. is leader of the given group.
If the above two conditions both hold, reject the write request and fail immediately.