### PR TITLE
[IOTDB-4223] Maintain default node ip config

### DIFF
--- a/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -22,7 +22,8 @@
 ####################
 
 
-# could set ip or hostname
+# Used for cluster internal RPC communication.
+# Could set 0.0.0.0, 127.0.0.1(for local test) or ipv4 address.
 # Datatype: String
 internal_address=0.0.0.0
 
@@ -43,8 +44,9 @@ consensus_port=22278
 # and the port should be consistent with the target ConfigNode's confignode_internal_port.
 # For the first ConfigNode to start, target_config_nodes points to its own internal_address:internal_port.
 # For other ConfigNodes that are started or restarted, target_config_nodes points to any running ConfigNode's internal_address:internal_port.
+# Notice: The ip for any target_config_node should never be 0.0.0.0
 # Datatype: String
-target_config_nodes=0.0.0.0:22277
+target_config_nodes=127.0.0.1:22277
 
 
 ####################

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -39,7 +39,7 @@ public class ConfigNodeConfig {
   private int consensusPort = 22278;
 
   /** Used for connecting to the ConfigNodeGroup */
-  private TEndPoint targetConfigNode = new TEndPoint("0.0.0.0", 22277);
+  private TEndPoint targetConfigNode = new TEndPoint("127.0.0.1", 22277);
 
   // TODO: Read from iotdb-confignode.properties
   private int partitionRegionId = 0;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -285,7 +285,9 @@ public class ConfigNodeDescriptor {
    * @return True if the target_config_nodes points to itself
    */
   public boolean isSeedConfigNode() {
-    return conf.getInternalAddress().equals(conf.getTargetConfigNode().getIp())
+    return (conf.getInternalAddress().equals(conf.getTargetConfigNode().getIp())
+            || (NodeUrlUtils.isLocalAddress(conf.getInternalAddress())
+                && NodeUrlUtils.isLocalAddress(conf.getTargetConfigNode().getIp())))
         && conf.getInternalPort() == conf.getTargetConfigNode().getPort();
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -92,10 +92,17 @@ public class ConfigNodeStartupCheck {
               "%s or %s", ConsensusFactory.StandAloneConsensus, ConsensusFactory.RatisConsensus));
     }
 
+    // The routing policy is limited
     if (!CONF.getRoutingPolicy().equals(RouteBalancer.LEADER_POLICY)
         && !CONF.getRoutingPolicy().equals(RouteBalancer.GREEDY_POLICY)) {
       throw new ConfigurationException(
           "routing_policy", CONF.getRoutingPolicy(), "leader or greedy");
+    }
+
+    // The ip of target ConfigNode couldn't be 0.0.0.0
+    if (CONF.getTargetConfigNode().getIp().equals("0.0.0.0")) {
+      throw new ConfigurationException(
+          "target_config_nodes", CONF.getTargetConfigNode().getIp(), "127.0.0.1 or ipv4 address");
     }
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -102,7 +102,7 @@ public class ConfigNodeStartupCheck {
     // The ip of target ConfigNode couldn't be 0.0.0.0
     if (CONF.getTargetConfigNode().getIp().equals("0.0.0.0")) {
       throw new ConfigurationException(
-          "target_config_nodes", CONF.getTargetConfigNode().getIp(), "127.0.0.1 or ipv4 address");
+          "The ip address of any target_config_nodes couldn't be 0.0.0.0");
     }
   }
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/exception/ConfigurationException.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/exception/ConfigurationException.java
@@ -39,10 +39,18 @@ public class ConfigurationException extends IoTDBException {
     this.correctValue = correctValue;
   }
 
