### PR TITLE
Disable StandaloneMppIT

### DIFF
--- a/.github/workflows/standalone-it-for-mpp.yml
+++ b/.github/workflows/standalone-it-for-mpp.yml
@@ -3,12 +3,10 @@ name: New Standalone IT
 on:
   push:
     branches:
-      - master
     paths-ignore:
       - 'docs/**'
   pull_request:
     branches:
-      - master
     paths-ignore:
       - 'docs/**'
   # allow manually run the action:

--- a/.github/workflows/standalone-it-for-mpp.yml
+++ b/.github/workflows/standalone-it-for-mpp.yml
@@ -1,16 +1,16 @@
 name: New Standalone IT
 
 on:
-  push:
-    branches:
-    paths-ignore:
-      - 'docs/**'
-  pull_request:
-    branches:
-    paths-ignore:
-      - 'docs/**'
-  # allow manually run the action:
-  workflow_dispatch:
+#  push:
+#    branches:
+#    paths-ignore:
+#      - 'docs/**'
+#  pull_request:
+#    branches:
+#    paths-ignore:
+#      - 'docs/**'
+#  # allow manually run the action:
+#  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

Since we don't decide the structure of final standalone version, StandaloneMppIT cannot test all IT cases. Therefore, we should disable it temporarily. 