### PR TITLE
[IOTDB-4230]fix start-cli.sh does not support -e

### DIFF
--- a/cli/src/assembly/resources/sbin/start-cli.sh
+++ b/cli/src/assembly/resources/sbin/start-cli.sh
@@ -111,14 +111,8 @@ IOTDB_CLI_CONF=${IOTDB_HOME}/conf
 MAIN_CLASS=org.apache.iotdb.cli.Cli
 
 
-if [ -d ${IOTDB_HOME}/lib ]; then
-LIB_PATH=${IOTDB_HOME}/lib
-else
-LIB_PATH=${IOTDB_HOME}/../lib
-fi
-
 CLASSPATH=""
-for f in ${LIB_PATH}/*.jar; do
+for f in ${IOTDB_HOME}/lib/*.jar; do
   CLASSPATH=${CLASSPATH}":"$f
 done
 
@@ -133,35 +127,6 @@ if [ -n "$JAVA_HOME" ]; then
 else
     JAVA=java
 fi
-
-PARAMETERS="$@"
-
-# if [ $# -eq 0 ]
-# then
-# 	PARAMETERS="-h 127.0.0.1 -p 6667 -u root -pw root"
-# fi
-
-# Added parameters when default parameters are missing
-
-# sh version
-case "$PARAMETERS" in
-*"-pw "*) PARAMETERS=$PARAMETERS ;;
-*            ) PARAMETERS="-pw root $PARAMETERS" ;;
-esac
-case "$PARAMETERS" in
-*"-u "*) PARAMETERS=$PARAMETERS ;;
-*            ) PARAMETERS="-u root $PARAMETERS" ;;
-esac
-case "$PARAMETERS" in
-*"-p "*) PARAMETERS=$PARAMETERS ;;
-*            ) PARAMETERS="-p 6667 $PARAMETERS" ;;
-esac
-case "$PARAMETERS" in
-*"-h "*) PARAMETERS=$PARAMETERS ;;
-*            ) PARAMETERS="-h 127.0.0.1 $PARAMETERS" ;;
-esac
-
-# echo $PARAMETERS
 
 set -o noglob
 iotdb_cli_params="-Dlogback.configurationFile=${IOTDB_CLI_CONF}/logback-cli.xml"


### PR DESCRIPTION
this pr fix "-e can not be used in start-cli.sh" bug introduced in https://github.com/apache/iotdb/pull/7802