### PR TITLE
[IOTDB-4346] restructure TVList, add TimSort interface

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -37,8 +37,6 @@ import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -47,29 +45,25 @@ import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 import static org.apache.iotdb.tsfile.utils.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 import static org.apache.iotdb.tsfile.utils.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
 
-public class AlignedTVList extends TVList {
+public abstract class AlignedTVList extends TVList {
   private static final int NULL_FLAG = -1;
 
   // data types of this aligned tvList
-  private List<TSDataType> dataTypes;
+  protected List<TSDataType> dataTypes;
 
   // data type list -> list of TVList, add 1 when expanded -> primitive array of basic type
   // index relation: columnIndex(dataTypeIndex) -> arrayIndex -> elementIndex
-  private List<List<Object>> values;
+  protected List<List<Object>> values;
 
   // list of index array, add 1 when expanded -> data point index array
   // index relation: arrayIndex -> elementIndex
   // used in sort method, sort only changes indices
-  private List<int[]> indices;
+  protected List<int[]> indices;
 
   // data type list -> list of BitMap, add 1 when expanded -> BitMap(maybe null), marked means the
   // value is null
   // index relation: columnIndex(dataTypeIndex) -> arrayIndex -> elementIndex
-  private List<List<BitMap>> bitMaps;
-
-  private int[][] sortedIndices;
-
-  private int pivotIndex;
+  protected List<List<BitMap>> bitMaps;
 
   AlignedTVList(List<TSDataType> types) {
     super();
@@ -82,8 +76,11 @@ public class AlignedTVList extends TVList {
   }
 
   public static AlignedTVList newAlignedList(List<TSDataType> dataTypes) {
-    return new AlignedTVList(dataTypes);
+    return new TimAlignedTVList(dataTypes);
   }
+
+  @Override
+  public abstract AlignedTVList clone();
 
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   @Override
@@ -223,36 +220,6 @@ public class AlignedTVList extends TVList {
       }
     }
     return TsPrimitiveType.getByType(TSDataType.VECTOR, vector);
-  }
-
-  @Override
-  public TVList getTvListByColumnIndex(List<Integer> columnIndex, List<TSDataType> dataTypeList) {
-    List<List<Object>> values = new ArrayList<>();
-    List<List<BitMap>> bitMaps = null;
-    for (int i = 0; i < columnIndex.size(); i++) {
-      // columnIndex == -1 means querying a non-exist column, add null column here
-      if (columnIndex.get(i) == -1) {
-        values.add(null);
-      } else {
-        values.add(this.values.get(columnIndex.get(i)));
-        if (this.bitMaps != null && this.bitMaps.get(columnIndex.get(i)) != null) {
-          if (bitMaps == null) {
-            bitMaps = new ArrayList<>(columnIndex.size());
-            for (int j = 0; j < columnIndex.size(); j++) {
-              bitMaps.add(null);
-            }
-          }
-          bitMaps.set(i, this.bitMaps.get(columnIndex.get(i)));
-        }
-      }
-    }
-    AlignedTVList alignedTvList = new AlignedTVList(dataTypeList);
-    alignedTvList.timestamps = this.timestamps;
-    alignedTvList.indices = this.indices;
-    alignedTvList.values = values;
-    alignedTvList.bitMaps = bitMaps;
-    alignedTvList.rowCount = this.rowCount;
-    return alignedTvList;
   }
 
   public void extendColumn(TSDataType dataType) {
@@ -472,7 +439,7 @@ public class AlignedTVList extends TVList {
     bitMaps.remove(columnIndex);
   }
 
-  private void set(int index, long timestamp, int value) {
+  protected void set(int index, long timestamp, int value) {
     int arrayIndex = index / ARRAY_SIZE;
     int elementIndex = index % ARRAY_SIZE;
     timestamps.get(arrayIndex)[elementIndex] = timestamp;
@@ -480,46 +447,13 @@ public class AlignedTVList extends TVList {
   }
 
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
-  @Override
-  public AlignedTVList clone() {
-    AlignedTVList cloneList = new AlignedTVList(dataTypes);
-    cloneAs(cloneList);
-    for (int[] indicesArray : indices) {
-      cloneList.indices.add(cloneIndex(indicesArray));
-    }
-    for (int i = 0; i < values.size(); i++) {
-      List<Object> columnValues = values.get(i);
-      for (Object valueArray : columnValues) {
-        cloneList.values.get(i).add(cloneValue(dataTypes.get(i), valueArray));
-      }
-      // clone bitmap in columnIndex
-      if (bitMaps != null && bitMaps.get(i) != null) {
-        List<BitMap> columnBitMaps = bitMaps.get(i);
-        if (cloneList.bitMaps == null) {
-          cloneList.bitMaps = new ArrayList<>(dataTypes.size());
-          for (int j = 0; j < dataTypes.size(); j++) {
-            cloneList.bitMaps.add(null);
-          }
-        }
-        if (cloneList.bitMaps.get(i) == null) {
-          List<BitMap> cloneColumnBitMaps = new ArrayList<>();
-          for (BitMap bitMap : columnBitMaps) {
-            cloneColumnBitMaps.add(bitMap == null ? null : bitMap.clone());
-          }
-          cloneList.bitMaps.set(i, cloneColumnBitMaps);
-        }
-      }
-    }
-    return cloneList;
-  }
-
-  private int[] cloneIndex(int[] array) {
+  protected int[] cloneIndex(int[] array) {
     int[] cloneArray = new int[array.length];
     System.arraycopy(array, 0, cloneArray, 0, array.length);
     return cloneArray;
   }
 
-  private Object cloneValue(TSDataType type, Object value) {
+  protected Object cloneValue(TSDataType type, Object value) {
     switch (type) {
       case TEXT:
         Binary[] valueT = (Binary[]) value;
@@ -557,25 +491,7 @@ public class AlignedTVList extends TVList {
   }
 
   @Override
-  public void sort() {
-    if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
-    }
-    if (sortedIndices == null
-        || sortedIndices.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedIndices =
-          (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, rowCount);
-    }
-    sort(0, rowCount);
-    clearSortedValue();
-    clearSortedTime();
-    sorted = true;
-  }
-
-  @Override
-  void clearValue() {
+  public void clearValue() {
     if (indices != null) {
       for (int[] dataArray : indices) {
         PrimitiveArrayManager.release(dataArray);
@@ -600,47 +516,6 @@ public class AlignedTVList extends TVList {
   }
 
   @Override
-  void clearSortedValue() {
-    if (sortedIndices != null) {
-      sortedIndices = null;
-    }
-  }
-
-  @Override
-  protected void setFromSorted(int src, int dest) {
-    set(
-        dest,
-        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
-        sortedIndices[src / ARRAY_SIZE][src % ARRAY_SIZE]);
-  }
-
-  @Override
-  protected void set(int src, int dest) {
-    long srcT = getTime(src);
-    int srcV = getValueIndex(src);
-    set(dest, srcT, srcV);
-  }
-
-  @Override
-  protected void setToSorted(int src, int dest) {
-    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
-    sortedIndices[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getValueIndex(src);
-  }
-
-  @Override
-  protected void reverseRange(int lo, int hi) {
-    hi--;
-    while (lo < hi) {
-      long loT = getTime(lo);
-      int loV = getValueIndex(lo);
-      long hiT = getTime(hi);
-      int hiV = getValueIndex(hi);
-      set(lo++, hiT, hiV);
-      set(hi--, loT, loV);
-    }
-  }
-
-  @Override
   protected void expandValues() {
     indices.add((int[]) getPrimitiveArraysByType(TSDataType.INT32));
     for (int i = 0; i < dataTypes.size(); i++) {
@@ -649,12 +524,6 @@ public class AlignedTVList extends TVList {
         bitMaps.get(i).add(null);
       }
     }
-  }
-
-  @Override
-  protected void saveAsPivot(int pos) {
-    pivotTime = getTime(pos);
-    pivotIndex = getValueIndex(pos);
   }
 
   /**
@@ -691,11 +560,6 @@ public class AlignedTVList extends TVList {
       }
     }
     return validRowIndex;
-  }
-
-  @Override
-  protected void setPivotTo(int pos) {
-    set(pos, pivotTime, pivotIndex);
   }
 
   @Override
@@ -874,17 +738,6 @@ public class AlignedTVList extends TVList {
     // Object references size in ArrayList
     size += (long) NUM_BYTES_OBJECT_REF * (2 + types.length);
     return size;
-  }
-
-  public void clear() {
-    rowCount = 0;
-    sorted = true;
-    minTime = Long.MAX_VALUE;
-    clearTime();
-    clearSortedTime();
-
-    clearValue();
-    clearSortedValue();
   }
 
   /** Build TsBlock by column. */
@@ -1083,99 +936,5 @@ public class AlignedTVList extends TVList {
         WALWriteUtils.write(isNullValue(rowIndex, columnIndex), buffer);
       }
     }
-  }
-
-  public static AlignedTVList deserialize(DataInputStream stream) throws IOException {
-    int dataTypeNum = stream.readInt();
-    List<TSDataType> dataTypes = new ArrayList<>(dataTypeNum);
-    int[] columnIndexArray = new int[dataTypeNum];
-    for (int columnIndex = 0; columnIndex < dataTypeNum; ++columnIndex) {
-      dataTypes.add(ReadWriteIOUtils.readDataType(stream));
-      columnIndexArray[columnIndex] = columnIndex;
-    }
-
-    int rowCount = stream.readInt();
-    // time
-    long[] times = new long[rowCount];
-    for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
-      times[rowIndex] = stream.readLong();
-    }
-    // read value and bitmap by column
-    Object[] values = new Object[dataTypeNum];
-    BitMap[] bitMaps = new BitMap[dataTypeNum];
-    for (int columnIndex = 0; columnIndex < dataTypeNum; ++columnIndex) {
-      BitMap bitMap = new BitMap(rowCount);
-      Object valuesOfOneColumn;
-      switch (dataTypes.get(columnIndex)) {
-        case TEXT:
-          Binary[] binaryValues = new Binary[rowCount];
-          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
-            binaryValues[rowIndex] = ReadWriteIOUtils.readBinary(stream);
-            if (ReadWriteIOUtils.readBool(stream)) {
-              bitMap.mark(rowIndex);
-            }
-          }
-          valuesOfOneColumn = binaryValues;
-          break;
-        case FLOAT:
-          float[] floatValues = new float[rowCount];
-          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
-            floatValues[rowIndex] = stream.readFloat();
-            if (ReadWriteIOUtils.readBool(stream)) {
-              bitMap.mark(rowIndex);
-            }
-          }
-          valuesOfOneColumn = floatValues;
-          break;
-        case INT32:
-          int[] intValues = new int[rowCount];
-          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
-            intValues[rowIndex] = stream.readInt();
-            if (ReadWriteIOUtils.readBool(stream)) {
-              bitMap.mark(rowIndex);
-            }
-          }
-          valuesOfOneColumn = intValues;
-          break;
-        case INT64:
-          long[] longValues = new long[rowCount];
-          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
-            longValues[rowIndex] = stream.readLong();
-            if (ReadWriteIOUtils.readBool(stream)) {
-              bitMap.mark(rowIndex);
-            }
-          }
-          valuesOfOneColumn = longValues;
-          break;
-        case DOUBLE:
-          double[] doubleValues = new double[rowCount];
-          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
-            doubleValues[rowIndex] = stream.readDouble();
-            if (ReadWriteIOUtils.readBool(stream)) {
-              bitMap.mark(rowIndex);
-            }
-          }
-          valuesOfOneColumn = doubleValues;
-          break;
-        case BOOLEAN:
-          boolean[] booleanValues = new boolean[rowCount];
-          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
-            booleanValues[rowIndex] = ReadWriteIOUtils.readBool(stream);
-            if (ReadWriteIOUtils.readBool(stream)) {
-              bitMap.mark(rowIndex);
-            }
-          }
-          valuesOfOneColumn = booleanValues;
-          break;
-        default:
-          throw new UnsupportedOperationException(ERR_DATATYPE_NOT_CONSISTENT);
-      }
-      values[columnIndex] = valuesOfOneColumn;
-      bitMaps[columnIndex] = bitMap;
-    }
-
-    AlignedTVList tvList = new AlignedTVList(dataTypes);
-    tvList.putAlignedValues(times, values, bitMaps, columnIndexArray, 0, rowCount);
-    return tvList;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
@@ -37,6 +37,8 @@ import java.util.List;
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
 public abstract class BinaryTVList extends TVList {
+  // list of primitive array, add 1 when expanded -> Binary primitive array
+  // index relation: arrayIndex -> elementIndex
   protected List<Binary[]> values;
 
   BinaryTVList() {

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
@@ -31,22 +31,13 @@ import org.apache.iotdb.tsfile.utils.BitMap;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
-public class BinaryTVList extends TVList {
-
-  // list of primitive array, add 1 when expanded -> Binary primitive array
-  // index relation: arrayIndex -> elementIndex
-  private List<Binary[]> values;
-
-  private Binary[][] sortedValues;
-
-  private Binary pivotValue;
+public abstract class BinaryTVList extends TVList {
+  protected List<Binary[]> values;
 
   BinaryTVList() {
     super();
@@ -88,40 +79,6 @@ public class BinaryTVList extends TVList {
   }
 
   @Override
-  public BinaryTVList clone() {
-    BinaryTVList cloneList = new BinaryTVList();
-    cloneAs(cloneList);
-    for (Binary[] valueArray : values) {
-      cloneList.values.add(cloneValue(valueArray));
-    }
-    return cloneList;
-  }
-
-  private Binary[] cloneValue(Binary[] array) {
-    Binary[] cloneArray = new Binary[array.length];
-    System.arraycopy(array, 0, cloneArray, 0, array.length);
-    return cloneArray;
-  }
-
-  @Override
-  public void sort() {
-    if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
-    }
-    if (sortedValues == null
-        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedValues =
-          (Binary[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.TEXT, rowCount);
-    }
-    sort(0, rowCount);
-    clearSortedValue();
-    clearSortedTime();
-    sorted = true;
-  }
-
-  @Override
   void clearValue() {
     if (values != null) {
       for (Binary[] dataArray : values) {
@@ -132,60 +89,8 @@ public class BinaryTVList extends TVList {
   }
 
   @Override
-  void clearSortedValue() {
-    if (sortedValues != null) {
-      sortedValues = null;
-    }
-  }
-
-  @Override
-  protected void setFromSorted(int src, int dest) {
-    set(
-        dest,
-        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
-        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
-  }
-
-  @Override
-  protected void set(int src, int dest) {
-    long srcT = getTime(src);
-    Binary srcV = getBinary(src);
-    set(dest, srcT, srcV);
-  }
-
-  @Override
-  protected void setToSorted(int src, int dest) {
-    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
-    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getBinary(src);
-  }
-
-  @Override
-  protected void reverseRange(int lo, int hi) {
-    hi--;
-    while (lo < hi) {
-      long loT = getTime(lo);
-      Binary loV = getBinary(lo);
-      long hiT = getTime(hi);
-      Binary hiV = getBinary(hi);
-      set(lo++, hiT, hiV);
-      set(hi--, loT, loV);
-    }
-  }
-
-  @Override
   protected void expandValues() {
     values.add((Binary[]) getPrimitiveArraysByType(TSDataType.TEXT));
-  }
-
-  @Override
-  protected void saveAsPivot(int pos) {
-    pivotTime = getTime(pos);
-    pivotValue = getBinary(pos);
-  }
-
-  @Override
-  protected void setPivotTo(int pos) {
-    set(pos, pivotTime, pivotValue);
   }
 
   @Override
@@ -320,18 +225,5 @@ public class BinaryTVList extends TVList {
       buffer.putLong(getTime(rowIdx));
       WALWriteUtils.write(getBinary(rowIdx), buffer);
     }
-  }
-
-  public static BinaryTVList deserialize(DataInputStream stream) throws IOException {
-    BinaryTVList tvList = new BinaryTVList();
-    int rowCount = stream.readInt();
-    long[] times = new long[rowCount];
-    Binary[] values = new Binary[rowCount];
-    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
-      times[rowIdx] = stream.readLong();
-      values[rowIdx] = ReadWriteIOUtils.readBinary(stream);
-    }
-    tvList.putBinaries(times, values, null, 0, rowCount);
-    return tvList;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
@@ -35,6 +35,8 @@ import java.util.List;
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
 public abstract class BooleanTVList extends TVList {
+  // list of primitive array, add 1 when expanded -> Binary primitive array
+  // index relation: arrayIndex -> elementIndex
   protected List<boolean[]> values;
 
   BooleanTVList() {

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BooleanTVList.java
@@ -27,25 +27,15 @@ import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.BitMap;
-import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
-public class BooleanTVList extends TVList {
-
-  // list of primitive array, add 1 when expanded -> boolean primitive array
-  // index relation: arrayIndex -> elementIndex
-  private List<boolean[]> values;
-
-  private boolean[][] sortedValues;
-
-  private boolean pivotValue;
+public abstract class BooleanTVList extends TVList {
+  protected List<boolean[]> values;
 
   BooleanTVList() {
     super();
@@ -87,40 +77,6 @@ public class BooleanTVList extends TVList {
   }
 
   @Override
-  public BooleanTVList clone() {
-    BooleanTVList cloneList = new BooleanTVList();
-    cloneAs(cloneList);
-    for (boolean[] valueArray : values) {
-      cloneList.values.add(cloneValue(valueArray));
-    }
-    return cloneList;
-  }
-
-  private boolean[] cloneValue(boolean[] array) {
-    boolean[] cloneArray = new boolean[array.length];
-    System.arraycopy(array, 0, cloneArray, 0, array.length);
-    return cloneArray;
-  }
-
-  @Override
-  public void sort() {
-    if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
-    }
-    if (sortedValues == null
-        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedValues =
-          (boolean[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.BOOLEAN, rowCount);
-    }
-    sort(0, rowCount);
-    clearSortedValue();
-    clearSortedTime();
-    sorted = true;
-  }
-
-  @Override
   void clearValue() {
     if (values != null) {
       for (boolean[] dataArray : values) {
@@ -131,60 +87,13 @@ public class BooleanTVList extends TVList {
   }
 
   @Override
-  void clearSortedValue() {
-    if (sortedValues != null) {
-      sortedValues = null;
-    }
-  }
-
-  @Override
-  protected void setFromSorted(int src, int dest) {
-    set(
-        dest,
-        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
-        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
-  }
-
-  @Override
-  protected void set(int src, int dest) {
-    long srcT = getTime(src);
-    boolean srcV = getBoolean(src);
-    set(dest, srcT, srcV);
-  }
-
-  @Override
-  protected void setToSorted(int src, int dest) {
-    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
-    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getBoolean(src);
-  }
-
-  @Override
-  protected void reverseRange(int lo, int hi) {
-    hi--;
-    while (lo < hi) {
-      long loT = getTime(lo);
-      boolean loV = getBoolean(lo);
-      long hiT = getTime(hi);
-      boolean hiV = getBoolean(hi);
-      set(lo++, hiT, hiV);
-      set(hi--, loT, loV);
-    }
-  }
-
-  @Override
   protected void expandValues() {
     values.add((boolean[]) getPrimitiveArraysByType(TSDataType.BOOLEAN));
   }
 
   @Override
-  protected void saveAsPivot(int pos) {
-    pivotTime = getTime(pos);
-    pivotValue = getBoolean(pos);
-  }
-
-  @Override
-  protected void setPivotTo(int pos) {
-    set(pos, pivotTime, pivotValue);
+  public TVList clone() {
+    return null;
   }
 
   @Override
@@ -316,18 +225,5 @@ public class BooleanTVList extends TVList {
       buffer.putLong(getTime(rowIdx));
       WALWriteUtils.write(getBoolean(rowIdx), buffer);
     }
-  }
-
-  public static BooleanTVList deserialize(DataInputStream stream) throws IOException {
-    BooleanTVList tvList = new BooleanTVList();
-    int rowCount = stream.readInt();
-    long[] times = new long[rowCount];
-    boolean[] values = new boolean[rowCount];
-    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
-      times[rowIdx] = stream.readLong();
-      values[rowIdx] = ReadWriteIOUtils.readBool(stream);
-    }
-    tvList.putBooleans(times, values, null, 0, rowCount);
-    return tvList;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
@@ -30,22 +30,13 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.BitMap;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
-public class DoubleTVList extends TVList {
-
-  // list of primitive array, add 1 when expanded -> double primitive array
-  // index relation: arrayIndex -> elementIndex
-  private List<double[]> values;
-
-  private double[][] sortedValues;
-
-  private double pivotValue;
+public abstract class DoubleTVList extends TVList {
+  protected List<double[]> values;
 
   DoubleTVList() {
     super();
@@ -87,40 +78,6 @@ public class DoubleTVList extends TVList {
   }
 
   @Override
-  public DoubleTVList clone() {
-    DoubleTVList cloneList = new DoubleTVList();
-    cloneAs(cloneList);
-    for (double[] valueArray : values) {
-      cloneList.values.add(cloneValue(valueArray));
-    }
-    return cloneList;
-  }
-
-  private double[] cloneValue(double[] array) {
-    double[] cloneArray = new double[array.length];
-    System.arraycopy(array, 0, cloneArray, 0, array.length);
-    return cloneArray;
-  }
-
-  @Override
-  public void sort() {
-    if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
-    }
-    if (sortedValues == null
-        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedValues =
-          (double[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.DOUBLE, rowCount);
-    }
-    sort(0, rowCount);
-    clearSortedValue();
-    clearSortedTime();
-    sorted = true;
-  }
-
-  @Override
   void clearValue() {
     if (values != null) {
       for (double[] dataArray : values) {
@@ -131,60 +88,8 @@ public class DoubleTVList extends TVList {
   }
 
   @Override
-  void clearSortedValue() {
-    if (sortedValues != null) {
-      sortedValues = null;
-    }
-  }
-
-  @Override
-  protected void setFromSorted(int src, int dest) {
-    set(
-        dest,
-        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
-        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
-  }
-
-  @Override
-  protected void set(int src, int dest) {
-    long srcT = getTime(src);
-    double srcV = getDouble(src);
-    set(dest, srcT, srcV);
-  }
-
-  @Override
-  protected void setToSorted(int src, int dest) {
-    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
-    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getDouble(src);
-  }
-
-  @Override
-  protected void reverseRange(int lo, int hi) {
-    hi--;
-    while (lo < hi) {
-      long loT = getTime(lo);
-      double loV = getDouble(lo);
-      long hiT = getTime(hi);
-      double hiV = getDouble(hi);
-      set(lo++, hiT, hiV);
-      set(hi--, loT, loV);
-    }
-  }
-
-  @Override
   protected void expandValues() {
     values.add((double[]) getPrimitiveArraysByType(TSDataType.DOUBLE));
-  }
-
-  @Override
-  protected void saveAsPivot(int pos) {
-    pivotTime = getTime(pos);
-    pivotValue = getDouble(pos);
-  }
-
-  @Override
-  protected void setPivotTo(int pos) {
-    set(pos, pivotTime, pivotValue);
   }
 
   @Override
@@ -321,18 +226,5 @@ public class DoubleTVList extends TVList {
       buffer.putLong(getTime(rowIdx));
       buffer.putDouble(getDouble(rowIdx));
     }
-  }
-
-  public static DoubleTVList deserialize(DataInputStream stream) throws IOException {
-    DoubleTVList tvList = new DoubleTVList();
-    int rowCount = stream.readInt();
-    long[] times = new long[rowCount];
-    double[] values = new double[rowCount];
-    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
-      times[rowIdx] = stream.readLong();
-      values[rowIdx] = stream.readDouble();
-    }
-    tvList.putDoubles(times, values, null, 0, rowCount);
-    return tvList;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/DoubleTVList.java
@@ -36,6 +36,8 @@ import java.util.List;
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
 public abstract class DoubleTVList extends TVList {
+  // list of primitive array, add 1 when expanded -> double primitive array
+  // index relation: arrayIndex -> elementIndex
   protected List<double[]> values;
 
   DoubleTVList() {

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
@@ -36,6 +36,8 @@ import java.util.List;
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
 public abstract class FloatTVList extends TVList {
+  // list of primitive array, add 1 when expanded -> float primitive array
+  // index relation: arrayIndex -> elementIndex
   protected List<float[]> values;
 
   FloatTVList() {

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FloatTVList.java
@@ -30,22 +30,13 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.BitMap;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
-public class FloatTVList extends TVList {
-
-  // list of primitive array, add 1 when expanded -> float primitive array
-  // index relation: arrayIndex -> elementIndex
-  private List<float[]> values;
-
-  private float[][] sortedValues;
-
-  private float pivotValue;
+public abstract class FloatTVList extends TVList {
+  protected List<float[]> values;
 
   FloatTVList() {
     super();
@@ -87,40 +78,6 @@ public class FloatTVList extends TVList {
   }
 
   @Override
-  public FloatTVList clone() {
-    FloatTVList cloneList = new FloatTVList();
-    cloneAs(cloneList);
-    for (float[] valueArray : values) {
-      cloneList.values.add(cloneValue(valueArray));
-    }
-    return cloneList;
-  }
-
-  private float[] cloneValue(float[] array) {
-    float[] cloneArray = new float[array.length];
-    System.arraycopy(array, 0, cloneArray, 0, array.length);
-    return cloneArray;
-  }
-
-  @Override
-  public void sort() {
-    if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
-    }
-    if (sortedValues == null
-        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedValues =
-          (float[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.FLOAT, rowCount);
-    }
-    sort(0, rowCount);
-    clearSortedValue();
-    clearSortedTime();
-    sorted = true;
-  }
-
-  @Override
   void clearValue() {
     if (values != null) {
       for (float[] dataArray : values) {
@@ -131,60 +88,8 @@ public class FloatTVList extends TVList {
   }
 
   @Override
-  void clearSortedValue() {
-    if (sortedValues != null) {
-      sortedValues = null;
-    }
-  }
-
-  @Override
-  protected void setFromSorted(int src, int dest) {
-    set(
-        dest,
-        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
-        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
-  }
-
-  @Override
-  protected void set(int src, int dest) {
-    long srcT = getTime(src);
-    float srcV = getFloat(src);
-    set(dest, srcT, srcV);
-  }
-
-  @Override
-  protected void setToSorted(int src, int dest) {
-    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
-    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getFloat(src);
-  }
-
-  @Override
-  protected void reverseRange(int lo, int hi) {
-    hi--;
-    while (lo < hi) {
-      long loT = getTime(lo);
-      float loV = getFloat(lo);
-      long hiT = getTime(hi);
-      float hiV = getFloat(hi);
-      set(lo++, hiT, hiV);
-      set(hi--, loT, loV);
-    }
-  }
-
-  @Override
   protected void expandValues() {
     values.add((float[]) getPrimitiveArraysByType(TSDataType.FLOAT));
-  }
-
-  @Override
-  protected void saveAsPivot(int pos) {
-    pivotTime = getTime(pos);
-    pivotValue = getFloat(pos);
-  }
-
-  @Override
-  protected void setPivotTo(int pos) {
-    set(pos, pivotTime, pivotValue);
   }
 
   @Override
@@ -321,18 +226,5 @@ public class FloatTVList extends TVList {
       buffer.putLong(getTime(rowIdx));
       buffer.putFloat(getFloat(rowIdx));
     }
-  }
-
-  public static FloatTVList deserialize(DataInputStream stream) throws IOException {
-    FloatTVList tvList = new FloatTVList();
-    int rowCount = stream.readInt();
-    long[] times = new long[rowCount];
-    float[] values = new float[rowCount];
-    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
-      times[rowIdx] = stream.readLong();
-      values[rowIdx] = stream.readFloat();
-    }
-    tvList.putFloats(times, values, null, 0, rowCount);
-    return tvList;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
@@ -35,6 +35,8 @@ import java.util.List;
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
 public abstract class IntTVList extends TVList {
+  // list of primitive array, add 1 when expanded -> int primitive array
+  // index relation: arrayIndex -> elementIndex
   protected List<int[]> values;
 
   IntTVList() {

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/IntTVList.java
@@ -29,26 +29,32 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.BitMap;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
-public class IntTVList extends TVList {
-
-  // list of primitive array, add 1 when expanded -> int primitive array
-  // index relation: arrayIndex -> elementIndex
-  private List<int[]> values;
-
-  private int[][] sortedValues;
-
-  private int pivotValue;
+public abstract class IntTVList extends TVList {
+  protected List<int[]> values;
 
   IntTVList() {
     super();
     values = new ArrayList<>();
+  }
+
+  public TimIntTVList clone() {
+    TimIntTVList cloneList = new TimIntTVList();
+    cloneAs(cloneList);
+    for (int[] valueArray : values) {
+      cloneList.values.add(cloneValue(valueArray));
+    }
+    return cloneList;
+  }
+
+  private int[] cloneValue(int[] array) {
+    int[] cloneArray = new int[array.length];
+    System.arraycopy(array, 0, cloneArray, 0, array.length);
+    return cloneArray;
   }
 
   @Override
@@ -86,40 +92,6 @@ public class IntTVList extends TVList {
   }
 
   @Override
-  public IntTVList clone() {
-    IntTVList cloneList = new IntTVList();
-    cloneAs(cloneList);
-    for (int[] valueArray : values) {
-      cloneList.values.add(cloneValue(valueArray));
-    }
-    return cloneList;
-  }
-
-  private int[] cloneValue(int[] array) {
-    int[] cloneArray = new int[array.length];
-    System.arraycopy(array, 0, cloneArray, 0, array.length);
-    return cloneArray;
-  }
-
-  @Override
-  public void sort() {
-    if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
-    }
-    if (sortedValues == null
-        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedValues =
-          (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, rowCount);
-    }
-    sort(0, rowCount);
-    clearSortedValue();
-    clearSortedTime();
-    sorted = true;
-  }
-
-  @Override
   void clearValue() {
     if (values != null) {
       for (int[] dataArray : values) {
@@ -130,60 +102,8 @@ public class IntTVList extends TVList {
   }
 
   @Override
-  void clearSortedValue() {
-    if (sortedValues != null) {
-      sortedValues = null;
-    }
-  }
-
-  @Override
-  protected void setFromSorted(int src, int dest) {
-    set(
-        dest,
-        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
-        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
-  }
-
-  @Override
-  protected void set(int src, int dest) {
-    long srcT = getTime(src);
-    int srcV = getInt(src);
-    set(dest, srcT, srcV);
-  }
-
-  @Override
-  protected void setToSorted(int src, int dest) {
-    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
-    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getInt(src);
-  }
-
-  @Override
-  protected void reverseRange(int lo, int hi) {
-    hi--;
-    while (lo < hi) {
-      long loT = getTime(lo);
-      int loV = getInt(lo);
-      long hiT = getTime(hi);
-      int hiV = getInt(hi);
-      set(lo++, hiT, hiV);
-      set(hi--, loT, loV);
-    }
-  }
-
-  @Override
   protected void expandValues() {
     values.add((int[]) getPrimitiveArraysByType(TSDataType.INT32));
-  }
-
-  @Override
-  protected void saveAsPivot(int pos) {
-    pivotTime = getTime(pos);
-    pivotValue = getInt(pos);
-  }
-
-  @Override
-  protected void setPivotTo(int pos) {
-    set(pos, pivotTime, pivotValue);
   }
 
   @Override
@@ -314,18 +234,5 @@ public class IntTVList extends TVList {
       buffer.putLong(getTime(rowIdx));
       buffer.putInt(getInt(rowIdx));
     }
-  }
-
-  public static IntTVList deserialize(DataInputStream stream) throws IOException {
-    IntTVList tvList = new IntTVList();
-    int rowCount = stream.readInt();
-    long[] times = new long[rowCount];
-    int[] values = new int[rowCount];
-    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
-      times[rowIdx] = stream.readLong();
-      values[rowIdx] = stream.readInt();
-    }
-    tvList.putInts(times, values, null, 0, rowCount);
-    return tvList;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
@@ -29,22 +29,13 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.BitMap;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
-import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
-public class LongTVList extends TVList {
-
-  // list of primitive array, add 1 when expanded -> long primitive array
-  // index relation: arrayIndex -> elementIndex
-  private List<long[]> values;
-
-  private long[][] sortedValues;
-
-  private long pivotValue;
+public abstract class LongTVList extends TVList {
+  protected List<long[]> values;
 
   LongTVList() {
     super();
@@ -86,40 +77,6 @@ public class LongTVList extends TVList {
   }
 
   @Override
-  public LongTVList clone() {
-    LongTVList cloneList = new LongTVList();
-    cloneAs(cloneList);
-    for (long[] valueArray : values) {
-      cloneList.values.add(cloneValue(valueArray));
-    }
-    return cloneList;
-  }
-
-  private long[] cloneValue(long[] array) {
-    long[] cloneArray = new long[array.length];
-    System.arraycopy(array, 0, cloneArray, 0, array.length);
-    return cloneArray;
-  }
-
-  @Override
-  public void sort() {
-    if (sortedTimestamps == null
-        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedTimestamps =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
-    }
-    if (sortedValues == null
-        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
-      sortedValues =
-          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
-    }
-    sort(0, rowCount);
-    clearSortedValue();
-    clearSortedTime();
-    sorted = true;
-  }
-
-  @Override
   void clearValue() {
     if (values != null) {
       for (long[] dataArray : values) {
@@ -130,60 +87,8 @@ public class LongTVList extends TVList {
   }
 
   @Override
-  void clearSortedValue() {
-    if (sortedValues != null) {
-      sortedValues = null;
-    }
-  }
-
-  @Override
-  protected void setFromSorted(int src, int dest) {
-    set(
-        dest,
-        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
-        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
-  }
-
-  @Override
-  protected void set(int src, int dest) {
-    long srcT = getTime(src);
-    long srcV = getLong(src);
-    set(dest, srcT, srcV);
-  }
-
-  @Override
-  protected void setToSorted(int src, int dest) {
-    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
-    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getLong(src);
-  }
-
-  @Override
-  protected void reverseRange(int lo, int hi) {
-    hi--;
-    while (lo < hi) {
-      long loT = getTime(lo);
-      long loV = getLong(lo);
-      long hiT = getTime(hi);
-      long hiV = getLong(hi);
-      set(lo++, hiT, hiV);
-      set(hi--, loT, loV);
-    }
-  }
-
-  @Override
   protected void expandValues() {
     values.add((long[]) getPrimitiveArraysByType(TSDataType.INT64));
-  }
-
-  @Override
-  protected void saveAsPivot(int pos) {
-    pivotTime = getTime(pos);
-    pivotValue = getLong(pos);
-  }
-
-  @Override
-  protected void setPivotTo(int pos) {
-    set(pos, pivotTime, pivotValue);
   }
 
   @Override
@@ -314,18 +219,5 @@ public class LongTVList extends TVList {
       buffer.putLong(getTime(rowIdx));
       buffer.putLong(getLong(rowIdx));
     }
-  }
-
-  public static LongTVList deserialize(DataInputStream stream) throws IOException {
-    LongTVList tvList = new LongTVList();
-    int rowCount = stream.readInt();
-    long[] times = new long[rowCount];
-    long[] values = new long[rowCount];
-    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
-      times[rowIdx] = stream.readLong();
-      values[rowIdx] = stream.readLong();
-    }
-    tvList.putLongs(times, values, null, 0, rowCount);
-    return tvList;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/LongTVList.java
@@ -35,6 +35,8 @@ import java.util.List;
 import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
 
 public abstract class LongTVList extends TVList {
+  // list of primitive array, add 1 when expanded -> long primitive array
+  // index relation: arrayIndex -> elementIndex
   protected List<long[]> values;
 
   LongTVList() {

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
@@ -53,14 +53,11 @@ public abstract class TVList implements WALEntryValue {
   protected List<long[]> timestamps;
   protected int rowCount;
 
-  protected long[][] sortedTimestamps;
   protected boolean sorted = true;
   // record reference count of this tv list
   // currently this reference will only be increase because we can't know when to decrease it
-  protected AtomicInteger referenceCount;
-  protected long pivotTime;
   protected long minTime;
-
+  protected AtomicInteger referenceCount;
   private long version;
 
   public TVList() {
@@ -73,17 +70,17 @@ public abstract class TVList implements WALEntryValue {
   public static TVList newList(TSDataType dataType) {
     switch (dataType) {
       case TEXT:
-        return new BinaryTVList();
+        return new TimBinaryTVList();
       case FLOAT:
-        return new FloatTVList();
+        return new TimFloatTVList();
       case INT32:
-        return new IntTVList();
+        return new TimIntTVList();
       case INT64:
-        return new LongTVList();
+        return new TimLongTVList();
       case DOUBLE:
-        return new DoubleTVList();
+        return new TimDoubleTVList();
       case BOOLEAN:
-        return new BooleanTVList();
+        return new TimBooleanTVList();
       default:
         break;
     }
@@ -106,6 +103,8 @@ public abstract class TVList implements WALEntryValue {
   public boolean isSorted() {
     return sorted;
   }
+
+  public abstract void sort();
 
   public void increaseReferenceCount() {
     referenceCount.incrementAndGet();
@@ -222,8 +221,6 @@ public abstract class TVList implements WALEntryValue {
     throw new UnsupportedOperationException(ERR_DATATYPE_NOT_CONSISTENT);
   }
 
-  public abstract void sort();
-
   public long getMinTime() {
     return minTime;
   }
@@ -233,12 +230,6 @@ public abstract class TVList implements WALEntryValue {
   }
 
   protected abstract void set(int src, int dest);
-
-  protected abstract void setFromSorted(int src, int dest);
-
-  protected abstract void setToSorted(int src, int dest);
-
-  protected abstract void reverseRange(int lo, int hi);
 
   protected abstract void expandValues();
 
@@ -295,10 +286,7 @@ public abstract class TVList implements WALEntryValue {
     sorted = true;
     minTime = Long.MAX_VALUE;
     clearTime();
-    clearSortedTime();
-
     clearValue();
-    clearSortedValue();
   }
 
   protected void clearTime() {
@@ -310,19 +298,7 @@ public abstract class TVList implements WALEntryValue {
     }
   }
 
-  protected void clearSortedTime() {
-    if (sortedTimestamps != null) {
-      sortedTimestamps = null;
-    }
-  }
-
   abstract void clearValue();
-
-  /**
-   * The arrays for sorting are not including in write memory now, the memory usage is considered as
-   * temporary memory.
-   */
-  abstract void clearSortedValue();
 
   protected void checkExpansion() {
     if ((rowCount % ARRAY_SIZE) == 0) {
@@ -339,154 +315,6 @@ public abstract class TVList implements WALEntryValue {
     long[] cloneArray = new long[array.length];
     System.arraycopy(array, 0, cloneArray, 0, array.length);
     return cloneArray;
-  }
-
-  protected void sort(int lo, int hi) {
-    if (sorted) {
-      return;
-    }
-
-    if (lo == hi) {
-      return;
-    }
-    if (hi - lo <= SMALL_ARRAY_LENGTH) {
-      int initRunLen = countRunAndMakeAscending(lo, hi);
-      binarySort(lo, hi, lo + initRunLen);
-      return;
-    }
-    int mid = (lo + hi) >>> 1;
-    sort(lo, mid);
-    sort(mid, hi);
-    merge(lo, mid, hi);
-  }
-
-  protected int countRunAndMakeAscending(int lo, int hi) {
-    assert lo < hi;
-    int runHi = lo + 1;
-    if (runHi == hi) {
-      return 1;
-    }
-
-    // Find end of run, and reverse range if descending
-    if (getTime(runHi++) < getTime(lo)) { // Descending
-      while (runHi < hi && getTime(runHi) < getTime(runHi - 1)) {
-        runHi++;
-      }
-      reverseRange(lo, runHi);
-    } else { // Ascending
-      while (runHi < hi && getTime(runHi) >= getTime(runHi - 1)) {
-        runHi++;
-      }
-    }
-
-    return runHi - lo;
-  }
-
-  protected int compare(int idx1, int idx2) {
-    long t1 = getTime(idx1);
-    long t2 = getTime(idx2);
-    return Long.compare(t1, t2);
-  }
-
-  protected abstract void saveAsPivot(int pos);
-
-  protected abstract void setPivotTo(int pos);
-
-  /** From TimSort.java */
-  protected void binarySort(int lo, int hi, int start) {
-    assert lo <= start && start <= hi;
-    if (start == lo) {
-      start++;
-    }
-    for (; start < hi; start++) {
-
-      saveAsPivot(start);
-      // Set left (and right) to the index where a[start] (pivot) belongs
-      int left = lo;
-      int right = start;
-      assert left <= right;
-      /*
-       * Invariants:
-       *   pivot >= all in [lo, left).
-       *   pivot <  all in [right, start).
-       */
-      while (left < right) {
-        int mid = (left + right) >>> 1;
-        if (compare(start, mid) < 0) {
-          right = mid;
-        } else {
-          left = mid + 1;
-        }
-      }
-      assert left == right;
-
-      /*
-       * The invariants still hold: pivot >= all in [lo, left) and
-       * pivot < all in [left, start), so pivot belongs at left.  Note
-       * that if there are elements equal to pivot, left points to the
-       * first slot after them -- that's why this sort is stable.
-       * Slide elements over to make room for pivot.
-       */
-      int n = start - left; // The number of elements to move
-      for (int i = n; i >= 1; i--) {
-        set(left + i - 1, left + i);
-      }
-      setPivotTo(left);
-    }
-    for (int i = lo; i < hi; i++) {
-      setToSorted(i, i);
-    }
-  }
-
-  protected void merge(int lo, int mid, int hi) {
-    // end of sorting buffer
-    int tmpIdx = 0;
-
-    // start of unmerged parts of each sequence
-    int leftIdx = lo;
-    int rightIdx = mid;
-
-    // copy the minimum elements to sorting buffer until one sequence is exhausted
-    int endSide = 0;
-    while (endSide == 0) {
-      if (compare(leftIdx, rightIdx) <= 0) {
-        setToSorted(leftIdx, lo + tmpIdx);
-        tmpIdx++;
-        leftIdx++;
-        if (leftIdx == mid) {
-          endSide = 1;
-        }
-      } else {
-        setToSorted(rightIdx, lo + tmpIdx);
-        tmpIdx++;
-        rightIdx++;
-        if (rightIdx == hi) {
-          endSide = 2;
-        }
-      }
-    }
-
-    // copy the remaining elements of another sequence
-    int start;
-    int end;
-    if (endSide == 1) {
-      start = rightIdx;
-      end = hi;
-    } else {
-      start = leftIdx;
-      end = mid;
-    }
-    for (; start < end; start++) {
-      setToSorted(start, lo + tmpIdx);
-      tmpIdx++;
-    }
-
-    // copy from sorting buffer to the original arrays so that they can be further sorted
-    // potential speed up: change the place of sorting buffer and origin data between merge
-    // iterations
-    for (int i = lo; i < hi; i++) {
-      setFromSorted(i, i);
-    }
   }
 
   void updateMinTimeAndSorted(long[] time, int start, int end) {
@@ -563,19 +391,19 @@ public abstract class TVList implements WALEntryValue {
     TSDataType dataType = ReadWriteIOUtils.readDataType(stream);
     switch (dataType) {
       case TEXT:
-        return BinaryTVList.deserialize(stream);
+        return TimBinaryTVList.deserialize(stream);
       case FLOAT:
-        return FloatTVList.deserialize(stream);
+        return TimFloatTVList.deserialize(stream);
       case INT32:
-        return IntTVList.deserialize(stream);
+        return TimIntTVList.deserialize(stream);
       case INT64:
-        return LongTVList.deserialize(stream);
+        return TimLongTVList.deserialize(stream);
       case DOUBLE:
-        return DoubleTVList.deserialize(stream);
+        return TimDoubleTVList.deserialize(stream);
       case BOOLEAN:
-        return BooleanTVList.deserialize(stream);
+        return TimBooleanTVList.deserialize(stream);
       case VECTOR:
-        return AlignedTVList.deserialize(stream);
+        return TimAlignedTVList.deserialize(stream);
       default:
         break;
     }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
@@ -54,9 +54,9 @@ public abstract class TVList implements WALEntryValue {
   protected int rowCount;
 
   protected boolean sorted = true;
+  protected long minTime;
   // record reference count of this tv list
   // currently this reference will only be increase because we can't know when to decrease it
-  protected long minTime;
   protected AtomicInteger referenceCount;
   private long version;
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimAlignedTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimAlignedTVList.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils.datastructure;
+
+import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.utils.Binary;
+import org.apache.iotdb.tsfile.utils.BitMap;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
+
+public class TimAlignedTVList extends AlignedTVList implements TimSort {
+
+  private long[][] sortedTimestamps;
+  private long pivotTime;
+
+  private int[][] sortedIndices;
+  private int pivotIndex;
+
+  TimAlignedTVList(List<TSDataType> types) {
+    super(types);
+  }
+
+  @Override
+  public TVList getTvListByColumnIndex(List<Integer> columnIndex, List<TSDataType> dataTypeList) {
+    List<List<Object>> values = new ArrayList<>();
+    List<List<BitMap>> bitMaps = null;
+    for (int i = 0; i < columnIndex.size(); i++) {
+      // columnIndex == -1 means querying a non-exist column, add null column here
+      if (columnIndex.get(i) == -1) {
+        values.add(null);
+      } else {
+        values.add(this.values.get(columnIndex.get(i)));
+        if (this.bitMaps != null && this.bitMaps.get(columnIndex.get(i)) != null) {
+          if (bitMaps == null) {
+            bitMaps = new ArrayList<>(columnIndex.size());
+            for (int j = 0; j < columnIndex.size(); j++) {
+              bitMaps.add(null);
+            }
+          }
+          bitMaps.set(i, this.bitMaps.get(columnIndex.get(i)));
+        }
+      }
+    }
+    TimAlignedTVList alignedTvList = new TimAlignedTVList(dataTypeList);
+    alignedTvList.timestamps = this.timestamps;
+    alignedTvList.indices = this.indices;
+    alignedTvList.values = values;
+    alignedTvList.bitMaps = bitMaps;
+    alignedTvList.rowCount = this.rowCount;
+    return alignedTvList;
+  }
+
+  @Override
+  public AlignedTVList clone() {
+    TimAlignedTVList cloneList = new TimAlignedTVList(dataTypes);
+    cloneAs(cloneList);
+    for (int[] indicesArray : indices) {
+      cloneList.indices.add(cloneIndex(indicesArray));
+    }
+    for (int i = 0; i < values.size(); i++) {
+      List<Object> columnValues = values.get(i);
+      for (Object valueArray : columnValues) {
+        cloneList.values.get(i).add(cloneValue(dataTypes.get(i), valueArray));
+      }
+      // clone bitmap in columnIndex
+      if (bitMaps != null && bitMaps.get(i) != null) {
+        List<BitMap> columnBitMaps = bitMaps.get(i);
+        if (cloneList.bitMaps == null) {
+          cloneList.bitMaps = new ArrayList<>(dataTypes.size());
+          for (int j = 0; j < dataTypes.size(); j++) {
+            cloneList.bitMaps.add(null);
+          }
+        }
+        if (cloneList.bitMaps.get(i) == null) {
+          List<BitMap> cloneColumnBitMaps = new ArrayList<>();
+          for (BitMap bitMap : columnBitMaps) {
+            cloneColumnBitMaps.add(bitMap == null ? null : bitMap.clone());
+          }
+          cloneList.bitMaps.set(i, cloneColumnBitMaps);
+        }
+      }
+    }
+    return cloneList;
+  }
+
+  @Override
+  public void sort() {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedTimestamps =
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
+    }
+    if (sortedIndices == null
+        || sortedIndices.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedIndices =
+          (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, rowCount);
+    }
+    if (!sorted) {
+      sort(0, rowCount);
+    }
+    clearSortedValue();
+    clearSortedTime();
+    sorted = true;
+  }
+
+  @Override
+  public void tim_set(int src, int dest) {
+    set(src, dest);
+  }
+
+  @Override
+  protected void set(int src, int dest) {
+    long srcT = getTime(src);
+    int srcV = getValueIndex(src);
+    set(dest, srcT, srcV);
+  }
+
+  @Override
+  public void setFromSorted(int src, int dest) {
+    set(
+        dest,
+        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
+        sortedIndices[src / ARRAY_SIZE][src % ARRAY_SIZE]);
+  }
+
+  @Override
+  public void setToSorted(int src, int dest) {
+    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
+    sortedIndices[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getValueIndex(src);
+  }
+
+  @Override
+  public void setPivotTo(int pos) {
+    set(pos, pivotTime, pivotIndex);
+  }
+
+  @Override
+  public void saveAsPivot(int pos) {
+    pivotTime = getTime(pos);
+    pivotIndex = getValueIndex(pos);
+  }
+
+  @Override
+  public void clearSortedTime() {
+    if (sortedTimestamps != null) {
+      sortedTimestamps = null;
+    }
+  }
+
+  @Override
+  public void clearSortedValue() {
+    if (sortedIndices != null) {
+      sortedIndices = null;
+    }
+  }
+
+  @Override
+  public int compare(int idx1, int idx2) {
+    long t1 = getTime(idx1);
+    long t2 = getTime(idx2);
+    return Long.compare(t1, t2);
+  }
+
+  @Override
+  public void reverseRange(int lo, int hi) {
+    hi--;
+    while (lo < hi) {
+      long loT = getTime(lo);
+      int loV = getValueIndex(lo);
+      long hiT = getTime(hi);
+      int hiV = getValueIndex(hi);
+      set(lo++, hiT, hiV);
+      set(hi--, loT, loV);
+    }
+  }
+
+  @Override
+  public void clear() {
+    rowCount = 0;
+    sorted = true;
+    minTime = Long.MAX_VALUE;
+    clearTime();
+    clearSortedTime();
+    clearValue();
+    clearSortedValue();
+  }
+
+  public static TimAlignedTVList deserialize(DataInputStream stream) throws IOException {
+    int dataTypeNum = stream.readInt();
+    List<TSDataType> dataTypes = new ArrayList<>(dataTypeNum);
+    int[] columnIndexArray = new int[dataTypeNum];
+    for (int columnIndex = 0; columnIndex < dataTypeNum; ++columnIndex) {
+      dataTypes.add(ReadWriteIOUtils.readDataType(stream));
+      columnIndexArray[columnIndex] = columnIndex;
+    }
+
+    int rowCount = stream.readInt();
+    // time
+    long[] times = new long[rowCount];
+    for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
+      times[rowIndex] = stream.readLong();
+    }
+    // read value and bitmap by column
+    Object[] values = new Object[dataTypeNum];
+    BitMap[] bitMaps = new BitMap[dataTypeNum];
+    for (int columnIndex = 0; columnIndex < dataTypeNum; ++columnIndex) {
+      BitMap bitMap = new BitMap(rowCount);
+      Object valuesOfOneColumn;
+      switch (dataTypes.get(columnIndex)) {
+        case TEXT:
+          Binary[] binaryValues = new Binary[rowCount];
+          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
+            binaryValues[rowIndex] = ReadWriteIOUtils.readBinary(stream);
+            if (ReadWriteIOUtils.readBool(stream)) {
+              bitMap.mark(rowIndex);
+            }
+          }
+          valuesOfOneColumn = binaryValues;
+          break;
+        case FLOAT:
+          float[] floatValues = new float[rowCount];
+          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
+            floatValues[rowIndex] = stream.readFloat();
+            if (ReadWriteIOUtils.readBool(stream)) {
+              bitMap.mark(rowIndex);
+            }
+          }
+          valuesOfOneColumn = floatValues;
+          break;
+        case INT32:
+          int[] intValues = new int[rowCount];
+          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
+            intValues[rowIndex] = stream.readInt();
+            if (ReadWriteIOUtils.readBool(stream)) {
+              bitMap.mark(rowIndex);
+            }
+          }
+          valuesOfOneColumn = intValues;
+          break;
+        case INT64:
+          long[] longValues = new long[rowCount];
+          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
+            longValues[rowIndex] = stream.readLong();
+            if (ReadWriteIOUtils.readBool(stream)) {
+              bitMap.mark(rowIndex);
+            }
+          }
+          valuesOfOneColumn = longValues;
+          break;
+        case DOUBLE:
+          double[] doubleValues = new double[rowCount];
+          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
+            doubleValues[rowIndex] = stream.readDouble();
+            if (ReadWriteIOUtils.readBool(stream)) {
+              bitMap.mark(rowIndex);
+            }
+          }
+          valuesOfOneColumn = doubleValues;
+          break;
+        case BOOLEAN:
+          boolean[] booleanValues = new boolean[rowCount];
+          for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
+            booleanValues[rowIndex] = ReadWriteIOUtils.readBool(stream);
+            if (ReadWriteIOUtils.readBool(stream)) {
+              bitMap.mark(rowIndex);
+            }
+          }
+          valuesOfOneColumn = booleanValues;
+          break;
+        default:
+          throw new UnsupportedOperationException(ERR_DATATYPE_NOT_CONSISTENT);
+      }
+      values[columnIndex] = valuesOfOneColumn;
+      bitMaps[columnIndex] = bitMap;
+    }
+
+    TimAlignedTVList tvList = new TimAlignedTVList(dataTypes);
+    tvList.putAlignedValues(times, values, bitMaps, columnIndexArray, 0, rowCount);
+    return tvList;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimAlignedTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimAlignedTVList.java
@@ -199,12 +199,8 @@ public class TimAlignedTVList extends AlignedTVList implements TimSort {
 
   @Override
   public void clear() {
-    rowCount = 0;
-    sorted = true;
-    minTime = Long.MAX_VALUE;
-    clearTime();
+    super.clear();
     clearSortedTime();
-    clearValue();
     clearSortedValue();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimBinaryTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimBinaryTVList.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils.datastructure;
+
+import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.utils.Binary;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
+
+public class TimBinaryTVList extends BinaryTVList implements TimSort {
+
+  private long[][] sortedTimestamps;
+  private long pivotTime;
+
+  private Binary[][] sortedValues;
+  private Binary pivotValue;
+
+  @Override
+  public TimBinaryTVList clone() {
+    TimBinaryTVList cloneList = new TimBinaryTVList();
+    cloneAs(cloneList);
+    for (Binary[] valueArray : values) {
+      cloneList.values.add(cloneValue(valueArray));
+    }
+    return cloneList;
+  }
+
+  private Binary[] cloneValue(Binary[] array) {
+    Binary[] cloneArray = new Binary[array.length];
+    System.arraycopy(array, 0, cloneArray, 0, array.length);
+    return cloneArray;
+  }
+
+  @Override
+  public void sort() {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedTimestamps =
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
+    }
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedValues =
+          (Binary[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.TEXT, rowCount);
+    }
+    sort(0, rowCount);
+    clearSortedValue();
+    clearSortedTime();
+    sorted = true;
+  }
+
+  @Override
+  public void tim_set(int src, int dest) {
+    set(src, dest);
+  }
+
+  @Override
+  public void set(int src, int dest) {
+    long srcT = getTime(src);
+    Binary srcV = getBinary(src);
+    set(dest, srcT, srcV);
+  }
+
+  @Override
+  public void setToSorted(int src, int dest) {
+    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
+    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getBinary(src);
+  }
+
+  @Override
+  public void saveAsPivot(int pos) {
+    pivotTime = getTime(pos);
+    pivotValue = getBinary(pos);
+  }
+
+  @Override
+  public void setFromSorted(int src, int dest) {
+    set(
+        dest,
+        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
+        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
+  }
+
+  @Override
+  public void setPivotTo(int pos) {
+    set(pos, pivotTime, pivotValue);
+  }
+
+  @Override
+  public void clearSortedTime() {
+    if (sortedTimestamps != null) {
+      sortedTimestamps = null;
+    }
+  }
+
+  @Override
+  public void clearSortedValue() {
+    if (sortedValues != null) {
+      sortedValues = null;
+    }
+  }
+
+  @Override
+  public int compare(int idx1, int idx2) {
+    long t1 = getTime(idx1);
+    long t2 = getTime(idx2);
+    return Long.compare(t1, t2);
+  }
+
+  @Override
+  public void reverseRange(int lo, int hi) {
+    hi--;
+    while (lo < hi) {
+      long loT = getTime(lo);
+      Binary loV = getBinary(lo);
+      long hiT = getTime(hi);
+      Binary hiV = getBinary(hi);
+      set(lo++, hiT, hiV);
+      set(hi--, loT, loV);
+    }
+  }
+
+  @Override
+  public void clear() {
+    rowCount = 0;
+    sorted = true;
+    minTime = Long.MAX_VALUE;
+    clearTime();
+    clearSortedTime();
+    clearValue();
+    clearSortedValue();
+  }
+
+  public static TimBinaryTVList deserialize(DataInputStream stream) throws IOException {
+    TimBinaryTVList tvList = new TimBinaryTVList();
+    int rowCount = stream.readInt();
+    long[] times = new long[rowCount];
+    Binary[] values = new Binary[rowCount];
+    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
+      times[rowIdx] = stream.readLong();
+      values[rowIdx] = ReadWriteIOUtils.readBinary(stream);
+    }
+    tvList.putBinaries(times, values, null, 0, rowCount);
+    return tvList;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimBinaryTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimBinaryTVList.java
@@ -143,12 +143,8 @@ public class TimBinaryTVList extends BinaryTVList implements TimSort {
 
   @Override
   public void clear() {
-    rowCount = 0;
-    sorted = true;
-    minTime = Long.MAX_VALUE;
-    clearTime();
+    super.clear();
     clearSortedTime();
-    clearValue();
     clearSortedValue();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimBooleanTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimBooleanTVList.java
@@ -143,12 +143,8 @@ public class TimBooleanTVList extends BooleanTVList implements TimSort {
 
   @Override
   public void clear() {
-    rowCount = 0;
-    sorted = true;
-    minTime = Long.MAX_VALUE;
-    clearTime();
+    super.clear();
     clearSortedTime();
-    clearValue();
     clearSortedValue();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimBooleanTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimBooleanTVList.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils.datastructure;
+
+import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
+
+public class TimBooleanTVList extends BooleanTVList implements TimSort {
+  private long[][] sortedTimestamps;
+  private long pivotTime;
+
+  private boolean[][] sortedValues;
+  private boolean pivotValue;
+
+  @Override
+  public TimBooleanTVList clone() {
+    TimBooleanTVList cloneList = new TimBooleanTVList();
+    cloneAs(cloneList);
+    for (boolean[] valueArray : values) {
+      cloneList.values.add(cloneValue(valueArray));
+    }
+    return cloneList;
+  }
+
+  private boolean[] cloneValue(boolean[] array) {
+    boolean[] cloneArray = new boolean[array.length];
+    System.arraycopy(array, 0, cloneArray, 0, array.length);
+    return cloneArray;
+  }
+
+  @Override
+  public void sort() {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedTimestamps =
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
+    }
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedValues =
+          (boolean[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.BOOLEAN, rowCount);
+    }
+    if (!sorted) {
+      sort(0, rowCount);
+    }
+    clearSortedValue();
+    clearSortedTime();
+    sorted = true;
+  }
+
+  @Override
+  public void tim_set(int src, int dest) {
+    set(src, dest);
+  }
+
+  @Override
+  public void set(int src, int dest) {
+    long srcT = getTime(src);
+    boolean srcV = getBoolean(src);
+    set(dest, srcT, srcV);
+  }
+
+  @Override
+  public void setToSorted(int src, int dest) {
+    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
+    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getBoolean(src);
+  }
+
+  @Override
+  public void saveAsPivot(int pos) {
+    pivotTime = getTime(pos);
+    pivotValue = getBoolean(pos);
+  }
+
+  @Override
+  public void setFromSorted(int src, int dest) {
+    set(
+        dest,
+        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
+        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
+  }
+
+  @Override
+  public void setPivotTo(int pos) {
+    set(pos, pivotTime, pivotValue);
+  }
+
+  @Override
+  public void clearSortedTime() {
+    if (sortedTimestamps != null) {
+      sortedTimestamps = null;
+    }
+  }
+
+  @Override
+  public void clearSortedValue() {
+    if (sortedValues != null) {
+      sortedValues = null;
+    }
+  }
+
+  @Override
+  public int compare(int idx1, int idx2) {
+    long t1 = getTime(idx1);
+    long t2 = getTime(idx2);
+    return Long.compare(t1, t2);
+  }
+
+  @Override
+  public void reverseRange(int lo, int hi) {
+    hi--;
+    while (lo < hi) {
+      long loT = getTime(lo);
+      boolean loV = getBoolean(lo);
+      long hiT = getTime(hi);
+      boolean hiV = getBoolean(hi);
+      set(lo++, hiT, hiV);
+      set(hi--, loT, loV);
+    }
+  }
+
+  @Override
+  public void clear() {
+    rowCount = 0;
+    sorted = true;
+    minTime = Long.MAX_VALUE;
+    clearTime();
+    clearSortedTime();
+    clearValue();
+    clearSortedValue();
+  }
+
+  public static TimBooleanTVList deserialize(DataInputStream stream) throws IOException {
+    TimBooleanTVList tvList = new TimBooleanTVList();
+    int rowCount = stream.readInt();
+    long[] times = new long[rowCount];
+    boolean[] values = new boolean[rowCount];
+    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
+      times[rowIdx] = stream.readLong();
+      values[rowIdx] = ReadWriteIOUtils.readBool(stream);
+    }
+    tvList.putBooleans(times, values, null, 0, rowCount);
+    return tvList;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimDoubleTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimDoubleTVList.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils.datastructure;
+
+import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
+
+public class TimDoubleTVList extends DoubleTVList implements TimSort {
+  private long[][] sortedTimestamps;
+  private long pivotTime;
+
+  private double[][] sortedValues;
+  private double pivotValue;
+
+  @Override
+  public TimDoubleTVList clone() {
+    TimDoubleTVList cloneList = new TimDoubleTVList();
+    cloneAs(cloneList);
+    for (double[] valueArray : values) {
+      cloneList.values.add(cloneValue(valueArray));
+    }
+    return cloneList;
+  }
+
+  private double[] cloneValue(double[] array) {
+    double[] cloneArray = new double[array.length];
+    System.arraycopy(array, 0, cloneArray, 0, array.length);
+    return cloneArray;
+  }
+
+  @Override
+  public void sort() {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedTimestamps =
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
+    }
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedValues =
+          (double[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.DOUBLE, rowCount);
+    }
+    if (!sorted) {
+      sort(0, rowCount);
+    }
+    clearSortedValue();
+    clearSortedTime();
+    sorted = true;
+  }
+
+  @Override
+  public void tim_set(int src, int dest) {
+    set(src, dest);
+  }
+
+  @Override
+  public void set(int src, int dest) {
+    long srcT = getTime(src);
+    double srcV = getDouble(src);
+    set(dest, srcT, srcV);
+  }
+
+  @Override
+  public void setToSorted(int src, int dest) {
+    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
+    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getDouble(src);
+  }
+
+  @Override
+  public void saveAsPivot(int pos) {
+    pivotTime = getTime(pos);
+    pivotValue = getDouble(pos);
+  }
+
+  @Override
+  public void setFromSorted(int src, int dest) {
+    set(
+        dest,
+        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
+        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
+  }
+
+  @Override
+  public void setPivotTo(int pos) {
+    set(pos, pivotTime, pivotValue);
+  }
+
+  @Override
+  public void clearSortedTime() {
+    if (sortedTimestamps != null) {
+      sortedTimestamps = null;
+    }
+  }
+
+  @Override
+  public void clearSortedValue() {
+    if (sortedValues != null) {
+      sortedValues = null;
+    }
+  }
+
+  @Override
+  public int compare(int idx1, int idx2) {
+    long t1 = getTime(idx1);
+    long t2 = getTime(idx2);
+    return Long.compare(t1, t2);
+  }
+
+  @Override
+  public void reverseRange(int lo, int hi) {
+    hi--;
+    while (lo < hi) {
+      long loT = getTime(lo);
+      double loV = getDouble(lo);
+      long hiT = getTime(hi);
+      double hiV = getDouble(hi);
+      set(lo++, hiT, hiV);
+      set(hi--, loT, loV);
+    }
+  }
+
+  @Override
+  public void clear() {
+    rowCount = 0;
+    sorted = true;
+    minTime = Long.MAX_VALUE;
+    clearTime();
+    clearValue();
+    clearSortedTime();
+    clearSortedValue();
+  }
+
+  public static TimDoubleTVList deserialize(DataInputStream stream) throws IOException {
+    TimDoubleTVList tvList = new TimDoubleTVList();
+    int rowCount = stream.readInt();
+    long[] times = new long[rowCount];
+    double[] values = new double[rowCount];
+    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
+      times[rowIdx] = stream.readLong();
+      values[rowIdx] = stream.readDouble();
+    }
+    tvList.putDoubles(times, values, null, 0, rowCount);
+    return tvList;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimDoubleTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimDoubleTVList.java
@@ -142,11 +142,7 @@ public class TimDoubleTVList extends DoubleTVList implements TimSort {
 
   @Override
   public void clear() {
-    rowCount = 0;
-    sorted = true;
-    minTime = Long.MAX_VALUE;
-    clearTime();
-    clearValue();
+    super.clear();
     clearSortedTime();
     clearSortedValue();
   }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimFloatTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimFloatTVList.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils.datastructure;
+
+import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
+
+public class TimFloatTVList extends FloatTVList implements TimSort {
+
+  private long[][] sortedTimestamps;
+  private long pivotTime;
+
+  private float[][] sortedValues;
+  private float pivotValue;
+
+  @Override
+  public TimFloatTVList clone() {
+    TimFloatTVList cloneList = new TimFloatTVList();
+    cloneAs(cloneList);
+    for (float[] valueArray : values) {
+      cloneList.values.add(cloneValue(valueArray));
+    }
+    return cloneList;
+  }
+
+  private float[] cloneValue(float[] array) {
+    float[] cloneArray = new float[array.length];
+    System.arraycopy(array, 0, cloneArray, 0, array.length);
+    return cloneArray;
+  }
+
+  @Override
+  public void sort() {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedTimestamps =
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
+    }
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedValues =
+          (float[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.FLOAT, rowCount);
+    }
+    if (!sorted) {
+      sort(0, rowCount);
+    }
+    clearSortedValue();
+    clearSortedTime();
+    sorted = true;
+  }
+
+  @Override
+  public void tim_set(int src, int dest) {
+    set(src, dest);
+  }
+
+  @Override
+  public void set(int src, int dest) {
+    long srcT = getTime(src);
+    float srcV = getFloat(src);
+    set(dest, srcT, srcV);
+  }
+
+  @Override
+  public void setToSorted(int src, int dest) {
+    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
+    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getFloat(src);
+  }
+
+  @Override
+  public void saveAsPivot(int pos) {
+    pivotTime = getTime(pos);
+    pivotValue = getFloat(pos);
+  }
+
+  @Override
+  public void setFromSorted(int src, int dest) {
+    set(
+        dest,
+        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
+        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
+  }
+
+  @Override
+  public void setPivotTo(int pos) {
+    set(pos, pivotTime, pivotValue);
+  }
+
+  @Override
+  public void clearSortedTime() {
+    if (sortedTimestamps != null) {
+      sortedTimestamps = null;
+    }
+  }
+
+  @Override
+  public void clearSortedValue() {
+    if (sortedValues != null) {
+      sortedValues = null;
+    }
+  }
+
+  @Override
+  public int compare(int idx1, int idx2) {
+    long t1 = getTime(idx1);
+    long t2 = getTime(idx2);
+    return Long.compare(t1, t2);
+  }
+
+  @Override
+  public void reverseRange(int lo, int hi) {
+    hi--;
+    while (lo < hi) {
+      long loT = getTime(lo);
+      float loV = getFloat(lo);
+      long hiT = getTime(hi);
+      float hiV = getFloat(hi);
+      set(lo++, hiT, hiV);
+      set(hi--, loT, loV);
+    }
+  }
+
+  @Override
+  public void clear() {
+    rowCount = 0;
+    sorted = true;
+    minTime = Long.MAX_VALUE;
+    clearTime();
+    clearSortedTime();
+    clearValue();
+    clearSortedValue();
+  }
+
+  public static TimFloatTVList deserialize(DataInputStream stream) throws IOException {
+    TimFloatTVList tvList = new TimFloatTVList();
+    int rowCount = stream.readInt();
+    long[] times = new long[rowCount];
+    float[] values = new float[rowCount];
+    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
+      times[rowIdx] = stream.readLong();
+      values[rowIdx] = stream.readFloat();
+    }
+    tvList.putFloats(times, values, null, 0, rowCount);
+    return tvList;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimFloatTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimFloatTVList.java
@@ -143,12 +143,8 @@ public class TimFloatTVList extends FloatTVList implements TimSort {
 
   @Override
   public void clear() {
-    rowCount = 0;
-    sorted = true;
-    minTime = Long.MAX_VALUE;
-    clearTime();
+    super.clear();
     clearSortedTime();
-    clearValue();
     clearSortedValue();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimIntTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimIntTVList.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils.datastructure;
+
+import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
+
+public class TimIntTVList extends IntTVList implements TimSort {
+
+  private long[][] sortedTimestamps;
+  private int[][] sortedValues;
+
+  private int pivotValue;
+  private long pivotTime;
+
+  @Override
+  public void sort() {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedTimestamps =
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
+    }
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedValues =
+          (int[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT32, rowCount);
+    }
+    if (!sorted) {
+      sort(0, rowCount);
+    }
+    clearSortedValue();
+    clearSortedTime();
+    sorted = true;
+  }
+
+  @Override
+  public void tim_set(int src, int dest) {
+    set(src, dest);
+  }
+
+  @Override
+  public void set(int src, int dest) {
+    long srcT = getTime(src);
+    int srcV = getInt(src);
+    set(dest, srcT, srcV);
+  }
+
+  @Override
+  public void setToSorted(int src, int dest) {
+    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
+    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getInt(src);
+  }
+
+  @Override
+  public void saveAsPivot(int pos) {
+    pivotTime = getTime(pos);
+    pivotValue = getInt(pos);
+  }
+
+  @Override
+  public void setFromSorted(int src, int dest) {
+    set(
+        dest,
+        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
+        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
+  }
+
+  @Override
+  public void setPivotTo(int pos) {
+    set(pos, pivotTime, pivotValue);
+  }
+
+  @Override
+  public void clearSortedTime() {
+    if (sortedTimestamps != null) {
+      sortedTimestamps = null;
+    }
+  }
+
+  @Override
+  public void clearSortedValue() {
+    if (sortedValues != null) {
+      sortedValues = null;
+    }
+  }
+
+  @Override
+  public int compare(int idx1, int idx2) {
+    long t1 = getTime(idx1);
+    long t2 = getTime(idx2);
+    return Long.compare(t1, t2);
+  }
+
+  @Override
+  public void reverseRange(int lo, int hi) {
+    hi--;
+    while (lo < hi) {
+      long loT = getTime(lo);
+      int loV = getInt(lo);
+      long hiT = getTime(hi);
+      int hiV = getInt(hi);
+      set(lo++, hiT, hiV);
+      set(hi--, loT, loV);
+    }
+  }
+
+  @Override
+  public void clear() {
+    rowCount = 0;
+    sorted = true;
+    minTime = Long.MAX_VALUE;
+    clearTime();
+    clearSortedTime();
+    clearValue();
+    clearSortedValue();
+  }
+
+  public static TimIntTVList deserialize(DataInputStream stream) throws IOException {
+    TimIntTVList tvList = new TimIntTVList();
+    int rowCount = stream.readInt();
+    long[] times = new long[rowCount];
+    int[] values = new int[rowCount];
+    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
+      times[rowIdx] = stream.readLong();
+      values[rowIdx] = stream.readInt();
+    }
+    tvList.putInts(times, values, null, 0, rowCount);
+    return tvList;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimIntTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimIntTVList.java
@@ -127,12 +127,8 @@ public class TimIntTVList extends IntTVList implements TimSort {
 
   @Override
   public void clear() {
-    rowCount = 0;
-    sorted = true;
-    minTime = Long.MAX_VALUE;
-    clearTime();
+    super.clear();
     clearSortedTime();
-    clearValue();
     clearSortedValue();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimLongTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimLongTVList.java
@@ -140,6 +140,13 @@ public class TimLongTVList extends LongTVList implements TimSort {
     }
   }
 
+  @Override
+  public void clear() {
+    super.clear();
+    clearSortedTime();
+    clearSortedValue();
+  }
+
   public static TimLongTVList deserialize(DataInputStream stream) throws IOException {
     TimLongTVList tvList = new TimLongTVList();
     int rowCount = stream.readInt();

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimLongTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimLongTVList.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils.datastructure;
+
+import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+import static org.apache.iotdb.db.rescon.PrimitiveArrayManager.ARRAY_SIZE;
+
+public class TimLongTVList extends LongTVList implements TimSort {
+  private long[][] sortedTimestamps;
+  private long pivotTime;
+
+  private long[][] sortedValues;
+  private long pivotValue;
+
+  @Override
+  public TimLongTVList clone() {
+    TimLongTVList cloneList = new TimLongTVList();
+    cloneAs(cloneList);
+    for (long[] valueArray : values) {
+      cloneList.values.add(cloneValue(valueArray));
+    }
+    return cloneList;
+  }
+
+  private long[] cloneValue(long[] array) {
+    long[] cloneArray = new long[array.length];
+    System.arraycopy(array, 0, cloneArray, 0, array.length);
+    return cloneArray;
+  }
+
+  @Override
+  public void sort() {
+    if (sortedTimestamps == null
+        || sortedTimestamps.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedTimestamps =
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
+    }
+    if (sortedValues == null
+        || sortedValues.length < PrimitiveArrayManager.getArrayRowCount(rowCount)) {
+      sortedValues =
+          (long[][]) PrimitiveArrayManager.createDataListsByType(TSDataType.INT64, rowCount);
+    }
+    if (!sorted) {
+      sort(0, rowCount);
+    }
+    clearSortedValue();
+    clearSortedTime();
+    sorted = true;
+  }
+
+  @Override
+  public void tim_set(int src, int dest) {
+    set(src, dest);
+  }
+
+  @Override
+  public void set(int src, int dest) {
+    long srcT = getTime(src);
+    long srcV = getLong(src);
+    set(dest, srcT, srcV);
+  }
+
+  @Override
+  public void setToSorted(int src, int dest) {
+    sortedTimestamps[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getTime(src);
+    sortedValues[dest / ARRAY_SIZE][dest % ARRAY_SIZE] = getLong(src);
+  }
+
+  @Override
+  public void saveAsPivot(int pos) {
+    pivotTime = getTime(pos);
+    pivotValue = getLong(pos);
+  }
+
+  @Override
+  public void setFromSorted(int src, int dest) {
+    set(
+        dest,
+        sortedTimestamps[src / ARRAY_SIZE][src % ARRAY_SIZE],
+        sortedValues[src / ARRAY_SIZE][src % ARRAY_SIZE]);
+  }
+
+  @Override
+  public void setPivotTo(int pos) {
+    set(pos, pivotTime, pivotValue);
+  }
+
+  @Override
+  public void clearSortedTime() {
+    if (sortedTimestamps != null) {
+      sortedTimestamps = null;
+    }
+  }
+
+  @Override
+  public void clearSortedValue() {
+    if (sortedValues != null) {
+      sortedValues = null;
+    }
+  }
+
+  @Override
+  public int compare(int idx1, int idx2) {
+    long t1 = getTime(idx1);
+    long t2 = getTime(idx2);
+    return Long.compare(t1, t2);
+  }
+
+  @Override
+  public void reverseRange(int lo, int hi) {
+    hi--;
+    while (lo < hi) {
+      long loT = getTime(lo);
+      long loV = getLong(lo);
+      long hiT = getTime(hi);
+      long hiV = getLong(hi);
+      set(lo++, hiT, hiV);
+      set(hi--, loT, loV);
+    }
+  }
+
+  public static TimLongTVList deserialize(DataInputStream stream) throws IOException {
+    TimLongTVList tvList = new TimLongTVList();
+    int rowCount = stream.readInt();
+    long[] times = new long[rowCount];
+    long[] values = new long[rowCount];
+    for (int rowIdx = 0; rowIdx < rowCount; ++rowIdx) {
+      times[rowIdx] = stream.readLong();
+      values[rowIdx] = stream.readLong();
+    }
+    tvList.putLongs(times, values, null, 0, rowCount);
+    return tvList;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimSort.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimSort.java
@@ -18,15 +18,15 @@
  */
 package org.apache.iotdb.db.utils.datastructure;
 
+/**
+ * The interface refers to TimSort.java, and is used for sort the TVList Functions for tim_sort like
+ * merge, sort, binary_sort is implemented here as default, reuse code whenever possible.
+ */
 public interface TimSort {
+  /** when array size <= 32, it's better to use binarysort. */
   int SMALL_ARRAY_LENGTH = 32;
 
-  /**
-   * the same as the 'set' function in TVList, the reason is to avoid two equal functions.
-   *
-   * @param src
-   * @param dest
-   */
+  /** the same as the 'set' function in TVList, the reason is to avoid two equal functions. */
   void tim_set(int src, int dest);
 
   void setFromSorted(int src, int dest);
@@ -45,11 +45,16 @@ public interface TimSort {
 
   void clearSortedValue();
 
+  /** compare the timestamps in idx1 and idx2 */
   int compare(int idx1, int idx2);
 
   /** From TimSort.java */
   void reverseRange(int lo, int hi);
 
+  /**
+   * the entrance of tim_sort; 1. array_size <= 32, use binary sort. 2. recursively invoke merge
+   * sort.
+   */
   default void sort(int lo, int hi) {
     if (lo == hi) {
       return;
@@ -131,6 +136,7 @@ public interface TimSort {
     }
   }
 
+  /** merge arrays [lo, mid) [mid, hi] */
   default void merge(int lo, int mid, int hi) {
     // end of sorting buffer
     int tmpIdx = 0;

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimSort.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TimSort.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils.datastructure;
+
+public interface TimSort {
+  int SMALL_ARRAY_LENGTH = 32;
+
+  /**
+   * the same as the 'set' function in TVList, the reason is to avoid two equal functions.
+   *
+   * @param src
+   * @param dest
+   */
+  void tim_set(int src, int dest);
+
+  void setFromSorted(int src, int dest);
+
+  void setToSorted(int src, int dest);
+
+  void setPivotTo(int pos);
+
+  void saveAsPivot(int pos);
+
+  /**
+   * The arrays for sorting are not including in write memory now, the memory usage is considered as
+   * temporary memory.
+   */
+  void clearSortedTime();
+
+  void clearSortedValue();
+
+  int compare(int idx1, int idx2);
+
+  /** From TimSort.java */
+  void reverseRange(int lo, int hi);
+
+  default void sort(int lo, int hi) {
+    if (lo == hi) {
+      return;
+    }
+    if (hi - lo <= SMALL_ARRAY_LENGTH) {
+      int initRunLen = countRunAndMakeAscending(lo, hi);
+      binarySort(lo, hi, lo + initRunLen);
+      return;
+    }
+    int mid = (lo + hi) >>> 1;
+    sort(lo, mid);
+    sort(mid, hi);
+    merge(lo, mid, hi);
+  }
+
+  default int countRunAndMakeAscending(int lo, int hi) {
+    assert lo < hi;
+    int runHi = lo + 1;
+    if (runHi == hi) {
+      return 1;
+    }
+    // Find end of run, and reverse range if descending
+    if (compare(runHi++, lo) == -1) { // Descending
+      while (runHi < hi && compare(runHi, runHi - 1) == -1) {
+        runHi++;
+      }
+      reverseRange(lo, runHi);
+    } else { // Ascending
+      while (runHi < hi && compare(runHi, runHi - 1) >= 0) {
+        runHi++;
+      }
+    }
+
+    return runHi - lo;
+  }
+
+  default void binarySort(int lo, int hi, int start) {
+    assert lo <= start && start <= hi;
+    if (start == lo) {
+      start++;
+    }
+    for (; start < hi; start++) {
+
+      saveAsPivot(start);
+      // Set left (and right) to the index where a[start] (pivot) belongs
+      int left = lo;
+      int right = start;
+      assert left <= right;
+      /*
+       * Invariants:
+       *   pivot >= all in [lo, left).
+       *   pivot <  all in [right, start).
+       */
+      while (left < right) {
+        int mid = (left + right) >>> 1;
+        if (compare(start, mid) < 0) {
+          right = mid;
+        } else {
+          left = mid + 1;
+        }
+      }
+      assert left == right;
+
+      /*
+       * The invariants still hold: pivot >= all in [lo, left) and
+       * pivot < all in [left, start), so pivot belongs at left.  Note
+       * that if there are elements equal to pivot, left points to the
+       * first slot after them -- that's why this sort is stable.
+       * Slide elements over to make room for pivot.
+       */
+      int n = start - left; // The number of elements to move
+      for (int i = n; i >= 1; i--) {
+        tim_set(left + i - 1, left + i);
+      }
+      setPivotTo(left);
+    }
+    for (int i = lo; i < hi; i++) {
+      setToSorted(i, i);
+    }
+  }
+
+  default void merge(int lo, int mid, int hi) {
+    // end of sorting buffer
+    int tmpIdx = 0;
+
+    // start of unmerged parts of each sequence
+    int leftIdx = lo;
+    int rightIdx = mid;
+
+    // copy the minimum elements to sorting buffer until one sequence is exhausted
+    int endSide = 0;
+    while (endSide == 0) {
+      if (compare(leftIdx, rightIdx) <= 0) {
+        setToSorted(leftIdx, lo + tmpIdx);
+        tmpIdx++;
+        leftIdx++;
+        if (leftIdx == mid) {
+          endSide = 1;
+        }
+      } else {
+        setToSorted(rightIdx, lo + tmpIdx);
+        tmpIdx++;
+        rightIdx++;
+        if (rightIdx == hi) {
+          endSide = 2;
+        }
+      }
+    }
+
+    // copy the remaining elements of another sequence
+    int start;
+    int end;
+    if (endSide == 1) {
+      start = rightIdx;
+      end = hi;
+    } else {
+      start = leftIdx;
+      end = mid;
+    }
+    for (; start < end; start++) {
+      setToSorted(start, lo + tmpIdx);
+      tmpIdx++;
+    }
+
+    // copy from sorting buffer to the original arrays so that they can be further sorted
+    // potential speed up: change the place of sorting buffer and origin data between merge
+    // iterations
+    for (int i = lo; i < hi; i++) {
+      setFromSorted(i, i);
+    }
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/BinaryTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/BinaryTVListTest.java
@@ -32,7 +32,7 @@ public class BinaryTVListTest {
 
   @Test
   public void testBinaryTVList() {
-    BinaryTVList tvList = new BinaryTVList();
+    TimBinaryTVList tvList = new TimBinaryTVList();
     for (int i = 0; i < 1000; i++) {
       tvList.putBinary(i, Binary.valueOf(String.valueOf(i)));
     }
@@ -44,7 +44,7 @@ public class BinaryTVListTest {
 
   @Test
   public void testPutBinariesWithoutBitMap() {
-    BinaryTVList tvList = new BinaryTVList();
+    TimBinaryTVList tvList = new TimBinaryTVList();
     Binary[] binaryList = new Binary[1001];
     List<Long> timeList = new ArrayList<>();
     for (int i = 1000; i >= 0; i--) {
@@ -60,7 +60,7 @@ public class BinaryTVListTest {
 
   @Test
   public void testPutBinariesWithBitMap() {
-    BinaryTVList tvList = new BinaryTVList();
+    TimBinaryTVList tvList = new TimBinaryTVList();
     Binary[] binaryList = new Binary[1001];
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);
@@ -88,7 +88,7 @@ public class BinaryTVListTest {
 
   @Test
   public void testClone() {
-    BinaryTVList tvList = new BinaryTVList();
+    TimBinaryTVList tvList = new TimBinaryTVList();
     Binary[] binaryList = new Binary[1001];
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/BooleanTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/BooleanTVListTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class BooleanTVListTest {
   @Test
   public void testBooleanTVList() {
-    BooleanTVList tvList = new BooleanTVList();
+    TimBooleanTVList tvList = new TimBooleanTVList();
     for (int i = 0; i < 50; i++) {
       tvList.putBoolean(i, true);
     }
@@ -49,7 +49,7 @@ public class BooleanTVListTest {
 
   @Test
   public void testPutBooleansWithoutBitMap() {
-    BooleanTVList tvList = new BooleanTVList();
+    TimBooleanTVList tvList = new TimBooleanTVList();
     List<Boolean> booleanList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     for (long i = 1000; i >= 0; i--) {
@@ -69,7 +69,7 @@ public class BooleanTVListTest {
 
   @Test
   public void testPutBooleansWithBitMap() {
-    BooleanTVList tvList = new BooleanTVList();
+    TimBooleanTVList tvList = new TimBooleanTVList();
     List<Boolean> booleanList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);
@@ -100,7 +100,7 @@ public class BooleanTVListTest {
 
   @Test
   public void testClone() {
-    BooleanTVList tvList = new BooleanTVList();
+    TimBooleanTVList tvList = new TimBooleanTVList();
     List<Boolean> booleanList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/DoubleTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/DoubleTVListTest.java
@@ -32,7 +32,7 @@ public class DoubleTVListTest {
 
   @Test
   public void testDoubleTVList1() {
-    DoubleTVList tvList = new DoubleTVList();
+    TimDoubleTVList tvList = new TimDoubleTVList();
     for (int i = 0; i < 1000; i++) {
       tvList.putDouble(i, i);
     }
@@ -45,7 +45,7 @@ public class DoubleTVListTest {
 
   @Test
   public void testDoubleTVList2() {
-    DoubleTVList tvList = new DoubleTVList();
+    TimDoubleTVList tvList = new TimDoubleTVList();
     for (int i = 1000; i >= 0; i--) {
       tvList.putDouble(i, i);
     }
@@ -58,7 +58,7 @@ public class DoubleTVListTest {
 
   @Test
   public void testPutDoublesWithoutBitMap() {
-    DoubleTVList tvList = new DoubleTVList();
+    TimDoubleTVList tvList = new TimDoubleTVList();
     List<Double> doubleList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     for (long i = 1000; i >= 0; i--) {
@@ -79,7 +79,7 @@ public class DoubleTVListTest {
 
   @Test
   public void testPutDoublesWithBitMap() {
-    DoubleTVList tvList = new DoubleTVList();
+    TimDoubleTVList tvList = new TimDoubleTVList();
     List<Double> doubleList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);
@@ -110,7 +110,7 @@ public class DoubleTVListTest {
 
   @Test
   public void testClone() {
-    DoubleTVList tvList = new DoubleTVList();
+    TimDoubleTVList tvList = new TimDoubleTVList();
     List<Double> doubleList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);
@@ -128,7 +128,7 @@ public class DoubleTVListTest {
         0,
         1000);
     tvList.sort();
-    DoubleTVList clonedTvList = tvList.clone();
+    TimDoubleTVList clonedTvList = tvList.clone();
     for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(tvList.getDouble((int) i), clonedTvList.getDouble((int) i), delta);
       Assert.assertEquals(tvList.getTime((int) i), clonedTvList.getTime((int) i));

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/FloatTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/FloatTVListTest.java
@@ -32,7 +32,7 @@ public class FloatTVListTest {
 
   @Test
   public void testFloatTVList1() {
-    FloatTVList tvList = new FloatTVList();
+    TimFloatTVList tvList = new TimFloatTVList();
     for (int i = 0; i < 1000; i++) {
       tvList.putFloat(i, (float) i);
     }
@@ -45,7 +45,7 @@ public class FloatTVListTest {
 
   @Test
   public void testFloatTVList2() {
-    FloatTVList tvList = new FloatTVList();
+    TimFloatTVList tvList = new TimFloatTVList();
     for (int i = 1000; i >= 0; i--) {
       tvList.putFloat(i, (float) i);
     }
@@ -58,7 +58,7 @@ public class FloatTVListTest {
 
   @Test
   public void testPutFloatsWithoutBitMap() {
-    FloatTVList tvList = new FloatTVList();
+    TimFloatTVList tvList = new TimFloatTVList();
     List<Float> floatList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     for (long i = 1000; i >= 0; i--) {
@@ -79,7 +79,7 @@ public class FloatTVListTest {
 
   @Test
   public void testPutFloatsWithBitMap() {
-    FloatTVList tvList = new FloatTVList();
+    TimFloatTVList tvList = new TimFloatTVList();
     List<Float> floatList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);
@@ -110,7 +110,7 @@ public class FloatTVListTest {
 
   @Test
   public void testClone() {
-    FloatTVList tvList = new FloatTVList();
+    TimFloatTVList tvList = new TimFloatTVList();
     List<Float> floatList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/IntTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/IntTVListTest.java
@@ -31,7 +31,7 @@ public class IntTVListTest {
 
   @Test
   public void testIntTVList1() {
-    IntTVList tvList = new IntTVList();
+    TimIntTVList tvList = new TimIntTVList();
     for (int i = 0; i < 1000; i++) {
       tvList.putInt(i, i);
     }
@@ -44,7 +44,7 @@ public class IntTVListTest {
 
   @Test
   public void testIntTVList2() {
-    IntTVList tvList = new IntTVList();
+    TimIntTVList tvList = new TimIntTVList();
     for (int i = 1000; i >= 0; i--) {
       tvList.putInt(i, i);
     }
@@ -57,7 +57,7 @@ public class IntTVListTest {
 
   @Test
   public void testPutIntsWithoutBitMap() {
-    IntTVList tvList = new IntTVList();
+    TimIntTVList tvList = new TimIntTVList();
     List<Integer> intList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     for (int i = 1000; i >= 0; i--) {
@@ -78,7 +78,7 @@ public class IntTVListTest {
 
   @Test
   public void testPutIntsWithBitMap() {
-    IntTVList tvList = new IntTVList();
+    TimIntTVList tvList = new TimIntTVList();
     List<Integer> intList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);
@@ -109,7 +109,7 @@ public class IntTVListTest {
 
   @Test
   public void testClone() {
-    IntTVList tvList = new IntTVList();
+    TimIntTVList tvList = new TimIntTVList();
     List<Integer> intList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);
@@ -127,7 +127,7 @@ public class IntTVListTest {
         0,
         1000);
     tvList.sort();
-    IntTVList clonedTvList = tvList.clone();
+    TimIntTVList clonedTvList = tvList.clone();
     for (long i = 0; i < tvList.rowCount; i++) {
       Assert.assertEquals(tvList.getInt((int) i), clonedTvList.getInt((int) i));
       Assert.assertEquals(tvList.getTime((int) i), clonedTvList.getTime((int) i));

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/LongTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/LongTVListTest.java
@@ -34,7 +34,7 @@ public class LongTVListTest {
 
   @Test
   public void testLongTVList1() {
-    LongTVList tvList = new LongTVList();
+    TimLongTVList tvList = new TimLongTVList();
     for (long i = 0; i < 1000; i++) {
       tvList.putLong(i, i);
     }
@@ -47,7 +47,7 @@ public class LongTVListTest {
 
   @Test
   public void testLongTVList2() {
-    LongTVList tvList = new LongTVList();
+    TimLongTVList tvList = new TimLongTVList();
     for (long i = 1000; i >= 0; i--) {
       tvList.putLong(i, i);
     }
@@ -61,7 +61,7 @@ public class LongTVListTest {
   @Test
   public void testLongTVList3() {
     Random random = new Random();
-    LongTVList tvList = new LongTVList();
+    TimLongTVList tvList = new TimLongTVList();
     List<TimeValuePair> inputs = new ArrayList<>();
     for (long i = 0; i < 10000; i++) {
       long time = random.nextInt(10000);
@@ -79,7 +79,7 @@ public class LongTVListTest {
 
   @Test
   public void testPutLongsWithoutBitMap() {
-    LongTVList tvList = new LongTVList();
+    TimLongTVList tvList = new TimLongTVList();
     List<Long> longList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     for (long i = 1000; i >= 0; i--) {
@@ -100,7 +100,7 @@ public class LongTVListTest {
 
   @Test
   public void testPutIntsWithBitMap() {
-    LongTVList tvList = new LongTVList();
+    TimLongTVList tvList = new TimLongTVList();
     List<Long> longList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);
@@ -131,7 +131,7 @@ public class LongTVListTest {
 
   @Test
   public void testClone() {
-    LongTVList tvList = new LongTVList();
+    TimLongTVList tvList = new TimLongTVList();
     List<Long> longList = new ArrayList<>();
     List<Long> timeList = new ArrayList<>();
     BitMap bitMap = new BitMap(1001);

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/VectorTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/VectorTVListTest.java
@@ -37,7 +37,7 @@ public class VectorTVListTest {
     for (int i = 0; i < 5; i++) {
       dataTypes.add(TSDataType.INT64);
     }
-    AlignedTVList tvList = new AlignedTVList(dataTypes);
+    TimAlignedTVList tvList = new TimAlignedTVList(dataTypes);
     for (long i = 0; i < 1000; i++) {
       Object[] value = new Object[5];
       int[] columnOrder = new int[5];
@@ -68,7 +68,7 @@ public class VectorTVListTest {
     dataTypes.add(TSDataType.FLOAT);
     dataTypes.add(TSDataType.DOUBLE);
     dataTypes.add(TSDataType.TEXT);
-    AlignedTVList tvList = new AlignedTVList(dataTypes);
+    TimAlignedTVList tvList = new TimAlignedTVList(dataTypes);
     for (int i = 1000; i >= 0; i--) {
       Object[] value = new Object[6];
       value[0] = false;
@@ -99,7 +99,7 @@ public class VectorTVListTest {
     for (int i = 0; i < 5; i++) {
       dataTypes.add(TSDataType.INT64);
     }
-    AlignedTVList tvList = new AlignedTVList(dataTypes);
+    TimAlignedTVList tvList = new TimAlignedTVList(dataTypes);
     long[][] vectorArray = new long[5][1001];
     List<Long> timeList = new ArrayList<>();
     int[] columnOrder = new int[5];
@@ -131,7 +131,7 @@ public class VectorTVListTest {
       dataTypes.add(TSDataType.INT64);
       bitMaps[i] = new BitMap(1001);
     }
-    AlignedTVList tvList = new AlignedTVList(dataTypes);
+    TimAlignedTVList tvList = new TimAlignedTVList(dataTypes);
     long[][] vectorArray = new long[5][1001];
     int[] columnOrder = new int[5];
     List<Long> timeList = new ArrayList<>();
@@ -170,7 +170,7 @@ public class VectorTVListTest {
       dataTypes.add(TSDataType.INT64);
       bitMaps[i] = new BitMap(1001);
     }
-    AlignedTVList tvList = new AlignedTVList(dataTypes);
+    TimAlignedTVList tvList = new TimAlignedTVList(dataTypes);
     long[][] vectorArray = new long[5][1001];
     int[] columnOrder = new int[5];
     List<Long> timeList = new ArrayList<>();


### PR DESCRIPTION
## Description

restructure TVList: Pull Timsort out of the structure and make it a separate interface
The final design is like TVList<-IntTVList<-TimIntTVList/QuickIntTVList/BackwardIntTVList

### IntTVList/... : restructure all subclasses and add TimIntTVList/...

### Timsort: pull sort, binarysort, merge,etc functions as interface

### Remarks: there are no new algorithms, it's just  a restructure, to add more sort algorithms later

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
