### PR TITLE
Rel/0.13-Delete information about rpc_port in UserGuide

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,16 +197,14 @@ Users can start IoTDB by the start-server script under the sbin folder.
 # Unix/OS X
 > nohup sbin/start-server.sh >/dev/null 2>&1 &
 or
-> nohup sbin/start-server.sh -c <conf_path> -rpc_port <rpc_port> >/dev/null 2>&1 &
+> nohup sbin/start-server.sh -c <conf_path> >/dev/null 2>&1 &
 
 # Windows
-> sbin\start-server.bat -c <conf_path> -rpc_port <rpc_port>
+> sbin\start-server.bat -c <conf_path>
 ```
 
-- "-c" and "-rpc_port" are optional.
+- "-c" is optional.
 - option "-c" specifies the system configuration file directory.
-- option "-rpc_port" specifies the rpc port.
-- if both option specified, the *rpc_port* will overrides the rpc_port in *conf_path*.
 
 
 ### Use IoTDB

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -182,15 +182,13 @@ git checkout vx.x.x
 # Unix/OS X
 > nohup sbin/start-server.sh >/dev/null 2>&1 &
 or
-> nohup sbin/start-server.sh -c <conf_path> -rpc_port <rpc_port> >/dev/null 2>&1 &
+> nohup sbin/start-server.sh -c <conf_path> >/dev/null 2>&1 &
 
 # Windows
-> sbin\start-server.bat -c <conf_path> -rpc_port <rpc_port>
+> sbin\start-server.bat -c <conf_path>
 ```
 - "-c" and "-rpc_port" 都是可选的。
 - 选项 "-c" 指定了配置文件所在的文件夹。
-- 选项 "-rpc_port" 指定了启动的 rpc port。
-- 如果两个选项同时指定，那么*rpc_port*将会覆盖*conf_path*下面的配置。
 
 ### 使用 IoTDB
 

--- a/docs/UserGuide/QuickStart/QuickStart.md
+++ b/docs/UserGuide/QuickStart/QuickStart.md
@@ -66,16 +66,14 @@ Users can start IoTDB by the start-server script under the sbin folder.
 # Unix/OS X
 > nohup sbin/start-server.sh >/dev/null 2>&1 &
 or
-> nohup sbin/start-server.sh -c <conf_path> -rpc_port <rpc_port> >/dev/null 2>&1 &
+> nohup sbin/start-server.sh -c <conf_path> >/dev/null 2>&1 &
 
 # Windows
-> sbin\start-server.bat -c <conf_path> -rpc_port <rpc_port>
+> sbin\start-server.bat -c <conf_path>
 ```
 
-- "-c" and "-rpc_port" are optional.
+- "-c" is optional.
 - option "-c" specifies the system configuration file directory.
-- option "-rpc_port" specifies the rpc port.
-- if both option specified, the *rpc_port* will overrides the rpc_port in *conf_path*.
 
 if you want to use JMX to connect IOTDB, you may need to add 
 

--- a/docs/zh/UserGuide/QuickStart/QuickStart.md
+++ b/docs/zh/UserGuide/QuickStart/QuickStart.md
@@ -59,18 +59,16 @@ Linux 系统与 MacOS 系统启动命令如下：
 ```
 > nohup sbin/start-server.sh >/dev/null 2>&1 &
 or
-> nohup sbin/start-server.sh -c <conf_path> -rpc_port <rpc_port> >/dev/null 2>&1 &
+> nohup sbin/start-server.sh -c <conf_path> >/dev/null 2>&1 &
 ```
 
 Windows 系统启动命令如下：
 
 ```
-> sbin\start-server.bat -c <conf_path> -rpc_port <rpc_port>
+> sbin\start-server.bat -c <conf_path>
 ```
 - "-c" and "-rpc_port" 都是可选的。
 - 选项 "-c" 指定了配置文件所在的文件夹。
-- 选项 "-rpc_port" 指定了启动的 rpc port。
-- 如果两个选项同时指定，那么* rpc_port *将会覆盖* conf_path *下面的配置。
 
 #### 使用 Cli 工具
 

--- a/docs/zh/UserGuide/QuickStart/QuickStart.md
+++ b/docs/zh/UserGuide/QuickStart/QuickStart.md
@@ -67,7 +67,7 @@ Windows 系统启动命令如下：
 ```
 > sbin\start-server.bat -c <conf_path>
 ```
-- "-c" and "-rpc_port" 都是可选的。
+- "-c"是可选的。
 - 选项 "-c" 指定了配置文件所在的文件夹。
 
 #### 使用 Cli 工具


### PR DESCRIPTION
In the start IoTDB command:
-rpc_port :The specified port number does not take effect
-c: The specified conf file path takes effect