### PR TITLE
[To rel/0.13] Fix PathAlreadyExistException during concurrent auto creating aligned timeseries

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -2213,7 +2213,17 @@ public class MManager {
       encodings.add(getDefaultEncoding(dataType));
       compressors.add(TSFileDescriptor.getInstance().getConfig().getCompressor());
     }
-    createAlignedTimeSeries(prefixPath, measurements, dataTypes, encodings, compressors);
+    try {
+      createAlignedTimeSeries(prefixPath, measurements, dataTypes, encodings, compressors);
+    } catch (PathAlreadyExistException | AliasAlreadyExistException e) {
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "Ignore PathAlreadyExistException and AliasAlreadyExistException when Concurrent inserting"
+                + " non-exist aligned time series {} under device {}",
+            measurements,
+            prefixPath);
+      }
+    }
   }
 
   // endregion


### PR DESCRIPTION
## Description

### Problem 

see https://github.com/apache/iotdb/issues/7552

### Modification

The already existing timeseries shall directly be used in schema validation rather than causing a PathAlreadyExistException, thus ignore the exception generated by concurrent creation.
