### PR TITLE
[IOTDB-4850] Disable first election

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -220,8 +220,8 @@ public class ConfigNodeConfig {
   private long dataRegionRatisPreserveLogsWhenPurge = 1000;
 
   /* first election timeout shares between 3 regions */
-  private long ratisFirstElectionTimeoutMinMs = 50;
-  private long ratisFirstElectionTimeoutMaxMs = 150;
+  private long ratisFirstElectionTimeoutMinMs = 2000;
+  private long ratisFirstElectionTimeoutMaxMs = 4000;
 
   public ConfigNodeConfig() {
     // empty constructor

--- a/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
@@ -222,10 +222,10 @@ public class RatisConfig {
       private TimeDuration slownessTimeout = TimeDuration.valueOf(10, TimeUnit.MINUTES);
 
       private TimeDuration firstElectionTimeoutMin =
-          TimeDuration.valueOf(50, TimeUnit.MILLISECONDS);
+          TimeDuration.valueOf(2000, TimeUnit.MILLISECONDS);
 
       private TimeDuration firstElectionTimeoutMax =
-          TimeDuration.valueOf(150, TimeUnit.MILLISECONDS);
+          TimeDuration.valueOf(4000, TimeUnit.MILLISECONDS);
 
       public Rpc build() {
         return new Rpc(

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -1153,8 +1153,8 @@ trigger_forward_mqtt_pool_size=4
 # data_region_ratis_preserve_logs_num_when_purge=1000
 
 # first election timeout
-# ratis_first_election_timeout_min_ms=50
-# ratis_first_election_timeout_max_ms=150
+# ratis_first_election_timeout_min_ms=2000
+# ratis_first_election_timeout_max_ms=4000
 
 ####################
 ### Disk Monitor

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1045,8 +1045,8 @@ public class IoTDBConfig {
   private long dataRatisConsensusPreserveWhenPurge = 1000L;
   private long schemaRatisConsensusPreserveWhenPurge = 1000L;
 
-  private long ratisFirstElectionTimeoutMinMs = 50L;
-  private long ratisFirstElectionTimeoutMaxMs = 150L;
+  private long ratisFirstElectionTimeoutMinMs = 2000L;
+  private long ratisFirstElectionTimeoutMaxMs = 4000L;
 
   // customizedProperties, this should be empty by default.
   private Properties customizedProperties = new Properties();


### PR DESCRIPTION
First election aims to reduce the unavailable time during consensus group starts-up. However, in current implementation, it may cause new follower receive SHUTDOWN errors. 

I'll disable it for now. 