### PR TITLE
[IOTDB-4862] optimize transfer leader implementation

### DIFF
--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -221,6 +221,24 @@ public class RatisConsensusTest {
     doConsensus(servers.get(0), gid, 10, 210);
   }
 
+  @Test
+  public void transferLeader() throws Exception {
+    servers.get(0).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(1).createPeer(group.getGroupId(), group.getPeers());
+    servers.get(2).createPeer(group.getGroupId(), group.getPeers());
+
+    doConsensus(servers.get(0), group.getGroupId(), 10, 10);
+
+    int leaderIndex = servers.get(0).getLeader(group.getGroupId()).getNodeId() - 1;
+
+    ConsensusGenericResponse resp =
+        servers.get(0).transferLeader(group.getGroupId(), peers.get((leaderIndex + 1) % 3));
+    Assert.assertTrue(resp.isSuccess());
+
+    int newLeaderIndex = servers.get(0).getLeader(group.getGroupId()).getNodeId() - 1;
+    Assert.assertEquals((leaderIndex + 1) % 3, newLeaderIndex);
+  }
+
   private void doConsensus(IConsensus consensus, ConsensusGroupId gid, int count, int target)
       throws Exception {
 


### PR DESCRIPTION
Ratis supports to transfer leader quietly.
That is, the new leader can start the election immediately without waiting for an election timeout.

Add new unit tests to verify.