### PR TITLE
[IOTDB-4683] Fix REJECT_THERSHOLD init error in SystemInfo

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -99,10 +99,11 @@ public class SystemInfo {
       return true;
     } else {
       logger.info(
-          "Change system to reject status. Triggered by: logical SG ({}), mem cost delta ({}), totalSgMemCost ({}).",
+          "Change system to reject status. Triggered by: logical SG ({}), mem cost delta ({}), totalSgMemCost ({}), REJECT_THERSHOLD ({})",
           dataRegionInfo.getDataRegion().getStorageGroupName(),
           delta,
-          totalStorageGroupMemCost);
+          totalStorageGroupMemCost,
+          REJECT_THERSHOLD);
       rejected = true;
       if (chooseMemTablesToMarkFlush(tsFileProcessor)) {
         if (totalStorageGroupMemCost < memorySizeForWrite) {
@@ -201,6 +202,8 @@ public class SystemInfo {
         (long) (config.getAllocateMemoryForStorageEngine() * config.getWriteProportion());
     memorySizeForCompaction =
         (long) (config.getAllocateMemoryForStorageEngine() * config.getCompactionProportion());
+    FLUSH_THERSHOLD = memorySizeForWrite * config.getFlushProportion();
+    REJECT_THERSHOLD = memorySizeForWrite * config.getRejectProportion();
   }
 
   @TestOnly


### PR DESCRIPTION
## Description

REJECT_THERSHOLD is initialized to 0.
 
![a57b5123f87b77996aa0a1678fad65e9](https://user-images.githubusercontent.com/25913899/196425962-8dcff31b-b06e-4f67-af37-4d377e4f3ce1.jpg)

![e3f072bea35125d5aaaaabea4c9bac63](https://user-images.githubusercontent.com/25913899/196425981-6d20ab66-1f6b-44ff-ae3b-914a88d9923e.jpg)
