### PR TITLE
[IOTDB-4868] Drop trigger should fail when trigger.OnDrop throws an exception 

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/trigger/TriggerTable.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/trigger/TriggerTable.java
@@ -57,8 +57,8 @@ public class TriggerTable {
     return triggerTable.get(triggerName);
   }
 
-  public TriggerInformation removeTriggerInformation(String triggerName) {
-    return triggerTable.remove(triggerName);
+  public void removeTriggerInformation(String triggerName) {
+    triggerTable.remove(triggerName);
   }
 
   public void setTriggerInformation(String triggerName, TriggerInformation triggerInformation) {

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -594,7 +594,7 @@ public class DataNode implements DataNodeMBean {
       List<ByteBuffer> jarList = resp.getJarList();
       for (int i = 0; i < triggerInformationList.size(); i++) {
         TriggerExecutableManager.getInstance()
-            .saveToLibDir(jarList.get(i), triggerInformationList.get(i).getJarName());
+            .saveToInstallDir(jarList.get(i), triggerInformationList.get(i).getJarName());
       }
     } catch (IOException | TException e) {
       throw new StartupException(e);

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -1341,7 +1341,8 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
     try {
       TriggerManagementService.getInstance().inactiveTrigger(req.triggerName);
     } catch (Exception e) {
-      LOGGER.error("Error occurred during ");
+      LOGGER.error("Error occurred when try to inactive trigger instance for trigger: {}. The cause is {}. ",
+              req.triggerName,e);
       return new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode())
           .setMessage(e.getMessage());
     }
@@ -1355,7 +1356,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
       TriggerManagementService.getInstance().dropTrigger(req.triggerName, req.needToDeleteJarFile);
     } catch (Exception e) {
       LOGGER.error(
-          "Error occurred during drop trigger instance for trigger: {}. The cause is {}.",
+          "Error occurred when dropping trigger instance for trigger: {}. The cause is {}.",
           req.triggerName,
           e);
       return new TSStatus(TSStatusCode.DROP_TRIGGER_INSTANCE_ERROR.getStatusCode())
@@ -1371,7 +1372,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
           .updateLocationOfStatefulTrigger(req.triggerName, req.newLocation);
     } catch (Exception e) {
       LOGGER.error(
-          "Error occurred during update Location for trigger: {}. The cause is {}.",
+          "Error occurred when updating Location for trigger: {}. The cause is {}.",
           req.triggerName,
           e);
       return new TSStatus(TSStatusCode.UPDATE_TRIGGER_LOCATION_ERROR.getStatusCode())

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -1341,8 +1341,10 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
     try {
       TriggerManagementService.getInstance().inactiveTrigger(req.triggerName);
     } catch (Exception e) {
-      LOGGER.error("Error occurred when try to inactive trigger instance for trigger: {}. The cause is {}. ",
-              req.triggerName,e);
+      LOGGER.error(
+          "Error occurred when try to inactive trigger instance for trigger: {}. The cause is {}. ",
+          req.triggerName,
+          e);
       return new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode())
           .setMessage(e.getMessage());
     }

--- a/server/src/main/java/org/apache/iotdb/db/trigger/service/TriggerManagementService.java
+++ b/server/src/main/java/org/apache/iotdb/db/trigger/service/TriggerManagementService.java
@@ -115,11 +115,15 @@ public class TriggerManagementService {
   public void dropTrigger(String triggerName, boolean needToDeleteJar) throws IOException {
     try {
       acquireLock();
-      TriggerInformation triggerInformation = triggerTable.removeTriggerInformation(triggerName);
-      TriggerExecutor executor = executorMap.remove(triggerName);
+      TriggerInformation triggerInformation = triggerTable.getTriggerInformation(triggerName);
+      TriggerExecutor executor = executorMap.get(triggerName);
       if (executor != null) {
         executor.onDrop();
       }
+      // exception could be thrown when executing executor.onDrop()
+      // we delete trigger in map after successfully executing onDrop
+      triggerTable.removeTriggerInformation(triggerName);
+      executorMap.remove(triggerName);
 
       if (triggerInformation == null) {
         return;


### PR DESCRIPTION
When drop trigger failed on DataNode, ConfigNode will send a retry rpc. We need to remove trigger in map after successfully exectuing trigger.OnDrop()