### PR TITLE
[To rel/0.13][IOTDB-4364]Reduce read amplication in compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
@@ -143,7 +143,7 @@ public class CompactionUtils {
             device,
             existedMeasurements,
             measurementSchemas,
-            new HashSet<>(existedMeasurements),
+            schemaMap.keySet(),
             queryContext,
             queryDataSource,
             true);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/SubCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/SubCompactionTask.java
@@ -47,17 +47,17 @@ public class SubCompactionTask implements Callable<Void> {
   private final String device;
   private final Set<String> measurementList;
 
-  private final Set<String> allMeasurements;
   private final QueryContext queryContext;
   private final QueryDataSource queryDataSource;
   private final AbstractCompactionWriter compactionWriter;
+
+  // schema of all measurements of this device
   private final Map<String, MeasurementSchema> schemaMap;
   private final int taskId;
 
   public SubCompactionTask(
       String device,
       Set<String> measurementList,
-      Set<String> allMeasurements,
       QueryContext queryContext,
       QueryDataSource queryDataSource,
       AbstractCompactionWriter compactionWriter,
@@ -65,7 +65,6 @@ public class SubCompactionTask implements Callable<Void> {
       int taskId) {
     this.device = device;
     this.measurementList = measurementList;
-    this.allMeasurements = allMeasurements;
     this.queryContext = queryContext;
     this.queryDataSource = queryDataSource;
     this.compactionWriter = compactionWriter;
@@ -84,7 +83,7 @@ public class SubCompactionTask implements Callable<Void> {
               device,
               Collections.singletonList(measurement),
               measurementSchemas,
-              allMeasurements,
+              schemaMap.keySet(),
               queryContext,
               queryDataSource,
               false);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/SubCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/SubCompactionTask.java
@@ -46,6 +46,8 @@ public class SubCompactionTask implements Callable<Void> {
       LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
   private final String device;
   private final Set<String> measurementList;
+
+  private final Set<String> allMeasurements;
   private final QueryContext queryContext;
   private final QueryDataSource queryDataSource;
   private final AbstractCompactionWriter compactionWriter;
@@ -55,6 +57,7 @@ public class SubCompactionTask implements Callable<Void> {
   public SubCompactionTask(
       String device,
       Set<String> measurementList,
+      Set<String> allMeasurements,
       QueryContext queryContext,
       QueryDataSource queryDataSource,
       AbstractCompactionWriter compactionWriter,
@@ -62,6 +65,7 @@ public class SubCompactionTask implements Callable<Void> {
       int taskId) {
     this.device = device;
     this.measurementList = measurementList;
+    this.allMeasurements = allMeasurements;
     this.queryContext = queryContext;
     this.queryDataSource = queryDataSource;
     this.compactionWriter = compactionWriter;
@@ -80,7 +84,7 @@ public class SubCompactionTask implements Callable<Void> {
               device,
               Collections.singletonList(measurement),
               measurementSchemas,
-              measurementList,
+              allMeasurements,
               queryContext,
               queryDataSource,
               false);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -82,7 +82,7 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
       List<TsFileResource> seqResources, List<TsFileResource> unseqResources) throws IOException {
     this.tsFileResources = new ArrayList<>(seqResources);
     tsFileResources.addAll(unseqResources);
-    Collections.sort(this.tsFileResources, TsFileResource::compareFileName);
+    Collections.sort(this.tsFileResources, TsFileResource::compareFileNameByDesc);
     for (TsFileResource tsFileResource : tsFileResources) {
       TsFileSequenceReader reader =
           FileReaderManager.getInstance().get(tsFileResource.getTsFilePath(), true);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -950,6 +950,18 @@ public class TsFileResource {
     }
   }
 
+  public static int compareFileNameByDesc(TsFileResource o1, TsFileResource o2) {
+    try {
+      TsFileNameGenerator.TsFileName n1 =
+          TsFileNameGenerator.getTsFileName(o1.getTsFile().getName());
+      TsFileNameGenerator.TsFileName n2 =
+          TsFileNameGenerator.getTsFileName(o2.getTsFile().getName());
+      return (int) (n2.getVersion() - n1.getVersion());
+    } catch (IOException e) {
+      return 0;
+    }
+  }
+
   public void setSeq(boolean seq) {
     isSeq = seq;
   }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileDeviceIterator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileDeviceIterator.java
@@ -24,9 +24,7 @@ import org.apache.iotdb.tsfile.file.metadata.MetadataIndexNode;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 
@@ -34,6 +32,8 @@ public class TsFileDeviceIterator implements Iterator<Pair<String, Boolean>> {
   private final TsFileSequenceReader reader;
   private final Queue<Pair<String, Pair<Long, Long>>> queue;
   private Pair<String, Boolean> currentDevice = null;
+
+  private MetadataIndexNode measurementNode;
 
   public TsFileDeviceIterator(
       TsFileSequenceReader reader, Queue<Pair<String, Pair<Long, Long>>> queue) {
@@ -56,18 +56,22 @@ public class TsFileDeviceIterator implements Iterator<Pair<String, Boolean>> {
       throw new NoSuchElementException();
     }
     Pair<String, Pair<Long, Long>> startEndPair = queue.remove();
-    List<Pair<String, Boolean>> devices = new ArrayList<>();
     try {
+      // first measurement node of this device
       MetadataIndexNode measurementNode =
           MetadataIndexNode.deserializeFrom(
               reader.readData(startEndPair.right.left, startEndPair.right.right));
-      // if tryToGetFirstTimeseriesMetadata(node) returns null, the device is not aligned
-      boolean isAligned = reader.tryToGetFirstTimeseriesMetadata(measurementNode) != null;
+      boolean isAligned = reader.isAlignedDevice(measurementNode);
       currentDevice = new Pair<>(startEndPair.left, isAligned);
+      this.measurementNode = measurementNode;
       return currentDevice;
     } catch (IOException e) {
       throw new TsFileRuntimeException(
           "Error occurred while reading a time series metadata block.");
     }
+  }
+
+  public MetadataIndexNode getMeasurementNode() {
+    return measurementNode;
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -793,6 +793,15 @@ public class TsFileSequenceReader implements AutoCloseable {
     }
   }
 
+  /**
+   * Check whether the deivce is aligned or not.
+   *
+   * @param measurementNode the next measurement layer node of specific device node
+   */
+  public boolean isAlignedDevice(MetadataIndexNode measurementNode) {
+    return "".equals(measurementNode.getChildren().get(0).getName());
+  }
+
   TimeseriesMetadata tryToGetFirstTimeseriesMetadata(MetadataIndexNode measurementNode)
       throws IOException {
     // Not aligned timeseries
@@ -823,6 +832,45 @@ public class TsFileSequenceReader implements AutoCloseable {
       return tryToGetFirstTimeseriesMetadata(metadataIndexNode);
     }
     return null;
+  }
+
+  /**
+   * @param measurementNode next layer measurement node of specific device leaf node
+   * @param excludedMeasurementIds skip timeseries whose measurementId is in the set
+   */
+  public void getDeviceTimeseriesMetadata(
+      List<TimeseriesMetadata> timeseriesMetadataList,
+      MetadataIndexNode measurementNode,
+      Set<String> excludedMeasurementIds,
+      boolean needChunkMetadata)
+      throws IOException {
+    int metadataIndexListSize = measurementNode.getChildren().size();
+    for (int i = 0; i < metadataIndexListSize; i++) {
+      long endOffset = measurementNode.getEndOffset();
+      if (i != metadataIndexListSize - 1) {
+        endOffset = measurementNode.getChildren().get(i + 1).getOffset();
+      }
+      ByteBuffer nextBuffer = readData(measurementNode.getChildren().get(i).getOffset(), endOffset);
+      if (measurementNode.getNodeType().equals(MetadataIndexNodeType.LEAF_MEASUREMENT)) {
+        // leaf measurement node
+        while (nextBuffer.hasRemaining()) {
+          TimeseriesMetadata timeseriesMetadata =
+              TimeseriesMetadata.deserializeFrom(
+                  nextBuffer, excludedMeasurementIds, needChunkMetadata);
+          if (timeseriesMetadata != null) {
+            timeseriesMetadataList.add(timeseriesMetadata);
+          }
+        }
+      } else {
+        // internal measurement node
+        MetadataIndexNode nextLayerMeasurementNode = MetadataIndexNode.deserializeFrom(nextBuffer);
+        getDeviceTimeseriesMetadata(
+            timeseriesMetadataList,
+            nextLayerMeasurementNode,
+            excludedMeasurementIds,
+            needChunkMetadata);
+      }
+    }
   }
 
   /**
@@ -1093,6 +1141,21 @@ public class TsFileSequenceReader implements AutoCloseable {
       logger.warn("Exception {} happened while reading chunk of {}", t.getMessage(), file);
       throw t;
     }
+  }
+
+  public MeasurementSchema getMeasurementSchema(List<IChunkMetadata> chunkMetadataList)
+      throws IOException {
+    if (chunkMetadataList.isEmpty()) {
+      return null;
+    }
+    IChunkMetadata lastChunkMetadata = chunkMetadataList.get(chunkMetadataList.size() - 1);
+    int chunkHeadSize = ChunkHeader.getSerializedSize(lastChunkMetadata.getMeasurementUid());
+    ChunkHeader header = readChunkHeader(lastChunkMetadata.getOffsetOfChunkHeader(), chunkHeadSize);
+    return new MeasurementSchema(
+        lastChunkMetadata.getMeasurementUid(),
+        header.getDataType(),
+        header.getEncodingType(),
+        header.getCompressionType());
   }
 
   /**


### PR DESCRIPTION
**Description**
In massive timeseries scenarios, each device has 20 timeseries, and each file has tens of thousands of devices, that is, millions of timeseries. Read throughput in cross compaction is 100~1000 times greater than write throughput.

**Solution**
When compacting, it is necessary to obtain devices and timeseries from all source files, as well as the metadata of each timeseries. To avoid traversing the Zesong tree multiple times, we record the intermediate nodes of the Zesong tree. Please refer to [IOTDB-4364](https://issues.apache.org/jira/browse/IOTDB-4364) for the experimental results.