### PR TITLE
[IOTDB-4810] Fix print-tsfile-sketch.bat bug when reading measurementID containing Chinese

### DIFF
--- a/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-sketch.bat
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-sketch.bat
@@ -33,6 +33,11 @@ if NOT DEFINED MAIN_CLASS set MAIN_CLASS=org.apache.iotdb.db.tools.TsFileSketchT
 if NOT DEFINED JAVA_HOME goto :err
 
 @REM -----------------------------------------------------------------------------
+@REM JVM Opts
+set JAVA_OPTS=-ea^
+ -Dfile.encoding=UTF-8
+
+@REM -----------------------------------------------------------------------------
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
 set CLASSPATH="%IOTDB_HOME%\lib\*"
@@ -46,7 +51,7 @@ goto :eof
 @REM -----------------------------------------------------------------------------
 :okClasspath
 
-"%JAVA_HOME%\bin\java" -cp "%CLASSPATH%" %MAIN_CLASS% %*
+"%JAVA_HOME%\bin\java" %JAVA_OPTS% -cp "%CLASSPATH%" %MAIN_CLASS% %*
 
 goto finally
 


### PR DESCRIPTION
`print-tsfile-sketch.bat` went wrong when reading measurementID with Chinese characters.
Specifically, it is the following code that does not return correct results:
```
int measurementIdLength = measurementID.getBytes(TSFileConfig.STRING_CHARSET).length; 
```
For example, if measurementID="电机绕组温度1", the correct measurementIdLength is 20,
while `print-tsfile-sketch.bat` assigns measurementIdLength as 30, which is wrong.
This pr fixes this bug by adding JAVA_OPTS -Dfile.encoding=UTF-8 in `print-tsfile-sketch.bat`.