### PR TITLE
Add detailed error messages while query is time out

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/exception/query/QueryTimeoutRuntimeException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/query/QueryTimeoutRuntimeException.java
@@ -24,11 +24,20 @@ public class QueryTimeoutRuntimeException extends RuntimeException {
   public static final String TIMEOUT_EXCEPTION_MESSAGE =
       "Current query is time out, please check your statement or modify timeout parameter.";
 
+  public static final String QUERY_TIMEOUT_EXCEPTION_MESSAGE =
+      "Current query is time out, query start time is %d, ddl is %d, current time is %d, please check your statement or modify timeout parameter.";
+
   public QueryTimeoutRuntimeException(String message, Throwable cause) {
     super(message, cause);
   }
 
   public QueryTimeoutRuntimeException() {
     super(TIMEOUT_EXCEPTION_MESSAGE);
+  }
+
+  public QueryTimeoutRuntimeException(long startTime, long currentTime, long timeout) {
+    super(
+        String.format(
+            QUERY_TIMEOUT_EXCEPTION_MESSAGE, startTime, startTime + timeout, currentTime));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -173,9 +173,11 @@ public class QueryExecution implements IQueryExecution {
       }
       return;
     }
-    long remainTime = context.getTimeOut() - (System.currentTimeMillis() - context.getStartTime());
+    long currentTime = System.currentTimeMillis();
+    long remainTime = context.getTimeOut() - (currentTime - context.getStartTime());
     if (remainTime <= 0) {
-      throw new QueryTimeoutRuntimeException();
+      throw new QueryTimeoutRuntimeException(
+          context.getStartTime(), currentTime, context.getTimeOut());
     }
     context.setTimeOut(remainTime);
 


### PR DESCRIPTION
I found a strange thing in failed CI logs. The execution time of this query doesn't exceed 60s(default query time out limit).
So in this pr, I add more detailed error messaes in QueryTimeoutExecption if this strange thing happen again, I can figure out the reason.
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/16079446/196086971-1fbd7b94-b5af-4226-b73e-1ffd63434edb.png">
