### PR TITLE
[IOTDB-3773] [IOTDB-4831] Optimize the rpc call numbers in query processing & make query cost time print more accurate

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
@@ -606,12 +606,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -651,12 +651,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -706,7 +706,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -952,7 +952,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -1061,7 +1061,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -1116,12 +1116,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -1230,12 +1230,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -1330,7 +1330,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -1399,7 +1399,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -1452,12 +1452,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -1501,12 +1501,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -1705,7 +1705,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -1761,12 +1761,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -1806,12 +1806,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -1952,7 +1952,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -2006,12 +2006,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -2047,12 +2047,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -2171,7 +2171,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -2211,7 +2211,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -2383,7 +2383,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -2560,7 +2560,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -2763,7 +2763,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         true,
         client,
         null,
-        0,
+        -1,
         sessionId,
         Collections.singletonList(tsBlock),
         null,
@@ -2806,12 +2806,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override
@@ -2860,12 +2860,12 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
         false,
         client,
         null,
-        0,
+        -1,
         sessionId,
         null,
         null,
         (long) 60 * 1000,
-        true);
+        false);
   }
 
   @Override

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
@@ -60,8 +60,6 @@ public class IoTDBJDBCResultSet implements ResultSet {
   protected List<String> columnTypeList;
   protected IoTDBRpcDataSet ioTDBRpcDataSet;
   protected IoTDBTracingInfo ioTDBRpcTracingInfo;
-  private boolean isRpcFetchResult = true;
-
   private String operationType = "";
   private List<String> columns = null;
   private List<String> sgColumns = null;
@@ -82,7 +80,8 @@ public class IoTDBJDBCResultSet implements ResultSet {
       String operationType,
       List<String> columns,
       List<String> sgColumns,
-      BitSet aliasColumnMap)
+      BitSet aliasColumnMap,
+      boolean moreData)
       throws SQLException {
     this.ioTDBRpcDataSet =
         new IoTDBRpcDataSet(
@@ -91,7 +90,7 @@ public class IoTDBJDBCResultSet implements ResultSet {
             columnTypeList,
             columnNameIndex,
             ignoreTimeStamp,
-            true,
+            moreData,
             queryId,
             ((IoTDBStatement) statement).getStmtId(),
             client,
@@ -125,7 +124,7 @@ public class IoTDBJDBCResultSet implements ResultSet {
       List<ByteBuffer> dataSet,
       TSTracingInfo tracingInfo,
       long timeout,
-      boolean isRpcFetchResult)
+      boolean moreData)
       throws SQLException {
     this.ioTDBRpcDataSet =
         new IoTDBRpcDataSet(
@@ -134,7 +133,7 @@ public class IoTDBJDBCResultSet implements ResultSet {
             columnTypeList,
             columnNameIndex,
             ignoreTimeStamp,
-            isRpcFetchResult,
+            moreData,
             queryId,
             ((IoTDBStatement) statement).getStmtId(),
             client,
@@ -144,7 +143,6 @@ public class IoTDBJDBCResultSet implements ResultSet {
             timeout);
     this.statement = statement;
     this.columnTypeList = columnTypeList;
-    this.isRpcFetchResult = isRpcFetchResult;
     if (tracingInfo != null) {
       ioTDBRpcTracingInfo = new IoTDBTracingInfo();
       ioTDBRpcTracingInfo.setTsTracingInfo(tracingInfo);

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -302,7 +302,7 @@ public class IoTDBStatement implements Statement {
                 execResp.queryResult,
                 execResp.tracingInfo,
                 execReq.timeout,
-                true);
+                execResp.moreData);
       }
       return true;
     }
@@ -457,7 +457,8 @@ public class IoTDBStatement implements Statement {
               execResp.operationType,
               execResp.columns,
               execResp.sgColumns,
-              aliasColumn);
+              aliasColumn,
+              execResp.moreData);
     }
     return resultSet;
   }

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
@@ -28,7 +28,6 @@ import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataResp;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
-import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.read.common.block.column.TsBlockSerde;
@@ -39,8 +38,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.sql.ResultSet;
@@ -51,7 +48,6 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import static org.mockito.Matchers.any;
@@ -248,127 +244,7 @@ public class IoTDBJDBCResultSetTest {
     }
 
     // The client get TSQueryDataSet at the first request
