### PR TITLE
[IOTDB-4551] Fix schema query npe with template

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -422,6 +422,9 @@ public abstract class Traverser {
     }
 
     Template upperTemplate = getUpperTemplate(node);
+    if (upperTemplate == null) {
+      return;
+    }
     isInTemplate = true;
     IMNode targetNode = upperTemplate.getDirectNode(targetName);
     if (targetNode != null) {
@@ -454,19 +457,31 @@ public abstract class Traverser {
           return ancestor.getSchemaTemplate();
         }
       }
+      throw new IllegalStateException(
+          "There should not be no template mounted on any ancestor of a node usingTemplate.");
     } else {
       // new cluster
+      Template template;
       if (node.getSchemaTemplateId() != NON_TEMPLATE) {
-        return templateMap.get(node.getSchemaTemplateId());
+        template = templateMap.get(node.getSchemaTemplateId());
+        if (template != null) {
+          return template;
+        }
+        // template == null means the template used by this node is not related to this query.
       }
       while (iterator.hasNext()) {
         ancestor = iterator.next();
         if (ancestor.getSchemaTemplateId() != NON_TEMPLATE) {
-          return templateMap.get(ancestor.getSchemaTemplateId());
+          template = templateMap.get(ancestor.getSchemaTemplateId());
+          if (template != null) {
+            return template;
+          }
+          // template == null means the template used by this node is not related to this query.
         }
       }
     }
-    // if the node is usingTemplate, the upperTemplate won't be null
+    // if the node is usingTemplate, the upperTemplate won't be null except the template is not
+    // related to this query in new cluster
     return null;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -250,6 +250,11 @@ public abstract class Traverser {
     }
 
     Template upperTemplate = getUpperTemplate(node);
+    if (upperTemplate == null) {
+      // template == null means the template used by this node is not related to this query in new
+      // cluster.
+      return;
+    }
     isInTemplate = true;
     traverseContext.push(node);
     for (IMNode childInTemplate : upperTemplate.getDirectNodes()) {
@@ -339,7 +344,11 @@ public abstract class Traverser {
     }
 
     Template upperTemplate = getUpperTemplate(node);
-
+    if (upperTemplate == null) {
+      // template == null means the template used by this node is not related to this query in new
+      // cluster.
+      return;
+    }
     isInTemplate = true;
     traverseContext.push(node);
     for (IMNode childInTemplate : upperTemplate.getDirectNodes()) {
@@ -423,6 +432,8 @@ public abstract class Traverser {
 
     Template upperTemplate = getUpperTemplate(node);
     if (upperTemplate == null) {
+      // template == null means the template used by this node is not related to this query in new
+      // cluster.
       return;
     }
     isInTemplate = true;
@@ -457,32 +468,22 @@ public abstract class Traverser {
           return ancestor.getSchemaTemplate();
         }
       }
-      throw new IllegalStateException(
-          "There should not be no template mounted on any ancestor of a node usingTemplate.");
     } else {
       // new cluster
-      Template template;
       if (node.getSchemaTemplateId() != NON_TEMPLATE) {
-        template = templateMap.get(node.getSchemaTemplateId());
-        if (template != null) {
-          return template;
-        }
-        // template == null means the template used by this node is not related to this query.
+        return templateMap.get(node.getSchemaTemplateId());
       }
       while (iterator.hasNext()) {
         ancestor = iterator.next();
         if (ancestor.getSchemaTemplateId() != NON_TEMPLATE) {
-          template = templateMap.get(ancestor.getSchemaTemplateId());
-          if (template != null) {
-            return template;
-          }
-          // template == null means the template used by this node is not related to this query.
+          return templateMap.get(ancestor.getSchemaTemplateId());
         }
       }
     }
-    // if the node is usingTemplate, the upperTemplate won't be null except the template is not
-    // related to this query in new cluster
-    return null;
+    // if the node is usingTemplate, the upperTemplate won't be null or the upperTemplateId won't be
+    // NON_TEMPLATE.
+    throw new IllegalStateException(
+        "There should not be no template mounted on any ancestor of a node usingTemplate.");
   }
 
   public void setTemplateMap(Map<Integer, Template> templateMap) {


### PR DESCRIPTION
## Description


### Cause

During planning stage of schema query or schema fetch, the related template will be taken and set to the plan node. The unrelated template used in involved schemaRegion won't be taken, which results in the npe occurring during traversing the MTree in schemaRegion.


### Solution

When traversing the MTree and meet template not provided in templateMap which passed in by schema query or fetch plan, ignore this node using such unrelated template.

