### PR TITLE
Make default timeout parameter in SessionIT from 1s to 60s

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionInsertNulIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionInsertNulIT.java
@@ -87,7 +87,7 @@ public class IoTDBSessionInsertNulIT {
 
   private long queryCountRecords(ISession session, String sql)
       throws StatementExecutionException, IoTDBConnectionException {
-    SessionDataSet dataSetWrapper = session.executeQueryStatement(sql, 1000);
+    SessionDataSet dataSetWrapper = session.executeQueryStatement(sql, 60_000);
     long count = 0;
     while (dataSetWrapper.hasNext()) {
       RowRecord record = dataSetWrapper.next();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -173,13 +173,18 @@ public class QueryExecution implements IQueryExecution {
       }
       return;
     }
-    long currentTime = System.currentTimeMillis();
-    long remainTime = context.getTimeOut() - (currentTime - context.getStartTime());
-    if (remainTime <= 0) {
-      throw new QueryTimeoutRuntimeException(
-          context.getStartTime(), currentTime, context.getTimeOut());
+
+    // only update query operation's timeout because we will never limit write operation's execution
+    // time
+    if (isQuery()) {
+      long currentTime = System.currentTimeMillis();
+      long remainTime = context.getTimeOut() - (currentTime - context.getStartTime());
+      if (remainTime <= 0) {
+        throw new QueryTimeoutRuntimeException(
+            context.getStartTime(), currentTime, context.getTimeOut());
+      }
+      context.setTimeOut(remainTime);
     }
-    context.setTimeOut(remainTime);
 
     doLogicalPlan();
     doDistributedPlan();


### PR DESCRIPTION
Sometimes, IoTDBSessionInsertNulIT will timeout because its timeout parameter is set to 1s which is too small, especially in github CI container, so I change it to 60s.
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/16079446/196423800-34a10584-3a98-41ed-b2d6-b3d527566ea6.png">
