### PR TITLE
[To rel/0.13] Fix String number infer bug

### DIFF
--- a/client-cpp/pom.xml
+++ b/client-cpp/pom.xml
@@ -116,8 +116,8 @@
                 <cmake.root.dir>${project.parent.basedir}/compile-tools/thrift/target/cmake-${cmake-version}-win64-x64/</cmake.root.dir>
                 <thrift.exec.absolute.path>${project.parent.basedir}/compile-tools/thrift/target/build/compiler/cpp/bin/${cmake.build.type}/thrift.exe</thrift.exec.absolute.path>
                 <iotdb.server.script>start-server.bat</iotdb.server.script>
-                <boost.include.dir />
-                <boost.library.dir />
+                <boost.include.dir/>
+                <boost.library.dir/>
             </properties>
         </profile>
         <profile>

--- a/compile-tools/pom.xml
+++ b/compile-tools/pom.xml
@@ -35,7 +35,7 @@
         <cmake-version>3.17.3</cmake-version>
         <openssl.include.dir>-Dtrue1=true1</openssl.include.dir>
         <bison.executable.dir>-Dtrue1=true1</bison.executable.dir>
-        <cmake.build.type />
+        <cmake.build.type/>
     </properties>
     <modules>
         <module>thrift</module>
@@ -138,8 +138,8 @@
                 <thrift.make.executable>make</thrift.make.executable>
                 <thrift.compiler.executable>thrift.exe</thrift.compiler.executable>
                 <gradlew.executable>gradlew.bat</gradlew.executable>
-                <boost.include.dir />
-                <boost.library.dir />
+                <boost.include.dir/>
+                <boost.library.dir/>
             </properties>
         </profile>
     </profiles>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -29,7 +29,7 @@
     </parent>
     <artifactId>iotdb-distribution</artifactId>
     <name>IoTDB Distribution</name>
-    <modules />
+    <modules/>
     <build>
         <plugins>
             <plugin>

--- a/example/client-cpp-example/pom.xml
+++ b/example/client-cpp-example/pom.xml
@@ -84,7 +84,7 @@
             <properties>
                 <cmake.generator>Visual Studio 16 2019</cmake.generator>
                 <cmake.root.dir>${project.parent.basedir}/../compile-tools/thrift/target/cmake-${cmake-version}-win64-x64/</cmake.root.dir>
-                <boost.include.dir />
+                <boost.include.dir/>
             </properties>
         </profile>
         <profile>

--- a/example/trigger/pom.xml
+++ b/example/trigger/pom.xml
@@ -118,7 +118,7 @@
                                 <importOrder>
                                     <order>org.apache.iotdb,,javax,java,\#</order>
                                 </importOrder>
-                                <removeUnusedImports />
+                                <removeUnusedImports/>
                             </java>
                         </configuration>
                         <executions>

--- a/example/udf/pom.xml
+++ b/example/udf/pom.xml
@@ -118,7 +118,7 @@
                                 <importOrder>
                                     <order>org.apache.iotdb,,javax,java,\#</order>
                                 </importOrder>
-                                <removeUnusedImports />
+                                <removeUnusedImports/>
                             </java>
                         </configuration>
                         <executions>

--- a/grafana-connector/pom.xml
+++ b/grafana-connector/pom.xml
@@ -170,7 +170,7 @@
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                         <resource>META-INF/spring.schemas</resource>
                                     </transformer>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <mainClass>${start-class}</mainClass>
                                     </transformer>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -80,7 +80,7 @@
             <id>LocalStandalone</id>
             <properties>
                 <test.includedGroups>org.apache.iotdb.itbase.category.LocalStandaloneTest</test.includedGroups>
-                <test.excludedGroups />
+                <test.excludedGroups/>
             </properties>
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -142,7 +142,7 @@
             <id>Remote</id>
             <properties>
                 <test.includedGroups>org.apache.iotdb.itbase.category.RemoteTest</test.includedGroups>
-                <test.excludedGroups />
+                <test.excludedGroups/>
             </properties>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -206,7 +206,7 @@
             <id>Cluster</id>
             <properties>
                 <test.includedGroups>org.apache.iotdb.itbase.category.ClusterTest</test.includedGroups>
-                <test.excludedGroups />
+                <test.excludedGroups/>
             </properties>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -203,7 +203,7 @@
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>
-                                                <ignore />
+                                                <ignore/>
                                             </action>
                                         </pluginExecution>
                                     </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <sonar.junit.reportPaths>target/surefire-reports,target/failsafe-reports</sonar.junit.reportPaths>
         <!-- By default, the argLine is empty-->
         <gson.version>2.8.8</gson.version>
-        <argLine />
+        <argLine/>
         <!-- whether enable compiling the cpp client-->
         <client-cpp>false</client-cpp>
         <!-- disable enforcer by default-->
@@ -695,7 +695,7 @@
                             <importOrder>
                                 <order>org.apache.iotdb,,javax,java,\#</order>
                             </importOrder>
-                            <removeUnusedImports />
+                            <removeUnusedImports/>
                         </java>
                         <lineEndings>UNIX</lineEndings>
                     </configuration>
@@ -770,7 +770,7 @@
                         <phase>validate</phase>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                         <goals>
@@ -816,7 +816,7 @@
                                 </requireJavaVersion>
                                 <!-- Disabled for now as it breaks the ability to build single modules -->
                                 <!--reactorModuleConvergence/-->
-                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies" />
+                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
                             </rules>
                         </configuration>
                     </execution>

--- a/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
@@ -63,7 +63,11 @@ public class TypeInferenceUtils {
   }
 
   private static boolean isConvertFloatPrecisionLack(String s) {
-    return Long.parseLong(s) > (2 << 24);
+    try {
+      return Long.parseLong(s) > (2 << 24);
+    } catch (NumberFormatException e) {
+      return true;
+    }
   }
 
   /** Get predicted DataType of the given value */

--- a/server/src/test/java/org/apache/iotdb/db/utils/TypeInferenceUtilsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/TypeInferenceUtilsTest.java
@@ -72,7 +72,8 @@ public class TypeInferenceUtilsTest {
       "9999999999999999",
       "true",
       "77123 ",
-      " 7112324 "
+      " 7112324 ",
+      "271840880000000000000000"
     };
     TSDataType[] encodings = {
       IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
@@ -85,7 +86,8 @@ public class TypeInferenceUtilsTest {
       IoTDBDescriptor.getInstance().getConfig().getLongStringInferType(),
       IoTDBDescriptor.getInstance().getConfig().getBooleanStringInferType(),
       IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
-      IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType()
+      IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
+      IoTDBDescriptor.getInstance().getConfig().getLongStringInferType()
     };
 
     for (int i = 0; i < values.length; i++) {


### PR DESCRIPTION
## Description

```
IoTDB> create timeseries root.sg.d1.s2 with datatype=double
Msg: The statement is executed successfully.
IoTDB> insert into root.sg.d1(time,s2) values(1,271840880000000000000000)
Msg: 500: [INTERNAL_SERVER_ERROR(500)] Exception occurred: executeNonQueryPlan failed. For input string: "271840880000000000000000"
```

After fixing
```
IoTDB> insert into root.sg.d1(time,s2) values(1,271840880000000000000000)
Msg: The statement is executed successfully.
IoTDB> select ** from root
+-----------------------------+-------------+
|                         Time|root.sg.d1.s2|
+-----------------------------+-------------+
|1970-01-01T08:00:00.001+08:00| 2.7184088E23|
+-----------------------------+-------------+
Total line number = 1
It costs 0.085s
```