### PR TITLE
[IOTDB-4951] Response failure if drop non-existent pipe

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/DropPipeProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/DropPipeProcedure.java
@@ -20,7 +20,6 @@ package org.apache.iotdb.confignode.procedure.impl.sync;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.exception.sync.PipeException;
-import org.apache.iotdb.commons.exception.sync.PipeNotExistException;
 import org.apache.iotdb.commons.sync.pipe.PipeInfo;
 import org.apache.iotdb.commons.sync.pipe.PipeStatus;
 import org.apache.iotdb.commons.sync.pipe.SyncOperation;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/DropPipeProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/DropPipeProcedure.java
@@ -60,12 +60,9 @@ public class DropPipeProcedure extends AbstractOperatePipeProcedure {
   @Override
   boolean executeCheckCanSkip(ConfigNodeProcedureEnv env) throws PipeException {
     LOGGER.info("Start to drop PIPE [{}]", pipeName);
-    try {
-      PipeInfo pipeInfo = env.getConfigManager().getSyncManager().getPipeInfo(pipeName);
-      return false;
-    } catch (PipeNotExistException e) {
-      return true;
-    }
+    // throw PipeNotExistException if pipe not exist
+    PipeInfo pipeInfo = env.getConfigManager().getSyncManager().getPipeInfo(pipeName);
+    return false;
   }
 
   @Override

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
@@ -158,7 +158,12 @@ public class IoTDBPipeIT {
       }
       statement.execute("DROP PIPE p1;");
       statement.execute("DROP PIPE p2;");
-      statement.execute("DROP PIPE p3;");
+      try {
+        statement.execute("DROP PIPE p3;");
+        Assert.fail();
+      } catch (Exception e) {
+        Assert.assertTrue(e.getMessage().contains("PIPE [p3] does not exist"));
+      }
       try (ResultSet resultSet = statement.executeQuery("SHOW PIPE")) {
         String[] expectedRetSet = new String[] {};
         assertResultSetEqual(resultSet, SHOW_PIPE_HEADER, expectedRetSet);


### PR DESCRIPTION
## Description

Even if pipe does not exist, drop pipe always succeed. But if pipesink does not exist，drop pipesink report error.

After this PR change, drop non-existent pipe operetion will fail and response `PIPE [aa] does not exist`.

<img width="693" alt="image" src="https://user-images.githubusercontent.com/43774645/202119808-84093be9-2ec1-4a7f-a1d7-39dd33076e4d.png">


