### PR TITLE
[IOTDB-4503] fix load error when autoregister is false

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
@@ -200,7 +200,8 @@ public class IOTDBLoadTsFileIT {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
 
-      statement.execute(String.format("load \"%s\" sglevel=2", tmpDir.getAbsolutePath()));
+      statement.execute(
+          String.format("load \"%s\" sglevel=2, autoregister=false", tmpDir.getAbsolutePath()));
 
       try (ResultSet resultSet =
           statement.executeQuery("select count(*) from root.** group by level=1,2")) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -3073,7 +3073,7 @@ public class DataRegion {
       if (deleteOriginFile) {
         FileUtils.moveFile(tsFileToLoad, targetFile);
       } else {
-        Files.createLink(targetFile.toPath(), tsFileToLoad.toPath());
+        Files.copy(tsFileToLoad.toPath(), targetFile.toPath());
       }
     } catch (IOException e) {
       logger.error(
@@ -3095,7 +3095,7 @@ public class DataRegion {
       if (deleteOriginFile) {
         FileUtils.moveFile(resourceFileToLoad, targetResourceFile);
       } else {
-        Files.createLink(targetResourceFile.toPath(), resourceFileToLoad.toPath());
+        Files.copy(resourceFileToLoad.toPath(), targetResourceFile.toPath());
       }
     } catch (IOException e) {
       logger.error(
@@ -3127,7 +3127,7 @@ public class DataRegion {
         if (deleteOriginFile) {
           FileUtils.moveFile(modFileToLoad, targetModFile);
         } else {
-          Files.createLink(targetModFile.toPath(), modFileToLoad.toPath());
+          Files.copy(modFileToLoad.toPath(), targetModFile.toPath());
         }
       } catch (IOException e) {
         logger.error(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -1477,7 +1477,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     }
 
     // auto create and verify schema
-    if (loadTsFileStatement.isVerifySchema() || loadTsFileStatement.isAutoCreateSchema()) {
+    if (loadTsFileStatement.isAutoCreateSchema()) {
       try {
         if (loadTsFileStatement.isVerifySchema()) {
           verifyLoadingMeasurements(device2Schemas);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
@@ -163,6 +163,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.utils.Pair;
 
+import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZoneId;
@@ -1437,12 +1438,16 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
 
   @Override
   public Statement visitLoadFile(IoTDBSqlParser.LoadFileContext ctx) {
-    LoadTsFileStatement loadTsFileStatement =
-        new LoadTsFileStatement(parseStringLiteral(ctx.fileName.getText()));
-    if (ctx.loadFilesClause() != null) {
-      parseLoadFiles(loadTsFileStatement, ctx.loadFilesClause());
+    try {
+      LoadTsFileStatement loadTsFileStatement =
+          new LoadTsFileStatement(parseStringLiteral(ctx.fileName.getText()));
+      if (ctx.loadFilesClause() != null) {
+        parseLoadFiles(loadTsFileStatement, ctx.loadFilesClause());
+      }
+      return loadTsFileStatement;
+    } catch (FileNotFoundException e) {
+      throw new SQLParserException(e.getMessage());
     }
-    return loadTsFileStatement;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileDispatcherImpl.java
@@ -162,7 +162,7 @@ public class LoadTsFileDispatcherImpl implements IFragInstanceDispatcher {
       try {
         StorageEngineV2.getInstance()
             .getDataRegion((DataRegionId) groupId)
-            .loadNewTsFile(((LoadSingleTsFileNode) planNode).getTsFileResource(), true);
+            .loadNewTsFile(((LoadSingleTsFileNode) planNode).getTsFileResource(), false);
       } catch (LoadFileException e) {
         logger.error(String.format("Load TsFile Node %s error.", planNode), e);
         TSStatus resultStatus = new TSStatus();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/LoadTsFileStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/LoadTsFileStatement.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.utils.FilePathUtils;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,7 +44,7 @@ public class LoadTsFileStatement extends Statement {
   private List<File> tsFiles;
   private List<TsFileResource> resources;
 
-  public LoadTsFileStatement(String filePath) {
+  public LoadTsFileStatement(String filePath) throws FileNotFoundException {
     this.file = new File(filePath);
     this.autoCreateSchema = true;
     this.sgLevel = IoTDBDescriptor.getInstance().getConfig().getDefaultStorageGroupLevel();
@@ -54,6 +55,10 @@ public class LoadTsFileStatement extends Statement {
     if (file.isFile()) {
       tsFiles.add(file);
     } else {
+      if (file.listFiles() == null) {
+        throw new FileNotFoundException(
+            "Can not find %s on this machine, note that load can only handle files on this machine.");
+      }
       findAllTsFile(file);
     }
     sortTsFiles(tsFiles);


### PR DESCRIPTION
problem:
- throw NPE when autoregister=false and enableAutoCreateSchema =false
- sill auto creating schema while autoregister=false
- file is deleted after load into local machine
- throw NPE when loading tsfile is not on local machine

solution:
- mandalically verify the metadata when registering metadata
- change `Files.createLink` to `Files.copy`
- return message to user to notice load function can only load local machine files.