### PR TITLE
[IOTDB-3149] There is a difference between adding ** path and without a path to list user privileges

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
@@ -296,7 +296,7 @@ public class AuthorInfo implements SnapshotProcessor {
         continue;
       }
       for (String path : plan.getNodeNameList()) {
-        if (AuthUtils.pathOrBelongsTo(path, pathPrivilege.getPath())) {
+        if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path)) {
           rolePrivilegesSet.add(pathPrivilege.toString());
         }
       }
@@ -341,7 +341,7 @@ public class AuthorInfo implements SnapshotProcessor {
           continue;
         }
         for (String path : plan.getNodeNameList()) {
-          if (AuthUtils.pathOrBelongsTo(path, pathPrivilege.getPath())
+          if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path)
               && !userPrivilegeSet.contains(pathPrivilege.toString())) {
             rolePrivileges.add("");
             userPrivilegeSet.add(pathPrivilege.toString());
@@ -363,7 +363,7 @@ public class AuthorInfo implements SnapshotProcessor {
             continue;
           }
           for (String path : plan.getNodeNameList()) {
-            if (AuthUtils.pathOrBelongsTo(path, pathPrivilege.getPath())
+            if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path)
                 && !rolePrivilegeSet.contains(pathPrivilege.toString())) {
               rolePrivileges.add(roleN);
               rolePrivilegeSet.add(pathPrivilege.toString());

--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/AuthorInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/AuthorInfoTest.java
@@ -268,7 +268,7 @@ public class AuthorInfoTest {
     status = permissionInfoResp.getStatus();
     Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
     Assert.assertEquals(
-        privilege, permissionInfoResp.getPermissionInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
+        "", permissionInfoResp.getPermissionInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
 
     // list user privileges
     authorPlan =

--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/AuthorInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/AuthorInfoTest.java
@@ -254,7 +254,7 @@ public class AuthorInfoTest {
     status = authorInfo.authorNonQuery(authorPlan);
     Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
 
-    // list privileges user
+    // list privileges user on root.ln.**
     authorPlan =
         new AuthorPlan(
             ConfigPhysicalPlanType.ListUserPrivilege,
@@ -268,7 +268,23 @@ public class AuthorInfoTest {
     status = permissionInfoResp.getStatus();
     Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
     Assert.assertEquals(
-        "", permissionInfoResp.getPermissionInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
+        0, permissionInfoResp.getPermissionInfo().get(IoTDBConstant.COLUMN_PRIVILEGE).size());
+
+    // list privileges user on root.**
+    authorPlan =
+        new AuthorPlan(
+            ConfigPhysicalPlanType.ListUserPrivilege,
+            "user0",
+            "",
+            "",
+            "",
+            new HashSet<>(),
+            Collections.singletonList("root.**"));
+    permissionInfoResp = authorInfo.executeListUserPrivileges(authorPlan);
+    status = permissionInfoResp.getStatus();
+    Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
+    Assert.assertEquals(
+        privilege, permissionInfoResp.getPermissionInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
 
     // list user privileges
     authorPlan =
@@ -286,7 +302,7 @@ public class AuthorInfoTest {
     Assert.assertEquals(
         privilege, permissionInfoResp.getPermissionInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
 
-    // list privileges role
+    // list privileges role on root.ln.**
     authorPlan =
         new AuthorPlan(
             ConfigPhysicalPlanType.ListRolePrivilege,
@@ -300,6 +316,22 @@ public class AuthorInfoTest {
     status = permissionInfoResp.getStatus();
     Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
     privilege.remove(0);
+    Assert.assertEquals(
+        0, permissionInfoResp.getPermissionInfo().get(IoTDBConstant.COLUMN_PRIVILEGE).size());
+
+    // list privileges role on root.**
+    authorPlan =
+        new AuthorPlan(
+            ConfigPhysicalPlanType.ListRolePrivilege,
+            "",
+            "role0",
+            "",
+            "",
+            new HashSet<>(),
+            Collections.singletonList("root.**"));
+    permissionInfoResp = authorInfo.executeListRolePrivileges(authorPlan);
+    status = permissionInfoResp.getStatus();
+    Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
     Assert.assertEquals(
         privilege, permissionInfoResp.getPermissionInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/IoTDBClusterAuthorityIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/IoTDBClusterAuthorityIT.java
@@ -328,8 +328,7 @@ public class IoTDBClusterAuthorityIT {
       authorizerResp = client.queryPermission(authorizerReq);
       status = authorizerResp.getStatus();
       assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
-      assertEquals(
-          "", authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
+      assertEquals("", authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
 
       // list user privileges
       authorizerReq =

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/IoTDBClusterAuthorityIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/IoTDBClusterAuthorityIT.java
@@ -315,7 +315,7 @@ public class IoTDBClusterAuthorityIT {
       status = client.operatePermission(authorizerReq);
       assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
 
-      // list privileges user
+      // list privileges user on root.ln.**
       authorizerReq =
           new TAuthorizerReq(
               AuthorOperator.AuthorType.LIST_USER_PRIVILEGE.ordinal(),
@@ -328,7 +328,24 @@ public class IoTDBClusterAuthorityIT {
       authorizerResp = client.queryPermission(authorizerReq);
       status = authorizerResp.getStatus();
       assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
-      assertEquals("", authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
+      Assert.assertEquals(
+          0, authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE).size());
+
+      // list privileges user on root.**
+      authorizerReq =
+          new TAuthorizerReq(
+              AuthorOperator.AuthorType.LIST_USER_PRIVILEGE.ordinal(),
+              "tempuser0",
+              "",
+              "",
+              "",
+              new HashSet<>(),
+              Collections.singletonList("root.**"));
+      authorizerResp = client.queryPermission(authorizerReq);
+      status = authorizerResp.getStatus();
+      assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
+      Assert.assertEquals(
+          privilege, authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
 
       // list user privileges
       authorizerReq =
@@ -346,7 +363,7 @@ public class IoTDBClusterAuthorityIT {
       Assert.assertEquals(
           privilege, authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
 
-      // list privileges role
+      // list privileges role on root.ln.**
       authorizerReq =
           new TAuthorizerReq(
               AuthorOperator.AuthorType.LIST_ROLE_PRIVILEGE.ordinal(),
@@ -360,6 +377,22 @@ public class IoTDBClusterAuthorityIT {
       status = authorizerResp.getStatus();
       assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
       privilege.remove(0);
+      assertEquals(
+          0, authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE).size());
+
+      // list privileges role on root.**
+      authorizerReq =
+          new TAuthorizerReq(
+              AuthorOperator.AuthorType.LIST_ROLE_PRIVILEGE.ordinal(),
+              "",
+              "temprole0",
+              "",
+              "",
+              new HashSet<>(),
+              Collections.singletonList("root.**"));
+      authorizerResp = client.queryPermission(authorizerReq);
+      status = authorizerResp.getStatus();
+      assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
       assertEquals(
           privilege, authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/IoTDBClusterAuthorityIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/IoTDBClusterAuthorityIT.java
@@ -329,7 +329,7 @@ public class IoTDBClusterAuthorityIT {
       status = authorizerResp.getStatus();
       assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
       assertEquals(
-          privilege, authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
+          "", authorizerResp.getAuthorizerInfo().get(IoTDBConstant.COLUMN_PRIVILEGE));
 
       // list user privileges
       authorizerReq =

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
@@ -228,7 +228,7 @@ public class AuthUtils {
     try {
       PartialPath partialPathA = new PartialPath(pathA);
       PartialPath partialPathB = new PartialPath(pathB);
-      return partialPathB.matchFullPath(partialPathA) || partialPathA.matchFullPath(partialPathB);
+      return partialPathA.matchFullPath(partialPathB);
     } catch (IllegalPathException e) {
       throw new AuthException(e);
     }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
@@ -218,23 +218,6 @@ public class AuthUtils {
   }
 
   /**
-   * check if pathA either belongs to pathB or pathB belongs to pathA according to path pattern.
-   *
-   * @param pathA path
-   * @param pathB path
-   * @return True if pathA is a sub pattern of pathB, or pathB is a sub pattern of pathA
-   */
-  public static boolean pathOrBelongsTo(String pathA, String pathB) throws AuthException {
-    try {
-      PartialPath partialPathA = new PartialPath(pathA);
-      PartialPath partialPathB = new PartialPath(pathB);
-      return partialPathA.matchFullPath(partialPathB);
-    } catch (IllegalPathException e) {
-      throw new AuthException(e);
-    }
-  }
-
-  /**
    * check privilege.
    *
    * @param path series path

--- a/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
@@ -1197,7 +1197,7 @@ public class LocalConfigNode {
         continue;
       }
       for (PartialPath path : authorStatement.getNodeNameList()) {
-        if (AuthUtils.pathOrBelongsTo(path.getFullPath(), pathPrivilege.getPath())) {
+        if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path.getFullPath())) {
           rolePrivilegeSet.add(pathPrivilege.toString());
         }
       }
@@ -1236,7 +1236,7 @@ public class LocalConfigNode {
           continue;
         }
         for (PartialPath path : authorStatement.getNodeNameList()) {
-          if (AuthUtils.pathOrBelongsTo(path.getFullPath(), pathPrivilege.getPath())
+          if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path.getFullPath())
               && !userPrivilegeSet.contains(pathPrivilege.toString())) {
             rolePrivileges.add("");
             userPrivilegeSet.add(pathPrivilege.toString());
@@ -1258,7 +1258,7 @@ public class LocalConfigNode {
             continue;
           }
           for (PartialPath path : authorStatement.getNodeNameList()) {
-            if (AuthUtils.pathOrBelongsTo(path.getFullPath(), pathPrivilege.getPath())
+            if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path.getFullPath())
                 && !rolePrivilegeSet.contains(pathPrivilege.toString())) {
               rolePrivileges.add(roleN);
               rolePrivilegeSet.add(pathPrivilege.toString());

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -2252,7 +2252,7 @@ public class PlanExecutor implements IPlanExecutor {
           continue;
         }
         for (PartialPath path : nodeNameList) {
-          if (AuthUtils.pathOrBelongsTo(path.getFullPath(), pathPrivilege.getPath())) {
+          if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path.getFullPath())) {
             RowRecord record = new RowRecord(index++);
             Field field = new Field(TSDataType.TEXT);
             field.setBinaryV(new Binary(pathPrivilege.toString()));
@@ -2307,7 +2307,7 @@ public class PlanExecutor implements IPlanExecutor {
           continue;
         }
         for (PartialPath path : nodeNameList) {
-          if (AuthUtils.pathOrBelongsTo(path.getFullPath(), pathPrivilege.getPath())) {
+          if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path.getFullPath())) {
             RowRecord record = new RowRecord(index++);
             Field roleF = new Field(TSDataType.TEXT);
             roleF.setBinaryV(new Binary(""));
@@ -2336,7 +2336,7 @@ public class PlanExecutor implements IPlanExecutor {
             dataSet.putRecord(record);
           }
           for (PartialPath path : nodeNameList) {
-            if (AuthUtils.pathOrBelongsTo(path.getFullPath(), pathPrivilege.getPath())) {
+            if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path.getFullPath())) {
               RowRecord record = new RowRecord(index++);
               Field roleF = new Field(TSDataType.TEXT);
               roleF.setBinaryV(new Binary(roleN));


### PR DESCRIPTION
This problem has been solved, but new problems have been found.

The user checks the permissions on the root. sg. ** path, and the root. ** is also matched

 
![图片](https://user-images.githubusercontent.com/79885238/198925159-1575eec9-b354-439f-9667-63870dd498a3.png)



after:

![图片](https://user-images.githubusercontent.com/79885238/198925187-86f24acc-33c0-4625-abaf-e3df433961c1.png)


