### PR TITLE
[IOTDB-4783] Optimize memory usage for LastFlushTimeManager

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -762,6 +762,15 @@ public abstract class AbstractMemTable implements IMemTable {
     this.flushStatus = flushStatus;
   }
 
+  @Override
+  public Map<String, Long> getLatestTime() {
+    Map<String, Long> latestTimeForEachDevice = new HashMap<>();
+    for (Entry<IDeviceID, IWritableMemChunkGroup> entry : memTableMap.entrySet()) {
+      latestTimeForEachDevice.put(entry.getKey().toStringID(), entry.getValue().getLatestTime());
+    }
+    return latestTimeForEachDevice;
+  }
+
   /** Notice: this method is concurrent unsafe */
   @Override
   public int serializedSize() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/IMemTable.java
@@ -188,4 +188,6 @@ public interface IMemTable extends WALEntryValue {
   FlushStatus getFlushStatus();
 
   void setFlushStatus(FlushStatus flushStatus);
+
+  Map<String, Long> getLatestTime();
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/IWritableMemChunkGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/IWritableMemChunkGroup.java
@@ -52,4 +52,6 @@ public interface IWritableMemChunkGroup extends WALEntryValue {
       PartialPath originalPath, PartialPath devicePath, long startTimestamp, long endTimestamp);
 
   long getCurrentTVListSize(String measurement);
+
+  long getLatestTime();
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunkGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunkGroup.java
@@ -41,6 +41,8 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
 
   private Map<String, IWritableMemChunk> memChunkMap;
 
+  long latestTime;
+
   public WritableMemChunkGroup() {
     memChunkMap = new HashMap<>();
   }
@@ -67,6 +69,9 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
               schemaList.get(i).getType(),
               start,
               end);
+    }
+    if (latestTime < times[end - 1]) {
+      latestTime = times[end - 1];
     }
     return flushFlag;
   }
@@ -107,6 +112,9 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
       }
       IWritableMemChunk memChunk = createMemChunkIfNotExistAndGet(schemaList.get(i));
       flushFlag |= memChunk.writeWithFlushCheck(insertTime, objectValue[i]);
+    }
+    if (latestTime < insertTime) {
+      latestTime = insertTime;
     }
     return flushFlag;
   }
@@ -151,9 +159,15 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
   }
 
   @Override
