### PR TITLE
[To Rel/0.13][IOTDB-4635] Fix data cannot be queried when flushing memtable

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/utils/MultiTsFileDeviceIterator.java
@@ -173,8 +173,6 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
    * return MeasurementIterator, who iterates the measurements of not aligned device
    *
    * @param device the full path of the device to be iterated
-   * @return
-   * @throws IOException
    */
   public MeasurementIterator iterateNotAlignedSeries(
       String device, boolean derserializeTimeseriesMetadata) throws IOException {
@@ -191,7 +189,6 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
    *
    * @return a list of pair(TsFileSequenceReader, the list of AlignedChunkMetadata for current
    *     device)
-   * @throws IOException
    */
   public LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
       getReaderAndChunkMetadataForCurrentAlignedSeries() throws IOException {
@@ -387,9 +384,6 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
      *
      * <p>If there are any modifications for these chunk, we will apply them to the metadata. Use
      * `ChunkMetadata.getDeleteIntervalList() == null` to judge if the chunk is modified.
-     *
-     * @return
-     * @throws IllegalPathException
      */
     public LinkedList<Pair<TsFileSequenceReader, List<ChunkMetadata>>>
         getMetadataListForCurrentSeries() throws IllegalPathException {

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -280,7 +280,6 @@ public class MemTableFlushTask {
               this.writer.setMinPlanIndex(memTable.getMinPlanIndex());
               this.writer.setMaxPlanIndex(memTable.getMaxPlanIndex());
               this.writer.endChunkGroup();
-              writer.checkMetadataSizeAndMayFlush();
             } else {
               ((IChunkWriter) ioMessage).writeToFileWriter(this.writer);
             }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -172,14 +172,7 @@ public class TsFileProcessor {
     this.storageGroupName = storageGroupName;
     this.tsFileResource = new TsFileResource(tsfile, this);
     this.storageGroupInfo = storageGroupInfo;
-    this.writer =
-        new RestorableTsFileIOWriter(
-            tsfile,
-            (long)
-                (IoTDBDescriptor.getInstance().getConfig().getMemtableSizeThreshold()
-                    * IoTDBDescriptor.getInstance()
-                        .getConfig()
-                        .getChunkMetadataMemorySizeProportion()));
+    this.writer = new RestorableTsFileIOWriter(tsfile);
     this.updateLatestFlushTimeCallback = updateLatestFlushTimeCallback;
     this.sequence = sequence;
     logger.info("create a new tsfile processor {}", tsfile.getAbsolutePath());

--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.writelog.recover;
 
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
 import org.apache.iotdb.db.engine.flush.MemTableFlushTask;
 import org.apache.iotdb.db.engine.memtable.IMemTable;
@@ -114,14 +113,7 @@ public class TsFileRecoverPerformer {
     // remove corrupted part of the TsFile
     RestorableTsFileIOWriter restorableTsFileIOWriter = null;
     try {
-      restorableTsFileIOWriter =
-          new RestorableTsFileIOWriter(
-              file,
-              (long)
-                  (IoTDBDescriptor.getInstance().getConfig().getMemtableSizeThreshold()
-                      * IoTDBDescriptor.getInstance()
-                          .getConfig()
-                          .getChunkMetadataMemorySizeProportion()));
+      restorableTsFileIOWriter = new RestorableTsFileIOWriter(file);
     } catch (NotCompatibleTsFileException e) {
       boolean result = file.delete();
       logger.warn("TsFile {} is incompatible. Delete it successfully {}", filePath, result);


### PR DESCRIPTION
See [IOTDB-4635](https://issues.apache.org/jira/browse/IOTDB-4635).

The reason for this bug is that the chunk metadata is persisted in disk when flushing memtable to control the memory usage, the query cannot get access to the chunk metadata.