### PR TITLE
[To rel/0.13] [IOTDB-4451] Add log for cross space compaction selection when a file has been compacted too many times

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
@@ -134,19 +134,27 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
       return;
     }
 
-    long totalSize = 0L;
+    double totalSize = 0;
+    double seqSize = 0;
+    double unseqSize = 0;
     for (TsFileResource resource : selectedSeqTsFileResourceList) {
       totalSize += resource.getTsFileSize();
     }
+    seqSize = totalSize;
     for (TsFileResource resource : selectedUnSeqTsFileResourceList) {
       totalSize += resource.getTsFileSize();
     }
+    unseqSize = totalSize - seqSize;
 
     logger.info(
-        "{} [Compaction] CrossSpaceCompactionTask start. Sequence files : {}, unsequence files : {}",
+        "{} [Compaction] CrossSpaceCompactionTask start. Sequence files : {}, unsequence files : {},"
+            + " seq files size is {} MB, unseq file size is {} MB, total size is {} MB",
         fullStorageGroupName,
         selectedSeqTsFileResourceList,
-        selectedUnSeqTsFileResourceList);
+        selectedUnSeqTsFileResourceList,
+        seqSize / 1024 / 1024,
+        unseqSize / 1024 / 1024,
+        totalSize / 1024 / 1024);
     logFile =
         new File(
             selectedSeqTsFileResourceList.get(0).getTsFile().getParent()

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -470,7 +470,6 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
           new File(
               TestConstant.OUTPUT_DATA_DIR.concat(
                   10
-                      + "seq"
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR
@@ -490,7 +489,6 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
           new File(
               TestConstant.OUTPUT_DATA_DIR.concat(
                   10
-                      + "unseq"
                       + IoTDBConstant.FILE_NAME_SEPARATOR
                       + i
                       + IoTDBConstant.FILE_NAME_SEPARATOR


### PR DESCRIPTION
See [IOTDB-4451](https://issues.apache.org/jira/browse/IOTDB-4451).