-    verify(fetchResultsResp, times(1)).getStatus();
-  }
-
-  // fake the first-time fetched result of 'testSql' from an IoTDB server
-  private TSQueryDataSet FakedFirstFetchResult() throws IOException {
-    List<TSDataType> tsDataTypeList = new ArrayList<>();
-    tsDataTypeList.add(TSDataType.FLOAT); // root.vehicle.d0.s2
-    tsDataTypeList.add(TSDataType.INT64); // root.vehicle.d0.s1
-    tsDataTypeList.add(TSDataType.INT32); // root.vehicle.d0.s0
-
-    Object[][] input = {
-      {
-        2L, 2.22F, 40000L, null,
-      },
-      {
-        3L, 3.33F, null, null,
-      },
-      {
-        4L, 4.44F, null, null,
-      },
-      {
-        50L, null, 50000L, null,
-      },
-      {
-        100L, null, 199L, null,
-      },
-      {
-        101L, null, 199L, null,
-      },
-      {
-        103L, null, 199L, null,
-      },
-      {
-        105L, 11.11F, 199L, 33333,
-      },
-      {
-        1000L, 1000.11F, 55555L, 22222,
-      }
-    };
-
-    int columnNum = tsDataTypeList.size();
-    TSQueryDataSet tsQueryDataSet = new TSQueryDataSet();
-    // one time column and each value column has a actual value buffer and a bitmap value to
-    // indicate whether it is a null
-    int columnNumWithTime = columnNum * 2 + 1;
-    DataOutputStream[] dataOutputStreams = new DataOutputStream[columnNumWithTime];
-    ByteArrayOutputStream[] byteArrayOutputStreams = new ByteArrayOutputStream[columnNumWithTime];
-    for (int i = 0; i < columnNumWithTime; i++) {
-      byteArrayOutputStreams[i] = new ByteArrayOutputStream();
-      dataOutputStreams[i] = new DataOutputStream(byteArrayOutputStreams[i]);
-    }
-
-    int rowCount = input.length;
-    int[] valueOccupation = new int[columnNum];
-    // used to record a bitmap for every 8 row record
-    int[] bitmap = new int[columnNum];
-    for (int i = 0; i < rowCount; i++) {
-      Object[] row = input[i];
-      // use columnOutput to write byte array
-      dataOutputStreams[0].writeLong((long) row[0]);
-      for (int k = 0; k < columnNum; k++) {
-        Object value = row[1 + k];
-        DataOutputStream dataOutputStream = dataOutputStreams[2 * k + 1]; // DO NOT FORGET +1
-        if (value == null) {
-          bitmap[k] = (bitmap[k] << 1);
-        } else {
-          bitmap[k] = (bitmap[k] << 1) | 0x01;
-          if (k == 0) { // TSDataType.FLOAT
-            dataOutputStream.writeFloat((float) value);
-            valueOccupation[k] += 4;
-          } else if (k == 1) { // TSDataType.INT64
-            dataOutputStream.writeLong((long) value);
-            valueOccupation[k] += 8;
-          } else { // TSDataType.INT32
-            dataOutputStream.writeInt((int) value);
-            valueOccupation[k] += 4;
-          }
-        }
-      }
-      if (i % 8 == 7) {
-        for (int j = 0; j < bitmap.length; j++) {
-          DataOutputStream dataBitmapOutputStream = dataOutputStreams[2 * (j + 1)];
-          dataBitmapOutputStream.writeByte(bitmap[j]);
-          // we should clear the bitmap every 8 row record
-          bitmap[j] = 0;
-        }
-      }
-    }
-
-    // feed the remaining bitmap
-    for (int j = 0; j < bitmap.length; j++) {
-      DataOutputStream dataBitmapOutputStream = dataOutputStreams[2 * (j + 1)];
-      dataBitmapOutputStream.writeByte(bitmap[j] << (8 - rowCount % 8));
-    }
-
-    // calculate the time buffer size
-    int timeOccupation = rowCount * 8;
-    ByteBuffer timeBuffer = ByteBuffer.allocate(timeOccupation);
-    timeBuffer.put(byteArrayOutputStreams[0].toByteArray());
-    timeBuffer.flip();
-    tsQueryDataSet.setTime(timeBuffer);
-
-    // calculate the bitmap buffer size
-    int bitmapOccupation = rowCount / 8 + 1;
-
-    List<ByteBuffer> bitmapList = new LinkedList<>();
-    List<ByteBuffer> valueList = new LinkedList<>();
-    for (int i = 1; i < byteArrayOutputStreams.length; i += 2) {
-      ByteBuffer valueBuffer = ByteBuffer.allocate(valueOccupation[(i - 1) / 2]);
-      valueBuffer.put(byteArrayOutputStreams[i].toByteArray());
-      valueBuffer.flip();
-      valueList.add(valueBuffer);
-
-      ByteBuffer bitmapBuffer = ByteBuffer.allocate(bitmapOccupation);
-      bitmapBuffer.put(byteArrayOutputStreams[i + 1].toByteArray());
-      bitmapBuffer.flip();
-      bitmapList.add(bitmapBuffer);
-    }
-    tsQueryDataSet.setBitmapList(bitmapList);
-    tsQueryDataSet.setValueList(valueList);
-    return tsQueryDataSet;
+    verify(fetchResultsResp, times(0)).getStatus();
   }
 
   private void constructObjectList(List<Object> standardObject) {
@@ -406,6 +282,7 @@ public class IoTDBJDBCResultSetTest {
     }
   }
 
