### PR TITLE
[IOTDB-4364]Reduce read amplication in compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/ReadPointPerformerSubTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/ReadPointPerformerSubTask.java
@@ -79,7 +79,7 @@ public class ReadPointPerformerSubTask implements Callable<Void> {
               device,
               Collections.singletonList(measurement),
               measurementSchemas,
-              measurementList,
+              schemaMap.keySet(),
               fragmentInstanceContext,
               queryDataSource,
               false);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.read.TsFileDeviceIterator;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,10 +49,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class MultiTsFileDeviceIterator implements AutoCloseable {
-  private List<TsFileResource> tsFileResources;
-  private Map<TsFileResource, TsFileSequenceReader> readerMap = new HashMap<>();
-  private Map<TsFileResource, TsFileDeviceIterator> deviceIteratorMap = new HashMap<>();
-  private Map<TsFileResource, List<Modification>> modificationCache = new HashMap<>();
+  // sorted from the newest to the oldest
+  private final List<TsFileResource> tsFileResources;
+  private final Map<TsFileResource, TsFileSequenceReader> readerMap = new HashMap<>();
+  private final Map<TsFileResource, TsFileDeviceIterator> deviceIteratorMap = new HashMap<>();
+  private final Map<TsFileResource, List<Modification>> modificationCache = new HashMap<>();
   private Pair<String, Boolean> currentDevice = null;
 
   /** Used for inner space compaction. */
@@ -77,13 +79,10 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
   /** Used for cross space compaction. */
   public MultiTsFileDeviceIterator(
       List<TsFileResource> seqResources, List<TsFileResource> unseqResources) throws IOException {
-    for (TsFileResource tsFileResource : seqResources) {
-      TsFileSequenceReader reader =
-          FileReaderManager.getInstance().get(tsFileResource.getTsFilePath(), true);
-      readerMap.put(tsFileResource, reader);
-      deviceIteratorMap.put(tsFileResource, reader.getAllDevicesIteratorWithIsAligned());
-    }
-    for (TsFileResource tsFileResource : unseqResources) {
+    this.tsFileResources = new ArrayList<>(seqResources);
+    tsFileResources.addAll(unseqResources);
+    Collections.sort(this.tsFileResources, TsFileResource::compareFileName);
+    for (TsFileResource tsFileResource : tsFileResources) {
       TsFileSequenceReader reader =
           FileReaderManager.getInstance().get(tsFileResource.getTsFilePath(), true);
       readerMap.put(tsFileResource, reader);
@@ -134,6 +133,30 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
     return currentDevice;
   }
 
+  public Map<String, MeasurementSchema> getAllMeasurementSchemas() throws IOException {
+    Map<String, MeasurementSchema> schemaMap = new ConcurrentHashMap<>();
+    for (Map.Entry<TsFileResource, TsFileDeviceIterator> entry : deviceIteratorMap.entrySet()) {
+      TsFileResource resource = entry.getKey();
+      TsFileSequenceReader reader = readerMap.get(resource);
+      List<TimeseriesMetadata> timeseriesMetadataList = new ArrayList<>();
+      reader.getDeviceTimeseriesMetadata(
+          timeseriesMetadataList,
+          deviceIteratorMap.get(resource).getMeasurementNode(),
+          schemaMap.keySet(),
+          true);
+      for (TimeseriesMetadata timeseriesMetadata : timeseriesMetadataList) {
+        if (!schemaMap.containsKey(timeseriesMetadata.getMeasurementId())
+            && !timeseriesMetadata.getChunkMetadataList().isEmpty()) {
+          schemaMap.put(
+              timeseriesMetadata.getMeasurementId(),
+              reader.getMeasurementSchema(timeseriesMetadata.getChunkMetadataList()));
+        }
+      }
+    }
+    schemaMap.remove("");
+    return schemaMap;
+  }
+
   /**
    * return MeasurementIterator, who iterates the measurements of not aligned device
    *
@@ -144,10 +167,6 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
   public MeasurementIterator iterateNotAlignedSeries(
       String device, boolean derserializeTimeseriesMetadata) throws IOException {
     return new MeasurementIterator(readerMap, device, derserializeTimeseriesMetadata);
-  }
-
-  public AlignedMeasurementIterator iterateAlignedSeries(String device) {
-    return new AlignedMeasurementIterator(device, new ArrayList<>(readerMap.values()));
   }
 
   /**
@@ -233,25 +252,6 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
   public void close() throws IOException {
     for (TsFileSequenceReader reader : readerMap.values()) {
       reader.close();
-    }
-  }
-
-  public class AlignedMeasurementIterator {
-    private List<TsFileSequenceReader> sequenceReaders;
-    private String device;
-
-    private AlignedMeasurementIterator(String device, List<TsFileSequenceReader> sequenceReaders) {
-      this.device = device;
-      this.sequenceReaders = sequenceReaders;
-    }
-
-    public Set<String> getAllMeasurements() throws IOException {
-      Map<String, TimeseriesMetadata> deviceMeasurementsMap = new ConcurrentHashMap<>();
-      for (TsFileSequenceReader reader : sequenceReaders) {
-        deviceMeasurementsMap.putAll(reader.readDeviceMetadata(device));
-      }
-      deviceMeasurementsMap.remove("");
-      return deviceMeasurementsMap.keySet();
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -142,7 +142,7 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
     Map<String, MeasurementSchema> schemaMap = new ConcurrentHashMap<>();
     // get schemas from the newest file to the oldest file
     for (TsFileResource resource : tsFileResources) {
-      if (!resource.mayContainsDevice(currentDevice.left)) {
+      if (!deviceIteratorMap.containsKey(resource)) {
         continue;
       }
       TsFileSequenceReader reader = readerMap.get(resource);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -81,7 +81,7 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
       List<TsFileResource> seqResources, List<TsFileResource> unseqResources) throws IOException {
     this.tsFileResources = new ArrayList<>(seqResources);
     tsFileResources.addAll(unseqResources);
-    Collections.sort(this.tsFileResources, TsFileResource::compareFileName);
+    Collections.sort(this.tsFileResources, TsFileResource::compareFileNameByDesc);
     for (TsFileResource tsFileResource : tsFileResources) {
       TsFileSequenceReader reader =
           FileReaderManager.getInstance().get(tsFileResource.getTsFilePath(), true);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -136,7 +136,7 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
   public Map<String, MeasurementSchema> getAllMeasurementSchemas() throws IOException {
     Map<String, MeasurementSchema> schemaMap = new ConcurrentHashMap<>();
     // get schemas from the newest file to the oldest file
-    for (TsFileResource resource : tsFileResources) {
+    for (TsFileResource resource : deviceIteratorMap.keySet()) {
       TsFileSequenceReader reader = readerMap.get(resource);
       List<TimeseriesMetadata> timeseriesMetadataList = new ArrayList<>();
       reader.getDeviceTimeseriesMetadata(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -135,8 +135,8 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
 
   public Map<String, MeasurementSchema> getAllMeasurementSchemas() throws IOException {
     Map<String, MeasurementSchema> schemaMap = new ConcurrentHashMap<>();
-    for (Map.Entry<TsFileResource, TsFileDeviceIterator> entry : deviceIteratorMap.entrySet()) {
-      TsFileResource resource = entry.getKey();
+    // get schemas from the newest file to the oldest file
+    for (TsFileResource resource : tsFileResources) {
       TsFileSequenceReader reader = readerMap.get(resource);
       List<TimeseriesMetadata> timeseriesMetadataList = new ArrayList<>();
       reader.getDeviceTimeseriesMetadata(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -28,7 +28,6 @@ import org.apache.iotdb.db.utils.QueryUtils;
 import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
-import org.apache.iotdb.tsfile.file.metadata.MetadataIndexNode;
 import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.read.TsFileDeviceIterator;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
@@ -56,10 +55,6 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
   private final Map<TsFileResource, TsFileDeviceIterator> deviceIteratorMap = new HashMap<>();
   private final Map<TsFileResource, List<Modification>> modificationCache = new HashMap<>();
   private Pair<String, Boolean> currentDevice = null;
-
-  // tsfileResource -> deviceID -> firstMeasurementNode
-  private final Map<TsFileResource, Map<String, MetadataIndexNode>> currentDeviceNode =
-      new HashMap<>();
 
   /** Used for inner space compaction. */
   public MultiTsFileDeviceIterator(List<TsFileResource> tsFileResources) throws IOException {
@@ -119,9 +114,6 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
       if (deviceIterator.current() == null || deviceIterator.current().equals(currentDevice)) {
         if (deviceIterator.hasNext()) {
           deviceIterator.next();
-          currentDeviceNode
-              .computeIfAbsent(resource, r -> new HashMap<>())
-              .put(deviceIterator.current().left, deviceIterator.getMeasurementNode());
         } else {
           // this iterator does not have next device
           // remove them after the loop
@@ -157,7 +149,7 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
       List<TimeseriesMetadata> timeseriesMetadataList = new ArrayList<>();
       reader.getDeviceTimeseriesMetadata(
           timeseriesMetadataList,
-          currentDeviceNode.get(resource).remove(currentDevice.left),
+          deviceIteratorMap.get(resource).getMeasurementNode(),
           schemaMap.keySet(),
           true);
       for (TimeseriesMetadata timeseriesMetadata : timeseriesMetadataList) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -141,6 +141,11 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
     return currentDevice;
   }
 
+  /**
+   * Get all measurements and schemas of the current device from source files. Traverse all the
+   * files from the newest to the oldest in turn and start traversing the index tree from the
+   * firstMeasurementNode node to get all the measurements under the current device.
+   */
   public Map<String, MeasurementSchema> getAllMeasurementSchemas() throws IOException {
     Map<String, MeasurementSchema> schemaMap = new ConcurrentHashMap<>();
     // get schemas from the newest file to the oldest file

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -948,6 +948,18 @@ public class TsFileResource {
     }
   }
 
+  public static int compareFileNameByDesc(TsFileResource o1, TsFileResource o2) {
+    try {
+      TsFileNameGenerator.TsFileName n1 =
+          TsFileNameGenerator.getTsFileName(o1.getTsFile().getName());
+      TsFileNameGenerator.TsFileName n2 =
+          TsFileNameGenerator.getTsFileName(o2.getTsFile().getName());
+      return (int) (n2.getVersion() - n1.getVersion());
+    } catch (IOException e) {
+      return 0;
+    }
+  }
+
   public void setSeq(boolean seq) {
     isSeq = seq;
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -341,15 +341,6 @@ public class AbstractCompactionTest {
     }
   }
 
-  protected void deleteTimeseriesInMManager(
-      int deviceIndex, int measurementIndex, boolean isAligned) throws MetadataException {
-    int offset = isAligned ? TsFileGeneratorUtils.getAlignDeviceOffset() : 0;
-    IoTDB.schemaProcessor.deleteTimeseries(
-        new PartialPath(
-            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + (deviceIndex + offset),
-            "s" + measurementIndex));
-  }
-
   protected void deleteTimeseriesInMManager(List<String> timeseries) throws MetadataException {
     for (String path : timeseries) {
       IoTDB.schemaProcessor.deleteTimeseries(new PartialPath(path));

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -57,6 +57,7 @@ public class AbstractCompactionTest {
   private int chunkGroupSize = 0;
   private int pageSize = 0;
   protected String COMPACTION_TEST_SG = TsFileGeneratorUtils.testStorageGroup;
+  private TSDataType dataType;
 
   private static final long oldTargetChunkSize =
       IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
@@ -110,7 +111,7 @@ public class AbstractCompactionTest {
     if (!UNSEQ_DIRS.exists()) {
       Assert.assertTrue(UNSEQ_DIRS.mkdirs());
     }
-
+    dataType = TSDataType.INT64;
     EnvironmentUtils.envSetUp();
     IoTDB.configManager.init();
   }
@@ -195,23 +196,101 @@ public class AbstractCompactionTest {
     }
   }
 
+  /**
+   * @param fileNum the number of file
+   * @param deviceIndexes device index in each file
+   * @param measurementIndexes measurement index in each device of each file
+   * @param pointNum data point number of each timeseries in each file
+   * @param startTime start time of each timeseries
+   * @param timeInterval time interval of each timeseries between files
+   * @param isAlign when it is true, it will create mix tsfile which contains aligned and nonAligned
+   *     timeseries
+   * @param isSeq
+   */
+  protected void createFilesWithTextValue(
+      int fileNum,
+      List<Integer> deviceIndexes,
+      List<Integer> measurementIndexes,
+      int pointNum,
+      int startTime,
+      int timeInterval,
+      boolean isAlign,
+      boolean isSeq)
+      throws IOException, WriteProcessException {
+
+    for (int i = 0; i < fileNum; i++) {
+      String fileName =
+          System.currentTimeMillis()
+              + FilePathUtils.FILE_NAME_SEPARATOR
+              + fileVersion++
+              + "-0-0.tsfile";
+      String filePath;
+      if (isSeq) {
+        filePath = SEQ_DIRS.getPath() + File.separator + fileName;
+      } else {
+        filePath = UNSEQ_DIRS.getPath() + File.separator + fileName;
+      }
+      File file;
+      if (isAlign) {
+        file =
+            TsFileGeneratorUtils.generateAlignedTsFileWithTextValues(
+                filePath,
+                deviceIndexes,
+                measurementIndexes,
+                pointNum,
+                startTime + pointNum * i + timeInterval * i,
+                chunkGroupSize,
+                pageSize);
+      } else {
+        file =
+            TsFileGeneratorUtils.generateNonAlignedTsFileWithTextValues(
+                filePath,
+                deviceIndexes,
+                measurementIndexes,
+                pointNum,
+                startTime + pointNum * i + timeInterval * i,
+                chunkGroupSize,
+                pageSize);
+      }
+      // add resource
+      TsFileResource resource = new TsFileResource(file);
+      int deviceStartindex = isAlign ? TsFileGeneratorUtils.getAlignDeviceOffset() : 0;
+      for (int j = 0; j < deviceIndexes.size(); j++) {
+        resource.updateStartTime(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + (deviceIndexes.get(j) + deviceStartindex),
+            startTime + pointNum * i + timeInterval * i);
+        resource.updateEndTime(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + (deviceIndexes.get(j) + deviceStartindex),
+            startTime + pointNum * i + timeInterval * i + pointNum - 1);
+      }
+      resource.updatePlanIndexes(fileVersion);
+      resource.setStatus(TsFileResourceStatus.CLOSED);
+      resource.serialize();
+      if (isSeq) {
+        seqResources.add(resource);
+      } else {
+        unseqResources.add(resource);
+      }
+    }
+    // sleep a few milliseconds to avoid generating files with same timestamps
+    try {
+      Thread.sleep(10);
+    } catch (Exception e) {
+
+    }
+  }
+
   private void addResource(
       File file, int deviceNum, long startTime, long endTime, boolean isAlign, boolean isSeq)
       throws IOException {
     TsFileResource resource = new TsFileResource(file);
-    int deviceStartindex = 0;
-    if (isAlign) {
-      deviceStartindex = TsFileGeneratorUtils.getAlignDeviceOffset();
-      for (int i = deviceStartindex; i < deviceStartindex + deviceNum; i++) {
-        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i, startTime);
-        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i, endTime);
-      }
-    } else {
-      for (int i = deviceStartindex; i < deviceStartindex + deviceNum; i++) {
-        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i, startTime);
-        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i, endTime);
-      }
+    int deviceStartindex = isAlign ? TsFileGeneratorUtils.getAlignDeviceOffset() : 0;
+
+    for (int i = deviceStartindex; i < deviceStartindex + deviceNum; i++) {
+      resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i, startTime);
+      resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i, endTime);
     }
+
     resource.updatePlanIndexes(fileVersion);
     resource.setStatus(TsFileResourceStatus.CLOSED);
     // resource.setTimeIndexType((byte) 0);
@@ -233,12 +312,12 @@ public class AbstractCompactionTest {
         List<CompressionType> compressionTypes = new ArrayList<>();
         for (int j = 0; j < measurementNum; j++) {
           measurements.add("s" + j);
-          dataTypes.add(TSDataType.INT64);
+          dataTypes.add(dataType);
           encodings.add(TSEncoding.PLAIN);
           compressionTypes.add(CompressionType.UNCOMPRESSED);
           IoTDB.schemaProcessor.createTimeseries(
               new PartialPath(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i, "s" + j),
-              TSDataType.INT64,
+              dataType,
               TSEncoding.PLAIN,
               CompressionType.UNCOMPRESSED,
               Collections.emptyMap());
@@ -253,12 +332,27 @@ public class AbstractCompactionTest {
         for (int j = 0; j < measurementNum; j++) {
           IoTDB.schemaProcessor.createTimeseries(
               new PartialPath(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i, "s" + j),
-              TSDataType.INT64,
+              dataType,
               TSEncoding.PLAIN,
               CompressionType.UNCOMPRESSED,
               Collections.emptyMap());
         }
       }
+    }
+  }
+
+  protected void deleteTimeseriesInMManager(
+      int deviceIndex, int measurementIndex, boolean isAligned) throws MetadataException {
+    int offset = isAligned ? TsFileGeneratorUtils.getAlignDeviceOffset() : 0;
+    IoTDB.schemaProcessor.deleteTimeseries(
+        new PartialPath(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + (deviceIndex + offset),
+            "s" + measurementIndex));
+  }
+
+  protected void deleteTimeseriesInMManager(List<String> timeseries) throws MetadataException {
+    for (String path : timeseries) {
+      IoTDB.schemaProcessor.deleteTimeseries(new PartialPath(path));
     }
   }
 
@@ -304,5 +398,9 @@ public class AbstractCompactionTest {
     for (File resourceFile : resourceFiles) {
       resourceFile.delete();
     }
+  }
+
+  protected void setDataType(TSDataType dataType) {
+    this.dataType = dataType;
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointCompactionPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointCompactionPerformerTest.java
@@ -2047,6 +2047,7 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
     seriesPaths.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3" + PATH_SEPARATOR + "s4");
     generateModsFile(seriesPaths, seqResources, Long.MIN_VALUE, Long.MAX_VALUE);
     generateModsFile(seriesPaths, unseqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    deleteTimeseriesInMManager(seriesPaths);
 
     for (int i = 0; i < 4; i++) {
       for (int j = 0; j < 5; j++) {
@@ -2245,6 +2246,7 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
     }
     generateModsFile(seriesPaths, seqResources, Long.MIN_VALUE, Long.MAX_VALUE);
     generateModsFile(seriesPaths, unseqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    deleteTimeseriesInMManager(seriesPaths);
 
     for (int i = 0; i < 4; i++) {
       for (int j = 0; j < 5; j++) {
@@ -2435,6 +2437,7 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
     }
     generateModsFile(seriesPaths, seqResources, Long.MIN_VALUE, Long.MAX_VALUE);
     generateModsFile(seriesPaths, unseqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    deleteTimeseriesInMManager(seriesPaths);
 
     for (int i = 0; i < 4; i++) {
       for (int j = 0; j < 5; j++) {
@@ -3094,6 +3097,7 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
             + "s4");
     generateModsFile(seriesPaths, seqResources, Long.MIN_VALUE, Long.MAX_VALUE);
     generateModsFile(seriesPaths, unseqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    deleteTimeseriesInMManager(seriesPaths);
 
     for (int i = TsFileGeneratorUtils.getAlignDeviceOffset();
         i < TsFileGeneratorUtils.getAlignDeviceOffset() + 4;
@@ -3332,6 +3336,7 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
     }
     generateModsFile(seriesPaths, seqResources, Long.MIN_VALUE, Long.MAX_VALUE);
     generateModsFile(seriesPaths, unseqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    deleteTimeseriesInMManager(seriesPaths);
 
     for (int i = TsFileGeneratorUtils.getAlignDeviceOffset();
         i < TsFileGeneratorUtils.getAlignDeviceOffset() + 4;
@@ -3481,6 +3486,215 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
   }
 
   /**
+   * Different source files have timeseries with the same path, but different data types. Because
+   * timeseries in the former file is been deleted.
+   */
+  @Test
+  public void testCrossSpaceCompactionWithSameTimeseriesInDifferentSourceFiles()
+      throws IOException, WriteProcessException, MetadataException, StorageEngineException,
+          InterruptedException {
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
+    registerTimeseriesInMManger(4, 5, false);
+    createFiles(2, 2, 3, 300, 0, 0, 50, 50, false, true);
+    createFiles(2, 4, 5, 300, 700, 700, 50, 50, false, true);
+    createFiles(3, 3, 4, 200, 20, 10020, 30, 30, false, false);
+    createFiles(2, 1, 5, 100, 450, 20450, 0, 0, false, false);
+
+    // generate mods file
+    List<String> seriesPaths = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      seriesPaths.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0" + PATH_SEPARATOR + "s" + i);
+      seriesPaths.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1" + PATH_SEPARATOR + "s" + i);
+      seriesPaths.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2" + PATH_SEPARATOR + "s" + i);
+    }
+    generateModsFile(seriesPaths, seqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    generateModsFile(seriesPaths, unseqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    deleteTimeseriesInMManager(seriesPaths);
+    setDataType(TSDataType.TEXT);
+    registerTimeseriesInMManger(2, 7, false);
+    List<Integer> deviceIndex = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      deviceIndex.add(i);
+    }
+    List<Integer> measurementIndex = new ArrayList<>();
+    for (int i = 0; i < 7; i++) {
+      measurementIndex.add(i);
+    }
+
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 300, 1350, 0, false, true);
+
+    List<TsFileResource> targetResources =
+        CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
+    ICompactionPerformer performer =
+        new ReadPointCompactionPerformer(seqResources, unseqResources, targetResources);
+    performer.setSummary(new CompactionTaskSummary());
+    performer.perform();
+    CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+  }
+
+  /** Each source file has different device. */
+  @Test
+  public void testCrossSpaceCompactionWithDifferentDevicesInDifferentSourceFiles()
+      throws IOException, WriteProcessException, MetadataException, StorageEngineException,
+          InterruptedException {
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
+    registerTimeseriesInMManger(5, 7, false);
+    List<Integer> deviceIndex = new ArrayList<>();
+    List<Integer> measurementIndex = new ArrayList<>();
+    for (int i = 0; i < 7; i++) {
+      measurementIndex.add(i);
+    }
+
+    deviceIndex.add(0);
+    deviceIndex.add(2);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 300, 0, 0, false, true);
+
+    deviceIndex.clear();
+    deviceIndex.add(1);
+    deviceIndex.add(3);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 300, 400, 0, false, true);
+
+    deviceIndex.clear();
+    deviceIndex.add(2);
+    deviceIndex.add(4);
+    deviceIndex.add(0);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 300, 800, 0, false, true);
+
+    deviceIndex.clear();
+    deviceIndex.add(1);
+    deviceIndex.add(4);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 200, 100, 0, false, false);
+
+    deviceIndex.clear();
+    deviceIndex.add(0);
+    deviceIndex.add(2);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 200, 400, 0, false, false);
+
+    List<TsFileResource> targetResources =
+        CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
+    ICompactionPerformer performer =
+        new ReadPointCompactionPerformer(seqResources, unseqResources, targetResources);
+    performer.setSummary(new CompactionTaskSummary());
+    performer.perform();
+    CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+  }
+
+  /**
+   * Different source files have timeseries with the same path, but different data types. Because
+   * timeseries in the former file is been deleted.
+   */
+  @Test
+  public void testAlignedCrossSpaceCompactionWithSameTimeseriesInDifferentSourceFiles()
+      throws IOException, WriteProcessException, MetadataException, StorageEngineException,
+          InterruptedException {
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
+    registerTimeseriesInMManger(4, 5, true);
+    createFiles(2, 2, 3, 300, 0, 0, 50, 50, true, true);
+    createFiles(2, 4, 5, 300, 700, 700, 50, 50, true, true);
+    createFiles(3, 3, 4, 200, 20, 10020, 30, 30, true, false);
+    createFiles(2, 1, 5, 100, 450, 20450, 0, 0, true, false);
+
+    // generate mods file
+    List<String> seriesPaths = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      seriesPaths.add(
+          COMPACTION_TEST_SG
+              + PATH_SEPARATOR
+              + "d"
+              + TsFileGeneratorUtils.getAlignDeviceOffset()
+              + PATH_SEPARATOR
+              + "s"
+              + i);
+      seriesPaths.add(
+          COMPACTION_TEST_SG
+              + PATH_SEPARATOR
+              + "d"
+              + (TsFileGeneratorUtils.getAlignDeviceOffset() + 1)
+              + PATH_SEPARATOR
+              + "s"
+              + i);
+      seriesPaths.add(
+          COMPACTION_TEST_SG
+              + PATH_SEPARATOR
+              + "d"
+              + (TsFileGeneratorUtils.getAlignDeviceOffset() + 2)
+              + PATH_SEPARATOR
+              + "s"
+              + i);
+    }
+    generateModsFile(seriesPaths, seqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    generateModsFile(seriesPaths, unseqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    deleteTimeseriesInMManager(seriesPaths);
+    setDataType(TSDataType.TEXT);
+    registerTimeseriesInMManger(2, 7, true);
+    List<Integer> deviceIndex = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      deviceIndex.add(i);
+    }
+    List<Integer> measurementIndex = new ArrayList<>();
+    for (int i = 0; i < 7; i++) {
+      measurementIndex.add(i);
+    }
+
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 300, 1350, 0, true, true);
+
+    List<TsFileResource> targetResources =
+        CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
+    ICompactionPerformer performer =
+        new ReadPointCompactionPerformer(seqResources, unseqResources, targetResources);
+    performer.setSummary(new CompactionTaskSummary());
+    performer.perform();
+    CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+  }
+
+  /** Each source file has different device. */
+  @Test
+  public void testAlignedCrossSpaceCompactionWithDifferentDevicesInDifferentSourceFiles()
+      throws IOException, WriteProcessException, MetadataException, StorageEngineException,
+          InterruptedException {
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
+    registerTimeseriesInMManger(5, 7, true);
+    List<Integer> deviceIndex = new ArrayList<>();
+    List<Integer> measurementIndex = new ArrayList<>();
+    for (int i = 0; i < 7; i++) {
+      measurementIndex.add(i);
+    }
+
+    deviceIndex.add(0);
+    deviceIndex.add(2);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 300, 0, 0, true, true);
+
+    deviceIndex.clear();
+    deviceIndex.add(1);
+    deviceIndex.add(3);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 300, 400, 0, true, true);
+
+    deviceIndex.clear();
+    deviceIndex.add(2);
+    deviceIndex.add(4);
+    deviceIndex.add(0);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 300, 800, 0, true, true);
+
+    deviceIndex.clear();
+    deviceIndex.add(1);
+    deviceIndex.add(4);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 200, 100, 0, true, false);
+
+    deviceIndex.clear();
+    deviceIndex.add(0);
+    deviceIndex.add(2);
+    createFilesWithTextValue(1, deviceIndex, measurementIndex, 200, 400, 0, true, false);
+
+    List<TsFileResource> targetResources =
+        CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
+    ICompactionPerformer performer =
+        new ReadPointCompactionPerformer(seqResources, unseqResources, targetResources);
+    performer.setSummary(new CompactionTaskSummary());
+    performer.perform();
+    CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+  }
+
+  /**
    * Total 4 seq files and 5 unseq files, each file has different aligned timeseries.
    *
    * <p>Seq files<br>
@@ -3538,6 +3752,7 @@ public class ReadPointCompactionPerformerTest extends AbstractCompactionTest {
     }
     generateModsFile(seriesPaths, seqResources, Long.MIN_VALUE, Long.MAX_VALUE);
     generateModsFile(seriesPaths, unseqResources, Long.MIN_VALUE, Long.MAX_VALUE);
+    deleteTimeseriesInMManager(seriesPaths);
 
     for (TsFileResource resource : seqResources) {
       resource.setTimeIndexType((byte) 2);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileDeviceIterator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileDeviceIterator.java
@@ -24,9 +24,7 @@ import org.apache.iotdb.tsfile.file.metadata.MetadataIndexNode;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 
@@ -34,6 +32,7 @@ public class TsFileDeviceIterator implements Iterator<Pair<String, Boolean>> {
   private final TsFileSequenceReader reader;
   private final Queue<Pair<String, Pair<Long, Long>>> queue;
   private Pair<String, Boolean> currentDevice = null;
+  private MetadataIndexNode measurementNode;
 
   public TsFileDeviceIterator(
       TsFileSequenceReader reader, Queue<Pair<String, Pair<Long, Long>>> queue) {
@@ -56,18 +55,21 @@ public class TsFileDeviceIterator implements Iterator<Pair<String, Boolean>> {
       throw new NoSuchElementException();
     }
     Pair<String, Pair<Long, Long>> startEndPair = queue.remove();
-    List<Pair<String, Boolean>> devices = new ArrayList<>();
     try {
-      MetadataIndexNode measurementNode =
+      // first measurement node of this device
+      this.measurementNode =
           MetadataIndexNode.deserializeFrom(
               reader.readData(startEndPair.right.left, startEndPair.right.right));
-      // if tryToGetFirstTimeseriesMetadata(node) returns null, the device is not aligned
-      boolean isAligned = reader.tryToGetFirstTimeseriesMetadata(measurementNode) != null;
+      boolean isAligned = reader.isAlignedDevice(measurementNode);
       currentDevice = new Pair<>(startEndPair.left, isAligned);
       return currentDevice;
     } catch (IOException e) {
       throw new TsFileRuntimeException(
           "Error occurred while reading a time series metadata block.");
     }
+  }
+
+  public MetadataIndexNode getMeasurementNode() {
+    return measurementNode;
   }
 }


### PR DESCRIPTION
**Description**
In massive timeseries scenarios, each device has 20 timeseries, and each file has tens of thousands of devices, that is, millions of timeseries. Read throughput in cross compaction is 100~1000 times greater than write throughput.

**Solution**
When compacting, it is necessary to obtain devices and timeseries from all source files, as well as the metadata of each timeseries. To avoid traversing the Zesong tree multiple times, we record the intermediate nodes of the Zesong tree. Please refer to [IOTDB-4364](https://issues.apache.org/jira/browse/IOTDB-4364) for the experimental results.