### PR TITLE
[IOTDB-4849] Fix the problem that internal_address is not consistent with target_confignode when first starts Seed-ConfigNode.

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -240,9 +240,15 @@ public class ConfigManager implements IManager {
   }
 
   public void close() throws IOException {
-    consensusManager.close();
-    partitionManager.getRegionMaintainer().shutdown();
-    procedureManager.shiftExecutor(false);
+    if (consensusManager != null) {
+      consensusManager.close();
+    }
+    if (partitionManager != null) {
+      partitionManager.getRegionMaintainer().shutdown();
+    }
+    if (procedureManager != null) {
+      procedureManager.shiftExecutor(false);
+    }
   }
 
   @Override

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
@@ -356,6 +356,16 @@ public class NodeManager {
   }
 
   public TConfigNodeRegisterResp registerConfigNode(TConfigNodeRegisterReq req) {
+    if (configManager.getConsensusManager() == null) {
+      TSStatus errorStatus = new TSStatus(TSStatusCode.ERROR_GLOBAL_CONFIG.getStatusCode());
+      errorStatus.setMessage(
+          "ConsensusManager of target-ConfigNode is not initialized, "
+              + "please make sure the target-ConfigNode has been started successfully.");
+      return new TConfigNodeRegisterResp()
+          .setStatus(errorStatus)
+          .setConfigNodeId(ERROR_STATUS_NODE_ID);
+    }
+
     // Check global configuration
     TSStatus status = configManager.getConsensusManager().confirmLeader();
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
@@ -357,7 +357,7 @@ public class NodeManager {
 
   public TConfigNodeRegisterResp registerConfigNode(TConfigNodeRegisterReq req) {
     if (configManager.getConsensusManager() == null) {
-      TSStatus errorStatus = new TSStatus(TSStatusCode.ERROR_GLOBAL_CONFIG.getStatusCode());
+      TSStatus errorStatus = new TSStatus(TSStatusCode.CONSENSUS_NOT_INITIALIZED.getStatusCode());
       errorStatus.setMessage(
           "ConsensusManager of target-ConfigNode is not initialized, "
               + "please make sure the target-ConfigNode has been started successfully.");

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -266,6 +266,11 @@ public class ConfigNode implements ConfigNodeMBean {
       } else if (status.getCode() == TSStatusCode.ERROR_GLOBAL_CONFIG.getStatusCode()) {
         LOGGER.error(status.getMessage());
         throw new StartupException("Configuration are not consistent!");
+      } else if (status.getCode() == TSStatusCode.CONSENSUS_NOT_INITIALIZED.getStatusCode()) {
+        LOGGER.error(status.getMessage());
+        throw new StartupException(
+            "The target ConfigNode is not started successfully, "
+                + "please check the cn_target_config_node_list config!");
       }
 
       try {


### PR DESCRIPTION
## Description

Fix the problem that internal_address is not consistent with target_confignode when first starts.

Before fix, the run result is as below:
![image](https://user-images.githubusercontent.com/6756545/201595688-f25294f9-ce2f-4076-9279-ab3982027a97.png)

After fix, the run result is as below:
![image](https://user-images.githubusercontent.com/6756545/201595328-2edc2549-41ad-4b51-8a35-eefb931689a0.png)

