### PR TITLE
[IOTDB-4701] expose TSocket from TElasticFramedTransport

### DIFF
--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
@@ -160,4 +160,8 @@ public class TElasticFramedTransport extends TTransport {
   public void write(byte[] buf, int off, int len) {
     writeBuffer.write(buf, off, len);
   }
+
+  public TTransport getSocket() {
+    return underlying;
+  }
 }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTFastFramedTransport.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTFastFramedTransport.java
@@ -66,4 +66,10 @@ public class TimeoutChangeableTFastFramedTransport extends TElasticFramedTranspo
       }
     }
   }
+
+  @Override
+  public TTransport getSocket() {
+    // in fact, this should be the same with underlying...
+    return underlyingSocket;
+  }
 }


### PR DESCRIPTION
expose TSocket can help developers control the connection better.

e.g., know client's connection info.