### PR TITLE
[IOTDB-4866] Fix schema tree bug when append nested device

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTree.java
@@ -196,6 +196,9 @@ public class ClusterSchemaTree implements ISchemaTree {
       } else if (i == nodes.length - 2 && !child.isEntity()) {
         SchemaEntityNode entityNode = new SchemaEntityNode(nodes[i]);
         cur.replaceChild(nodes[i], entityNode);
+        if (!entityNode.isAligned()) {
+          entityNode.setAligned(isAligned);
+        }
         child = entityNode;
       }
       cur = child;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaEntityNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/node/SchemaEntityNode.java
@@ -78,6 +78,7 @@ public class SchemaEntityNode extends SchemaInternalNode {
       return;
     }
     SchemaEntityNode entityNode = schemaNode.getAsEntityNode();
+    entityNode.setAligned(isAligned);
     if (aliasChildren != null) {
       for (SchemaMeasurementNode child : aliasChildren.values()) {
         entityNode.addAliasChild(child.getAlias(), child);

--- a/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTreeTest.java
@@ -37,6 +37,7 @@ import org.mockito.internal.util.collections.Sets;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -566,5 +567,29 @@ public class ClusterSchemaTreeTest {
       schemaTreeList.add(schemaTree);
     }
     return schemaTreeList;
+  }
+
+  @Test
+  public void testNestedDevice() throws Exception {
+    List<MeasurementPath> measurementPathList = new ArrayList<>();
+
+    MeasurementSchema schema1 = new MeasurementSchema("s1", TSDataType.INT32);
+
+    MeasurementPath measurementPath = new MeasurementPath("root.sg.d1.a.s1");
+    measurementPath.setMeasurementSchema(schema1);
+    measurementPathList.add(measurementPath);
+
+    measurementPath = new MeasurementPath("root.sg.d1.s1");
+    measurementPath.setMeasurementSchema(schema1);
+    measurementPath.setUnderAlignedEntity(true);
+    measurementPathList.add(measurementPath);
+
+    ClusterSchemaTree schemaTree = new ClusterSchemaTree();
+    schemaTree.appendMeasurementPaths(measurementPathList);
+
+    Assert.assertTrue(
+        schemaTree
+            .searchDeviceSchemaInfo(new PartialPath("root.sg.d1"), Collections.singletonList("s1"))
+            .isAligned());
   }
 }


### PR DESCRIPTION
## Description

### Problem

When appending nested devices into one schema tree in sequence, for example non-aligned device ``` root.sg1.d2.others.ver``` and aligned device ``` root.sg1.d2```, the device node d2 in final schema tree won't be aligned.

### Solution

This problem is caused by info missing during node replacement. Add the check when replace internal node d2 with device node d2.
