### PR TITLE
[IOTDB-4597] add option to set query timeout in Cli

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
@@ -80,6 +80,8 @@ public abstract class AbstractCli {
   private static final String MAX_PRINT_ROW_COUNT_NAME = "maxPrintRowCount";
   static final String RPC_COMPRESS_ARGS = "c";
   private static final String RPC_COMPRESS_NAME = "rpcCompressed";
+  static final String TIMEOUT_ARGS = "timeout";
+  private static final String TIMEOUT_NAME = "queryTimeout";
   static final String SET_MAX_DISPLAY_NUM = "set max_display_num";
   static final String SET_TIMESTAMP_DISPLAY = "set time_display_type";
   static final String SHOW_TIMESTAMP_DISPLAY = "show time_display_type";
@@ -98,6 +100,7 @@ public abstract class AbstractCli {
   private static final String IMPORT_CMD = "import";
   static int maxPrintRowCount = 1000;
   private static int fetchSize = 1000;
+  static int queryTimeout = 0;
   static String timestampPrecision = "ms";
   static String timeFormat = RpcUtils.DEFAULT_TIME_FORMAT;
   private static boolean continuePrint = false;
@@ -199,6 +202,15 @@ public abstract class AbstractCli {
             .desc("Rpc Compression enabled or not")
             .build();
     options.addOption(isRpcCompressed);
+
+    Option queryTimeout =
+        Option.builder(TIMEOUT_ARGS)
+            .argName(TIMEOUT_NAME)
+            .hasArg()
+            .desc(
+                "The timeout in second. Using the configuration of server if it's not set (optional)")
+            .build();
+    options.addOption(queryTimeout);
     return options;
   }
 
@@ -242,6 +254,15 @@ public abstract class AbstractCli {
       continuePrint = true;
     } else {
       maxPrintRowCount = Integer.parseInt(maxDisplayNum.trim());
+    }
+  }
+
+  static void setQueryTimeout(String timeoutString) {
+    long timeout = Long.parseLong(timeoutString.trim());
+    if (timeout > Integer.MAX_VALUE || timeout < 0) {
+      queryTimeout = 0;
+    } else {
+      queryTimeout = Integer.parseInt(timeoutString.trim());
     }
   }
 

--- a/cli/src/main/java/org/apache/iotdb/cli/Cli.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/Cli.java
@@ -110,6 +110,9 @@ public class Cli extends AbstractCli {
       if (commandLine.hasOption(MAX_PRINT_ROW_COUNT_ARGS)) {
         setMaxDisplayNumber(commandLine.getOptionValue(MAX_PRINT_ROW_COUNT_ARGS));
       }
+      if (commandLine.hasOption(TIMEOUT_ARGS)) {
+        setQueryTimeout(commandLine.getOptionValue(TIMEOUT_ARGS));
+      }
     } catch (ParseException e) {
       println(
           "Require more params input, eg. ./start-cli.sh(start-cli.bat if Windows) "
@@ -134,6 +137,7 @@ public class Cli extends AbstractCli {
             (IoTDBConnection)
                 DriverManager.getConnection(
                     Config.IOTDB_URL_PREFIX + host + ":" + port + "/", username, password)) {
+          connection.setQueryTimeout(queryTimeout);
           properties = connection.getServerProperties();
           timestampPrecision = properties.getTimestampPrecision();
           AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
@@ -160,6 +164,7 @@ public class Cli extends AbstractCli {
             DriverManager.getConnection(
                 Config.IOTDB_URL_PREFIX + host + ":" + port + "/", username, password)) {
       String s;
+      connection.setQueryTimeout(queryTimeout);
       properties = connection.getServerProperties();
       AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
       timestampPrecision = properties.getTimestampPrecision();


### PR DESCRIPTION
The user can set timeout in Cli through -timeout in command line.
