### PR TITLE
[IOTDB-4529] Close active connections in prometheus reporter's disposable server when metric service stop.

### DIFF
--- a/metrics/dropwizard-metrics/src/main/java/org/apache/iotdb/metrics/dropwizard/reporter/DropwizardPrometheusReporter.java
+++ b/metrics/dropwizard-metrics/src/main/java/org/apache/iotdb/metrics/dropwizard/reporter/DropwizardPrometheusReporter.java
@@ -27,6 +27,8 @@ import org.apache.iotdb.metrics.utils.ReporterType;
 
 import com.codahale.metrics.MetricRegistry;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -53,6 +55,7 @@ public class DropwizardPrometheusReporter implements Reporter {
     httpServer =
         HttpServer.create()
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000)
+            .channelGroup(new DefaultChannelGroup(GlobalEventExecutor.INSTANCE))
             .port(port)
             .route(
                 routes ->


### PR DESCRIPTION
Now, when metric service stop, we simply call `DisposableServer#disposeNow()` to close all inactive connections.
After some search, I find setting channelGroup when create DisposableServer makes it possible to close active connections at the same time when call `DisposableServer#disposeNow()`.

Related issues in reactor:
1. [Use the new Transport API for TCP/UDP/HTTP implementations](https://github.com/reactor/reactor-netty/pull/1046)
2. [Connections are not disposed when server is closed](https://github.com/reactor/reactor-netty/issues/495)
3. [HTTP client connection is not disposed on server side](https://github.com/reactor/reactor-netty/issues/581)

Related Comments in code:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/46039728/192421365-da1fbe44-4936-4041-a77f-94fe6cd646ea.png">
