### PR TITLE
Fix Segment size estimation in SchemaFile

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -376,6 +376,7 @@ public class SchemaFile implements ISchemaFile {
     return (short) (globalIndex & SchemaFileConfig.SEG_INDEX_MASK);
   }
 
+  /** TODO: shall merge with {@linkplain PageManager#reEstimateSegSize} */
   static short reEstimateSegSize(int oldSize) {
     for (short size : SchemaFileConfig.SEG_SIZE_LST) {
       if (oldSize < size) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
@@ -62,6 +62,7 @@ import static org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFil
 import static org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFileConfig.SEG_HEADER_SIZE;
 import static org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFileConfig.SEG_MAX_SIZ;
 import static org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFileConfig.SEG_MIN_SIZ;
+import static org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFileConfig.SEG_OFF_DIG;
 import static org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFileConfig.SEG_SIZE_LST;
 import static org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFileConfig.SEG_SIZE_METRIC;
 
@@ -148,7 +149,6 @@ public abstract class PageManager implements IPageManager {
     ISchemaPage curPage;
     ByteBuffer childBuffer;
     String alias;
-    int secIdxEntrance = -1; // first page of secondary index
     // TODO: reserve order of insert in container may be better
     for (Map.Entry<String, IMNode> entry :
         ICachedMNodeContainer.getCachedMNodeContainer(node).getNewChildBuffer().entrySet().stream()
@@ -477,7 +477,7 @@ public abstract class PageManager implements IPageManager {
   @Deprecated
   // TODO: improve to remove
   private long preAllocateSegment(short size) throws IOException, MetadataException {
-    ISegmentedPage page = getMinApplSegmentedPageInMem(size);
+    ISegmentedPage page = getMinApplSegmentedPageInMem((short) (size + SEG_OFF_DIG));
     return SchemaFile.getGlobalIndex(page.getPageIndex(), page.allocNewSegment(size));
   }
 
@@ -621,6 +621,9 @@ public abstract class PageManager implements IPageManager {
    * SchemaPageOverflowException} occurs. It is designed to accelerate when there is lots of new
    * children nodes, avoiding segments extend several times.
    *
+   * <p>Notice that SegmentOverflowException inside a page with sufficient space will not reach
+   * here. Supposed to merge with SchemaFile#reEstimateSegSize.
+   *
    * @param expSize expected size calculated from next new record
    * @param batchSize size of children within one {@linkplain #writeNewChildren(IMNode)}
    * @return estimated size
@@ -630,14 +633,21 @@ public abstract class PageManager implements IPageManager {
     if (batchSize < SEG_SIZE_METRIC[0]) {
       return reEstimateSegSize(expSize);
     }
+    int base_tier = 0;
+    for (int i = 0; i < SEG_SIZE_LST.length; i++) {
+      if (SEG_SIZE_LST[i] >= expSize) {
+        base_tier = i;
+        break;
+      }
+    }
     int tier = SEG_SIZE_LST.length - 1;
-    while (tier > 0) {
+    while (tier >= base_tier) {
       if (batchSize > SEG_SIZE_METRIC[tier]) {
         return SEG_SIZE_LST[tier];
       }
       tier--;
     }
-    return SEG_SIZE_LST[0];
+    return SEG_SIZE_LST[base_tier];
   }
 
   private static short reEstimateSegSize(int expSize) throws MetadataException {


### PR DESCRIPTION
## Description
This pr fixs a bug involved from https://github.com/apache/iotdb/pull/7726 where tried to optimize performance by an extra segment estimation method. The method takes into account the size of write batch but ignores to compare it with the original size, which throws an exception with message that cannot extend a segment into a smaller buffer.

The problem is fixed by this pr, in comany with a new ut to verify it.