### PR TITLE
[To rel/0.13] [IOTDB-4938] Fix error for storage group not ready

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncConsumer.java
+++ b/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncConsumer.java
@@ -19,7 +19,9 @@
 package org.apache.iotdb.db.doublelive;
 
 import org.apache.iotdb.db.engine.StorageEngine;
+import org.apache.iotdb.rpc.BatchExecutionException;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.pool.SessionPool;
 import org.apache.iotdb.tsfile.utils.Pair;
 
@@ -29,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.BlockingQueue;
+
+import static org.apache.iotdb.rpc.TSStatusCode.STORAGE_GROUP_NOT_READY;
 
 public class OperationSyncConsumer implements Runnable {
   private static final Logger LOGGER = LoggerFactory.getLogger(OperationSyncConsumer.class);
@@ -68,10 +72,26 @@ public class OperationSyncConsumer implements Runnable {
         } catch (IoTDBConnectionException connectionException) {
           // warn IoTDBConnectionException and do serialization
           LOGGER.warn(
-              "OperationSyncConsumer can't transmit because network failure", connectionException);
+              "OperationSyncConsumer can't transmit for connection error", connectionException);
+        } catch (BatchExecutionException batchExecutionException) {
+          LOGGER.error(
+              "OperationSyncConsumer can't transmit for batchExecutionException",
+              batchExecutionException);
+          if (batchExecutionException.getStatusList().stream()
+              .noneMatch(s -> s.getCode() == STORAGE_GROUP_NOT_READY.getStatusCode())) {
+            continue;
+          }
+        } catch (StatementExecutionException statementExecutionException) {
+          LOGGER.error(
+              "OperationSyncConsumer can't transmit for statementExecutionException",
+              statementExecutionException);
+          if (statementExecutionException.getStatusCode()
+              != STORAGE_GROUP_NOT_READY.getStatusCode()) {
+            continue;
+          }
         } catch (Exception e) {
           // The PhysicalPlan has internal error, reject transmit
-          LOGGER.error("OperationSyncConsumer can't transmit", e);
+          LOGGER.error("OperationSyncConsumer can't transmit, discard it", e);
           continue;
         }
       }

