### PR TITLE
[IOTDB-3671] terminate workerMonitorExecutor in Join method

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -858,6 +858,7 @@ public class ProcedureExecutor<Env> {
 
   public void join() {
     timeoutExecutor.awaitTermination();
+    workerMonitorExecutor.awaitTermination();
     for (WorkerThread workerThread : workerThreads) {
       workerThread.awaitTermination();
     }


### PR DESCRIPTION
see: https://issues.apache.org/jira/browse/IOTDB-3671
add a terminate method