### PR TITLE
[IOTDB-4616] Support serialization and deserialization for confignode standalone mode

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -701,7 +701,7 @@ public class ConfigNodeConfig {
   }
 
   public void setPartitionRegionStandAloneLogSegmentSizeMax(
-          long partitionRegionStandAloneLogSegmentSizeMax) {
+      long partitionRegionStandAloneLogSegmentSizeMax) {
     this.partitionRegionStandAloneLogSegmentSizeMax = partitionRegionStandAloneLogSegmentSizeMax;
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -169,6 +169,7 @@ public class ConfigNodeConfig {
 
   private long partitionRegionRatisLogSegmentSizeMax = 24 * 1024 * 1024L;
   private long schemaRegionRatisLogSegmentSizeMax = 24 * 1024 * 1024L;
+  private long partitionRegionStandAloneLogSegmentSizeMax = 24 * 1024 * 1024L;
 
   /** RatisConsensus protocol, flow control window for ratis grpc log appender */
   private long dataRegionRatisGrpcFlowControlWindow = 4 * 1024 * 1024L;
@@ -693,6 +694,15 @@ public class ConfigNodeConfig {
 
   public void setSchemaRegionRatisLogSegmentSizeMax(long schemaRegionRatisLogSegmentSizeMax) {
     this.schemaRegionRatisLogSegmentSizeMax = schemaRegionRatisLogSegmentSizeMax;
+  }
+
+  public long getPartitionRegionStandAloneLogSegmentSizeMax() {
+    return partitionRegionStandAloneLogSegmentSizeMax;
+  }
+
+  public void setPartitionRegionStandAloneLogSegmentSizeMax(
+          long partitionRegionStandAloneLogSegmentSizeMax) {
+    this.partitionRegionStandAloneLogSegmentSizeMax = partitionRegionStandAloneLogSegmentSizeMax;
   }
 
   public long getSchemaRegionRatisGrpcFlowControlWindow() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -357,10 +357,10 @@ public class ConfigNodeDescriptor {
                 String.valueOf(conf.getSchemaRegionRatisLogSegmentSizeMax()))));
 
     conf.setPartitionRegionStandAloneLogSegmentSizeMax(
-            Long.parseLong(
-                    properties.getProperty(
-                            "partition_region_standalone_log_segment_size_max",
-                            String.valueOf(conf.getPartitionRegionStandAloneLogSegmentSizeMax()))));
+        Long.parseLong(
+            properties.getProperty(
+                "partition_region_standalone_log_segment_size_max",
+                String.valueOf(conf.getPartitionRegionStandAloneLogSegmentSizeMax()))));
 
     conf.setDataRegionRatisGrpcFlowControlWindow(
         Long.parseLong(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -356,6 +356,12 @@ public class ConfigNodeDescriptor {
                 "schema_region_ratis_log_segment_size_max",
                 String.valueOf(conf.getSchemaRegionRatisLogSegmentSizeMax()))));
 
