### PR TITLE
[IOTDB-4250][IOTDB-4628] Support multiple pipes and update drop semantics

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlan.java
@@ -61,6 +61,7 @@ import org.apache.iotdb.confignode.consensus.request.write.storagegroup.SetStora
 import org.apache.iotdb.confignode.consensus.request.write.storagegroup.SetTTLPlan;
 import org.apache.iotdb.confignode.consensus.request.write.storagegroup.SetTimePartitionIntervalPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.CreatePipeSinkPlan;
+import org.apache.iotdb.confignode.consensus.request.write.sync.DropPipePlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.DropPipeSinkPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.GetPipeSinkPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.PreCreatePipePlan;
@@ -282,6 +283,9 @@ public abstract class ConfigPhysicalPlan implements IConsensusRequest {
           break;
         case SetPipeStatus:
           req = new SetPipeStatusPlan();
+          break;
+        case DropPipe:
+          req = new DropPipePlan();
           break;
         case ShowPipe:
           req = new ShowPipePlan();

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanType.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanType.java
@@ -83,6 +83,7 @@ public enum ConfigPhysicalPlanType {
   GetPipeSink,
   PreCreatePipe,
   SetPipeStatus,
+  DropPipe,
   ShowPipe,
   AddTriggerInTable,
   DeleteTriggerInTable,

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/sync/DropPipePlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/sync/DropPipePlan.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.confignode.consensus.request.write.sync;
+
+import org.apache.iotdb.commons.utils.BasicStructureSerDeUtil;
+import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
+import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class DropPipePlan extends ConfigPhysicalPlan {
+
+  private String pipeName;
+
+  public DropPipePlan() {
+    super(ConfigPhysicalPlanType.DropPipe);
+  }
+
+  public DropPipePlan(String pipeName) {
+    this();
+    this.pipeName = pipeName;
+  }
+
+  public String getPipeName() {
+    return pipeName;
+  }
+
+  @Override
+  protected void serializeImpl(DataOutputStream stream) throws IOException {
+    stream.writeInt(ConfigPhysicalPlanType.DropPipe.ordinal());
+    BasicStructureSerDeUtil.write(pipeName, stream);
+  }
+
+  @Override
+  protected void deserializeImpl(ByteBuffer buffer) throws IOException {
+    pipeName = BasicStructureSerDeUtil.readString(buffer);
+  }
+}

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/SyncManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/SyncManager.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.exception.sync.PipeException;
 import org.apache.iotdb.commons.exception.sync.PipeSinkException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkNotExistException;
 import org.apache.iotdb.commons.sync.pipe.PipeInfo;
 import org.apache.iotdb.commons.sync.pipe.PipeStatus;
 import org.apache.iotdb.commons.sync.pipe.SyncOperation;
@@ -112,7 +113,7 @@ public class SyncManager {
   // region Implement of Pipe
   // ======================================================
 
-  public void checkAddPipe(PipeInfo pipeInfo) throws PipeException {
+  public void checkAddPipe(PipeInfo pipeInfo) throws PipeException, PipeSinkNotExistException {
     clusterSyncInfo.checkAddPipe(pipeInfo);
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/SyncManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/SyncManager.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.confignode.client.DataNodeRequestType;
 import org.apache.iotdb.confignode.client.async.AsyncDataNodeClientPool;
 import org.apache.iotdb.confignode.client.async.handlers.AsyncClientHandler;
 import org.apache.iotdb.confignode.consensus.request.write.sync.CreatePipeSinkPlan;
+import org.apache.iotdb.confignode.consensus.request.write.sync.DropPipePlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.DropPipeSinkPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.GetPipeSinkPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.PreCreatePipePlan;
@@ -122,6 +123,10 @@ public class SyncManager {
 
   public TSStatus setPipeStatus(String pipeName, PipeStatus pipeStatus) {
     return getConsensusManager().write(new SetPipeStatusPlan(pipeName, pipeStatus)).getStatus();
+  }
+
+  public TSStatus dropPipe(String pipeName) {
+    return getConsensusManager().write(new DropPipePlan(pipeName)).getStatus();
   }
 
   public TShowPipeResp showPipe(String pipeName) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -60,6 +60,7 @@ import org.apache.iotdb.confignode.consensus.request.write.storagegroup.SetStora
 import org.apache.iotdb.confignode.consensus.request.write.storagegroup.SetTTLPlan;
 import org.apache.iotdb.confignode.consensus.request.write.storagegroup.SetTimePartitionIntervalPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.CreatePipeSinkPlan;
+import org.apache.iotdb.confignode.consensus.request.write.sync.DropPipePlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.DropPipeSinkPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.GetPipeSinkPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.PreCreatePipePlan;
@@ -276,7 +277,9 @@ public class ConfigPlanExecutor {
       case PreCreatePipe:
         return syncInfo.preCreatePipe((PreCreatePipePlan) physicalPlan);
       case SetPipeStatus:
-        return syncInfo.operatePipe((SetPipeStatusPlan) physicalPlan);
+        return syncInfo.setPipeStatus((SetPipeStatusPlan) physicalPlan);
+      case DropPipe:
+        return syncInfo.dropPipe((DropPipePlan) physicalPlan);
       default:
         throw new UnknownPhysicalPlanTypeException(physicalPlan.getType());
     }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.exception.sync.PipeException;
 import org.apache.iotdb.commons.exception.sync.PipeNotExistException;
 import org.apache.iotdb.commons.exception.sync.PipeSinkException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkNotExistException;
 import org.apache.iotdb.commons.snapshot.SnapshotProcessor;
 import org.apache.iotdb.commons.sync.metadata.SyncMetadata;
 import org.apache.iotdb.commons.sync.pipe.PipeInfo;
@@ -122,7 +123,7 @@ public class ClusterSyncInfo implements SnapshotProcessor {
    * @param pipeInfo pipe info
    * @throws PipeException if there is Pipe with the same name exists or PipeSink does not exist
    */
-  public void checkAddPipe(PipeInfo pipeInfo) throws PipeException {
+  public void checkAddPipe(PipeInfo pipeInfo) throws PipeException, PipeSinkNotExistException {
     syncMetadata.checkAddPipe(pipeInfo);
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.commons.snapshot.SnapshotProcessor;
 import org.apache.iotdb.commons.sync.metadata.SyncMetadata;
 import org.apache.iotdb.commons.sync.pipe.PipeInfo;
 import org.apache.iotdb.confignode.consensus.request.write.sync.CreatePipeSinkPlan;
+import org.apache.iotdb.confignode.consensus.request.write.sync.DropPipePlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.DropPipeSinkPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.GetPipeSinkPlan;
 import org.apache.iotdb.confignode.consensus.request.write.sync.PreCreatePipePlan;
@@ -132,7 +133,7 @@ public class ClusterSyncInfo implements SnapshotProcessor {
     return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
   }
 
-  public TSStatus operatePipe(SetPipeStatusPlan physicalPlan) {
+  public TSStatus setPipeStatus(SetPipeStatusPlan physicalPlan) {
     TSStatus status = new TSStatus();
     try {
       syncMetadata.setPipeStatus(physicalPlan.getPipeName(), physicalPlan.getPipeStatus());
@@ -143,6 +144,11 @@ public class ClusterSyncInfo implements SnapshotProcessor {
       LOGGER.error(e.getMessage());
     }
     return status;
+  }
+
+  public TSStatus dropPipe(DropPipePlan physicalPlan) {
+    syncMetadata.dropPipe(physicalPlan.getPipeName());
+    return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
   }
 
   public PipeResp showPipe(ShowPipePlan plan) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
@@ -45,9 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 public class ClusterSyncInfo implements SnapshotProcessor {
 
@@ -153,18 +151,12 @@ public class ClusterSyncInfo implements SnapshotProcessor {
 
   public PipeResp showPipe(ShowPipePlan plan) {
     PipeResp resp = new PipeResp();
-    // TODO(sync): optimize logic later
-    List<PipeInfo> allPipeInfos = syncMetadata.getAllPipeInfos();
     if (StringUtils.isEmpty(plan.getPipeName())) {
-      resp.setPipeInfoList(allPipeInfos);
+      // show all
+      resp.setPipeInfoList(syncMetadata.getAllPipeInfos());
     } else {
-      List<PipeInfo> pipeInfoList = new ArrayList<>();
-      for (PipeInfo pipeInfo : allPipeInfos) {
-        if (plan.getPipeName().equals(pipeInfo.getPipeName())) {
-          pipeInfoList.add(pipeInfo);
-        }
-      }
-      resp.setPipeInfoList(pipeInfoList);
+      // show specific pipe
+      resp.setPipeInfoList(Collections.singletonList(syncMetadata.getPipeInfo(plan.getPipeName())));
     }
     resp.setStatus(RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS));
     return resp;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
@@ -171,8 +171,8 @@ public class ClusterSyncInfo implements SnapshotProcessor {
    * @throws PipeNotExistException if there is Pipe does not exist
    */
   public PipeInfo getPipeInfo(String pipeName) throws PipeNotExistException {
-    PipeInfo pipeInfo = syncMetadata.getRunningPipeInfo();
-    if (pipeInfo == null || !pipeInfo.getPipeName().equals(pipeName)) {
+    PipeInfo pipeInfo = syncMetadata.getPipeInfo(pipeName);
+    if (pipeInfo == null) {
       throw new PipeNotExistException(pipeName);
     }
     return pipeInfo;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
@@ -132,16 +132,8 @@ public class ClusterSyncInfo implements SnapshotProcessor {
   }
 
   public TSStatus setPipeStatus(SetPipeStatusPlan physicalPlan) {
-    TSStatus status = new TSStatus();
-    try {
-      syncMetadata.setPipeStatus(physicalPlan.getPipeName(), physicalPlan.getPipeStatus());
-      status.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
-    } catch (PipeException e) {
-      LOGGER.error("failed to execute OperatePipePlan {} on ClusterSyncInfo", physicalPlan, e);
-      status.setCode(TSStatusCode.PIPE_ERROR.getStatusCode());
-      LOGGER.error(e.getMessage());
-    }
-    return status;
+    syncMetadata.setPipeStatus(physicalPlan.getPipeName(), physicalPlan.getPipeStatus());
+    return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
   }
 
   public TSStatus dropPipe(DropPipePlan physicalPlan) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/AbstractOperatePipeProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/AbstractOperatePipeProcedure.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.confignode.procedure.impl.sync;
 
 import org.apache.iotdb.commons.exception.sync.PipeException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkException;
 import org.apache.iotdb.commons.sync.pipe.SyncOperation;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
@@ -44,7 +45,8 @@ abstract class AbstractOperatePipeProcedure
    *
    * @return true if procedure can finish directly
    */
-  abstract boolean executeCheckCanSkip(ConfigNodeProcedureEnv env) throws PipeException;
+  abstract boolean executeCheckCanSkip(ConfigNodeProcedureEnv env)
+      throws PipeException, PipeSinkException;
 
   /** Execute at state PRE_OPERATE_PIPE_CONFIGNODE */
   abstract void executePreOperatePipeOnConfigNode(ConfigNodeProcedureEnv env) throws PipeException;
@@ -80,7 +82,7 @@ abstract class AbstractOperatePipeProcedure
           executeOperatePipeOnConfigNode(env);
           return Flow.NO_MORE_STATE;
       }
-    } catch (PipeException e) {
+    } catch (PipeException | PipeSinkException e) {
       if (isRollbackSupported(state)) {
         LOGGER.error("Fail in OperatePipeProcedure", e);
         setFailure(new ProcedureException(e.getMessage()));

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/CreatePipeProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/CreatePipeProcedure.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.confignode.procedure.impl.sync;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.exception.sync.PipeException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkException;
 import org.apache.iotdb.commons.sync.pipe.PipeInfo;
 import org.apache.iotdb.commons.sync.pipe.PipeStatus;
 import org.apache.iotdb.commons.sync.pipe.SyncOperation;
@@ -55,7 +56,7 @@ public class CreatePipeProcedure extends AbstractOperatePipeProcedure {
   }
 
   @Override
-  boolean executeCheckCanSkip(ConfigNodeProcedureEnv env) throws PipeException {
+  boolean executeCheckCanSkip(ConfigNodeProcedureEnv env) throws PipeException, PipeSinkException {
     LOGGER.info("Start to create PIPE [{}]", pipeInfo.getPipeName());
     env.getConfigManager().getSyncManager().checkAddPipe(pipeInfo);
     return false;

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
@@ -65,9 +65,19 @@ public class IoTDBPipeIT {
   public void testOperatePipe() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
+
+      try {
+        // check exception1: PIPESINK not exist
+        statement.execute("CREATE PIPE p to demo;");
+        Assert.fail();
+      } catch (Exception e) {
+        Assert.assertTrue(e.getMessage().contains("Can not find PIPESINK [demo]"));
+      }
+
       statement.execute(
           String.format("CREATE PIPESINK demo AS IoTDB (ip='%s',port='%d');", ip, port));
-      statement.execute("CREATE PIPE p to demo;");
+      statement.execute("CREATE PIPE p1 to demo;");
+      statement.execute("CREATE PIPE p2 to demo;");
       String expectedHeader =
           ColumnHeaderConstant.COLUMN_PIPE_CREATE_TIME
               + ","
@@ -82,33 +92,74 @@ public class IoTDBPipeIT {
               + ColumnHeaderConstant.COLUMN_PIPE_MESSAGE
               + ",";
 
-      String createTime = getCreateTime("p");
+      // check pipe operation
+      String createTime1 = getCreateTime("p1");
+      String createTime2 = getCreateTime("p2");
       try (ResultSet resultSet = statement.executeQuery("SHOW PIPE")) {
         String[] expectedRetSet =
-            new String[] {String.format("%s,p,sender,demo,STOP,NORMAL,", createTime)};
+            new String[] {
+              String.format("%s,p1,sender,demo,STOP,NORMAL,", createTime1),
+              String.format("%s,p2,sender,demo,STOP,NORMAL,", createTime2)
+            };
         assertResultSetEqual(resultSet, expectedHeader, expectedRetSet);
       }
-      statement.execute("START PIPE p;");
+      statement.execute("START PIPE p1;");
       try (ResultSet resultSet = statement.executeQuery("SHOW PIPE")) {
         String[] expectedRetSet =
             new String[] {
               // there is no data now, so no connection in receiver
-              String.format("%s,p,sender,demo,RUNNING,NORMAL,", createTime),
+              String.format("%s,p1,sender,demo,RUNNING,NORMAL,", createTime1),
+              String.format("%s,p2,sender,demo,STOP,NORMAL,", createTime2)
             };
         assertResultSetEqual(resultSet, expectedHeader, expectedRetSet);
       }
-      statement.execute("STOP PIPE p;");
+      statement.execute("START PIPE p2;");
       try (ResultSet resultSet = statement.executeQuery("SHOW PIPE")) {
         String[] expectedRetSet =
-            new String[] {String.format("%s,p,sender,demo,STOP,NORMAL,", createTime)};
+            new String[] {
+              // there is no data now, so no connection in receiver
+              String.format("%s,p1,sender,demo,RUNNING,NORMAL,", createTime1),
+              String.format("%s,p2,sender,demo,RUNNING,NORMAL,", createTime2)
+            };
         assertResultSetEqual(resultSet, expectedHeader, expectedRetSet);
       }
-      statement.execute("DROP PIPE p;");
+      try (ResultSet resultSet = statement.executeQuery("SHOW PIPE p1")) {
+        String[] expectedRetSet =
+            new String[] {String.format("%s,p1,sender,demo,RUNNING,NORMAL,", createTime1)};
+        assertResultSetEqual(resultSet, expectedHeader, expectedRetSet);
+      }
+      statement.execute("STOP PIPE p1;");
       try (ResultSet resultSet = statement.executeQuery("SHOW PIPE")) {
         String[] expectedRetSet =
-            new String[] {String.format("%s,p,sender,demo,DROP,NORMAL,", createTime)};
+            new String[] {
+              String.format("%s,p1,sender,demo,STOP,NORMAL,", createTime1),
+              String.format("%s,p2,sender,demo,RUNNING,NORMAL,", createTime2)
+            };
         assertResultSetEqual(resultSet, expectedHeader, expectedRetSet);
       }
+      statement.execute("DROP PIPE p1;");
+      try (ResultSet resultSet = statement.executeQuery("SHOW PIPE")) {
+        String[] expectedRetSet =
+            new String[] {String.format("%s,p2,sender,demo,RUNNING,NORMAL,", createTime2)};
+        assertResultSetEqual(resultSet, expectedHeader, expectedRetSet);
+      }
+
+      try {
+        // check exception2: PIPE already exist
+        statement.execute("CREATE PIPE p2 to demo;");
+        Assert.fail();
+      } catch (Exception e) {
+        Assert.assertTrue(
+            e.getMessage().contains("PIPE [p2] is RUNNING, please retry after drop it"));
+      }
+      try {
+        // check exception3: PIPE not exist
+        statement.execute("START PIPE p;");
+        Assert.fail();
+      } catch (Exception e) {
+        Assert.assertTrue(e.getMessage().contains("PIPE [p] does not exist"));
+      }
+
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail();

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
@@ -71,7 +71,7 @@ public class IoTDBPipeIT {
         statement.execute("CREATE PIPE p to demo;");
         Assert.fail();
       } catch (Exception e) {
-        Assert.assertTrue(e.getMessage().contains("Can not find PIPESINK [demo]"));
+        Assert.assertTrue(e.getMessage().contains("PIPESINK [demo] does not exist"));
       }
 
       statement.execute(

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeSinkIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeSinkIT.java
@@ -76,10 +76,7 @@ public class IoTDBPipeSinkIT {
         statement.execute("CREATE PIPESINK demo2 AS IoTDB (ip='192.168.0.2',port='6678');");
         Assert.fail();
       } catch (Exception e) {
-        Assert.assertTrue(
-            e.getMessage()
-                .contains(
-                    "There is a PipeSink named demo2 in IoTDB, please drop it before recreation."));
+        Assert.assertTrue(e.getMessage().contains("PIPESINK [demo2] already exists in IoTDB."));
       }
       statement.execute("CREATE PIPESINK demo3 AS IoTDB;");
       statement.execute("DROP PIPESINK demo2;");
@@ -87,7 +84,7 @@ public class IoTDBPipeSinkIT {
         statement.execute("DROP PIPESINK demo2;");
         Assert.fail();
       } catch (Exception e) {
-        Assert.assertTrue(e.getMessage().contains("PipeSink demo2 does not exist."));
+        Assert.assertTrue(e.getMessage().contains("PIPESINK [demo2] does not exist"));
       }
       String expectedHeader =
           ColumnHeaderConstant.COLUMN_PIPESINK_NAME

--- a/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeAlreadyExistException.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeAlreadyExistException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.commons.exception.sync;
+
+import org.apache.iotdb.commons.sync.pipe.PipeStatus;
+
+public class PipeAlreadyExistException extends PipeException {
+  public PipeAlreadyExistException(String pipeName) {
+    super(String.format("PIPE [%s] already exists in IoTDB.", pipeName));
+  }
+
+  public PipeAlreadyExistException(String pipeName, PipeStatus status) {
+    super(String.format("PIPE [%s] is %s, please retry after drop it.", pipeName, status.name()));
+  }
+}

--- a/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeNotExistException.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeNotExistException.java
@@ -19,10 +19,6 @@
 package org.apache.iotdb.commons.exception.sync;
 
 public class PipeNotExistException extends PipeException {
-  public PipeNotExistException(String pipeName, int errorCode) {
-    super(String.format("PIPE [%s] does not exist", pipeName), errorCode);
-  }
-
   public PipeNotExistException(String pipeName) {
     super(String.format("PIPE [%s] does not exist", pipeName));
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeSinkAlreadyExistException.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeSinkAlreadyExistException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.commons.exception.sync;
+
+public class PipeSinkAlreadyExistException extends PipeSinkException {
+  public PipeSinkAlreadyExistException(String pipeSinkName) {
+    super(String.format("PIPESINK [%s] already exists in IoTDB.", pipeSinkName));
+  }
+}

--- a/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeSinkBeingUsedException.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeSinkBeingUsedException.java
@@ -16,15 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iotdb.commons.sync.pipe;
+package org.apache.iotdb.commons.exception.sync;
 
-public enum PipeStatus {
-  // a new pipe should be stop status
-  RUNNING,
-  STOP,
-  // internal status
-  PREPARE_CREATE,
-  PREPARE_START,
-  PREPARE_STOP,
-  PREPARE_DROP
+public class PipeSinkBeingUsedException extends PipeSinkException {
+  public PipeSinkBeingUsedException(String pipeSinkName, String pipeName) {
+    super(
+        String.format(
+            "Can not drop PIPESINK %s, because PIPE %s is using it.", pipeSinkName, pipeName));
+  }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeSinkNotExistException.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/exception/sync/PipeSinkNotExistException.java
@@ -16,15 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iotdb.commons.sync.pipe;
+package org.apache.iotdb.commons.exception.sync;
 
-public enum PipeStatus {
-  // a new pipe should be stop status
-  RUNNING,
-  STOP,
-  // internal status
-  PREPARE_CREATE,
-  PREPARE_START,
-  PREPARE_STOP,
-  PREPARE_DROP
+public class PipeSinkNotExistException extends PipeSinkException {
+  public PipeSinkNotExistException(String pipeSinkName) {
+    super(String.format("PIPESINK [%s] does not exist", pipeSinkName));
+  }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.commons.sync.metadata;
 
 import org.apache.iotdb.commons.exception.sync.PipeException;
 import org.apache.iotdb.commons.exception.sync.PipeNotExistException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkAlreadyExistException;
 import org.apache.iotdb.commons.exception.sync.PipeSinkBeingUsedException;
 import org.apache.iotdb.commons.exception.sync.PipeSinkException;
 import org.apache.iotdb.commons.exception.sync.PipeSinkNotExistException;
@@ -92,10 +93,7 @@ public class SyncMetadata implements SnapshotProcessor {
 
   public void checkAddPipeSink(String pipeSinkName) throws PipeSinkException {
     if (isPipeSinkExist(pipeSinkName)) {
-      throw new PipeSinkException(
-          "There is a PipeSink named "
-              + pipeSinkName
-              + " in IoTDB, please drop it before recreation.");
+      throw new PipeSinkAlreadyExistException(pipeSinkName);
     }
   }
 
@@ -140,14 +138,14 @@ public class SyncMetadata implements SnapshotProcessor {
     // check PipeSink exists
     if (!isPipeSinkExist(pipeInfo.getPipeSinkName())) {
       throw new PipeException(
-          String.format("can not find PIPESINK %s.", pipeInfo.getPipeSinkName()));
+          String.format("Can not find PIPESINK [%s].", pipeInfo.getPipeSinkName()));
     }
     // check Pipe does not exist
     if (pipes.containsKey(pipeInfo.getPipeName())) {
       PipeInfo runningPipe = pipes.get(pipeInfo.getPipeName());
       throw new PipeException(
           String.format(
-              "PIPE %s is %s, please retry after drop it.",
+              "PIPE [%s] is %s, please retry after drop it.",
               runningPipe.getPipeName(), runningPipe.getStatus().name()));
     }
   }
@@ -156,7 +154,7 @@ public class SyncMetadata implements SnapshotProcessor {
     pipes.putIfAbsent(pipeInfo.getPipeName(), pipeInfo);
   }
 
-  public void drop(String pipeName) {
+  public void dropPipe(String pipeName) {
     pipes.remove(pipeName);
   }
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
@@ -20,7 +20,9 @@ package org.apache.iotdb.commons.sync.metadata;
 
 import org.apache.iotdb.commons.exception.sync.PipeException;
 import org.apache.iotdb.commons.exception.sync.PipeNotExistException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkBeingUsedException;
 import org.apache.iotdb.commons.exception.sync.PipeSinkException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkNotExistException;
 import org.apache.iotdb.commons.snapshot.SnapshotProcessor;
 import org.apache.iotdb.commons.sync.persistence.SyncLogReader;
 import org.apache.iotdb.commons.sync.persistence.SyncLogWriter;
@@ -50,9 +52,8 @@ public class SyncMetadata implements SnapshotProcessor {
   // <PipeSinkName, PipeSink>
   private Map<String, PipeSink> pipeSinks;
 
-  private PipeInfo runningPipe;
   // <PipeName, <CreateTime, PipeInfo>>
-  private Map<String, Map<Long, PipeInfo>> pipes;
+  private Map<String, PipeInfo> pipes;
 
   public SyncMetadata() {
     this.pipes = new ConcurrentHashMap<>();
@@ -71,19 +72,11 @@ public class SyncMetadata implements SnapshotProcessor {
     this.pipeSinks = pipeSinks;
   }
 
-  public PipeInfo getRunningPipe() {
-    return runningPipe;
-  }
-
-  public void setRunningPipe(PipeInfo runningPipe) {
-    this.runningPipe = runningPipe;
-  }
-
-  public Map<String, Map<Long, PipeInfo>> getPipes() {
+  public Map<String, PipeInfo> getPipes() {
     return pipes;
   }
 
-  public void setPipes(Map<String, Map<Long, PipeInfo>> pipes) {
+  public void setPipes(Map<String, PipeInfo> pipes) {
     this.pipes = pipes;
   }
 
@@ -112,15 +105,12 @@ public class SyncMetadata implements SnapshotProcessor {
 
   public void checkDropPipeSink(String pipeSinkName) throws PipeSinkException {
     if (!isPipeSinkExist(pipeSinkName)) {
-      throw new PipeSinkException("PipeSink " + pipeSinkName + " does not exist.");
+      throw new PipeSinkNotExistException(pipeSinkName);
     }
-    if (runningPipe != null
-        && runningPipe.getStatus() != PipeStatus.DROP
-        && runningPipe.getPipeSinkName().equals(pipeSinkName)) {
-      throw new PipeSinkException(
-          String.format(
-              "Can not drop PipeSink %s, because Pipe %s is using it.",
-              pipeSinkName, runningPipe.getPipeName()));
+    for (PipeInfo pipeInfo : pipes.values()) {
+      if (pipeInfo.getPipeSinkName().equals(pipeSinkName)) {
+        throw new PipeSinkBeingUsedException(pipeSinkName, pipeInfo.getPipeName());
+      }
     }
   }
 
@@ -153,7 +143,8 @@ public class SyncMetadata implements SnapshotProcessor {
           String.format("can not find PIPESINK %s.", pipeInfo.getPipeSinkName()));
     }
     // check Pipe does not exist
-    if (runningPipe != null && runningPipe.getStatus() != PipeStatus.DROP) {
+    if (pipes.containsKey(pipeInfo.getPipeName())) {
+      PipeInfo runningPipe = pipes.get(pipeInfo.getPipeName());
       throw new PipeException(
           String.format(
               "PIPE %s is %s, please retry after drop it.",
@@ -162,42 +153,28 @@ public class SyncMetadata implements SnapshotProcessor {
   }
 
   public void addPipe(PipeInfo pipeInfo) {
-    runningPipe = pipeInfo;
-    pipes
-        .computeIfAbsent(runningPipe.getPipeName(), i -> new ConcurrentHashMap<>())
-        .computeIfAbsent(runningPipe.getCreateTime(), i -> runningPipe);
+    pipes.putIfAbsent(pipeInfo.getPipeName(), pipeInfo);
+  }
+
+  public void drop(String pipeName) {
+    pipes.remove(pipeName);
   }
 
   public void setPipeStatus(String pipeName, PipeStatus status) throws PipeException {
-    runningPipe.setStatus(status);
+    pipes.get(pipeName).setStatus(status);
   }
 
-  public PipeInfo getPipeInfo(String pipeName, long createTime) {
-    return pipes.get(pipeName).get(createTime);
+  public PipeInfo getPipeInfo(String pipeName) {
+    return pipes.get(pipeName);
   }
 
   public List<PipeInfo> getAllPipeInfos() {
-    List<PipeInfo> pipeInfos = new ArrayList<>();
-    for (Map<Long, PipeInfo> timePipeInfoMap : pipes.values()) {
-      pipeInfos.addAll(timePipeInfoMap.values());
-    }
-    return pipeInfos;
-  }
-
-  /** @return null if no pipe has been created */
-  public PipeInfo getRunningPipeInfo() {
-    return runningPipe;
+    return new ArrayList<>(pipes.values());
   }
 
   public void checkIfPipeExist(String pipeName) throws PipeException {
-    if (runningPipe == null || runningPipe.getStatus() == PipeStatus.DROP) {
+    if (!pipes.containsKey(pipeName)) {
       throw new PipeNotExistException(pipeName);
-    }
-    if (!runningPipe.getPipeName().equals(pipeName)) {
-      throw new PipeException(
-          String.format(
-              "PIPE %s is %s, please retry after drop it.",
-              runningPipe.getPipeName(), runningPipe.getStatus()));
     }
   }
 
@@ -206,13 +183,11 @@ public class SyncMetadata implements SnapshotProcessor {
    * NORMAL.
    *
    * @param pipeName name of pipe
-   * @param createTime createTime of pipe
    * @param messageType pipe message type
    */
-  public void changePipeMessage(
-      String pipeName, long createTime, PipeMessage.PipeMessageType messageType) {
-    if (messageType.compareTo(pipes.get(pipeName).get(createTime).getMessageType()) > 0) {
-      pipes.get(pipeName).get(createTime).setMessageType(messageType);
+  public void changePipeMessage(String pipeName, PipeMessage.PipeMessageType messageType) {
+    if (messageType.compareTo(pipes.get(pipeName).getMessageType()) > 0) {
+      pipes.get(pipeName).setMessageType(messageType);
     }
   }
 
@@ -230,20 +205,15 @@ public class SyncMetadata implements SnapshotProcessor {
       for (PipeSink pipeSink : pipeSinks.values()) {
         writer.addPipeSink(pipeSink);
       }
-      for (Map<Long, PipeInfo> map : pipes.values()) {
-        for (PipeInfo pipeInfo : map.values()) {
-          writer.addPipe(pipeInfo);
-          switch (pipeInfo.getStatus()) {
-            case RUNNING:
-              writer.operatePipe(pipeInfo.getPipeName(), SyncOperation.START_PIPE);
-              break;
-            case STOP:
-              writer.operatePipe(pipeInfo.getPipeName(), SyncOperation.STOP_PIPE);
-              break;
-            case DROP:
-              writer.operatePipe(pipeInfo.getPipeName(), SyncOperation.DROP_PIPE);
-              break;
-          }
+      for (PipeInfo pipeInfo : pipes.values()) {
+        writer.addPipe(pipeInfo);
+        switch (pipeInfo.getStatus()) {
+          case RUNNING:
+            writer.operatePipe(pipeInfo.getPipeName(), SyncOperation.START_PIPE);
+            break;
+          case STOP:
+            writer.operatePipe(pipeInfo.getPipeName(), SyncOperation.STOP_PIPE);
+            break;
         }
       }
     }
@@ -259,11 +229,10 @@ public class SyncMetadata implements SnapshotProcessor {
           snapshotFile.getAbsolutePath());
       return;
     }
-    SyncLogReader reader = new SyncLogReader(snapshotDir);
+    SyncLogReader reader = new SyncLogReader(snapshotDir, snapshotFile.getName());
     reader.recover();
-    setPipes(reader.getAllPipeInfos());
+    setPipes(reader.getPipes());
     setPipeSinks(reader.getAllPipeSinks());
-    setRunningPipe(reader.getRunningPipeInfo());
   }
 
   // endregion

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
@@ -53,7 +53,7 @@ public class SyncMetadata implements SnapshotProcessor {
   // <PipeSinkName, PipeSink>
   private Map<String, PipeSink> pipeSinks;
 
-  // <PipeName, <CreateTime, PipeInfo>>
+  // <PipeName, PipeInfo>
   private Map<String, PipeInfo> pipes;
 
   public SyncMetadata() {
@@ -158,7 +158,7 @@ public class SyncMetadata implements SnapshotProcessor {
     pipes.remove(pipeName);
   }
 
-  public void setPipeStatus(String pipeName, PipeStatus status) throws PipeException {
+  public void setPipeStatus(String pipeName, PipeStatus status) {
     pipes.get(pipeName).setStatus(status);
   }
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.commons.sync.metadata;
 
+import org.apache.iotdb.commons.exception.sync.PipeAlreadyExistException;
 import org.apache.iotdb.commons.exception.sync.PipeException;
 import org.apache.iotdb.commons.exception.sync.PipeNotExistException;
 import org.apache.iotdb.commons.exception.sync.PipeSinkAlreadyExistException;
@@ -134,19 +135,15 @@ public class SyncMetadata implements SnapshotProcessor {
   // region Implement of Pipe
   // ======================================================
 
-  public void checkAddPipe(PipeInfo pipeInfo) throws PipeException {
+  public void checkAddPipe(PipeInfo pipeInfo) throws PipeException, PipeSinkNotExistException {
     // check PipeSink exists
     if (!isPipeSinkExist(pipeInfo.getPipeSinkName())) {
-      throw new PipeException(
-          String.format("Can not find PIPESINK [%s].", pipeInfo.getPipeSinkName()));
+      throw new PipeSinkNotExistException(pipeInfo.getPipeSinkName());
     }
     // check Pipe does not exist
     if (pipes.containsKey(pipeInfo.getPipeName())) {
       PipeInfo runningPipe = pipes.get(pipeInfo.getPipeName());
-      throw new PipeException(
-          String.format(
-              "PIPE [%s] is %s, please retry after drop it.",
-              runningPipe.getPipeName(), runningPipe.getStatus().name()));
+      throw new PipeAlreadyExistException(runningPipe.getPipeName(), runningPipe.getStatus());
     }
   }
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/persistence/SyncLogReader.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/persistence/SyncLogReader.java
@@ -39,7 +39,7 @@ public class SyncLogReader {
   private static final Logger logger = LoggerFactory.getLogger(SyncLogReader.class);
   // <pipeSinkName, PipeSink>
   private final Map<String, PipeSink> pipeSinks = new ConcurrentHashMap<>();
-  // <pipeName, PipeSink>
+  // <pipeName, Pipe>
   private final Map<String, PipeInfo> pipes = new ConcurrentHashMap<>();
   private final File dir;
   private final String fileName;

--- a/node-commons/src/test/java/org/apache/iotdb/commons/sync/metedata/SyncMetadataTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/sync/metedata/SyncMetadataTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.commons.sync.metedata;
 
+import org.apache.iotdb.commons.exception.sync.PipeAlreadyExistException;
 import org.apache.iotdb.commons.exception.sync.PipeException;
 import org.apache.iotdb.commons.exception.sync.PipeNotExistException;
 import org.apache.iotdb.commons.exception.sync.PipeSinkAlreadyExistException;
@@ -118,8 +119,8 @@ public class SyncMetadataTest {
     try {
       syncMetadata.checkAddPipe(pipeInfo1);
       Assert.fail();
-    } catch (PipeException e) {
-      Assert.assertTrue(e.getMessage().contains("Can not find PIPESINK"));
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof PipeSinkNotExistException);
     }
     try {
       syncMetadata.checkIfPipeExist(PIPE_NAME_1);
@@ -131,7 +132,7 @@ public class SyncMetadataTest {
     syncMetadata.addPipeSink(ioTDBPipeSink2);
     try {
       syncMetadata.checkAddPipe(pipeInfo1);
-    } catch (PipeException e) {
+    } catch (Exception e) {
       Assert.fail(e.getMessage());
     }
     syncMetadata.addPipe(pipeInfo1);
@@ -139,7 +140,8 @@ public class SyncMetadataTest {
       syncMetadata.checkAddPipe(
           new TsFilePipeInfo(PIPE_NAME_1, PIPESINK_NAME_2, System.currentTimeMillis(), 99, false));
       Assert.fail();
-    } catch (PipeException e) {
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof PipeAlreadyExistException);
       Assert.assertTrue(e.getMessage().contains("please retry after drop it"));
     }
     syncMetadata.addPipe(pipeInfo2);

--- a/node-commons/src/test/java/org/apache/iotdb/commons/sync/metedata/SyncMetadataTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/sync/metedata/SyncMetadataTest.java
@@ -16,15 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iotdb.commons.sync.pipe;
+package org.apache.iotdb.commons.sync.metedata;
 
-public enum PipeStatus {
-  // a new pipe should be stop status
-  RUNNING,
-  STOP,
-  // internal status
-  PREPARE_CREATE,
-  PREPARE_START,
-  PREPARE_STOP,
-  PREPARE_DROP
+import org.junit.Test;
+
+public class SyncMetadataTest {
+  @Test
+  public void testPipeSinkOperation() {}
+
+  @Test
+  public void testPipeOperation() {}
+
+  @Test
+  public void testSnapshot() {}
 }

--- a/node-commons/src/test/java/org/apache/iotdb/commons/sync/metedata/SyncMetadataTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/sync/metedata/SyncMetadataTest.java
@@ -18,15 +18,170 @@
  */
 package org.apache.iotdb.commons.sync.metedata;
 
+import org.apache.iotdb.commons.exception.sync.PipeException;
+import org.apache.iotdb.commons.exception.sync.PipeNotExistException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkAlreadyExistException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkBeingUsedException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkNotExistException;
+import org.apache.iotdb.commons.sync.metadata.SyncMetadata;
+import org.apache.iotdb.commons.sync.pipe.PipeInfo;
+import org.apache.iotdb.commons.sync.pipe.PipeMessage;
+import org.apache.iotdb.commons.sync.pipe.PipeStatus;
+import org.apache.iotdb.commons.sync.pipe.TsFilePipeInfo;
+import org.apache.iotdb.commons.sync.pipesink.IoTDBPipeSink;
+import org.apache.iotdb.commons.sync.pipesink.PipeSink;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.File;
+
 public class SyncMetadataTest {
-  @Test
-  public void testPipeSinkOperation() {}
+  private static final File snapshotDir = new File("target", "snapshot");
+
+  private static final String PIPESINK_NAME_1 = "pipeSink1";
+  private static final String PIPESINK_NAME_2 = "pipeSink2";
+  private static PipeSink ioTDBPipeSink1;
+  private static PipeSink ioTDBPipeSink2;
+
+  private static final String PIPE_NAME_1 = "pipe1";
+  private static final String PIPE_NAME_2 = "pipe2";
+  private static PipeInfo pipeInfo1;
+  private static PipeInfo pipeInfo2;
+
+  @BeforeClass
+  public static void setUp() {
+    ioTDBPipeSink1 = new IoTDBPipeSink(PIPESINK_NAME_1);
+    ioTDBPipeSink2 = new IoTDBPipeSink(PIPESINK_NAME_2);
+    pipeInfo1 =
+        new TsFilePipeInfo(PIPE_NAME_1, PIPESINK_NAME_1, System.currentTimeMillis(), 0, true);
+    pipeInfo2 =
+        new TsFilePipeInfo(PIPE_NAME_2, PIPESINK_NAME_2, System.currentTimeMillis(), 99, false);
+  }
 
   @Test
-  public void testPipeOperation() {}
+  public void testPipeSinkOperation() {
+    SyncMetadata syncMetadata = new SyncMetadata();
+    Assert.assertFalse(syncMetadata.isPipeSinkExist(PIPESINK_NAME_1));
+    // check and add ioTDBPipeSink1
+    try {
+      syncMetadata.checkAddPipeSink(PIPESINK_NAME_1);
+    } catch (PipeSinkException e) {
+      Assert.fail(e.getMessage());
+    }
+    syncMetadata.addPipeSink(ioTDBPipeSink1);
+    Assert.assertTrue(syncMetadata.isPipeSinkExist(PIPESINK_NAME_1));
+    try {
+      syncMetadata.checkAddPipeSink(PIPESINK_NAME_1);
+      Assert.fail();
+    } catch (PipeSinkException e) {
+      Assert.assertTrue(e instanceof PipeSinkAlreadyExistException);
+    }
+    // add ioTDBPipeSink2
+    try {
+      syncMetadata.checkDropPipeSink(PIPESINK_NAME_2);
+      Assert.fail();
+    } catch (PipeSinkException e) {
+      Assert.assertTrue(e instanceof PipeSinkNotExistException);
+    }
+    syncMetadata.addPipeSink(ioTDBPipeSink2);
+    // get PipeSink
+    Assert.assertEquals(ioTDBPipeSink1, syncMetadata.getPipeSink(PIPESINK_NAME_1));
+    Assert.assertEquals(ioTDBPipeSink2, syncMetadata.getPipeSink(PIPESINK_NAME_2));
+    Assert.assertEquals(2, syncMetadata.getAllPipeSink().size());
+    // drop ioTDBPipeSink2
+    syncMetadata.addPipe(pipeInfo2);
+    try {
+      syncMetadata.checkDropPipeSink(PIPESINK_NAME_2);
+      Assert.fail();
+    } catch (PipeSinkException e) {
+      Assert.assertTrue(e instanceof PipeSinkBeingUsedException);
+    }
+    syncMetadata.dropPipe(PIPE_NAME_2);
+    try {
+      syncMetadata.checkDropPipeSink(PIPESINK_NAME_2);
+    } catch (PipeSinkException e) {
+      Assert.fail(e.getMessage());
+    }
+    syncMetadata.dropPipeSink(PIPESINK_NAME_2);
+    Assert.assertNull(syncMetadata.getPipeSink(PIPESINK_NAME_2));
+    Assert.assertEquals(1, syncMetadata.getAllPipeSink().size());
+  }
 
   @Test
-  public void testSnapshot() {}
+  public void testPipeOperation() {
+    SyncMetadata syncMetadata = new SyncMetadata();
+    // check add pipe
+    try {
+      syncMetadata.checkAddPipe(pipeInfo1);
+      Assert.fail();
+    } catch (PipeException e) {
+      Assert.assertTrue(e.getMessage().contains("Can not find PIPESINK"));
+    }
+    try {
+      syncMetadata.checkIfPipeExist(PIPE_NAME_1);
+      Assert.fail();
+    } catch (PipeException e) {
+      Assert.assertTrue(e instanceof PipeNotExistException);
+    }
+    syncMetadata.addPipeSink(ioTDBPipeSink1);
+    syncMetadata.addPipeSink(ioTDBPipeSink2);
+    try {
+      syncMetadata.checkAddPipe(pipeInfo1);
+    } catch (PipeException e) {
+      Assert.fail(e.getMessage());
+    }
+    syncMetadata.addPipe(pipeInfo1);
+    try {
+      syncMetadata.checkAddPipe(
+          new TsFilePipeInfo(PIPE_NAME_1, PIPESINK_NAME_2, System.currentTimeMillis(), 99, false));
+      Assert.fail();
+    } catch (PipeException e) {
+      Assert.assertTrue(e.getMessage().contains("please retry after drop it"));
+    }
+    syncMetadata.addPipe(pipeInfo2);
+    // check get pipe
+    Assert.assertEquals(pipeInfo1, syncMetadata.getPipeInfo(PIPE_NAME_1));
+    Assert.assertEquals(pipeInfo2, syncMetadata.getPipeInfo(PIPE_NAME_2));
+    Assert.assertEquals(2, syncMetadata.getAllPipeInfos().size());
+    // check setter
+    syncMetadata.setPipeStatus(PIPE_NAME_1, PipeStatus.RUNNING);
+    syncMetadata.changePipeMessage(PIPE_NAME_1, PipeMessage.PipeMessageType.WARN);
+    Assert.assertEquals(PipeStatus.RUNNING, syncMetadata.getPipeInfo(PIPE_NAME_1).getStatus());
+    Assert.assertEquals(
+        PipeMessage.PipeMessageType.WARN, syncMetadata.getPipeInfo(PIPE_NAME_1).getMessageType());
+    // check drop
+    syncMetadata.dropPipe(PIPE_NAME_1);
+    Assert.assertNull(syncMetadata.getPipeInfo(PIPE_NAME_1));
+    Assert.assertEquals(1, syncMetadata.getAllPipeInfos().size());
+  }
+
+  @Test
+  public void testSnapshot() throws Exception {
+    try {
+      if (snapshotDir.exists()) {
+        FileUtils.deleteDirectory(snapshotDir);
+      }
+      snapshotDir.mkdirs();
+      SyncMetadata syncMetadata = new SyncMetadata();
+      syncMetadata.addPipeSink(ioTDBPipeSink1);
+      syncMetadata.addPipeSink(ioTDBPipeSink2);
+      syncMetadata.addPipe(pipeInfo1);
+      syncMetadata.addPipe(pipeInfo2);
+      syncMetadata.processTakeSnapshot(snapshotDir);
+      SyncMetadata syncMetadata1 = new SyncMetadata();
+      syncMetadata1.processLoadSnapshot(snapshotDir);
+      Assert.assertEquals(pipeInfo1, syncMetadata.getPipeInfo(PIPE_NAME_1));
+      Assert.assertEquals(pipeInfo2, syncMetadata.getPipeInfo(PIPE_NAME_2));
+      Assert.assertEquals(ioTDBPipeSink1, syncMetadata.getPipeSink(PIPESINK_NAME_1));
+      Assert.assertEquals(ioTDBPipeSink2, syncMetadata.getPipeSink(PIPESINK_NAME_2));
+    } finally {
+      if (snapshotDir.exists()) {
+        FileUtils.deleteDirectory(snapshotDir);
+      }
+    }
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1000,14 +1000,14 @@ public class TsFileProcessor {
               : workMemTable;
 
       try {
-        // When invoke closing TsFile after insert data to memTable, we shouldn't flush until invoke
-        // flushing memTable in System module.
-        addAMemtableIntoFlushingList(tmpMemTable);
         for (ISyncManager syncManager :
             SyncService.getInstance()
                 .getOrCreateSyncManager(storageGroupInfo.getDataRegion().getDataRegionId())) {
           syncManager.syncRealTimeTsFile(tsFileResource.getTsFile());
         }
+        // When invoke closing TsFile after insert data to memTable, we shouldn't flush until invoke
+        // flushing memTable in System module.
+        addAMemtableIntoFlushingList(tmpMemTable);
         logger.info("Memtable {} has been added to flushing list", tmpMemTable);
         shouldClose = true;
       } catch (Exception e) {

--- a/server/src/main/java/org/apache/iotdb/db/sync/SyncService.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/SyncService.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.ShutdownException;
 import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.commons.exception.sync.PipeException;
+import org.apache.iotdb.commons.exception.sync.PipeNotExistException;
 import org.apache.iotdb.commons.exception.sync.PipeSinkException;
 import org.apache.iotdb.commons.service.IService;
 import org.apache.iotdb.commons.service.ServiceType;
@@ -74,23 +75,28 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SyncService implements IService {
   private static final Logger logger = LoggerFactory.getLogger(SyncService.class);
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
-  private Pipe runningPipe;
+  private final Map<String, Pipe> pipes;
 
   /* handle external Pipe */
-  private ExtPipePluginManager extPipePluginManager;
+  // TODO(ext-pipe): adapt multi pipe
+  private final Map<String, ExtPipePluginManager> extPipePluginManagers;
 
-  private ISyncInfoFetcher syncInfoFetcher;
+  private final ISyncInfoFetcher syncInfoFetcher;
 
   /* handle rpc in receiver-side*/
   private final ReceiverManager receiverManager;
 
   private SyncService() {
     receiverManager = new ReceiverManager();
+    pipes = new ConcurrentHashMap<>();
+    extPipePluginManagers = new ConcurrentHashMap<>();
     if (config.isClusterMode()) {
       syncInfoFetcher = ClusterSyncInfoFetcher.getInstance();
     } else {
@@ -195,34 +201,32 @@ public class SyncService implements IService {
       throw new PipeException(String.format("failed to add PIPE because %s", e.getMessage()));
     }
 
-    runningPipe = SyncPipeUtil.parseTPipeSinkInfoAsPipeSink(pipeInfo, runningPipeSink);
+    Pipe runningPipe = SyncPipeUtil.parsePipeInfoAsPipe(pipeInfo, runningPipeSink);
+    pipes.put(pipeInfo.getPipeName(), runningPipe);
     if (runningPipe.getPipeSink().getType()
         == PipeSink.PipeSinkType.ExternalPipe) { // for external pipe
       // == start ExternalPipeProcessor for send data to external pipe plugin
-      startExternalPipeManager(false);
+      startExternalPipeManager(pipeInfo.getPipeName(), false);
     }
   }
 
   public synchronized void stopPipe(String pipeName) throws PipeException {
     logger.info("Execute stop PIPE {}", pipeName);
-    checkRunningPipeExistAndName(pipeName);
+    Pipe runningPipe = getPipe(pipeName);
     if (runningPipe.getStatus() == PipeStatus.RUNNING) {
-      if (runningPipe.getPipeSink().getType() == PipeSink.PipeSinkType.IoTDB) {
-        runningPipe.stop();
-      } else { // for external PIPE
+      if (runningPipe.getPipeSink().getType() != PipeSink.PipeSinkType.IoTDB) { // for external PIPE
         // == pause externalPipeProcessor's task
-        if (extPipePluginManager != null) {
+        if (extPipePluginManagers.containsKey(pipeName)) {
           try {
             String extPipeSinkTypeName =
                 ((ExternalPipeSink) (runningPipe.getPipeSink())).getExtPipeSinkTypeName();
-            extPipePluginManager.stopExtPipe(extPipeSinkTypeName);
+            extPipePluginManagers.get(pipeName).stopExtPipe(extPipeSinkTypeName);
           } catch (Exception e) {
             throw new PipeException("Failed to stop externalPipeProcessor. " + e.getMessage());
           }
         }
-
-        runningPipe.stop();
       }
+      runningPipe.stop();
     }
     TSStatus status = syncInfoFetcher.stopPipe(pipeName);
     if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
@@ -232,13 +236,13 @@ public class SyncService implements IService {
 
   public synchronized void startPipe(String pipeName) throws PipeException {
     logger.info("Execute start PIPE {}", pipeName);
-    checkRunningPipeExistAndName(pipeName);
+    Pipe runningPipe = getPipe(pipeName);
     if (runningPipe.getStatus() == PipeStatus.STOP) {
       if (runningPipe.getPipeSink().getType() == PipeSink.PipeSinkType.IoTDB) {
         runningPipe.start();
       } else { // for external PIPE
         runningPipe.start();
-        startExternalPipeManager(true);
+        startExternalPipeManager(pipeName, true);
       }
     }
     TSStatus status = syncInfoFetcher.startPipe(pipeName);
@@ -249,21 +253,21 @@ public class SyncService implements IService {
 
   public synchronized void dropPipe(String pipeName) throws PipeException {
     logger.info("Execute drop PIPE {}", pipeName);
-    checkRunningPipeExistAndName(pipeName);
-    if (runningPipe.getPipeSink().getType() == PipeSink.PipeSinkType.IoTDB) {
-      runningPipe.drop();
-    } else { // for external pipe
-      // == drop ExternalPipeProcesser
-      if (extPipePluginManager != null) {
+    Pipe runningPipe = getPipe(pipeName);
+    if (runningPipe.getPipeSink().getType() != PipeSink.PipeSinkType.IoTDB) { // for external pipe
+      // == drop ExternalPipeProcessor
+      if (extPipePluginManagers.containsKey(pipeName)) {
         String extPipeSinkTypeName =
             ((ExternalPipeSink) runningPipe.getPipeSink()).getExtPipeSinkTypeName();
-        extPipePluginManager.dropExtPipe(extPipeSinkTypeName);
-        extPipePluginManager = null;
+        extPipePluginManagers.get(pipeName).dropExtPipe(extPipeSinkTypeName);
+        extPipePluginManagers.remove(pipeName);
       }
-      runningPipe.drop();
     }
+    runningPipe.drop();
 
     TSStatus status = syncInfoFetcher.dropPipe(pipeName);
+    // remove dropped pipe from map
+    pipes.remove(pipeName);
     if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       throw new PipeException(status.message);
     }
@@ -273,42 +277,34 @@ public class SyncService implements IService {
     return syncInfoFetcher.getAllPipeInfos();
   }
 
-  private void checkRunningPipeExistAndName(String pipeName) throws PipeException {
-    if (runningPipe == null || runningPipe.getStatus() == PipeStatus.DROP) {
-      throw new PipeException("There is no existing PIPE.");
-    }
-    if (!runningPipe.getName().equals(pipeName)) {
-      throw new PipeException(
-          String.format(
-              "PIPE %s is %s, please retry after drop it.",
-              runningPipe.getName(), runningPipe.getStatus()));
+  private Pipe getPipe(String pipeName) throws PipeException {
+    if (!pipes.containsKey(pipeName)) {
+      throw new PipeNotExistException(pipeName);
+    } else {
+      return pipes.get(pipeName);
     }
   }
 
-  public synchronized void recordMessage(PipeMessage message) {
-    if (runningPipe == null || runningPipe.getStatus() == PipeStatus.DROP) {
-      logger.info(String.format("No running PIPE for message %s.", message));
+  public synchronized void recordMessage(String pipeName, PipeMessage message) {
+    if (!pipes.containsKey(pipeName)) {
+      logger.warn(String.format("No running PIPE for message %s.", message));
       return;
     }
     TSStatus status = null;
     switch (message.getType()) {
       case ERROR:
         logger.error("{}", message);
-        status =
-            syncInfoFetcher.recordMsg(runningPipe.getName(), runningPipe.getCreateTime(), message);
+        status = syncInfoFetcher.recordMsg(pipeName, message);
         try {
-          stopPipe(runningPipe.getName());
+          stopPipe(pipeName);
         } catch (PipeException e) {
           logger.error(
-              String.format(
-                  "Stop PIPE %s when meeting error in sender service.", runningPipe.getName()),
-              e);
+              String.format("Stop PIPE %s when meeting error in sender service.", pipeName), e);
         }
         break;
       case WARN:
         logger.warn("{}", message);
-        status =
-            syncInfoFetcher.recordMsg(runningPipe.getName(), runningPipe.getCreateTime(), message);
+        status = syncInfoFetcher.recordMsg(pipeName, message);
         break;
       default:
         logger.error(String.format("Unknown message type: %s", message));
@@ -371,7 +367,7 @@ public class SyncService implements IService {
           PipeSink pipeSink = syncInfoFetcher.getPipeSink(pipe.getPipeSinkName());
           if (pipeSink.getType() == PipeSink.PipeSinkType.ExternalPipe) { // for external pipe
             ExtPipePluginManager extPipePluginManager =
-                SyncService.getInstance().getExternalPipeManager();
+                SyncService.getInstance().getExternalPipeManager(pipe.getPipeName());
 
             if (extPipePluginManager != null) {
               String extPipeType = ((ExternalPipeSink) pipeSink).getExtPipeSinkTypeName();
@@ -419,13 +415,14 @@ public class SyncService implements IService {
   // region Interfaces and Implementation of External-Pipe
 
   /** Start ExternalPipeProcessor who handle externalPipe */
-  private void startExternalPipeManager(boolean startExtPipe) throws PipeException {
-    if (!(runningPipe instanceof TsFilePipe)) {
-      logger.error("startExternalPipeManager(), runningPipe is not TsFilePipe. " + runningPipe);
+  private void startExternalPipeManager(String pipeName, boolean startExtPipe)
+      throws PipeException {
+    if (!(pipes.get(pipeName) instanceof TsFilePipe)) {
+      logger.error("startExternalPipeManager(), runningPipe is not TsFilePipe. " + pipeName);
       return;
     }
 
-    PipeSink pipeSink = runningPipe.getPipeSink();
+    PipeSink pipeSink = pipes.get(pipeName).getPipeSink();
     if (!(pipeSink instanceof ExternalPipeSink)) {
       logger.error("startExternalPipeManager(), pipeSink is not ExternalPipeSink." + pipeSink);
       return;
@@ -442,8 +439,10 @@ public class SyncService implements IService {
       throw new PipeException("Can not found ExternalPipe plugin for " + extPipeSinkTypeName + ".");
     }
 
-    if (extPipePluginManager == null) {
-      extPipePluginManager = new ExtPipePluginManager((TsFilePipe) this.runningPipe);
+    ExtPipePluginManager extPipePluginManager =
+        new ExtPipePluginManager((TsFilePipe) pipes.get(pipeName));
+    if (!extPipePluginManagers.containsKey(pipeName)) {
+      extPipePluginManagers.put(pipeName, extPipePluginManager);
     }
 
     if (startExtPipe) {
@@ -458,8 +457,8 @@ public class SyncService implements IService {
     }
   }
 
-  public ExtPipePluginManager getExternalPipeManager() {
-    return extPipePluginManager;
+  public ExtPipePluginManager getExternalPipeManager(String pipeName) {
+    return extPipePluginManagers.get(pipeName);
   }
 
   // endregion
@@ -490,28 +489,25 @@ public class SyncService implements IService {
 
   @Override
   public void stop() {
-    if (runningPipe != null && !PipeStatus.DROP.equals(runningPipe.getStatus())) {
+    for (Pipe pipe : pipes.values()) {
       try {
-        runningPipe.close();
+        pipe.close();
       } catch (PipeException e) {
         logger.warn(
-            String.format("Stop PIPE %s error when stop Sender Service.", runningPipe.getName()),
-            e);
+            String.format("Stop PIPE %s error when stop Sender Service.", pipe.getName()), e);
       }
     }
   }
 
   @Override
   public void shutdown(long milliseconds) throws ShutdownException {
-    if (runningPipe != null && !PipeStatus.DROP.equals(runningPipe.getStatus())) {
+
+    for (Pipe pipe : pipes.values()) {
       try {
-        runningPipe.stop();
-        runningPipe.close();
+        pipe.close();
       } catch (PipeException e) {
         logger.warn(
-            String.format(
-                "Stop pipe %s error when shutdown Sender Service.", runningPipe.getName()),
-            e);
+            String.format("Stop PIPE %s error when shutdown Sender Service.", pipe.getName()), e);
         throw new ShutdownException(e);
       }
     }
@@ -523,55 +519,51 @@ public class SyncService implements IService {
   }
 
   private void recover() throws IOException, PipeException, PipeSinkException {
-    PipeInfo runningPipeInfo = syncInfoFetcher.getRunningPipeInfo();
-    if (runningPipeInfo == null || PipeStatus.DROP.equals(runningPipeInfo.getStatus())) {
-      return;
-    } else {
-      this.runningPipe =
-          SyncPipeUtil.parseTPipeSinkInfoAsPipeSink(
-              runningPipeInfo, syncInfoFetcher.getPipeSink(runningPipeInfo.getPipeSinkName()));
-      switch (runningPipeInfo.getStatus()) {
+    List<PipeInfo> allPipeInfos = syncInfoFetcher.getAllPipeInfos();
+    for (PipeInfo pipeInfo : allPipeInfos) {
+      Pipe pipe =
+          SyncPipeUtil.parsePipeInfoAsPipe(
+              pipeInfo, syncInfoFetcher.getPipeSink(pipeInfo.getPipeSinkName()));
+      pipes.put(pipeInfo.getPipeName(), pipe);
+      switch (pipeInfo.getStatus()) {
         case RUNNING:
-          runningPipe.start();
+          pipe.start();
           break;
         case STOP:
-          runningPipe.stop();
-          break;
-        case DROP:
-          runningPipe.drop();
+          pipe.stop();
           break;
         default:
           throw new IOException(
-              String.format(
-                  "Can not recognize running pipe status %s.", runningPipeInfo.getStatus()));
+              String.format("Can not recognize running pipe status %s.", pipe.getStatus()));
       }
-    }
-
-    if (runningPipe.getPipeSink().getType()
-        == PipeSink.PipeSinkType.ExternalPipe) { // for external pipe
-      // == start ExternalPipeProcessor for send data to external pipe plugin
-      startExternalPipeManager(runningPipe.getStatus() == PipeStatus.RUNNING);
+      if (pipe.getPipeSink().getType() == PipeSink.PipeSinkType.ExternalPipe) { // for external pipe
+        // == start ExternalPipeProcessor for send data to external pipe plugin
+        startExternalPipeManager(pipeInfo.getPipeName(), pipe.getStatus() == PipeStatus.RUNNING);
+      }
     }
   }
 
   public List<ISyncManager> getOrCreateSyncManager(String dataRegionId) {
     // TODO(sync): maybe add cache to accelerate
     List<ISyncManager> syncManagerList = new ArrayList<>();
-    if (runningPipe != null) {
-      syncManagerList.add(runningPipe.getOrCreateSyncManager(dataRegionId));
+    for (Pipe pipe : pipes.values()) {
+      if (pipe.isHistoryCollectFinished()) {
+        // Only need to deal with pipe that has finished history file collection,
+        syncManagerList.add(pipe.getOrCreateSyncManager(dataRegionId));
+      }
     }
     return syncManagerList;
   }
 
   /** This method will be called before deleting dataRegion */
   public synchronized void unregisterDataRegion(String dataRegionId) {
-    if (runningPipe != null) {
-      runningPipe.unregisterDataRegion(dataRegionId);
+    for (Pipe pipe : pipes.values()) {
+      pipe.unregisterDataRegion(dataRegionId);
     }
   }
 
   @TestOnly
   public SenderManager getSenderManager() {
-    return runningPipe.getSenderManager();
+    return null;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/sync/common/ClusterSyncInfoFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/common/ClusterSyncInfoFetcher.java
@@ -119,12 +119,7 @@ public class ClusterSyncInfoFetcher implements ISyncInfoFetcher {
   }
 
   @Override
-  public PipeInfo getRunningPipeInfo() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public TSStatus recordMsg(String pipeName, long createTime, PipeMessage message) {
+  public TSStatus recordMsg(String pipeName, PipeMessage message) {
     return null;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/sync/common/ISyncInfoFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/common/ISyncInfoFetcher.java
@@ -55,9 +55,7 @@ public interface ISyncInfoFetcher {
 
   List<PipeInfo> getAllPipeInfos();
 
-  PipeInfo getRunningPipeInfo();
-
-  TSStatus recordMsg(String pipeName, long createTime, PipeMessage message);
+  TSStatus recordMsg(String pipeName, PipeMessage message);
 
   // endregion
 }

--- a/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfo.java
@@ -104,7 +104,7 @@ public class LocalSyncInfo {
 
   // region Implement of Pipe
 
-  public void addPipe(PipeInfo pipeInfo) throws PipeException, IOException {
+  public void addPipe(PipeInfo pipeInfo) throws PipeException, IOException, PipeSinkException {
     syncMetadata.checkAddPipe(pipeInfo);
     syncMetadata.addPipe(pipeInfo);
     syncLogWriter.addPipe(pipeInfo);

--- a/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfo.java
@@ -121,7 +121,7 @@ public class LocalSyncInfo {
         syncMetadata.setPipeStatus(pipeName, PipeStatus.STOP);
         break;
       case DROP_PIPE:
-        syncMetadata.drop(pipeName);
+        syncMetadata.dropPipe(pipeName);
         break;
       default:
         throw new PipeException("Unknown operatorType " + syncOperation);

--- a/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfo.java
@@ -54,9 +54,8 @@ public class LocalSyncInfo {
     SyncLogReader logReader = new SyncLogReader(new File(SyncPathUtil.getSysDir()));
     try {
       logReader.recover();
-      syncMetadata.setPipes(logReader.getAllPipeInfos());
+      syncMetadata.setPipes(logReader.getPipes());
       syncMetadata.setPipeSinks(logReader.getAllPipeSinks());
-      syncMetadata.setRunningPipe(logReader.getRunningPipeInfo());
     } catch (IOException e) {
       LOGGER.error(
           "Cannot recover ReceiverInfo because {}. Use default info values.", e.getMessage());
@@ -122,7 +121,7 @@ public class LocalSyncInfo {
         syncMetadata.setPipeStatus(pipeName, PipeStatus.STOP);
         break;
       case DROP_PIPE:
-        syncMetadata.setPipeStatus(pipeName, PipeStatus.DROP);
+        syncMetadata.drop(pipeName);
         break;
       default:
         throw new PipeException("Unknown operatorType " + syncOperation);
@@ -130,17 +129,12 @@ public class LocalSyncInfo {
     syncLogWriter.operatePipe(pipeName, syncOperation);
   }
 
-  public PipeInfo getPipeInfo(String pipeName, long createTime) {
-    return syncMetadata.getPipeInfo(pipeName, createTime);
+  public PipeInfo getPipeInfo(String pipeName) {
+    return syncMetadata.getPipeInfo(pipeName);
   }
 
   public List<PipeInfo> getAllPipeInfos() {
     return syncMetadata.getAllPipeInfos();
-  }
-
-  /** @return null if no pipe has been created */
-  public PipeInfo getRunningPipeInfo() {
-    return syncMetadata.getRunningPipeInfo();
   }
 
   /**
@@ -148,12 +142,10 @@ public class LocalSyncInfo {
    * NORMAL.
    *
    * @param pipeName name of pipe
-   * @param createTime createTime of pipe
    * @param messageType pipe message type
    */
-  public void changePipeMessage(
-      String pipeName, long createTime, PipeMessage.PipeMessageType messageType) {
-    syncMetadata.changePipeMessage(pipeName, createTime, messageType);
+  public void changePipeMessage(String pipeName, PipeMessage.PipeMessageType messageType) {
+    syncMetadata.changePipeMessage(pipeName, messageType);
   }
 
   // endregion

--- a/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfoFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfoFetcher.java
@@ -145,13 +145,8 @@ public class LocalSyncInfoFetcher implements ISyncInfoFetcher {
   }
 
   @Override
-  public PipeInfo getRunningPipeInfo() {
-    return localSyncInfo.getRunningPipeInfo();
-  }
-
-  @Override
-  public TSStatus recordMsg(String pipeName, long createTime, PipeMessage pipeMessage) {
-    localSyncInfo.changePipeMessage(pipeName, createTime, pipeMessage.getType());
+  public TSStatus recordMsg(String pipeName, PipeMessage pipeMessage) {
+    localSyncInfo.changePipeMessage(pipeName, pipeMessage.getType());
     return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfoFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfoFetcher.java
@@ -100,6 +100,8 @@ public class LocalSyncInfoFetcher implements ISyncInfoFetcher {
       return RpcUtils.getStatus(TSStatusCode.PIPE_ERROR, e.getMessage());
     } catch (IOException e) {
       return RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());
+    } catch (PipeSinkException e) {
+      return RpcUtils.getStatus(TSStatusCode.PIPESINK_ERROR, e.getMessage());
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/Pipe.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/Pipe.java
@@ -127,6 +127,13 @@ public interface Pipe {
 
   void unregisterDataRegion(String dataRegionId);
 
+  /**
+   * If false, no need to collect realtime file
+   *
+   * @return whether finish collect history file.
+   */
+  boolean isHistoryCollectFinished();
+
   @TestOnly
   SenderManager getSenderManager();
 

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/TsFilePipe.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/TsFilePipe.java
@@ -53,11 +53,18 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class TsFilePipe implements Pipe {
   private static final Logger logger = LoggerFactory.getLogger(TsFilePipe.class);
   // <DataRegionId, ISyncManager>
   private final Map<String, ISyncManager> syncManagerMap = new ConcurrentHashMap<>();
+  /**
+   * Write lock needs to be added to block the real-time data collection process when collecting
+   * historical data, otherwise data may be lost. Because historical data collection operations are
+   * rare, it will not affect write performance.
+   */
+  private final ReentrantReadWriteLock syncManagerReadWriteLock = new ReentrantReadWriteLock(false);
 
   private final TsFilePipeInfo pipeInfo;
 
@@ -71,6 +78,9 @@ public class TsFilePipe implements Pipe {
 
   /* handle rpc send logic in sender-side*/
   private final SenderManager senderManager;
+
+  /* whether finish collect history file. If false, no need to collect realtime file*/
+  private boolean isCollectFinished;
 
   //  private long maxSerialNumber;
   private AtomicLong maxSerialNumber;
@@ -89,6 +99,7 @@ public class TsFilePipe implements Pipe {
     this.pipeSink = pipeSink;
 
     this.pipeLog = new TsFilePipeLogger(this);
+    this.isCollectFinished = pipeLog.isCollectFinished();
     this.collectRealTimeDataLock = new ReentrantLock();
     this.senderManager = new SenderManager(this, pipeSink);
 
@@ -123,39 +134,40 @@ public class TsFilePipe implements Pipe {
 
   @Override
   public synchronized void start() throws PipeException {
-    if (pipeInfo.getStatus() == PipeStatus.DROP) {
-      throw new PipeException(
-          String.format(
-              "Can not start pipe %s, because the pipe has been drop.", pipeInfo.getPipeName()));
-    } else if (pipeInfo.getStatus() == PipeStatus.RUNNING) {
+    if (pipeInfo.getStatus() == PipeStatus.RUNNING) {
       return;
     }
-
-    // init sync manager
-    List<DataRegion> dataRegions = StorageEngineV2.getInstance().getAllDataRegions();
-    for (DataRegion dataRegion : dataRegions) {
-      logger.info(
-          logFormat(
-              "init syncManager for %s-%s",
-              dataRegion.getStorageGroupName(), dataRegion.getDataRegionId()));
-      getOrCreateSyncManager(dataRegion.getDataRegionId());
-    }
     try {
-      if (!pipeLog.isCollectFinished()) {
-        pipeLog.clear();
-        collectHistoryData();
-        pipeLog.finishCollect();
+      syncManagerReadWriteLock.writeLock().lock();
+      // init sync manager
+      List<DataRegion> dataRegions = StorageEngineV2.getInstance().getAllDataRegions();
+      for (DataRegion dataRegion : dataRegions) {
+        logger.info(
+            logFormat(
+                "init syncManager for %s-%s",
+                dataRegion.getStorageGroupName(), dataRegion.getDataRegionId()));
+        getOrCreateSyncManager(dataRegion.getDataRegionId());
       }
+      try {
+        if (!isCollectFinished) {
+          pipeLog.clear();
+          collectHistoryData();
+          pipeLog.finishCollect();
+          isCollectFinished = true;
+        }
 
-      pipeInfo.setStatus(PipeStatus.RUNNING);
-      senderManager.start();
-    } catch (IOException e) {
-      logger.error(
-          logFormat(
-              "Clear pipe dir %s error.",
-              SyncPathUtil.getSenderPipeDir(pipeInfo.getPipeName(), pipeInfo.getCreateTime())),
-          e);
-      throw new PipeException("Start error, can not clear pipe log.");
+        pipeInfo.setStatus(PipeStatus.RUNNING);
+        senderManager.start();
+      } catch (IOException e) {
+        logger.error(
+            logFormat(
+                "Clear pipe dir %s error.",
+                SyncPathUtil.getSenderPipeDir(pipeInfo.getPipeName(), pipeInfo.getCreateTime())),
+            e);
+        throw new PipeException("Start error, can not clear pipe log.");
+      }
+    } finally {
+      syncManagerReadWriteLock.writeLock().unlock();
     }
   }
 
@@ -283,14 +295,20 @@ public class TsFilePipe implements Pipe {
 
   @Override
   public ISyncManager getOrCreateSyncManager(String dataRegionId) {
-    return syncManagerMap.computeIfAbsent(
-        dataRegionId,
-        id -> {
-          registerDataRegion(id);
-          return new LocalSyncManager(
-              StorageEngineV2.getInstance().getDataRegion(new DataRegionId(Integer.parseInt(id))),
-              this);
-        });
+    try {
+      //
+      syncManagerReadWriteLock.readLock().lock();
+      return syncManagerMap.computeIfAbsent(
+          dataRegionId,
+          id -> {
+            registerDataRegion(id);
+            return new LocalSyncManager(
+                StorageEngineV2.getInstance().getDataRegion(new DataRegionId(Integer.parseInt(id))),
+                this);
+          });
+    } finally {
+      syncManagerReadWriteLock.readLock().unlock();
+    }
   }
 
   private void registerDataRegion(String dataRegionId) {
@@ -319,6 +337,11 @@ public class TsFilePipe implements Pipe {
   }
 
   @Override
+  public boolean isHistoryCollectFinished() {
+    return isCollectFinished;
+  }
+
+  @Override
   public PipeInfo getPipeInfo() {
     return pipeInfo;
   }
@@ -338,22 +361,14 @@ public class TsFilePipe implements Pipe {
 
   @Override
   public synchronized void stop() throws PipeException {
-    if (pipeInfo.getStatus() == PipeStatus.DROP) {
-      throw new PipeException(
-          String.format("Can not stop pipe %s, because the pipe is drop.", pipeInfo.getPipeName()));
-    }
     senderManager.stop();
     pipeInfo.setStatus(PipeStatus.STOP);
   }
 
   @Override
   public synchronized void drop() throws PipeException {
-    if (pipeInfo.getStatus() == PipeStatus.DROP) {
-      return;
-    }
-    senderManager.close();
+    close();
     clear();
-    pipeInfo.setStatus(PipeStatus.DROP);
   }
 
   private void clear() {
@@ -376,9 +391,6 @@ public class TsFilePipe implements Pipe {
 
   @Override
   public void close() throws PipeException {
-    if (pipeInfo.getStatus() == PipeStatus.DROP) {
-      return;
-    }
     historyQueueMap.values().forEach(PipeDataQueue::close);
     realTimeQueueMap.values().forEach(PipeDataQueue::close);
     senderManager.close();

--- a/server/src/main/java/org/apache/iotdb/db/sync/transport/client/SenderManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/transport/client/SenderManager.java
@@ -118,6 +118,7 @@ public class SenderManager {
           if (!syncClient.handshake()) {
             SyncService.getInstance()
                 .recordMessage(
+                    pipe.getName(),
                     new PipeMessage(
                         PipeMessage.PipeMessageType.ERROR,
                         String.format("Can not handshake with %s", pipeSink)));
@@ -129,6 +130,7 @@ public class SenderManager {
               // can do something.
               SyncService.getInstance()
                   .recordMessage(
+                      pipe.getName(),
                       new PipeMessage(
                           PipeMessage.PipeMessageType.WARN,
                           String.format(

--- a/server/src/main/java/org/apache/iotdb/db/utils/sync/SyncPipeUtil.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/sync/SyncPipeUtil.java
@@ -109,7 +109,7 @@ public class SyncPipeUtil {
   }
 
   /** parse PipeInfo to Pipe, ignore status */
-  public static Pipe parseTPipeSinkInfoAsPipeSink(PipeInfo pipeInfo, PipeSink pipeSink)
+  public static Pipe parsePipeInfoAsPipe(PipeInfo pipeInfo, PipeSink pipeSink)
       throws PipeException {
     if (pipeInfo instanceof TsFilePipeInfo) {
       return new TsFilePipe(

--- a/server/src/test/java/org/apache/iotdb/db/sync/persistence/LocalSyncInfoTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/persistence/LocalSyncInfoTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iotdb.db.sync.receiver.manager;
+package org.apache.iotdb.db.sync.persistence;
 
 import org.apache.iotdb.commons.exception.sync.PipeException;
 import org.apache.iotdb.commons.sync.pipe.PipeInfo;
@@ -66,25 +66,26 @@ public class LocalSyncInfoTest {
       }
       localSyncInfo.addPipeSink(createPipeSinkPlan);
       localSyncInfo.addPipe(new TsFilePipeInfo(pipe1, "demo", createdTime1, 0, true));
+      localSyncInfo.addPipe(new TsFilePipeInfo(pipe2, "demo", createdTime2, 0, true));
       try {
         localSyncInfo.addPipe(new TsFilePipeInfo(pipe2, "demo", createdTime2, 0, true));
         Assert.fail();
       } catch (PipeException e) {
-        // throw exception because only one pipe is allowed now
+        // throw exception because pipe already exists
       }
-      localSyncInfo.operatePipe(pipe1, SyncOperation.DROP_PIPE);
-      localSyncInfo.addPipe(new TsFilePipeInfo(pipe2, "demo", createdTime2, 0, true));
       localSyncInfo.operatePipe(pipe2, SyncOperation.STOP_PIPE);
       localSyncInfo.operatePipe(pipe2, SyncOperation.START_PIPE);
       Assert.assertEquals(1, localSyncInfo.getAllPipeSink().size());
       Assert.assertEquals(2, localSyncInfo.getAllPipeInfos().size());
-      localSyncInfo.changePipeMessage(pipe2, createdTime2, PipeMessage.PipeMessageType.WARN);
-      localSyncInfo.changePipeMessage(pipe2, createdTime2, PipeMessage.PipeMessageType.NORMAL);
-      PipeInfo pipeInfo1 = localSyncInfo.getPipeInfo(pipe2, createdTime2);
+      localSyncInfo.changePipeMessage(pipe2, PipeMessage.PipeMessageType.WARN);
+      localSyncInfo.changePipeMessage(pipe2, PipeMessage.PipeMessageType.NORMAL);
+      PipeInfo pipeInfo1 = localSyncInfo.getPipeInfo(pipe2);
       Assert.assertEquals(PipeMessage.PipeMessageType.WARN, pipeInfo1.getMessageType());
-      localSyncInfo.changePipeMessage(pipe2, createdTime2, PipeMessage.PipeMessageType.ERROR);
-      PipeInfo pipeInfo2 = localSyncInfo.getPipeInfo(pipe2, createdTime2);
+      localSyncInfo.changePipeMessage(pipe2, PipeMessage.PipeMessageType.ERROR);
+      PipeInfo pipeInfo2 = localSyncInfo.getPipeInfo(pipe2);
       Assert.assertEquals(PipeMessage.PipeMessageType.ERROR, pipeInfo2.getMessageType());
+      localSyncInfo.operatePipe(pipe1, SyncOperation.DROP_PIPE);
+      Assert.assertEquals(1, localSyncInfo.getAllPipeInfos().size());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail();

--- a/server/src/test/java/org/apache/iotdb/db/sync/persistence/LocalSyncInfoTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/persistence/LocalSyncInfoTest.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.sync.persistence;
 
 import org.apache.iotdb.commons.exception.sync.PipeException;
+import org.apache.iotdb.commons.exception.sync.PipeSinkNotExistException;
 import org.apache.iotdb.commons.sync.pipe.PipeInfo;
 import org.apache.iotdb.commons.sync.pipe.PipeMessage;
 import org.apache.iotdb.commons.sync.pipe.SyncOperation;
@@ -61,7 +62,8 @@ public class LocalSyncInfoTest {
       try {
         localSyncInfo.addPipe(new TsFilePipeInfo(pipe1, "demo", createdTime1, 0, true));
         Assert.fail();
-      } catch (PipeException e) {
+      } catch (Exception e) {
+        Assert.assertTrue(e instanceof PipeSinkNotExistException);
         // throw exception because can not find pipeSink
       }
       localSyncInfo.addPipeSink(createPipeSinkPlan);


### PR DESCRIPTION
## Description

### IOTDB-4250
Support multiple pipes running at the same time. 
![multipipe](https://user-images.githubusercontent.com/43774645/195346846-8dbf5145-19de-4ce1-8e6e-6976f594fbce.png)



### IOTDB-4628

In old version, pipe infomation will be stored even if pipe has been dropped. There are two advantages to not storing pipe infomation after drop can.

1. Support rollback logic in procedure better. If failed to create pipe, drop directlt.
2. Other modules(e.g.Trigger) do the same thing. Doing so can keep the semantics consistent in IoTDB.
