### PR TITLE
[IOTDB-4861] Show DataNodes' Internal Address:Port when executing show cluster

### DIFF
--- a/docs/UserGuide/Cluster/Cluster-Setup.md
+++ b/docs/UserGuide/Cluster/Cluster-Setup.md
@@ -227,12 +227,12 @@ the default number of replica is one.
   command on the Cli. The result is shown below:
 ```
 IoTDB> show cluster
-+------+----------+-------+---------+------------+
-|NodeID|  NodeType| Status|     Host|InternalPort|
-+------+----------+-------+---------+------------+
-|     0|ConfigNode|Running|  0.0.0.0|       22277|
-|     1|  DataNode|Running|127.0.0.1|        9003|
-+------+----------+-------+---------+------------+
++------+----------+-------+---------------+------------+
+|NodeID|  NodeType| Status|InternalAddress|InternalPort|
++------+----------+-------+---------------+------------+
+|     0|ConfigNode|Running|        0.0.0.0|       22277|
+|     1|  DataNode|Running|      127.0.0.1|        9003|
++------+----------+-------+---------------+------------+
 Total line number = 2
 It costs 0.160s
 ```
@@ -308,16 +308,16 @@ The following commands can be executed in no particular order.
 Execute the show cluster command, the result is shown below:
 ```
 IoTDB> show cluster
-+------+----------+-------+---------+------------+
-|NodeID|  NodeType| Status|     Host|InternalPort|
-+------+----------+-------+---------+------------+
-|     0|ConfigNode|Running|  0.0.0.0|       22277|
-|     2|ConfigNode|Running|  0.0.0.0|       22279|
-|     3|ConfigNode|Running|  0.0.0.0|       22281|
-|     1|  DataNode|Running|127.0.0.1|        9003|
-|     4|  DataNode|Running|127.0.0.1|        9004|
-|     5|  DataNode|Running|127.0.0.1|        9005|
-+------+----------+-------+---------+------------+
++------+----------+-------+---------------+------------+
+|NodeID|  NodeType| Status|InternalAddress|InternalPort|
++------+----------+-------+---------------+------------+
+|     0|ConfigNode|Running|        0.0.0.0|       22277|
+|     2|ConfigNode|Running|        0.0.0.0|       22279|
+|     3|ConfigNode|Running|        0.0.0.0|       22281|
+|     1|  DataNode|Running|      127.0.0.1|        9003|
+|     4|  DataNode|Running|      127.0.0.1|        9004|
+|     5|  DataNode|Running|      127.0.0.1|        9005|
++------+----------+-------+---------------+------------+
 Total line number = 6
 It costs 0.012s
 ```
@@ -339,14 +339,14 @@ It costs 0.012s
 Execute the show cluster command, the result is shown below:
 ```
 IoTDB> show cluster
-+------+----------+-------+---------+------------+
-|NodeID|  NodeType| Status|     Host|InternalPort|
-+------+----------+-------+---------+------------+
-|     0|ConfigNode|Running|  0.0.0.0|       22277|
-|     3|ConfigNode|Running|  0.0.0.0|       22281|
-|     1|  DataNode|Running|127.0.0.1|        9003|
-|     5|  DataNode|Running|127.0.0.1|        9005|
-+------+----------+-------+---------+------------+
++------+----------+-------+---------------+------------+
+|NodeID|  NodeType| Status|InternalAddress|InternalPort|
++------+----------+-------+---------------+------------+
+|     0|ConfigNode|Running|        0.0.0.0|       22277|
+|     3|ConfigNode|Running|        0.0.0.0|       22281|
+|     1|  DataNode|Running|      127.0.0.1|        9003|
+|     5|  DataNode|Running|      127.0.0.1|        9005|
++------+----------+-------+---------------+------------+
 Total line number = 4
 It costs 0.007s
 ```

--- a/docs/UserGuide/Maintenance-Tools/Maintenance-Command.md
+++ b/docs/UserGuide/Maintenance-Tools/Maintenance-Command.md
@@ -239,16 +239,16 @@ Eg：
 
 ```
 IoTDB> show cluster
-+------+----------+-------+---------+------------+
-|NodeID|  NodeType| Status|     Host|InternalPort|
-+------+----------+-------+---------+------------+
-|     0|ConfigNode|Running|  0.0.0.0|       22277|
-|     1|ConfigNode|Running|  0.0.0.0|       22279|
-|     2|ConfigNode|Running|  0.0.0.0|       22281|
-|     3|  DataNode|Running|127.0.0.1|        9003|
-|     4|  DataNode|Running|127.0.0.1|        9005|
-|     5|  DataNode|Running|127.0.0.1|        9007|
-+------+----------+-------+---------+------------+
++------+----------+-------+---------------+------------+
+|NodeID|  NodeType| Status|InternalAddress|InternalPort|
++------+----------+-------+---------------+------------+
+|     0|ConfigNode|Running|        0.0.0.0|       22277|
+|     1|ConfigNode|Running|        0.0.0.0|       22279|
+|     2|ConfigNode|Running|        0.0.0.0|       22281|
+|     3|  DataNode|Running|      127.0.0.1|        9003|
+|     4|  DataNode|Running|      127.0.0.1|        9005|
+|     5|  DataNode|Running|      127.0.0.1|        9007|
++------+----------+-------+---------------+------------+
 Total line number = 6
 It costs 0.011s
 ```
