### PR TITLE
[IOTDB-4466]error code is incorrect in query with time when session has expired

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
@@ -383,7 +383,13 @@ public class SessionManager {
   }
 
   public ZoneId getZoneId(Long sessionId) {
-    return sessionIdToZoneId.get(sessionId);
+    ZoneId zoneId = sessionIdToZoneId.get(sessionId);
+    if (zoneId == null) {
+      throw new RuntimeException(
+          new IoTDBException(
+              "session expired, please re-login.", TSStatusCode.SESSION_EXPIRED.getStatusCode()));
+    }
+    return zoneId;
   }
 
   public void setTimezone(Long sessionId, String zone) {


### PR DESCRIPTION
When session has expired, the error code is incorrect:
IoTDB > select s_70, top_k(s_70, 'k'='2'), bottom_k(s_70, 'k'='2') from root.test.g_19.d_59 where time > 2018-05-21T08:40:25.976+08:00;
Msg: 303: Check metadata error: Input time format 2018-05-21T08:40:25.976+08:00 error. Input like yyyy-MM-dd HH:mm:ss, yyyy-MM-ddTHH:mm:ss or refer to user document for more info.

It happens on zoneId is null when session has expired and occurs NPE when we get org.apache.iotdb.db.qp.utils.DatetimeUtils#toZoneOffset().


