### PR TITLE
[IOTDB-4293] BufferedPipeDataQueue supports discontinuous serialNumber

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/sync/pipedata/queue/BufferedPipeDataQueue.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/pipedata/queue/BufferedPipeDataQueue.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.sync.utils.SyncPathUtil;
 import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.sync.pipedata.PipeData;
 import org.apache.iotdb.db.sync.pipedata.TsFilePipeData;
+import org.apache.iotdb.tsfile.exception.NotImplementedException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,8 +125,7 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
               : recoverPipeData.get(recoverPipeDataSize - 1).getSerialNumber();
     } catch (IOException e) {
       logger.error(
-          String.format(
-              "Can not recover inputQueue from %s, because %s.", writingPipeLog.getPath(), e));
+          String.format("Can not recover inputQueue from %s.", writingPipeLog.getPath()), e);
     }
   }
 
@@ -146,8 +146,9 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
     } catch (IOException e) {
       logger.error(
           String.format(
-              "deserialize remove serial number error, remove serial number has been set to %d, because %s",
-              commitSerialNumber, e));
+              "deserialize remove serial number error, remove serial number has been set to %d.",
+              commitSerialNumber),
+          e);
     }
   }
 
@@ -170,9 +171,8 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
       }
     } catch (IOException e) {
       logger.error(
-          String.format(
-              "Recover output deque from pipe log %s error, because %s.",
-              readingPipeLog.getPath(), e));
+          String.format("Recover output deque from pipe log %s error.", readingPipeLog.getPath()),
+          e);
     }
   }
 
@@ -191,7 +191,7 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
       try {
         moveToNextPipeLog(pipeData.getSerialNumber());
       } catch (IOException e) {
-        logger.error(String.format("Move to next pipe log %s error, because %s.", pipeData, e));
+        logger.error(String.format("Move to next pipe log %s error.", pipeData), e);
       }
     }
     if (!inputDeque.offer(pipeData)) {
@@ -204,7 +204,7 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
     try {
       writeToDisk(pipeData);
     } catch (IOException e) {
-      logger.error(String.format("Record pipe data %s error, because %s.", pipeData, e));
+      logger.error(String.format("Record pipe data %s error.", pipeData), e);
       return false;
     }
     return true;
@@ -264,30 +264,7 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
 
   @Override
   public List<PipeData> pull(long serialNumber) {
-    List<PipeData> resPipeData = new ArrayList<>();
-
-    pullSerialNumber = commitSerialNumber;
-    while (pullSerialNumber < serialNumber) {
-      try {
-        PipeData pullPipeData = pullOnePipeData(pullSerialNumber);
-        if (pullPipeData != null) {
-          resPipeData.add(pullPipeData);
-          pullSerialNumber = pullPipeData.getSerialNumber();
-        } else {
-          break;
-        }
-      } catch (IOException e) {
-        logger.error(
-            String.format(
-                "Pull pipe data serial number %s error, because %s.", pullSerialNumber + 1, e));
-        break;
-      }
-    }
-
-    for (int i = resPipeData.size() - 1; i >= 0; --i) {
-      outputDeque.addFirst(resPipeData.get(i));
-    }
-    return resPipeData;
+    throw new NotImplementedException("Not implement pull");
   }
 
   @Override
@@ -302,8 +279,7 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
       }
     } catch (IOException e) {
       logger.error(
-          String.format(
-              "Blocking pull pipe data number %s error, because %s", commitSerialNumber + 1, e));
+          String.format("Blocking pull pipe data number %s error.", commitSerialNumber + 1), e);
     }
     outputDeque.addFirst(pipeData);
     pullSerialNumber = pipeData.getSerialNumber();
@@ -327,11 +303,10 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
 
   private void deletePipeData(long serialNumber) {
     while (commitSerialNumber < serialNumber) {
-      commitSerialNumber += 1;
       try {
         PipeData commitData = pullOnePipeData(commitSerialNumber);
         if (commitData == null) {
-          continue;
+          return;
         }
         if (PipeData.PipeDataType.TSFILE.equals(commitData.getType())) {
           List<File> tsFiles = ((TsFilePipeData) commitData).getTsFiles(false);
@@ -339,10 +314,10 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
             Files.deleteIfExists(file.toPath());
           }
         }
+        commitSerialNumber = commitData.getSerialNumber();
       } catch (IOException e) {
         logger.error(
-            String.format(
-                "Commit pipe data serial number %s error, because %s.", commitSerialNumber, e));
+            String.format("Commit pipe data serial number %s error.", commitSerialNumber), e);
       }
     }
   }
