### PR TITLE
Fix cycle initializing IoTDBDescriptor

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1005,7 +1005,8 @@ public class IoTDBDescriptor {
     loadAuthorCache(properties);
 
     conf.setTimePartitionIntervalForStorage(
-        DateTimeUtils.convertMilliTimeWithPrecision(conf.getTimePartitionIntervalForStorage()));
+        DateTimeUtils.convertMilliTimeWithPrecision(
+            conf.getTimePartitionIntervalForStorage(), conf.getTimestampPrecision()));
   }
 
   private void loadAuthorCache(Properties properties) {
@@ -1918,7 +1919,8 @@ public class IoTDBDescriptor {
     conf.setSeriesPartitionExecutorClass(globalConfig.getSeriesPartitionExecutorClass());
     conf.setSeriesPartitionSlotNum(globalConfig.getSeriesPartitionSlotNum());
     conf.setTimePartitionIntervalForRouting(
-        DateTimeUtils.convertMilliTimeWithPrecision(globalConfig.timePartitionInterval));
+        DateTimeUtils.convertMilliTimeWithPrecision(
+            globalConfig.timePartitionInterval, conf.getTimestampPrecision()));
     conf.setReadConsistencyLevel(globalConfig.getReadConsistencyLevel());
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -3298,7 +3298,9 @@ public class DataRegion {
 
   public void setDataTTLWithTimePrecisionCheck(long dataTTL) {
     if (dataTTL != Long.MAX_VALUE) {
-      dataTTL = DateTimeUtils.convertMilliTimeWithPrecision(dataTTL);
+      dataTTL =
+          DateTimeUtils.convertMilliTimeWithPrecision(
+              dataTTL, IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision());
     }
     this.dataTTL = dataTTL;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/utils/DateTimeUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/utils/DateTimeUtils.java
@@ -686,9 +686,8 @@ public class DateTimeUtils {
     return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millisecond), ZoneId.systemDefault());
   }
 
-  public static long convertMilliTimeWithPrecision(long milliTime) {
+  public static long convertMilliTimeWithPrecision(long milliTime, String timePrecision) {
     long result = milliTime;
-    String timePrecision = IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision();
     switch (timePrecision) {
       case "ns":
         result = milliTime * 1000_000L;


### PR DESCRIPTION
See these error logs during starting.

![image](https://user-images.githubusercontent.com/3821212/195618465-ecf67e0f-41f9-4cb9-80ad-e357ac7fc33d.png)

This is a bug caused by #7577 

The root cause is that `IoTDBDescriptor` is a singleton and when the constructor is called, `loadProperties()` is called. However, there's a call of `IoTDBDescriptor.getInstance()` in `convertMilliTimeWithPrecision()`. As the initializing hasn't been finished, the `getInstance()` just returns `null`.

`DatetimeUtils` is a static class, so it's better not to depend on dynamic components, just decouples with `IoTDBDescriptor` through a method parameter.