### PR TITLE
[IOTDB-4711] Bind DataNodeInternalService to correct address

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterTask.java
@@ -97,8 +97,8 @@ public class ShowClusterTask implements IConfigTask {
                     e.getDataNodeId(),
                     NODE_TYPE_DATA_NODE,
                     clusterNodeInfos.getNodeStatus().get(e.getDataNodeId()),
-                    e.getInternalEndPoint().getIp(),
-                    e.getInternalEndPoint().getPort()));
+                    e.getClientRpcEndPoint().getIp(),
+                    e.getClientRpcEndPoint().getPort()));
 
     DatasetHeader datasetHeader = DatasetHeaderFactory.getShowClusterHeader();
     future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS, builder.build(), datasetHeader));

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNodeInternalRPCService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNodeInternalRPCService.java
@@ -78,7 +78,7 @@ public class DataNodeInternalRPCService extends ThriftService
 
   @Override
   public String getBindIP() {
-    return IoTDBDescriptor.getInstance().getConfig().getRpcAddress();
+    return IoTDBDescriptor.getInstance().getConfig().getInternalAddress();
   }
 
   @Override


### PR DESCRIPTION
The reason for this error is that the DataNodeInternalService binds to `rpc_address` instead of `internal_address`. Thus the ConfigNode can't send heartbeat to DataNode correctly. By the way, I also make the shown `host` information of cluster DataNodes consistent both in `show cluster` and `show datanodes`.

Local test screenshot: 
<img width="850" alt="image" src="https://user-images.githubusercontent.com/33111881/197109774-3fe3a06b-ec2f-4028-a9c1-35a146361c89.png">