+    conf.setPartitionRegionStandAloneLogSegmentSizeMax(
+            Long.parseLong(
+                    properties.getProperty(
+                            "partition_region_standalone_log_segment_size_max",
+                            String.valueOf(conf.getPartitionRegionStandAloneLogSegmentSizeMax()))));
+
     conf.setDataRegionRatisGrpcFlowControlWindow(
         Long.parseLong(
             properties.getProperty(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
@@ -81,102 +81,103 @@ public class ConsensusManager {
 
     if (ConsensusFactory.StandAloneConsensus.equals(CONF.getConfigNodeConsensusProtocolClass())) {
       consensusImpl =
-              ConsensusFactory.getConsensusImpl(
-                              ConsensusFactory.StandAloneConsensus,
-                              ConsensusConfig.newBuilder()
-                                      .setThisNode(
-                                              new TEndPoint(CONF.getInternalAddress(), CONF.getConsensusPort()))
-                                      .setStorageDir("target" + java.io.File.separator + "standalone")
-                                      .build(),
-                              gid -> stateMachine)
-                      .orElseThrow(
-                              () ->
-                                      new IllegalArgumentException(
-                                              String.format(
-                                                      ConsensusFactory.CONSTRUCT_FAILED_MSG,
-                                                      ConsensusFactory.StandAloneConsensus)));
+          ConsensusFactory.getConsensusImpl(
+                  ConsensusFactory.StandAloneConsensus,
+                  ConsensusConfig.newBuilder()
+                      .setThisNode(
+                          new TEndPoint(CONF.getInternalAddress(), CONF.getConsensusPort()))
+                      .setStorageDir("target" + java.io.File.separator + "standalone")
+                      .build(),
+                  gid -> stateMachine)
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          String.format(
+                              ConsensusFactory.CONSTRUCT_FAILED_MSG,
+                              ConsensusFactory.StandAloneConsensus)));
     } else {
 
       // Implement local ConsensusLayer by ConfigNodeConfig
       consensusImpl =
-              ConsensusFactory.getConsensusImpl(
-                              CONF.getConfigNodeConsensusProtocolClass(),
-                              ConsensusConfig.newBuilder()
-                                      .setThisNodeId(CONF.getConfigNodeId())
-                                      .setThisNode(new TEndPoint(CONF.getInternalAddress(), CONF.getConsensusPort()))
-                                      .setRatisConfig(
-                                              RatisConfig.newBuilder()
-                                                      .setLeaderLogAppender(
-                                                              RatisConfig.LeaderLogAppender.newBuilder()
-                                                                      .setBufferByteLimit(
-                                                                              CONF
-                                                                                      .getPartitionRegionRatisConsensusLogAppenderBufferSize())
-                                                                      .build())
-                                                      .setSnapshot(
-                                                              RatisConfig.Snapshot.newBuilder()
-                                                                      .setAutoTriggerThreshold(
-                                                                              CONF.getPartitionRegionRatisSnapshotTriggerThreshold())
-                                                                      .build())
-                                                      .setLog(
-                                                              RatisConfig.Log.newBuilder()
-                                                                      .setUnsafeFlushEnabled(
-                                                                              CONF.isPartitionRegionRatisLogUnsafeFlushEnable())
-                                                                      .setSegmentCacheSizeMax(
-                                                                              SizeInBytes.valueOf(
-                                                                                      CONF.getPartitionRegionRatisLogSegmentSizeMax()))
-                                                                      .build())
-                                                      .setGrpc(
-                                                              RatisConfig.Grpc.newBuilder()
-                                                                      .setFlowControlWindow(
-                                                                              SizeInBytes.valueOf(
-                                                                                      CONF.getPartitionRegionRatisGrpcFlowControlWindow()))
-                                                                      .build())
-                                                      .setRpc(
-                                                              RatisConfig.Rpc.newBuilder()
-                                                                      .setTimeoutMin(
-                                                                              TimeDuration.valueOf(
-                                                                                      CONF
-                                                                                              .getPartitionRegionRatisRpcLeaderElectionTimeoutMinMs(),
-                                                                                      TimeUnit.MILLISECONDS))
-                                                                      .setTimeoutMax(
-                                                                              TimeDuration.valueOf(
-                                                                                      CONF
-                                                                                              .getPartitionRegionRatisRpcLeaderElectionTimeoutMaxMs(),
-                                                                                      TimeUnit.MILLISECONDS))
-                                                                      .setRequestTimeout(
-                                                                              TimeDuration.valueOf(
-                                                                                      CONF.getPartitionRegionRatisRequestTimeoutMs(),
-                                                                                      TimeUnit.MILLISECONDS))
-                                                                      .setFirstElectionTimeoutMin(
-                                                                              TimeDuration.valueOf(
-                                                                                      CONF.getRatisFirstElectionTimeoutMinMs(),
-                                                                                      TimeUnit.MILLISECONDS))
-                                                                      .setFirstElectionTimeoutMax(
-                                                                              TimeDuration.valueOf(
-                                                                                      CONF.getRatisFirstElectionTimeoutMaxMs(),
-                                                                                      TimeUnit.MILLISECONDS))
-                                                                      .build())
-                                                      .setRatisConsensus(
-                                                              RatisConfig.RatisConsensus.newBuilder()
-                                                                      .setClientRequestTimeoutMillis(
-                                                                              CONF.getPartitionRegionRatisRequestTimeoutMs())
-                                                                      .setClientMaxRetryAttempt(
-                                                                              CONF.getPartitionRegionRatisMaxRetryAttempts())
-                                                                      .setClientRetryInitialSleepTimeMs(
-                                                                              CONF.getPartitionRegionRatisInitialSleepTimeMs())
-                                                                      .setClientRetryMaxSleepTimeMs(
-                                                                              CONF.getPartitionRegionRatisMaxSleepTimeMs())
-                                                                      .build())
-                                                      .build())
-                                      .setStorageDir(CONF.getConsensusDir())
-                                      .build(),
-                              gid -> stateMachine)
-                      .orElseThrow(
-                              () ->
-                                      new IllegalArgumentException(
-                                              String.format(
-                                                      ConsensusFactory.CONSTRUCT_FAILED_MSG,
-                                                      CONF.getConfigNodeConsensusProtocolClass())));
+          ConsensusFactory.getConsensusImpl(
+                  CONF.getConfigNodeConsensusProtocolClass(),
+                  ConsensusConfig.newBuilder()
+                      .setThisNodeId(CONF.getConfigNodeId())
+                      .setThisNode(
+                          new TEndPoint(CONF.getInternalAddress(), CONF.getConsensusPort()))
+                      .setRatisConfig(
+                          RatisConfig.newBuilder()
+                              .setLeaderLogAppender(
+                                  RatisConfig.LeaderLogAppender.newBuilder()
+                                      .setBufferByteLimit(
+                                          CONF
+                                              .getPartitionRegionRatisConsensusLogAppenderBufferSize())
+                                      .build())
+                              .setSnapshot(
+                                  RatisConfig.Snapshot.newBuilder()
+                                      .setAutoTriggerThreshold(
+                                          CONF.getPartitionRegionRatisSnapshotTriggerThreshold())
+                                      .build())
+                              .setLog(
+                                  RatisConfig.Log.newBuilder()
+                                      .setUnsafeFlushEnabled(
+                                          CONF.isPartitionRegionRatisLogUnsafeFlushEnable())
+                                      .setSegmentCacheSizeMax(
+                                          SizeInBytes.valueOf(
+                                              CONF.getPartitionRegionRatisLogSegmentSizeMax()))
+                                      .build())
+                              .setGrpc(
+                                  RatisConfig.Grpc.newBuilder()
+                                      .setFlowControlWindow(
+                                          SizeInBytes.valueOf(
+                                              CONF.getPartitionRegionRatisGrpcFlowControlWindow()))
+                                      .build())
+                              .setRpc(
+                                  RatisConfig.Rpc.newBuilder()
+                                      .setTimeoutMin(
+                                          TimeDuration.valueOf(
+                                              CONF
+                                                  .getPartitionRegionRatisRpcLeaderElectionTimeoutMinMs(),
+                                              TimeUnit.MILLISECONDS))
+                                      .setTimeoutMax(
+                                          TimeDuration.valueOf(
+                                              CONF
+                                                  .getPartitionRegionRatisRpcLeaderElectionTimeoutMaxMs(),
+                                              TimeUnit.MILLISECONDS))
+                                      .setRequestTimeout(
+                                          TimeDuration.valueOf(
+                                              CONF.getPartitionRegionRatisRequestTimeoutMs(),
+                                              TimeUnit.MILLISECONDS))
+                                      .setFirstElectionTimeoutMin(
+                                          TimeDuration.valueOf(
+                                              CONF.getRatisFirstElectionTimeoutMinMs(),
+                                              TimeUnit.MILLISECONDS))
+                                      .setFirstElectionTimeoutMax(
+                                          TimeDuration.valueOf(
+                                              CONF.getRatisFirstElectionTimeoutMaxMs(),
+                                              TimeUnit.MILLISECONDS))
+                                      .build())
+                              .setRatisConsensus(
+                                  RatisConfig.RatisConsensus.newBuilder()
+                                      .setClientRequestTimeoutMillis(
+                                          CONF.getPartitionRegionRatisRequestTimeoutMs())
+                                      .setClientMaxRetryAttempt(
+                                          CONF.getPartitionRegionRatisMaxRetryAttempts())
+                                      .setClientRetryInitialSleepTimeMs(
+                                          CONF.getPartitionRegionRatisInitialSleepTimeMs())
+                                      .setClientRetryMaxSleepTimeMs(
+                                          CONF.getPartitionRegionRatisMaxSleepTimeMs())
+                                      .build())
+                              .build())
+                      .setStorageDir(CONF.getConsensusDir())
+                      .build(),
+                  gid -> stateMachine)
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          String.format(
+                              ConsensusFactory.CONSTRUCT_FAILED_MSG,
+                              CONF.getConfigNodeConsensusProtocolClass())));
     }
     consensusImpl.start();
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
@@ -79,86 +79,105 @@ public class ConsensusManager {
     // There is only one ConfigNodeGroup
     consensusGroupId = new PartitionRegionId(CONF.getPartitionRegionId());
 
-    // Implement local ConsensusLayer by ConfigNodeConfig
-    consensusImpl =
-        ConsensusFactory.getConsensusImpl(
-                CONF.getConfigNodeConsensusProtocolClass(),
-                ConsensusConfig.newBuilder()
-                    .setThisNodeId(CONF.getConfigNodeId())
-                    .setThisNode(new TEndPoint(CONF.getInternalAddress(), CONF.getConsensusPort()))
-                    .setRatisConfig(
-                        RatisConfig.newBuilder()
-                            .setLeaderLogAppender(
-                                RatisConfig.LeaderLogAppender.newBuilder()
-                                    .setBufferByteLimit(
-                                        CONF
-                                            .getPartitionRegionRatisConsensusLogAppenderBufferSize())
-                                    .build())
-                            .setSnapshot(
-                                RatisConfig.Snapshot.newBuilder()
-                                    .setAutoTriggerThreshold(
-                                        CONF.getPartitionRegionRatisSnapshotTriggerThreshold())
-                                    .build())
-                            .setLog(
-                                RatisConfig.Log.newBuilder()
-                                    .setUnsafeFlushEnabled(
-                                        CONF.isPartitionRegionRatisLogUnsafeFlushEnable())
-                                    .setSegmentCacheSizeMax(
-                                        SizeInBytes.valueOf(
-                                            CONF.getPartitionRegionRatisLogSegmentSizeMax()))
-                                    .build())
-                            .setGrpc(
-                                RatisConfig.Grpc.newBuilder()
-                                    .setFlowControlWindow(
-                                        SizeInBytes.valueOf(
-                                            CONF.getPartitionRegionRatisGrpcFlowControlWindow()))
-                                    .build())
-                            .setRpc(
-                                RatisConfig.Rpc.newBuilder()
-                                    .setTimeoutMin(
-                                        TimeDuration.valueOf(
-                                            CONF
-                                                .getPartitionRegionRatisRpcLeaderElectionTimeoutMinMs(),
-                                            TimeUnit.MILLISECONDS))
-                                    .setTimeoutMax(
-                                        TimeDuration.valueOf(
-                                            CONF
-                                                .getPartitionRegionRatisRpcLeaderElectionTimeoutMaxMs(),
-                                            TimeUnit.MILLISECONDS))
-                                    .setRequestTimeout(
-                                        TimeDuration.valueOf(
-                                            CONF.getPartitionRegionRatisRequestTimeoutMs(),
-                                            TimeUnit.MILLISECONDS))
-                                    .setFirstElectionTimeoutMin(
-                                        TimeDuration.valueOf(
-                                            CONF.getRatisFirstElectionTimeoutMinMs(),
-                                            TimeUnit.MILLISECONDS))
-                                    .setFirstElectionTimeoutMax(
-                                        TimeDuration.valueOf(
-                                            CONF.getRatisFirstElectionTimeoutMaxMs(),
-                                            TimeUnit.MILLISECONDS))
-                                    .build())
-                            .setRatisConsensus(
-                                RatisConfig.RatisConsensus.newBuilder()
-                                    .setClientRequestTimeoutMillis(
-                                        CONF.getPartitionRegionRatisRequestTimeoutMs())
-                                    .setClientMaxRetryAttempt(
-                                        CONF.getPartitionRegionRatisMaxRetryAttempts())
-                                    .setClientRetryInitialSleepTimeMs(
-                                        CONF.getPartitionRegionRatisInitialSleepTimeMs())
-                                    .setClientRetryMaxSleepTimeMs(
-                                        CONF.getPartitionRegionRatisMaxSleepTimeMs())
-                                    .build())
-                            .build())
-                    .setStorageDir(CONF.getConsensusDir())
-                    .build(),
-                gid -> stateMachine)
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        String.format(
-                            ConsensusFactory.CONSTRUCT_FAILED_MSG,
-                            CONF.getConfigNodeConsensusProtocolClass())));
+    if (ConsensusFactory.StandAloneConsensus.equals(CONF.getConfigNodeConsensusProtocolClass())) {
+      consensusImpl =
+              ConsensusFactory.getConsensusImpl(
+                              ConsensusFactory.StandAloneConsensus,
+                              ConsensusConfig.newBuilder()
+                                      .setThisNode(
+                                              new TEndPoint(CONF.getInternalAddress(), CONF.getConsensusPort()))
+                                      .setStorageDir("target" + java.io.File.separator + "standalone")
+                                      .build(),
+                              gid -> stateMachine)
+                      .orElseThrow(
+                              () ->
+                                      new IllegalArgumentException(
+                                              String.format(
+                                                      ConsensusFactory.CONSTRUCT_FAILED_MSG,
+                                                      ConsensusFactory.StandAloneConsensus)));
+    } else {
+
+      // Implement local ConsensusLayer by ConfigNodeConfig
+      consensusImpl =
+              ConsensusFactory.getConsensusImpl(
+                              CONF.getConfigNodeConsensusProtocolClass(),
+                              ConsensusConfig.newBuilder()
+                                      .setThisNodeId(CONF.getConfigNodeId())
+                                      .setThisNode(new TEndPoint(CONF.getInternalAddress(), CONF.getConsensusPort()))
+                                      .setRatisConfig(
+                                              RatisConfig.newBuilder()
+                                                      .setLeaderLogAppender(
+                                                              RatisConfig.LeaderLogAppender.newBuilder()
+                                                                      .setBufferByteLimit(
+                                                                              CONF
+                                                                                      .getPartitionRegionRatisConsensusLogAppenderBufferSize())
+                                                                      .build())
+                                                      .setSnapshot(
+                                                              RatisConfig.Snapshot.newBuilder()
+                                                                      .setAutoTriggerThreshold(
+                                                                              CONF.getPartitionRegionRatisSnapshotTriggerThreshold())
+                                                                      .build())
+                                                      .setLog(
+                                                              RatisConfig.Log.newBuilder()
+                                                                      .setUnsafeFlushEnabled(
+                                                                              CONF.isPartitionRegionRatisLogUnsafeFlushEnable())
+                                                                      .setSegmentCacheSizeMax(
+                                                                              SizeInBytes.valueOf(
+                                                                                      CONF.getPartitionRegionRatisLogSegmentSizeMax()))
+                                                                      .build())
+                                                      .setGrpc(
+                                                              RatisConfig.Grpc.newBuilder()
+                                                                      .setFlowControlWindow(
+                                                                              SizeInBytes.valueOf(
+                                                                                      CONF.getPartitionRegionRatisGrpcFlowControlWindow()))
+                                                                      .build())
+                                                      .setRpc(
+                                                              RatisConfig.Rpc.newBuilder()
+                                                                      .setTimeoutMin(
+                                                                              TimeDuration.valueOf(
+                                                                                      CONF
+                                                                                              .getPartitionRegionRatisRpcLeaderElectionTimeoutMinMs(),
+                                                                                      TimeUnit.MILLISECONDS))
+                                                                      .setTimeoutMax(
+                                                                              TimeDuration.valueOf(
+                                                                                      CONF
+                                                                                              .getPartitionRegionRatisRpcLeaderElectionTimeoutMaxMs(),
+                                                                                      TimeUnit.MILLISECONDS))
+                                                                      .setRequestTimeout(
+                                                                              TimeDuration.valueOf(
+                                                                                      CONF.getPartitionRegionRatisRequestTimeoutMs(),
+                                                                                      TimeUnit.MILLISECONDS))
+                                                                      .setFirstElectionTimeoutMin(
+                                                                              TimeDuration.valueOf(
+                                                                                      CONF.getRatisFirstElectionTimeoutMinMs(),
+                                                                                      TimeUnit.MILLISECONDS))
+                                                                      .setFirstElectionTimeoutMax(
+                                                                              TimeDuration.valueOf(
+                                                                                      CONF.getRatisFirstElectionTimeoutMaxMs(),
+                                                                                      TimeUnit.MILLISECONDS))
+                                                                      .build())
+                                                      .setRatisConsensus(
+                                                              RatisConfig.RatisConsensus.newBuilder()
+                                                                      .setClientRequestTimeoutMillis(
+                                                                              CONF.getPartitionRegionRatisRequestTimeoutMs())
+                                                                      .setClientMaxRetryAttempt(
+                                                                              CONF.getPartitionRegionRatisMaxRetryAttempts())
+                                                                      .setClientRetryInitialSleepTimeMs(
+                                                                              CONF.getPartitionRegionRatisInitialSleepTimeMs())
+                                                                      .setClientRetryMaxSleepTimeMs(
+                                                                              CONF.getPartitionRegionRatisMaxSleepTimeMs())
+                                                                      .build())
+                                                      .build())
+                                      .setStorageDir(CONF.getConsensusDir())
+                                      .build(),
+                              gid -> stateMachine)
+                      .orElseThrow(
+                              () ->
+                                      new IllegalArgumentException(
+                                              String.format(
+                                                      ConsensusFactory.CONSTRUCT_FAILED_MSG,
+                                                      CONF.getConfigNodeConsensusProtocolClass())));
+    }
     consensusImpl.start();
 
     if (SystemPropertiesUtils.isRestarted()) {


### PR DESCRIPTION
## Description

Support serialization and deserialization for confignode standalone mode.
We used local file to complete the data persistence.

This pr only add `if (ConsensusFactory.StandAloneConsensus.equals(CONF.getConfigNodeConsensusProtocolClass())) {` judgement, and this branch will never be reached.


