### PR TITLE
[IOTDB-4942] Only checkDirectory when start DataNode

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -89,6 +89,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.iotdb.db.service.DataNodeServerCommandLine.MODE_START;
+
 public class DataNode implements DataNodeMBean {
   private static final Logger logger = LoggerFactory.getLogger(DataNode.class);
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
@@ -128,10 +130,13 @@ public class DataNode implements DataNodeMBean {
     new DataNodeServerCommandLine().doMain(args);
   }
 
-  protected void serverCheckAndInit() throws ConfigurationException, IOException {
+  protected void serverCheckAndInit(String mode) throws ConfigurationException, IOException {
     config.setClusterMode(true);
     IoTDBStartCheck.getInstance().checkConfig();
-    IoTDBStartCheck.getInstance().checkDirectory();
+    if (MODE_START.equals(mode)) {
+      // Only checkDirectory when start DataNode
+      IoTDBStartCheck.getInstance().checkDirectory();
+    }
     // TODO: check configuration for data node
 
     for (TEndPoint endPoint : config.getTargetConfigNodeList()) {

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNodeServerCommandLine.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNodeServerCommandLine.java
@@ -48,10 +48,10 @@ public class DataNodeServerCommandLine extends ServerCommandLine {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeServerCommandLine.class);
 
   // join an established cluster
-  private static final String MODE_START = "-s";
+  public static final String MODE_START = "-s";
   // send a request to remove a node, more arguments: ip-of-removed-node
   // metaport-of-removed-node
-  private static final String MODE_REMOVE = "-r";
+  public static final String MODE_REMOVE = "-r";
 
   private static final String USAGE =
       "Usage: <-s|-r> "
@@ -72,15 +72,17 @@ public class DataNodeServerCommandLine extends ServerCommandLine {
     }
 
     DataNode dataNode = DataNode.getInstance();
+
+    String mode = args[0];
+    LOGGER.info("Running mode {}", mode);
+
     // Check config of IoTDB, and set some configs in cluster mode
     try {
-      dataNode.serverCheckAndInit();
+      dataNode.serverCheckAndInit(mode);
     } catch (ConfigurationException | IOException e) {
       LOGGER.error("Meet error when doing start checking", e);
       return -1;
     }
-    String mode = args[0];
-    LOGGER.info("Running mode {}", mode);
 
     // Initialize the current node and its services
     if (!dataNode.initLocalEngines()) {


### PR DESCRIPTION
## Description

Only checkDirectory when start DataNode because remove-datanode.sh will cause error.

![image](https://user-images.githubusercontent.com/6756545/201916729-7bad425d-3748-4592-a380-8c90271d305d.png)


