### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka_2.13 to 2.8.2

### DIFF
--- a/example/kafka/pom.xml
+++ b/example/kafka/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.13</artifactId>
-            <version>2.8.1</version>
+            <version>2.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka_2.13 2.8.1
- [CVE-2022-34917](https://www.oscs1024.com/hd/CVE-2022-34917)


### What did I do？
Upgrade org.apache.kafka:kafka_2.13 from 2.8.1 to 2.8.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS