### PR TITLE
[IOTDB-4358] set read consistency level to 'weak', quey SimpleFragmentParallelPlanner may exist out of bounds exception

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
@@ -149,6 +149,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
       targetIndex = 0;
     } else {
       targetIndex = (int) (queryContext.getSession().getSessionId() % availableDataNodes.size());
+      targetIndex = Math.abs(targetIndex);
     }
     return availableDataNodes.get(targetIndex);
   }


### PR DESCRIPTION
set read consistency level to 'weak', quey SimpleFragmentParallelPlanner may exist out of bounds exception
see: https://issues.apache.org/jira/browse/IOTDB-4358