### PR TITLE
Improve query performance

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -645,7 +645,10 @@ public class TsFileResource {
       return isSatisfied(timeFilter, isSeq, ttl, debug);
     }
 
-    if (!mayContainsDevice(deviceId)) {
+    long[] startAndEndTime = timeIndex.getStartAndEndTime(deviceId);
+
+    // doesn't contain this device
+    if (startAndEndTime == null) {
       if (debug) {
         DEBUG_LOGGER.info(
             "Path: {} file {} is not satisfied because of no device!", deviceId, file);
@@ -653,8 +656,8 @@ public class TsFileResource {
       return false;
     }
 
-    long startTime = getStartTime(deviceId);
-    long endTime = isClosed() || !isSeq ? getEndTime(deviceId) : Long.MAX_VALUE;
+    long startTime = startAndEndTime[0];
+    long endTime = isClosed() || !isSeq ? startAndEndTime[1] : Long.MAX_VALUE;
 
     if (!isAlive(endTime, ttl)) {
       if (debug) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
@@ -363,6 +363,17 @@ public class DeviceTimeIndex implements ITimeIndex {
   }
 
   @Override
+  public long[] getStartAndEndTime(String deviceId) {
+    Integer index = deviceToIndex.get(deviceId);
+    if (index == null) {
+      return null;
+    } else {
+      int i = index;
+      return new long[] {startTimes[i], endTimes[i]};
+    }
+  }
+
+  @Override
   public Pair<Long, Long> getPossibleStartTimeAndEndTime(PartialPath devicePattern) {
     boolean hasMatchedDevice = false;
     long startTime = Long.MAX_VALUE;

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/FileTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/FileTimeIndex.java
@@ -229,6 +229,11 @@ public class FileTimeIndex implements ITimeIndex {
   }
 
   @Override
+  public long[] getStartAndEndTime(String deviceId) {
+    return new long[] {startTime, endTime};
+  }
+
+  @Override
   public Pair<Long, Long> getPossibleStartTimeAndEndTime(PartialPath devicePattern) {
     return new Pair<>(startTime, endTime);
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/ITimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/ITimeIndex.java
@@ -194,6 +194,11 @@ public interface ITimeIndex {
    */
   boolean mayContainsDevice(String device);
 
+  /**
+   * @return null if the deviceId doesn't exist, otherwise index 0 is startTime, index 1 is endTime
+   */
+  long[] getStartAndEndTime(String deviceId);
+
   Pair<Long, Long> getPossibleStartTimeAndEndTime(PartialPath devicePattern);
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/V012FileTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/V012FileTimeIndex.java
@@ -186,6 +186,12 @@ public class V012FileTimeIndex implements ITimeIndex {
   }
 
   @Override
+  public long[] getStartAndEndTime(String deviceId) {
+    throw new UnsupportedOperationException(
+        "V012FileTimeIndex should be rewritten while upgrading and getStartAndEndTime() method should not be called any more.");
+  }
+
+  @Override
   public Pair<Long, Long> getPossibleStartTimeAndEndTime(PartialPath devicePattern) {
     throw new UnsupportedOperationException(
         "V012FileTimeIndex should be rewritten while upgrading and getPossibleStartTimeAndEndTime() method should not be called any more.");

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
@@ -86,7 +86,11 @@ public class ClusterScheduler implements IScheduler {
               stateMachine, scheduledExecutor, instances, internalServiceClientManager);
       this.queryTerminator =
           new SimpleQueryTerminator(
-              scheduledExecutor, queryContext, instances, internalServiceClientManager);
+              scheduledExecutor,
+              queryContext,
+              instances,
+              internalServiceClientManager,
+              stateTracker);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FixedRateFragInsStateTracker.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FixedRateFragInsStateTracker.java
@@ -28,12 +28,14 @@ import org.apache.iotdb.db.mpp.execution.QueryStateMachine;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceState;
 import org.apache.iotdb.db.mpp.plan.planner.plan.FragmentInstance;
 import org.apache.iotdb.db.utils.SetThreadName;
+import org.apache.iotdb.mpp.rpc.thrift.TFragmentInstanceId;
 
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +80,24 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
   }
 
   @Override
+  public synchronized List<TFragmentInstanceId> filterUnFinishedFIs(
+      List<TFragmentInstanceId> instanceIds) {
+    List<TFragmentInstanceId> res = new ArrayList<>();
+    if (instanceIds == null) {
+      return res;
+    }
+    for (TFragmentInstanceId tFragmentInstanceId : instanceIds) {
+      InstanceStateMetrics stateMetrics =
+          instanceStateMap.get(FragmentInstanceId.fromThrift(tFragmentInstanceId));
+      if (stateMetrics != null
+          && (stateMetrics.lastState == null || !stateMetrics.lastState.isDone())) {
+        res.add(tFragmentInstanceId);
+      }
+    }
+    return res;
+  }
+
+  @Override
   public synchronized void abort() {
     aborted = true;
     if (trackTask != null) {
@@ -96,18 +116,20 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
     for (FragmentInstance instance : instances) {
       try (SetThreadName threadName = new SetThreadName(instance.getId().getFullId())) {
         FragmentInstanceState state = fetchState(instance);
-        InstanceStateMetrics metrics =
-            instanceStateMap.computeIfAbsent(
-                instance.getId(), k -> new InstanceStateMetrics(instance.isRoot()));
-        if (needPrintState(metrics.lastState, state, metrics.durationToLastPrintInMS)) {
-          logger.debug("[PrintFIState] state is {}", state);
-          metrics.reset(state);
-        } else {
-          metrics.addDuration(STATE_FETCH_INTERVAL_IN_MS);
-        }
+        synchronized (this) {
+          InstanceStateMetrics metrics =
+              instanceStateMap.computeIfAbsent(
+                  instance.getId(), k -> new InstanceStateMetrics(instance.isRoot()));
+          if (needPrintState(metrics.lastState, state, metrics.durationToLastPrintInMS)) {
+            logger.debug("[PrintFIState] state is {}", state);
+            metrics.reset(state);
+          } else {
+            metrics.addDuration(STATE_FETCH_INTERVAL_IN_MS);
+          }
 
-        if (state != null) {
-          updateQueryState(instance.getId(), state);
+          if (state != null) {
+            updateQueryState(instance.getId(), state);
+          }
         }
       } catch (TException | IOException e) {
         // TODO: do nothing ?

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/IFragInstanceStateTracker.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/IFragInstanceStateTracker.java
@@ -19,8 +19,14 @@
 
 package org.apache.iotdb.db.mpp.plan.scheduler;
 
+import org.apache.iotdb.mpp.rpc.thrift.TFragmentInstanceId;
+
+import java.util.List;
+
 public interface IFragInstanceStateTracker {
   void start();
 
   void abort();
+
+  List<TFragmentInstanceId> filterUnFinishedFIs(List<TFragmentInstanceId> instanceIds);
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
@@ -160,9 +160,6 @@ public class FileLoaderUtils {
     AlignedTimeSeriesMetadata alignedTimeSeriesMetadata = null;
     // If the tsfile is closed, we need to load from tsfile
     if (resource.isClosed()) {
-      if (!resource.getTsFile().exists()) {
-        return null;
-      }
       // load all the TimeseriesMetadata of vector, the first one is for time column and the
       // remaining is for sub sensors
       // the order of timeSeriesMetadata list is same as subSensorList's order


### PR DESCRIPTION
In this pr, i did the following performance improvement:

1. Avoid duplicated map.get in TsResource.isSatisfied() method by adding a new method to directly return a long array. If the long array is null, it means that this device doesn't exist. And the index 0 is startTime, index 1 is endTime.
<img width="1578" alt="image" src="https://user-images.githubusercontent.com/16079446/199662766-c6b2d751-de7f-4157-8612-9f17082ad7ba.png">
2. Avoid needless cancelQuery rpc call. Previously, we will send cancelQuery request whenever possible. However, if the query is finished normally(all FIs are in done state), we don't need to do that.
<img width="1477" alt="image" src="https://user-images.githubusercontent.com/16079446/199663280-5601b02a-3fc9-40cf-b03d-88283f19a419.png">
3. Remove a useless File.exist() check in FileLoaderUtils, tsfile must exist and will never be deleted because we have already lock it before putting it into query resource list.
