### PR TITLE
[IOTDB-4245] Fix wrong integer upper bound about data type inferring of timeseries

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
@@ -64,7 +64,7 @@ public class TypeInferenceUtils {
   }
 
   private static boolean isConvertFloatPrecisionLack(String s) {
-    return Long.parseLong(s) > (2 << 24);
+    return Long.parseLong(s) > (1 << 24);
   }
 
   /** Get predicted DataType of the given value */

--- a/server/src/test/java/org/apache/iotdb/db/utils/TypeInferenceUtilsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/TypeInferenceUtilsTest.java
@@ -72,7 +72,9 @@ public class TypeInferenceUtilsTest {
       "9999999999999999",
       "true",
       "77123 ",
-      " 7112324 "
+      " 7112324 ",
+      "16777217", // 2^24 + 1
+      "16777216", // 2^24
     };
     TSDataType[] encodings = {
       IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
@@ -85,7 +87,9 @@ public class TypeInferenceUtilsTest {
       IoTDBDescriptor.getInstance().getConfig().getLongStringInferType(),
       IoTDBDescriptor.getInstance().getConfig().getBooleanStringInferType(),
       IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
-      IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType()
+      IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
+      IoTDBDescriptor.getInstance().getConfig().getLongStringInferType(),
+      IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
     };
 
     for (int i = 0; i < values.length; i++) {


### PR DESCRIPTION
 Fix wrong integer upper bound about data type inferring of timeseries. According to userdoc, it should be 2^24, not 2^25.