### PR TITLE
[To rel/0.13] Fix wal delete error in the DeletionFileNodeTest 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1450,7 +1450,7 @@ public class IoTDBConfig {
             new RuntimeException("System mode is set to ERROR"));
         System.exit(-1);
       }
-    } else {
+    } else if (status != newStatus) {
       logger.warn("Set system mode from {} to {}.", status, newStatus);
     }
     this.status = newStatus;

--- a/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/node/ExclusiveWriteLogNode.java
@@ -76,8 +76,8 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
   private final ReentrantLock lock = new ReentrantLock();
   private final ExecutorService FLUSH_BUFFER_THREAD_POOL;
 
-  private volatile long fileId = 0;
-  private volatile long lastFlushedId = 0;
+  private long fileId = 0;
+  private long lastFlushedId = 0;
 
   private int bufferedLogNum = 0;
 
@@ -221,21 +221,11 @@ public class ExclusiveWriteLogNode implements WriteLogNode, Comparable<Exclusive
 
   @Override
   public void notifyEndFlush() {
-    // sleep a while to make sure last file is closed
-    long deleteFileId = lastFlushedId + 1;
-    while (deleteFileId == fileId) {
-      try {
-        Thread.sleep(100);
-      } catch (InterruptedException e) {
-        logger.error("Interrupted when waiting for last file closed");
-        Thread.currentThread().interrupt();
-      }
-    }
     lock.lock();
     try {
-      File logFile = SystemFileFactory.INSTANCE.getFile(logDirectory, WAL_FILE_NAME + deleteFileId);
+      File logFile =
+          SystemFileFactory.INSTANCE.getFile(logDirectory, WAL_FILE_NAME + ++lastFlushedId);
       discard(logFile);
-      lastFlushedId = deleteFileId;
     } finally {
       lock.unlock();
     }

--- a/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionFileNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionFileNodeTest.java
@@ -123,7 +123,7 @@ public class DeletionFileNodeTest {
 
   @Test
   public void testDeleteWithTimePartitionFilter()
-      throws StorageEngineException, QueryProcessException, IOException {
+      throws StorageEngineException, QueryProcessException, IOException, InterruptedException {
     boolean prevEnablePartition = StorageEngine.isEnablePartition();
     long prevPartitionInterval = StorageEngine.getTimePartitionInterval();
     int prevConcurrentTimePartition =
@@ -140,6 +140,8 @@ public class DeletionFileNodeTest {
         TSRecord record = new TSRecord(i * newPartitionInterval, processorName);
         record.addTuple(new DoubleDataPoint(measurements[0], i * 1.0));
         StorageEngine.getInstance().insert(new InsertRowPlan(record));
+        // make sure tsfiles have different timestamps
+        Thread.sleep(10);
       }
       // the filter only allows to delete the first 5 partitions
       StorageEngine.getInstance()

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -51,6 +51,7 @@ import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
 import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.db.rescon.TsFileResourceManager;
 import org.apache.iotdb.db.service.IoTDB;
+import org.apache.iotdb.db.writelog.manager.MultiFileLogNodeManager;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TSocketWrapper;
@@ -152,6 +153,8 @@ public class EnvironmentUtils {
     // unit tests.
     IoTDBDescriptor.getInstance().getConfig().setEnableMQTTService(false);
 
+    // clean wal
+    MultiFileLogNodeManager.getInstance().stop();
     // clean cache
     if (config.isMetaDataCacheEnable()) {
       ChunkCache.getInstance().clear();

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -154,7 +154,7 @@ public class EnvironmentUtils {
     IoTDBDescriptor.getInstance().getConfig().setEnableMQTTService(false);
 
     // clean wal
-    MultiFileLogNodeManager.getInstance().stop();
+    MultiFileLogNodeManager.getInstance().close();
     // clean cache
     if (config.isMetaDataCacheEnable()) {
       ChunkCache.getInstance().clear();


### PR DESCRIPTION
We found error like this, `java.nio.file.FileSystemException: target\wal\root.vehicle.d0\root.vehicle.d0-1666293644043-2-0-0.tsfile\wal2: The process cannot access the file because it is being used by another process.`

I assume this is caused by last wal file's discard operation is called before it has been closed. To fix it, discard operation will wait until last file has been close, which means `deleteFileId < fileId`.