### PR TITLE
Hide all SchemaFile options in config file

### DIFF
--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -244,7 +244,7 @@
 ### Schema Engine Configuration
 ####################
 
-# Choose the mode of schema engine. The value could be Memory,Schema_File and Rocksdb_based. If the provided value doesn't match any pre-defined value, Memory mode will be used as default.
+# Choose the mode of schema engine. The value could be Memory and Rocksdb_based. If the provided value doesn't match any pre-defined value, Memory mode will be used as default.
 # Datatype: string
 # schema_engine_mode=Memory
 
@@ -271,25 +271,6 @@
 # It is possible to lose at most tag_attribute_flush_interval records
 # tag_attribute_flush_interval=1000
 
-####################
-### Schema File Configuration
-####################
-# The minimum size (in bytes) allocated for a node in schema file
-# A large number for this will make it faster while occupying more space, or otherwise
-# The default 0 means if a flushed internal(entity) had less than 20 children, it will get a segment with the size calculated from total size of its children
-# If no child, it would get a segment of 25 bytes, which is the size of segment header
-# Datatype: short
-# minimum_schema_file_segment_in_bytes=0
-
-# The cache size for schema page in one schema file
-# A bigger cache makes it faster but costs more space and more volatile when evicts item from cache
-# Datatype: int
-# page_cache_in_schema_file=1024
-
-# The maximum number of log entries before the log is erased, impacting performance if too small
-# Since pages in Schema File is set to 16KiB, the log can be restricted as 16Kib * schema_log_size, 256MB default
-# Datatype: int
-# schema_file_log_size=16384
 
 ####################
 ### Cache Configuration

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -244,10 +244,6 @@
 ### Schema Engine Configuration
 ####################
 
-# Choose the mode of schema engine. The value could be Memory and Rocksdb_based. If the provided value doesn't match any pre-defined value, Memory mode will be used as default.
-# Datatype: string
-# schema_engine_mode=Memory
-
 # cache size for SchemaRegion.
 # This cache is used to improve insert speed where all path check and TSDataType will be cached in SchemaRegion with corresponding Path.
 # Datatype: int


### PR DESCRIPTION
## Description
Since SchemaFile has not been finished, all config entries has been hide from iotdb-common.properties.