### PR TITLE
[IOTDB-4348] Fix NoSuchFileException when taking snapshot

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/snapshot/SnapshotTaker.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/snapshot/SnapshotTaker.java
@@ -145,6 +145,9 @@ public class SnapshotTaker {
   private boolean createSnapshot(List<TsFileResource> resources, String snapshotId) {
     try {
       for (TsFileResource resource : resources) {
+        if (!resource.isClosed()) {
+          continue;
+        }
         File tsFile = resource.getTsFile();
         File snapshotTsFile = getSnapshotFilePathForTsFile(tsFile, snapshotId);
         // create hard link for tsfile, resource, mods

--- a/server/src/test/java/org/apache/iotdb/db/engine/snapshot/IoTDBSnapshotTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/snapshot/IoTDBSnapshotTest.java
@@ -128,6 +128,44 @@ public class IoTDBSnapshotTest {
   }
 
   @Test
+  public void testCreateSnapshotWithUnclosedTsFile()
+      throws IOException, WriteProcessException, DirectoryNotLegalException {
+    String[] originDataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();
+    IoTDBDescriptor.getInstance().getConfig().setDataDirs(testDataDirs);
+    DirectoryManager.getInstance().resetFolders();
+    try {
+      List<TsFileResource> resources = writeTsFiles();
+      resources.subList(50, 100).forEach(x -> x.setStatus(TsFileResourceStatus.UNCLOSED));
+      DataRegion region = new DataRegion(testSgName, "0");
+      region.getTsFileManager().addAll(resources, true);
+      File snapshotDir = new File("target" + File.separator + "snapshot");
+      Assert.assertTrue(snapshotDir.exists() || snapshotDir.mkdirs());
+      try {
+        new SnapshotTaker(region).takeFullSnapshot(snapshotDir.getAbsolutePath(), true);
+        File[] files =
+            snapshotDir.listFiles((dir, name) -> name.equals(SnapshotLogger.SNAPSHOT_LOG_NAME));
+        Assert.assertEquals(1, files.length);
+        SnapshotLogAnalyzer analyzer = new SnapshotLogAnalyzer(files[0]);
+        int cnt = 0;
+        while (analyzer.hasNext()) {
+          analyzer.getNextPairs();
+          cnt++;
+        }
+        analyzer.close();
+        Assert.assertEquals(100, cnt);
+        for (TsFileResource resource : resources) {
+          Assert.assertTrue(resource.tryWriteLock());
+        }
+      } finally {
+        FileUtils.recursiveDeleteFolder(snapshotDir.getAbsolutePath());
+      }
+    } finally {
+      IoTDBDescriptor.getInstance().getConfig().setDataDirs(originDataDirs);
+      DirectoryManager.getInstance().resetFolders();
+    }
+  }
+
+  @Test
   public void testLoadSnapshot()
       throws IOException, WriteProcessException, DataRegionException, DirectoryNotLegalException {
     String[] originDataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();


### PR DESCRIPTION
See [IOTDB-4348](https://issues.apache.org/jira/browse/IOTDB-4348).

The reason for this bug is that, the writing process of IoTDB does not stop when taking snapshot, which causes the SnapshotTaker gets the unclosed TsFileResource. The SnapshotTaker tries to create hard link for the resource file, while the unclosed tsfile doesn't have one. Then it comes to a NoSuchFileException.