### PR TITLE
[IOTDB-4939] Remove unsupported compression type

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSchemaTemplateIT.java
@@ -78,7 +78,7 @@ public class IoTDBSessionSchemaTemplateIT {
         Arrays.asList(TSDataType.FLOAT, TSDataType.FLOAT, TSDataType.DOUBLE);
     List<TSEncoding> encodings = Arrays.asList(TSEncoding.RLE, TSEncoding.RLE, TSEncoding.GORILLA);
     List<CompressionType> compressors =
-        Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY, CompressionType.GZIP);
+        Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY, CompressionType.LZ4);
 
     session.setStorageGroup("root.sg");
 

--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSchemaTemplateIT.java
@@ -78,7 +78,7 @@ public class IoTDBSessionSchemaTemplateIT {
         Arrays.asList(TSDataType.FLOAT, TSDataType.FLOAT, TSDataType.DOUBLE);
     List<TSEncoding> encodings = Arrays.asList(TSEncoding.RLE, TSEncoding.RLE, TSEncoding.GORILLA);
     List<CompressionType> compressors =
-        Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY, CompressionType.LZ4);
+        Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY, CompressionType.GZIP);
 
     session.setStorageGroup("root.sg");
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/StatementGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/StatementGenerator.java
@@ -546,9 +546,10 @@ public class StatementGenerator {
       String prefix = ReadWriteIOUtils.readString(buffer);
       isAlign = ReadWriteIOUtils.readBool(buffer);
       String measurementName = ReadWriteIOUtils.readString(buffer);
-      TSDataType dataType = TSDataType.values()[ReadWriteIOUtils.readByte(buffer)];
-      TSEncoding encoding = TSEncoding.values()[ReadWriteIOUtils.readByte(buffer)];
-      CompressionType compressionType = CompressionType.values()[ReadWriteIOUtils.readByte(buffer)];
+      TSDataType dataType = TSDataType.deserialize(ReadWriteIOUtils.readByte(buffer));
+      TSEncoding encoding = TSEncoding.deserialize(ReadWriteIOUtils.readByte(buffer));
+      CompressionType compressionType =
+          CompressionType.deserialize(ReadWriteIOUtils.readByte(buffer));
 
       if (alignedPrefix.containsKey(prefix) && !isAlign) {
         throw new MetadataException("Align designation incorrect at: " + prefix);

--- a/server/src/test/java/org/apache/iotdb/db/metadata/SchemaBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/SchemaBasicTest.java
@@ -963,7 +963,7 @@ public abstract class SchemaBasicTest {
     encodingList.add(Arrays.asList(TSEncoding.RLE, TSEncoding.RLE));
 
     List<List<CompressionType>> compressionTypes = new ArrayList<>();
-    compressionTypes.add(Collections.singletonList(CompressionType.SDT));
+    compressionTypes.add(Collections.singletonList(CompressionType.GZIP));
     compressionTypes.add(Collections.singletonList(CompressionType.SNAPPY));
     compressionTypes.add(Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
 
@@ -1095,7 +1095,7 @@ public abstract class SchemaBasicTest {
     encodingList.add(Arrays.asList(TSEncoding.RLE, TSEncoding.RLE));
 
     List<List<CompressionType>> compressionTypes = new ArrayList<>();
-    compressionTypes.add(Collections.singletonList(CompressionType.SDT));
+    compressionTypes.add(Collections.singletonList(CompressionType.GZIP));
     compressionTypes.add(Collections.singletonList(CompressionType.SNAPPY));
     compressionTypes.add(Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
 

--- a/server/src/test/java/org/apache/iotdb/db/metadata/plan/SchemaRegionPlanCompatibilityTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/plan/SchemaRegionPlanCompatibilityTest.java
@@ -197,7 +197,7 @@ public class SchemaRegionPlanCompatibilityTest {
     oldPlan.setMeasurements(Arrays.asList("s1", "s2"));
     oldPlan.setDataTypes(Arrays.asList(TSDataType.INT32, TSDataType.FLOAT));
     oldPlan.setEncodings(Arrays.asList(TSEncoding.GORILLA, TSEncoding.BITMAP));
-    oldPlan.setCompressors(Arrays.asList(CompressionType.PLA, CompressionType.GZIP));
+    oldPlan.setCompressors(Arrays.asList(CompressionType.SNAPPY, CompressionType.GZIP));
     oldPlan.setAliasList(Arrays.asList("status", "temperature"));
     Map<String, String> tagMap = new HashMap<>();
     tagMap.put("tag-key", "tag-value");

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/CompressionType.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/CompressionType.java
@@ -28,19 +28,8 @@ public enum CompressionType {
   /** GZIP */
   GZIP(".gzip", (byte) 2),
 
-  /** LZO */
-  LZO(".lzo", (byte) 3),
-
-  /** SDT */
-  SDT(".sdt", (byte) 4),
-
-  /** PAA */
-  PAA(".paa", (byte) 5),
-
-  /** PLA */
-  PLA(".pla", (byte) 6),
-
   /** LZ4 */
+  // NOTICE: To ensure the compatibility of existing files, do not change the byte LZ4 binds to.
   LZ4(".lz4", (byte) 7);
 
   private final String extensionName;
@@ -65,14 +54,6 @@ public enum CompressionType {
         return CompressionType.SNAPPY;
       case 2:
         return CompressionType.GZIP;
-      case 3:
-        return CompressionType.LZO;
-      case 4:
-        return CompressionType.SDT;
-      case 5:
-        return CompressionType.PAA;
-      case 6:
-        return CompressionType.PLA;
       case 7:
         return CompressionType.LZ4;
       default:


### PR DESCRIPTION
See [IOTDB-4939](https://issues.apache.org/jira/browse/IOTDB-4939).

This pr removes LZO, SDT, PAA, PLA compression.