### PR TITLE
[IOTDB-4337] Fix failed to query data after loading snapshot from other node

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/snapshot/SnapshotLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/snapshot/SnapshotLoader.java
@@ -114,6 +114,13 @@ public class SnapshotLoader {
 
   private DataRegion loadSnapshotWithoutLog() {
     try {
+      try {
+        deleteAllFilesInDataDirs();
+        LOGGER.info("Remove all data files in original data dir");
+      } catch (IOException e) {
+        LOGGER.error("Failed to remove origin data files", e);
+        return null;
+      }
       LOGGER.info("Moving snapshot file to data dirs");
       createLinksFromSnapshotDirToDataDirWithoutLog(new File(snapshotPath));
       return loadSnapshot();
@@ -137,6 +144,7 @@ public class SnapshotLoader {
         deleteAllFilesInDataDirs();
         LOGGER.info("Remove all data files in original data dir");
       } catch (IOException e) {
+        LOGGER.error("Failed to remove origin data files", e);
         return null;
       }
 


### PR DESCRIPTION
See [IOTDB-4337](https://issues.apache.org/jira/browse/IOTDB-4337).

The reason for this bug is that SnapshotLoader does not remove origin data files before moving the snapshot files to the data dirs.