### PR TITLE
[IOTDB-4901][IOTDB-4860] Fix concurrent auto create schema bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
@@ -69,7 +69,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 
 public class RegionWriteExecutor {
 
@@ -348,19 +347,15 @@ public class RegionWriteExecutor {
               continue;
             }
 
-            // filter failed measurement and keep the rest for execution
-            List<Integer> failingMeasurementIndexList =
-                failingMeasurementMap.keySet().stream().sorted().collect(Collectors.toList());
-            int removedNum = 0;
-            for (Integer index : failingMeasurementIndexList) {
-              entry.getValue().removeMeasurement(index - removedNum);
-              removedNum++;
-              LOGGER.error("Metadata error: ", failingMeasurementMap.get(index));
+            for (Map.Entry<Integer, MetadataException> failingMeasurement :
+                failingMeasurementMap.entrySet()) {
+              LOGGER.error("Metadata error: ", failingMeasurement.getValue());
               failingStatus.add(
                   RpcUtils.getStatus(
-                      failingMeasurementMap.get(index).getErrorCode(),
-                      failingMeasurementMap.get(index).getMessage()));
+                      failingMeasurement.getValue().getErrorCode(),
+                      failingMeasurement.getValue().getMessage()));
             }
+            entry.getValue().removeMeasurements(failingMeasurementMap.keySet());
 
             if (entry.getValue().isEmpty()) {
               emptyDeviceList.add(entry.getKey());
@@ -435,8 +430,8 @@ public class RegionWriteExecutor {
                   RpcUtils.getStatus(
                       metadataException.getErrorCode(), metadataException.getMessage()));
             }
-            measurementGroup.removeMeasurement(failingMeasurement.getKey());
           }
+          measurementGroup.removeMeasurements(failingMeasurementMap.keySet());
 
           RegionExecutionResult executionResult =
               super.visitInternalCreateTimeSeries(node, context);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ClusterSchemaFetcher.java
@@ -485,6 +485,11 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
       return Collections.emptyList();
     }
 
+    if (statusCode != TSStatusCode.MULTIPLE_ERROR.getStatusCode()) {
+      throw new RuntimeException(
+          new IoTDBException(executionResult.status.getMessage(), statusCode));
+    }
+
     List<String> failedCreationList = new ArrayList<>();
     List<MeasurementPath> alreadyExistingMeasurements = new ArrayList<>();
     for (TSStatus subStatus : executionResult.status.subStatus) {
@@ -501,7 +506,8 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
       for (String message : failedCreationList) {
         stringBuilder.append(message).append("\n");
       }
-      throw new RuntimeException(String.format("Failed to auto create schema\n %s", stringBuilder));
+      throw new RuntimeException(
+          new MetadataException(String.format("Failed to auto create schema\n %s", stringBuilder)));
     }
 
     return alreadyExistingMeasurements;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/write/MeasurementGroup.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/write/MeasurementGroup.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class MeasurementGroup {
 
@@ -139,6 +140,50 @@ public class MeasurementGroup {
     if (attributesList != null) {
       attributesList.remove(index);
     }
+  }
+
+  public void removeMeasurements(Set<Integer> indexSet) {
+    int restSize = this.measurements.size() - indexSet.size();
+    List<String> measurements = new ArrayList<>(restSize);
+    List<TSDataType> dataTypes = new ArrayList<>(restSize);
+    List<TSEncoding> encodings = new ArrayList<>(restSize);
+    List<CompressionType> compressors = new ArrayList<>(restSize);
+    List<String> aliasList = this.aliasList == null ? null : new ArrayList<>(restSize);
+    List<Map<String, String>> propsList = this.propsList == null ? null : new ArrayList<>(restSize);
+    List<Map<String, String>> tagsList = this.tagsList == null ? null : new ArrayList<>(restSize);
+    List<Map<String, String>> attributesList =
+        this.attributesList == null ? null : new ArrayList<>(restSize);
+
+    for (int i = 0; i < this.measurements.size(); i++) {
+      if (indexSet.contains(i)) {
+        continue;
+      }
+      measurements.add(this.measurements.get(i));
+      dataTypes.add(this.dataTypes.get(i));
+      encodings.add(this.encodings.get(i));
+      compressors.add(this.compressors.get(i));
+      if (aliasList != null) {
+        aliasList.add(this.aliasList.get(i));
+      }
+      if (propsList != null) {
+        propsList.add(this.propsList.get(i));
+      }
+      if (tagsList != null) {
+        tagsList.add(this.tagsList.get(i));
+      }
+      if (attributesList != null) {
+        attributesList.add(this.attributesList.get(i));
+      }
+    }
+
+    this.measurements = measurements;
+    this.dataTypes = dataTypes;
+    this.encodings = encodings;
+    this.compressors = compressors;
+    this.aliasList = aliasList;
+    this.propsList = propsList;
+    this.tagsList = tagsList;
+    this.attributesList = attributesList;
   }
 
   public int size() {


### PR DESCRIPTION
## Description

see IOTDB-4901 IOTDB-4860

The index of measurement in measurementGroup will go invalid during removing some measurement, thus fix it by moving the needed measurements to new list.
