### PR TITLE
[IOTDB-4791] Optimize the endFile in `TsFileIOWriter`

### DIFF
--- a/cross-tests/src/test/java/org/apache/iotdb/cross/tests/tools/tsfile/ExportTsFileTestIT.java
+++ b/cross-tests/src/test/java/org/apache/iotdb/cross/tests/tools/tsfile/ExportTsFileTestIT.java
@@ -89,9 +89,9 @@ public class ExportTsFileTestIT extends AbstractScript {
     try (TsFileSequenceReader reader = new TsFileSequenceReader(path);
         TsFileReader readTsFile = new TsFileReader(reader)) {
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("root.test.t2", "c1"));
-      paths.add(new Path("root.test.t2", "c2"));
-      paths.add(new Path("root.test.t2", "c3"));
+      paths.add(new Path("root.test.t2", "c1", true));
+      paths.add(new Path("root.test.t2", "c2", true));
+      paths.add(new Path("root.test.t2", "c3", true));
       QueryExpression queryExpression = QueryExpression.create(paths, null);
       return readTsFile.query(queryExpression);
     }

--- a/example/tsfile/src/main/java/org/apache/iotdb/tsfile/TsFileRead.java
+++ b/example/tsfile/src/main/java/org/apache/iotdb/tsfile/TsFileRead.java
@@ -66,9 +66,9 @@ public class TsFileRead {
 
       // use these paths(all measurements) for all the queries
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path(DEVICE_1, SENSOR_1));
-      paths.add(new Path(DEVICE_1, SENSOR_2));
-      paths.add(new Path(DEVICE_1, SENSOR_3));
+      paths.add(new Path(DEVICE_1, SENSOR_1, true));
+      paths.add(new Path(DEVICE_1, SENSOR_2, true));
+      paths.add(new Path(DEVICE_1, SENSOR_3, true));
 
       // no filter, should select 1 2 3 4 6 7 8
       queryAndPrint(paths, readTsFile, null);
