### PR TITLE
Reset ResultHandleContext before retry

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/MPPQueryContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/MPPQueryContext.java
@@ -64,7 +64,7 @@ public class MPPQueryContext {
     this.session = session;
     this.localDataBlockEndpoint = localDataBlockEndpoint;
     this.localInternalEndpoint = localInternalEndpoint;
-    this.resultNodeContext = new ResultNodeContext(queryId);
+    this.initResultNodeContext();
   }
 
   public MPPQueryContext(
@@ -76,9 +76,17 @@ public class MPPQueryContext {
       long timeOut,
       long startTime) {
     this(sql, queryId, session, localDataBlockEndpoint, localInternalEndpoint);
-    this.resultNodeContext = new ResultNodeContext(queryId);
     this.timeOut = timeOut;
     this.startTime = startTime;
+    this.initResultNodeContext();
+  }
+
+  public void prepareForRetry() {
+    this.initResultNodeContext();
+  }
+
+  private void initResultNodeContext() {
+    this.resultNodeContext = new ResultNodeContext(queryId);
   }
 
   public QueryId getQueryId() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -205,6 +205,8 @@ public class QueryExecution implements IQueryExecution {
     stateMachine.transitionToQueued();
     // force invalid PartitionCache
     partitionFetcher.invalidAllCache();
+    // clear runtime variables in MPPQueryContext
+    context.prepareForRetry();
     // re-analyze the query
     this.analysis = analyze(rawStatement, context, partitionFetcher, schemaFetcher);
     // re-start the QueryExecution


### PR DESCRIPTION
## Description
Before this change, the FragmentId of ResultHandle won't change when retrying, which will lead to conflicts in DataBlockManager.

<img width="1359" alt="image" src="https://user-images.githubusercontent.com/18027703/191705917-ed1a2b43-b75d-4eb7-a0a1-01b771b79c68.png">



<img width="510" alt="image" src="https://user-images.githubusercontent.com/18027703/191705807-174342c8-3b5f-47bc-a7da-4d05e8c9e18f.png">
