### PR TITLE
[IOTDB-4435] Fix show child nodes failed

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/NodePathsConvertOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/NodePathsConvertOperator.java
@@ -53,7 +53,7 @@ public class NodePathsConvertOperator implements ProcessOperator {
     this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
     this.child = requireNonNull(child, "child operator is null");
     this.outputDataTypes =
-        ColumnHeaderConstant.showChildPathsColumnHeaders.stream()
+        ColumnHeaderConstant.showChildNodesColumnHeaders.stream()
             .map(ColumnHeader::getColumnType)
             .collect(Collectors.toList());
   }


### PR DESCRIPTION
fix show child nodes failed issue, the fragment instance exec has exception:
Failed to execute fragment instance 20220919_014959_00084_3.1.0 | org.apache.iotdb.db.mpp.execution.driver.Driver (Driver.java:199) 
java.lang.IllegalStateException: Declared positions (1) does not match column 1's number of entries (0)
    at org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder.build(TsBlockBuilder.java:310)
    at org.apache.iotdb.db.mpp.execution.operator.schema.NodePathsConvertOperator.next(NodePathsConvertOperator.java:99)
    at org.apache.iotdb.db.mpp.execution.driver.Driver.processInternal(Driver.java:192)
    at org.apache.iotdb.db.mpp.execution.driver.Driver.lambda$processFor$1(Driver.java:131)
    at org.apache.iotdb.db.mpp.execution.driver.Driver.tryWithLock(Driver.java:277)
    at org.apache.iotdb.db.mpp.execution.driver.Driver.processFor(Driver.java:124)
    at org.apache.iotdb.db.mpp.execution.schedule.DriverTaskThread.execute(DriverTaskThread.java:69)
    at org.apache.iotdb.db.mpp.execution.schedule.AbstractDriverThread.run(AbstractDriverThread.java:70)

see: https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-4435
IOTDB-4435 has test result 


