### PR TITLE
[IOTDB-4950] Add TsFileResourceStatus DELETED

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -510,6 +510,7 @@ public class TsFileResource {
    * file physically.
    */
   public boolean remove() {
+    this.status = TsFileResourceStatus.DELETED;
     try {
       fsFactory.deleteIfExists(file);
       fsFactory.deleteIfExists(
@@ -577,7 +578,7 @@ public class TsFileResource {
   }
 
   public boolean isDeleted() {
-    return !this.file.exists();
+    return this.status == TsFileResourceStatus.DELETED;
   }
 
   public boolean isCompacting() {
@@ -862,6 +863,7 @@ public class TsFileResource {
               .getFile(file.toPath() + TsFileResource.RESOURCE_SUFFIX)
               .toPath());
     }
+    this.status = TsFileResourceStatus.DELETED;
   }
 
   public long getMaxPlanIndex() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResourceStatus.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResourceStatus.java
@@ -22,5 +22,6 @@ public enum TsFileResourceStatus {
   UNCLOSED,
   CLOSED,
   COMPACTION_CANDIDATE,
-  COMPACTING
+  COMPACTING,
+  DELETED
 }


### PR DESCRIPTION
See [IOTDB-4950](https://issues.apache.org/jira/browse/IOTDB-4950).

If we do not use a `DELETED` status for a deleted tsfile resource, every time the program call `isDelete` method in TsFileResource, it has to access the file system to check whether a tsfile exists or not, which may lead to bad performance.