### PR TITLE
[IOTDB-4609] Add more progress tips for remove-datanode and make deleteOldPeer available in ratis 1 replica situation

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConstant.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConstant.java
@@ -45,6 +45,8 @@ public class ConfigNodeConstant {
   public static final String METRIC_STATUS_ONLINE = "Online";
   public static final String METRIC_STATUS_UNKNOWN = "Unknown";
 
+  public static final String REMOVE_DATANODE_PROCESS = "[REMOVE_DATANODE_PROCESS]";
+
   private ConfigNodeConstant() {
     // empty constructor
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeRemoveCheck.java
@@ -40,6 +40,7 @@ import java.util.Properties;
 import static org.apache.commons.lang3.StringUtils.isNumeric;
 
 public class ConfigNodeRemoveCheck {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigNodeStartupCheck.class);
 
   private static final ConfigNodeConfig CONF = ConfigNodeDescriptor.getInstance().getConf();

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
@@ -62,6 +62,8 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static org.apache.iotdb.confignode.conf.ConfigNodeConstant.REMOVE_DATANODE_PROCESS;
+
 /**
  * The NodeInfo stores cluster node information. The cluster node information including: 1. DataNode
  * information 2. ConfigNode information
@@ -167,7 +169,8 @@ public class NodeInfo implements SnapshotProcessor {
    */
   public TSStatus removeDataNode(RemoveDataNodePlan req) {
     LOGGER.info(
-        "there are {} data node in cluster before executed remove-datanode.sh",
+        "{}, There are {} data node in cluster before executed remove-datanode.sh",
+        REMOVE_DATANODE_PROCESS,
         registeredDataNodes.size());
     try {
       dataNodeInfoReadWriteLock.writeLock().lock();
@@ -181,7 +184,8 @@ public class NodeInfo implements SnapshotProcessor {
       dataNodeInfoReadWriteLock.writeLock().unlock();
     }
     LOGGER.info(
-        "there are {} data node in cluster after executed remove-datanode.sh",
+        "{}, There are {} data node in cluster after executed remove-datanode.sh",
+        REMOVE_DATANODE_PROCESS,
         registeredDataNodes.size());
     return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/NodeInfo.java
@@ -166,7 +166,9 @@ public class NodeInfo implements SnapshotProcessor {
    * @return TSStatus
    */
   public TSStatus removeDataNode(RemoveDataNodePlan req) {
-    LOGGER.info("there are {} data node in cluster before remove some", registeredDataNodes.size());
+    LOGGER.info(
+        "there are {} data node in cluster before executed remove-datanode.sh",
+        registeredDataNodes.size());
     try {
       dataNodeInfoReadWriteLock.writeLock().lock();
       req.getDataNodeLocations()
@@ -178,7 +180,9 @@ public class NodeInfo implements SnapshotProcessor {
     } finally {
       dataNodeInfoReadWriteLock.writeLock().unlock();
     }
-    LOGGER.info("there are {} data node in cluster after remove some", registeredDataNodes.size());
+    LOGGER.info(
+        "there are {} data node in cluster after executed remove-datanode.sh",
+        registeredDataNodes.size());
     return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/DataNodeRemoveHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/DataNodeRemoveHandler.java
@@ -559,10 +559,10 @@ public class DataNodeRemoveHandler {
   /**
    * Filter a DataNode who contains other RegionReplica excepts the given one.
    *
-   * <p> Choose the RUNNING status datanode firstly, if no RUNNING status datanode match the condition,
-   * then we choose the REMOVING status datanode.
+   * <p>Choose the RUNNING status datanode firstly, if no RUNNING status datanode match the
+   * condition, then we choose the REMOVING status datanode.
    *
-   * <p> `addRegionPeer`, `removeRegionPeer` and `changeRegionLeader` invoke this method.
+   * <p>`addRegionPeer`, `removeRegionPeer` and `changeRegionLeader` invoke this method.
    *
    * @param regionId The specific RegionId
    * @param filterLocation The DataNodeLocation that should be filtered

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/DataNodeRemoveHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/DataNodeRemoveHandler.java
@@ -557,7 +557,12 @@ public class DataNodeRemoveHandler {
   }
 
   /**
-   * Filter a DataNode who contains other RegionReplica excepts the given one
+   * Filter a DataNode who contains other RegionReplica excepts the given one.
+   *
+   * <p> Choose the RUNNING status datanode firstly, if no RUNNING status datanode match the condition,
+   * then we choose the REMOVING status datanode.
+   *
+   * <p> `addRegionPeer`, `removeRegionPeer` and `changeRegionLeader` invoke this method.
    *
    * @param regionId The specific RegionId
    * @param filterLocation The DataNodeLocation that should be filtered

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/node/RemoveDataNodeProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/node/RemoveDataNodeProcedure.java
@@ -38,6 +38,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.iotdb.confignode.conf.ConfigNodeConstant.REMOVE_DATANODE_PROCESS;
+
 /** remove data node procedure */
 public class RemoveDataNodeProcedure extends AbstractNodeProcedure<RemoveDataNodeState> {
   private static final Logger LOG = LoggerFactory.getLogger(RemoveDataNodeProcedure.class);
@@ -68,7 +70,10 @@ public class RemoveDataNodeProcedure extends AbstractNodeProcedure<RemoveDataNod
           env.markDataNodeAsRemovingAndBroadCast(disableDataNodeLocation);
           execDataNodeRegionIds =
               env.getDataNodeRemoveHandler().getDataNodeRegionIds(disableDataNodeLocation);
-          LOG.info("DataNode region id is {}", execDataNodeRegionIds);
+          LOG.info(
+              "{}, DataNode regions to be removed is {}",
+              REMOVE_DATANODE_PROCESS,
+              execDataNodeRegionIds);
           setNextState(RemoveDataNodeState.BROADCAST_DISABLE_DATA_NODE);
           break;
         case BROADCAST_DISABLE_DATA_NODE:

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/statemachine/RegionMigrateProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/statemachine/RegionMigrateProcedure.java
@@ -142,7 +142,7 @@ public class RegionMigrateProcedure
         setFailure(new ProcedureException("Region migrate failed at state: " + state));
       } else {
         LOG.error(
-            "{}, Failed state is not support rollback, filed state {}, originalDataNode: {}",
+            "{}, Failed state is not support rollback, failed state {}, originalDataNode: {}",
             REMOVE_DATANODE_PROCESS,
             state,
             originalDataNode);

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
@@ -72,8 +72,8 @@ public class NodeUrlUtils {
   public static TEndPoint parseTEndPointUrl(String endPointUrl) throws BadNodeUrlException {
     String[] split = endPointUrl.split(":");
     if (split.length != 2) {
-      logger.warn("Bad node url: {}, please check the IP:PORT inputs", endPointUrl);
-      throw new BadNodeUrlException(String.format("Bad node url: %s", endPointUrl));
+      logger.warn("Illegal endpoint url format: {}", endPointUrl);
+      throw new BadNodeUrlException(String.format("Bad endpoint url: %s", endPointUrl));
     }
     String ip = split[0];
     TEndPoint result;
@@ -81,7 +81,7 @@ public class NodeUrlUtils {
       int port = Integer.parseInt(split[1]);
       result = new TEndPoint(ip, port);
     } catch (NumberFormatException e) {
-      logger.warn("Bad node url: {}, please check the IP:PORT inputs", endPointUrl);
+      logger.warn("Illegal endpoint url format: {}", endPointUrl);
       throw new BadNodeUrlException(String.format("Bad node url: %s", endPointUrl));
     }
     return result;

--- a/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
@@ -262,7 +262,7 @@ public class ConfigNodeClient
         configLeader = null;
       }
       logger.warn(
-          "Failed to connect to ConfigNode {} from DataNode {},because the current node is not leader,try next node",
+          "Failed to connect to ConfigNode {} from DataNode {}, because the current node is not leader, try next node",
           configNode,
           config.getAddressAndPort());
       return true;

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNodeServerCommandLine.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNodeServerCommandLine.java
@@ -117,7 +117,7 @@ public class DataNodeServerCommandLine extends ServerCommandLine {
     if (dataNodeLocations.isEmpty()) {
       throw new BadNodeUrlException("No DataNode to remove");
     }
-    logger.info("Start to remove datanode, detail:{}", dataNodeLocations);
+    logger.info("Start to remove datanode, removed datanode: {}", dataNodeLocations);
     TDataNodeRemoveReq removeReq = new TDataNodeRemoveReq(dataNodeLocations);
     try (ConfigNodeClient configNodeClient = new ConfigNodeClient()) {
       TDataNodeRemoveResp removeResp = configNodeClient.removeDataNode(removeReq);


### PR DESCRIPTION
## Description

1. Fix the problem when ratis 1 replica is migrated failed. Now support Ratis 1 replica SchemaRegion deleteOldRegionPeer.

2. Add `REMOVE_DATANODE_PROCESS` logs for the progress of removing datanode and region migration.

3. Now can choose the Removing datanode to execute `addPeer` process.
