### PR TITLE
Fix isBlocked bug of schema query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperator.java
@@ -37,11 +37,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import static com.google.common.util.concurrent.Futures.successfulAsList;
+
 public class CountMergeOperator implements ProcessOperator {
   private final PlanNodeId planNodeId;
   private final OperatorContext operatorContext;
 
-  private List<TsBlock> tsBlockList = new ArrayList<>();
+  private final TsBlock[] childrenTsBlocks;
+
+  private List<TsBlock> resultTsBlockList;
   private int currentIndex = 0;
 
   private final List<Operator> children;
@@ -54,6 +58,8 @@ public class CountMergeOperator implements ProcessOperator {
     this.operatorContext = operatorContext;
     this.children = children;
     isGroupByLevel = children.get(0) instanceof LevelTimeSeriesCountOperator;
+
+    childrenTsBlocks = new TsBlock[children.size()];
   }
 
   @Override
@@ -63,24 +69,17 @@ public class CountMergeOperator implements ProcessOperator {
 
   @Override
   public ListenableFuture<?> isBlocked() {
-    for (Operator child : children) {
-      while (!child.isFinished()) {
-        ListenableFuture<?> blocked = child.isBlocked();
+    List<ListenableFuture<?>> listenableFutureList = new ArrayList<>(children.size());
+    for (int i = 0; i < children.size(); i++) {
+      if (childrenTsBlocks[i] == null) {
+        ListenableFuture<?> blocked = children.get(i).isBlocked();
         if (!blocked.isDone()) {
-          return blocked;
-        }
-        if (child.hasNext()) {
-          TsBlock tsBlock = child.next();
-          if (null != tsBlock && !tsBlock.isEmpty()) {
-            tsBlockList.add(tsBlock);
-          }
+          listenableFutureList.add(blocked);
         }
       }
     }
 
-    generateResultTsBlockList();
-
-    return NOT_BLOCKED;
+    return listenableFutureList.isEmpty() ? NOT_BLOCKED : successfulAsList(listenableFutureList);
   }
 
   @Override
@@ -88,8 +87,32 @@ public class CountMergeOperator implements ProcessOperator {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
-    currentIndex++;
-    return tsBlockList.get(currentIndex - 1);
+    if (resultTsBlockList != null) {
+      currentIndex++;
+      return resultTsBlockList.get(currentIndex - 1);
+    }
+    boolean allChildrenReady = true;
+    for (int i = 0; i < children.size(); i++) {
+      if (childrenTsBlocks[i] == null) {
+        // when this operator is not blocked, it means all children that have not return TsBlock is
+        // not blocked.
+        if (children.get(i).hasNext()) {
+          TsBlock tsBlock = children.get(i).next();
+          if (tsBlock == null || tsBlock.isEmpty()) {
+            allChildrenReady = false;
+          } else {
+            childrenTsBlocks[i] = tsBlock;
+          }
+        }
+      }
+    }
+    if (allChildrenReady) {
+      generateResultTsBlockList();
+      currentIndex++;
+      return resultTsBlockList.get(currentIndex - 1);
+    } else {
+      return null;
+    }
   }
 
   private void generateResultTsBlockList() {
@@ -102,7 +125,7 @@ public class CountMergeOperator implements ProcessOperator {
 
   private void generateResultWithoutGroupByLevel() {
     int totalCount = 0;
-    for (TsBlock tsBlock : tsBlockList) {
+    for (TsBlock tsBlock : childrenTsBlocks) {
       int count = tsBlock.getColumn(0).getInt(0);
       totalCount += count;
     }
@@ -110,19 +133,19 @@ public class CountMergeOperator implements ProcessOperator {
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
     tsBlockBuilder.getColumnBuilder(0).writeInt(totalCount);
     tsBlockBuilder.declarePosition();
-    this.tsBlockList = Collections.singletonList(tsBlockBuilder.build());
+    this.resultTsBlockList = Collections.singletonList(tsBlockBuilder.build());
   }
 
   private void generateResultWithGroupByLevel() {
     Map<String, Integer> countMap = new HashMap<>();
-    for (TsBlock tsBlock : tsBlockList) {
+    for (TsBlock tsBlock : childrenTsBlocks) {
       for (int i = 0; i < tsBlock.getPositionCount(); i++) {
         String columnName = tsBlock.getColumn(0).getBinary(i).getStringValue();
         int count = tsBlock.getColumn(1).getInt(i);
         countMap.put(columnName, countMap.getOrDefault(columnName, 0) + count);
       }
     }
-    this.tsBlockList =
+    this.resultTsBlockList =
         SchemaTsBlockUtil.transferSchemaResultToTsBlockList(
             countMap.entrySet().iterator(),
             Arrays.asList(TSDataType.TEXT, TSDataType.INT32),
@@ -136,7 +159,7 @@ public class CountMergeOperator implements ProcessOperator {
 
   @Override
   public boolean hasNext() {
-    return currentIndex < tsBlockList.size();
+    return resultTsBlockList == null || currentIndex < resultTsBlockList.size();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/NodePathsCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/NodePathsCountOperator.java
@@ -65,26 +65,11 @@ public class NodePathsCountOperator implements ProcessOperator {
 
   @Override
   public TsBlock next() {
-    isFinished = true;
-    TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
-
-    tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-    tsBlockBuilder.getColumnBuilder(0).writeInt(nodePaths.size());
-    tsBlockBuilder.declarePosition();
-    return tsBlockBuilder.build();
-  }
-
-  @Override
-  public boolean hasNext() {
-    return !isFinished;
-  }
-
-  @Override
-  public ListenableFuture<?> isBlocked() {
     while (!child.isFinished()) {
+      // read as much child result as possible
       ListenableFuture<?> blocked = child.isBlocked();
       if (!blocked.isDone()) {
-        return blocked;
+        return null;
       }
       if (child.hasNext()) {
         TsBlock tsBlock = child.next();
@@ -96,7 +81,23 @@ public class NodePathsCountOperator implements ProcessOperator {
         }
       }
     }
-    return NOT_BLOCKED;
+    isFinished = true;
+    TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
+
+    tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
+    tsBlockBuilder.getColumnBuilder(0).writeInt(nodePaths.size());
+    tsBlockBuilder.declarePosition();
+    return tsBlockBuilder.build();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return !child.isFinished() || !isFinished;
+  }
+
+  @Override
+  public ListenableFuture<?> isBlocked() {
+    return child.isBlocked();
   }
 
   @Override

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperatorTest.java
@@ -191,7 +191,9 @@ public class CountMergeOperatorTest {
       Assert.assertTrue(countMergeOperator.isBlocked().isDone());
       while (countMergeOperator.hasNext()) {
         tsBlock = countMergeOperator.next();
-        assertFalse(countMergeOperator.hasNext());
+        if (tsBlock != null) {
+          assertFalse(countMergeOperator.hasNext());
+        }
       }
       assertNotNull(tsBlock);
       for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
## Description

The isBlocked ListenableFuture of child will change status after returned from current merge operator to query driver, which results in the driver may directly start invoking hasNext and next method of current merge operator before all data prepared well.