### PR TITLE
Rerun a new query execution thread while previous one is interrupted

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/AbstractDriverThread.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/AbstractDriverThread.java
@@ -59,7 +59,7 @@ public abstract class AbstractDriverThread extends Thread implements Closeable {
         try {
           next = queue.poll();
         } catch (InterruptedException e) {
-          logger.error("Executor " + this.getName() + "failed to poll driver task from queue");
+          logger.error("Executor " + this.getName() + " failed to poll driver task from queue");
           Thread.currentThread().interrupt();
           break;
         }
@@ -84,7 +84,16 @@ public abstract class AbstractDriverThread extends Thread implements Closeable {
         }
       }
     } finally {
-      producer.produce(getName(), getThreadGroup(), queue, producer);
+      // unless we have been closed, we need to replace this thread
+      if (!closed) {
+        logger.warn(
+            "Executor "
+                + this.getName()
+                + " exits because it's interrupted, and we will produce another thread to replace.");
+        producer.produce(getName(), getThreadGroup(), queue, producer);
+      } else {
+        logger.info("Executor " + this.getName() + " exits because it is closed.");
+      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskThread.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskThread.java
@@ -48,8 +48,9 @@ public class DriverTaskThread extends AbstractDriverThread {
       String workerId,
       ThreadGroup tg,
       IndexedBlockingQueue<DriverTask> queue,
-      ITaskScheduler scheduler) {
-    super(workerId, tg, queue, scheduler);
+      ITaskScheduler scheduler,
+      ThreadProducer producer) {
+    super(workerId, tg, queue, scheduler, producer);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskTimeoutSentinelThread.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskTimeoutSentinelThread.java
@@ -34,8 +34,9 @@ public class DriverTaskTimeoutSentinelThread extends AbstractDriverThread {
       String workerId,
       ThreadGroup tg,
       IndexedBlockingQueue<DriverTask> queue,
-      ITaskScheduler scheduler) {
-    super(workerId, tg, queue, scheduler);
+      ITaskScheduler scheduler,
+      ThreadProducer producer) {
+    super(workerId, tg, queue, scheduler, producer);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/ThreadProducer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/ThreadProducer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.mpp.execution.schedule;
+
+import org.apache.iotdb.db.mpp.execution.schedule.queue.IndexedBlockingQueue;
+import org.apache.iotdb.db.mpp.execution.schedule.task.DriverTask;
+
+@FunctionalInterface
+public interface ThreadProducer {
+
+  void produce(
+      String threadName,
+      ThreadGroup workerGroups,
+      IndexedBlockingQueue<DriverTask> queue,
+      ThreadProducer producer);
+}

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskTimeoutSentinelThreadTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/schedule/DriverTaskTimeoutSentinelThreadTest.java
@@ -40,6 +40,11 @@ import java.util.concurrent.TimeUnit;
 
 public class DriverTaskTimeoutSentinelThreadTest {
 
+  private static final ThreadProducer producer =
+      (threadName, workerGroups, queue, producer) -> {
+        // do nothing;
+      };
+
   @Test
   public void testHandleInvalidStateTask() throws ExecutionException, InterruptedException {
     ITaskScheduler mockScheduler = Mockito.mock(ITaskScheduler.class);
@@ -62,7 +67,8 @@ public class DriverTaskTimeoutSentinelThreadTest {
     Mockito.when(mockDriver.getInfo()).thenReturn(instanceId);
 
     AbstractDriverThread executor =
-        new DriverTaskThread("0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler);
+        new DriverTaskThread(
+            "0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler, producer);
 
     // FINISHED status test
     DriverTask testTask = new DriverTask(mockDriver, 100L, DriverTaskStatus.FINISHED);
@@ -123,7 +129,8 @@ public class DriverTaskTimeoutSentinelThreadTest {
         .thenReturn(Futures.immediateCancelledFuture());
 
     AbstractDriverThread executor =
-        new DriverTaskThread("0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler);
+        new DriverTaskThread(
+            "0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler, producer);
     DriverTask testTask = new DriverTask(mockDriver, 100L, DriverTaskStatus.READY);
     executor.execute(testTask);
     Mockito.verify(mockDriver, Mockito.times(1)).processFor(Mockito.any());
@@ -162,7 +169,8 @@ public class DriverTaskTimeoutSentinelThreadTest {
         .thenAnswer(ans -> Futures.immediateVoidFuture());
     Mockito.when(mockDriver.isFinished()).thenReturn(true);
     AbstractDriverThread executor =
-        new DriverTaskThread("0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler);
+        new DriverTaskThread(
+            "0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler, producer);
     DriverTask testTask = new DriverTask(mockDriver, 100L, DriverTaskStatus.READY);
     executor.execute(testTask);
     Mockito.verify(mockDriver, Mockito.times(1)).processFor(Mockito.any());
@@ -210,7 +218,8 @@ public class DriverTaskTimeoutSentinelThreadTest {
     Mockito.when(mockDriver.processFor(Mockito.any())).thenAnswer(ans -> mockFuture);
     Mockito.when(mockDriver.isFinished()).thenReturn(false);
     AbstractDriverThread executor =
-        new DriverTaskThread("0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler);
+        new DriverTaskThread(
+            "0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler, producer);
     DriverTask testTask = new DriverTask(mockDriver, 100L, DriverTaskStatus.READY);
     executor.execute(testTask);
     Mockito.verify(mockDriver, Mockito.times(1)).processFor(Mockito.any());
@@ -259,7 +268,8 @@ public class DriverTaskTimeoutSentinelThreadTest {
     Mockito.when(mockDriver.processFor(Mockito.any())).thenAnswer(ans -> mockFuture);
     Mockito.when(mockDriver.isFinished()).thenReturn(false);
     AbstractDriverThread executor =
-        new DriverTaskThread("0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler);
+        new DriverTaskThread(
+            "0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler, producer);
     DriverTask testTask = new DriverTask(mockDriver, 100L, DriverTaskStatus.READY);
     executor.execute(testTask);
     Mockito.verify(mockDriver, Mockito.times(1)).processFor(Mockito.any());
@@ -292,7 +302,8 @@ public class DriverTaskTimeoutSentinelThreadTest {
     FragmentInstanceId instanceId = new FragmentInstanceId(fragmentId, "inst-0");
     Mockito.when(mockDriver.getInfo()).thenReturn(instanceId);
     AbstractDriverThread executor =
-        new DriverTaskThread("0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler);
+        new DriverTaskThread(
+            "0", new ThreadGroup("timeout-test"), taskQueue, mockScheduler, producer);
     Mockito.when(mockDriver.processFor(Mockito.any()))
         .thenAnswer(
             ans -> {


### PR DESCRIPTION
I found a strange thing in a timeout CI logs that there are no `Query-Worker-Thread-i` threads in thread dump file.
After digging into related codes, I found that if the `Query-Worker-Thread-i` is interrupted by others, it will exit quitely and will not print any logs. Then I refer to related codes in `Trino` and find that `Trino` will submit another execution thread in such case, so I did so in this pr.