### PR TITLE
[To rel/0.13][IOTDB-4554] Start compaction only when IoTDB is fully recovered

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionTaskManager.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.db.engine.compaction.constant.CompactionTaskStatus;
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.compaction.task.CompactionTaskSummary;
 import org.apache.iotdb.db.service.IService;
+import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.service.ServiceType;
 import org.apache.iotdb.db.utils.TestOnly;
 import org.apache.iotdb.db.utils.datastructure.FixedPriorityBlockingQueue;
@@ -248,7 +249,8 @@ public class CompactionTaskManager implements IService {
    */
   public synchronized void submitTaskFromTaskQueue() {
     try {
-      while (currentTaskNum.get()
+      while (IoTDB.activated
+          && currentTaskNum.get()
               < IoTDBDescriptor.getInstance().getConfig().getConcurrentCompactionThread()
           && !candidateCompactionTaskQueue.isEmpty()) {
         AbstractCompactionTask task = candidateCompactionTaskQueue.take();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
@@ -417,7 +417,7 @@ public class CompactionUtils {
 
   private static void checkThreadInterrupted(List<TsFileResource> tsFileResource)
       throws InterruptedException {
-    if (Thread.currentThread().isInterrupted() || !IoTDB.activated) {
+    if (Thread.interrupted() || !IoTDB.activated) {
       throw new InterruptedException(
           String.format(
               "[Compaction] compaction for target file %s abort", tsFileResource.toString()));

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/InnerSpaceCompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/InnerSpaceCompactionUtils.java
@@ -90,7 +90,7 @@ public class InnerSpaceCompactionUtils {
 
   private static void checkThreadInterrupted(TsFileResource tsFileResource)
       throws InterruptedException {
-    if (Thread.currentThread().isInterrupted() || !IoTDB.activated) {
+    if (Thread.interrupted() || !IoTDB.activated) {
       throw new InterruptedException(
           String.format(
               "[Compaction] compaction for target file %s abort", tsFileResource.toString()));


### PR DESCRIPTION
See [IOTDB-4554](https://issues.apache.org/jira/browse/IOTDB-4554).