### PR TITLE
[IOTDB-4680] fix error msg "%s" in load statement

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/LoadTsFileStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/LoadTsFileStatement.java
@@ -59,7 +59,9 @@ public class LoadTsFileStatement extends Statement {
     } else {
       if (file.listFiles() == null) {
         throw new FileNotFoundException(
-            "Can not find %s on this machine, notice that load can only handle files on this machine.");
+            String.format(
+                "Can not find %s on this machine, notice that load can only handle files on this machine.",
+                filePath));
       }
       findAllTsFile(file);
     }


### PR DESCRIPTION
problem:
if load error, a "%s" will be printed to user as follow:
![image](https://user-images.githubusercontent.com/87161145/196389694-edc93792-16d6-4ee8-af45-9094c98afcd5.png)

solution:
fix a correct format in msg.

and
NoSuchFileException has been fix in #7354 