### PR TITLE
[IOTDB-4876] Fix PathPatternTree missing information on subpaths

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -104,6 +104,7 @@ public class PathPatternTree {
   private void appendBranchWithoutPrune(
       PathPatternNode<Void, VoidSerializer> curNode, String[] pathNodes, int pos) {
     if (pos == pathNodes.length - 1) {
+      curNode.setRoleType(PathPatternNode.Role.MEASUREMENT);
       return;
     }
 
@@ -124,6 +125,7 @@ public class PathPatternTree {
       curNode.addChild(newNode);
       curNode = newNode;
     }
+    curNode.setRoleType(PathPatternNode.Role.MEASUREMENT);
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -145,15 +147,17 @@ public class PathPatternTree {
   private void searchDevicePattern(
       PathPatternNode<Void, VoidSerializer> curNode, List<String> nodes, Set<String> results) {
     nodes.add(curNode.getName());
-    if (curNode.isLeaf()) {
+    if (curNode.isMeasurement()) {
       if (!curNode.getName().equals(IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD)) {
         results.add(
             nodes.size() == 1 ? "" : convertNodesToString(nodes.subList(0, nodes.size() - 1)));
       } else {
         results.add(convertNodesToString(nodes));
       }
-      nodes.remove(nodes.size() - 1);
-      return;
+      if (curNode.isLeaf()) {
+        nodes.remove(nodes.size() - 1);
+        return;
+      }
     }
     if (curNode.isWildcard()) {
       results.add(convertNodesToString(nodes));
@@ -177,9 +181,11 @@ public class PathPatternTree {
       PathPatternNode<Void, VoidSerializer> node,
       Deque<String> ancestors,
       List<PartialPath> fullPaths) {
-    if (node.isLeaf()) {
+    if (node.isMeasurement()) {
       fullPaths.add(convertNodesToPartialPath(node, ancestors));
-      return;
+      if (node.isLeaf()) {
+        return;
+      }
     }
 
     ancestors.push(node.getName());

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -104,7 +104,7 @@ public class PathPatternTree {
   private void appendBranchWithoutPrune(
       PathPatternNode<Void, VoidSerializer> curNode, String[] pathNodes, int pos) {
     if (pos == pathNodes.length - 1) {
-      curNode.setRoleType(PathPatternNode.Role.MEASUREMENT);
+      curNode.markPathPattern(true);
       return;
     }
 
@@ -125,7 +125,7 @@ public class PathPatternTree {
       curNode.addChild(newNode);
       curNode = newNode;
     }
-    curNode.setRoleType(PathPatternNode.Role.MEASUREMENT);
+    curNode.markPathPattern(true);
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -147,7 +147,7 @@ public class PathPatternTree {
   private void searchDevicePattern(
       PathPatternNode<Void, VoidSerializer> curNode, List<String> nodes, Set<String> results) {
     nodes.add(curNode.getName());
-    if (curNode.isMeasurement()) {
+    if (curNode.isPathPattern()) {
       if (!curNode.getName().equals(IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD)) {
         results.add(
             nodes.size() == 1 ? "" : convertNodesToString(nodes.subList(0, nodes.size() - 1)));
@@ -181,7 +181,7 @@ public class PathPatternTree {
       PathPatternNode<Void, VoidSerializer> node,
       Deque<String> ancestors,
       List<PartialPath> fullPaths) {
-    if (node.isMeasurement()) {
+    if (node.isPathPattern()) {
       fullPaths.add(convertNodesToPartialPath(node, ancestors));
       if (node.isLeaf()) {
         return;

--- a/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
@@ -159,6 +159,25 @@ public class PathPatternTreeTest {
   }
 
   /**
+   * This use case is used to test the completeness of getAllDevicePatterns and getAllPathPatterns
+   * results.
+   *
+   * <p>After appending root.sg1.d1 and root.sg1.d1.** to an empty pathPatternTree.
+   *
+   * <p>root.sg1.d1.** and root.sg1.d1 should be taken by invoking getAllPathPatterns.
+   */
+  @Test
+  public void pathPatternTreeTest9() throws IllegalPathException, IOException {
+    checkPathPatternTree(
+        Arrays.asList(
+            new PartialPath("root.sg1.d1"),
+            new PartialPath("root.sg1.d1.**"),
+            new PartialPath("root.sg1.d1.s1")),
+        Arrays.asList(new PartialPath("root.sg1.d1"), new PartialPath("root.sg1.d1.**")),
+        Arrays.asList(new PartialPath("root.sg1"), new PartialPath("root.sg1.d1.**")));
+  }
+
+  /**
    * @param paths PartialPath list to create PathPatternTree
    * @param compressedPaths Expected PartialPath list of getAllPathPatterns
    * @param compressedDevicePaths Expected PartialPath list of getAllDevicePatterns


### PR DESCRIPTION
## Description

### BUG description
 After appending root.sg.d and root.sg.d.** to an empty pathPatternTree and invoking constructTree(), only root.sg.d.** can be taken by invoking getAllPathPatterns() and root.sg.d is missing.

### Solution
In the original design, only the leaf nodes on the PathPatternTree are considered as measurement. However, the information is lost when there is a subpath for measurement. e.g. root->sg->d(measurement)->**(measurement).

So we use an additional roleType field to identify whether the node in the tree is internal or measurement.

To avoid compatibility problema, new semantics are given to the original valueSet field in the serialization method.