### PR TITLE
[IOTDB-4575] Remove max_chunk_raw_size_threshold by target_chunk_size

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -385,11 +385,6 @@ timestamp_precision=ms
 # Datatype: int
 # avg_series_point_number_threshold=100000
 
-# When a chunk in memtable reaches this threshold, flush the memtable to disk.
-# The default threshold is 20 MB.
-# Datatype: long
-# max_chunk_raw_size_threshold = 20971520
-
 # How many threads can concurrently flush. When <= 0, use CPU core number.
 # Datatype: int
 # concurrent_flush_thread=0
@@ -599,7 +594,8 @@ timestamp_precision=ms
 # Datatype: long, Unit: byte
 # target_compaction_file_size=1073741824
 
-# The target chunk size in compaction, default is 1MB
+# The target chunk size in compaction and when memtable reaches this threshold, flush the memtable to disk.
+# default is 1MB
 # Datatype: long, Unit: byte
 # target_chunk_size=1048576
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -397,9 +397,6 @@ public class IoTDBConfig {
   /** When average series point number reaches this, flush the memtable to disk */
   private int avgSeriesPointNumberThreshold = 100000;
 
-  /** When a chunk in memtable reaches this threshold, flush the memtable to disk */
-  private long maxChunkRawSizeThreshold = 1024 * 1024 * 20L;
-
   /** Enable inner space compaction for sequence files */
   private boolean enableSeqSpaceCompaction = true;
 
@@ -2003,14 +2000,6 @@ public class IoTDBConfig {
 
   public void setAvgSeriesPointNumberThreshold(int avgSeriesPointNumberThreshold) {
     this.avgSeriesPointNumberThreshold = avgSeriesPointNumberThreshold;
-  }
-
-  public long getMaxChunkRawSizeThreshold() {
-    return maxChunkRawSizeThreshold;
-  }
-
-  public void setMaxChunkRawSizeThreshold(long maxChunkRawSizeThreshold) {
-    this.maxChunkRawSizeThreshold = maxChunkRawSizeThreshold;
   }
 
   public long getCrossCompactionFileSelectionTimeBudget() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -405,12 +405,6 @@ public class IoTDBDescriptor {
                 "avg_series_point_number_threshold",
                 Integer.toString(conf.getAvgSeriesPointNumberThreshold()))));
 
-    conf.setMaxChunkRawSizeThreshold(
-        Long.parseLong(
-            properties.getProperty(
-                "max_chunk_raw_size_threshold",
-                Long.toString(conf.getMaxChunkRawSizeThreshold()))));
-
     conf.setCheckPeriodWhenInsertBlocked(
         Integer.parseInt(
             properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -152,7 +152,7 @@ public abstract class AlignedTVList extends TVList {
               columnValue != null
                   ? getBinarySize((Binary) columnValue)
                   : getBinarySize(Binary.EMPTY_VALUE);
-          if (memoryBinaryChunkSize[i] >= maxChunkRawSizeThreshold) {
+          if (memoryBinaryChunkSize[i] >= targetChunkSize) {
             reachMaxChunkSizeFlag = true;
           }
           break;
@@ -739,7 +739,7 @@ public abstract class AlignedTVList extends TVList {
             memoryBinaryChunkSize[i] +=
                 arrayT[elementIndex + i1] != null ? getBinarySize(arrayT[elementIndex + i1]) : 0;
           }
-          if (memoryBinaryChunkSize[i] > maxChunkRawSizeThreshold) {
+          if (memoryBinaryChunkSize[i] > targetChunkSize) {
             reachMaxChunkSizeFlag = true;
           }
           break;

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/BinaryTVList.java
@@ -95,7 +95,7 @@ public abstract class BinaryTVList extends TVList {
 
   @Override
   public boolean reachMaxChunkSizeThreshold() {
-    return memoryBinaryChunkSize >= maxChunkRawSizeThreshold;
+    return memoryBinaryChunkSize >= targetChunkSize;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
@@ -49,8 +49,8 @@ public abstract class TVList implements WALEntryValue {
 
   protected static final int SMALL_ARRAY_LENGTH = 32;
   protected static final String ERR_DATATYPE_NOT_CONSISTENT = "DataType not consistent";
-  protected static final long maxChunkRawSizeThreshold =
-      IoTDBDescriptor.getInstance().getConfig().getMaxChunkRawSizeThreshold();
+  protected static final long targetChunkSize =
+      IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
   // list of timestamp array, add 1 when expanded -> data point timestamp array
   // index relation: arrayIndex -> elementIndex
   protected List<long[]> timestamps;


### PR DESCRIPTION
The target_chunk_size is the only one we control the size of chunk in IoTDB, which could be used in all modules.