### PR TITLE
[IOTDB-4850] Disable first election feature

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/Utils.java
@@ -188,10 +188,6 @@ public class Utils {
     RaftServerConfigKeys.Rpc.setTimeoutMin(properties, config.getRpc().getTimeoutMin());
     RaftServerConfigKeys.Rpc.setTimeoutMax(properties, config.getRpc().getTimeoutMax());
     RaftServerConfigKeys.Rpc.setSleepTime(properties, config.getRpc().getSleepTime());
-    RaftServerConfigKeys.Rpc.setFirstElectionTimeoutMin(
-        properties, config.getRpc().getFirstElectionTimeoutMin());
-    RaftServerConfigKeys.Rpc.setFirstElectionTimeoutMax(
-        properties, config.getRpc().getFirstElectionTimeoutMax());
     RaftClientConfigKeys.Rpc.setRequestTimeout(properties, config.getRpc().getRequestTimeout());
 
     RaftServerConfigKeys.LeaderElection.setLeaderStepDownWaitTime(

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -1048,10 +1048,6 @@
 # schema_region_ratis_preserve_logs_num_when_purge=1000
 # data_region_ratis_preserve_logs_num_when_purge=1000
 
-# first election timeout
-# ratis_first_election_timeout_min_ms=50
-# ratis_first_election_timeout_max_ms=150
-
 ####################
 ### Procedure Configuration
 ####################


### PR DESCRIPTION
## What is First Election
First election is a new feature recently introduced by Ratis 2.4.0, the original issue is https://issues.apache.org/jira/browse/RATIS-1638. The motivation of first election is to reduce unavailable time during start up.
However, this new feature is experimental. There are some known issues when applying in IoTDB. For example, when first election timeout is 50ms, migrate region will first call createPeer then call addPeer. If election timeouts before addPeer (after createPeer), the leader will tell it to shutdown and the migration will fail.
failure examples can be seen at https://github.com/apache/iotdb/actions/runs/3478206562/jobs/5815284797. 

Therefore, this PR proposes to disable first election feature.

This feature may be re-opened when addNewNodeToExistedGroup is implemented and stand the test of tests/production env.