### PR TITLE
[IOTDB-4699] Override peer's equals and hashcode

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/Peer.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/Peer.java
@@ -79,23 +79,21 @@ public class Peer {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
     Peer peer = (Peer) o;
-    return Objects.equals(groupId, peer.groupId) && Objects.equals(endpoint, peer.endpoint);
+    return nodeId == peer.nodeId
+        && Objects.equals(groupId, peer.groupId)
+        && Objects.equals(endpoint, peer.endpoint);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(groupId, endpoint);
+    return Objects.hash(groupId, endpoint, nodeId);
   }
 
   @Override
   public String toString() {
-    return "Peer{" + "groupId=" + groupId + ", endpoint=" + endpoint + '}';
+    return "Peer{" + "groupId=" + groupId + ", endpoint=" + endpoint + ", nodeId=" + nodeId + '}';
   }
 }


### PR DESCRIPTION
Peer contains a new member `nodeId`. Override the equals and hashcode method.
Otherwise the remove datanode would not function.