### PR TITLE
[IOTDB-4544] Implement tsblock split for schema query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/DevicesSchemaScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/DevicesSchemaScanOperator.java
@@ -57,18 +57,18 @@ public class DevicesSchemaScanOperator extends SchemaQueryScanOperator {
   }
 
   @Override
-  protected TsBlock createTsBlock() {
-    TsBlockBuilder builder = new TsBlockBuilder(outputDataTypes);
+  protected List<TsBlock> createTsBlockList() {
     try {
-      ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
-          .getSchemaRegion()
-          .getMatchedDevices(convertToPhysicalPlan())
-          .left
-          .forEach(device -> setColumns(device, builder));
+      List<ShowDevicesResult> schemaRegionResult =
+          ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
+              .getSchemaRegion()
+              .getMatchedDevices(convertToPhysicalPlan())
+              .left;
+      return SchemaTsBlockUtil.transferSchemaResultToTsBlockList(
+          schemaRegionResult.iterator(), outputDataTypes, this::setColumns);
     } catch (MetadataException e) {
       throw new RuntimeException(e.getMessage(), e);
     }
-    return builder.build();
   }
 
   // ToDo @xinzhongtianxia remove this temporary converter after mpp online

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/LevelTimeSeriesCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/LevelTimeSeriesCountOperator.java
@@ -29,11 +29,11 @@ import org.apache.iotdb.db.mpp.execution.operator.source.SourceOperator;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
-import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.Binary;
 
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.tsfile.read.common.block.TsBlockBuilderStatus.DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
@@ -48,7 +48,8 @@ public class LevelTimeSeriesCountOperator implements SourceOperator {
   private final String value;
   private final boolean isContains;
 
-  private boolean isFinished;
+  private List<TsBlock> tsBlockList;
+  private int currentIndex = 0;
 
   private final List<TSDataType> outputDataTypes;
 
@@ -87,8 +88,23 @@ public class LevelTimeSeriesCountOperator implements SourceOperator {
 
   @Override
   public TsBlock next() {
-    isFinished = true;
-    TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    currentIndex++;
+    return tsBlockList.get(currentIndex - 1);
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (tsBlockList == null) {
+      createTsBlockList();
+    }
+
+    return currentIndex < tsBlockList.size();
+  }
+
+  public void createTsBlockList() {
     Map<PartialPath, Integer> countMap;
     try {
       if (key != null && value != null) {
@@ -107,24 +123,24 @@ public class LevelTimeSeriesCountOperator implements SourceOperator {
     } catch (MetadataException e) {
       throw new RuntimeException(e.getMessage(), e);
     }
-    countMap.forEach(
-        (path, count) -> {
-          tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-          tsBlockBuilder.getColumnBuilder(0).writeBinary(new Binary(path.getFullPath()));
-          tsBlockBuilder.getColumnBuilder(1).writeInt(count);
-          tsBlockBuilder.declarePosition();
-        });
-    return tsBlockBuilder.build();
-  }
 
-  @Override
-  public boolean hasNext() {
-    return !isFinished;
+    tsBlockList =
+        SchemaTsBlockUtil.transferSchemaResultToTsBlockList(
+            countMap.entrySet().iterator(),
+            outputDataTypes,
+            (entry, tsBlockBuilder) -> {
+              tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
+              tsBlockBuilder
+                  .getColumnBuilder(0)
+                  .writeBinary(new Binary(entry.getKey().getFullPath()));
+              tsBlockBuilder.getColumnBuilder(1).writeInt(entry.getValue());
+              tsBlockBuilder.declarePosition();
+            });
   }
 
   @Override
   public boolean isFinished() {
-    return isFinished;
+    return !hasNext();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/PathsUsingTemplateScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/PathsUsingTemplateScanOperator.java
@@ -50,17 +50,17 @@ public class PathsUsingTemplateScanOperator extends SchemaQueryScanOperator {
   }
 
   @Override
-  protected TsBlock createTsBlock() {
-    TsBlockBuilder builder = new TsBlockBuilder(outputDataTypes);
+  protected List<TsBlock> createTsBlockList() {
     try {
-      ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
-          .getSchemaRegion()
-          .getPathsUsingTemplate(templateId)
-          .forEach(path -> setColumns(path, builder));
+      List<String> schemaRegionResult =
+          ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
+              .getSchemaRegion()
+              .getPathsUsingTemplate(templateId);
+      return SchemaTsBlockUtil.transferSchemaResultToTsBlockList(
+          schemaRegionResult.iterator(), outputDataTypes, this::setColumns);
     } catch (MetadataException e) {
       throw new RuntimeException(e.getMessage(), e);
     }
-    return builder.build();
   }
 
   private void setColumns(String path, TsBlockBuilder builder) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaTsBlockUtil.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaTsBlockUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.execution.operator.schema;
+
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static org.apache.iotdb.tsfile.read.common.block.TsBlockBuilderStatus.DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
+
+public class SchemaTsBlockUtil {
+
+  private static final long MAX_SIZE = DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
+
+  public static <T> List<TsBlock> transferSchemaResultToTsBlockList(
+      Iterator<T> schemaRegionResultIterator,
+      List<TSDataType> outputDataTypes,
+      BiConsumer<T, TsBlockBuilder> consumer) {
+    List<TsBlock> result = new ArrayList<>();
+    TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
+    T schemaRegionResultElement;
+    while (schemaRegionResultIterator.hasNext()) {
+      schemaRegionResultElement = schemaRegionResultIterator.next();
+      consumer.accept(schemaRegionResultElement, tsBlockBuilder);
+      if (tsBlockBuilder.getRetainedSizeInBytes() >= MAX_SIZE) {
+        result.add(tsBlockBuilder.build());
+        tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
+      }
+    }
+    if (!tsBlockBuilder.isEmpty()) {
+      result.add(tsBlockBuilder.build());
+    }
+    return result;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/TimeSeriesSchemaScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/TimeSeriesSchemaScanOperator.java
@@ -89,18 +89,18 @@ public class TimeSeriesSchemaScanOperator extends SchemaQueryScanOperator {
   }
 
   @Override
-  protected TsBlock createTsBlock() {
-    TsBlockBuilder builder = new TsBlockBuilder(outputDataTypes);
+  protected List<TsBlock> createTsBlockList() {
     try {
-      ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
-          .getSchemaRegion()
-          .showTimeseries(convertToPhysicalPlan(), operatorContext.getInstanceContext())
-          .left
-          .forEach(series -> setColumns(series, builder));
+      List<ShowTimeSeriesResult> schemaRegionResult =
+          ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
+              .getSchemaRegion()
+              .showTimeseries(convertToPhysicalPlan(), operatorContext.getInstanceContext())
+              .left;
+      return SchemaTsBlockUtil.transferSchemaResultToTsBlockList(
+          schemaRegionResult.iterator(), outputDataTypes, this::setColumns);
     } catch (MetadataException e) {
       throw new RuntimeException(e.getMessage(), e);
     }
-    return builder.build();
   }
 
   // ToDo @xinzhongtianxia remove this temporary converter after mpp online

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperatorTest.java
@@ -39,6 +39,7 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -187,6 +188,7 @@ public class CountMergeOperatorTest {
               fragmentInstanceContext.getOperatorContexts().get(0),
               Arrays.asList(timeSeriesCountOperator1, timeSeriesCountOperator2));
       TsBlock tsBlock = null;
+      Assert.assertTrue(countMergeOperator.isBlocked().isDone());
       while (countMergeOperator.hasNext()) {
         tsBlock = countMergeOperator.next();
         assertFalse(countMergeOperator.hasNext());


### PR DESCRIPTION
## Description


### Motivation

The result of schema query in one schemaRegion is always transferred by only on TsBlock no matter how many the records there are. In specific scenarios, especially the timeseries schema query, too many records may results in the size of result tsblock beyond the sink constraint of mpp.

### Modification

Split the result records of schema query into several tsBlocks, the max size of which is default tsblock size.
