### PR TITLE
[IOTDB-4518] Fix cannot delete .cmt file in disk

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/task/CompactionRecoverTask.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.utils.TsFileUtils;
+import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -349,6 +350,12 @@ public class CompactionRecoverTask {
         File tmpTargetFile = targetFileIdentifier.getFileFromDataDirs();
         if (tmpTargetFile != null) {
           tmpTargetFile.delete();
+          File chunkMetadataTempFile =
+              new File(
+                  tmpTargetFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX);
+          if (chunkMetadataTempFile.exists()) {
+            chunkMetadataTempFile.delete();
+          }
         }
       }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -45,6 +45,7 @@ import org.apache.iotdb.tsfile.utils.PublicBAOS;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.write.writer.tsmiterator.TSMIterator;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,7 +117,7 @@ public class TsFileIOWriter implements AutoCloseable {
   protected boolean enableMemoryControl = false;
   private Path lastSerializePath = null;
   protected LinkedList<Long> endPosInCMTForDevice = new LinkedList<>();
-  public static final String CHUNK_METADATA_TEMP_FILE_SUFFIX = ".cmt";
+  public static final String CHUNK_METADATA_TEMP_FILE_SUFFIX = ".meta";
 
   /** empty construct function. */
   protected TsFileIOWriter() {}
@@ -312,6 +313,12 @@ public class TsFileIOWriter implements AutoCloseable {
     out.close();
     if (resourceLogger.isDebugEnabled() && file != null) {
       resourceLogger.debug("{} writer is closed.", file.getName());
+    }
+    if (file != null) {
+      File chunkMetadataFile = new File(file.getAbsolutePath() + CHUNK_METADATA_TEMP_FILE_SUFFIX);
+      if (chunkMetadataFile.exists()) {
+        FileUtils.delete(chunkMetadataFile);
+      }
     }
     canWrite = false;
   }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriterMemoryControlTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriterMemoryControlTest.java
@@ -293,6 +293,9 @@ public class TsFileIOWriterMemoryControlTest {
       Assert.assertTrue(writer.hasChunkMetadataInDisk);
       writer.endFile();
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originData);
   }
@@ -377,6 +380,9 @@ public class TsFileIOWriterMemoryControlTest {
       Assert.assertTrue(writer.hasChunkMetadataInDisk);
       writer.endFile();
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originData);
   }
@@ -464,6 +470,9 @@ public class TsFileIOWriterMemoryControlTest {
       Assert.assertFalse(writer.chunkGroupMetadataList.isEmpty());
       writer.endFile();
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originData);
   }
@@ -552,6 +561,9 @@ public class TsFileIOWriterMemoryControlTest {
     } finally {
       TEST_CHUNK_SIZE = originTestChunkSize;
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originData);
   }
@@ -640,6 +652,9 @@ public class TsFileIOWriterMemoryControlTest {
     } finally {
       TEST_CHUNK_SIZE = originTestChunkSize;
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originTimes);
   }
@@ -728,6 +743,9 @@ public class TsFileIOWriterMemoryControlTest {
     } finally {
       TEST_CHUNK_SIZE = originTestChunkSize;
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originTimes);
   }
@@ -762,6 +780,9 @@ public class TsFileIOWriterMemoryControlTest {
       writer.endFile();
       Assert.assertTrue(writer.hasChunkMetadataInDisk);
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originData);
   }
@@ -798,6 +819,9 @@ public class TsFileIOWriterMemoryControlTest {
       writer.endFile();
       Assert.assertTrue(writer.hasChunkMetadataInDisk);
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originData);
   }
@@ -840,6 +864,9 @@ public class TsFileIOWriterMemoryControlTest {
     } finally {
       TEST_CHUNK_SIZE = originTestPointNum;
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originData);
   }
@@ -878,6 +905,9 @@ public class TsFileIOWriterMemoryControlTest {
     } finally {
       TEST_CHUNK_SIZE = originTestPointNum;
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originData);
   }
@@ -934,6 +964,9 @@ public class TsFileIOWriterMemoryControlTest {
       }
       writer.endFile();
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originValue);
   }
@@ -1030,6 +1063,9 @@ public class TsFileIOWriterMemoryControlTest {
       writer.endFile();
       Assert.assertTrue(writer.hasChunkMetadataInDisk);
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originData);
   }
@@ -1081,6 +1117,9 @@ public class TsFileIOWriterMemoryControlTest {
       }
       writer.endFile();
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originValue);
   }
@@ -1136,6 +1175,9 @@ public class TsFileIOWriterMemoryControlTest {
       }
       writer.endFile();
     }
+    Assert.assertFalse(
+        new File(testFile.getAbsolutePath() + TsFileIOWriter.CHUNK_METADATA_TEMP_FILE_SUFFIX)
+            .exists());
     TsFileIntegrityCheckingTool.checkIntegrityBySequenceRead(testFile.getPath());
     TsFileIntegrityCheckingTool.checkIntegrityByQuery(testFile.getPath(), originValue);
   }


### PR DESCRIPTION
See [IOTDB-4518](https://issues.apache.org/jira/browse/IOTDB-4518).

Temporal files for chunk metadata should be deleted in `TsFileIOWriter::endFile`.