@@ -257,16 +257,16 @@ After a node is stopped, its status will change, as shown below:
 
 ```
 IoTDB> show cluster
-+------+----------+-------+---------+------------+
-|NodeID|  NodeType| Status|     Host|InternalPort|
-+------+----------+-------+---------+------------+
-|     0|ConfigNode|Running|  0.0.0.0|       22277|
-|     1|ConfigNode|Unknown|  0.0.0.0|       22279|
-|     2|ConfigNode|Running|  0.0.0.0|       22281|
-|     3|  DataNode|Running|127.0.0.1|        9003|
-|     4|  DataNode|Running|127.0.0.1|        9005|
-|     5|  DataNode|Running|127.0.0.1|        9007|
-+------+----------+-------+---------+------------+
++------+----------+-------+---------------+------------+
+|NodeID|  NodeType| Status|InternalAddress|InternalPort|
++------+----------+-------+---------------+------------+
+|     0|ConfigNode|Running|        0.0.0.0|       22277|
+|     1|ConfigNode|Unknown|        0.0.0.0|       22279|
+|     2|ConfigNode|Running|        0.0.0.0|       22281|
+|     3|  DataNode|Running|      127.0.0.1|        9003|
+|     4|  DataNode|Running|      127.0.0.1|        9005|
+|     5|  DataNode|Running|      127.0.0.1|        9007|
++------+----------+-------+---------------+------------+
 Total line number = 6
 It costs 0.012s
 ```

--- a/docs/zh/UserGuide/Cluster/Cluster-Setup.md
+++ b/docs/zh/UserGuide/Cluster/Cluster-Setup.md
@@ -228,12 +228,12 @@ datanode\sbin\remove-datanode.bat <rpc_address>:<rpc_port>
 指令，结果如下所示：
 ```
 IoTDB> show cluster
-+------+----------+-------+---------+------------+
-|NodeID|  NodeType| Status|     Host|InternalPort|
-+------+----------+-------+---------+------------+
-|     0|ConfigNode|Running|  0.0.0.0|       22277|
-|     1|  DataNode|Running|127.0.0.1|        9003|
-+------+----------+-------+---------+------------+
++------+----------+-------+---------------+------------+
+|NodeID|  NodeType| Status|InternalAddress|InternalPort|
++------+----------+-------+---------------+------------+
+|     0|ConfigNode|Running|        0.0.0.0|       22277|
+|     1|  DataNode|Running|      127.0.0.1|        9003|
++------+----------+-------+---------------+------------+
 Total line number = 2
 It costs 0.160s
 ```
@@ -308,16 +308,16 @@ It costs 0.160s
 在 Cli 执行 show cluster，结果如下：
 ```
 IoTDB> show cluster
-+------+----------+-------+---------+------------+
-|NodeID|  NodeType| Status|     Host|InternalPort|
-+------+----------+-------+---------+------------+
-|     0|ConfigNode|Running|  0.0.0.0|       22277|
-|     2|ConfigNode|Running|  0.0.0.0|       22279|
-|     3|ConfigNode|Running|  0.0.0.0|       22281|
-|     1|  DataNode|Running|127.0.0.1|        9003|
-|     4|  DataNode|Running|127.0.0.1|        9004|
-|     5|  DataNode|Running|127.0.0.1|        9005|
-+------+----------+-------+---------+------------+
++------+----------+-------+---------------+------------+
+|NodeID|  NodeType| Status|InternalAddress|InternalPort|
++------+----------+-------+---------------+------------+
+|     0|ConfigNode|Running|        0.0.0.0|       22277|
+|     2|ConfigNode|Running|        0.0.0.0|       22279|
+|     3|ConfigNode|Running|        0.0.0.0|       22281|
+|     1|  DataNode|Running|      127.0.0.1|        9003|
+|     4|  DataNode|Running|      127.0.0.1|        9004|
+|     5|  DataNode|Running|      127.0.0.1|        9005|
++------+----------+-------+---------------+------------+
 Total line number = 6
 It costs 0.012s
 ```
