### PR TITLE
[IOTDB-4449][IOTDB-4450] Optimize SchemaFetch

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
@@ -788,7 +788,7 @@ public class LogicalPlanBuilder {
         for (PartialPath pathPattern :
             patternTree.getOverlappedPathPatterns(
                 storageGroupPath.concatNode(MULTI_LEVEL_PATH_WILDCARD))) {
-          overlappedPatternTree.appendPathPattern(pathPattern);
+         overlappedPatternTree.appendFullPath(pathPattern);
         }
         this.root.addChild(
             new SchemaFetchScanNode(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
@@ -776,6 +776,7 @@ public class LogicalPlanBuilder {
     return this;
   }
 
+  @SuppressWarnings({"checkstyle:Indentation", "checkstyle:CommentsIndentation"})
   public LogicalPlanBuilder planSchemaFetchSource(
       List<String> storageGroupList,
       PathPatternTree patternTree,
@@ -788,7 +789,8 @@ public class LogicalPlanBuilder {
         for (PartialPath pathPattern :
             patternTree.getOverlappedPathPatterns(
                 storageGroupPath.concatNode(MULTI_LEVEL_PATH_WILDCARD))) {
-         overlappedPatternTree.appendFullPath(pathPattern);
+          // pathPattern has been deduplicated, no need to deduplicate again
+          overlappedPatternTree.appendFullPath(pathPattern);
         }
         this.root.addChild(
             new SchemaFetchScanNode(


### PR DESCRIPTION
We find there are no need to deduplicate path in planSchemaFetchSource.

**Tests:**
**ENV:** 5 DEVICES and 10000 SENSOR each.

Before this PR:
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/18027703/191656667-afa692a3-5a5d-40f4-9d6f-23d17c2a1312.png">

After this PR:
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/18027703/191656681-feecb245-b4c3-42f5-88bb-eac5ab32e480.png">

