### PR TITLE
[To rel/0.13][IOTDB-4640] Allow setting the same data archiving task after canceling it

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -1316,13 +1316,8 @@ public class StorageEngine implements IService {
   }
 
   /** push the archiving info to archivingManager */
-  public void setArchiving(PartialPath storageGroup, File targetDir, long ttl, long startTime) {
-    boolean result = archivingManager.setArchiving(storageGroup, targetDir, ttl, startTime);
-    if (result) {
-      logger.info("set archiving task successfully.");
-    } else {
-      logger.info("set archiving task failed.");
-    }
+  public boolean setArchiving(PartialPath storageGroup, File targetDir, long ttl, long startTime) {
+    return archivingManager.setArchiving(storageGroup, targetDir, ttl, startTime);
   }
 
   public boolean operateArchiving(

--- a/server/src/main/java/org/apache/iotdb/db/engine/archiving/ArchivingManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/archiving/ArchivingManager.java
@@ -212,11 +212,14 @@ public class ArchivingManager {
 
       // check if there are duplicates
       for (ArchivingTask archivingTask : archivingTasks) {
-        if (archivingTask.getStorageGroup().getFullPath().equals(storageGroup.getFullPath())
+        if (archivingTask.isActive()
+            && archivingTask.getStorageGroup().getFullPath().equals(storageGroup.getFullPath())
             && archivingTask.getTargetDir().equals(targetDir)
             && archivingTask.getTTL() == ttl
             && archivingTask.getStartTime() == startTime) {
-          logger.warn("archiving task already equals archiving task {}", archivingTask.getTaskId());
+          logger.warn(
+              "Fail to set archiving task, it's same as the archiving task {}",
+              archivingTask.getTaskId());
           return false;
         }
       }


### PR DESCRIPTION
1. Judge active info when comparing two archiving task
2. Return info to the client when failing to set archiving task