@@ -82,7 +82,7 @@ public class TsFileRead {
 
       // value filter : device_1.sensor_2 <= 20, should select 1 2 4 6 7
       IExpression valueFilter =
-          new SingleSeriesExpression(new Path(DEVICE_1, SENSOR_2), ValueFilter.ltEq(20L));
+          new SingleSeriesExpression(new Path(DEVICE_1, SENSOR_2, true), ValueFilter.ltEq(20L));
       queryAndPrint(paths, readTsFile, valueFilter);
 
       // time filter : 4 <= time <= 10, value filter : device_1.sensor_3 >= 20, should select 4 7 8
@@ -90,7 +90,8 @@ public class TsFileRead {
           BinaryExpression.and(
               new GlobalTimeExpression(TimeFilter.gtEq(4L)),
               new GlobalTimeExpression(TimeFilter.ltEq(10L)));
-      valueFilter = new SingleSeriesExpression(new Path(DEVICE_1, SENSOR_3), ValueFilter.gtEq(20L));
+      valueFilter =
+          new SingleSeriesExpression(new Path(DEVICE_1, SENSOR_3, true), ValueFilter.gtEq(20L));
       IExpression finalFilter = BinaryExpression.and(timeFilter, valueFilter);
       queryAndPrint(paths, readTsFile, finalFilter);
     }

--- a/hadoop/src/main/java/org/apache/iotdb/hadoop/tsfile/TSFRecordReader.java
+++ b/hadoop/src/main/java/org/apache/iotdb/hadoop/tsfile/TSFRecordReader.java
@@ -112,7 +112,7 @@ public class TSFRecordReader extends RecordReader<NullWritable, MapWritable> imp
       for (String deviceId : deviceIds) {
         List<Path> paths =
             measurementIds.stream()
-                .map(measurementId -> new Path(deviceId, measurementId))
+                .map(measurementId -> new Path(deviceId, measurementId, true))
                 .collect(toList());
         QueryExpression queryExpression = QueryExpression.create(paths, null);
         QueryDataSet dataSet =

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
@@ -122,7 +122,8 @@ public class IOTDBLoadTsFileIT {
     String sql =
         String.format(
             "create timeseries %s %s",
-            new Path(device, schema.getMeasurementId()).getFullPath(), schema.getType().name());
+            new Path(device, schema.getMeasurementId(), true).getFullPath(),
+            schema.getType().name());
     LOGGER.info(String.format("schema execute: %s.", sql));
     return sql;
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
@@ -653,7 +653,7 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
 
   @TestOnly
   public Path toTSFilePath() {
-    return new Path(getDevice(), getMeasurement());
+    return new Path(getDevice(), getMeasurement(), true);
   }
 
   public static List<String> toStringList(List<PartialPath> pathList) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -127,7 +127,8 @@ public class TimeSeriesMetadataCache {
         return null;
       }
       TimeseriesMetadata timeseriesMetadata =
-          reader.readTimeseriesMetadata(new Path(key.device, key.measurement), ignoreNotExists);
+          reader.readTimeseriesMetadata(
+              new Path(key.device, key.measurement, true), ignoreNotExists);
       return (timeseriesMetadata == null || timeseriesMetadata.getStatistics().getCount() == 0)
           ? null
           : timeseriesMetadata;
@@ -147,7 +148,7 @@ public class TimeSeriesMetadataCache {
         // double check
         timeseriesMetadata = lruCache.getIfPresent(key);
         if (timeseriesMetadata == null) {
-          Path path = new Path(key.device, key.measurement);
+          Path path = new Path(key.device, key.measurement, true);
           // bloom filter part
           BloomFilter bloomFilter =
               BloomFilterCache.getInstance()

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1533,7 +1533,7 @@ public class PlanExecutor implements IPlanExecutor {
         if (!registeredSeries.contains(series)) {
           registeredSeries.add(series);
           IMeasurementSchema schema =
-              knownSchemas.get(new Path(series.getDevice(), series.getMeasurement()));
+              knownSchemas.get(new Path(series.getDevice(), series.getMeasurement(), true));
           if (schema == null) {
             throw new MetadataException(
                 String.format(

--- a/server/src/main/java/org/apache/iotdb/db/sync/datasource/TsFileOpBlock.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/datasource/TsFileOpBlock.java
@@ -250,7 +250,7 @@ public class TsFileOpBlock extends AbstractOpBlock {
           ChunkInfo chunkInfo = new ChunkInfo();
 
           chunkInfo.measurementFullPath =
-              new Path(device, chunkMetadata.getMeasurementUid()).getFullPath();
+              new Path(device, chunkMetadata.getMeasurementUid(), true).getFullPath();
           chunkInfo.chunkOffsetInFile = chunkMetadata.getOffsetOfChunkHeader();
           chunkInfo.pointCount = chunkMetadata.getStatistics().getCount();
 
@@ -1101,7 +1101,8 @@ public class TsFileOpBlock extends AbstractOpBlock {
             timeseriesMetadataMap.put(
                 pos,
                 new Pair<>(
-                    new Path(deviceId, timeseriesMetadata.getMeasurementId()), timeseriesMetadata));
+                    new Path(deviceId, timeseriesMetadata.getMeasurementId(), true),
+                    timeseriesMetadata));
           }
         } else { // deviceId should be determined by LEAF_DEVICE node
           if (type.equals(MetadataIndexNodeType.LEAF_DEVICE)) {

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSelfCheckTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSelfCheckTool.java
@@ -129,7 +129,8 @@ public class TsFileSelfCheckTool {
             timeseriesMetadataMap.put(
                 pos,
                 new Pair<>(
-                    new Path(deviceId, timeseriesMetadata.getMeasurementId()), timeseriesMetadata));
+                    new Path(deviceId, timeseriesMetadata.getMeasurementId(), true),
+                    timeseriesMetadata));
           }
         } else {
           // deviceId should be determined by LEAF_DEVICE node

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
@@ -456,7 +456,8 @@ public class TsFileSketchTool {
             timeseriesMetadataMap.put(
                 pos,
                 new Pair<>(
-                    new Path(deviceId, timeseriesMetadata.getMeasurementId()), timeseriesMetadata));
+                    new Path(deviceId, timeseriesMetadata.getMeasurementId(), true),
+                    timeseriesMetadata));
           }
         } else {
           // deviceId should be determined by LEAF_DEVICE node

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/ReadChunkCompactionPerformerOldTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/ReadChunkCompactionPerformerOldTest.java
@@ -119,7 +119,7 @@ public class ReadChunkCompactionPerformerOldTest extends InnerCompactionTest {
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);
     sizeTieredCompactionLogger.close();
-    Path path = new Path(deviceIds[0], measurementSchemas[0].getMeasurementId());
+    Path path = new Path(deviceIds[0], measurementSchemas[0].getMeasurementId(), true);
     try (TsFileSequenceReader reader =
             new TsFileSequenceReader(targetTsFileResource.getTsFilePath());
         TsFileReader readTsFile = new TsFileReader(reader)) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionTest.java
@@ -204,7 +204,7 @@ public class SizeTieredCompactionTest {
     for (String deviceId : deviceIds) {
       for (MeasurementSchema measurementSchema : measurementSchemas) {
         fileWriter.registerTimeseries(
-            new Path(deviceId, measurementSchema.getMeasurementId()), measurementSchema);
+            new Path(deviceId, measurementSchema.getMeasurementId(), true), measurementSchema);
       }
     }
     for (long i = timeOffset; i < timeOffset + ptNum; i++) {
@@ -248,7 +248,8 @@ public class SizeTieredCompactionTest {
     tsFileResource1.updatePlanIndexes((long) 0);
     TsFileWriter fileWriter1 = new TsFileWriter(tsFileResource1.getTsFile());
     fileWriter1.registerTimeseries(
-        new Path(deviceIds[0], measurementSchemas[0].getMeasurementId()), measurementSchemas[0]);
+        new Path(deviceIds[0], measurementSchemas[0].getMeasurementId(), true),
+        measurementSchemas[0]);
     TSRecord record1 = new TSRecord(0, deviceIds[0]);
     record1.addTuple(
         DataPoint.getDataPoint(
@@ -275,7 +276,8 @@ public class SizeTieredCompactionTest {
     tsFileResource2.updatePlanIndexes((long) 1);
     TsFileWriter fileWriter2 = new TsFileWriter(tsFileResource2.getTsFile());
     fileWriter2.registerTimeseries(
-        new Path(deviceIds[0], measurementSchemas[1].getMeasurementId()), measurementSchemas[1]);
+        new Path(deviceIds[0], measurementSchemas[1].getMeasurementId(), true),
+        measurementSchemas[1]);
     TSRecord record2 = new TSRecord(0, deviceIds[0]);
     record2.addTuple(
         DataPoint.getDataPoint(

--- a/server/src/test/java/org/apache/iotdb/db/qp/other/TSPlanContextAuthorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/other/TSPlanContextAuthorTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.fail;
 public class TSPlanContextAuthorTest {
 
   private static Path[] emptyPaths = new Path[] {};
-  private static Path[] testPaths = new Path[] {new Path("root.node1.a", "b")};
+  private static Path[] testPaths = new Path[] {new Path("root.node1.a", "b", true)};
 
   private String inputSQL;
   private Path[] paths;

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/ConcatOptimizerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/ConcatOptimizerTest.java
@@ -119,7 +119,7 @@ public class ConcatOptimizerTest {
     String inputSQL = "select s1 from root.laptop.d1 where s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(inputSQL);
     SingleSeriesExpression seriesExpression =
-        new SingleSeriesExpression(new Path("root.laptop.d1", "s1"), ValueFilter.lt(10));
+        new SingleSeriesExpression(new Path("root.laptop.d1", "s1", true), ValueFilter.lt(10));
     assertEquals(seriesExpression.toString(), ((RawDataQueryPlan) plan).getExpression().toString());
   }
 
@@ -130,9 +130,11 @@ public class ConcatOptimizerTest {
     IExpression expression =
         BinaryExpression.and(
             BinaryExpression.and(
-                new SingleSeriesExpression(new Path("root.laptop.d1", "s1"), ValueFilter.lt(10)),
-                new SingleSeriesExpression(new Path("root.laptop.d2", "s1"), ValueFilter.lt(10))),
-            new SingleSeriesExpression(new Path("root.laptop.d3", "s1"), ValueFilter.lt(10)));
+                new SingleSeriesExpression(
+                    new Path("root.laptop.d1", "s1", true), ValueFilter.lt(10)),
+                new SingleSeriesExpression(
+                    new Path("root.laptop.d2", "s1", true), ValueFilter.lt(10))),
+            new SingleSeriesExpression(new Path("root.laptop.d3", "s1", true), ValueFilter.lt(10)));
     assertEquals(expression.toString(), ((RawDataQueryPlan) plan).getExpression().toString());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/physical/PhysicalPlanTest.java
@@ -666,7 +666,7 @@ public class PhysicalPlanTest {
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
         new SingleSeriesExpression(
-            new Path("root.vehicle.d1", "s1"),
+            new Path("root.vehicle.d1", "s1", true),
             new OrFilter(
                 new AndFilter(TimeFilter.gt(50), TimeFilter.ltEq(100)), ValueFilter.lt(10.0)));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -680,7 +680,7 @@ public class PhysicalPlanTest {
 
     IExpression expect =
         new SingleSeriesExpression(
-            new Path("root.vehicle.d1", "s1"),
+            new Path("root.vehicle.d1", "s1", true),
             new AndFilter(
                 ValueFilter.lt(10.0), new AndFilter(TimeFilter.gt(50), TimeFilter.ltEq(100))));
 
@@ -697,7 +697,7 @@ public class PhysicalPlanTest {
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
         new SingleSeriesExpression(
-            new Path("root.vehicle.d1", "s1"),
+            new Path("root.vehicle.d1", "s1", true),
             FilterFactory.or(ValueFilter.gt(20.0), ValueFilter.lt(10.0)));
     assertEquals(expect.toString(), queryFilter.toString());
   }
@@ -754,7 +754,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(20.5e3));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(20.5e3));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -764,7 +764,8 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(20.5e-3));
+        new SingleSeriesExpression(
+            new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(20.5e-3));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -774,7 +775,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(2.5));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(2.5));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -784,7 +785,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(2.5));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(2.5));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -794,7 +795,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(-2.5));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(-2.5));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -804,7 +805,8 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(-2.5e-1));
+        new SingleSeriesExpression(
+            new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(-2.5e-1));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -814,7 +816,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(2.5e+2));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(2.5e+2));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -824,7 +826,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(0.2e+2));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(0.2e+2));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -834,7 +836,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(0.2));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(0.2));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -844,7 +846,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(2.0));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(2.0));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -854,7 +856,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(2.0));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(2.0));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -864,7 +866,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(-2.0));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(-2.0));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -874,7 +876,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(-0.2));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(-0.2));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -884,7 +886,7 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.gt(-20.0));
+        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1", true), ValueFilter.gt(-20.0));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -899,7 +901,7 @@ public class PhysicalPlanTest {
     values.add(40.0f);
     IExpression expect =
         new SingleSeriesExpression(
-            new Path("root.vehicle.d1", "s1"), ValueFilter.in(values, false));
+            new Path("root.vehicle.d1", "s1", true), ValueFilter.in(values, false));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -913,7 +915,8 @@ public class PhysicalPlanTest {
     values.add(30.0f);
     values.add(40.0f);
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d1", "s1"), ValueFilter.in(values, true));
+        new SingleSeriesExpression(
+            new Path("root.vehicle.d1", "s1", true), ValueFilter.in(values, true));
     assertEquals(expect.toString(), queryFilter.toString());
 
     sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE not(s1 not in (25, 30, 40))";
@@ -921,7 +924,7 @@ public class PhysicalPlanTest {
     queryFilter = ((RawDataQueryPlan) plan).getExpression();
     expect =
         new SingleSeriesExpression(
-            new Path("root.vehicle.d1", "s1"), ValueFilter.in(values, false));
+            new Path("root.vehicle.d1", "s1", true), ValueFilter.in(values, false));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
@@ -1056,13 +1059,15 @@ public class PhysicalPlanTest {
     RawDataQueryPlan plan = (RawDataQueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
     Assert.assertEquals(1, plan.getDeduplicatedPaths().size());
     Assert.assertEquals(1, plan.getDeduplicatedDataTypes().size());
-    Assert.assertEquals(new Path("root.vehicle.d1", "s1"), plan.getDeduplicatedPaths().get(0));
+    Assert.assertEquals(
+        new Path("root.vehicle.d1", "s1", true), plan.getDeduplicatedPaths().get(0));
 
     sqlStr = "select count(*) from root.vehicle.d1,root.vehicle.d1,root.vehicle.d1";
     plan = (RawDataQueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
     Assert.assertEquals(1, plan.getDeduplicatedPaths().size());
     Assert.assertEquals(1, plan.getDeduplicatedDataTypes().size());
-    Assert.assertEquals(new Path("root.vehicle.d1", "s1"), plan.getDeduplicatedPaths().get(0));
+    Assert.assertEquals(
+        new Path("root.vehicle.d1", "s1", true), plan.getDeduplicatedPaths().get(0));
   }
 
   @Test
@@ -1071,8 +1076,8 @@ public class PhysicalPlanTest {
     String sqlStr2 = "SELECT last s1 FROM root.vehicle.d1, root.vehicle.d2";
     PhysicalPlan plan1 = processor.parseSQLToPhysicalPlan(sqlStr1);
     PhysicalPlan plan2 = processor.parseSQLToPhysicalPlan(sqlStr2);
-    Path path1 = new Path("root.vehicle.d1", "s1");
-    Path path2 = new Path("root.vehicle.d2", "s1");
+    Path path1 = new Path("root.vehicle.d1", "s1", true);
+    Path path2 = new Path("root.vehicle.d2", "s1", true);
     assertEquals(1, plan1.getPaths().size());
     assertEquals(path1.toString(), plan1.getPaths().get(0).getFullPath());
     assertEquals(2, plan2.getPaths().size());
@@ -1452,7 +1457,8 @@ public class PhysicalPlanTest {
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect =
-        new SingleSeriesExpression(new Path("root.vehicle.d5", "s1"), ValueFilter.like("string*"));
+        new SingleSeriesExpression(
+            new Path("root.vehicle.d5", "s1", true), ValueFilter.like("string*"));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/utils/TsFileRewriteToolTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/TsFileRewriteToolTest.java
@@ -340,7 +340,7 @@ public class TsFileRewriteToolTest {
         String device = entry.getKey();
         for (String sensor : entry.getValue()) {
           totalSensorCount++;
-          paths.add(new Path(device, sensor));
+          paths.add(new Path(device, sensor, true));
         }
       }
 
@@ -438,7 +438,7 @@ public class TsFileRewriteToolTest {
     try (TsFileSequenceReader reader = new TsFileSequenceReader(tsFilePath);
         TsFileReader readTsFile = new TsFileReader(reader)) {
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path(device, sensor));
+      paths.add(new Path(device, sensor, true));
 
       QueryExpression queryExpression = QueryExpression.create(paths, null);
       QueryDataSet queryDataSet = readTsFile.query(queryExpression);

--- a/server/src/test/java/org/apache/iotdb/db/wal/recover/WALRecoverManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/recover/WALRecoverManagerTest.java
@@ -299,13 +299,13 @@ public class WALRecoverManagerTest {
     // check file content
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_WITH_WAL_NAME);
     List<ChunkMetadata> chunkMetadataList =
-        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1"));
+        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
     assertEquals(2, chunkMetadataList.size());
     Chunk chunk = reader.readMemChunk(chunkMetadataList.get(0));
@@ -326,13 +326,13 @@ public class WALRecoverManagerTest {
     // region check file without wal
     // check file content
     reader = new TsFileSequenceReader(FILE_WITHOUT_WAL_NAME);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
     assertEquals(1, chunkMetadataList.size());
     chunk = reader.readMemChunk(chunkMetadataList.get(0));

--- a/server/src/test/java/org/apache/iotdb/db/wal/recover/file/SealedTsFileRecoverPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/recover/file/SealedTsFileRecoverPerformerTest.java
@@ -100,13 +100,13 @@ public class SealedTsFileRecoverPerformerTest {
     // check file content
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
     List<ChunkMetadata> chunkMetadataList =
-        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1"));
+        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
     reader.close();
     // check .resource file in memory
@@ -142,13 +142,13 @@ public class SealedTsFileRecoverPerformerTest {
     // check file content
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
     List<ChunkMetadata> chunkMetadataList =
-        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1"));
+        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
     reader.close();
     // check .resource file in memory
@@ -179,13 +179,13 @@ public class SealedTsFileRecoverPerformerTest {
     // check file content
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
     List<ChunkMetadata> chunkMetadataList =
-        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1"));
+        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
     reader.close();
     // check .resource file in memory
@@ -245,13 +245,13 @@ public class SealedTsFileRecoverPerformerTest {
     // check file content
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
     List<ChunkMetadata> chunkMetadataList =
-        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1"));
+        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
     assertEquals(1, chunkMetadataList.size());
     Chunk chunk = reader.readMemChunk(chunkMetadataList.get(0));

--- a/server/src/test/java/org/apache/iotdb/db/wal/recover/file/UnsealedTsFileRecoverPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/recover/file/UnsealedTsFileRecoverPerformerTest.java
@@ -146,13 +146,13 @@ public class UnsealedTsFileRecoverPerformerTest {
     // check file content
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
     List<ChunkMetadata> chunkMetadataList =
-        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1"));
+        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
     assertEquals(2, chunkMetadataList.size());
     Chunk chunk = reader.readMemChunk(chunkMetadataList.get(0));
@@ -201,13 +201,13 @@ public class UnsealedTsFileRecoverPerformerTest {
     // check file content
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
     List<ChunkMetadata> chunkMetadataList =
-        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1"));
+        reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE1_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path(DEVICE2_NAME, "s2", true));
     assertNotNull(chunkMetadataList);
     assertEquals(1, chunkMetadataList.size());
     Chunk chunk = reader.readMemChunk(chunkMetadataList.get(0));

--- a/spark-tsfile/src/main/scala/org/apache/iotdb/spark/tsfile/DefaultSource.scala
+++ b/spark-tsfile/src/main/scala/org/apache/iotdb/spark/tsfile/DefaultSource.scala
@@ -19,9 +19,6 @@
 
 package org.apache.iotdb.spark.tsfile
 
-import java.io.{ObjectInputStream, ObjectOutputStream, _}
-import java.net.URI
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce.Job
@@ -41,9 +38,10 @@ import org.apache.spark.sql.execution.datasources.{FileFormat, OutputWriterFacto
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
+
+import java.io._
+import java.net.URI
 import scala.collection.JavaConversions._
-import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 
 private[tsfile] class DefaultSource extends FileFormat with DataSourceRegister {
 
@@ -189,7 +187,7 @@ private[tsfile] class DefaultSource extends FileFormat with DataSourceRegister {
               }
               else {
                 val pos = paths.indexOf(new org.apache.iotdb.tsfile.read.common.Path(deviceName,
-                  field.name))
+                  field.name, true))
                 var curField: Field = null
                 if (pos != -1) {
                   curField = fields.get(pos)

--- a/spark-tsfile/src/main/scala/org/apache/iotdb/spark/tsfile/NarrowConverter.scala
+++ b/spark-tsfile/src/main/scala/org/apache/iotdb/spark/tsfile/NarrowConverter.scala
@@ -19,16 +19,14 @@
 
 package org.apache.iotdb.spark.tsfile
 
-import java.util
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileStatus
 import org.apache.iotdb.hadoop.fileSystem.HDFSInput
 import org.apache.iotdb.spark.tsfile.qp.QueryProcessor
-import org.apache.iotdb.tsfile.common.constant.QueryConstant
-import org.apache.iotdb.tsfile.file.metadata.enums.{TSDataType, TSEncoding}
 import org.apache.iotdb.spark.tsfile.qp.common.{BasicOperator, FilterOperator, SQLConstant, TSQueryPlan}
+import org.apache.iotdb.tsfile.common.constant.QueryConstant
 import org.apache.iotdb.tsfile.file.metadata.TsFileMetadata
+import org.apache.iotdb.tsfile.file.metadata.enums.{TSDataType, TSEncoding}
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader
 import org.apache.iotdb.tsfile.read.common.Path
 import org.apache.iotdb.tsfile.read.expression.impl.{BinaryExpression, GlobalTimeExpression, SingleSeriesExpression}
@@ -36,33 +34,34 @@ import org.apache.iotdb.tsfile.read.expression.{IExpression, QueryExpression}
 import org.apache.iotdb.tsfile.read.filter.{TimeFilter, ValueFilter}
 import org.apache.iotdb.tsfile.write.record.TSRecord
 import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint
-import org.apache.iotdb.tsfile.write.schema.{IMeasurementSchema, MeasurementSchema, Schema}
+import org.apache.iotdb.tsfile.write.schema.{MeasurementSchema, Schema}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 
+import java.util
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 /**
-  * This object contains methods that are used to convert schema and data between SparkSQL
-  * and TSFile.
-  *
-  */
+ * This object contains methods that are used to convert schema and data between SparkSQL
+ * and TSFile.
+ *
+ */
 object NarrowConverter extends Converter {
 
   val TEMPLATE_NAME = "spark_template"
   val DEVICE_NAME = "device_name"
 
   /**
-    * Get union series in all tsfiles.
-    * e.g. (tsfile1:s1,s2) & (tsfile2:s2,s3) = s1,s2,s3
-    *
-    * @param files tsfiles
-    * @param conf  hadoop configuration
-    * @return union series
-    */
+   * Get union series in all tsfiles.
+   * e.g. (tsfile1:s1,s2) & (tsfile2:s2,s3) = s1,s2,s3
+   *
+   * @param files tsfiles
+   * @param conf  hadoop configuration
+   * @return union series
+   */
   def getUnionSeries(files: Seq[FileStatus], conf: Configuration): util.ArrayList[Series] = {
     val unionSeries = new util.ArrayList[Series]()
     var seriesSet: mutable.Set[String] = mutable.Set()
@@ -88,12 +87,12 @@ object NarrowConverter extends Converter {
 
 
   /**
-    * Construct fields with the TSFile data type converted to the SparkSQL data type.
-    *
-    * @param tsfileSchema tsfileSchema
-    * @param addTimeField true to add a time field; false to not
-    * @return the converted list of fields
-    */
+   * Construct fields with the TSFile data type converted to the SparkSQL data type.
+   *
+   * @param tsfileSchema tsfileSchema
+   * @param addTimeField true to add a time field; false to not
+   * @return the converted list of fields
+   */
   override def toSqlField(tsfileSchema: util.ArrayList[Series], addTimeField: Boolean):
   ListBuffer[StructField] = {
     val fields = new ListBuffer[StructField]()
@@ -120,12 +119,12 @@ object NarrowConverter extends Converter {
 
 
   /**
-    * Prepare queriedSchema from requiredSchema.
-    *
-    * @param requiredSchema requiredSchema
-    * @param tsFileMetaData tsFileMetaData
-    * @return
-    */
+   * Prepare queriedSchema from requiredSchema.
+   *
+   * @param requiredSchema requiredSchema
+   * @param tsFileMetaData tsFileMetaData
+   * @return
+   */
   def prepSchema(requiredSchema: StructType, tsFileMetaData: TsFileMetadata,
                  reader: TsFileSequenceReader): StructType = {
     var queriedSchema: StructType = new StructType()
@@ -158,13 +157,13 @@ object NarrowConverter extends Converter {
 
 
   /**
-    * Construct queryExpression based on queriedSchema and filters.
-    *
-    * @param schema           schema
-    * @param device_name      device_names
-    * @param measurement_name measurement_names
-    * @return query expression
-    */
+   * Construct queryExpression based on queriedSchema and filters.
+   *
+   * @param schema           schema
+   * @param device_name      device_names
+   * @param measurement_name measurement_names
+   * @return query expression
+   */
   def toQueryExpression(schema: StructType,
                         device_name: util.List[String],
                         measurement_name: util.Set[String],
@@ -210,11 +209,11 @@ object NarrowConverter extends Converter {
   }
 
   /**
-    * Used in toQueryConfigs() to convert one query plan to one QueryConfig.
-    *
-    * @param queryPlan TsFile logical query plan
-    * @return TsFile physical query plan
-    */
+   * Used in toQueryConfigs() to convert one query plan to one QueryConfig.
+   *
+   * @param queryPlan TsFile logical query plan
+   * @return TsFile physical query plan
+   */
   private def queryToExpression(schema: StructType, queryPlan: TSQueryPlan): QueryExpression = {
     val selectedColumns = queryPlan.getPaths
     val timeFilter = queryPlan.getTimeFilterOperator
@@ -244,11 +243,11 @@ object NarrowConverter extends Converter {
   }
 
   /**
-    * Transform sparkSQL's filter binary tree to filterOperator binary tree.
-    *
-    * @param node filter tree's node
-    * @return TSFile filterOperator binary tree
-    */
+   * Transform sparkSQL's filter binary tree to filterOperator binary tree.
+   *
+   * @param node filter tree's node
+   * @return TSFile filterOperator binary tree
+   */
   private def transformFilter(node: Filter): FilterOperator = {
     var operator: FilterOperator = null
     node match {
@@ -297,12 +296,12 @@ object NarrowConverter extends Converter {
   }
 
   /**
-    * Transform SparkSQL's filter binary tree to TsFile's filter expression.
-    *
-    * @param schema to get relative columns' dataType information
-    * @param node   filter tree's node
-    * @return TSFile filter expression
-    */
+   * Transform SparkSQL's filter binary tree to TsFile's filter expression.
+   *
+   * @param schema to get relative columns' dataType information
+   * @param node   filter tree's node
+   * @return TSFile filter expression
+   */
   private def transformFilterToExpression(schema: StructType, node: FilterOperator,
                                           device_name: String): IExpression = {
     var filter: IExpression = null
@@ -402,7 +401,7 @@ object NarrowConverter extends Converter {
     val index = fieldNames.indexOf(nodeName)
     if (index == -1) {
       // placeholder for an invalid filter in the current TsFile
-      val filter = new SingleSeriesExpression(new Path(device_name, nodeName), null)
+      val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true), null)
       filter
     } else {
       val dataType = schema.get(index).dataType
@@ -411,27 +410,27 @@ object NarrowConverter extends Converter {
         case FilterTypes.Eq =>
           dataType match {
             case BooleanType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.eq(new java.lang.Boolean(nodeValue)))
               filter
             case IntegerType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.eq(new java.lang.Integer(nodeValue)))
               filter
             case LongType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.eq(new java.lang.Long(nodeValue)))
               filter
             case FloatType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.eq(new java.lang.Float(nodeValue)))
               filter
             case DoubleType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.eq(new java.lang.Double(nodeValue)))
               filter
             case StringType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.eq(nodeValue))
               filter
             case other => throw new UnsupportedOperationException(s"Unsupported type $other")
@@ -439,19 +438,19 @@ object NarrowConverter extends Converter {
         case FilterTypes.Gt =>
           dataType match {
             case IntegerType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.gt(new java.lang.Integer(nodeValue)))
               filter
             case LongType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.gt(new java.lang.Long(nodeValue)))
               filter
             case FloatType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.gt(new java.lang.Float(nodeValue)))
               filter
             case DoubleType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.gt(new java.lang.Double(nodeValue)))
               filter
             case other => throw new UnsupportedOperationException(s"Unsupported type $other")
@@ -459,19 +458,19 @@ object NarrowConverter extends Converter {
         case FilterTypes.GtEq =>
           dataType match {
             case IntegerType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.gtEq(new java.lang.Integer(nodeValue)))
               filter
             case LongType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.gtEq(new java.lang.Long(nodeValue)))
               filter
             case FloatType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.gtEq(new java.lang.Float(nodeValue)))
               filter
             case DoubleType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.gtEq(new java.lang.Double(nodeValue)))
               filter
             case other => throw new UnsupportedOperationException(s"Unsupported type $other")
@@ -479,19 +478,19 @@ object NarrowConverter extends Converter {
         case FilterTypes.Lt =>
           dataType match {
             case IntegerType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.lt(new java.lang.Integer(nodeValue)))
               filter
             case LongType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.lt(new java.lang.Long(nodeValue)))
               filter
             case FloatType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.lt(new java.lang.Float(nodeValue)))
               filter
             case DoubleType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.lt(new java.lang.Double(nodeValue)))
               filter
             case other => throw new UnsupportedOperationException(s"Unsupported type $other")
@@ -499,19 +498,19 @@ object NarrowConverter extends Converter {
         case FilterTypes.LtEq =>
           dataType match {
             case IntegerType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.ltEq(new java.lang.Integer(nodeValue)))
               filter
             case LongType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.ltEq(new java.lang.Long(nodeValue)))
               filter
             case FloatType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.ltEq(new java.lang.Float(nodeValue)))
               filter
             case DoubleType =>
-              val filter = new SingleSeriesExpression(new Path(device_name, nodeName),
+              val filter = new SingleSeriesExpression(new Path(device_name, nodeName, true),
                 ValueFilter.ltEq(new java.lang.Double(nodeValue)))
               filter
             case other => throw new UnsupportedOperationException(s"Unsupported type $other")
@@ -521,12 +520,12 @@ object NarrowConverter extends Converter {
   }
 
   /**
-    * Construct MeasurementSchema from the given field.
-    *
-    * @param field   field
-    * @param options encoding options
-    * @return MeasurementSchema
-    */
+   * Construct MeasurementSchema from the given field.
+   *
+   * @param field   field
+   * @param options encoding options
+   * @return MeasurementSchema
+   */
   def getSeriesSchema(field: StructField, options: Map[String, String]): MeasurementSchema = {
     val dataType = getTsDataType(field.dataType)
     val encodingStr = dataType match {
@@ -543,12 +542,12 @@ object NarrowConverter extends Converter {
   }
 
   /**
-    * Given a SparkSQL struct type, generate the TsFile schema.
-    * Note: Measurements of the same name should have the same schema.
-    *
-    * @param structType given sql schema
-    * @return TsFile schema
-    */
+   * Given a SparkSQL struct type, generate the TsFile schema.
+   * Note: Measurements of the same name should have the same schema.
+   *
+   * @param structType given sql schema
+   * @return TsFile schema
+   */
   def toTsFileSchema(structType: StructType, options: Map[String, String]): Schema = {
     val schema = new Schema()
     structType.fields.filter(f => {
@@ -561,11 +560,11 @@ object NarrowConverter extends Converter {
   }
 
   /**
-    * Convert a row in the spark table to a list of TSRecord.
-    *
-    * @param row given spark sql row
-    * @return TSRecord
-    */
+   * Convert a row in the spark table to a list of TSRecord.
+   *
+   * @param row given spark sql row
+   * @return TSRecord
+   */
   def toTsRecord(row: InternalRow, dataSchema: StructType): TSRecord = {
     val time = row.getLong(0)
     val res = new TSRecord(time, row.getString(1))

--- a/spark-tsfile/src/test/scala/org/apache/iotdb/spark/tsfile/TSFileSuit.scala
+++ b/spark-tsfile/src/test/scala/org/apache/iotdb/spark/tsfile/TSFileSuit.scala
@@ -19,10 +19,6 @@
 
 package org.apache.iotdb.spark.tsfile
 
-import java.io.{ByteArrayOutputStream, File}
-import java.net.URI
-import java.util
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.iotdb.hadoop.fileSystem.HDFSInput
@@ -34,6 +30,10 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
 import org.junit.Assert
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+import java.io.{ByteArrayOutputStream, File}
+import java.net.URI
+import java.util
 
 
 class TSFileSuit extends FunSuite with BeforeAndAfterAll {
@@ -343,7 +343,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(1).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")
@@ -361,7 +361,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val actual = outCapture.toByteArray.map(_.toChar)
 
     val expect =
-        "+------+-----------+--------+--------+--------+\n" +
+      "+------+-----------+--------+--------+--------+\n" +
         "|time  |device_name|sensor_3|sensor_1|sensor_2|\n" +
         "+------+-----------+--------+--------+--------+\n" +
         "|131042|device_2   |true    |131042  |131042.0|\n" +
@@ -406,7 +406,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(2).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")
@@ -456,7 +456,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(2).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")
@@ -479,7 +479,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(2).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")
@@ -503,7 +503,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(2).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")
@@ -526,7 +526,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(2).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")
@@ -549,7 +549,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(2).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")
@@ -572,7 +572,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(2).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")
@@ -596,7 +596,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(2).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")
@@ -620,7 +620,7 @@ device_2: 400000 rows, time range [0,799998], interval 2
     val in = new HDFSInput(new Path(new URI(tsfile4)), conf)
     val reader: TsFileSequenceReader = new TsFileSequenceReader(in)
     val tsFileMetaData = reader.readFileMetadata
-    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1"))
+    val chunkMetadataList = reader.getChunkMetadataList(new common.Path("device_1", "sensor_1", true))
     val endOffsetOfChunkGroup = chunkMetadataList.get(2).getOffsetOfChunkHeader
 
     val tmp = spark.conf.get("spark.sql.files.maxPartitionBytes")

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -707,7 +707,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     for (String device : getAllDevices()) {
       Map<String, TimeseriesMetadata> timeseriesMetadataMap = readDeviceMetadata(device);
       for (String measurementId : timeseriesMetadataMap.keySet()) {
-        paths.add(new Path(device, measurementId));
+        paths.add(new Path(device, measurementId, true));
       }
     }
     return paths;
@@ -752,7 +752,8 @@ public class TsFileSequenceReader implements AutoCloseable {
             paths.add(
                 new Path(
                     startEndPair.left,
-                    TimeseriesMetadata.deserializeFrom(nextBuffer, false).getMeasurementId()));
+                    TimeseriesMetadata.deserializeFrom(nextBuffer, false).getMeasurementId(),
+                    true));
           }
           return paths;
         } catch (IOException e) {
@@ -1542,7 +1543,7 @@ public class TsFileSequenceReader implements AutoCloseable {
               if (newSchema != null) {
                 for (IMeasurementSchema tsSchema : measurementSchemaList) {
                   newSchema.putIfAbsent(
-                      new Path(lastDeviceId, tsSchema.getMeasurementId()), tsSchema);
+                      new Path(lastDeviceId, tsSchema.getMeasurementId(), true), tsSchema);
                 }
               }
               measurementSchemaList = new ArrayList<>();
@@ -1561,7 +1562,7 @@ public class TsFileSequenceReader implements AutoCloseable {
               if (newSchema != null) {
                 for (IMeasurementSchema tsSchema : measurementSchemaList) {
                   newSchema.putIfAbsent(
-                      new Path(lastDeviceId, tsSchema.getMeasurementId()), tsSchema);
+                      new Path(lastDeviceId, tsSchema.getMeasurementId(), true), tsSchema);
                 }
               }
               measurementSchemaList = new ArrayList<>();
@@ -1583,7 +1584,8 @@ public class TsFileSequenceReader implements AutoCloseable {
         // schema of last chunk group
         if (newSchema != null) {
           for (IMeasurementSchema tsSchema : measurementSchemaList) {
-            newSchema.putIfAbsent(new Path(lastDeviceId, tsSchema.getMeasurementId()), tsSchema);
+            newSchema.putIfAbsent(
+                new Path(lastDeviceId, tsSchema.getMeasurementId(), true), tsSchema);
           }
         }
         // last chunk group Metadata

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Path.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Path.java
@@ -93,10 +93,17 @@ public class Path implements Serializable, Comparable<Path> {
    *
    * @param device root.deviceType.d1
    * @param measurement s1 , does not contain TsFileConstant.PATH_SEPARATOR
+   * @param needCheck need to validate the correctness of the path
    */
-  public Path(String device, String measurement) {
+  public Path(String device, String measurement, boolean needCheck) {
     if (device == null || measurement == null) {
       throw new PathParseException(ILLEGAL_PATH_ARGUMENT);
+    }
+    if (!needCheck) {
+      this.measurement = measurement;
+      this.device = device;
+      this.fullPath = device + "." + measurement;
+      return;
     }
     // use PathNodesGenerator to check whether path is legal.
     if (!StringUtils.isEmpty(device) && !StringUtils.isEmpty(measurement)) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/controller/MetadataQuerierByFileImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/controller/MetadataQuerierByFileImpl.java
@@ -130,7 +130,8 @@ public class MetadataQuerierByFileImpl implements IMetadataQuerier {
         } else {
           measurementId = ((TimeseriesMetadata) timeseriesMetadata).getMeasurementId();
         }
-        this.chunkMetaDataCache.put(new Path(selectedDevice, measurementId), chunkMetadataList);
+        this.chunkMetaDataCache.put(
+            new Path(selectedDevice, measurementId, true), chunkMetadataList);
         count += chunkMetadataList.size();
         if (count == CACHED_ENTRY_NUMBER) {
           enough = true;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -299,6 +299,7 @@ public class TsFileIOWriter implements AutoCloseable {
    */
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void endFile() throws IOException {
+    long startTime = System.currentTimeMillis();
     checkInMemoryPathCount();
     readChunkMetadataAndConstructIndexTree();
 
@@ -322,6 +323,8 @@ public class TsFileIOWriter implements AutoCloseable {
       }
     }
     canWrite = false;
+    long cost = System.currentTimeMillis() - startTime;
+    logger.info("Time for flushing metadata is {} ms", cost);
   }
 
   private void checkInMemoryPathCount() {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -503,7 +503,7 @@ public class TsFileIOWriter implements AutoCloseable {
           chunkGroupMetaData.getChunkMetadataList().iterator();
       while (chunkMetaDataIterator.hasNext()) {
         IChunkMetadata chunkMetaData = chunkMetaDataIterator.next();
-        Path path = new Path(deviceId, chunkMetaData.getMeasurementUid());
+        Path path = new Path(deviceId, chunkMetaData.getMeasurementUid(), true);
         int startTimeIdx = startTimeIdxes.get(path);
 
         List<Long> pathChunkStartTimes = chunkStartTimes.get(path);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriterEndFileTest.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriterEndFileTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tsfile.write.writer;
+
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.write.chunk.ChunkWriterImpl;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+
+import java.io.File;
+
+public class TsFileIOWriterEndFileTest {
+  public static void main(String[] args) throws Exception {
+    TsFileIOWriter writer = new TsFileIOWriter(new File("test.tsfile"));
+    for (int deviceIndex = 0; deviceIndex < 1000; deviceIndex++) {
+      writer.startChunkGroup("root.sg.d" + deviceIndex);
+      for (int seriesIndex = 0; seriesIndex < 1000; seriesIndex++) {
+        ChunkWriterImpl chunkWriter =
+            new ChunkWriterImpl(
+                new MeasurementSchema(
+                    "s" + seriesIndex, TSDataType.INT32, TSEncoding.RLE, CompressionType.GZIP));
+        for (long time = 0; time < 10; ++time) {
+          chunkWriter.write(time, 0);
+        }
+        chunkWriter.writeToFileWriter(writer);
+      }
+      writer.endChunkGroup();
+    }
+    writer.endFile();
+  }
+}

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/tsmiterator/DiskTSMIterator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/tsmiterator/DiskTSMIterator.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.reader.LocalTsFileInput;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
@@ -75,7 +76,7 @@ public class DiskTSMIterator extends TSMIterator {
   }
 
   @Override
-  public Pair<String, TimeseriesMetadata> next() {
+  public Pair<Path, TimeseriesMetadata> next() {
     try {
       if (remainsInFile) {
         // deserialize from file
@@ -90,7 +91,7 @@ public class DiskTSMIterator extends TSMIterator {
     }
   }
 
-  private Pair<String, TimeseriesMetadata> getTimeSerisMetadataFromFile() throws IOException {
+  private Pair<Path, TimeseriesMetadata> getTimeSerisMetadataFromFile() throws IOException {
     if (currentPos == nextEndPosForDevice) {
       // deserialize the current device name
       currentDevice = ReadWriteIOUtils.readString(input.wrapAsInputStream());
@@ -118,7 +119,7 @@ public class DiskTSMIterator extends TSMIterator {
     }
     updateCurrentPos();
     return new Pair<>(
-        currentDevice + "." + measurementUid,
+        new Path(currentDevice, measurementUid),
         constructOneTimeseriesMetadata(measurementUid, chunkMetadataList));
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/tsmiterator/DiskTSMIterator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/tsmiterator/DiskTSMIterator.java
@@ -119,7 +119,7 @@ public class DiskTSMIterator extends TSMIterator {
     }
     updateCurrentPos();
     return new Pair<>(
-        new Path(currentDevice, measurementUid),
+        new Path(currentDevice, measurementUid, false),
         constructOneTimeseriesMetadata(measurementUid, chunkMetadataList));
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/tsmiterator/TSMIterator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/tsmiterator/TSMIterator.java
@@ -70,10 +70,10 @@ public class TSMIterator {
     return iterator.hasNext();
   }
 
-  public Pair<String, TimeseriesMetadata> next() throws IOException {
+  public Pair<Path, TimeseriesMetadata> next() throws IOException {
     Pair<Path, List<IChunkMetadata>> nextPair = iterator.next();
     return new Pair<>(
-        nextPair.left.getFullPath(),
+        nextPair.left,
         constructOneTimeseriesMetadata(nextPair.left.getMeasurement(), nextPair.right));
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/tsmiterator/TSMIterator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/tsmiterator/TSMIterator.java
@@ -119,7 +119,7 @@ public class TSMIterator {
         chunkMetadataMap
             .get(chunkGroupMetadata.getDevice())
             .computeIfAbsent(
-                new Path(chunkGroupMetadata.getDevice(), chunkMetadata.getMeasurementUid()),
+                new Path(chunkGroupMetadata.getDevice(), chunkMetadata.getMeasurementUid(), false),
                 x -> new ArrayList<>())
             .add(chunkMetadata);
       }
@@ -129,7 +129,8 @@ public class TSMIterator {
         chunkMetadataMap
             .computeIfAbsent(currentDevice, x -> new TreeMap<>())
             .computeIfAbsent(
-                new Path(currentDevice, chunkMetadata.getMeasurementUid()), x -> new ArrayList<>())
+                new Path(currentDevice, chunkMetadata.getMeasurementUid(), false),
+                x -> new ArrayList<>())
             .add(chunkMetadata);
       }
     }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/MeasurementChunkMetadataListMapIteratorTest.java
@@ -133,7 +133,7 @@ public class MeasurementChunkMetadataListMapIteratorTest {
           expectedDeviceMeasurementChunkMetadataListMap
               .computeIfAbsent(device, d -> new HashMap<>())
               .computeIfAbsent(measurement, m -> new ArrayList<>())
-              .addAll(fileReader.getChunkMetadataList(new Path(device, measurement)));
+              .addAll(fileReader.getChunkMetadataList(new Path(device, measurement, true)));
         }
       }
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/ReadInPartitionTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/ReadInPartitionTest.java
@@ -72,7 +72,7 @@ public class ReadInPartitionTest {
     // different test environments,
     // we get metadata from the real-time generated TsFile instead of using a fixed
     // parameter setting.
-    List<ChunkMetadata> d1s6List = reader.getChunkMetadataList(new Path("d1", "s6"));
+    List<ChunkMetadata> d1s6List = reader.getChunkMetadataList(new Path("d1", "s6", true));
     for (ChunkMetadata chunkMetaData : d1s6List) {
       // get a series of [startTime, endTime] of d1.s6 from the chunkGroupMetaData of
       // d1
@@ -89,7 +89,7 @@ public class ReadInPartitionTest {
       d1chunkGroupMetaDataOffsetList.add(startEndOffsets);
     }
 
-    List<ChunkMetadata> d2s1List = reader.getChunkMetadataList(new Path("d2", "s1"));
+    List<ChunkMetadata> d2s1List = reader.getChunkMetadataList(new Path("d2", "s1", true));
     for (ChunkMetadata chunkMetaData : d2s1List) {
       d2s1timeRangeList.add(
           new TimeRange(chunkMetaData.getStartTime(), chunkMetaData.getEndTime()));
@@ -105,8 +105,8 @@ public class ReadInPartitionTest {
   @Test
   public void test0() throws IOException {
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("d1", "s6"));
-    paths.add(new Path("d2", "s1"));
+    paths.add(new Path("d1", "s6", true));
+    paths.add(new Path("d2", "s1", true));
     QueryExpression queryExpression = QueryExpression.create(paths, null);
 
     QueryDataSet queryDataSet = roTsFile.query(queryExpression, 0L, 0L);
@@ -121,8 +121,8 @@ public class ReadInPartitionTest {
   @Test
   public void test1() throws IOException, QueryFilterOptimizationException {
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("d1", "s6"));
-    paths.add(new Path("d2", "s1"));
+    paths.add(new Path("d1", "s6", true));
+    paths.add(new Path("d2", "s1", true));
     QueryExpression queryExpression = QueryExpression.create(paths, null);
 
     QueryDataSet queryDataSet =
@@ -156,8 +156,8 @@ public class ReadInPartitionTest {
   @Test
   public void test2() throws IOException, QueryFilterOptimizationException {
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("d1", "s6"));
-    paths.add(new Path("d2", "s1"));
+    paths.add(new Path("d1", "s6", true));
+    paths.add(new Path("d2", "s1", true));
     IExpression expression = new GlobalTimeExpression(TimeFilter.gt(50L));
     QueryExpression queryExpression = QueryExpression.create(paths, expression);
 
@@ -193,10 +193,10 @@ public class ReadInPartitionTest {
   @Test
   public void test3() throws IOException, QueryFilterOptimizationException {
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("d1", "s6"));
-    paths.add(new Path("d2", "s1"));
+    paths.add(new Path("d1", "s6", true));
+    paths.add(new Path("d2", "s1", true));
     Filter filter = ValueFilter.gt(10L);
-    IExpression expression = new SingleSeriesExpression(new Path("d1", "s3"), filter);
+    IExpression expression = new SingleSeriesExpression(new Path("d1", "s3", true), filter);
     QueryExpression queryExpression = QueryExpression.create(paths, expression);
 
     QueryDataSet queryDataSet =

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/ReadTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/ReadTest.java
@@ -66,7 +66,7 @@ public class ReadTest {
   @Test
   public void queryOneMeasurementWithoutFilterTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
+    pathList.add(new Path("d1", "s1", true));
     QueryExpression queryExpression = QueryExpression.create(pathList, null);
     QueryDataSet dataSet = roTsFile.query(queryExpression);
 
@@ -87,8 +87,8 @@ public class ReadTest {
   @Test
   public void queryTwoMeasurementsWithoutFilterTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d2", "s2"));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d2", "s2", true));
     QueryExpression queryExpression = QueryExpression.create(pathList, null);
     QueryDataSet dataSet = roTsFile.query(queryExpression);
 
@@ -106,9 +106,10 @@ public class ReadTest {
   @Test
   public void queryTwoMeasurementsWithSingleFilterTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d2", "s1"));
-    pathList.add(new Path("d2", "s4"));
-    IExpression valFilter = new SingleSeriesExpression(new Path("d2", "s2"), ValueFilter.gt(9722L));
+    pathList.add(new Path("d2", "s1", true));
+    pathList.add(new Path("d2", "s4", true));
+    IExpression valFilter =
+        new SingleSeriesExpression(new Path("d2", "s2", true), ValueFilter.gt(9722L));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -127,8 +128,9 @@ public class ReadTest {
   @Test
   public void queryOneMeasurementsWithSameFilterTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d2", "s2"));
-    IExpression valFilter = new SingleSeriesExpression(new Path("d2", "s2"), ValueFilter.gt(9722L));
+    pathList.add(new Path("d2", "s2", true));
+    IExpression valFilter =
+        new SingleSeriesExpression(new Path("d2", "s2", true), ValueFilter.gt(9722L));
     QueryExpression queryExpression = QueryExpression.create(pathList, valFilter);
     QueryDataSet dataSet = roTsFile.query(queryExpression);
 
@@ -154,10 +156,10 @@ public class ReadTest {
   @Test
   public void queryWithTwoSeriesTimeValueFilterCrossTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d2", "s2"));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d2", "s2", true));
     IExpression valFilter =
-        new SingleSeriesExpression(new Path("d2", "s2"), ValueFilter.notEq(9722L));
+        new SingleSeriesExpression(new Path("d2", "s2", true), ValueFilter.notEq(9722L));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -186,10 +188,10 @@ public class ReadTest {
   @Test
   public void queryWithCrossSeriesTimeValueFilterTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d2", "s2"));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d2", "s2", true));
     IExpression valFilter =
-        new SingleSeriesExpression(new Path("d2", "s2"), ValueFilter.notEq(9722L));
+        new SingleSeriesExpression(new Path("d2", "s2", true), ValueFilter.notEq(9722L));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -221,9 +223,9 @@ public class ReadTest {
     assertEquals(5, cnt);
 
     pathList.clear();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d2", "s2"));
-    valFilter = new SingleSeriesExpression(new Path("d2", "s2"), ValueFilter.ltEq(9082L));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d2", "s2", true));
+    valFilter = new SingleSeriesExpression(new Path("d2", "s2", true), ValueFilter.ltEq(9082L));
     tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618906L)),
@@ -251,8 +253,9 @@ public class ReadTest {
   @Test
   public void queryBooleanTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s5"));
-    IExpression valFilter = new SingleSeriesExpression(new Path("d1", "s5"), ValueFilter.eq(false));
+    pathList.add(new Path("d1", "s5", true));
+    IExpression valFilter =
+        new SingleSeriesExpression(new Path("d1", "s5", true), ValueFilter.eq(false));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -281,7 +284,7 @@ public class ReadTest {
   @Test
   public void queryStringTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s4"));
+    pathList.add(new Path("d1", "s4", true));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -302,7 +305,7 @@ public class ReadTest {
     Assert.assertEquals(1, cnt);
 
     pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s4"));
+    pathList.add(new Path("d1", "s4", true));
     tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -325,9 +328,9 @@ public class ReadTest {
   @Test
   public void queryFloatTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s6"));
+    pathList.add(new Path("d1", "s6", true));
     IExpression valFilter =
-        new SingleSeriesExpression(new Path("d1", "s6"), ValueFilter.gt(103.0f));
+        new SingleSeriesExpression(new Path("d1", "s6", true), ValueFilter.gt(103.0f));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -356,8 +359,9 @@ public class ReadTest {
   @Test
   public void queryDoubleTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s7"));
-    IExpression valFilter = new SingleSeriesExpression(new Path("d1", "s7"), ValueFilter.gt(1.0));
+    pathList.add(new Path("d1", "s7", true));
+    IExpression valFilter =
+        new SingleSeriesExpression(new Path("d1", "s7", true), ValueFilter.gt(1.0));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618011L)),

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimePlainEncodeReadTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimePlainEncodeReadTest.java
@@ -69,7 +69,7 @@ public class TimePlainEncodeReadTest {
   @Test
   public void queryOneMeasurementWithoutFilterTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
+    pathList.add(new Path("d1", "s1", true));
     QueryExpression queryExpression = QueryExpression.create(pathList, null);
     QueryDataSet dataSet = roTsFile.query(queryExpression);
 
@@ -90,8 +90,8 @@ public class TimePlainEncodeReadTest {
   @Test
   public void queryTwoMeasurementsWithoutFilterTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d2", "s2"));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d2", "s2", true));
     QueryExpression queryExpression = QueryExpression.create(pathList, null);
     QueryDataSet dataSet = roTsFile.query(queryExpression);
 
@@ -111,9 +111,10 @@ public class TimePlainEncodeReadTest {
   @Test
   public void queryTwoMeasurementsWithSingleFilterTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d2", "s1"));
-    pathList.add(new Path("d2", "s4"));
-    IExpression valFilter = new SingleSeriesExpression(new Path("d2", "s2"), ValueFilter.gt(9722L));
+    pathList.add(new Path("d2", "s1", true));
+    pathList.add(new Path("d2", "s4", true));
+    IExpression valFilter =
+        new SingleSeriesExpression(new Path("d2", "s2", true), ValueFilter.gt(9722L));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -130,9 +131,9 @@ public class TimePlainEncodeReadTest {
   @Test
   public void queryWithTwoSeriesTimeValueFilterCrossTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d2", "s2"));
+    pathList.add(new Path("d2", "s2", true));
     IExpression valFilter =
-        new SingleSeriesExpression(new Path("d2", "s2"), ValueFilter.notEq(9722L));
+        new SingleSeriesExpression(new Path("d2", "s2", true), ValueFilter.notEq(9722L));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -161,9 +162,10 @@ public class TimePlainEncodeReadTest {
   @Test
   public void queryWithCrossSeriesTimeValueFilterTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d2", "s2"));
-    IExpression valFilter = new SingleSeriesExpression(new Path("d2", "s2"), ValueFilter.gt(9722L));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d2", "s2", true));
+    IExpression valFilter =
+        new SingleSeriesExpression(new Path("d2", "s2", true), ValueFilter.gt(9722L));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -195,12 +197,13 @@ public class TimePlainEncodeReadTest {
     assertEquals(5, cnt);
 
     pathList.clear();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d2", "s2"));
-    valFilter = new SingleSeriesExpression(new Path("d1", "s1"), ValueFilter.ltEq(9321));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d2", "s2", true));
+    valFilter = new SingleSeriesExpression(new Path("d1", "s1", true), ValueFilter.ltEq(9321));
     valFilter =
         BinaryExpression.and(
-            new SingleSeriesExpression(new Path("d2", "s2"), ValueFilter.ltEq(9312L)), valFilter);
+            new SingleSeriesExpression(new Path("d2", "s2", true), ValueFilter.ltEq(9312L)),
+            valFilter);
     tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618906L)),
@@ -238,8 +241,9 @@ public class TimePlainEncodeReadTest {
   @Test
   public void queryBooleanTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s5"));
-    IExpression valFilter = new SingleSeriesExpression(new Path("d1", "s5"), ValueFilter.eq(false));
+    pathList.add(new Path("d1", "s5", true));
+    IExpression valFilter =
+        new SingleSeriesExpression(new Path("d1", "s5", true), ValueFilter.eq(false));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -268,9 +272,9 @@ public class TimePlainEncodeReadTest {
   @Test
   public void queryStringTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s4"));
+    pathList.add(new Path("d1", "s4", true));
     IExpression valFilter =
-        new SingleSeriesExpression(new Path("d1", "s4"), ValueFilter.gt(new Binary("dog97")));
+        new SingleSeriesExpression(new Path("d1", "s4", true), ValueFilter.gt(new Binary("dog97")));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -292,9 +296,9 @@ public class TimePlainEncodeReadTest {
     Assert.assertEquals(1, cnt);
 
     pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s4"));
+    pathList.add(new Path("d1", "s4", true));
     valFilter =
-        new SingleSeriesExpression(new Path("d1", "s4"), ValueFilter.lt(new Binary("dog97")));
+        new SingleSeriesExpression(new Path("d1", "s4", true), ValueFilter.lt(new Binary("dog97")));
     tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -318,9 +322,9 @@ public class TimePlainEncodeReadTest {
   @Test
   public void queryFloatTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s6"));
+    pathList.add(new Path("d1", "s6", true));
     IExpression valFilter =
-        new SingleSeriesExpression(new Path("d1", "s6"), ValueFilter.gt(103.0f));
+        new SingleSeriesExpression(new Path("d1", "s6", true), ValueFilter.gt(103.0f));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618970L)),
@@ -349,8 +353,9 @@ public class TimePlainEncodeReadTest {
   @Test
   public void queryDoubleTest() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s7"));
-    IExpression valFilter = new SingleSeriesExpression(new Path("d1", "s7"), ValueFilter.gt(7.0));
+    pathList.add(new Path("d1", "s7", true));
+    IExpression valFilter =
+        new SingleSeriesExpression(new Path("d1", "s7", true), ValueFilter.gt(7.0));
     IExpression tFilter =
         BinaryExpression.and(
             new GlobalTimeExpression(TimeFilter.gtEq(1480562618021L)),

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimeSeriesMetadataReadTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimeSeriesMetadataReadTest.java
@@ -64,7 +64,7 @@ public class TimeSeriesMetadataReadTest {
   @Test
   public void testReadTimeseriesMetadata() throws IOException {
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_PATH);
-    Path path = new Path("d1", "s1");
+    Path path = new Path("d1", "s1", true);
     Set<String> set = new HashSet<>();
     set.add("s1");
     set.add("s2");
@@ -78,7 +78,7 @@ public class TimeSeriesMetadataReadTest {
       Assert.assertEquals("s" + i, timeseriesMetadataList.get(i - 1).getMeasurementId());
     }
 
-    path = new Path("d1", "s5");
+    path = new Path("d1", "s5", true);
     set.clear();
     set.add("s5");
     set.add("s6");

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileReaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileReaderTest.java
@@ -77,7 +77,7 @@ public class TsFileReaderTest {
     tsFileConfig.setGroupSizeInByte(100 * 1024 * 1024);
     TsFileWriter tsFileWriter = new TsFileWriter(file, new Schema(), tsFileConfig);
 
-    Path path = new Path("t", "id");
+    Path path = new Path("t", "id", true);
     tsFileWriter.registerTimeseries(
         new Path(path.getDevice()),
         new MeasurementSchema("id", TSDataType.INT32, TSEncoding.PLAIN, CompressionType.LZ4));
@@ -147,14 +147,14 @@ public class TsFileReaderTest {
     IExpression IExpression =
         BinaryExpression.or(
             BinaryExpression.and(
-                new SingleSeriesExpression(new Path("d1", "s1"), filter),
-                new SingleSeriesExpression(new Path("d1", "s4"), filter2)),
+                new SingleSeriesExpression(new Path("d1", "s1", true), filter),
+                new SingleSeriesExpression(new Path("d1", "s4", true), filter2)),
             new GlobalTimeExpression(filter3));
 
     QueryExpression queryExpression =
         QueryExpression.create()
-            .addSelectedPath(new Path("d1", "s1"))
-            .addSelectedPath(new Path("d1", "s4"))
+            .addSelectedPath(new Path("d1", "s1", true))
+            .addSelectedPath(new Path("d1", "s4", true))
             .setExpression(IExpression);
     QueryDataSet queryDataSet = tsFile.query(queryExpression);
     long aimedTimestamp = 1480562618000L;
@@ -166,8 +166,8 @@ public class TsFileReaderTest {
 
     queryExpression =
         QueryExpression.create()
-            .addSelectedPath(new Path("d1", "s1"))
-            .addSelectedPath(new Path("d1", "s4"));
+            .addSelectedPath(new Path("d1", "s1", true))
+            .addSelectedPath(new Path("d1", "s4", true));
     queryDataSet = tsFile.query(queryExpression);
     aimedTimestamp = 1480562618000L;
     int count = 0;
@@ -181,8 +181,8 @@ public class TsFileReaderTest {
 
     queryExpression =
         QueryExpression.create()
-            .addSelectedPath(new Path("d1", "s1"))
-            .addSelectedPath(new Path("d1", "s4"))
+            .addSelectedPath(new Path("d1", "s1", true))
+            .addSelectedPath(new Path("d1", "s4", true))
             .setExpression(new GlobalTimeExpression(filter3));
     queryDataSet = tsFile.query(queryExpression);
     aimedTimestamp = 1480562618000L;
@@ -211,8 +211,8 @@ public class TsFileReaderTest {
 
   void queryTest2() throws IOException {
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("d1", "s6"));
-    paths.add(new Path("d2", "s1"));
+    paths.add(new Path("d1", "s6", true));
+    paths.add(new Path("d2", "s1", true));
 
     IExpression expression = new GlobalTimeExpression(TimeFilter.gt(1480562664760L));
 
@@ -230,8 +230,8 @@ public class TsFileReaderTest {
 
   void queryNonExistPathTest() throws Exception {
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("d1", "s1"));
-    paths.add(new Path("d2", "s1"));
+    paths.add(new Path("d1", "s1", true));
+    paths.add(new Path("d2", "s1", true));
     IExpression expression = new GlobalTimeExpression(TimeFilter.gt(1480562664760L));
     QueryExpression queryExpression = QueryExpression.create(paths, expression);
     try {
@@ -249,10 +249,10 @@ public class TsFileReaderTest {
     try (TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(filePath)); ) {
       // timeseries path for query
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
-      paths.add(new Path("d1", "s2"));
-      paths.add(new Path("d1", "s3"));
-      paths.add(new Path("d2", "s1"));
+      paths.add(new Path("d1", "s1", true));
+      paths.add(new Path("d1", "s2", true));
+      paths.add(new Path("d1", "s3", true));
+      paths.add(new Path("d2", "s1", true));
 
       long rowCount = queryAndPrint(paths, tsFileReader, null);
       Assert.assertNotEquals(0, rowCount);
@@ -267,10 +267,10 @@ public class TsFileReaderTest {
     try (TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(filePath)); ) {
       // timeseries path for query
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
-      paths.add(new Path("d1", "s2"));
-      paths.add(new Path("d1", "s3"));
-      paths.add(new Path("d2", "s2"));
+      paths.add(new Path("d1", "s1", true));
+      paths.add(new Path("d1", "s2", true));
+      paths.add(new Path("d1", "s3", true));
+      paths.add(new Path("d2", "s2", true));
 
       IExpression timeFilter =
           BinaryExpression.and(
@@ -289,13 +289,13 @@ public class TsFileReaderTest {
     try (TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(filePath)); ) {
       // timeseries path for query
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
-      paths.add(new Path("d1", "s2"));
-      paths.add(new Path("d1", "s3"));
-      paths.add(new Path("d2", "s2"));
+      paths.add(new Path("d1", "s1", true));
+      paths.add(new Path("d1", "s2", true));
+      paths.add(new Path("d1", "s3", true));
+      paths.add(new Path("d2", "s2", true));
 
       IExpression valueFilter =
-          new SingleSeriesExpression(new Path("d2", "s1"), ValueFilter.ltEq(9L));
+          new SingleSeriesExpression(new Path("d2", "s1", true), ValueFilter.ltEq(9L));
       long rowCount = queryAndPrint(paths, tsFileReader, valueFilter);
       Assert.assertNotEquals(0, rowCount);
     }
@@ -309,15 +309,15 @@ public class TsFileReaderTest {
     try (TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(filePath)); ) {
       // timeseries path for query
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
-      paths.add(new Path("d1", "s2"));
-      paths.add(new Path("d1", "s3"));
-      paths.add(new Path("d2", "s1"));
+      paths.add(new Path("d1", "s1", true));
+      paths.add(new Path("d1", "s2", true));
+      paths.add(new Path("d1", "s3", true));
+      paths.add(new Path("d2", "s1", true));
 
       IExpression valueFilter1 =
-          new SingleSeriesExpression(new Path("d2", "s1"), ValueFilter.gtEq(100L));
+          new SingleSeriesExpression(new Path("d2", "s1", true), ValueFilter.gtEq(100L));
       IExpression valueFilter2 =
-          new SingleSeriesExpression(new Path("d1", "s2"), ValueFilter.ltEq(10000L));
+          new SingleSeriesExpression(new Path("d1", "s2", true), ValueFilter.ltEq(10000L));
       IExpression binaryExpression = BinaryExpression.and(valueFilter1, valueFilter2);
       long rowCount = queryAndPrint(paths, tsFileReader, binaryExpression);
       Assert.assertNotEquals(0, rowCount);
@@ -332,15 +332,15 @@ public class TsFileReaderTest {
     try (TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(filePath)); ) {
       // timeseries path for query
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
-      paths.add(new Path("d1", "s2"));
-      paths.add(new Path("d1", "s3"));
-      paths.add(new Path("d2", "s1"));
+      paths.add(new Path("d1", "s1", true));
+      paths.add(new Path("d1", "s2", true));
+      paths.add(new Path("d1", "s3", true));
+      paths.add(new Path("d2", "s1", true));
 
       IExpression valueFilter =
           BinaryExpression.and(
-              new SingleSeriesExpression(new Path("d2", "s1"), ValueFilter.gtEq(7000L)),
-              new SingleSeriesExpression(new Path("d1", "s1"), ValueFilter.ltEq(10000L)));
+              new SingleSeriesExpression(new Path("d2", "s1", true), ValueFilter.gtEq(7000L)),
+              new SingleSeriesExpression(new Path("d1", "s1", true), ValueFilter.ltEq(10000L)));
       IExpression timeFilter =
           BinaryExpression.and(
               new GlobalTimeExpression(TimeFilter.gtEq(2000)),
@@ -359,15 +359,15 @@ public class TsFileReaderTest {
     try (TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(filePath)); ) {
       // timeseries path for query
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
-      paths.add(new Path("d1", "s2"));
-      paths.add(new Path("d1", "s3"));
-      paths.add(new Path("d2", "s1"));
+      paths.add(new Path("d1", "s1", true));
+      paths.add(new Path("d1", "s2", true));
+      paths.add(new Path("d1", "s3", true));
+      paths.add(new Path("d2", "s1", true));
 
       IExpression valueFilter1 =
-          new SingleSeriesExpression(new Path("d2", "s1"), ValueFilter.gtEq(100L));
+          new SingleSeriesExpression(new Path("d2", "s1", true), ValueFilter.gtEq(100L));
       IExpression valueFilter2 =
-          new SingleSeriesExpression(new Path("d1", "s2"), ValueFilter.ltEq(10000L));
+          new SingleSeriesExpression(new Path("d1", "s2", true), ValueFilter.ltEq(10000L));
       IExpression valueFilter = BinaryExpression.and(valueFilter1, valueFilter2);
       IExpression timeFilter =
           BinaryExpression.and(
@@ -387,15 +387,15 @@ public class TsFileReaderTest {
     try (TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(filePath)); ) {
       // timeseries path for query
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
-      paths.add(new Path("d1", "s3"));
-      paths.add(new Path("d2", "s1"));
-      paths.add(new Path("d2", "s2"));
+      paths.add(new Path("d1", "s1", true));
+      paths.add(new Path("d1", "s3", true));
+      paths.add(new Path("d2", "s1", true));
+      paths.add(new Path("d2", "s2", true));
 
       IExpression valueFilter1 =
-          new SingleSeriesExpression(new Path("d2", "s1"), ValueFilter.gtEq(100L));
+          new SingleSeriesExpression(new Path("d2", "s1", true), ValueFilter.gtEq(100L));
       IExpression valueFilter2 =
-          new SingleSeriesExpression(new Path("d1", "s2"), ValueFilter.ltEq(10000L));
+          new SingleSeriesExpression(new Path("d1", "s2", true), ValueFilter.ltEq(10000L));
       IExpression valueFilter = BinaryExpression.and(valueFilter1, valueFilter2);
       IExpression timeFilter =
           BinaryExpression.and(
@@ -415,16 +415,16 @@ public class TsFileReaderTest {
     try (TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(filePath)); ) {
       // timeseries path for query
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
-      paths.add(new Path("d1", "s9"));
-      paths.add(new Path("d2", "s1"));
-      paths.add(new Path("d2", "s8"));
-      paths.add(new Path("d9", "s8"));
+      paths.add(new Path("d1", "s1", true));
+      paths.add(new Path("d1", "s9", true));
+      paths.add(new Path("d2", "s1", true));
+      paths.add(new Path("d2", "s8", true));
+      paths.add(new Path("d9", "s8", true));
 
       IExpression valueFilter1 =
-          new SingleSeriesExpression(new Path("d2", "s1"), ValueFilter.gtEq(100L));
+          new SingleSeriesExpression(new Path("d2", "s1", true), ValueFilter.gtEq(100L));
       IExpression valueFilter2 =
-          new SingleSeriesExpression(new Path("d1", "s2"), ValueFilter.ltEq(10000L));
+          new SingleSeriesExpression(new Path("d1", "s2", true), ValueFilter.ltEq(10000L));
       IExpression valueFilter = BinaryExpression.and(valueFilter1, valueFilter2);
       IExpression timeFilter =
           BinaryExpression.and(
@@ -444,15 +444,15 @@ public class TsFileReaderTest {
     try (TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(filePath)); ) {
       // timeseries path for query
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
-      paths.add(new Path("d1", "s9"));
-      paths.add(new Path("d2", "s1"));
-      paths.add(new Path("d9", "s8"));
+      paths.add(new Path("d1", "s1", true));
+      paths.add(new Path("d1", "s9", true));
+      paths.add(new Path("d2", "s1", true));
+      paths.add(new Path("d9", "s8", true));
 
       IExpression valueFilter1 =
-          new SingleSeriesExpression(new Path("d2", "s9"), ValueFilter.gtEq(100L));
+          new SingleSeriesExpression(new Path("d2", "s9", true), ValueFilter.gtEq(100L));
       IExpression valueFilter2 =
-          new SingleSeriesExpression(new Path("d1", "s2"), ValueFilter.ltEq(10000L));
+          new SingleSeriesExpression(new Path("d1", "s2", true), ValueFilter.ltEq(10000L));
       IExpression valueFilter = BinaryExpression.and(valueFilter1, valueFilter2);
       IExpression timeFilter =
           BinaryExpression.and(

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/controller/ChunkLoaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/controller/ChunkLoaderTest.java
@@ -55,7 +55,7 @@ public class ChunkLoaderTest {
     fileReader = new TsFileSequenceReader(FILE_PATH);
     MetadataQuerierByFileImpl metadataQuerierByFile = new MetadataQuerierByFileImpl(fileReader);
     List<IChunkMetadata> chunkMetadataList =
-        metadataQuerierByFile.getChunkMetaDataList(new Path("d2", "s1"));
+        metadataQuerierByFile.getChunkMetaDataList(new Path("d2", "s1", true));
 
     CachedChunkLoaderImpl seriesChunkLoader = new CachedChunkLoaderImpl(fileReader);
     for (IChunkMetadata chunkMetaData : chunkMetadataList) {

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/controller/IMetadataQuerierByFileImplTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/controller/IMetadataQuerierByFileImplTest.java
@@ -46,7 +46,7 @@ public class IMetadataQuerierByFileImplTest {
   public void before() throws IOException {
     TsFileGeneratorForTest.generateFile(10000, 1024, 100);
     reader = new TsFileSequenceReader(FILE_PATH);
-    List<ChunkMetadata> d1s6List = reader.getChunkMetadataList(new Path("d1", "s6"));
+    List<ChunkMetadata> d1s6List = reader.getChunkMetadataList(new Path("d1", "s6", true));
     for (ChunkMetadata chunkMetaData : d1s6List) {
       // get a series of [startTime, endTime] of d1.s6 from the chunkGroupMetaData of
       // d1
@@ -63,7 +63,7 @@ public class IMetadataQuerierByFileImplTest {
       d1chunkGroupMetaDataOffsetList.add(startEndOffsets);
     }
 
-    List<ChunkMetadata> d2s1List = reader.getChunkMetadataList(new Path("d2", "s1"));
+    List<ChunkMetadata> d2s1List = reader.getChunkMetadataList(new Path("d2", "s1", true));
     for (ChunkMetadata chunkMetaData : d2s1List) {
       d2s1timeRangeList.add(
           new TimeRange(chunkMetaData.getStartTime(), chunkMetaData.getEndTime()));
@@ -90,8 +90,8 @@ public class IMetadataQuerierByFileImplTest {
     MetadataQuerierByFileImpl metadataQuerierByFile = new MetadataQuerierByFileImpl(reader);
 
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("d1", "s6"));
-    paths.add(new Path("d2", "s1"));
+    paths.add(new Path("d1", "s6", true));
+    paths.add(new Path("d2", "s1", true));
 
     ArrayList<TimeRange> resTimeRanges =
         new ArrayList<>(metadataQuerierByFile.convertSpace2TimePartition(paths, 0L, 0L));
@@ -104,8 +104,8 @@ public class IMetadataQuerierByFileImplTest {
     MetadataQuerierByFileImpl metadataQuerierByFile = new MetadataQuerierByFileImpl(reader);
 
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("d1", "s6"));
-    paths.add(new Path("d2", "s1"));
+    paths.add(new Path("d1", "s6", true));
+    paths.add(new Path("d2", "s1", true));
 
     long spacePartitionStartPos = d1chunkGroupMetaDataOffsetList.get(0)[0];
     long spacePartitionEndPos = d1chunkGroupMetaDataOffsetList.get(1)[1];
@@ -127,8 +127,8 @@ public class IMetadataQuerierByFileImplTest {
     MetadataQuerierByFileImpl metadataQuerierByFile = new MetadataQuerierByFileImpl(reader);
 
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("d1", "s6"));
-    paths.add(new Path("d2", "s1"));
+    paths.add(new Path("d1", "s6", true));
+    paths.add(new Path("d2", "s1", true));
 
     long spacePartitionStartPos = d2chunkGroupMetaDataOffsetList.get(0)[0];
     long spacePartitionEndPos = d2chunkGroupMetaDataOffsetList.get(0)[1];

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/filter/IExpressionOptimizerTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/filter/IExpressionOptimizerTest.java
@@ -44,10 +44,10 @@ public class IExpressionOptimizerTest {
   @Before
   public void before() {
     selectedSeries = new ArrayList<>();
-    selectedSeries.add(new Path("d1", "s1"));
-    selectedSeries.add(new Path("d2", "s1"));
-    selectedSeries.add(new Path("d1", "s2"));
-    selectedSeries.add(new Path("d2", "s2"));
+    selectedSeries.add(new Path("d1", "s1", true));
+    selectedSeries.add(new Path("d2", "s1", true));
+    selectedSeries.add(new Path("d1", "s2", true));
+    selectedSeries.add(new Path("d2", "s2", true));
   }
 
   @After
@@ -80,20 +80,20 @@ public class IExpressionOptimizerTest {
           FilterFactory.and(
               FilterFactory.or(ValueFilter.gt(100L), ValueFilter.lt(50L)), TimeFilter.gt(1400L));
       SingleSeriesExpression singleSeriesExp1 =
-          new SingleSeriesExpression(new Path("d2", "s1"), filter1);
+          new SingleSeriesExpression(new Path("d2", "s1", true), filter1);
 
       Filter filter2 =
           FilterFactory.and(
               FilterFactory.or(ValueFilter.gt(100.5f), ValueFilter.lt(50.6f)),
               TimeFilter.gt(1400L));
       SingleSeriesExpression singleSeriesExp2 =
-          new SingleSeriesExpression(new Path("d1", "s2"), filter2);
+          new SingleSeriesExpression(new Path("d1", "s2", true), filter2);
 
       Filter filter3 =
           FilterFactory.or(
               FilterFactory.or(ValueFilter.gt(100.5), ValueFilter.lt(50.6)), TimeFilter.gt(1400L));
       SingleSeriesExpression singleSeriesExp3 =
-          new SingleSeriesExpression(new Path("d2", "s2"), filter3);
+          new SingleSeriesExpression(new Path("d2", "s2", true), filter3);
 
       IExpression expression =
           BinaryExpression.and(
@@ -111,11 +111,11 @@ public class IExpressionOptimizerTest {
   public void testOneTimeAndSeries() {
     Filter filter1 = FilterFactory.or(ValueFilter.gt(100L), ValueFilter.lt(50L));
     SingleSeriesExpression singleSeriesExp1 =
-        new SingleSeriesExpression(new Path("d2", "s1"), filter1);
+        new SingleSeriesExpression(new Path("d2", "s1", true), filter1);
 
     Filter filter2 = FilterFactory.or(ValueFilter.gt(100.5f), ValueFilter.lt(50.6f));
     SingleSeriesExpression singleSeriesExp2 =
-        new SingleSeriesExpression(new Path("d1", "s2"), filter2);
+        new SingleSeriesExpression(new Path("d1", "s2", true), filter2);
 
     Filter timeFilter = TimeFilter.lt(14001234L);
     IExpression globalTimeFilter = new GlobalTimeExpression(timeFilter);
@@ -136,7 +136,7 @@ public class IExpressionOptimizerTest {
   public void testSeriesAndGlobalOrGlobal() {
     Filter filter1 = FilterFactory.or(ValueFilter.gt(100L), ValueFilter.lt(50L));
     SingleSeriesExpression singleSeriesExp1 =
-        new SingleSeriesExpression(new Path("d2", "s1"), filter1);
+        new SingleSeriesExpression(new Path("d2", "s1", true), filter1);
 
     Filter timeFilter = TimeFilter.lt(14001234L);
     IExpression globalTimeFilter = new GlobalTimeExpression(timeFilter);
@@ -161,7 +161,7 @@ public class IExpressionOptimizerTest {
   public void testSeriesAndGlobal() {
     Filter filter1 = FilterFactory.or(ValueFilter.gt(100L), ValueFilter.lt(50L));
     SingleSeriesExpression singleSeriesExp1 =
-        new SingleSeriesExpression(new Path("d2", "s1"), filter1);
+        new SingleSeriesExpression(new Path("d2", "s1", true), filter1);
 
     Filter timeFilter = TimeFilter.lt(14001234L);
     IExpression globalTimeFilter = new GlobalTimeExpression(timeFilter);
@@ -181,11 +181,11 @@ public class IExpressionOptimizerTest {
   public void testOneTimeOrSeries() {
     Filter filter1 = FilterFactory.or(ValueFilter.gt(100L), ValueFilter.lt(50L));
     SingleSeriesExpression singleSeriesExp1 =
-        new SingleSeriesExpression(new Path("d2", "s1"), filter1);
+        new SingleSeriesExpression(new Path("d2", "s1", true), filter1);
 
     Filter filter2 = FilterFactory.or(ValueFilter.gt(100.5f), ValueFilter.lt(50.6f));
     SingleSeriesExpression singleSeriesExp2 =
-        new SingleSeriesExpression(new Path("d1", "s2"), filter2);
+        new SingleSeriesExpression(new Path("d1", "s2", true), filter2);
 
     Filter timeFilter = TimeFilter.lt(14001234L);
     IExpression globalTimeFilter = new GlobalTimeExpression(timeFilter);
@@ -210,11 +210,11 @@ public class IExpressionOptimizerTest {
   public void testTwoTimeCombine() {
     Filter filter1 = FilterFactory.or(ValueFilter.gt(100L), ValueFilter.lt(50L));
     SingleSeriesExpression singleSeriesExp1 =
-        new SingleSeriesExpression(new Path("d2", "s1"), filter1);
+        new SingleSeriesExpression(new Path("d2", "s1", true), filter1);
 
     Filter filter2 = FilterFactory.or(ValueFilter.gt(100.5f), ValueFilter.lt(50.6f));
     SingleSeriesExpression singleSeriesExp2 =
-        new SingleSeriesExpression(new Path("d1", "s2"), filter2);
+        new SingleSeriesExpression(new Path("d1", "s2", true), filter2);
 
     IExpression globalTimeFilter1 = new GlobalTimeExpression(TimeFilter.lt(14001234L));
     IExpression globalTimeFilter2 = new GlobalTimeExpression(TimeFilter.gt(14001000L));

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/executor/QueryExecutorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/executor/QueryExecutorTest.java
@@ -77,15 +77,15 @@ public class QueryExecutorTest {
 
     IExpression IExpression =
         BinaryExpression.and(
-            new SingleSeriesExpression(new Path("d1", "s1"), filter),
-            new SingleSeriesExpression(new Path("d1", "s4"), filter2));
+            new SingleSeriesExpression(new Path("d1", "s1", true), filter),
+            new SingleSeriesExpression(new Path("d1", "s4", true), filter2));
 
     QueryExpression queryExpression =
         QueryExpression.create()
-            .addSelectedPath(new Path("d1", "s1"))
-            .addSelectedPath(new Path("d1", "s2"))
-            .addSelectedPath(new Path("d1", "s4"))
-            .addSelectedPath(new Path("d1", "s5"))
+            .addSelectedPath(new Path("d1", "s1", true))
+            .addSelectedPath(new Path("d1", "s2", true))
+            .addSelectedPath(new Path("d1", "s4", true))
+            .addSelectedPath(new Path("d1", "s5", true))
             .setExpression(IExpression);
     long startTimestamp = System.currentTimeMillis();
     QueryDataSet queryDataSet = queryExecutorWithQueryFilter.execute(queryExpression);
@@ -104,11 +104,11 @@ public class QueryExecutorTest {
 
     QueryExpression queryExpression =
         QueryExpression.create()
-            .addSelectedPath(new Path("d1", "s1"))
-            .addSelectedPath(new Path("d1", "s2"))
-            .addSelectedPath(new Path("d1", "s3"))
-            .addSelectedPath(new Path("d1", "s4"))
-            .addSelectedPath(new Path("d1", "s5"));
+            .addSelectedPath(new Path("d1", "s1", true))
+            .addSelectedPath(new Path("d1", "s2", true))
+            .addSelectedPath(new Path("d1", "s3", true))
+            .addSelectedPath(new Path("d1", "s4", true))
+            .addSelectedPath(new Path("d1", "s5", true));
 
     long aimedTimestamp = 1480562618000L;
     int count = 0;
@@ -133,11 +133,11 @@ public class QueryExecutorTest {
             FilterFactory.and(TimeFilter.gtEq(1480562618100L), TimeFilter.lt(1480562618200L)));
     QueryExpression queryExpression =
         QueryExpression.create()
-            .addSelectedPath(new Path("d1", "s1"))
-            .addSelectedPath(new Path("d1", "s2"))
-            .addSelectedPath(new Path("d1", "s3"))
-            .addSelectedPath(new Path("d1", "s4"))
-            .addSelectedPath(new Path("d1", "s5"))
+            .addSelectedPath(new Path("d1", "s1", true))
+            .addSelectedPath(new Path("d1", "s2", true))
+            .addSelectedPath(new Path("d1", "s3", true))
+            .addSelectedPath(new Path("d1", "s4", true))
+            .addSelectedPath(new Path("d1", "s5", true))
             .setExpression(IExpression);
 
     long aimedTimestamp = 1480562618100L;

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/ReadWriteTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/ReadWriteTest.java
@@ -76,15 +76,15 @@ public class ReadWriteTest {
 
     IExpression valueExpression =
         BinaryExpression.and(
-            new SingleSeriesExpression(new Path("d1", "s1"), ValueFilter.gt(1.0f)),
-            new SingleSeriesExpression(new Path("d1", "s2"), ValueFilter.lt(22)));
+            new SingleSeriesExpression(new Path("d1", "s1", true), ValueFilter.gt(1.0f)),
+            new SingleSeriesExpression(new Path("d1", "s2", true), ValueFilter.lt(22)));
 
     IExpression finalExpression = BinaryExpression.and(valueExpression, timeExpression);
 
     QueryExpression queryExpression =
         QueryExpression.create()
-            .addSelectedPath(new Path("d1", "s1"))
-            .addSelectedPath(new Path("d1", "s2"))
+            .addSelectedPath(new Path("d1", "s1", true))
+            .addSelectedPath(new Path("d1", "s2", true))
             .setExpression(finalExpression);
 
     try (TsFileSequenceReader fileReader = new TsFileSequenceReader(tsfilePath)) {

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/ReaderByTimestampTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/ReaderByTimestampTest.java
@@ -63,7 +63,7 @@ public class ReaderByTimestampTest {
   public void readByTimestamp() throws IOException {
     CachedChunkLoaderImpl seriesChunkLoader = new CachedChunkLoaderImpl(fileReader);
     List<IChunkMetadata> chunkMetadataList =
-        metadataQuerierByFile.getChunkMetaDataList(new Path("d1", "s1"));
+        metadataQuerierByFile.getChunkMetaDataList(new Path("d1", "s1", true));
     AbstractFileSeriesReader seriesReader =
         new FileSeriesReader(seriesChunkLoader, chunkMetadataList, null);
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGeneratorReadEmptyTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGeneratorReadEmptyTest.java
@@ -77,15 +77,15 @@ public class TimeGeneratorReadEmptyTest {
 
     IExpression valueExpression =
         BinaryExpression.or(
-            new SingleSeriesExpression(new Path("d1", "s1"), ValueFilter.gt(1.0f)),
-            new SingleSeriesExpression(new Path("d1", "s2"), ValueFilter.lt(22)));
+            new SingleSeriesExpression(new Path("d1", "s1", true), ValueFilter.gt(1.0f)),
+            new SingleSeriesExpression(new Path("d1", "s2", true), ValueFilter.lt(22)));
 
     IExpression finalExpression = BinaryExpression.and(valueExpression, timeExpression);
 
     QueryExpression queryExpression =
         QueryExpression.create()
-            .addSelectedPath(new Path("d1", "s1"))
-            .addSelectedPath(new Path("d1", "s2"))
+            .addSelectedPath(new Path("d1", "s1", true))
+            .addSelectedPath(new Path("d1", "s2", true))
             .setExpression(finalExpression);
 
     try (TsFileSequenceReader fileReader = new TsFileSequenceReader(tsfilePath)) {

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGeneratorReadWriteTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGeneratorReadWriteTest.java
@@ -77,15 +77,15 @@ public class TimeGeneratorReadWriteTest {
 
     IExpression valueExpression =
         BinaryExpression.and(
-            new SingleSeriesExpression(new Path("d1", "s1"), ValueFilter.gt(1.0f)),
-            new SingleSeriesExpression(new Path("d1", "s2"), ValueFilter.lt(22)));
+            new SingleSeriesExpression(new Path("d1", "s1", true), ValueFilter.gt(1.0f)),
+            new SingleSeriesExpression(new Path("d1", "s2", true), ValueFilter.lt(22)));
 
     IExpression finalExpression = BinaryExpression.and(valueExpression, timeExpression);
 
     QueryExpression queryExpression =
         QueryExpression.create()
-            .addSelectedPath(new Path("d1", "s1"))
-            .addSelectedPath(new Path("d1", "s2"))
+            .addSelectedPath(new Path("d1", "s1", true))
+            .addSelectedPath(new Path("d1", "s2", true))
             .setExpression(finalExpression);
 
     try (TsFileSequenceReader fileReader = new TsFileSequenceReader(tsfilePath)) {

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGeneratorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGeneratorTest.java
@@ -74,9 +74,9 @@ public class TimeGeneratorTest {
     IExpression IExpression =
         BinaryExpression.or(
             BinaryExpression.and(
-                new SingleSeriesExpression(new Path("d1", "s1"), filter),
-                new SingleSeriesExpression(new Path("d1", "s4"), filter2)),
-            new SingleSeriesExpression(new Path("d1", "s1"), filter3));
+                new SingleSeriesExpression(new Path("d1", "s1", true), filter),
+                new SingleSeriesExpression(new Path("d1", "s4", true), filter2)),
+            new SingleSeriesExpression(new Path("d1", "s1", true), filter3));
 
     TsFileTimeGenerator timestampGenerator =
         new TsFileTimeGenerator(IExpression, chunkLoader, metadataQuerierByFile);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/ChunkReaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/ChunkReaderTest.java
@@ -93,7 +93,7 @@ public class ChunkReaderTest {
         for (int j = 0; j < measurementNum; j++) {
           List<ChunkMetadata> chunkMetadataList =
               tsFileSequenceReader.getChunkMetadataList(
-                  new Path(testStorageGroup + PATH_SEPARATOR + "d" + i, "s" + j));
+                  new Path(testStorageGroup + PATH_SEPARATOR + "d" + i, "s" + j, true));
           for (ChunkMetadata chunkMetadata : chunkMetadataList) {
             Chunk chunk = tsFileSequenceReader.readMemChunk(chunkMetadata);
             ChunkReader chunkReader = new ChunkReader(chunk, null);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/FakedTimeGenerator.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/FakedTimeGenerator.java
@@ -41,13 +41,14 @@ public class FakedTimeGenerator extends TimeGenerator {
         BinaryExpression.and(
             BinaryExpression.and(
                 new SingleSeriesExpression(
-                    new Path("d1", "s1"),
+                    new Path("d1", "s1", true),
                     FilterFactory.and(TimeFilter.gtEq(3L), TimeFilter.ltEq(8L))),
                 new SingleSeriesExpression(
-                    new Path("d2", "s2"),
+                    new Path("d2", "s2", true),
                     FilterFactory.and(TimeFilter.gtEq(1L), TimeFilter.ltEq(10L)))),
             new SingleSeriesExpression(
-                new Path("d2", "s2"), FilterFactory.and(TimeFilter.gtEq(2L), TimeFilter.ltEq(6L))));
+                new Path("d2", "s2", true),
+                FilterFactory.and(TimeFilter.gtEq(2L), TimeFilter.ltEq(6L))));
 
     super.constructNode(expression);
   }
@@ -70,7 +71,7 @@ public class FakedTimeGenerator extends TimeGenerator {
   @Test
   public void testTimeGenerator() throws IOException {
     FakedTimeGenerator fakedTimeGenerator = new FakedTimeGenerator();
-    Path path = new Path("d1", "s1");
+    Path path = new Path("d1", "s1", true);
     long count = 0;
     while (fakedTimeGenerator.hasNext()) {
       fakedTimeGenerator.next();

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/ReaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/ReaderTest.java
@@ -72,7 +72,7 @@ public class ReaderTest {
     int count = 0;
     CachedChunkLoaderImpl seriesChunkLoader = new CachedChunkLoaderImpl(fileReader);
     List<IChunkMetadata> chunkMetadataList =
-        metadataQuerierByFile.getChunkMetaDataList(new Path("d1", "s1"));
+        metadataQuerierByFile.getChunkMetaDataList(new Path("d1", "s1", true));
 
     AbstractFileSeriesReader seriesReader =
         new FileSeriesReader(seriesChunkLoader, chunkMetadataList, null);
@@ -90,7 +90,7 @@ public class ReaderTest {
     }
     Assert.assertEquals(rowCount, count);
 
-    chunkMetadataList = metadataQuerierByFile.getChunkMetaDataList(new Path("d1", "s4"));
+    chunkMetadataList = metadataQuerierByFile.getChunkMetaDataList(new Path("d1", "s4", true));
     seriesReader = new FileSeriesReader(seriesChunkLoader, chunkMetadataList, null);
     count = 0;
 
@@ -108,7 +108,7 @@ public class ReaderTest {
   public void readWithFilterTest() throws IOException {
     CachedChunkLoaderImpl seriesChunkLoader = new CachedChunkLoaderImpl(fileReader);
     List<IChunkMetadata> chunkMetadataList =
-        metadataQuerierByFile.getChunkMetaDataList(new Path("d1", "s1"));
+        metadataQuerierByFile.getChunkMetaDataList(new Path("d1", "s1", true));
 
     Filter filter =
         new FilterFactory()
@@ -116,7 +116,7 @@ public class ReaderTest {
                 FilterFactory.and(TimeFilter.gt(1480563570029L), TimeFilter.lt(1480563570033L)),
                 FilterFactory.and(ValueFilter.gtEq(9520331), ValueFilter.ltEq(9520361)));
     SingleSeriesExpression singleSeriesExp =
-        new SingleSeriesExpression(new Path("d1", "s1"), filter);
+        new SingleSeriesExpression(new Path("d1", "s1", true), filter);
     AbstractFileSeriesReader seriesReader =
         new FileSeriesReader(seriesChunkLoader, chunkMetadataList, singleSeriesExp.getFilter());
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/DefaultSchemaTemplateTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/DefaultSchemaTemplateTest.java
@@ -95,7 +95,7 @@ public class DefaultSchemaTemplateTest {
 
       // use these paths(all measurements) for all the queries
       ArrayList<Path> paths = new ArrayList<>();
-      paths.add(new Path("d1", "s1"));
+      paths.add(new Path("d1", "s1", true));
 
       QueryExpression queryExpression = QueryExpression.create(paths, null);
       QueryDataSet queryDataSet = readTsFile.query(queryExpression);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/MetadataIndexConstructorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/MetadataIndexConstructorTest.java
@@ -376,19 +376,19 @@ public class MetadataIndexConstructorTest {
       if (singleMeasurement != null) {
         for (String measurement : singleMeasurement[i]) {
           measurements.add(measurement);
-          correctPaths.add(new Path(device, measurement).getFullPath());
+          correctPaths.add(new Path(device, measurement, true).getFullPath());
         }
       }
       // multi-variable measurement
       for (int vectorIndex = 0; vectorIndex < vectorMeasurement[i].length; vectorIndex++) {
         measurements.add("");
-        correctPaths.add(new Path(device, "").getFullPath());
+        correctPaths.add(new Path(device, "", true).getFullPath());
         int measurementNum = vectorMeasurement[i][vectorIndex];
         for (int measurementIndex = 0; measurementIndex < measurementNum; measurementIndex++) {
           String measurementName =
               measurementPrefix + generateIndexString(measurementIndex, measurementNum);
           measurements.add(TsFileConstant.PATH_SEPARATOR + measurementName);
-          correctPaths.add(new Path(device, measurementName).getFullPath());
+          correctPaths.add(new Path(device, measurementName, true).getFullPath());
         }
       }
       Collections.sort(measurements);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/SameMeasurementsWithDifferentDataTypesTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/SameMeasurementsWithDifferentDataTypesTest.java
@@ -74,8 +74,8 @@ public class SameMeasurementsWithDifferentDataTypesTest {
   @Test
   public void testSameMeasurementsWithDiffrentDataTypes() throws IOException {
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d2", "s1"));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d2", "s1", true));
     QueryExpression queryExpression = QueryExpression.create(pathList, null);
     TsFileSequenceReader fileReader = new TsFileSequenceReader(tsfilePath);
     TsFileReader tsFileReader = new TsFileReader(fileReader);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/TsFileReadWriteTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/TsFileReadWriteTest.java
@@ -180,7 +180,7 @@ public class TsFileReadWriteTest {
     TsFileSequenceReader reader = new TsFileSequenceReader(path);
     TsFileReader readTsFile = new TsFileReader(reader);
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("device_1", "sensor_2"));
+    paths.add(new Path("device_1", "sensor_2", true));
     QueryExpression queryExpression = QueryExpression.create(paths, null);
     try {
       QueryDataSet queryDataSet = readTsFile.query(queryExpression);
@@ -225,7 +225,7 @@ public class TsFileReadWriteTest {
     TsFileSequenceReader reader = new TsFileSequenceReader(path);
     TsFileReader readTsFile = new TsFileReader(reader);
     ArrayList<Path> paths = new ArrayList<>();
-    paths.add(new Path("device_1", "sensor_1"));
+    paths.add(new Path("device_1", "sensor_1", true));
     QueryExpression queryExpression = QueryExpression.create(paths, null);
 
     QueryDataSet queryDataSet = readTsFile.query(queryExpression);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/TsFileWriterTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/TsFileWriterTest.java
@@ -325,8 +325,8 @@ public class TsFileWriterTest {
       QueryDataSet dataSet =
           tsFileReader.query(
               QueryExpression.create()
-                  .addSelectedPath(new Path("d1", "s1"))
-                  .addSelectedPath(new Path("d1", "s2")));
+                  .addSelectedPath(new Path("d1", "s1", true))
+                  .addSelectedPath(new Path("d1", "s2", true)));
       assertFalse(dataSet.hasNext());
       tsFileReader.close();
     } catch (IOException e) {
@@ -345,9 +345,9 @@ public class TsFileWriterTest {
       QueryDataSet dataSet =
           tsFileReader.query(
               QueryExpression.create()
-                  .addSelectedPath(new Path("d1", "s1"))
-                  .addSelectedPath(new Path("d1", "s2"))
-                  .addSelectedPath(new Path("d1", "s3")));
+                  .addSelectedPath(new Path("d1", "s1", true))
+                  .addSelectedPath(new Path("d1", "s2", true))
+                  .addSelectedPath(new Path("d1", "s3", true)));
       while (dataSet.hasNext()) {
         RowRecord result = dataSet.next();
         assertEquals(2, result.getFields().size());

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/WriteTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/WriteTest.java
@@ -122,7 +122,7 @@ public class WriteTest {
     measurementArray.add(new MeasurementSchema("s4", TSDataType.BOOLEAN, TSEncoding.PLAIN));
     pathArray = new ArrayList<>();
     for (int i = 0; i < 5; i++) {
-      pathArray.add(new Path("d1", "s" + i));
+      pathArray.add(new Path("d1", "s" + i, true));
     }
     schema = new Schema();
     LOG.info(schema.toString());

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/ForceAppendTsFileWriterTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/ForceAppendTsFileWriterTest.java
@@ -99,8 +99,8 @@ public class ForceAppendTsFileWriterTest {
     writer.close();
     TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(file.getPath()));
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d1", "s2"));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d1", "s2", true));
     QueryExpression queryExpression = QueryExpression.create(pathList, null);
     QueryDataSet dataSet = tsFileReader.query(queryExpression);
     RowRecord record = dataSet.next();

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriterTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriterTest.java
@@ -215,8 +215,8 @@ public class RestorableTsFileIOWriterTest {
 
     TsFileReader tsFileReader = new TsFileReader(new TsFileSequenceReader(file.getPath()));
     List<Path> pathList = new ArrayList<>();
-    pathList.add(new Path("d1", "s1"));
-    pathList.add(new Path("d1", "s2"));
+    pathList.add(new Path("d1", "s1", true));
+    pathList.add(new Path("d1", "s2", true));
     QueryExpression queryExpression = QueryExpression.create(pathList, null);
     QueryDataSet dataSet = tsFileReader.query(queryExpression);
     RowRecord record = dataSet.next();
@@ -256,9 +256,9 @@ public class RestorableTsFileIOWriterTest {
     rWriter.close();
 
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
-    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1"));
+    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2", true));
     assertNotNull(chunkMetadataList);
     reader.close();
   }
@@ -300,13 +300,13 @@ public class RestorableTsFileIOWriterTest {
     rWriter.close();
 
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
-    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1"));
+    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s2", true));
     assertNotNull(chunkMetadataList);
     reader.close();
   }
@@ -348,13 +348,13 @@ public class RestorableTsFileIOWriterTest {
     rWriter.close();
 
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
-    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1"));
+    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s2", true));
     assertNotNull(chunkMetadataList);
     reader.close();
   }
@@ -397,13 +397,13 @@ public class RestorableTsFileIOWriterTest {
     rWriter.close();
 
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
-    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1"));
+    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s1"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d2", "s2", true));
     assertNotNull(chunkMetadataList);
     reader.close();
   }
@@ -434,9 +434,9 @@ public class RestorableTsFileIOWriterTest {
     rWriter.close();
 
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
-    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1"));
+    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1", true));
     assertNotNull(chunkMetadataList);
-    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2"));
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2", true));
     assertNotNull(chunkMetadataList);
     reader.close();
   }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriterMemoryControlTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriterMemoryControlTest.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
@@ -132,7 +133,7 @@ public class TsFileIOWriterMemoryControlTest {
               writer.chunkGroupMetadataList,
               writer.endPosInCMTForDevice);
       for (int i = 0; iterator.hasNext(); ++i) {
-        Pair<String, TimeseriesMetadata> timeseriesMetadataPair = iterator.next();
+        Pair<Path, TimeseriesMetadata> timeseriesMetadataPair = iterator.next();
         TimeseriesMetadata timeseriesMetadata = timeseriesMetadataPair.right;
         Assert.assertEquals(sortedSeriesId.get(i % 5), timeseriesMetadata.getMeasurementId());
         Assert.assertEquals(
@@ -169,8 +170,8 @@ public class TsFileIOWriterMemoryControlTest {
           TSMIterator.getTSMIteratorInDisk(
               writer.chunkMetadataTempFile, new ArrayList<>(), writer.endPosInCMTForDevice);
       for (int i = 0; iterator.hasNext(); ++i) {
-        Pair<String, TimeseriesMetadata> timeseriesMetadataPair = iterator.next();
-        String fullPath = timeseriesMetadataPair.left;
+        Pair<Path, TimeseriesMetadata> timeseriesMetadataPair = iterator.next();
+        String fullPath = timeseriesMetadataPair.left.getFullPath();
         TimeseriesMetadata timeseriesMetadata = timeseriesMetadataPair.right;
         Assert.assertEquals(measurementIds.get(i), fullPath);
         Assert.assertEquals(
@@ -233,8 +234,8 @@ public class TsFileIOWriterMemoryControlTest {
           TSMIterator.getTSMIteratorInDisk(
               writer.chunkMetadataTempFile, new ArrayList<>(), writer.endPosInCMTForDevice);
       for (int i = 0; i < originChunkMetadataList.size(); ++i) {
-        Pair<String, TimeseriesMetadata> timeseriesMetadataPair = iterator.next();
-        Assert.assertEquals(seriesIds.get(i), timeseriesMetadataPair.left);
+        Pair<Path, TimeseriesMetadata> timeseriesMetadataPair = iterator.next();
+        Assert.assertEquals(seriesIds.get(i), timeseriesMetadataPair.left.getFullPath());
         Assert.assertEquals(
             originChunkMetadataList.get(i).getDataType(),
             timeseriesMetadataPair.right.getTSDataType());


### PR DESCRIPTION
See [IOTDB-4791](https://issues.apache.org/jira/browse/IOTDB-4791).

The may reason for the performance bottleneck of `TsFileIOWriter::endFile` is the path validation for in the constructor function of Path. This pr optimizes it by skipping the validation of path when flushing metadata because the path is validated when data is inserting.