### PR TITLE
[IOTDB-4395] fix size statistic of disk.

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -18,7 +18,9 @@
  */
 package org.apache.iotdb.db.service.metrics.predefined;
 
+import com.sun.management.OperatingSystemMXBean;
 import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.service.metrics.enums.Metric;
 import org.apache.iotdb.db.service.metrics.enums.Tag;
 import org.apache.iotdb.metrics.AbstractMetricService;
@@ -26,20 +28,28 @@ import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.metricsets.IMetricSet;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.MetricType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.sun.management.OperatingSystemMXBean;
-
-import java.io.File;
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class SystemMetrics implements IMetricSet {
+  private static final Logger logger = LoggerFactory.getLogger(SystemMetrics.class);
   private com.sun.management.OperatingSystemMXBean osMXBean;
   private Future<?> currentServiceFuture;
   private final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+  private Set<FileStore> fileStores = new HashSet<>();
   private long systemDiskTotalSpace = 0L;
   private long systemDiskFreeSpace = 0L;
 
@@ -50,6 +60,17 @@ public class SystemMetrics implements IMetricSet {
   @Override
   public void bindTo(AbstractMetricService metricService) {
     collectSystemCpuInfo(metricService);
+    //
+    String[] dataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();
+    for (String dataDir: dataDirs) {
+      Path path = Paths.get(dataDir);
+      try {
+        FileStore fileStore = Files.getFileStore(path);
+        fileStores.add(fileStore);
+      } catch (IOException e) {
+        logger.error("Failed to get storage path of {}", dataDir);
+      }
+    }
     collectSystemDiskInfo(metricService);
     collectSystemMemInfo(metricService);
 
@@ -191,12 +212,15 @@ public class SystemMetrics implements IMetricSet {
   }
 
   private void collect() {
-    File[] files = File.listRoots();
     long sysTotalSpace = 0L;
     long sysFreeSpace = 0L;
-    for (File file : files) {
-      sysTotalSpace += file.getTotalSpace();
-      sysFreeSpace += file.getFreeSpace();
+    for (FileStore fileStore: fileStores) {
+      try {
+        sysTotalSpace += fileStore.getTotalSpace();
+        sysFreeSpace += fileStore.getUsableSpace();
+      } catch (IOException e) {
+        logger.error("Failed to statistic the size of {}", fileStore);
+      }
     }
     systemDiskTotalSpace = sysTotalSpace;
     systemDiskFreeSpace = sysFreeSpace;

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -69,7 +69,14 @@ public class SystemMetrics implements IMetricSet {
         FileStore fileStore = Files.getFileStore(path);
         fileStores.add(fileStore);
       } catch (IOException e) {
-        logger.error("Failed to get storage path of {}, because", dataDir, e);
+        // try to get parent
+        path = path.getParent();
+        try {
+          FileStore fileStore = Files.getFileStore(path);
+          fileStores.add(fileStore);
+        } catch (IOException innerException) {
+          logger.error("Failed to get storage path of {}, because", dataDir, innerException);
+        }
       }
     }
     collectSystemDiskInfo(metricService);

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -215,6 +215,7 @@ public class SystemMetrics implements IMetricSet {
   }
 
   private void removeSystemDiskInfo(AbstractMetricService metricService) {
+    fileStores.clear();
     metricService.remove(
         MetricType.GAUGE, Metric.SYS_DISK_TOTAL_SPACE.toString(), Tag.NAME.toString(), "system");
     metricService.remove(

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -69,7 +69,7 @@ public class SystemMetrics implements IMetricSet {
         FileStore fileStore = Files.getFileStore(path);
         fileStores.add(fileStore);
       } catch (IOException e) {
-        logger.error("Failed to get storage path of {}", dataDir);
+        logger.error("Failed to get storage path of {}, because", dataDir, e);
       }
     }
     collectSystemDiskInfo(metricService);
@@ -220,7 +220,7 @@ public class SystemMetrics implements IMetricSet {
         sysTotalSpace += fileStore.getTotalSpace();
         sysFreeSpace += fileStore.getUsableSpace();
       } catch (IOException e) {
-        logger.error("Failed to statistic the size of {}", fileStore);
+        logger.error("Failed to statistic the size of {}, because", fileStore, e);
       }
     }
     systemDiskTotalSpace = sysTotalSpace;

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/predefined/SystemMetrics.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.service.metrics.predefined;
 
-import com.sun.management.OperatingSystemMXBean;
 import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.service.metrics.enums.Metric;
@@ -28,6 +27,8 @@ import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.metricsets.IMetricSet;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.MetricType;
+
+import com.sun.management.OperatingSystemMXBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +63,7 @@ public class SystemMetrics implements IMetricSet {
     collectSystemCpuInfo(metricService);
     //
     String[] dataDirs = IoTDBDescriptor.getInstance().getConfig().getDataDirs();
-    for (String dataDir: dataDirs) {
+    for (String dataDir : dataDirs) {
       Path path = Paths.get(dataDir);
       try {
         FileStore fileStore = Files.getFileStore(path);
@@ -214,7 +215,7 @@ public class SystemMetrics implements IMetricSet {
   private void collect() {
     long sysTotalSpace = 0L;
     long sysFreeSpace = 0L;
-    for (FileStore fileStore: fileStores) {
+    for (FileStore fileStore : fileStores) {
       try {
         sysTotalSpace += fileStore.getTotalSpace();
         sysFreeSpace += fileStore.getUsableSpace();


### PR DESCRIPTION
`File.listroots()` can't get all root disks in machine.

See: https://issues.apache.org/jira/browse/IOTDB-4395