### PR TITLE
fix a document typo

### DIFF
--- a/docs/UserGuide/UDF-Library/M4.md
+++ b/docs/UserGuide/UDF-Library/M4.md
@@ -24,4 +24,4 @@
 
 ## M4
 
-The documentation of M4 has been removed to [Query Data->Select Expression->Time Series Generating Functions](../Query-Data/Select-Expression.md).
+The documentation of M4 has been moved to [Query Data->Select Expression->Time Series Generating Functions](../Query-Data/Select-Expression.md).


### PR DESCRIPTION
Fix a typo in `docs/UserGuide/UDF-Library/M4.md`. (I need to conserve the website link of docs/UserGuide/UDF-Library/M4.md for some time, so I don't remove that doc right now.)