### PR TITLE
[IOTDB-4896] Fix error in closing a TsFileProcessor with an empty memtable

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1407,6 +1407,7 @@ public class DataRegion {
     if (isEmptyFile) {
       try {
         fsFactory.deleteIfExists(tsFileProcessor.getTsFileResource().getTsFile());
+        tsFileManager.remove(tsFileProcessor.getTsFileResource(), sequence);
       } catch (IOException e) {
         logger.error(
             "Remove empty file {} error",

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1380,6 +1380,8 @@ public class DataRegion {
     logger.info(
         "Async close tsfile: {}",
         tsFileProcessor.getTsFileResource().getTsFile().getAbsolutePath());
+
+    boolean isEmptyFile = tsFileProcessor.isEmpty();
     if (sequence) {
       closingSequenceTsFileProcessor.add(tsFileProcessor);
       tsFileProcessor.asyncClose();
@@ -1400,6 +1402,15 @@ public class DataRegion {
       // controller
       if (!workSequenceTsFileProcessors.containsKey(tsFileProcessor.getTimeRangeId())) {
         timePartitionIdVersionControllerMap.remove(tsFileProcessor.getTimeRangeId());
+      }
+    }
+    if (isEmptyFile) {
+      try {
+        fsFactory.deleteIfExists(tsFileProcessor.getTsFileResource().getTsFile());
+      } catch (IOException e) {
+        logger.error(
+            "Remove empty file {} error",
+            tsFileProcessor.getTsFileResource().getTsFile().getAbsolutePath());
       }
     }
   }
@@ -2061,7 +2072,7 @@ public class DataRegion {
     }
   }
 
-  private boolean unsequenceFlushCallback(
+  private void unsequenceFlushCallback(
       TsFileProcessor processor, Map<String, Long> updateMap, long systemFlushTime) {
     TimePartitionManager.getInstance()
         .updateAfterFlushing(
@@ -2070,21 +2081,11 @@ public class DataRegion {
             systemFlushTime,
             lastFlushTimeMap.getMemSize(processor.getTimeRangeId()),
             workSequenceTsFileProcessors.get(processor.getTimeRangeId()) != null);
-    return true;
   }
 
-  private boolean sequenceFlushCallback(
+  private void sequenceFlushCallback(
       TsFileProcessor processor, Map<String, Long> updateMap, long systemFlushTime) {
-    boolean res = lastFlushTimeMap.updateLatestFlushTime(processor.getTimeRangeId(), updateMap);
-    if (!res) {
-      logger.warn(
-          "Partition: {} does't have latest time for each device. "
-              + "No valid record is written into memtable. Flushing tsfile is: {}",
-          processor.getTimeRangeId(),
-          processor.getTsFileResource().getTsFile());
-      return res;
-    }
-
+    lastFlushTimeMap.updateLatestFlushTime(processor.getTimeRangeId(), updateMap);
     TimePartitionManager.getInstance()
         .updateAfterFlushing(
             new DataRegionId(Integer.valueOf(dataRegionId)),
@@ -2092,7 +2093,6 @@ public class DataRegion {
             systemFlushTime,
             lastFlushTimeMap.getMemSize(processor.getTimeRangeId()),
             workUnsequenceTsFileProcessors.get(processor.getTimeRangeId()) != null);
-    return res;
   }
 
   /** used for upgrading */
@@ -3279,7 +3279,7 @@ public class DataRegion {
   @FunctionalInterface
   public interface UpdateEndTimeCallBack {
 
-    boolean call(TsFileProcessor caller, Map<String, Long> updateMap, long systemFlushTime);
+    void call(TsFileProcessor caller, Map<String, Long> updateMap, long systemFlushTime);
   }
 
   @FunctionalInterface

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
@@ -181,7 +181,7 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
   }
 
   @Override
-  public boolean updateLatestFlushTime(long partitionId, Map<String, Long> updateMap) {
+  public void updateLatestFlushTime(long partitionId, Map<String, Long> updateMap) {
     for (Map.Entry<String, Long> entry : updateMap.entrySet()) {
       partitionLatestFlushedTimeForEachDevice
           .computeIfAbsent(partitionId, id -> new HashMap<>())
@@ -193,7 +193,6 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
         globalLatestFlushedTimeForEachDevice.put(entry.getKey(), entry.getValue());
       }
     }
-    return true;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/IDTableLastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/IDTableLastFlushTimeMap.java
@@ -113,7 +113,7 @@ public class IDTableLastFlushTimeMap implements ILastFlushTimeMap {
   }
 
   @Override
-  public boolean updateLatestFlushTime(long partitionId, Map<String, Long> updateMap) {
+  public void updateLatestFlushTime(long partitionId, Map<String, Long> updateMap) {
     for (Map.Entry<String, Long> entry : updateMap.entrySet()) {
       DeviceEntry deviceEntry = idTable.getDeviceEntry(entry.getKey());
       deviceEntry.updateFlushTimeMap(partitionId, entry.getValue());
@@ -121,7 +121,6 @@ public class IDTableLastFlushTimeMap implements ILastFlushTimeMap {
         deviceEntry.setGlobalFlushTime(entry.getValue());
       }
     }
-    return true;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/ILastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/ILastFlushTimeMap.java
@@ -52,7 +52,7 @@ public interface ILastFlushTimeMap {
   // region support upgrade methods
   void applyNewlyFlushedTimeToFlushedTime();
 
-  boolean updateLatestFlushTime(long partitionId, Map<String, Long> updateMap);
+  void updateLatestFlushTime(long partitionId, Map<String, Long> updateMap);
   // endregion
 
   // region query

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1273,7 +1273,7 @@ public class TsFileProcessor {
     logger.info("Start to end file {}", tsFileResource);
     long closeStartTime = System.currentTimeMillis();
     writer.endFile();
-    // tsFileResource.serialize();
+    tsFileResource.serialize();
     for (ISyncManager syncManager :
         SyncService.getInstance()
             .getOrCreateSyncManager(dataRegionInfo.getDataRegion().getDataRegionId())) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -1307,11 +1307,12 @@ public class TsFileProcessor {
   }
 
   /** end empty file and remove it from file system */
-  private void endEmptyFile() throws TsFileProcessorException {
+  private void endEmptyFile() throws TsFileProcessorException, IOException {
     logger.info("Start to end empty file {}", tsFileResource);
 
     // remove this processor from Closing list in DataRegion,
     // mark the TsFileResource closed, no need writer anymore
+    writer.close();
     for (CloseFileListener closeFileListener : closeFileListeners) {
       closeFileListener.onClosed(this);
     }

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/DataRegionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/DataRegionTest.java
@@ -1087,7 +1087,7 @@ public class DataRegionTest {
     // delete data which is in flushing memtable
     dataRegion.deleteByDevice(new PartialPath("root.vehicle.d0.s0"), 50, 100, 0, null);
     dataRegion.deleteByDevice(new PartialPath("root.vehicle.d0.s0"), 50, 150, 0, null);
-    dataRegion.deleteByDevice(new PartialPath("root.vehicle.d0.s0"), 100, 300, 0, null);
+    dataRegion.deleteByDevice(new PartialPath("root.vehicle.d0.s0"), 100, 190, 0, null);
 
     dataRegion.syncCloseAllWorkingTsFileProcessors();
     Assert.assertTrue(tsFileResource.getModFile().exists());

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorV2Test.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorV2Test.java
@@ -110,7 +110,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor, updateMap, systemFlushTime) -> true,
+            (tsFileProcessor, updateMap, systemFlushTime) -> {},
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
@@ -169,7 +169,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor, updateMap, systemFlushTime) -> true,
+            (tsFileProcessor, updateMap, systemFlushTime) -> {},
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
@@ -256,7 +256,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor, updateMap, systemFlushTime) -> true,
+            (tsFileProcessor, updateMap, systemFlushTime) -> {},
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
@@ -299,7 +299,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor, updateMap, systemFlushTime) -> true,
+            (tsFileProcessor, updateMap, systemFlushTime) -> {},
             true);
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
     processor.setTsFileProcessorInfo(tsFileProcessorInfo);
@@ -335,7 +335,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor, updateMap, systemFlushTime) -> true,
+            (tsFileProcessor, updateMap, systemFlushTime) -> {},
             true);
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);
     processor.setTsFileProcessorInfo(tsFileProcessorInfo);
@@ -371,7 +371,7 @@ public class TsFileProcessorV2Test {
             SystemFileFactory.INSTANCE.getFile(filePath),
             sgInfo,
             this::closeTsFileProcessor,
-            (tsFileProcessor, updateMap, systemFlushTime) -> true,
+            (tsFileProcessor, updateMap, systemFlushTime) -> {},
             true);
 
     TsFileProcessorInfo tsFileProcessorInfo = new TsFileProcessorInfo(sgInfo);


### PR DESCRIPTION
Now, when executing some inserting requests and then deleting all data, there will be an empty memtable in the tsfileProcessor. When executing flush request and closing this tsfileProcessor,  this request will be blocked.