### PR TITLE
Fix schema region recover bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/impl/ActivateTemplateInClusterPlanImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/impl/ActivateTemplateInClusterPlanImpl.java
@@ -53,8 +53,8 @@ public class ActivateTemplateInClusterPlanImpl implements IActivateTemplateInClu
   }
 
   @Override
-  public void setTemplateId(int templateSetLevel) {
-    this.templateSetLevel = templateSetLevel;
+  public void setTemplateId(int templateId) {
+    this.templateId = templateId;
   }
 
   @Override
@@ -63,8 +63,8 @@ public class ActivateTemplateInClusterPlanImpl implements IActivateTemplateInClu
   }
 
   @Override
-  public void setTemplateSetLevel(int templateId) {
-    this.templateId = templateId;
+  public void setTemplateSetLevel(int templateSetLevel) {
+    this.templateSetLevel = templateSetLevel;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/write/IActivateTemplateInClusterPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/write/IActivateTemplateInClusterPlan.java
@@ -44,11 +44,11 @@ public interface IActivateTemplateInClusterPlan extends ISchemaRegionPlan {
 
   int getTemplateSetLevel();
 
-  void setTemplateSetLevel(int templateId);
+  void setTemplateSetLevel(int templateSetLevel);
 
   int getTemplateId();
 
-  void setTemplateId(int templateSetLevel);
+  void setTemplateId(int templateId);
 
   boolean isAligned();
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -2128,7 +2128,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
     }
 
     private boolean isFailed() {
-      return e == null;
+      return e != null;
     }
 
     private Exception getException() {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -1988,7 +1988,7 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
     }
 
     private boolean isFailed() {
-      return e == null;
+      return e != null;
     }
 
     private Exception getException() {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ActivateTemplateInClusterPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ActivateTemplateInClusterPlan.java
@@ -70,8 +70,8 @@ public class ActivateTemplateInClusterPlan extends PhysicalPlan
   }
 
   @Override
-  public void setTemplateId(int templateSetLevel) {
-    this.templateSetLevel = templateSetLevel;
+  public void setTemplateId(int templateId) {
+    this.templateId = templateId;
   }
 
   public int getTemplateSetLevel() {
@@ -79,8 +79,8 @@ public class ActivateTemplateInClusterPlan extends PhysicalPlan
   }
 
   @Override
-  public void setTemplateSetLevel(int templateId) {
-    this.templateId = templateId;
+  public void setTemplateSetLevel(int templateSetLevel) {
+    this.templateSetLevel = templateSetLevel;
   }
 
   public boolean isAligned() {


### PR DESCRIPTION
## Description

1. There's mistake when check the operation result of schema region recover. The check condition is opposite.
2. When recover ActivateTemplateInClusterPlan, the set method templateId and templateSetLevel attributes has been mistakened.