@@ -339,14 +339,14 @@ It costs 0.012s
 在 Cli 执行 show cluster，结果如下：
 ```
 IoTDB> show cluster
-+------+----------+-------+---------+------------+
-|NodeID|  NodeType| Status|     Host|InternalPort|
-+------+----------+-------+---------+------------+
-|     0|ConfigNode|Running|  0.0.0.0|       22277|
-|     3|ConfigNode|Running|  0.0.0.0|       22281|
-|     1|  DataNode|Running|127.0.0.1|        9003|
-|     5|  DataNode|Running|127.0.0.1|        9005|
-+------+----------+-------+---------+------------+
++------+----------+-------+---------------+------------+
+|NodeID|  NodeType| Status|InternalAddress|InternalPort|
++------+----------+-------+---------------+------------+
+|     0|ConfigNode|Running|        0.0.0.0|       22277|
+|     3|ConfigNode|Running|        0.0.0.0|       22281|
+|     1|  DataNode|Running|      127.0.0.1|        9003|
+|     5|  DataNode|Running|      127.0.0.1|        9005|
++------+----------+-------+---------------+------------+
 Total line number = 4
 It costs 0.007s
 ```

--- a/docs/zh/UserGuide/Maintenance-Tools/Maintenance-Command.md
+++ b/docs/zh/UserGuide/Maintenance-Tools/Maintenance-Command.md
@@ -237,16 +237,16 @@ SHOW CLUSTER
 
 ```
 IoTDB> show cluster
-+------+----------+-------+---------+------------+
-|NodeID|  NodeType| Status|     Host|InternalPort|
-+------+----------+-------+---------+------------+
-|     0|ConfigNode|Running|  0.0.0.0|       22277|
-|     1|ConfigNode|Running|  0.0.0.0|       22279|
-|     2|ConfigNode|Running|  0.0.0.0|       22281|
-|     3|  DataNode|Running|127.0.0.1|        9003|
-|     4|  DataNode|Running|127.0.0.1|        9005|
-|     5|  DataNode|Running|127.0.0.1|        9007|
-+------+----------+-------+---------+------------+
++------+----------+-------+---------------+------------+
+|NodeID|  NodeType| Status|InternalAddress|InternalPort|
++------+----------+-------+---------------+------------+
+|     0|ConfigNode|Running|        0.0.0.0|       22277|
+|     1|ConfigNode|Running|        0.0.0.0|       22279|
+|     2|ConfigNode|Running|        0.0.0.0|       22281|
+|     3|  DataNode|Running|      127.0.0.1|        9003|
+|     4|  DataNode|Running|      127.0.0.1|        9005|
+|     5|  DataNode|Running|      127.0.0.1|        9007|
++------+----------+-------+---------------+------------+
 Total line number = 6
 It costs 0.011s
 ```

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
@@ -67,6 +67,7 @@ public class ColumnHeaderConstant {
   public static final String COLUMN_NODE_TYPE = "NodeType";
   public static final String COLUMN_STATUS = "Status";
   public static final String COLUMN_HOST = "Host";
+  public static final String COLUMN_INTERNAL_ADDRESS = "InternalAddress";
   public static final String COLUMN_INTERNAL_PORT = "InternalPort";
   public static final String COLUMN_RPC_PORT = "RpcPort";
 
@@ -248,7 +249,7 @@ public class ColumnHeaderConstant {
           new ColumnHeader(COLUMN_NODE_ID, TSDataType.INT32),
           new ColumnHeader(COLUMN_NODE_TYPE, TSDataType.TEXT),
           new ColumnHeader(COLUMN_STATUS, TSDataType.TEXT),
-          new ColumnHeader(COLUMN_HOST, TSDataType.TEXT),
+          new ColumnHeader(COLUMN_INTERNAL_ADDRESS, TSDataType.TEXT),
           new ColumnHeader(COLUMN_INTERNAL_PORT, TSDataType.INT32));
 
   public static final List<ColumnHeader> showFunctionsColumnHeaders =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterTask.java
@@ -97,8 +97,8 @@ public class ShowClusterTask implements IConfigTask {
                     e.getDataNodeId(),
                     NODE_TYPE_DATA_NODE,
                     clusterNodeInfos.getNodeStatus().get(e.getDataNodeId()),
-                    e.getClientRpcEndPoint().getIp(),
-                    e.getClientRpcEndPoint().getPort()));
+                    e.getInternalEndPoint().getIp(),
+                    e.getInternalEndPoint().getPort()));
 
     DatasetHeader datasetHeader = DatasetHeaderFactory.getShowClusterHeader();
     future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS, builder.build(), datasetHeader));


### PR DESCRIPTION
1. rename `Host` to `InternalAddress`
2. show datanodes' Internal Address:Port when executing show cluster

![e177e658c39a1c8b0725d377508a7f1](https://user-images.githubusercontent.com/42286868/200243215-a997781f-3a06-4ad9-aa77-489c560ea835.png)
