### PR TITLE
[IOTDB-4842] Fix type infer error when insert a large number

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
@@ -337,4 +337,15 @@ public class IoTDBInsertAlignedValuesIT {
       assertTrue(e.getMessage(), e.getMessage().contains("data type is not consistent"));
     }
   }
+
+  @Test
+  public void testInsertLargeNumber() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          "insert into root.sg1.d1(time, s98, s99) aligned values(10, 2, 271840880000000000000000)");
+    } catch (SQLException e) {
+      fail();
+    }
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
@@ -64,7 +64,11 @@ public class TypeInferenceUtils {
   }
 
   private static boolean isConvertFloatPrecisionLack(String s) {
-    return Long.parseLong(s) > (1 << 24);
+    try {
+      return Long.parseLong(s) > (1 << 24);
+    } catch (NumberFormatException e) {
+      return true;
+    }
   }
 
   /** Get predicted DataType of the given value */

--- a/server/src/test/java/org/apache/iotdb/db/utils/TypeInferenceUtilsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/TypeInferenceUtilsTest.java
@@ -75,6 +75,7 @@ public class TypeInferenceUtilsTest {
       " 7112324 ",
       "16777217", // 2^24 + 1
       "16777216", // 2^24
+      "271840880000000000000000",
     };
     TSDataType[] encodings = {
       IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
@@ -90,6 +91,7 @@ public class TypeInferenceUtilsTest {
       IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
       IoTDBDescriptor.getInstance().getConfig().getLongStringInferType(),
       IoTDBDescriptor.getInstance().getConfig().getIntegerStringInferType(),
+      IoTDBDescriptor.getInstance().getConfig().getLongStringInferType(),
     };
 
     for (int i = 0; i < values.length; i++) {


### PR DESCRIPTION
See IOTDB-4842 

After fixing:
```
IoTDB> insert into root.sg.d1(time,s2) values(1,271840880000000000000000)
Msg: The statement is executed successfully.
IoTDB> select ** from root
+-----------------------------+-------------+
|                         Time|root.sg.d1.s2|
+-----------------------------+-------------+
|1970-01-01T08:00:00.001+08:00| 2.7184088E23|
+-----------------------------+-------------+
Total line number = 1
It costs 0.085s
```