### PR TITLE
fix: submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "iotdb-client-go"]
+[submodule "client-go"]
 	path = client-go
-	url = git@github.com:apache/iotdb-client-go.git
+	url = https://github.com/apache/iotdb-client-go.git


### PR DESCRIPTION
Current submodule settings cause:

```
Cloning into '/Users/chenzili/Brittani/iotdb/client-go'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:apache/iotdb-client-go.git' into submodule path '/Users/chenzili/Brittani/iotdb/client-go' failed
Failed to clone 'client-go'. Retry scheduled
Cloning into '/Users/chenzili/Brittani/iotdb/client-go'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:apache/iotdb-client-go.git' into submodule path '/Users/chenzili/Brittani/iotdb/client-go' failed
Failed to clone 'client-go' a second time, aborting
```