@@ -357,8 +332,7 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
             Files.deleteIfExists(
                 new File(pipeLogDir, SyncPathUtil.getPipeLogName(nowPipeLogStartNumber)).toPath());
           } catch (IOException e) {
-            logger.warn(
-                String.format("Delete %s-pipe.log error, because %s.", nowPipeLogStartNumber, e));
+            logger.warn(String.format("Delete %s-pipe.log error.", nowPipeLogStartNumber), e);
           }
         } else {
           break;
@@ -385,8 +359,7 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
       }
     } catch (IOException e) {
       logger.error(
-          String.format(
-              "Serialize commit serial number %s error, because %s.", commitSerialNumber, e));
+          String.format("Serialize commit serial number %s error.", commitSerialNumber), e);
     }
   }
 
@@ -439,7 +412,7 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
       }
     } catch (EOFException e) {
     } catch (IllegalPathException e) {
-      logger.error(String.format("Parsing pipeLog %s error, because %s", file.getPath(), e));
+      logger.error(String.format("Parsing pipeLog %s error.", file.getPath()), e);
       throw new IOException(e);
     }
     return pipeData;

--- a/server/src/main/java/org/apache/iotdb/db/sync/pipedata/queue/BufferedPipeDataQueue.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/pipedata/queue/BufferedPipeDataQueue.java
@@ -249,8 +249,10 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
       } else if (serialNumber == pipeLogStartNumber.peekLast() && inputDeque != null) {
         outputDeque = inputDeque;
       } else {
+        long nextStartNumber =
+            pipeLogStartNumber.stream().filter(o -> o >= serialNumber).findFirst().get();
         List<PipeData> parsePipeData =
-            parsePipeLog(new File(pipeLogDir, SyncPathUtil.getPipeLogName(serialNumber)));
+            parsePipeLog(new File(pipeLogDir, SyncPathUtil.getPipeLogName(nextStartNumber)));
         int parsePipeDataSize = parsePipeData.size();
         outputDeque = new LinkedBlockingDeque<>();
         for (int i = 0; i < parsePipeDataSize; i++) {

--- a/server/src/main/java/org/apache/iotdb/db/sync/pipedata/queue/BufferedPipeDataQueue.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/pipedata/queue/BufferedPipeDataQueue.java
@@ -303,8 +303,9 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
 
   private void deletePipeData(long serialNumber) {
     while (commitSerialNumber < serialNumber) {
+      PipeData commitData = null;
       try {
-        PipeData commitData = pullOnePipeData(commitSerialNumber);
+        commitData = pullOnePipeData(commitSerialNumber);
         if (commitData == null) {
           return;
         }
@@ -314,10 +315,12 @@ public class BufferedPipeDataQueue implements PipeDataQueue {
             Files.deleteIfExists(file.toPath());
           }
         }
-        commitSerialNumber = commitData.getSerialNumber();
       } catch (IOException e) {
         logger.error(
             String.format("Commit pipe data serial number %s error.", commitSerialNumber), e);
+      }
+      if (commitData != null) {
+        commitSerialNumber = commitData.getSerialNumber();
       }
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/sync/pipedata/BufferedPipeDataQueueTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/pipedata/BufferedPipeDataQueueTest.java
@@ -32,6 +32,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -43,6 +45,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class BufferedPipeDataQueueTest {
+  private static final Logger logger = LoggerFactory.getLogger(BufferedPipeDataQueueTest.class);
+
   File pipeLogDir =
       new File(
           SyncPathUtil.getReceiverPipeLogDir("pipe", "192.168.0.11", System.currentTimeMillis()));
@@ -592,7 +596,7 @@ public class BufferedPipeDataQueueTest {
             while (true) {
               try {
                 PipeData pipeData = pipeDataQueue.take();
-                System.out.println(pipeData);
+                logger.info(String.format("PipeData: %s", pipeData));
                 pipeDataTakeList.add(pipeData);
                 pipeDataQueue.commit();
               } catch (InterruptedException e) {
@@ -620,7 +624,7 @@ public class BufferedPipeDataQueueTest {
         e.printStackTrace();
         Assert.fail();
       }
-      System.out.println(pipeDataTakeList);
+      logger.info(String.format("PipeDataTakeList: %s", pipeDataTakeList));
       Assert.assertEquals(10, pipeDataTakeList.size());
       for (int i = 0; i < 6; i++) {
         Assert.assertEquals(pipeDataList.get(i), pipeDataTakeList.get(i));

--- a/server/src/test/java/org/apache/iotdb/db/sync/pipedata/BufferedPipeDataQueueTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/pipedata/BufferedPipeDataQueueTest.java
@@ -510,6 +510,9 @@ public class BufferedPipeDataQueueTest {
                 pipeDataQueue.commit();
               } catch (InterruptedException e) {
                 break;
+              } catch (Exception e) {
+                e.printStackTrace();
+                break;
               }
             }
           });


### PR DESCRIPTION
Add commit(long serialNumber) to interface PipeDataQueue
When serialNum is not discontinuous (e.g. 1, 2, 5, 8, 10),  the correctness of the interface in PipeDataQueue should be ensured.
Add UT for discontinuous serialNumber case