--- a/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncConsumer.java
+++ b/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncConsumer.java
@@ -74,19 +74,27 @@ public class OperationSyncConsumer implements Runnable {
           LOGGER.warn(
               "OperationSyncConsumer can't transmit for connection error", connectionException);
         } catch (BatchExecutionException batchExecutionException) {
-          LOGGER.error(
-              "OperationSyncConsumer can't transmit for batchExecutionException",
-              batchExecutionException);
           if (batchExecutionException.getStatusList().stream()
-              .noneMatch(s -> s.getCode() == STORAGE_GROUP_NOT_READY.getStatusCode())) {
+              .anyMatch(s -> s.getCode() == STORAGE_GROUP_NOT_READY.getStatusCode())) {
+            LOGGER.warn(
+                "OperationSyncConsumer can't transmit for STORAGE_GROUP_NOT_READY",
+                batchExecutionException);
+          } else {
+            LOGGER.warn(
+                "OperationSyncConsumer can't transmit for batchExecutionException, discard it",
+                batchExecutionException);
             continue;
           }
         } catch (StatementExecutionException statementExecutionException) {
-          LOGGER.error(
-              "OperationSyncConsumer can't transmit for statementExecutionException",
-              statementExecutionException);
           if (statementExecutionException.getStatusCode()
-              != STORAGE_GROUP_NOT_READY.getStatusCode()) {
+              == STORAGE_GROUP_NOT_READY.getStatusCode()) {
+            LOGGER.warn(
+                "OperationSyncConsumer can't transmit for STORAGE_GROUP_NOT_READY",
+                statementExecutionException);
+          } else {
+            LOGGER.warn(
+                "OperationSyncConsumer can't transmit for statementExecutionException, discard it",
+                statementExecutionException);
             continue;
           }
         } catch (Exception e) {

--- a/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncDDLProtector.java
+++ b/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncDDLProtector.java
@@ -20,7 +20,9 @@ package org.apache.iotdb.db.doublelive;
 
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
+import org.apache.iotdb.rpc.BatchExecutionException;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.pool.SessionPool;
 
 import org.slf4j.Logger;
@@ -28,6 +30,8 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
+
+import static org.apache.iotdb.rpc.TSStatusCode.STORAGE_GROUP_NOT_READY;
 
 public class OperationSyncDDLProtector extends OperationSyncProtector {
 
@@ -57,7 +61,25 @@ public class OperationSyncDDLProtector extends OperationSyncProtector {
           transmitStatus = operationSyncSessionPool.operationSyncTransmit(planBuffer);
         } catch (IoTDBConnectionException connectionException) {
           // warn IoTDBConnectionException and retry
-          LOGGER.warn("OperationSyncDDLProtector can't transmit, retrying...", connectionException);
+          LOGGER.warn(
+              "OperationSyncDDLProtector can't transmit for connection error, retrying...",
+              connectionException);
+        } catch (BatchExecutionException batchExecutionException) {
+          LOGGER.error(
+              "OperationSyncDDLProtector can't transmit for batchExecutionException",
+              batchExecutionException);
+          if (batchExecutionException.getStatusList().stream()
+              .noneMatch(s -> s.getCode() == STORAGE_GROUP_NOT_READY.getStatusCode())) {
+            break;
+          }
+        } catch (StatementExecutionException statementExecutionException) {
+          LOGGER.error(
+              "OperationSyncDDLProtector can't transmit for statementExecutionException",
+              statementExecutionException);
+          if (statementExecutionException.getStatusCode()
+              != STORAGE_GROUP_NOT_READY.getStatusCode()) {
+            break;
+          }
         } catch (Exception e) {
           // error exception and break
           LOGGER.error("OperationSyncDDLProtector can't transmit", e);

--- a/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncDMLProtector.java
+++ b/server/src/main/java/org/apache/iotdb/db/doublelive/OperationSyncDMLProtector.java
@@ -70,25 +70,31 @@ public class OperationSyncDMLProtector extends OperationSyncProtector {
               "OperationSyncDMLProtector can't transmit for connection error, retrying...",
               connectionException);
         } catch (BatchExecutionException batchExecutionException) {
-          LOGGER.error(
-              "OperationSyncDMLProtector can't transmit for batchExecutionException",
-              batchExecutionException);
           if (batchExecutionException.getStatusList().stream()
-              .noneMatch(s -> s.getCode() == STORAGE_GROUP_NOT_READY.getStatusCode())) {
+              .anyMatch(s -> s.getCode() == STORAGE_GROUP_NOT_READY.getStatusCode())) {
+            sleepTimeInSeconds = 10;
+            LOGGER.warn(
+                "OperationSyncDMLProtector can't transmit for STORAGE_GROUP_NOT_READY",
+                batchExecutionException);
+          } else {
+            LOGGER.warn(
+                "OperationSyncDMLProtector can't transmit for batchExecutionException, discard it",
+                batchExecutionException);
             break;
           }
-          // sleep more time when meets `StorageGroupNotReadyException`
-          sleepTimeInSeconds = 30;
         } catch (StatementExecutionException statementExecutionException) {
-          LOGGER.error(
-              "OperationSyncDMLProtector can't transmit for statementExecutionException",
-              statementExecutionException);
           if (statementExecutionException.getStatusCode()
-              != STORAGE_GROUP_NOT_READY.getStatusCode()) {
+              == STORAGE_GROUP_NOT_READY.getStatusCode()) {
+            LOGGER.warn(
+                "OperationSyncDMLProtector can't transmit for STORAGE_GROUP_NOT_READY",
+                statementExecutionException);
+            sleepTimeInSeconds = 10;
+          } else {
+            LOGGER.warn(
+                "OperationSyncDMLProtector can't transmit for statementExecutionException, discard it",
+                statementExecutionException);
             break;
           }
-          // sleep more time when meets `StorageGroupNotReadyException`
-          sleepTimeInSeconds = 30;
         } catch (Exception e) {
           // error exception and break
           LOGGER.error("OperationSyncDMLProtector can't transmit, discard it", e);


### PR DESCRIPTION
## Description

### The error reason: 
Start primary db and backup db, maintain write requests, and stop backup db for 5 minutes(write requests for primary db is not stopped), then restart backup db, then meets exception 'org.apache.iotdb.rpc.BatchExecutionException: 506: org.apache.iotdb.db.exception.StorageGroupNotReadyException: the sg root.sg1 may not ready now, please wait and retry later; '.   And these data are not persistent in operation sync log, so these data are lost.

![image](https://user-images.githubusercontent.com/6756545/201850566-a6c83e16-5a2e-4f2b-a2d8-b130a77dbe0c.png)

### Resolution:
Persistent the data in operation sync log when meets `StorageGroupNotReadyException`.

### TestResults:
![image](https://user-images.githubusercontent.com/6756545/201852464-e9d68487-4d47-4ac3-892d-aae3619c1c5f.png)
![image](https://user-images.githubusercontent.com/6756545/201852557-b17f200b-479a-4f9a-a59c-8ebd0db591d8.png)


