### PR TITLE
[IOTDB-4453] Fix the overflow of compareTo in TimeRange

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/TimeRange.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/TimeRange.java
@@ -57,16 +57,14 @@ public class TimeRange implements Comparable<TimeRange> {
     if (r == null) {
       throw new NullPointerException("The input cannot be null!");
     }
-    long res1 = this.min - r.min;
-    if (res1 > 0) {
+    if (this.min > r.min) {
       return 1;
-    } else if (res1 < 0) {
+    } else if (this.min < r.min) {
       return -1;
     } else {
-      long res2 = this.max - r.max;
-      if (res2 > 0) {
+      if (this.max > r.max) {
         return 1;
-      } else if (res2 < 0) {
+      } else if (this.max < r.max) {
         return -1;
       } else {
         return 0;

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/common/TimeRangeTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/common/TimeRangeTest.java
@@ -429,4 +429,23 @@ public class TimeRangeTest {
     assertEquals(remainRanges.get(0).getLeftClose(), true);
     assertEquals(remainRanges.get(0).getRightClose(), true);
   }
+
+  @Test
+  public void testCompareTo() {
+    Assert.assertTrue(new TimeRange(Long.MIN_VALUE, 1).compareTo(new TimeRange(5, 6)) < 0);
+    Assert.assertTrue(
+        new TimeRange(Long.MIN_VALUE, 1).compareTo(new TimeRange(Long.MIN_VALUE, 2)) < 0);
+    Assert.assertTrue(new TimeRange(Long.MIN_VALUE, 1).compareTo(new TimeRange(-1, 6)) < 0);
+    Assert.assertTrue(
+        new TimeRange(Long.MIN_VALUE, Long.MAX_VALUE).compareTo(new TimeRange(Long.MIN_VALUE, 2))
+            > 0);
+    Assert.assertTrue(
+        new TimeRange(Long.MIN_VALUE, 1).compareTo(new TimeRange(Long.MIN_VALUE, 0)) > 0);
+    Assert.assertTrue(new TimeRange(0, 3).compareTo(new TimeRange(0, 2)) > 0);
+    Assert.assertTrue(new TimeRange(0, 3).compareTo(new TimeRange(-2, -1)) > 0);
+    Assert.assertTrue(new TimeRange(0, 3).compareTo(new TimeRange(-2, 1)) > 0);
+    Assert.assertTrue(new TimeRange(0, 3).compareTo(new TimeRange(-2, 3)) > 0);
+    Assert.assertTrue(new TimeRange(0, 3).compareTo(new TimeRange(1, 2)) < 0);
+    Assert.assertTrue(new TimeRange(5, 6).compareTo(new TimeRange(5, 6)) == 0);
+  }
 }


### PR DESCRIPTION
## Description

The original implementation used the result value calculated by `this.min - r.min` or`this.max - r.max`. This may encounter Long type overflow.