### PR TITLE
[IOTDB-4517] Fix cross_space and unseq_space compaction are slower at common timeseries and template timeseries

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
@@ -199,11 +199,12 @@ public class ReadPointCompactionPerformer
     if (subTaskNums > 0) {
       // assign the measurements for each subtask
       List<String>[] measurementListArray = new List[subTaskNums];
-      for (int i = 0; i < allMeasurements.size(); ++i) {
-        if (measurementListArray[i % subTaskNums] == null) {
-          measurementListArray[i % subTaskNums] = new LinkedList<>();
+      for (int i = 0, size = allMeasurements.size(); i < size; ++i) {
+        int index = i % subTaskNums;
+        if (measurementListArray[index] == null) {
+          measurementListArray[index] = new LinkedList<>();
         }
-        measurementListArray[i % subTaskNums].add(allMeasurements.get(i));
+        measurementListArray[index].add(allMeasurements.get(i));
       }
 
       compactionWriter.startChunkGroup(device, false);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadPointCompactionPerformer.java
@@ -301,10 +301,20 @@ public class ReadPointCompactionPerformer
             tsBlock.getPositionCount());
       } else {
         IPointReader pointReader = tsBlock.getTsBlockSingleColumnIterator();
+        TimeValuePair timeValuePair = null;
+        boolean updateFirstTime = false;
         while (pointReader.hasNextTimeValuePair()) {
-          TimeValuePair timeValuePair = pointReader.nextTimeValuePair();
+          timeValuePair = pointReader.nextTimeValuePair();
+          if (!updateFirstTime) {
+            // update start time
+            writer.updateStartTimeAndEndTime(device, timeValuePair.getTimestamp(), subTaskId);
+            updateFirstTime = true;
+          }
           writer.write(
               timeValuePair.getTimestamp(), timeValuePair.getValue().getValue(), subTaskId);
+        }
+        // update end time
+        if (timeValuePair != null) {
           writer.updateStartTimeAndEndTime(device, timeValuePair.getTimestamp(), subTaskId);
         }
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
@@ -62,8 +62,8 @@ public class CrossSpaceCompactionWriter extends AbstractCompactionWriter {
   private AtomicLong[] startTimeForCurDeviceForEachFile;
   private AtomicLong[] endTimeForCurDeviceForEachFile;
   private AtomicBoolean[] hasCurDeviceForEachFile;
-  private AtomicLong[][] startTimeForEachDevice;
-  private AtomicLong[][] endTimeForEachDevice;
+  private AtomicLong[][] startTimeForEachDevice = new AtomicLong[subTaskNum][];
+  private AtomicLong[][] endTimeForEachDevice = new AtomicLong[subTaskNum][];
 
   public CrossSpaceCompactionWriter(
       List<TsFileResource> targetResources, List<TsFileResource> seqFileResources)

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
@@ -122,6 +122,7 @@ public class CrossSpaceCompactionWriter extends AbstractCompactionWriter {
       } else {
         targetFileWriter.truncate(targetFileWriter.getPos() - chunkGroupHeaderSize);
       }
+      isDeviceExistedInTargetFiles[i] = false;
     }
     for (int i = 0, size = targetTsFileResources.size(); i < size; ++i) {
       for (int j = 0; j < subTaskNum; ++j) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkMetadata.java
@@ -285,10 +285,11 @@ public class ChunkMetadata implements IChunkMetadata {
   }
 
   public long calculateRamSize() {
-    return CHUNK_METADATA_FIXED_RAM_SIZE
-        + RamUsageEstimator.sizeOf(tsFilePrefixPath)
-        + RamUsageEstimator.sizeOf(measurementUid)
-        + statistics.calculateRamSize();
+    long memSize = CHUNK_METADATA_FIXED_RAM_SIZE;
+    memSize += RamUsageEstimator.sizeOf(tsFilePrefixPath);
+    memSize += RamUsageEstimator.sizeOf(measurementUid);
+    memSize += statistics.calculateRamSize();
+    return memSize;
   }
 
   public static long calculateRamSize(String measurementId, TSDataType dataType) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
@@ -92,7 +92,9 @@ public class ChunkWriterImpl implements IChunkWriter {
 
   private Statistics<?> firstPageStatistics;
 
-  /** @param schema schema of this measurement */
+  /**
+   * @param schema schema of this measurement
+   */
   public ChunkWriterImpl(IMeasurementSchema schema) {
     this.measurementSchema = schema;
     this.compressor = ICompressor.getCompressor(schema.getCompressor());

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
@@ -92,9 +92,7 @@ public class ChunkWriterImpl implements IChunkWriter {
 
   private Statistics<?> firstPageStatistics;
 
-  /**
-   * @param schema schema of this measurement
-   */
+  /** @param schema schema of this measurement */
   public ChunkWriterImpl(IMeasurementSchema schema) {
     this.measurementSchema = schema;
     this.compressor = ICompressor.getCompressor(schema.getCompressor());

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -619,8 +619,6 @@ public class TsFileIOWriter implements AutoCloseable {
               currentChunkMetadataSize / chunkMetadataCount);
         }
         sortAndFlushChunkMetadata();
-        chunkMetadataCount = 0;
-        currentChunkMetadataSize = 0;
       } catch (IOException e) {
         logger.error("Meets exception when flushing metadata to temp file for {}", file, e);
         throw e;
@@ -660,6 +658,8 @@ public class TsFileIOWriter implements AutoCloseable {
     if (chunkMetadataList != null) {
       chunkMetadataList.clear();
     }
+    chunkMetadataCount = 0;
+    currentChunkMetadataSize = 0;
   }
 
   private void writeChunkMetadataToTempFile(

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -611,11 +611,13 @@ public class TsFileIOWriter implements AutoCloseable {
     // This function should be called after all data of an aligned device has been written
     if (enableMemoryControl && currentChunkMetadataSize > maxMetadataSize) {
       try {
-        logger.info(
-            "Flushing chunk metadata, total size is {}, count is {}, avg size is {}",
-            currentChunkMetadataSize,
-            chunkMetadataCount,
-            currentChunkMetadataSize / chunkMetadataCount);
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              "Flushing chunk metadata, total size is {}, count is {}, avg size is {}",
+              currentChunkMetadataSize,
+              chunkMetadataCount,
+              currentChunkMetadataSize / chunkMetadataCount);
+        }
         sortAndFlushChunkMetadata();
         chunkMetadataCount = 0;
         currentChunkMetadataSize = 0;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -685,4 +685,8 @@ public class TsFileIOWriter implements AutoCloseable {
     ReadWriteIOUtils.write(totalSize, tempOutput.wrapAsStream());
     buffer.writeTo(tempOutput);
   }
+
+  public String getCurrentChunkGroupDeviceId() {
+    return currentChunkGroupDeviceId;
+  }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -611,7 +611,7 @@ public class TsFileIOWriter implements AutoCloseable {
     // This function should be called after all data of an aligned device has been written
     if (enableMemoryControl && currentChunkMetadataSize > maxMetadataSize) {
       try {
-        logger.debug(
+        logger.info(
             "Flushing chunk metadata, total size is {}, count is {}, avg size is {}",
             currentChunkMetadataSize,
             chunkMetadataCount,


### PR DESCRIPTION
See [IOTDB-4517](https://issues.apache.org/jira/browse/IOTDB-4517).

The fisrt reason is that the `currentChunkSize` does not reset when flushing chunk metadata to temp file in disk, leading to frequent flushing of chunk metadata.
The second reason is the concurrent issue caused by update to the start time and end time of tsfile resource in the compaction sub-task.