### PR TITLE
[IOTDB-4679] Make MPPDataExchangeService use internal_address instead of rpc_address

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeService.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeService.java
@@ -75,8 +75,7 @@ public class MPPDataExchangeService extends ThriftService implements MPPDataExch
   }
 
   @Override
-  public void initTProcessor()
-      throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+  public void initTProcessor() {
     initSyncedServiceImpl(null);
     processor = new Processor<>(mppDataExchangeManager.getOrCreateMPPDataExchangeServiceImpl());
   }
@@ -86,8 +85,7 @@ public class MPPDataExchangeService extends ThriftService implements MPPDataExch
   }
 
   @Override
-  public void initThriftServiceThread()
-      throws IllegalAccessException, InstantiationException, ClassNotFoundException {
+  public void initThriftServiceThread() throws IllegalAccessException {
     try {
       IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
       thriftServiceThread =
@@ -112,7 +110,7 @@ public class MPPDataExchangeService extends ThriftService implements MPPDataExch
 
   @Override
   public String getBindIP() {
-    return IoTDBDescriptor.getInstance().getConfig().getRpcAddress();
+    return IoTDBDescriptor.getInstance().getConfig().getInternalAddress();
   }
 
   @Override


### PR DESCRIPTION
Currently, MPPDataExchangeService uses the `rpc_address` which should be `internal_address`.