### PR TITLE
[To rel/0.13][IOTDB-4636] Fix IndexOutOfBoundsException when compacting aligned series

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/AlignedSeriesCompactionExecutor.java
@@ -111,6 +111,7 @@ public class AlignedSeriesCompactionExecutor {
   }
 
   public void execute() throws IOException {
+    writer.startChunkGroup(device);
     while (readerAndChunkMetadataList.size() > 0) {
       Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> readerListPair =
           readerAndChunkMetadataList.removeFirst();
@@ -135,6 +136,7 @@ public class AlignedSeriesCompactionExecutor {
           chunkWriter.estimateMaxSeriesMemSize());
       chunkWriter.writeToFileWriter(writer);
     }
+    writer.endChunkGroup();
     writer.checkMetadataSizeAndMayFlush();
   }
 


### PR DESCRIPTION
See [IOTDB-4636](https://issues.apache.org/jira/browse/IOTDB-4636).

The reason for this bug is that there is an aligned chunk group in which every chunk in it is empty. This pr fix that by checking aligned chunk metadata before compacting it.