### PR TITLE
[IOTDB-4403] Add retry interface for IStateMachine

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
@@ -170,4 +170,22 @@ public class PartitionRegionStateMachine
   public boolean isReadOnly() {
     return CommonDescriptor.getInstance().getConfig().isReadOnly();
   }
+
+  @Override
+  public boolean shouldRetry(TSStatus writeResult) {
+    // TODO implement this
+    return RetryPolicy.super.shouldRetry(writeResult);
+  }
+
+  @Override
+  public TSStatus updateResult(TSStatus previousResult, TSStatus retryResult) {
+    // TODO implement this
+    return RetryPolicy.super.updateResult(previousResult, retryResult);
+  }
+
+  @Override
+  public long getSleepTime() {
+    // TODO implement this
+    return RetryPolicy.super.getSleepTime();
+  }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
@@ -41,7 +41,7 @@ import java.io.File;
 import java.io.IOException;
 
 /** StateMachine for PartitionRegion */
-public class PartitionRegionStateMachine implements IStateMachine, IStateMachine.EventApi {
+public class PartitionRegionStateMachine implements IStateMachine, IStateMachine.EventApi, IStateMachine.RetryPolicy {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionRegionStateMachine.class);
   private final ConfigPlanExecutor executor;
@@ -168,5 +168,24 @@ public class PartitionRegionStateMachine implements IStateMachine, IStateMachine
   @Override
   public boolean isReadOnly() {
     return CommonDescriptor.getInstance().getConfig().isReadOnly();
+  }
+
+
+  @Override
+  public boolean shouldRetry(TSStatus writeResult) {
+    // TODO implement this method
+    return RetryPolicy.super.shouldRetry(writeResult);
+  }
+
+  @Override
+  public TSStatus updateResult(TSStatus retryResult) {
+    // TODO implement this method
+    return RetryPolicy.super.updateResult(retryResult);
+  }
+
+  @Override
+  public long getSleepTime() {
+    // TODO implement this method
+    return RetryPolicy.super.getSleepTime();
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
@@ -170,22 +170,4 @@ public class PartitionRegionStateMachine
   public boolean isReadOnly() {
     return CommonDescriptor.getInstance().getConfig().isReadOnly();
   }
-
-  @Override
-  public boolean shouldRetry(TSStatus writeResult) {
-    // TODO implement this method
-    return RetryPolicy.super.shouldRetry(writeResult);
-  }
-
-  @Override
-  public TSStatus updateResult(TSStatus retryResult) {
-    // TODO implement this method
-    return RetryPolicy.super.updateResult(retryResult);
-  }
-
-  @Override
-  public long getSleepTime() {
-    // TODO implement this method
-    return RetryPolicy.super.getSleepTime();
-  }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/PartitionRegionStateMachine.java
@@ -41,7 +41,8 @@ import java.io.File;
 import java.io.IOException;
 
 /** StateMachine for PartitionRegion */
-public class PartitionRegionStateMachine implements IStateMachine, IStateMachine.EventApi, IStateMachine.RetryPolicy {
+public class PartitionRegionStateMachine
+    implements IStateMachine, IStateMachine.EventApi, IStateMachine.RetryPolicy {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionRegionStateMachine.class);
   private final ConfigPlanExecutor executor;
@@ -169,7 +170,6 @@ public class PartitionRegionStateMachine implements IStateMachine, IStateMachine
   public boolean isReadOnly() {
     return CommonDescriptor.getInstance().getConfig().isReadOnly();
   }
-
 
   @Override
   public boolean shouldRetry(TSStatus writeResult) {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -95,7 +95,7 @@ public interface IStateMachine {
   /**
    * To guarantee the statemachine replication property, when {@link #write(IConsensusRequest)}
    * failed in this statemachine, Upper consensus implementation like RatisConsensus may choose to
-   * retry the operation until it exceeds.
+   * retry the operation until it succeed.
    */
   interface RetryPolicy {
 
@@ -107,10 +107,11 @@ public interface IStateMachine {
     /**
      * Use the latest write result to update final write result
      *
-     * @param retryResult the latest write result
+     * @param previousResult previous write result
+     * @param retryResult latest write result
      * @return the aggregated result upon current retry
      */
-    default TSStatus updateResult(TSStatus retryResult) {
+    default TSStatus updateResult(TSStatus previousResult, TSStatus retryResult) {
       return retryResult;
     }
 
@@ -120,8 +121,12 @@ public interface IStateMachine {
      * @return time in millis
      */
     default long getSleepTime() {
-      return 0;
+      return 100;
     };
+  }
+
+  default RetryPolicy retryPolicy() {
+    return (IStateMachine.RetryPolicy) this;
   }
 
   /** An optional API for event notifications. */

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -92,6 +92,38 @@ public interface IStateMachine {
     return Utils.listAllRegularFilesRecursively(latestSnapshotRootDir);
   }
 
+  /**
+   * To guarantee the statemachine replication property, when {@link #write(IConsensusRequest)}
+   * failed in this statemachine, Upper consensus implementation like RatisConsensus may choose to
+   * retry the operation until it exceeds.
+   */
+  interface RetryPolicy {
+
+    /** Given the last write result, should we retry? */
+    default boolean shouldRetry(TSStatus writeResult) {
+      return false;
+    }
+
+    /**
+     * Use the latest write result to update final write result
+     *
+     * @param retryResult the latest write result
+     * @return the aggregated result upon current retry
+     */
+    default TSStatus updateResult(TSStatus retryResult) {
+      return retryResult;
+    }
+
+    /**
+     * sleep time before the next retry
+     *
+     * @return time in millis
+     */
+    default long getSleepTime() {
+      return 0;
+    };
+  }
+
   /** An optional API for event notifications. */
   interface EventApi {
     /**

--- a/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -125,10 +125,6 @@ public interface IStateMachine {
     };
   }
 
-  default RetryPolicy retryPolicy() {
-    return (IStateMachine.RetryPolicy) this;
-  }
-
   /** An optional API for event notifications. */
   interface EventApi {
     /**

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
@@ -27,8 +27,8 @@ import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.common.request.ByteBufferConsensusRequest;
 import org.apache.iotdb.consensus.common.request.IConsensusRequest;
-
 import org.apache.iotdb.rpc.TSStatusCode;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,27 +167,6 @@ public class TestUtils {
 
     public List<Peer> getConfiguration() {
       return configuration;
-    }
-
-    static class Retry3Times implements IStateMachine.RetryPolicy {
-      private int retryTimes = 3;
-
-      @Override
-      public boolean shouldRetry(TSStatus writeResult) {
-        // retry when Series overflow and max retry time is 3
-        return retryTimes > 0 && writeResult.getCode() == TSStatusCode.SERIES_OVERFLOW.getStatusCode();
-      }
-
-      @Override
-      public TSStatus updateResult(TSStatus previousResult, TSStatus retryResult) {
-        retryTimes--;
-        return retryResult;
-      }
-    }
-
-    @Override
-    public RetryPolicy retryPolicy() {
-      return new Retry3Times();
     }
   }
 }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.common.request.ByteBufferConsensusRequest;
 import org.apache.iotdb.consensus.common.request.IConsensusRequest;
-import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/BaseStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/BaseStateMachine.java
@@ -31,7 +31,7 @@ import org.apache.iotdb.db.wal.buffer.WALEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class BaseStateMachine implements IStateMachine, IStateMachine.EventApi {
+public abstract class BaseStateMachine implements IStateMachine, IStateMachine.EventApi, IStateMachine.RetryPolicy {
 
   private static final Logger logger = LoggerFactory.getLogger(BaseStateMachine.class);
 

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/BaseStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/BaseStateMachine.java
@@ -31,7 +31,8 @@ import org.apache.iotdb.db.wal.buffer.WALEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class BaseStateMachine implements IStateMachine, IStateMachine.EventApi, IStateMachine.RetryPolicy {
+public abstract class BaseStateMachine
+    implements IStateMachine, IStateMachine.EventApi, IStateMachine.RetryPolicy {
 
   private static final Logger logger = LoggerFactory.getLogger(BaseStateMachine.class);
 

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -379,4 +379,22 @@ public class DataRegionStateMachine extends BaseStateMachine {
       return QUERY_INSTANCE_MANAGER.execDataQueryFragmentInstance(fragmentInstance, region);
     }
   }
+
+  @Override
+  public boolean shouldRetry(TSStatus writeResult) {
+    // TODO implement this
+    return super.shouldRetry(writeResult);
+  }
+
+  @Override
+  public TSStatus updateResult(TSStatus previousResult, TSStatus retryResult) {
+    // TODO implement this
+    return super.updateResult(previousResult, retryResult);
+  }
+
+  @Override
+  public long getSleepTime() {
+    // TODO implement this
+    return super.getSleepTime();
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -379,22 +379,4 @@ public class DataRegionStateMachine extends BaseStateMachine {
       return QUERY_INSTANCE_MANAGER.execDataQueryFragmentInstance(fragmentInstance, region);
     }
   }
-
-  @Override
-  public boolean shouldRetry(TSStatus writeResult) {
-    // TODO implement this method
-    return super.shouldRetry(writeResult);
-  }
-
-  @Override
-  public TSStatus updateResult(TSStatus retryResult) {
-    // TODO implement this method
-    return super.updateResult(retryResult);
-  }
-
-  @Override
-  public long getSleepTime() {
-    // TODO implement this method
-    return super.getSleepTime();
-  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -379,4 +379,22 @@ public class DataRegionStateMachine extends BaseStateMachine {
       return QUERY_INSTANCE_MANAGER.execDataQueryFragmentInstance(fragmentInstance, region);
     }
   }
+
+  @Override
+  public boolean shouldRetry(TSStatus writeResult) {
+    // TODO implement this method
+    return super.shouldRetry(writeResult);
+  }
+
+  @Override
+  public TSStatus updateResult(TSStatus retryResult) {
+    // TODO implement this method
+    return super.updateResult(retryResult);
+  }
+
+  @Override
+  public long getSleepTime() {
+    // TODO implement this method
+    return super.getSleepTime();
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
@@ -94,7 +94,6 @@ public class SchemaRegionStateMachine extends BaseStateMachine {
     return QUERY_INSTANCE_MANAGER.execSchemaQueryFragmentInstance(fragmentInstance, schemaRegion);
   }
 
-
   @Override
   public boolean shouldRetry(TSStatus writeResult) {
     // TODO implement this method

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
@@ -93,4 +93,23 @@ public class SchemaRegionStateMachine extends BaseStateMachine {
         fragmentInstance.getId());
     return QUERY_INSTANCE_MANAGER.execSchemaQueryFragmentInstance(fragmentInstance, schemaRegion);
   }
+
+
+  @Override
+  public boolean shouldRetry(TSStatus writeResult) {
+    // TODO implement this
+    return super.shouldRetry(writeResult);
+  }
+
+  @Override
+  public TSStatus updateResult(TSStatus previousResult, TSStatus retryResult) {
+    // TODO implement this
+    return super.updateResult(previousResult, retryResult);
+  }
+
+  @Override
+  public long getSleepTime() {
+    // TODO implement this
+    return super.getSleepTime();
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
@@ -94,7 +94,6 @@ public class SchemaRegionStateMachine extends BaseStateMachine {
     return QUERY_INSTANCE_MANAGER.execSchemaQueryFragmentInstance(fragmentInstance, schemaRegion);
   }
 
-
   @Override
   public boolean shouldRetry(TSStatus writeResult) {
     // TODO implement this

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
@@ -93,22 +93,4 @@ public class SchemaRegionStateMachine extends BaseStateMachine {
         fragmentInstance.getId());
     return QUERY_INSTANCE_MANAGER.execSchemaQueryFragmentInstance(fragmentInstance, schemaRegion);
   }
-
-  @Override
-  public boolean shouldRetry(TSStatus writeResult) {
-    // TODO implement this method
-    return super.shouldRetry(writeResult);
-  }
-
-  @Override
-  public TSStatus updateResult(TSStatus retryResult) {
-    // TODO implement this method
-    return super.updateResult(retryResult);
-  }
-
-  @Override
-  public long getSleepTime() {
-    // TODO implement this method
-    return super.getSleepTime();
-  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/SchemaRegionStateMachine.java
@@ -93,4 +93,23 @@ public class SchemaRegionStateMachine extends BaseStateMachine {
         fragmentInstance.getId());
     return QUERY_INSTANCE_MANAGER.execSchemaQueryFragmentInstance(fragmentInstance, schemaRegion);
   }
+
+
+  @Override
+  public boolean shouldRetry(TSStatus writeResult) {
+    // TODO implement this method
+    return super.shouldRetry(writeResult);
+  }
+
+  @Override
+  public TSStatus updateResult(TSStatus retryResult) {
+    // TODO implement this method
+    return super.updateResult(retryResult);
+  }
+
+  @Override
+  public long getSleepTime() {
+    // TODO implement this method
+    return super.getSleepTime();
+  }
 }


### PR DESCRIPTION
To guarantee consistency in RatisConsensus, we should retry some failed apply write result.

refer to design doc: https://apache-iotdb.feishu.cn/docx/doxcnj0pH6Jm9pFWEEexa4opdXb