### PR TITLE
[IOTDB-4584] Correct the ChunkMetadata proportion in writing TsFile

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -466,9 +466,9 @@ timestamp_precision=ms
 # Datatype: int
 # primitive_array_size=32
 
-# the percentage of write memory for chunk metadata remains in a single file writer when flushing memtable
+# size proportion for chunk metadata maintains in memory when writing tsfile
 # Datatype: double
-# chunk_metadata_size_proportion_in_write=0.1
+# chunk_metadata_size_proportion=0.1
 
 # Ratio of write memory for invoking flush disk, 0.4 by default
 # If you have extremely high write load (like batch=1000), it can be set lower than the default value like 0.2
@@ -586,9 +586,7 @@ timestamp_precision=ms
 # BALANCE: alternate two compaction types
 # compaction_priority=BALANCE
 
-# size proportion for chunk metadata maintains in memory when compacting
-# Datatype: double
-# chunk_metadata_size_proportion_in_compaction=0.05
+
 
 # The target tsfile size in compaction
 # Datatype: long, Unit: byte

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -586,8 +586,6 @@ timestamp_precision=ms
 # BALANCE: alternate two compaction types
 # compaction_priority=BALANCE
 
-
-
 # The target tsfile size in compaction
 # Datatype: long, Unit: byte
 # target_compaction_file_size=1073741824

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -152,8 +152,6 @@ public class IoTDBConfig {
   /** The proportion of write memory for memtable */
   private double writeProportion = 0.8;
 
-  private double chunkMetadataSizeProportionInWrite = 0.1;
-
   /** The proportion of write memory for compaction */
   private double compactionProportion = 0.2;
 
@@ -441,7 +439,7 @@ public class IoTDBConfig {
    */
   private CompactionPriority compactionPriority = CompactionPriority.BALANCE;
 
-  private double chunkMetadataSizeProportionInCompaction = 0.05;
+  private double chunkMetadataSizeProportion = 0.1;
 
   /** The target tsfile size in compaction, 1 GB by default */
   private long targetCompactionFileSize = 1073741824L;
@@ -3241,21 +3239,12 @@ public class IoTDBConfig {
     this.throttleThreshold = throttleThreshold;
   }
 
-  public double getChunkMetadataSizeProportionInWrite() {
-    return chunkMetadataSizeProportionInWrite;
+  public double getChunkMetadataSizeProportion() {
+    return chunkMetadataSizeProportion;
   }
 
-  public void setChunkMetadataSizeProportionInWrite(double chunkMetadataSizeProportionInWrite) {
-    this.chunkMetadataSizeProportionInWrite = chunkMetadataSizeProportionInWrite;
-  }
-
-  public double getChunkMetadataSizeProportionInCompaction() {
-    return chunkMetadataSizeProportionInCompaction;
-  }
-
-  public void setChunkMetadataSizeProportionInCompaction(
-      double chunkMetadataSizeProportionInCompaction) {
-    this.chunkMetadataSizeProportionInCompaction = chunkMetadataSizeProportionInCompaction;
+  public void setChunkMetadataSizeProportion(double chunkMetadataSizeProportion) {
+    this.chunkMetadataSizeProportion = chunkMetadataSizeProportion;
   }
 
   public long getCacheWindowTimeInMs() {
@@ -3427,5 +3416,9 @@ public class IoTDBConfig {
       long schemaRatisConsensusLeaderElectionTimeoutMaxMs) {
     this.schemaRatisConsensusLeaderElectionTimeoutMaxMs =
         schemaRatisConsensusLeaderElectionTimeoutMaxMs;
+  }
+
+  public double getUsableCompactionMemoryProportion() {
+    return 1.0d - chunkMetadataSizeProportion;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -630,11 +630,11 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "concurrent_compaction_thread",
                 Integer.toString(conf.getConcurrentCompactionThread()))));
-    conf.setChunkMetadataSizeProportionInCompaction(
+    conf.setChunkMetadataSizeProportion(
         Double.parseDouble(
             properties.getProperty(
-                "chunk_metadata_size_proportion_in_compaction",
-                Double.toString(conf.getChunkMetadataSizeProportionInCompaction()))));
+                "chunk_metadata_size_proportion",
+                Double.toString(conf.getChunkMetadataSizeProportion()))));
     conf.setTargetCompactionFileSize(
         Long.parseLong(
             properties.getProperty(
@@ -1472,12 +1472,6 @@ public class IoTDBDescriptor {
 
       // update tsfile-format config
       loadTsFileProps(properties);
-
-      conf.setChunkMetadataSizeProportionInWrite(
-          Double.parseDouble(
-              properties.getProperty(
-                  "chunk_metadata_size_proportion_in_write",
-                  Double.toString(conf.getChunkMetadataSizeProportionInWrite()))));
 
       // update max_deduplicated_path_num
       conf.setMaxQueryDeduplicatedPathNum(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
@@ -81,8 +81,11 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
     this.timePartition = timePartition;
     this.tsFileManager = tsFileManager;
     this.memoryBudget =
-        SystemInfo.getInstance().getMemorySizeForCompaction()
-            / IoTDBDescriptor.getInstance().getConfig().getConcurrentCompactionThread();
+        (long)
+            ((double)
+                    (SystemInfo.getInstance().getMemorySizeForCompaction()
+                        / IoTDBDescriptor.getInstance().getConfig().getConcurrentCompactionThread())
+                * config.getUsableCompactionMemoryProportion());
     this.maxCrossCompactionFileNum =
         IoTDBDescriptor.getInstance().getConfig().getMaxCrossCompactionCandidateFileNum();
     this.maxCrossCompactionFileSize =

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadChunkCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/ReadChunkCompactionPerformer.java
@@ -69,9 +69,7 @@ public class ReadChunkCompactionPerformer implements ISeqCompactionPerformer {
         (long)
             (SystemInfo.getInstance().getMemorySizeForCompaction()
                 / IoTDBDescriptor.getInstance().getConfig().getConcurrentCompactionThread()
-                * IoTDBDescriptor.getInstance()
-                    .getConfig()
-                    .getChunkMetadataSizeProportionInCompaction());
+                * IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion());
     try (MultiTsFileDeviceIterator deviceIterator = new MultiTsFileDeviceIterator(seqFiles);
         TsFileIOWriter writer =
             new TsFileIOWriter(targetResource.getTsFile(), true, sizeForFileWriter)) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/CrossSpaceCompactionWriter.java
@@ -79,9 +79,7 @@ public class CrossSpaceCompactionWriter extends AbstractCompactionWriter {
         (long)
             (SystemInfo.getInstance().getMemorySizeForCompaction()
                 / IoTDBDescriptor.getInstance().getConfig().getConcurrentCompactionThread()
-                * IoTDBDescriptor.getInstance()
-                    .getConfig()
-                    .getChunkMetadataSizeProportionInCompaction()
+                * IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion()
                 / targetResources.size());
     for (int i = 0; i < targetResources.size(); i++) {
       this.fileWriterList.add(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/InnerSpaceCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/InnerSpaceCompactionWriter.java
@@ -48,9 +48,7 @@ public class InnerSpaceCompactionWriter extends AbstractCompactionWriter {
         (long)
             (SystemInfo.getInstance().getMemorySizeForCompaction()
                 / IoTDBDescriptor.getInstance().getConfig().getConcurrentCompactionThread()
-                * IoTDBDescriptor.getInstance()
-                    .getConfig()
-                    .getChunkMetadataSizeProportionInCompaction());
+                * IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion());
     this.fileWriter = new TsFileIOWriter(targetFileResource.getTsFile(), true, sizeForFileWriter);
     isEmptyFile = true;
     resource = targetFileResource;

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -113,7 +113,7 @@ public class MemTableFlushTask {
                   * config.getIoTaskQueueSizeForFlushing();
       long memorySizeForMetadata =
           (long)
-              (IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportionInWrite()
+              (IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion()
                   * memTable.memSize());
       writer.setMemorySizeForMetadata(memorySizeForMetadata);
       estimatedTemporaryMemSize += memorySizeForMetadata;

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -111,6 +111,12 @@ public class MemTableFlushTask {
               : memTable.memSize()
                   / memTable.getSeriesNumber()
                   * config.getIoTaskQueueSizeForFlushing();
+      long memorySizeForMetadata =
+          (long)
+              (IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportionInWrite()
+                  * estimatedTemporaryMemSize);
+      writer.setMemorySizeForMetadata(memorySizeForMetadata);
+      estimatedTemporaryMemSize += memorySizeForMetadata;
       SystemInfo.getInstance().applyTemporaryMemoryForFlushing(estimatedTemporaryMemSize);
     }
     long start = System.currentTimeMillis();

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -114,7 +114,7 @@ public class MemTableFlushTask {
       long memorySizeForMetadata =
           (long)
               (IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportionInWrite()
-                  * estimatedTemporaryMemSize);
+                  * memTable.memSize());
       writer.setMemorySizeForMetadata(memorySizeForMetadata);
       estimatedTemporaryMemSize += memorySizeForMetadata;
       SystemInfo.getInstance().applyTemporaryMemoryForFlushing(estimatedTemporaryMemSize);

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -288,7 +288,6 @@ public class MemTableFlushTask {
               this.writer.endChunkGroup();
             } else {
               ((IChunkWriter) ioMessage).writeToFileWriter(this.writer);
-              writer.checkMetadataSizeAndMayFlush();
             }
           } catch (IOException e) {
             LOGGER.error(

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -111,12 +111,6 @@ public class MemTableFlushTask {
               : memTable.memSize()
                   / memTable.getSeriesNumber()
                   * config.getIoTaskQueueSizeForFlushing();
-      long memorySizeForMetadata =
-          (long)
-              (IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion()
-                  * memTable.memSize());
-      writer.setMemorySizeForMetadata(memorySizeForMetadata);
-      estimatedTemporaryMemSize += memorySizeForMetadata;
       SystemInfo.getInstance().applyTemporaryMemoryForFlushing(estimatedTemporaryMemSize);
     }
     long start = System.currentTimeMillis();

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -184,9 +184,7 @@ public class TsFileProcessor {
             tsfile,
             (long)
                 (IoTDBDescriptor.getInstance().getConfig().getMemtableSizeThreshold()
-                    * IoTDBDescriptor.getInstance()
-                        .getConfig()
-                        .getChunkMetadataSizeProportionInWrite()));
+                    * IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion()));
     this.updateLatestFlushTimeCallback = updateLatestFlushTimeCallback;
     this.sequence = sequence;
     this.walNode = WALManager.getInstance().applyForWALNode(storageGroupName);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -179,12 +179,7 @@ public class TsFileProcessor {
     this.storageGroupName = storageGroupName;
     this.tsFileResource = new TsFileResource(tsfile, this);
     this.storageGroupInfo = storageGroupInfo;
-    this.writer =
-        new RestorableTsFileIOWriter(
-            tsfile,
-            (long)
-                (IoTDBDescriptor.getInstance().getConfig().getMemtableSizeThreshold()
-                    * IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion()));
+    this.writer = new RestorableTsFileIOWriter(tsfile);
     this.updateLatestFlushTimeCallback = updateLatestFlushTimeCallback;
     this.sequence = sequence;
     this.walNode = WALManager.getInstance().applyForWALNode(storageGroupName);

--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/file/AbstractTsFileRecoverPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/file/AbstractTsFileRecoverPerformer.java
@@ -84,7 +84,7 @@ public abstract class AbstractTsFileRecoverPerformer implements Closeable {
                   (IoTDBDescriptor.getInstance().getConfig().getMemtableSizeThreshold()
                       * IoTDBDescriptor.getInstance()
                           .getConfig()
-                          .getChunkMetadataSizeProportionInWrite()));
+                          .getChunkMetadataSizeProportion()));
     } catch (NotCompatibleTsFileException e) {
       boolean result = tsFile.delete();
       logger.warn(

--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/file/AbstractTsFileRecoverPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/file/AbstractTsFileRecoverPerformer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.wal.recover.file;
 
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.DataRegionException;
 import org.apache.iotdb.db.utils.FileLoaderUtils;
@@ -77,14 +76,7 @@ public abstract class AbstractTsFileRecoverPerformer implements Closeable {
 
     // try to remove corrupted part of the TsFile
     try {
-      writer =
-          new RestorableTsFileIOWriter(
-              tsFile,
-              (long)
-                  (IoTDBDescriptor.getInstance().getConfig().getMemtableSizeThreshold()
-                      * IoTDBDescriptor.getInstance()
-                          .getConfig()
-                          .getChunkMetadataSizeProportion()));
+      writer = new RestorableTsFileIOWriter(tsFile);
     } catch (NotCompatibleTsFileException e) {
       boolean result = tsFile.delete();
       logger.warn(

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -691,8 +691,4 @@ public class TsFileIOWriter implements AutoCloseable {
   public String getCurrentChunkGroupDeviceId() {
     return currentChunkGroupDeviceId;
   }
-
-  public void setMemorySizeForMetadata(long size) {
-    maxMetadataSize = size;
-  }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -691,4 +691,8 @@ public class TsFileIOWriter implements AutoCloseable {
   public String getCurrentChunkGroupDeviceId() {
     return currentChunkGroupDeviceId;
   }
+
+  public void setMemorySizeForMetadata(long size) {
+    maxMetadataSize = size;
+  }
 }


### PR DESCRIPTION
See [IOTDB-4584](https://issues.apache.org/jira/browse/IOTDB-4584).

This PR calculates the budget of metadata by the size of memtable before flushing memtable, the external size for metadata is managed by `SystemInfo`.