### PR TITLE
[MultiLeader] Fix the issue that the wal won't be deleted when leader transfer to follower

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/LogDispatcher.java
@@ -270,9 +270,7 @@ public class LogDispatcher {
       // indicating that insert nodes whose search index are before this value can be deleted
       // safely
       long currentSafelyDeletedSearchIndex = impl.getCurrentSafelyDeletedSearchIndex();
-      reader.setSafelyDeletedSearchIndex(
-          currentSafelyDeletedSearchIndex
-              - currentSafelyDeletedSearchIndex % config.getReplication().getCheckpointGap());
+      reader.setSafelyDeletedSearchIndex(currentSafelyDeletedSearchIndex);
       // notify
       if (impl.unblockWrite()) {
         impl.signal();

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -683,15 +683,21 @@ public class WALNode implements IWALNode {
 
     @Override
     public void waitForNextReady() throws InterruptedException {
+      boolean walFileRolled = false;
       while (!hasNext()) {
-        boolean timeout =
-            !buffer.waitForFlush(WAIT_FOR_NEXT_WAL_ENTRY_TIMEOUT_IN_SEC, TimeUnit.SECONDS);
-        if (timeout) {
-          logger.info(
-              "timeout when waiting for next WAL entry ready, execute rollWALFile. Current search index in wal buffer is {}, and next target index is {}",
-              buffer.getCurrentSearchIndex(),
-              nextSearchIndex);
-          rollWALFile();
+        if (!walFileRolled) {
+          boolean timeout =
+              !buffer.waitForFlush(WAIT_FOR_NEXT_WAL_ENTRY_TIMEOUT_IN_SEC, TimeUnit.SECONDS);
+          if (timeout) {
+            logger.info(
+                "timeout when waiting for next WAL entry ready, execute rollWALFile. Current search index in wal buffer is {}, and next target index is {}",
+                buffer.getCurrentSearchIndex(),
+                nextSearchIndex);
+            rollWALFile();
+            walFileRolled = true;
+          }
+        } else {
+          buffer.waitForFlush();
         }
       }
     }
@@ -735,6 +741,10 @@ public class WALNode implements IWALNode {
       int fileIndex = WALFileUtils.binarySearchFileBySearchIndex(filesToSearch, nextSearchIndex);
       logger.debug(
           "searchIndex: {}, result: {}, files: {}, ", nextSearchIndex, fileIndex, filesToSearch);
+      // (xingtanzjr) When the target entry does not exist, the reader will return minimum one whose searchIndex is larger than target searchIndex
+      if (fileIndex == -1) {
+        fileIndex = 0;
+      }
       if (filesToSearch != null
           && (fileIndex >= 0 && fileIndex < filesToSearch.length - 1)) { // possible to find next
         this.filesToSearch = filesToSearch;


### PR DESCRIPTION
## Description
In MultiLeader consensus, if a leader transfer to follower, the wal files may won't be deleted due to the reason that `SafeIndex` is not set to the latest one.

In this PR, we change two places to solve this issue:
1. update the `SafeIndex` to the latest one to WALReader rather than keep it the same as the persistence value in IndexController
2. When finding an entry which is already deleted in WAL files, the WALReader will return the minimum one whose searchIndex is larger than the target entry