### PR TITLE
[IOTDB-4469] Frame size larger than protect max size!

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -99,10 +99,6 @@ target_config_nodes=127.0.0.1:22277
 # Datatype: int
 # connection_timeout_ms=20000
 
-# max plan node size, note that thrift max frame size must be larger than max plan node size.
-# Datatype: int
-# max_plan_node_size=536870912
-
 # The maximum number of clients that can be idle for a node's InternalService.
 # When the number of idle clients on a node exceeds this number, newly returned clients will be released
 # Datatype: int

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -32,8 +32,6 @@ import org.apache.iotdb.db.engine.compaction.constant.InnerUnsequenceCompactionS
 import org.apache.iotdb.db.engine.storagegroup.timeindex.TimeIndexLevel;
 import org.apache.iotdb.db.exception.LoadConfigurationException;
 import org.apache.iotdb.db.metadata.LocalSchemaProcessor;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.load.LoadTsFileNode;
 import org.apache.iotdb.db.service.thrift.impl.InfluxDBServiceImpl;
 import org.apache.iotdb.db.service.thrift.impl.TSServiceImpl;
 import org.apache.iotdb.db.utils.datastructure.TVListSortAlgorithm;
@@ -810,9 +808,6 @@ public class IoTDBConfig {
   /** Unit: byte */
   private int thriftMaxFrameSize = 536870912;
 
-  /** Max size of a {@link PlanNode}, mainly used to control memory of {@link LoadTsFileNode}. */
-  private int maxPlanNodeSize = thriftMaxFrameSize;
-
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;
 
   /** time interval in minute for calculating query frequency. Unit: minute */
@@ -1091,10 +1086,6 @@ public class IoTDBConfig {
 
   public void setPartitionInterval(long partitionInterval) {
     this.partitionInterval = partitionInterval;
-  }
-
-  public long getMaxPlanNodeSize() {
-    return maxPlanNodeSize;
   }
 
   public TimeIndexLevel getTimeIndexLevel() {
@@ -1772,6 +1763,13 @@ public class IoTDBConfig {
     this.allocateMemoryForRead = allocateMemoryForRead;
   }
 
+  public long getAllocateMemoryForFree() {
+    return Runtime.getRuntime().maxMemory()
+        - allocateMemoryForStorageEngine
+        - allocateMemoryForRead
+        - allocateMemoryForSchema;
+  }
+
   public boolean isEnableExternalSort() {
     return enableExternalSort;
   }
@@ -2443,10 +2441,6 @@ public class IoTDBConfig {
   public void setThriftMaxFrameSize(int thriftMaxFrameSize) {
     this.thriftMaxFrameSize = thriftMaxFrameSize;
     RpcTransportFactory.setThriftMaxFrameSize(this.thriftMaxFrameSize);
-  }
-
-  public void setMaxPlanNodeSize(int maxPlanNodeSize) {
-    this.maxPlanNodeSize = maxPlanNodeSize;
   }
 
   public int getThriftDefaultBufferSize() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -773,21 +773,6 @@ public class IoTDBDescriptor {
       conf.setThriftMaxFrameSize(IoTDBConstant.LEFT_SIZE_IN_REQUEST * 2);
     }
 
-    conf.setMaxPlanNodeSize(
-        Integer.parseInt(
-            properties.getProperty(
-                "max_plan_node_size", String.valueOf(conf.getThriftMaxFrameSize()))));
-
-    if (conf.getMaxPlanNodeSize() > conf.getThriftMaxFrameSize()) {
-      logger.warn(
-          String.format(
-              "MAX PLAN NODE SIZE %d can not be larger than THRIFT MAX FRAME SIZE %d, MAX PLAN NODE SIZE has been reset to %d",
-              conf.getMaxPlanNodeSize(),
-              conf.getThriftMaxFrameSize(),
-              conf.getThriftMaxFrameSize()));
-      conf.setMaxPlanNodeSize(conf.getThriftMaxFrameSize());
-    }
-
     conf.setThriftDefaultBufferSize(
         Integer.parseInt(
             properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterPartitionFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterPartitionFetcher.java
@@ -116,6 +116,7 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
       }
       return schemaPartition;
     } catch (TException | IOException e) {
+      logger.error("Get Schema Partition error", e);
       throw new StatementAnalyzeException(
           "An error occurred when executing getSchemaPartition():" + e.getMessage());
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/load/LoadTsFilePieceNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/load/LoadTsFilePieceNode.java
@@ -66,7 +66,8 @@ public class LoadTsFilePieceNode extends WritePlanNode {
   }
 
   public boolean exceedSize() {
-    return dataSize >= config.getMaxPlanNodeSize() / 2;
+    return dataSize >= config.getThriftMaxFrameSize() / 2
+        || dataSize >= config.getAllocateMemoryForFree() / 2;
   }
 
   public void addChunkData(ChunkData chunkData) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/load/LoadTsFilePieceNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/load/LoadTsFilePieceNode.java
@@ -66,7 +66,7 @@ public class LoadTsFilePieceNode extends WritePlanNode {
   }
 
   public boolean exceedSize() {
-    return dataSize >= config.getMaxPlanNodeSize();
+    return dataSize >= config.getMaxPlanNodeSize() / 2;
   }
 
   public void addChunkData(ChunkData chunkData) {
@@ -164,13 +164,6 @@ public class LoadTsFilePieceNode extends WritePlanNode {
 
   @Override
   public String toString() {
-    return "LoadTsFilePieceNode{"
-        + "tsFile="
-        + tsFile
-        + ", dataSize="
-        + dataSize
-        + ", chunkDataList="
-        + chunkDataList
-        + '}';
+    return "LoadTsFilePieceNode{" + "tsFile=" + tsFile + ", dataSize=" + dataSize + '}';
   }
 }


### PR DESCRIPTION
problem:
Transporting frame size of LoadTsFilePieceNode is larger than MAX FRAME SIZE
too much log info of LoadTsFilePieceNode

solution:
set the max data size of LoadTsFilePieceNode is the half of MAX FRAME SIZE
delete info about chunk data.