+  // fake the first-time fetched result of 'testSql' from an IoTDB server
   private List<ByteBuffer> FakedFirstFetchTsBlockResult() {
     List<TSDataType> tsDataTypeList = new ArrayList<>();
     tsDataTypeList.add(TSDataType.FLOAT); // root.vehicle.d0.s2

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/IQueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/IQueryExecution.java
@@ -49,4 +49,8 @@ public interface IQueryExecution {
   boolean isQuery();
 
   String getQueryId();
+
+  long getStartExecutionTime();
+
+  Optional<String> getExecuteSQL();
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -579,6 +579,16 @@ public class QueryExecution implements IQueryExecution {
     return context.getQueryId().getId();
   }
 
+  @Override
+  public long getStartExecutionTime() {
+    return context.getStartTime();
+  }
+
+  @Override
+  public Optional<String> getExecuteSQL() {
+    return Optional.ofNullable(context.getSql());
+  }
+
   public String toString() {
     return String.format("QueryExecution[%s]", context.getQueryId());
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ConfigExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ConfigExecution.java
@@ -219,4 +219,14 @@ public class ConfigExecution implements IQueryExecution {
   public String getQueryId() {
     return context.getQueryId().getId();
   }
+
+  @Override
+  public long getStartExecutionTime() {
+    return context.getStartTime();
+  }
+
+  @Override
+  public Optional<String> getExecuteSQL() {
+    return Optional.ofNullable(context.getSql());
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -127,11 +127,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.iotdb.db.service.basic.ServiceProvider.AUDIT_LOGGER;
-import static org.apache.iotdb.db.service.basic.ServiceProvider.CONFIG;
 import static org.apache.iotdb.db.service.basic.ServiceProvider.CURRENT_RPC_VERSION;
 import static org.apache.iotdb.db.service.basic.ServiceProvider.QUERY_FREQUENCY_RECORDER;
-import static org.apache.iotdb.db.service.basic.ServiceProvider.SESSION_MANAGER;
-import static org.apache.iotdb.db.service.basic.ServiceProvider.SLOW_SQL_LOGGER;
 import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onIoTDBException;
 import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onNPEOrUnexpectedException;
 import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onQueryException;
@@ -239,10 +236,6 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
           onQueryException(e, "\"" + statement + "\". " + OperationType.EXECUTE_STATEMENT));
     } finally {
       addOperationLatency(Operation.EXECUTE_QUERY, startTime);
-      long costTime = System.currentTimeMillis() - startTime;
-      if (costTime >= CONFIG.getSlowQueryThreshold()) {
-        SLOW_SQL_LOGGER.info("Cost: {} ms, sql is {}", costTime, statement);
-      }
     }
   }
 
@@ -300,10 +293,6 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
           onQueryException(e, "\"" + req + "\". " + OperationType.EXECUTE_RAW_DATA_QUERY));
     } finally {
       addOperationLatency(Operation.EXECUTE_QUERY, startTime);
-      long costTime = System.currentTimeMillis() - startTime;
-      if (costTime >= CONFIG.getSlowQueryThreshold()) {
-        SLOW_SQL_LOGGER.info("Cost: {} ms, sql is {}", costTime, req);
-      }
     }
   }
 
