### PR TITLE
[IOTDB-4654] Fix concurrent bug caused by sharing same ChunkMetadata

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/metadata/DiskAlignedChunkMetadataLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/metadata/DiskAlignedChunkMetadataLoader.java
@@ -58,7 +58,7 @@ public class DiskAlignedChunkMetadataLoader implements IChunkMetadataLoader {
   @Override
   public List<IChunkMetadata> loadChunkMetadataList(ITimeSeriesMetadata timeSeriesMetadata) {
     List<AlignedChunkMetadata> alignedChunkMetadataList =
-        ((AlignedTimeSeriesMetadata) timeSeriesMetadata).getChunkMetadataList();
+        ((AlignedTimeSeriesMetadata) timeSeriesMetadata).getCopiedChunkMetadataList();
 
     // get all sub sensors' modifications
     List<List<Modification>> pathModifications =

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/metadata/DiskChunkMetadataLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/chunk/metadata/DiskChunkMetadataLoader.java
@@ -57,7 +57,7 @@ public class DiskChunkMetadataLoader implements IChunkMetadataLoader {
   public List<IChunkMetadata> loadChunkMetadataList(ITimeSeriesMetadata timeSeriesMetadata) {
 
     List<IChunkMetadata> chunkMetadataList =
-        ((TimeseriesMetadata) timeSeriesMetadata).getChunkMetadataList();
+        ((TimeseriesMetadata) timeSeriesMetadata).getCopiedChunkMetadataList();
 
     List<Modification> pathModifications =
         context.getPathModifications(resource.getModFile(), seriesPath);

--- a/server/src/main/java/org/apache/iotdb/db/utils/QueryUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/QueryUtils.java
@@ -79,9 +79,7 @@ public class QueryUtils {
               if (range.contains(metaData.getStartTime(), metaData.getEndTime())) {
                 return true;
               } else {
-                if (!metaData.isModified()
-                    && range.overlaps(
-                        new TimeRange(metaData.getStartTime(), metaData.getEndTime()))) {
+                if (range.overlaps(new TimeRange(metaData.getStartTime(), metaData.getEndTime()))) {
                   metaData.setModified(true);
                 }
               }
@@ -137,11 +135,9 @@ public class QueryUtils {
                   currentRemoved = true;
                   break;
                 } else {
-                  if (!valueChunkMetadata.isModified()
-                      && range.overlaps(
-                          new TimeRange(
-                              valueChunkMetadata.getStartTime(),
-                              valueChunkMetadata.getEndTime()))) {
+                  if (range.overlaps(
+                      new TimeRange(
+                          valueChunkMetadata.getStartTime(), valueChunkMetadata.getEndTime()))) {
                     valueChunkMetadata.setModified(true);
                     modified = true;
                   }
@@ -154,9 +150,7 @@ public class QueryUtils {
               removed = false;
             }
           }
-          if (!alignedChunkMetadata.isModified()) {
-            alignedChunkMetadata.setModified(modified);
-          }
+          alignedChunkMetadata.setModified(modified);
           return removed;
         });
   }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/AlignedTimeSeriesMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/AlignedTimeSeriesMetadata.java
@@ -103,6 +103,16 @@ public class AlignedTimeSeriesMetadata implements ITimeSeriesMetadata {
     return chunkMetadataLoader.loadChunkMetadataList(this);
   }
 
+  public List<AlignedChunkMetadata> getCopiedChunkMetadataList() {
+    List<IChunkMetadata> timeChunkMetadata = timeseriesMetadata.getCopiedChunkMetadataList();
+    List<List<IChunkMetadata>> valueChunkMetadataList = new ArrayList<>();
+    for (TimeseriesMetadata metadata : valueTimeseriesMetadataList) {
+      valueChunkMetadataList.add(metadata == null ? null : metadata.getCopiedChunkMetadataList());
+    }
+
+    return getAlignedChunkMetadata(timeChunkMetadata, valueChunkMetadataList);
+  }
+
   public List<AlignedChunkMetadata> getChunkMetadataList() {
     List<IChunkMetadata> timeChunkMetadata = timeseriesMetadata.getChunkMetadataList();
     List<List<IChunkMetadata>> valueChunkMetadataList = new ArrayList<>();
@@ -110,6 +120,11 @@ public class AlignedTimeSeriesMetadata implements ITimeSeriesMetadata {
       valueChunkMetadataList.add(metadata == null ? null : metadata.getChunkMetadataList());
     }
 
+    return getAlignedChunkMetadata(timeChunkMetadata, valueChunkMetadataList);
+  }
+
+  private List<AlignedChunkMetadata> getAlignedChunkMetadata(
+      List<IChunkMetadata> timeChunkMetadata, List<List<IChunkMetadata>> valueChunkMetadataList) {
     List<AlignedChunkMetadata> res = new ArrayList<>();
     for (int i = 0; i < timeChunkMetadata.size(); i++) {
       List<IChunkMetadata> chunkMetadataList = new ArrayList<>();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkMetadata.java
@@ -103,6 +103,24 @@ public class ChunkMetadata implements IChunkMetadata {
     this.statistics = statistics;
   }
 
+  // won't clone deleteIntervalList & modified
+  public ChunkMetadata(ChunkMetadata other) {
+    this.measurementUid = other.measurementUid;
+    this.offsetOfChunkHeader = other.offsetOfChunkHeader;
+    this.tsDataType = other.tsDataType;
+    this.version = other.version;
+    this.chunkLoader = other.chunkLoader;
+    this.statistics = other.statistics;
+    this.isFromOldTsFile = other.isFromOldTsFile;
+    this.ramSize = other.ramSize;
+    this.isSeq = other.isSeq;
+    this.isClosed = other.isClosed;
+    this.filePath = other.filePath;
+    this.mask = other.mask;
+    this.tsFilePrefixPath = other.tsFilePrefixPath;
+    this.compactionVersion = other.compactionVersion;
+  }
+
   @Override
   public String toString() {
     return String.format(

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/TimeseriesMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/TimeseriesMetadata.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class TimeseriesMetadata implements ITimeSeriesMetadata {
 
@@ -243,6 +244,12 @@ public class TimeseriesMetadata implements ITimeSeriesMetadata {
 
   public List<IChunkMetadata> getChunkMetadataList() {
     return chunkMetadataList;
+  }
+
+  public List<IChunkMetadata> getCopiedChunkMetadataList() {
+    return chunkMetadataList.stream()
+        .map(chunkMetadata -> new ChunkMetadata((ChunkMetadata) chunkMetadata))
+        .collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
Each query requires regenerating the `deleteIntervalList` and `modified` for the `ChunkMetadata`. Since the same `ChunkMetadata` is shared, the `deleteIntervalList` and `modified` will be modified at the same time between multiple threads, resulting in incorrect query result.

**Solution:** Construct new `ChunkMetadataList` for each query.