### PR TITLE
[IOTDB-4689] Use seperate channel for heartbeat / appendEntries

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
@@ -239,5 +239,7 @@ public class Utils {
         properties, config.getLeaderLogAppender().getSnapshotChunkSizeMax());
     RaftServerConfigKeys.Log.Appender.setInstallSnapshotEnabled(
         properties, config.getLeaderLogAppender().isInstallSnapshotEnabled());
+
+    GrpcConfigKeys.Server.setHeartbeatChannel(properties, true);
   }
 }


### PR DESCRIPTION
# original design
Currently, AppendEntries and Heartbeat uses the same gRPC channel.
Under heavy workloads, AppendEntries with lots of logs will consume a lot of processing time, so the follower may respond to this AppendEntries after a long latency. The leader would consider this long latency abnormal and step down.
So uses a separate channel can avoid heartbeat being blocked by AppendEntries.

# What's the downside?
We need two channels which means we have to establish a new http2 connection.