### PR TITLE
[To rel/0.13] [IOTDB-4579] Remove the update of start time and end time in the target file after cross space compaction

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionSchedulerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionSchedulerTest.java
@@ -89,6 +89,7 @@ public class CompactionSchedulerTest {
 
   @Before
   public void setUp() throws MetadataException, IOException {
+    IoTDB.activated = true;
     CompactionClearUtils.clearAllCompactionFiles();
     EnvironmentUtils.cleanAllDir();
     IoTDB.metaManager.init();
@@ -112,6 +113,7 @@ public class CompactionSchedulerTest {
 
   @After
   public void tearDown() throws IOException, StorageEngineException {
+    IoTDB.activated = false;
     new CompactionConfigRestorer().restoreCompactionConfig();
     ChunkCache.getInstance().clear();
     TimeSeriesMetadataCache.getInstance().clear();


### PR DESCRIPTION
See [IOTDB-4579](https://issues.apache.org/jira/browse/IOTDB-4579).

