### PR TITLE
[To rel/0.13] [IOTDB-4561] Improve the RowRecord computing speed in GroupByWithoutValueFilterDataSet by multi thread

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
@@ -185,8 +185,9 @@ public class GroupByWithValueFilterDataSet extends GroupByEngineDataSet {
     List<String> gbAggregations = groupByTimePlan.getDeduplicatedAggregations();
     List<TSDataType> gbTsDataTypes = groupByTimePlan.getDeduplicatedDataTypes();
     for (int i = 0; i < curAggregateResults.length; ++i) {
-      curAggregateResults[i] = AggregateResultFactory.getAggrResultByName(
-          gbAggregations.get(i), gbTsDataTypes.get(i), ascending);
+      curAggregateResults[i] =
+          AggregateResultFactory.getAggrResultByName(
+              gbAggregations.get(i), gbTsDataTypes.get(i), ascending);
     }
 
     long[] timestampArray = new long[timeStampFetchSize];

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.db.query.timegenerator.ServerTimeGenerator;
 import org.apache.iotdb.db.utils.QueryUtils;
 import org.apache.iotdb.db.utils.TestOnly;
 import org.apache.iotdb.db.utils.ValueIterator;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
 import org.apache.iotdb.tsfile.read.filter.TimeFilter;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
@@ -181,12 +182,11 @@ public class GroupByWithValueFilterDataSet extends GroupByEngineDataSet {
     }
     hasCachedTimeInterval = false;
     curAggregateResults = new AggregateResult[paths.size()];
-    for (int i = 0; i < paths.size(); i++) {
-      curAggregateResults[i] =
-          AggregateResultFactory.getAggrResultByName(
-              groupByTimePlan.getDeduplicatedAggregations().get(i),
-              groupByTimePlan.getDeduplicatedDataTypes().get(i),
-              ascending);
+    List<String> gbAggregations = groupByTimePlan.getDeduplicatedAggregations();
+    List<TSDataType> gbTsDataTypes = groupByTimePlan.getDeduplicatedDataTypes();
+    for (int i = 0; i < curAggregateResults.length; ++i) {
+      curAggregateResults[i] = AggregateResultFactory.getAggrResultByName(
+          gbAggregations.get(i), gbTsDataTypes.get(i), ascending);
     }
 
     long[] timestampArray = new long[timeStampFetchSize];

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithoutValueFilterDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithoutValueFilterDataSet.java
@@ -19,9 +19,6 @@
 
 package org.apache.iotdb.db.query.dataset.groupby;
 
-import java.util.Objects;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.storagegroup.VirtualStorageGroupProcessor;
 import org.apache.iotdb.db.exception.StorageEngineException;
@@ -50,7 +47,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class GroupByWithoutValueFilterDataSet extends GroupByEngineDataSet {
 

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithoutValueFilterDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithoutValueFilterDataSet.java
@@ -19,6 +19,9 @@
 
 package org.apache.iotdb.db.query.dataset.groupby;
 
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.storagegroup.VirtualStorageGroupProcessor;
 import org.apache.iotdb.db.exception.StorageEngineException;
@@ -201,41 +204,83 @@ public class GroupByWithoutValueFilterDataSet extends GroupByEngineDataSet {
   }
 
   private AggregateResult[] getNextAggregateResult() throws IOException {
-    curAggregateResults = new AggregateResult[paths.size()];
-    try {
-      // get aggregate results of non-aligned series
-      for (Map.Entry<PartialPath, List<Integer>> entry : pathToAggrIndexesMap.entrySet()) {
-        MeasurementPath path = (MeasurementPath) entry.getKey();
-        List<Integer> indexes = entry.getValue();
-        GroupByExecutor groupByExecutor = pathExecutors.get(path);
-        List<AggregateResult> aggregations = groupByExecutor.calcResult(curStartTime, curEndTime);
-        for (int i = 0; i < aggregations.size(); i++) {
-          int resultIndex = indexes.get(i);
-          curAggregateResults[resultIndex] = aggregations.get(i);
-        }
-      }
-      // get aggregate results of aligned series
-      for (Map.Entry<AlignedPath, List<List<Integer>>> entry :
-          alignedPathToAggrIndexesMap.entrySet()) {
-        AlignedPath path = entry.getKey();
-        List<List<Integer>> indexesList = entry.getValue();
-        AlignedGroupByExecutor groupByExecutor = alignedPathExecutors.get(path);
-        List<List<AggregateResult>> aggregationsList =
-            groupByExecutor.calcAlignedResult(curStartTime, curEndTime);
-        for (int i = 0; i < path.getMeasurementList().size(); i++) {
-          List<AggregateResult> aggregations = aggregationsList.get(i);
-          List<Integer> indexes = indexesList.get(i);
-          for (int j = 0; j < aggregations.size(); j++) {
-            int resultIndex = indexes.get(j);
-            curAggregateResults[resultIndex] = aggregations.get(j);
-          }
-        }
-      }
-    } catch (QueryProcessException e) {
-      logger.error("GroupByWithoutValueFilterDataSet execute has error", e);
+    AggregateResult[] aggregateResults = new AggregateResult[paths.size()];
+    // exceptions queue
+    Queue<Exception> exs = new ConcurrentLinkedQueue<>();
+
+    // get aggregate results of non-aligned series
+    // multi thread optimization
+    pathToAggrIndexesMap
+        .entrySet()
+        .parallelStream()
+        .map(
+            entry -> {
+              MeasurementPath path = (MeasurementPath) entry.getKey();
+              GroupByExecutor groupByExecutor = pathExecutors.get(path);
+              try {
+                return new Pair<>(
+                    entry.getValue(), groupByExecutor.calcResult(curStartTime, curEndTime));
+              } catch (Exception e) {
+                logger.error("GroupByWithoutValueFilterDataSet execute has error", e);
+                exs.offer(e);
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .forEach(
+            pair -> {
+              List<Integer> indexes = pair.left;
+              List<AggregateResult> aggregations = pair.right;
+              for (int i = 0; i < aggregations.size(); ++i) {
+                int resultIndex = indexes.get(i);
+                aggregateResults[resultIndex] = aggregations.get(i);
+              }
+            });
+
+    if (!exs.isEmpty()) {
+      Exception e = exs.peek();
       throw new IOException(e.getMessage(), e);
     }
-    return curAggregateResults;
+
+    // get aggregate results of aligned series
+    // multi thread optimization
+    alignedPathToAggrIndexesMap
+        .entrySet()
+        .parallelStream()
+        .map(
+            entry -> {
+              AlignedGroupByExecutor groupByExecutor = alignedPathExecutors.get(entry.getKey());
+              try {
+                return new Pair<>(
+                    entry, groupByExecutor.calcAlignedResult(curStartTime, curEndTime));
+              } catch (Exception e) {
+                logger.error("GroupByWithoutValueFilterDataSet execute has error", e);
+                exs.offer(e);
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .forEach(
+            pair -> {
+              int pathMeasurementsNum = pair.left.getKey().getMeasurementList().size();
+              List<List<Integer>> indexesList = pair.left.getValue();
+              List<List<AggregateResult>> aggregationsList = pair.right;
+              for (int i = 0; i < pathMeasurementsNum; ++i) {
+                List<AggregateResult> aggregations = aggregationsList.get(i);
+                List<Integer> indexes = indexesList.get(i);
+                for (int j = 0; j < aggregations.size(); ++j) {
+                  int resultIndex = indexes.get(j);
+                  aggregateResults[resultIndex] = aggregations.get(j);
+                }
+              }
+            });
+
+    if (!exs.isEmpty()) {
+      Exception e = exs.peek();
+      throw new IOException(e.getMessage(), e);
+    }
+
+    return aggregateResults;
   }
 
   protected GroupByExecutor getGroupByExecutor(


### PR DESCRIPTION
1. Improve the RowRecord computing speed in GroupByWithoutValueFilterDataSet by multi thread strategy