### PR TITLE
[IOTDB-4879] Use CAS in reserve method of MultiLeaderMemoryManager

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/MultiLeaderMemoryManager.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/multileader/logdispatcher/MultiLeaderMemoryManager.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.service.metric.MetricService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class MultiLeaderMemoryManager {
@@ -36,23 +37,28 @@ public class MultiLeaderMemoryManager {
   }
 
   public boolean reserve(long size) {
-    synchronized (this) {
-      if (size > maxMemorySizeInByte - memorySizeInByte.get()) {
-        logger.debug(
-            "consensus memory limited. required: {}, used: {}, total: {}",
-            size,
-            memorySizeInByte.get(),
-            maxMemorySizeInByte);
-        return false;
-      }
-      memorySizeInByte.addAndGet(size);
-    }
-    logger.debug(
-        "{} add {} bytes, total memory size: {} bytes.",
-        Thread.currentThread().getName(),
-        size,
-        memorySizeInByte.get());
-    return true;
+    AtomicBoolean result = new AtomicBoolean(false);
+    memorySizeInByte.updateAndGet(
+        (memorySize) -> {
+          if (size > maxMemorySizeInByte - memorySize) {
+            logger.debug(
+                "consensus memory limited. required: {}, used: {}, total: {}",
+                size,
+                memorySize,
+                maxMemorySizeInByte);
+            result.set(false);
+            return memorySize;
+          } else {
+            logger.debug(
+                "{} add {} bytes, total memory size: {} bytes.",
+                Thread.currentThread().getName(),
+                size,
+                memorySize + size);
+            result.set(true);
+            return memorySize + size;
+          }
+        });
+    return result.get();
   }
 
   public void free(long size) {


### PR DESCRIPTION
Try to use CAS in reserve method of MultiLeaderMemoryManager to avoid `synchronized` way.