+  /**
+   * @param parameter The error parameter
+   * @param badValue The bad value
+   */
   public ConfigurationException(String parameter, String badValue) {
     super(
         String.format("Parameter %s can not be %s", parameter, badValue),
         TSStatusCode.CONFIG_ERROR.getStatusCode());
+  }
+
+  public ConfigurationException(String errorStr) {
+    super(errorStr, TSStatusCode.CONFIG_ERROR.getStatusCode());
   }
 
   public String getParameter() {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/exception/ConfigurationException.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/exception/ConfigurationException.java
@@ -22,9 +22,14 @@ package org.apache.iotdb.commons.exception;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 public class ConfigurationException extends IoTDBException {
-  final String parameter;
-  final String correctValue;
+  private String parameter;
+  private String correctValue;
 
+  /**
+   * @param parameter The error parameter
+   * @param badValue The bad value
+   * @param correctValue The correct value (if it could be listed)
+   */
   public ConfigurationException(String parameter, String badValue, String correctValue) {
     super(
         String.format(
@@ -32,6 +37,12 @@ public class ConfigurationException extends IoTDBException {
         TSStatusCode.CONFIG_ERROR.getStatusCode());
     this.parameter = parameter;
     this.correctValue = correctValue;
+  }
+
+  public ConfigurationException(String parameter, String badValue) {
+    super(
+        String.format("Parameter %s can not be %s", parameter, badValue),
+        TSStatusCode.CONFIG_ERROR.getStatusCode());
   }
 
   public String getParameter() {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
@@ -187,4 +187,11 @@ public class NodeUrlUtils {
       throws BadNodeUrlException {
     return parseTConfigNodeUrls(Arrays.asList(configNodeUrls.split(";")));
   }
+
+  public static boolean isLocalAddress(String ip) {
+    if (ip == null) {
+      return false;
+    }
+    return ip.equals("0.0.0.0") || ip.equals("127.0.0.1") || ip.equals("localhost");
+  }
 }

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -21,6 +21,7 @@
 ### RPC Configuration
 ####################
 
+# could set 0.0.0.0, 127.0.0.1(for local test) or ipv4 address
 # Datatype: String
 rpc_address=0.0.0.0
 
@@ -44,8 +45,8 @@ mpp_data_exchange_port=8777
 
 # Datatype: String
 # used for communication between cluster nodes.
-# if this parameter is commented, then the IP that binded by the hostname will be used.
-internal_address=127.0.0.1
+# could set 0.0.0.0, 127.0.0.1(for local test) or ipv4 address.
+internal_address=0.0.0.0
 
 # Datatype: int
 # port for coordinator's communication between cluster nodes.
@@ -66,6 +67,7 @@ schema_region_consensus_port=50010
 # When successfully connecting to the ConfigNodeGroup, DataNode will get all online
 # config nodes and store them in memory.
 # Datatype: String
+# Notice: The ip for any target_config_node should never be 0.0.0.0
 target_config_nodes=127.0.0.1:22277
 
 # Datatype: boolean

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -852,7 +852,7 @@ public class IoTDBConfig {
   private int pageCacheSizeInSchemaFile = 1024;
 
   /** Internal address for data node */
-  private String internalAddress = "127.0.0.1";
+  private String internalAddress = "0.0.0.0";
 
   /** Internal port for coordinator */
   private int internalPort = 9003;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -399,7 +399,8 @@ public class IoTDBStartCheck {
       }
       for (TEndPoint endPoint : targetConfigNodes) {
         if (endPoint.getIp().equals("0.0.0.0")) {
-          throw new ConfigurationException(TARGET_CONFIG_NODES, "0.0.0.0");
+          throw new ConfigurationException(
+              "The ip address of any target_config_nodes couldn't be 0.0.0.0");
         }
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -19,12 +19,9 @@
 package org.apache.iotdb.db.conf;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
-import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
-import org.apache.iotdb.commons.exception.BadNodeUrlException;
 import org.apache.iotdb.commons.exception.ConfigurationException;
 import org.apache.iotdb.commons.file.SystemFileFactory;
-import org.apache.iotdb.commons.utils.NodeUrlUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TGlobalConfig;
 import org.apache.iotdb.db.metadata.upgrade.MetadataUpgrader;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
@@ -43,7 +40,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -117,8 +113,6 @@ public class IoTDBStartCheck {
   private static final String SCHEMA_REGION_CONSENSUS_PROTOCOL = "schema_region_consensus_protocol";
 
   private static final String DATA_REGION_CONSENSUS_PROTOCOL = "data_region_consensus_protocol";
-
-  private static final String TARGET_CONFIG_NODES = "target_config_nodes";
 
   private static final String IOTDB_VERSION_STRING = "iotdb_version";
 
@@ -387,22 +381,6 @@ public class IoTDBStartCheck {
 
     if (!(properties.getProperty(SCHEMA_ENGINE_MODE).equals(schemaEngineMode))) {
       throwException(SCHEMA_ENGINE_MODE, schemaEngineMode);
-    }
-
-    if (properties.getProperty(TARGET_CONFIG_NODES, null) != null) {
-      String rawString = properties.getProperty(TARGET_CONFIG_NODES);
-      List<TEndPoint> targetConfigNodes;
-      try {
-        targetConfigNodes = NodeUrlUtils.parseTEndPointUrls(rawString);
-      } catch (BadNodeUrlException e) {
-        throw new ConfigurationException(TARGET_CONFIG_NODES, rawString);
-      }
-      for (TEndPoint endPoint : targetConfigNodes) {
-        if (endPoint.getIp().equals("0.0.0.0")) {
-          throw new ConfigurationException(
-              "The ip address of any target_config_nodes couldn't be 0.0.0.0");
-        }
-      }
     }
 
     // load configuration from system properties only when start as Data node

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -111,11 +111,17 @@ public class DataNode implements DataNodeMBean {
     IoTDBStartCheck.getInstance().checkConfig();
     // TODO: check configuration for data node
 
+    for (TEndPoint endPoint : config.getTargetConfigNodeList()) {
+      if (endPoint.getIp().equals("0.0.0.0")) {
+        throw new ConfigurationException(
+            "The ip address of any target_config_nodes couldn't be 0.0.0.0");
+      }
+    }
+
     // if client ip is the default address, set it same with internal ip
     if (config.getRpcAddress().equals("0.0.0.0")) {
       config.setRpcAddress(config.getInternalAddress());
     }
-
     thisNode.setIp(IoTDBDescriptor.getInstance().getConfig().getInternalAddress());
     thisNode.setPort(IoTDBDescriptor.getInstance().getConfig().getInternalPort());
   }


### PR DESCRIPTION
We make some constraints on node ip addresses:

1. DataNode's rpc_address: could set 0.0.0.0, 127.0.0.1 or ipv4 address(default is 0.0.0.0)
2. DataNode's internal_address: could set 0.0.0.0, 127.0.0.1 or ipv4 address(default is 0.0.0.0)
3. DataNode's target_config_nodes: the ip should never be 0.0.0.0(default is 127.0.0.1)
4. ConfigNode's internal_address: could set 0.0.0.0, 127.0.0.1 or ipv4 address(default is 0.0.0.0)
5. ConfigNode's target_config_nodes: the ip should never be 0.0.0.0(default is 127.0.0.1)

I performed some simple tests on my local machine:

1. Start 1C1D with default configuration, success:
![image](https://user-images.githubusercontent.com/33111881/188665715-14f54fe3-a707-41aa-9037-03df0d52c038.png)

2. Start 1C1D with rpc_address and internal_address set to 127.0.0.1, success:
![image](https://user-images.githubusercontent.com/33111881/188666217-de67c82e-804b-4b29-97d9-097e99e51421.png)

3. Start 1C with target_config_nodes set to 0.0.0.0, failed:
![image](https://user-images.githubusercontent.com/33111881/188666672-8d5c6b3d-ef09-41f0-a7af-8bfeb447c505.png)

4. Start 1C1D with DataNode's target_config_nodes's ip set to 0.0.0.0, failed:
![image](https://user-images.githubusercontent.com/33111881/188672237-ef501faf-4666-42f3-8879-9fad6b0a6967.png)
