### PR TITLE
[IOTDB-4501]fix FileAlreadyExistsException when taking snapshot

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/snapshot/SnapshotTaker.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/snapshot/SnapshotTaker.java
@@ -169,6 +169,7 @@ public class SnapshotTaker {
   }
 
   private void createHardLink(File target, File source) throws IOException {
+    Files.deleteIfExists(target.toPath());
     Files.createLink(target.toPath(), source.toPath());
     snapshotLogger.logFile(source.getAbsolutePath(), target.getAbsolutePath());
   }


### PR DESCRIPTION
When we use snapshot to backup data, when a snapshotTsFile already has a hard link and point to the same tsfile, it will occurs FileAlreadyExistsException. So each time when we do hard link function, we need to check and delete.