@@ -360,10 +349,6 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
           onQueryException(e, "\"" + req + "\". " + OperationType.EXECUTE_LAST_DATA_QUERY));
     } finally {
       addOperationLatency(Operation.EXECUTE_QUERY, startTime);
-      long costTime = System.currentTimeMillis() - startTime;
-      if (costTime >= CONFIG.getSlowQueryThreshold()) {
-        SLOW_SQL_LOGGER.info("Cost: {} ms, sql is {}", costTime, req);
-      }
     }
   }
 
@@ -1516,10 +1501,6 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       return null;
     } finally {
       addOperationLatency(Operation.EXECUTE_QUERY, startTime);
-      long costTime = System.currentTimeMillis() - startTime;
-      if (costTime >= CONFIG.getSlowQueryThreshold()) {
-        SLOW_SQL_LOGGER.info("Cost: {} ms, sql is {}", costTime, statement);
-      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -414,7 +414,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
 
       if (queryExecution == null) {
         resp.setHasResultSet(false);
-        resp.setMoreData(true);
+        resp.setMoreData(false);
         return resp;
       }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.BitMap;
 import org.apache.iotdb.tsfile.utils.BytesUtils;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -179,8 +180,9 @@ public class QueryDataSetUtils {
     return tsQueryDataSet;
   }
 
-  public static TSQueryDataSet convertTsBlockByFetchSize(
+  public static Pair<TSQueryDataSet, Boolean> convertTsBlockByFetchSize(
       IQueryExecution queryExecution, int fetchSize) throws IOException, IoTDBException {
+    boolean finished = false;
     int columnNum = queryExecution.getOutputValueColumnCount();
     TSQueryDataSet tsQueryDataSet = new TSQueryDataSet();
     // one time column and each value column has an actual value buffer and a bitmap value to
@@ -201,6 +203,7 @@ public class QueryDataSetUtils {
     while (rowCount < fetchSize) {
       Optional<TsBlock> optionalTsBlock = queryExecution.getBatchResult();
       if (!optionalTsBlock.isPresent()) {
+        finished = true;
         break;
       }
       TsBlock tsBlock = optionalTsBlock.get();
@@ -371,17 +374,20 @@ public class QueryDataSetUtils {
     }
     tsQueryDataSet.setBitmapList(bitmapList);
     tsQueryDataSet.setValueList(valueList);
-    return tsQueryDataSet;
+    return new Pair<>(tsQueryDataSet, finished);
   }
 
+  /** pair.left is serialized TsBlock pair.right indicates if the query finished */
   // To fetch required amounts of data and combine them through List
-  public static List<ByteBuffer> convertQueryResultByFetchSize(
+  public static Pair<List<ByteBuffer>, Boolean> convertQueryResultByFetchSize(
       IQueryExecution queryExecution, int fetchSize) throws IoTDBException {
     int rowCount = 0;
     List<ByteBuffer> res = new ArrayList<>();
+    boolean finished = false;
     while (rowCount < fetchSize) {
       Optional<ByteBuffer> optionalByteBuffer = queryExecution.getByteBufferBatchResult();
       if (!optionalByteBuffer.isPresent()) {
+        finished = true;
         break;
       }
       ByteBuffer byteBuffer = optionalByteBuffer.get();
@@ -397,7 +403,7 @@ public class QueryDataSetUtils {
       }
       rowCount += positionCount;
     }
-    return res;
+    return new Pair<>(res, finished);
   }
 
   public static long[] readTimesFromBuffer(ByteBuffer buffer, int size) {

--- a/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
@@ -383,11 +383,9 @@ public class QueryDataSetUtils {
       IQueryExecution queryExecution, int fetchSize) throws IoTDBException {
     int rowCount = 0;
     List<ByteBuffer> res = new ArrayList<>();
-    boolean finished = false;
     while (rowCount < fetchSize) {
       Optional<ByteBuffer> optionalByteBuffer = queryExecution.getByteBufferBatchResult();
       if (!optionalByteBuffer.isPresent()) {
-        finished = true;
         break;
       }
       ByteBuffer byteBuffer = optionalByteBuffer.get();
@@ -403,7 +401,7 @@ public class QueryDataSetUtils {
       }
       rowCount += positionCount;
     }
-    return new Pair<>(res, finished);
+    return new Pair<>(res, !queryExecution.hasNextResult());
   }
 
   public static long[] readTimesFromBuffer(ByteBuffer buffer, int size) {

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -377,7 +377,8 @@ public class SessionConnection {
         sessionId,
         execResp.queryResult,
         execResp.isIgnoreTimeStamp(),
-        timeout);
+        timeout,
+        execResp.moreData);
   }
 
   protected void executeNonQueryStatement(String sql)
@@ -439,7 +440,8 @@ public class SessionConnection {
         client,
         sessionId,
         execResp.queryResult,
-        execResp.isIgnoreTimeStamp());
+        execResp.isIgnoreTimeStamp(),
+        execResp.moreData);
   }
 
   protected SessionDataSet executeLastDataQuery(List<String> paths, long time, long timeOut)
@@ -478,7 +480,8 @@ public class SessionConnection {
         client,
         sessionId,
         tsExecuteStatementResp.queryResult,
-        tsExecuteStatementResp.isIgnoreTimeStamp());
+        tsExecuteStatementResp.isIgnoreTimeStamp(),
+        tsExecuteStatementResp.moreData);
   }
 
   protected void insertRecord(TSInsertRecordReq request)

--- a/session/src/main/java/org/apache/iotdb/session/SessionDataSet.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionDataSet.java
@@ -51,7 +51,8 @@ public class SessionDataSet implements AutoCloseable {
       IClientRPCService.Iface client,
       long sessionId,
       List<ByteBuffer> queryResult,
-      boolean ignoreTimeStamp) {
+      boolean ignoreTimeStamp,
+      boolean moreData) {
     this.ioTDBRpcDataSet =
         new IoTDBRpcDataSet(
             sql,
@@ -59,7 +60,7 @@ public class SessionDataSet implements AutoCloseable {
             columnTypeList,
             columnNameIndex,
             ignoreTimeStamp,
-            true,
+            moreData,
             queryId,
             statementId,
             client,
@@ -80,7 +81,8 @@ public class SessionDataSet implements AutoCloseable {
       long sessionId,
       List<ByteBuffer> queryResult,
       boolean ignoreTimeStamp,
-      long timeout) {
+      long timeout,
+      boolean moreData) {
     this.ioTDBRpcDataSet =
         new IoTDBRpcDataSet(
             sql,
@@ -88,7 +90,7 @@ public class SessionDataSet implements AutoCloseable {
             columnTypeList,
             columnNameIndex,
             ignoreTimeStamp,
-            true,
+            moreData,
             queryId,
             statementId,
             client,

--- a/thrift/src/main/thrift/client.thrift
+++ b/thrift/src/main/thrift/client.thrift
@@ -68,6 +68,7 @@ struct TSExecuteStatementResp {
   11: optional list<byte> aliasColumns
   12: optional TSTracingInfo tracingInfo
   13: optional list<binary> queryResult
+  14: optional bool moreData
 }
 
 enum TSProtocolVersion {
@@ -176,6 +177,7 @@ struct TSFetchResultsResp{
   4: optional TSQueryDataSet queryDataSet
   5: optional TSQueryNonAlignDataSet nonAlignQueryDataSet
   6: optional list<binary> queryResult
+  7: optional bool moreData
 }
 
 struct TSFetchMetadataResp{


### PR DESCRIPTION
In this pr, i did two optimization
1. [[IOTDB-3773]](https://issues.apache.org/jira/browse/IOTDB-3773) previously we will print slow query time cost after the first batch is returned which is totally wrong because the printed time is not the real time it cost. So, in this pr, I move the print logics into cleanUpQuery which is the end point of this query.
2. [[IOTDB-4831]](https://issues.apache.org/jira/browse/IOTDB-4831) previously, even if there is no more data in server side, client will still need one more rpc call to fetch result and then client found that this rpc call return no data, it will end.
However, we can add a `moreData` field in response to indicate that there is no more data in server side after this rpc call and client can use this filed to decide whether to do another one rpc to fetch data from server side. I also release QueryResource after there is no more data in server side which can to some extent prevent users from forgetting to call close which may cause resource leaky.