+  public long getLatestTime() {
+    return latestTime;
+  }
+
+  @Override
   public int serializedSize() {
     int size = 0;
     size += Integer.BYTES;
+    size += Long.BYTES;
     for (Map.Entry<String, IWritableMemChunk> entry : memChunkMap.entrySet()) {
       size += ReadWriteIOUtils.sizeToWrite(entry.getKey());
       size += entry.getValue().serializedSize();
@@ -164,6 +178,7 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
   @Override
   public void serializeToWAL(IWALByteBufferView buffer) {
     buffer.putInt(memChunkMap.size());
+    buffer.putLong(latestTime);
     for (Map.Entry<String, IWritableMemChunk> entry : memChunkMap.entrySet()) {
       WALWriteUtils.write(entry.getKey(), buffer);
       IWritableMemChunk memChunk = entry.getValue();
@@ -174,6 +189,7 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
   public static WritableMemChunkGroup deserialize(DataInputStream stream) throws IOException {
     WritableMemChunkGroup memChunkGroup = new WritableMemChunkGroup();
     int memChunkMapSize = stream.readInt();
+    memChunkGroup.latestTime = stream.readLong();
     for (int i = 0; i < memChunkMapSize; ++i) {
       String measurement = ReadWriteIOUtils.readString(stream);
       IWritableMemChunk memChunk = WritableMemChunk.deserialize(stream);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/ILastFlushTimeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/ILastFlushTimeManager.java
@@ -24,10 +24,6 @@ import java.util.Map;
 public interface ILastFlushTimeManager {
 
   // region set
-  void setMultiDeviceLastTime(long timePartitionId, Map<String, Long> lastTimeMap);
-
-  void setOneDeviceLastTime(long timePartitionId, String path, long time);
-
   void setMultiDeviceFlushedTime(long timePartitionId, Map<String, Long> flushedTimeMap);
 
   void setOneDeviceFlushedTime(long timePartitionId, String path, long time);
@@ -38,8 +34,6 @@ public interface ILastFlushTimeManager {
   // endregion
 
   // region update
-  void updateLastTime(long timePartitionId, String path, long time);
-
   void updateFlushedTime(long timePartitionId, String path, long time);
 
   void updateGlobalFlushedTime(String path, long time);
@@ -49,7 +43,6 @@ public interface ILastFlushTimeManager {
   // endregion
 
   // region ensure
-  void ensureLastTimePartition(long timePartitionId);
 
   void ensureFlushedTimePartition(long timePartitionId);
 
@@ -59,29 +52,20 @@ public interface ILastFlushTimeManager {
   // region support upgrade methods
   void applyNewlyFlushedTimeToFlushedTime();
 
-  /**
-   * update latest flush time for partition id
-   *
-   * @param partitionId partition id
-   * @param latestFlushTime lastest flush time
-   * @return true if update latest flush time success
-   */
-  boolean updateLatestFlushTimeToPartition(long partitionId, long latestFlushTime);
-
-  boolean updateLatestFlushTime(long partitionId);
+  boolean updateLatestFlushTime(long partitionId, Map<String, Long> latestFlushTimeMap);
   // endregion
 
   // region query
   long getFlushedTime(long timePartitionId, String path);
 
-  long getLastTime(long timePartitionId, String path);
-
   long getGlobalFlushedTime(String path);
   // endregion
 
-  // region clear
-  void clearLastTime();
+  // region remove
+  void removePartition(long timePartitionId);
+  // endregion
 
+  // region clear
   void clearFlushedTime();
 
   void clearGlobalFlushedTime();

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1106,8 +1106,14 @@ public class TsFileProcessor {
    * flushManager again.
    */
   private void addAMemtableIntoFlushingList(IMemTable tobeFlushed) throws IOException {
+    Map<String, Long> lastTimeForEachDevice = new HashMap<>();
+    if (sequence) {
+      lastTimeForEachDevice = tobeFlushed.getLatestTime();
+      tsFileResource.updateEndTime(lastTimeForEachDevice);
+    }
     if (!tobeFlushed.isSignalMemTable()
-        && (!updateLatestFlushTimeCallback.call(this) || tobeFlushed.memSize() == 0)) {
+        && (!updateLatestFlushTimeCallback.call(this, lastTimeForEachDevice)
+            || tobeFlushed.memSize() == 0)) {
       logger.warn(
           "This normal memtable is empty, skip it in flush. {}: {} Memetable info: {}",
           storageGroupName,
@@ -1642,6 +1648,10 @@ public class TsFileProcessor {
       logger.error("device id is illegal");
       throw e;
     }
+  }
+
+  public Map<String, Long> getLastTimeForEachDevice() {
+    return new HashMap<>();
   }
 
   @TestOnly

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -317,6 +317,12 @@ public class TsFileResource {
     timeIndex.updateEndTime(device, time);
   }
 
+  public void updateEndTime(Map<String, Long> times) {
+    for (Map.Entry<String, Long> entry : times.entrySet()) {
+      timeIndex.updateEndTime(entry.getKey(), entry.getValue());
+    }
+  }
+
   public boolean resourceFileExists() {
     return fsFactory.getFile(file + RESOURCE_SUFFIX).exists();
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/idtable/entry/DeviceEntry.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/idtable/entry/DeviceEntry.java
@@ -34,10 +34,6 @@ public class DeviceEntry {
 
   boolean isAligned;
 
-  // for managing last time
-  // time partition -> last time
-  Map<Long, Long> lastTimeMapOfEachPartition;
-
   // for managing flush time
   // time partition -> flush time
   Map<Long, Long> flushTimeMapOfEachPartition;
@@ -47,7 +43,6 @@ public class DeviceEntry {
   public DeviceEntry(IDeviceID deviceID) {
     this.deviceID = deviceID;
     measurementMap = new ConcurrentHashMap<>();
-    lastTimeMapOfEachPartition = new HashMap<>();
     flushTimeMapOfEachPartition = new HashMap<>();
   }
 
@@ -94,17 +89,8 @@ public class DeviceEntry {
   }
 
   // region support flush time
-  public void putLastTimeMap(long timePartition, long lastTime) {
-    lastTimeMapOfEachPartition.put(timePartition, lastTime);
-  }
-
   public void putFlushTimeMap(long timePartition, long flushTime) {
     flushTimeMapOfEachPartition.put(timePartition, flushTime);
-  }
-
-  public long updateLastTimeMap(long timePartition, long lastTime) {
-    return lastTimeMapOfEachPartition.compute(
-        timePartition, (k, v) -> v == null ? lastTime : Math.max(v, lastTime));
   }
 
   public long updateFlushTimeMap(long timePartition, long flushTime) {
@@ -120,16 +106,8 @@ public class DeviceEntry {
     this.globalFlushTime = globalFlushTime;
   }
 
-  public Long getLastTime(long timePartition) {
-    return lastTimeMapOfEachPartition.get(timePartition);
-  }
-
   public Long getFlushTime(long timePartition) {
     return flushTimeMapOfEachPartition.get(timePartition);
-  }
-
-  public Long getLastTimeWithDefaultValue(long timePartition) {
-    return lastTimeMapOfEachPartition.getOrDefault(timePartition, Long.MIN_VALUE);
   }
 
   public Long getFLushTimeWithDefaultValue(long timePartition) {
@@ -140,14 +118,14 @@ public class DeviceEntry {
     return globalFlushTime;
   }
 
-  public void clearLastTime() {
-    lastTimeMapOfEachPartition.clear();
-  }
-
   public void clearFlushTime() {
     flushTimeMapOfEachPartition.clear();
   }
   // endregion
+
+  public void removePartition(long partitionId) {
+    flushTimeMapOfEachPartition.remove(partitionId);
+  }
 
   public Map<String, SchemaEntry> getMeasurementMap() {
     return measurementMap;
@@ -166,18 +144,12 @@ public class DeviceEntry {
         && globalFlushTime == that.globalFlushTime
         && deviceID.equals(that.deviceID)
         && measurementMap.equals(that.measurementMap)
-        && lastTimeMapOfEachPartition.equals(that.lastTimeMapOfEachPartition)
         && flushTimeMapOfEachPartition.equals(that.flushTimeMapOfEachPartition);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        deviceID,
-        measurementMap,
-        isAligned,
-        lastTimeMapOfEachPartition,
-        flushTimeMapOfEachPartition,
-        globalFlushTime);
+        deviceID, measurementMap, isAligned, flushTimeMapOfEachPartition, globalFlushTime);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
@@ -109,7 +109,7 @@ public class TsFileProcessorTest {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
@@ -168,7 +168,7 @@ public class TsFileProcessorTest {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
@@ -255,7 +255,7 @@ public class TsFileProcessorTest {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
@@ -298,7 +298,7 @@ public class TsFileProcessorTest {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
     processor.setTsFileProcessorInfo(tsFileProcessorInfo);
@@ -333,7 +333,7 @@ public class TsFileProcessorTest {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
     processor.setTsFileProcessorInfo(tsFileProcessorInfo);
@@ -367,7 +367,7 @@ public class TsFileProcessorTest {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorV2Test.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorV2Test.java
@@ -110,7 +110,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
@@ -169,7 +169,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
@@ -256,7 +256,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
@@ -299,7 +299,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
     processor.setTsFileProcessorInfo(tsFileProcessorInfo);
@@ -335,7 +335,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
     processor.setTsFileProcessorInfo(tsFileProcessorInfo);
@@ -371,7 +371,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor) -> true,
+            (tsFileProcessor, updateMap) -> true,
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);

--- a/server/src/test/java/org/apache/iotdb/db/metadata/idtable/IDTableFlushTimeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/idtable/IDTableFlushTimeTest.java
@@ -162,8 +162,6 @@ public class IDTableFlushTimeTest {
     assertEquals(
         103L, storageGroupProcessor.getLastFlushTimeManager().getFlushedTime(0L, "root.isp.d1"));
     assertEquals(
-        123L, storageGroupProcessor.getLastFlushTimeManager().getLastTime(0L, "root.isp.d1"));
-    assertEquals(
         103L, storageGroupProcessor.getLastFlushTimeManager().getGlobalFlushedTime("root.isp.d1"));
 
     // delete time partition
@@ -176,9 +174,6 @@ public class IDTableFlushTimeTest {
     assertEquals(
         Long.MIN_VALUE,
         storageGroupProcessor.getLastFlushTimeManager().getFlushedTime(0L, "root.isp.d1"));
-    assertEquals(
-        Long.MIN_VALUE,
-        storageGroupProcessor.getLastFlushTimeManager().getLastTime(0L, "root.isp.d1"));
     assertEquals(
         123L, storageGroupProcessor.getLastFlushTimeManager().getGlobalFlushedTime("root.isp.d1"));
   }


### PR DESCRIPTION
LastFlushTimeManager maintains a lastTimeMap to update latestFlushTimeMap when a working memtable has been added to flushList. In fact, we can get latest time for each device from the working memtable to update the latestFlushTimeMap, so we can optimize memory usage of flushTimeManager by reducing the lastTimeMap.