### PR TITLE
[IOTDB-4478] [Ratis] Add RatisConsensus config parameters in confignode.properties

### DIFF
--- a/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -343,3 +343,21 @@ target_config_nodes=127.0.0.1:22277
 
 # max payload size for a single log-sync-RPC from leader to follower
 # ratis_log_appender_buffer_size_max = 4194304
+
+# trigger a snapshot when ratis_snapshot_trigger_threshold logs are written
+# ratis_snapshot_trigger_threshold = 400000
+
+# allow flushing Raft Log asynchronously
+# ratis_log_unsafe_flush_enable = false
+
+# max capacity of a single Raft Log segment (by default 24MB)
+# ratis_log_segment_size_max = 25165824
+
+# flow control window for ratis grpc log appender
+# ratis_grpc_flow_control_window = 4194304
+
+# min election timeout for leader election
+# ratis_rpc_leader_election_timeout_min_ms = 2000
+
+# max election timeout for leader election
+# ratis_rpc_leader_election_timeout_max_ms = 4000

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -132,7 +132,28 @@ public class ConfigNodeConfig {
   private String readConsistencyLevel = "strong";
 
   /** RatisConsensus protocol, Max size for a single log append request from leader */
-  private long RatisConsensusLogAppenderBufferSize = 4 * 1024 * 1024L;
+  private long ratisConsensusLogAppenderBufferSize = 4 * 1024 * 1024L;
+
+  /**
+   * RatisConsensus protocol, trigger a snapshot when ratis_snapshot_trigger_threshold logs are
+   * written
+   */
+  private long ratisSnapshotTriggerThreshold = 400000L;
+
+  /** RatisConsensus protocol, allow flushing Raft Log asynchronously */
+  private boolean ratisLogUnsafeFlushEnable = false;
+
+  /** RatisConsensus protocol, max capacity of a single Raft Log segment */
+  private long ratisLogSegmentSizeMax = 24 * 1024 * 1024L;
+
+  /** RatisConsensus protocol, flow control window for ratis grpc log appender */
+  private long ratisGrpcFlowControlWindow = 4 * 1024 * 1024L;
+
+  /** RatisConsensus protocol, min election timeout for leader election */
+  private long ratisRpcLeaderElectionTimeoutMinMs = 2000L;
+
+  /** RatisConsensus protocol, max election timeout for leader election */
+  private long ratisRpcLeaderElectionTimeoutMaxMs = 4000L;
 
   public ConfigNodeConfig() {
     // empty constructor
@@ -416,10 +437,58 @@ public class ConfigNodeConfig {
   }
 
   public long getRatisConsensusLogAppenderBufferSize() {
-    return RatisConsensusLogAppenderBufferSize;
+    return ratisConsensusLogAppenderBufferSize;
   }
 
   public void setRatisConsensusLogAppenderBufferSize(long ratisConsensusLogAppenderBufferSize) {
-    RatisConsensusLogAppenderBufferSize = ratisConsensusLogAppenderBufferSize;
+    this.ratisConsensusLogAppenderBufferSize = ratisConsensusLogAppenderBufferSize;
+  }
+
+  public long getRatisSnapshotTriggerThreshold() {
+    return ratisSnapshotTriggerThreshold;
+  }
+
+  public void setRatisSnapshotTriggerThreshold(long ratisSnapshotTriggerThreshold) {
+    this.ratisSnapshotTriggerThreshold = ratisSnapshotTriggerThreshold;
+  }
+
+  public boolean isRatisLogUnsafeFlushEnable() {
+    return ratisLogUnsafeFlushEnable;
+  }
+
+  public void setRatisLogUnsafeFlushEnable(boolean ratisLogUnsafeFlushEnable) {
+    this.ratisLogUnsafeFlushEnable = ratisLogUnsafeFlushEnable;
+  }
+
+  public long getRatisLogSegmentSizeMax() {
+    return ratisLogSegmentSizeMax;
+  }
+
+  public void setRatisLogSegmentSizeMax(long ratisLogSegmentSizeMax) {
+    this.ratisLogSegmentSizeMax = ratisLogSegmentSizeMax;
+  }
+
+  public long getRatisGrpcFlowControlWindow() {
+    return ratisGrpcFlowControlWindow;
+  }
+
+  public void setRatisGrpcFlowControlWindow(long ratisGrpcFlowControlWindow) {
+    this.ratisGrpcFlowControlWindow = ratisGrpcFlowControlWindow;
+  }
+
+  public long getRatisRpcLeaderElectionTimeoutMinMs() {
+    return ratisRpcLeaderElectionTimeoutMinMs;
+  }
+
+  public void setRatisRpcLeaderElectionTimeoutMinMs(long ratisRpcLeaderElectionTimeoutMinMs) {
+    this.ratisRpcLeaderElectionTimeoutMinMs = ratisRpcLeaderElectionTimeoutMinMs;
+  }
+
+  public long getRatisRpcLeaderElectionTimeoutMaxMs() {
+    return ratisRpcLeaderElectionTimeoutMaxMs;
+  }
+
+  public void setRatisRpcLeaderElectionTimeoutMaxMs(long ratisRpcLeaderElectionTimeoutMaxMs) {
+    this.ratisRpcLeaderElectionTimeoutMaxMs = ratisRpcLeaderElectionTimeoutMaxMs;
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -286,6 +286,41 @@ public class ConfigNodeDescriptor {
             properties.getProperty(
                 "ratis_log_appender_buffer_size_max",
                 String.valueOf(conf.getRatisConsensusLogAppenderBufferSize()))));
+
+    conf.setRatisSnapshotTriggerThreshold(
+        Long.parseLong(
+            properties.getProperty(
+                "ratis_snapshot_trigger_threshold",
+                String.valueOf(conf.getRatisConsensusLogAppenderBufferSize()))));
+
+    conf.setRatisLogUnsafeFlushEnable(
+        Boolean.parseBoolean(
+            properties.getProperty(
+                "ratis_log_unsafe_flush_enable",
+                String.valueOf(conf.isRatisLogUnsafeFlushEnable()))));
+
+    conf.setRatisLogSegmentSizeMax(
+        Long.parseLong(
+            properties.getProperty(
+                "ratis_log_segment_size_max", String.valueOf(conf.getRatisLogSegmentSizeMax()))));
+
+    conf.setRatisGrpcFlowControlWindow(
+        Long.parseLong(
+            properties.getProperty(
+                "ratis_grpc_flow_control_window",
+                String.valueOf(conf.getRatisGrpcFlowControlWindow()))));
+
+    conf.setRatisRpcLeaderElectionTimeoutMinMs(
+        Long.parseLong(
+            properties.getProperty(
+                "ratis_rpc_leader_election_timeout_min_ms",
+                String.valueOf(conf.getRatisRpcLeaderElectionTimeoutMinMs()))));
+
+    conf.setRatisRpcLeaderElectionTimeoutMinMs(
+        Long.parseLong(
+            properties.getProperty(
+                "ratis_rpc_leader_election_timeout_max_ms",
+                String.valueOf(conf.getRatisRpcLeaderElectionTimeoutMaxMs()))));
   }
 
   /**

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/NodeManager.java
@@ -134,6 +134,12 @@ public class NodeManager {
     final ConfigNodeConfig conf = ConfigNodeDescriptor.getInstance().getConf();
     TRatisConfig ratisConfig = new TRatisConfig();
     ratisConfig.setAppenderBufferSize(conf.getRatisConsensusLogAppenderBufferSize());
+    ratisConfig.setSnapshotTriggerThreshold(conf.getRatisSnapshotTriggerThreshold());
+    ratisConfig.setLogUnsafeFlushEnable(conf.isRatisLogUnsafeFlushEnable());
+    ratisConfig.setLogSegmentSizeMax(conf.getRatisLogSegmentSizeMax());
+    ratisConfig.setGrpcFlowControlWindow(conf.getRatisGrpcFlowControlWindow());
+    ratisConfig.setLeaderElectionTimeoutMin(conf.getRatisRpcLeaderElectionTimeoutMinMs());
+    ratisConfig.setLeaderElectionTimeoutMax(conf.getRatisRpcLeaderElectionTimeoutMaxMs());
     dataSet.setRatisConfig(ratisConfig);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1003,7 +1003,19 @@ public class IoTDBConfig {
   /** Maximum wait time of write cache in MultiLeader consensus. Unit: ms */
   private long cacheWindowTimeInMs = 60 * 1000;
 
-  private long RatisConsensusLogAppenderBufferSizeMax = 4 * 1024 * 1024L;
+  private long ratisConsensusLogAppenderBufferSizeMax = 4 * 1024 * 1024L;
+
+  private long ratisConsensusSnapshotTriggerThreshold = 400000L;
+
+  private boolean ratisConsensusLogUnsafeFlushEnable = false;
+
+  private long ratisConsensusLogSegmentSizeMax = 24 * 1024 * 1024L;
+
+  private long ratisConsensusGrpcFlowControlWindow = 4 * 1024 * 1024L;
+
+  private long ratisConsensusLeaderElectionTimeoutMinMs = 2000L;
+
+  private long RatisConsensusLeaderElectionTimeoutMaxMs = 4000L;
 
   IoTDBConfig() {}
 
@@ -3182,12 +3194,12 @@ public class IoTDBConfig {
   }
 
   public long getRatisConsensusLogAppenderBufferSizeMax() {
-    return RatisConsensusLogAppenderBufferSizeMax;
+    return ratisConsensusLogAppenderBufferSizeMax;
   }
 
   public void setRatisConsensusLogAppenderBufferSizeMax(
       long ratisConsensusLogAppenderBufferSizeMax) {
-    RatisConsensusLogAppenderBufferSizeMax = ratisConsensusLogAppenderBufferSizeMax;
+    this.ratisConsensusLogAppenderBufferSizeMax = ratisConsensusLogAppenderBufferSizeMax;
   }
 
   public String getConfigMessage() {
@@ -3221,5 +3233,56 @@ public class IoTDBConfig {
       }
     }
     return configMessage;
+  }
+
+  public long getRatisConsensusSnapshotTriggerThreshold() {
+    return ratisConsensusSnapshotTriggerThreshold;
+  }
+
+  public void setRatisConsensusSnapshotTriggerThreshold(
+      long ratisConsensusSnapshotTriggerThreshold) {
+    this.ratisConsensusSnapshotTriggerThreshold = ratisConsensusSnapshotTriggerThreshold;
+  }
+
+  public boolean isRatisConsensusLogUnsafeFlushEnable() {
+    return ratisConsensusLogUnsafeFlushEnable;
+  }
+
+  public void setRatisConsensusLogUnsafeFlushEnable(boolean ratisConsensusLogUnsafeFlushEnable) {
+    this.ratisConsensusLogUnsafeFlushEnable = ratisConsensusLogUnsafeFlushEnable;
+  }
+
+  public long getRatisConsensusLogSegmentSizeMax() {
+    return ratisConsensusLogSegmentSizeMax;
+  }
+
+  public void setRatisConsensusLogSegmentSizeMax(long ratisConsensusLogSegmentSizeMax) {
+    this.ratisConsensusLogSegmentSizeMax = ratisConsensusLogSegmentSizeMax;
+  }
+
+  public long getRatisConsensusGrpcFlowControlWindow() {
+    return ratisConsensusGrpcFlowControlWindow;
+  }
+
+  public void setRatisConsensusGrpcFlowControlWindow(long ratisConsensusGrpcFlowControlWindow) {
+    this.ratisConsensusGrpcFlowControlWindow = ratisConsensusGrpcFlowControlWindow;
+  }
+
+  public long getRatisConsensusLeaderElectionTimeoutMinMs() {
+    return ratisConsensusLeaderElectionTimeoutMinMs;
+  }
+
+  public void setRatisConsensusLeaderElectionTimeoutMinMs(
+      long ratisConsensusLeaderElectionTimeoutMinMs) {
+    this.ratisConsensusLeaderElectionTimeoutMinMs = ratisConsensusLeaderElectionTimeoutMinMs;
+  }
+
+  public long getRatisConsensusLeaderElectionTimeoutMaxMs() {
+    return RatisConsensusLeaderElectionTimeoutMaxMs;
+  }
+
+  public void setRatisConsensusLeaderElectionTimeoutMaxMs(
+      long ratisConsensusLeaderElectionTimeoutMaxMs) {
+    RatisConsensusLeaderElectionTimeoutMaxMs = ratisConsensusLeaderElectionTimeoutMaxMs;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1892,6 +1892,12 @@ public class IoTDBDescriptor {
 
   public void loadRatisConfig(TRatisConfig ratisConfig) {
     conf.setRatisConsensusLogAppenderBufferSizeMax(ratisConfig.getAppenderBufferSize());
+    conf.setRatisConsensusSnapshotTriggerThreshold(ratisConfig.getSnapshotTriggerThreshold());
+    conf.setRatisConsensusLogUnsafeFlushEnable(ratisConfig.isLogUnsafeFlushEnable());
+    conf.setRatisConsensusLogSegmentSizeMax(ratisConfig.getLogSegmentSizeMax());
+    conf.setRatisConsensusGrpcFlowControlWindow(ratisConfig.getGrpcFlowControlWindow());
+    conf.setRatisConsensusLeaderElectionTimeoutMinMs(ratisConfig.getLeaderElectionTimeoutMin());
+    conf.setRatisConsensusLeaderElectionTimeoutMaxMs(ratisConfig.getLeaderElectionTimeoutMax());
   }
 
   public void initClusterSchemaMemoryAllocate() {

--- a/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/thrift-confignode/src/main/thrift/confignode.thrift
@@ -49,6 +49,12 @@ struct TGlobalConfig {
 
 struct TRatisConfig {
   1: optional i64 appenderBufferSize
+  2: optional i64 snapshotTriggerThreshold
+  3: optional bool logUnsafeFlushEnable
+  4: optional i64 logSegmentSizeMax
+  5: optional i64 grpcFlowControlWindow
+  6: optional i64 leaderElectionTimeoutMin
+  7: optional i64 leaderElectionTimeoutMax
 }
 
 struct TDataNodeRemoveReq {


### PR DESCRIPTION
# Description
Currently, there are many config parameters available for RatisConsensus. All params can refer to `RatisConfig`.
In this PR, I propose to expose **workload-related** params in confignode.properties so that the user can tune these params according to their workloads.
# Param List
1. ratis_snapshot_trigger_threshold, determine how many logs written to trigger a snapshot.
2. ratis_log_unsafe_flush_enable, determine whether we can flush raft log asynchronous without wait FileChannel.force to return.
3. ratis_log_segment_size_max, determine max capacity of a single Raft Log segment.
4. ratis_grpc_flow_control_window, determine gRPC log appender's flow control window size
5. ratis_rpc_leader_election_timeout_min_ms, determine min election timeout
6. ratis_rpc_leader_election_timeout_max_ms, determine max election timeout