### PR TITLE
print redundancy clean session log when no session exist

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/control/SessionTimeoutManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/SessionTimeoutManager.java
@@ -53,8 +53,10 @@ public class SessionTimeoutManager {
     ScheduledExecutorUtil.safelyScheduleAtFixedRate(
         executorService,
         () -> {
-          LOGGER.info("cleaning up expired sessions");
-          cleanup();
+          if (!sessionIdToLastActiveTime.isEmpty()) {
+            LOGGER.info("cleaning up expired sessions");
+            cleanup();
+          }
         },
         0,
         Math.max(MINIMUM_CLEANUP_PERIOD, SESSION_TIMEOUT / 5),
@@ -97,9 +99,9 @@ public class SessionTimeoutManager {
             entry -> {
               if (unregister(entry.getKey())) {
                 LOGGER.debug(
-                    String.format(
-                        "session-%s timed out in %d ms",
-                        entry.getKey(), currentTime - entry.getValue()));
+                    "session-{} timed out in {} ms",
+                    entry.getKey(),
+                    currentTime - entry.getValue());
               }
             });
   }


### PR DESCRIPTION
When session_timeout_threshold is set, SessionTimeoutManager will continue output cleaning log and check cleanup() function even though there is not session exist. So add a judgment before it to save printing redundancy log.
