### PR TITLE
[IOTDB-3462] Update ratis version to 2.4.0

### DIFF
--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <ratis.version>2.3.0</ratis.version>
+        <ratis.version>2.4.0</ratis.version>
         <consensus.test.skip>false</consensus.test.skip>
         <consensus.it.skip>${consensus.test.skip}</consensus.it.skip>
         <consensus.ut.skip>${consensus.test.skip}</consensus.ut.skip>

--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
@@ -46,6 +46,9 @@ public class SnapshotTest {
   private static class EmptyStorageWithOnlySMDir implements RaftStorage {
 
     @Override
+    public void initialize() throws IOException {}
+
+    @Override
     public RaftStorageDirectory getStorageDir() {
       return new RaftStorageDirectory() {
         @Override


### PR DESCRIPTION
Recently Ratis Community releases its new version 2.4.0.
Ratis 2.4.0 includes multiple bug-fixes and improvements.

This PR only updates version (and fixes incompatibilities). Run CI to verify its correctness.