### PR TITLE
[IOTDB-4747][IOTDB-4776] Modify default write path of iotdb metric reporter

### DIFF
--- a/metrics/interface/src/main/assembly/resources/conf/iotdb-confignode-metric.yml
+++ b/metrics/interface/src/main/assembly/resources/conf/iotdb-confignode-metric.yml
@@ -47,5 +47,5 @@ ioTDBReporterConfig:
   username: root
   password: root
   maxConnectionNumber: 3
-  database: _metric
+  database: metric
   pushPeriodInSecond: 15

--- a/metrics/interface/src/main/assembly/resources/conf/iotdb-datanode-metric.yml
+++ b/metrics/interface/src/main/assembly/resources/conf/iotdb-datanode-metric.yml
@@ -47,5 +47,5 @@ ioTDBReporterConfig:
   username: root
   password: root
   maxConnectionNumber: 3
-  database: _metric
+  database: metric
   pushPeriodInSecond: 15

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
@@ -64,7 +64,7 @@ public class MetricConfig {
     /** The max number of connection */
     private Integer maxConnectionNumber = 3;
     /** The monitor database of iotdb */
-    private String database = "_metric";
+    private String database = "metric";
     /** The period of data pushed by the reporter to the remote monitoring system. */
     private Integer pushPeriodInSecond = 15;
 

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
@@ -36,7 +36,7 @@ public class IoTDBMetricsUtils {
   private static final MetricConfig metricConfig =
       MetricConfigDescriptor.getInstance().getMetricConfig();
   private static final String STORAGE_GROUP =
-      "root." + metricConfig.getIoTDBReporterConfig().getDatabase();
+      "root.system" + metricConfig.getIoTDBReporterConfig().getDatabase();
 
   public static String generatePath(String name, Map<String, String> labels) {
     StringBuilder stringBuilder = new StringBuilder();

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
@@ -36,7 +36,7 @@ public class IoTDBMetricsUtils {
   private static final MetricConfig metricConfig =
       MetricConfigDescriptor.getInstance().getMetricConfig();
   private static final String STORAGE_GROUP =
-      "root.system" + metricConfig.getIoTDBReporterConfig().getDatabase();
+      "root.system." + metricConfig.getIoTDBReporterConfig().getDatabase();
 
   public static String generatePath(String name, Map<String, String> labels) {
     StringBuilder stringBuilder = new StringBuilder();


### PR DESCRIPTION
There are some built-in storage, such as: root._metric(metrics), root.system.audit(system audit log). We need to unify the prefix of the built-int system storage group which is `root.system`. So we will modify the default write path of iotdb metric reporter from `root.${database}` to `root.system.${database}`.