### PR TITLE
[IOTDB-4578] Refactor: Use rename to guarantee snapshot atomicity

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.concurrent.CompletableFuture;
@@ -221,7 +220,12 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
     try {
       Files.move(snapshotTmpDir.toPath(), snapshotDir.toPath(), StandardCopyOption.ATOMIC_MOVE);
     } catch (IOException e) {
-      logger.error("{} atomic rename {} to {} failed with exception {}", this, snapshotTmpDir, snapshotDir, e);
+      logger.error(
+          "{} atomic rename {} to {} failed with exception {}",
+          this,
+          snapshotTmpDir,
+          snapshotDir,
+          e);
       deleteIncompleteSnapshot(snapshotTmpDir);
       return RaftLog.INVALID_LOG_INDEX;
     }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -169,6 +169,7 @@ public class SnapshotStorage implements StateMachineStorage {
   }
 
   public File getSnapshotTmpDir(String snapshotMetadata) {
-    return new File(stateMachineDir.getAbsolutePath() + File.separator + TMP_PREFIX + snapshotMetadata);
+    return new File(
+        stateMachineDir.getAbsolutePath() + File.separator + TMP_PREFIX + snapshotMetadata);
   }
 }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
@@ -34,7 +34,6 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Scanner;


### PR DESCRIPTION
Currently, Ratis Consensus guarantees atomicity guarantee by adding metafile.
We should now use temp directory and rename operation to guarantee atomicity.