### PR TITLE
[IOTDB-4649] Fix the problem that constants which have same valueString but different types can not be distinguished.

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -50,7 +50,6 @@ import org.apache.iotdb.db.mpp.plan.Coordinator;
 import org.apache.iotdb.db.mpp.plan.execution.ExecutionResult;
 import org.apache.iotdb.db.mpp.plan.expression.Expression;
 import org.apache.iotdb.db.mpp.plan.expression.ExpressionType;
-import org.apache.iotdb.db.mpp.plan.expression.leaf.ConstantOperand;
 import org.apache.iotdb.db.mpp.plan.expression.leaf.TimeSeriesOperand;
 import org.apache.iotdb.db.mpp.plan.expression.multi.FunctionExpression;
 import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.FillDescriptor;
@@ -737,7 +736,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     outputExpressions.clear();
     for (String tagKey : tagKeys) {
-      Expression tagKeyExpression = new ConstantOperand(TSDataType.TEXT, tagKey);
+      Expression tagKeyExpression = TimeSeriesOperand.constructColumnHeaderExpression(tagKey);
       analyzeExpression(analysis, tagKeyExpression);
       outputExpressions.add(new Pair<>(tagKeyExpression, null));
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -736,7 +736,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     outputExpressions.clear();
     for (String tagKey : tagKeys) {
-      Expression tagKeyExpression = TimeSeriesOperand.constructColumnHeaderExpression(tagKey);
+      Expression tagKeyExpression =
+          TimeSeriesOperand.constructColumnHeaderExpression(tagKey, TSDataType.TEXT);
       analyzeExpression(analysis, tagKeyExpression);
       outputExpressions.add(new Pair<>(tagKeyExpression, null));
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/leaf/ConstantOperand.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/leaf/ConstantOperand.java
@@ -113,6 +113,8 @@ public class ConstantOperand extends LeafOperand {
 
   @Override
   public String getExpressionStringInternal() {
+    // Currently, we use Expression String to distinguish the expressions.
+    // So we need to distinguish number 1 and text "1"
     return dataType.equals(TSDataType.TEXT) ? String.format("\"%s\"", valueString) : valueString;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/leaf/ConstantOperand.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/leaf/ConstantOperand.java
@@ -113,7 +113,7 @@ public class ConstantOperand extends LeafOperand {
 
   @Override
   public String getExpressionStringInternal() {
-    return valueString;
+    return dataType.equals(TSDataType.TEXT) ? String.format("\"%s\"", valueString) : valueString;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/leaf/TimeSeriesOperand.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/leaf/TimeSeriesOperand.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.mpp.plan.expression.leaf;
 
+import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathDeserializeUtil;
 import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
@@ -28,6 +29,7 @@ import org.apache.iotdb.db.mpp.plan.expression.visitor.ExpressionVisitor;
 import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.mpp.transformation.dag.memory.LayerMemoryAssigner;
 import org.apache.iotdb.db.qp.physical.crud.UDTFPlan;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -46,6 +48,12 @@ public class TimeSeriesOperand extends LeafOperand {
 
   public TimeSeriesOperand(ByteBuffer byteBuffer) {
     path = (PartialPath) PathDeserializeUtil.deserialize(byteBuffer);
+  }
+
+  public static TimeSeriesOperand constructColumnHeaderExpression(String columnName) {
+    MeasurementPath measurementPath =
+        new MeasurementPath(new PartialPath(columnName, false), TSDataType.TEXT);
+    return new TimeSeriesOperand(measurementPath);
   }
 
   public PartialPath getPath() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/leaf/TimeSeriesOperand.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/leaf/TimeSeriesOperand.java
@@ -50,9 +50,10 @@ public class TimeSeriesOperand extends LeafOperand {
     path = (PartialPath) PathDeserializeUtil.deserialize(byteBuffer);
   }
 
-  public static TimeSeriesOperand constructColumnHeaderExpression(String columnName) {
+  public static TimeSeriesOperand constructColumnHeaderExpression(
+      String columnName, TSDataType dataType) {
     MeasurementPath measurementPath =
-        new MeasurementPath(new PartialPath(columnName, false), TSDataType.TEXT);
+        new MeasurementPath(new PartialPath(columnName, false), dataType);
     return new TimeSeriesOperand(measurementPath);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/input/ConstantInputReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/input/ConstantInputReader.java
@@ -46,8 +46,7 @@ public class ConstantInputReader implements LayerPointReader {
   public ConstantInputReader(ConstantOperand expression) throws QueryProcessException {
     this.expression = Validate.notNull(expression);
 
-    Object value =
-        CommonUtils.parseValue(expression.getDataType(), expression.getExpressionString());
+    Object value = CommonUtils.parseValue(expression.getDataType(), expression.getValueString());
     if (value == null) {
       throw new QueryProcessException(
           "Invalid constant operand: " + expression.getExpressionString());

--- a/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/util/TransformUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/util/TransformUtils.java
@@ -68,8 +68,7 @@ public class TransformUtils {
 
     try {
       Object value =
-          CommonUtils.parseValue(
-              constantOperand.getDataType(), constantOperand.getExpressionString());
+          CommonUtils.parseValue(constantOperand.getDataType(), constantOperand.getValueString());
       if (value == null) {
         throw new UnsupportedOperationException(
             "Invalid constant operand: " + constantOperand.getExpressionString());

--- a/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/NodeRefTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/NodeRefTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.common.schematree;
+
+import org.apache.iotdb.db.mpp.common.NodeRef;
+import org.apache.iotdb.db.mpp.plan.expression.Expression;
+import org.apache.iotdb.db.mpp.plan.expression.leaf.ConstantOperand;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NodeRefTest {
+
+  @Test
+  public void testHashCode() {
+    ConstantOperand constantOperand1 = new ConstantOperand(TSDataType.INT64, "2");
+    ConstantOperand constantOperand2 = new ConstantOperand(TSDataType.TEXT, "2");
+    NodeRef<Expression> constant1 = NodeRef.of(constantOperand1);
+    NodeRef<Expression> constant2 = NodeRef.of(constantOperand2);
+    NodeRef<Expression> constant3 = NodeRef.of(constantOperand1);
+    Map<NodeRef<Expression>, String> map = new HashMap<>();
+    map.put(constant1, "test");
+    Assert.assertNull(map.get(constant2));
+    Assert.assertEquals("test", map.get(constant3));
+  }
+}


### PR DESCRIPTION
Before this PR, we use expressionString to distinguish the expressions. However, Long value 1 and String value "1" has the same expressionString. The details could be found at: https://issues.apache.org/jira/browse/IOTDB-4649