### PR TITLE
[To rel/0.13] Accelerate restart process

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
@@ -513,8 +513,8 @@ public class VirtualStorageGroupProcessor {
           splitResourcesByPartition(tmpSeqTsFiles);
       Map<Long, List<TsFileResource>> partitionTmpUnseqTsFiles =
           splitResourcesByPartition(tmpUnseqTsFiles);
-      for (Map.Entry<Long, List<TsFileResource>> entry : partitionTmpSeqTsFiles.entrySet()) {
-        recoverTsFiles(entry.getValue(), recoveryContext, true);
+      for (List<TsFileResource> value : partitionTmpSeqTsFiles.values()) {
+        recoverTsFiles(value, recoveryContext, true);
       }
       for (List<TsFileResource> value : partitionTmpUnseqTsFiles.values()) {
         recoverTsFiles(value, recoveryContext, false);


### PR DESCRIPTION
We found that when memory is limited and there are too many TsFileResources, during restart prcessing, there are too much time spent on deserializing devices from TsFile, because `ITimeIndex` degrade to `FileTimeIndex`.
Dive into the restart process, we found that deserializing devices is for updating flush time of each device, so we can improve restarting by updating it before TsFileResource being added to `TsFileResourceManagement` when it can be degraded.
<img width="1914" alt="image" src="https://user-images.githubusercontent.com/16079446/192787095-6d68bac9-1170-4676-a13b-5c55b4229de1.png">
