### PR TITLE
[IOTDB-4237] Add new wal node allocation strategy to reduce wal size

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -138,7 +138,7 @@ target_config_nodes=127.0.0.1:22277
 # wal_dirs=data/datanode/wal
 
 # Max number of wal nodes, each node corresponds to one wal directory
-# The default value 0 means twice the number of wal dirs.
+# The default value 0 means the number is determined by the system.
 # Notice: this value affects write performance significantly.
 # For non-SSD disks, values between one third and half of storage groups number are recommended.
 # Datatype: int

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -3767,6 +3767,10 @@ public class DataRegion {
     return new ArrayList<>(partitionMaxFileVersions.keySet());
   }
 
+  public Long getLatestTimePartition() {
+    return partitionMaxFileVersions.keySet().stream().max(Long::compareTo).orElse(0L);
+  }
+
   public String getInsertWriteLockHolder() {
     return insertWriteLockHolder;
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -182,7 +182,9 @@ public class TsFileProcessor {
     this.writer = new RestorableTsFileIOWriter(tsfile);
     this.updateLatestFlushTimeCallback = updateLatestFlushTimeCallback;
     this.sequence = sequence;
-    this.walNode = WALManager.getInstance().applyForWALNode(storageGroupName);
+    this.walNode =
+        WALManager.getInstance()
+            .applyForWALNode(WALManager.getApplicantUniqueId(storageGroupName, sequence));
     flushListeners.add(FlushListener.DefaultMemTableFLushListener.INSTANCE);
     flushListeners.add(this.walNode);
     closeFileListeners.add(closeTsFileCallback);
@@ -204,7 +206,9 @@ public class TsFileProcessor {
     this.writer = writer;
     this.updateLatestFlushTimeCallback = updateLatestFlushTimeCallback;
     this.sequence = sequence;
-    this.walNode = WALManager.getInstance().applyForWALNode(storageGroupName);
+    this.walNode =
+        WALManager.getInstance()
+            .applyForWALNode(WALManager.getApplicantUniqueId(storageGroupName, sequence));
     flushListeners.add(FlushListener.DefaultMemTableFLushListener.INSTANCE);
     flushListeners.add(this.walNode);
     closeFileListeners.add(closeUnsealedTsFileProcessor);

--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -32,7 +32,6 @@ import org.apache.iotdb.db.exception.WriteProcessRejectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -217,21 +216,18 @@ public class SystemInfo {
   }
 
   /**
-   * Order all working memtables in system by time partition and memory cost of actual data points
-   * in memtable. Mark the top K TSPs as to be flushed, so that after flushing the K TSPs, the
-   * memory cost should be less than FLUSH_THRESHOLD
+   * Order all working memtables in system by memory cost of actual data points in memtable. Mark
+   * the top K TSPs as to be flushed, so that after flushing the K TSPs, the memory cost should be
+   * less than FLUSH_THRESHOLD
    */
   private boolean chooseMemTablesToMarkFlush(TsFileProcessor currentTsFileProcessor) {
     // If invoke flush by replaying logs, do not flush now!
     if (reportedStorageGroupMemCostMap.size() == 0) {
       return false;
     }
-    // first compare time partition id, then compare memory cost
     PriorityQueue<TsFileProcessor> allTsFileProcessors =
         new PriorityQueue<>(
-            Comparator.comparingLong(TsFileProcessor::getTimeRangeId)
-                .thenComparing(
-                    Comparator.comparingLong(TsFileProcessor::getTimeRangeId).reversed()));
+            (o1, o2) -> Long.compare(o2.getWorkMemTableRamCost(), o1.getWorkMemTableRamCost()));
     for (DataRegionInfo dataRegionInfo : reportedStorageGroupMemCostMap.keySet()) {
       allTsFileProcessors.addAll(dataRegionInfo.getAllReportedTsp());
     }

--- a/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
@@ -21,8 +21,6 @@ package org.apache.iotdb.db.wal;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
-import org.apache.iotdb.commons.conf.CommonConfig;
-import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.commons.service.IService;
@@ -54,7 +52,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class WALManager implements IService {
   private static final Logger logger = LoggerFactory.getLogger(WALManager.class);
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
-  private static final CommonConfig commonConfig = CommonDescriptor.getInstance().getConfig();
 
   /** manage all wal nodes and decide how to allocate them */
   private final NodeAllocationStrategy walNodesManager;

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/ElasticStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/ElasticStrategy.java
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class ElasticStrategy extends AbstractNodeAllocationStrategy {
   /** each wal node manages fixed number of memTables */
-  private static final int APPLICATION_NODE_RATIO = 4;
+  public static final int APPLICATION_NODE_RATIO = 4;
 
   /** protect concurrent safety of wal nodes, including walNodes, nodeCursor and nodeIdCounter */
   private final Lock nodesLock = new ReentrantLock();

--- a/server/src/main/java/org/apache/iotdb/db/wal/allocation/ElasticStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/allocation/ElasticStrategy.java
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class ElasticStrategy extends AbstractNodeAllocationStrategy {
   /** each wal node manages fixed number of memTables */
-  private static final int APPLICATION_NODE_RATIO = 5;
+  private static final int APPLICATION_NODE_RATIO = 4;
 
   /** protect concurrent safety of wal nodes, including walNodes, nodeCursor and nodeIdCounter */
   private final Lock nodesLock = new ReentrantLock();

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -266,7 +266,7 @@ public class WALNode implements IWALNode {
       // then delete old .wal files again
       if (effectiveInfoRatio < config.getWalMinEffectiveInfoRatio()) {
         logger.info(
-            "Effective information ratio {} (active memTables cost is {}, flushed memTables cost is {}) of wal node-{} is below wal min effective info ratio {}, some mamTables will be snapshot or flushed.",
+            "Effective information ratio {} (active memTables cost is {}, flushed memTables cost is {}) of wal node-{} is below wal min effective info ratio {}, some memTables will be snapshot or flushed.",
             effectiveInfoRatio,
             costOfActiveMemTables,
             costOfFlushedMemTables,
@@ -378,9 +378,12 @@ public class WALNode implements IWALNode {
         return false;
       }
 
-      // snapshot or flush memTable
+      // snapshot or flush memTable, flush memTable when it belongs to an old time partition, or
+      // it's snapshot count or size reach threshold.
       int snapshotCount = memTableSnapshotCount.getOrDefault(oldestMemTable.getMemTableId(), 0);
-      if (snapshotCount >= config.getMaxWalMemTableSnapshotNum()
+      if (TsFileUtils.getTimePartition(new File(oldestMemTableInfo.getTsFilePath()))
+              < dataRegion.getLatestTimePartition()
+          || snapshotCount >= config.getMaxWalMemTableSnapshotNum()
           || oldestMemTable.getTVListsRamCost() > config.getWalMemTableSnapshotThreshold()) {
         flushMemTable(dataRegion, oldestTsFile, oldestMemTable);
       } else {

--- a/server/src/test/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategyTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/allocation/FirstCreateStrategyTest.java
@@ -22,8 +22,6 @@ import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.conf.IoTDBConfig;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
@@ -43,7 +41,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class FirstCreateStrategyTest {
-  private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static final CommonConfig commonConfig = CommonDescriptor.getInstance().getConfig();
   private final String[] walDirs =
       new String[] {

--- a/server/src/test/java/org/apache/iotdb/db/wal/allocation/RoundRobinStrategyTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/allocation/RoundRobinStrategyTest.java
@@ -22,8 +22,6 @@ import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.conf.IoTDBConfig;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
@@ -43,7 +41,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class RoundRobinStrategyTest {
-  private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static final CommonConfig commonConfig = CommonDescriptor.getInstance().getConfig();
   private final String[] walDirs =
       new String[] {


### PR DESCRIPTION
1. ElasticStrategy creates wal nodes according to the number of memTables. Each wal node manages fixed number of memTable. MemTables sharing the same unique id will be allocated to the same wal node.
2. WAL node wil trigger old memTables‘ flush when new time partition's memTable coming and wal_min_effective_info_ratio is below the threshold.