### PR TITLE
[IOTDB-4848] fix Bug: TimeSeries cannot be used in logical operator

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBFilterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBFilterIT.java
@@ -35,6 +35,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import static org.apache.iotdb.db.it.utils.TestUtils.resultSetEqualTest;
+import static org.apache.iotdb.itbase.constant.TestConstant.TIMESTAMP_STR;
+import static org.apache.iotdb.itbase.constant.TestConstant.count;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -80,6 +83,10 @@ public class IoTDBFilterIT {
           "create TIMESERIES root.vehicle.testNaN.d1 with datatype=DOUBLE,encoding=PLAIN");
       statement.execute(
           "create TIMESERIES root.vehicle.testNaN.d2 with datatype=DOUBLE,encoding=PLAIN");
+      statement.execute(
+          "create TIMESERIES root.vehicle.testTimeSeries.s1 with datatype=BOOLEAN,encoding=PLAIN");
+      statement.execute(
+          "create TIMESERIES root.vehicle.testTimeSeries.s2 with datatype=BOOLEAN,encoding=PLAIN");
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
@@ -92,12 +99,65 @@ public class IoTDBFilterIT {
         statement.execute(
             String.format(
                 "insert into root.vehicle.testNaN(timestamp,d1,d2) values(%d,%d,%d)", i, i, i));
+
+        switch (i % 3) {
+          case 0:
+            statement.execute(
+                String.format(
+                    "insert into root.vehicle.testTimeSeries(timestamp,s1,s2) values(%d,true,true)",
+                    i));
+            break;
+          case 1:
+            statement.execute(
+                String.format(
+                    "insert into root.vehicle.testTimeSeries(timestamp,s1,s2) values(%d,true,false)",
+                    i));
+            break;
+          case 2:
+            statement.execute(
+                String.format(
+                    "insert into root.vehicle.testTimeSeries(timestamp,s1,s2) values(%d,false,false)",
+                    i));
+            break;
+        }
       }
       statement.execute(
           " insert into root.sg1.d1(time, s1, s2) aligned values (1,1, \"1\"), (2,2,\"2\")");
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
+  }
+
+  @Test
+  public void testFilterBooleanSeries() {
+    String[] expectedHeader =
+        new String[] {
+          TIMESTAMP_STR, "root.vehicle.testTimeSeries.s1", "root.vehicle.testTimeSeries.s2"
+        };
+    String[] retArray =
+        new String[] {"0,true,true,", "3,true,true,", "6,true,true,", "9,true,true,"};
+    resultSetEqualTest(
+        "select s1, s2 from root.vehicle.testTimeSeries " + "Where s2", expectedHeader, retArray);
+
+    resultSetEqualTest(
+        "select s1, s2 from root.vehicle.testTimeSeries " + "Where s1 && s2",
+        expectedHeader,
+        retArray);
+
+    retArray =
+        new String[] {
+          "0,true,true,",
+          "1,true,false,",
+          "3,true,true,",
+          "4,true,false,",
+          "6,true,true,",
+          "7,true,false,",
+          "9,true,true,"
+        };
+    resultSetEqualTest(
+        "select s1, s2 from root.vehicle.testTimeSeries " + "Where s1 || s2",
+        expectedHeader,
+        retArray);
   }
 
   @Test
@@ -124,7 +184,7 @@ public class IoTDBFilterIT {
         Statement statement = connection.createStatement();
         ResultSet resultSet =
             statement.executeQuery(
-                "select s2 from root.** where s1 = 1 and s2 >= \"1\" and s2 <= \"2\";")) {
+                "select s2 from root.sg1.d1 where s1 = 1 and s2 >= \"1\" and s2 <= \"2\";")) {
       int count = 0;
       while (resultSet.next()) {
         ++count;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
@@ -898,6 +898,8 @@ public class ExpressionAnalyzer {
             false);
       }
       return new Pair<>(null, true);
+    } else if (predicate.getExpressionType().equals(ExpressionType.TIMESERIES)) {
+      return new Pair<>(null, true);
     } else {
       throw new IllegalArgumentException(
           "unsupported expression type: " + predicate.getExpressionType());


### PR DESCRIPTION
cause: The case where predicate is a TimeSeries is not considered in method `extractGlobalTimeFilter()`