### PR TITLE
[IOTDB-4957] Add check for create pipesink and optimize re-connection

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/SyncManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/SyncManager.java
@@ -91,7 +91,7 @@ public class SyncManager {
 
   public TSStatus createPipeSink(CreatePipeSinkPlan plan) {
     try {
-      clusterSyncInfo.checkAddPipeSink(plan.getPipeSinkInfo().getPipeSinkName());
+      clusterSyncInfo.checkAddPipeSink(plan);
       return getConsensusManager().write(plan).getStatus();
     } catch (PipeSinkException e) {
       LOGGER.error(e.getMessage());

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/sync/ClusterSyncInfo.java
@@ -68,11 +68,15 @@ public class ClusterSyncInfo implements SnapshotProcessor {
   /**
    * Check PipeSink before create operation
    *
-   * @param pipeSinkName name
-   * @throws PipeSinkException if there is PipeSink with the same name exists
+   * @param createPipeSinkPlan createPipeSinkPlan
+   * @throws PipeSinkException if there is PipeSink with the same name exists or attributes is
+   *     unsupported
    */
-  public void checkAddPipeSink(String pipeSinkName) throws PipeSinkException {
-    syncMetadata.checkAddPipeSink(pipeSinkName);
+  public void checkAddPipeSink(CreatePipeSinkPlan createPipeSinkPlan) throws PipeSinkException {
+    // check no exist
+    syncMetadata.checkPipeSinkNoExist(createPipeSinkPlan.getPipeSinkInfo().getPipeSinkName());
+    // check attributes
+    SyncPipeUtil.parseTPipeSinkInfoAsPipeSink(createPipeSinkPlan.getPipeSinkInfo());
   }
 
   public TSStatus addPipeSink(CreatePipeSinkPlan plan) {

--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/ClusterSyncInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/ClusterSyncInfoTest.java
@@ -99,15 +99,49 @@ public class ClusterSyncInfoTest {
   @Test
   public void testPipeSinkOperation() {
     prepareClusterSyncInfo();
+    Map<String, String> attributes1 = new HashMap<>();
+    attributes1.put("ip", "192.168.11.11");
+    attributes1.put("port", "7766");
+    Map<String, String> attributes2 = new HashMap<>();
+    attributes2.put("ip", "Nonstandard");
+    attributes2.put("port", "7777");
+    TPipeSinkInfo alreadyExistSink =
+        new TPipeSinkInfo()
+            .setPipeSinkName("demo1")
+            .setPipeSinkType("IoTDB")
+            .setAttributes(attributes1);
+    TPipeSinkInfo errorAttributeSink =
+        new TPipeSinkInfo()
+            .setPipeSinkName("demo3")
+            .setPipeSinkType("IoTDB")
+            .setAttributes(attributes2);
+    TPipeSinkInfo nonExistSink =
+        new TPipeSinkInfo()
+            .setPipeSinkName("demo3")
+            .setPipeSinkType("IoTDB")
+            .setAttributes(attributes1);
+
     try {
-      clusterSyncInfo.checkAddPipeSink("demo1");
-      clusterSyncInfo.checkDropPipeSink("demo3");
+      clusterSyncInfo.checkAddPipeSink(new CreatePipeSinkPlan(alreadyExistSink));
       Assert.fail("checkOperatePipeSink ignore failure.");
     } catch (PipeSinkException e) {
       // nothing
     }
     try {
-      clusterSyncInfo.checkAddPipeSink("demo3");
+      clusterSyncInfo.checkAddPipeSink(new CreatePipeSinkPlan(alreadyExistSink));
+      Assert.fail("checkOperatePipeSink ignore failure.");
+    } catch (PipeSinkException e) {
+      // nothing
+    }
+    try {
+      clusterSyncInfo.checkAddPipeSink(new CreatePipeSinkPlan(errorAttributeSink));
+      Assert.fail("checkOperatePipeSink ignore failure.");
+    } catch (PipeSinkException e) {
+      // nothing
+    }
+
+    try {
+      clusterSyncInfo.checkAddPipeSink(new CreatePipeSinkPlan(nonExistSink));
       clusterSyncInfo.checkDropPipeSink("demo1");
     } catch (PipeSinkException e) {
       Assert.fail("checkOperatePipeSink should not throw exception.");

--- a/confignode/src/test/resources/confignode1conf/iotdb-common.properties
+++ b/confignode/src/test/resources/confignode1conf/iotdb-common.properties
@@ -20,8 +20,8 @@
 timestamp_precision=ms
 data_region_consensus_protocol_class=org.apache.iotdb.consensus.multileader.MultiLeaderConsensus
 schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
-schema_replication_factor=1
-data_replication_factor=1
+schema_replication_factor=3
+data_replication_factor=3
 udf_lib_dir=target/confignode1/ext/udf
 trigger_lib_dir=target/confignode1/ext/trigger
 config_node_ratis_log_appender_buffer_size_max = 14194304

--- a/confignode/src/test/resources/confignode1conf/iotdb-common.properties
+++ b/confignode/src/test/resources/confignode1conf/iotdb-common.properties
@@ -20,8 +20,8 @@
 timestamp_precision=ms
 data_region_consensus_protocol_class=org.apache.iotdb.consensus.multileader.MultiLeaderConsensus
 schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
-schema_replication_factor=3
-data_replication_factor=3
+schema_replication_factor=1
+data_replication_factor=1
 udf_lib_dir=target/confignode1/ext/udf
 trigger_lib_dir=target/confignode1/ext/trigger
 config_node_ratis_log_appender_buffer_size_max = 14194304

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
@@ -92,7 +92,7 @@ public class SyncMetadata implements SnapshotProcessor {
     return pipeSinks.containsKey(name);
   }
 
-  public void checkAddPipeSink(String pipeSinkName) throws PipeSinkException {
+  public void checkPipeSinkNoExist(String pipeSinkName) throws PipeSinkException {
     if (isPipeSinkExist(pipeSinkName)) {
       throw new PipeSinkAlreadyExistException(pipeSinkName);
     }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipe/TsFilePipeInfo.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipe/TsFilePipeInfo.java
@@ -84,7 +84,7 @@ public class TsFilePipeInfo extends PipeInfo {
     return new TShowPipeInfo(
         createTime,
         pipeName,
-            SyncConstant.ROLE_SENDER,
+        SyncConstant.ROLE_SENDER,
         pipeSinkName,
         status.name(),
         String.format("syncDelOp=%s,dataStartTimestamp=%s", syncDelOp, dataStartTimestamp),

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipe/TsFilePipeInfo.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipe/TsFilePipeInfo.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.commons.sync.pipe;
 
+import org.apache.iotdb.commons.sync.utils.SyncConstant;
 import org.apache.iotdb.confignode.rpc.thrift.TShowPipeInfo;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
@@ -83,7 +84,7 @@ public class TsFilePipeInfo extends PipeInfo {
     return new TShowPipeInfo(
         createTime,
         pipeName,
-        "sender",
+            SyncConstant.ROLE_SENDER,
         pipeSinkName,
         status.name(),
         String.format("syncDelOp=%s,dataStartTimestamp=%s", syncDelOp, dataStartTimestamp),

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipesink/IoTDBPipeSink.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipesink/IoTDBPipeSink.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 public class IoTDBPipeSink implements PipeSink {
   private final PipeSinkType pipeSinkType = PipeSinkType.IoTDB;
@@ -84,6 +85,10 @@ public class IoTDBPipeSink implements PipeSink {
 
       attr = attr.toLowerCase();
       if (attr.equals(ATTRIBUTE_IP_KEY)) {
+        if (!Pattern.matches(SyncConstant.IPV4_PATTERN, value)) {
+          throw new PipeSinkException(
+              String.format("%s is nonstandard IP address, only support IPv4 now.", value));
+        }
         ip = value;
       } else if (attr.equals(ATTRIBUTE_PORT_KEY)) {
         try {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipesink/IoTDBPipeSink.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipesink/IoTDBPipeSink.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.commons.exception.sync.PipeSinkException;
 import org.apache.iotdb.commons.sync.utils.SyncConstant;
 import org.apache.iotdb.confignode.rpc.thrift.TPipeSinkInfo;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.IOException;
@@ -31,7 +30,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -53,28 +51,6 @@ public class IoTDBPipeSink implements PipeSink {
     this.ip = SyncConstant.DEFAULT_PIPE_SINK_IP;
     this.port = SyncConstant.DEFAULT_PIPE_SINK_PORT;
     this.name = name;
-  }
-
-  @Override
-  public void setAttribute(List<Pair<String, String>> params) throws PipeSinkException {
-    for (Pair<String, String> pair : params) {
-      String attr = pair.left;
-      String value = pair.right;
-
-      attr = attr.toLowerCase();
-      if (attr.equals(ATTRIBUTE_IP_KEY)) {
-        ip = value;
-      } else if (attr.equals(ATTRIBUTE_PORT_KEY)) {
-        try {
-          port = Integer.parseInt(value);
-        } catch (NumberFormatException e) {
-          throw new PipeSinkException(attr, value, TSDataType.INT32.name());
-        }
-      } else {
-        throw new PipeSinkException(
-            "There is No attribute " + attr + " in " + PipeSinkType.IoTDB + " pipeSink.");
-      }
-    }
   }
 
   @Override

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipesink/PipeSink.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipesink/PipeSink.java
@@ -33,9 +33,6 @@ import java.util.Map;
 
 public interface PipeSink {
 
-  // TODO: delete this in new-standalone version
-  void setAttribute(List<Pair<String, String>> params) throws PipeSinkException;
-
   void setAttribute(Map<String, String> params) throws PipeSinkException;
 
   String getPipeSinkName();

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipesink/PipeSink.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/pipesink/PipeSink.java
@@ -21,14 +21,12 @@ package org.apache.iotdb.commons.sync.pipesink;
 
 import org.apache.iotdb.commons.exception.sync.PipeSinkException;
 import org.apache.iotdb.confignode.rpc.thrift.TPipeSinkInfo;
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.Map;
 
 public interface PipeSink {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/utils/SyncConstant.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/utils/SyncConstant.java
@@ -57,15 +57,12 @@ public class SyncConstant {
   public static final String DEFAULT_PIPE_SINK_IP = "127.0.0.1";
   public static final int DEFAULT_PIPE_SINK_PORT = 6667;
 
-  public static final Long HEARTBEAT_DELAY_SECONDS = 30L;
   public static final int CONNECT_TIMEOUT_MILLISECONDS = 1_000;
   public static final int SOCKET_TIMEOUT_MILLISECONDS = 100_000;
 
   public static final Long DEFAULT_WAITING_FOR_TSFILE_CLOSE_MILLISECONDS = 500L;
   public static final Long DEFAULT_WAITING_FOR_TSFILE_RETRY_NUMBER = 10L;
   public static final Long DEFAULT_WAITING_FOR_STOP_MILLISECONDS = 1000L;
-
-  public static final int MESSAGE_NUMBER_LIMIT = 1; // do not support multi lines now
 
   /** transport */
 
@@ -76,7 +73,7 @@ public class SyncConstant {
   public static final String PATCH_SUFFIX = ".patch";
   public static final String IPV4_PATTERN =
       "^([1-9]|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5])(\\.(\\d|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5])){3}$";
-  public static final int RETRY_INTERVAL_MILLISECONDS = 5_000;
+  public static final int HEARTBEAT_INTERVAL_SECONDS = 5;
 
   /** receiver */
   public static final String RECEIVER_DIR_NAME = "receiver";

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/utils/SyncConstant.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/utils/SyncConstant.java
@@ -76,6 +76,7 @@ public class SyncConstant {
   public static final String PATCH_SUFFIX = ".patch";
   public static final String IPV4_PATTERN =
       "^([1-9]|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5])(\\.(\\d|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5])){3}$";
+  public static final int RETRY_INTERVAL_MILLISECONDS = 5_000;
 
   /** receiver */
   public static final String RECEIVER_DIR_NAME = "receiver";

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/utils/SyncConstant.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/utils/SyncConstant.java
@@ -73,7 +73,8 @@ public class SyncConstant {
   public static final String PATCH_SUFFIX = ".patch";
   public static final String IPV4_PATTERN =
       "^([1-9]|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5])(\\.(\\d|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5])){3}$";
-  public static final int HEARTBEAT_INTERVAL_SECONDS = 5;
+  public static final int HEARTBEAT_INTERVAL_MILLISECONDS = 5_000;
+  public static final int LOST_CONNECT_REPORT_MILLISECONDS = 30_000;
 
   /** receiver */
   public static final String RECEIVER_DIR_NAME = "receiver";

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/utils/SyncConstant.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/utils/SyncConstant.java
@@ -74,6 +74,8 @@ public class SyncConstant {
       Math.min(16 * 1024 * 1024, RpcUtils.THRIFT_FRAME_MAX_SIZE);
 
   public static final String PATCH_SUFFIX = ".patch";
+  public static final String IPV4_PATTERN =
+      "^([1-9]|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5])(\\.(\\d|[1-9]\\d|1\\d{2}|2[0-4]\\d|25[0-5])){3}$";
 
   /** receiver */
   public static final String RECEIVER_DIR_NAME = "receiver";

--- a/node-commons/src/test/java/org/apache/iotdb/commons/sync/metedata/SyncMetadataTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/sync/metedata/SyncMetadataTest.java
@@ -69,14 +69,14 @@ public class SyncMetadataTest {
     Assert.assertFalse(syncMetadata.isPipeSinkExist(PIPESINK_NAME_1));
     // check and add ioTDBPipeSink1
     try {
-      syncMetadata.checkAddPipeSink(PIPESINK_NAME_1);
+      syncMetadata.checkPipeSinkNoExist(PIPESINK_NAME_1);
     } catch (PipeSinkException e) {
       Assert.fail(e.getMessage());
     }
     syncMetadata.addPipeSink(ioTDBPipeSink1);
     Assert.assertTrue(syncMetadata.isPipeSinkExist(PIPESINK_NAME_1));
     try {
-      syncMetadata.checkAddPipeSink(PIPESINK_NAME_1);
+      syncMetadata.checkPipeSinkNoExist(PIPESINK_NAME_1);
       Assert.fail();
     } catch (PipeSinkException e) {
       Assert.assertTrue(e instanceof PipeSinkAlreadyExistException);

--- a/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/common/LocalSyncInfo.java
@@ -69,7 +69,7 @@ public class LocalSyncInfo {
 
   public void addPipeSink(CreatePipeSinkStatement createPipeSinkStatement)
       throws PipeSinkException, IOException {
-    syncMetadata.checkAddPipeSink(createPipeSinkStatement.getPipeSinkName());
+    syncMetadata.checkPipeSinkNoExist(createPipeSinkStatement.getPipeSinkName());
     PipeSink pipeSink = SyncPipeUtil.parseCreatePipeSinkStatement(createPipeSinkStatement);
     // should guarantee the adding pipesink is not exist.
     syncMetadata.addPipeSink(pipeSink);

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/ExternalPipeSink.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/ExternalPipeSink.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.commons.exception.sync.PipeSinkException;
 import org.apache.iotdb.commons.sync.pipesink.PipeSink;
 import org.apache.iotdb.confignode.rpc.thrift.TPipeSinkInfo;
 import org.apache.iotdb.db.sync.externalpipe.ExtPipePluginRegister;
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import org.slf4j.Logger;
@@ -33,7 +32,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -53,24 +51,6 @@ public class ExternalPipeSink implements PipeSink {
   public ExternalPipeSink(String pipeSinkName, String extPipeSinkTypeName) {
     this.pipeSinkName = pipeSinkName;
     this.extPipeSinkTypeName = extPipeSinkTypeName;
-  }
-
-  @Override
-  public void setAttribute(List<Pair<String, String>> params) throws PipeSinkException {
-    String regex = "^'|'$|^\"|\"$";
-    sinkParams =
-        params.stream()
-            .collect(
-                Collectors.toMap(
-                    e -> e.left, e -> e.right.trim().replaceAll(regex, ""), (key1, key2) -> key2));
-
-    try {
-      ExtPipePluginRegister.getInstance()
-          .getWriteFactory(extPipeSinkTypeName)
-          .validateSinkParams(sinkParams);
-    } catch (Exception e) {
-      throw new PipeSinkException(e.getMessage());
-    }
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/TsFilePipe.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/TsFilePipe.java
@@ -138,7 +138,7 @@ public class TsFilePipe implements Pipe {
     if (pipeInfo.getStatus() == PipeStatus.RUNNING) {
       return;
     }
-    //
+
     // init sync manager
     List<DataRegion> dataRegions = StorageEngineV2.getInstance().getAllDataRegions();
     for (DataRegion dataRegion : dataRegions) {

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/TsFilePipe.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/pipe/TsFilePipe.java
@@ -138,6 +138,7 @@ public class TsFilePipe implements Pipe {
     if (pipeInfo.getStatus() == PipeStatus.RUNNING) {
       return;
     }
+    //
     // init sync manager
     List<DataRegion> dataRegions = StorageEngineV2.getInstance().getAllDataRegions();
     for (DataRegion dataRegion : dataRegions) {

--- a/server/src/main/java/org/apache/iotdb/db/sync/transport/client/IoTDBSyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/transport/client/IoTDBSyncClient.java
@@ -152,7 +152,6 @@ public class IoTDBSyncClient implements ISyncClient {
         return false;
       }
     } catch (TException e) {
-      logger.warn("Cannot connect to the receiver because {}", e.getMessage());
       throw new SyncConnectionException(
           String.format("Cannot connect to the receiver because %s.", e.getMessage()));
     }

--- a/server/src/main/java/org/apache/iotdb/db/sync/transport/client/IoTDBSyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/transport/client/IoTDBSyncClient.java
@@ -75,6 +75,8 @@ public class IoTDBSyncClient implements ISyncClient {
   private final Pipe pipe;
 
   /**
+   * Create IoTDBSyncClient only for data transfer
+   *
    * @param pipe sync task
    * @param remoteAddress remote ip address
    * @param port remote port
@@ -92,6 +94,8 @@ public class IoTDBSyncClient implements ISyncClient {
   }
 
   /**
+   * Create IoTDBSyncClient only for heartbeat
+   *
    * @param pipe sync task
    * @param remoteAddress remote ip address
    * @param port remote port

--- a/server/src/main/java/org/apache/iotdb/db/sync/transport/client/IoTDBSyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/transport/client/IoTDBSyncClient.java
@@ -102,12 +102,7 @@ public class IoTDBSyncClient implements ISyncClient {
    * @param localAddress local ip address
    */
   public IoTDBSyncClient(Pipe pipe, String remoteAddress, int port, String localAddress) {
-    RpcTransportFactory.setThriftMaxFrameSize(config.getThriftMaxFrameSize());
-    this.pipe = pipe;
-    this.ipAddress = remoteAddress;
-    this.port = port;
-    this.localIP = localAddress;
-    this.storageGroupName = "heartbeat";
+    this(pipe, remoteAddress, port, localAddress, "");
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/sync/transport/client/IoTDBSyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/transport/client/IoTDBSyncClient.java
@@ -92,6 +92,21 @@ public class IoTDBSyncClient implements ISyncClient {
   }
 
   /**
+   * @param pipe sync task
+   * @param remoteAddress remote ip address
+   * @param port remote port
+   * @param localAddress local ip address
+   */
+  public IoTDBSyncClient(Pipe pipe, String remoteAddress, int port, String localAddress) {
+    RpcTransportFactory.setThriftMaxFrameSize(config.getThriftMaxFrameSize());
+    this.pipe = pipe;
+    this.ipAddress = remoteAddress;
+    this.port = port;
+    this.localIP = localAddress;
+    this.storageGroupName = "heartbeat";
+  }
+
+  /**
    * Create thrift connection to receiver. Check IoTDB version to make sure compatibility
    *
    * @return true if success; false if failed to check IoTDB version.

--- a/server/src/main/java/org/apache/iotdb/db/sync/transport/client/SenderManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/transport/client/SenderManager.java
@@ -221,7 +221,7 @@ public class SenderManager {
           } catch (SyncConnectionException e) {
             // If failed to connect to receiver, it will hang up until scheduled heartbeat task
             // successfully reconnect to receiver.
-            logger.error(String.format("Connect to receiver %s error, because %s.", pipeSink, e));
+            logger.error("Connect to receiver {} error, because {}.", pipeSink, e.getMessage(), e);
             lostConnectionTime = Math.min(lostConnectionTime, System.currentTimeMillis());
             blockingQueue.offer(lock);
             lock.wait();

--- a/server/src/main/java/org/apache/iotdb/db/sync/transport/client/SenderManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/transport/client/SenderManager.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.sync.transport.client;
 
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.concurrent.ThreadName;
+import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
 import org.apache.iotdb.commons.exception.sync.PipeException;
 import org.apache.iotdb.commons.sync.pipe.PipeMessage;
 import org.apache.iotdb.commons.sync.pipesink.PipeSink;
@@ -96,8 +97,12 @@ public class SenderManager {
               () -> takePipeDataAndTransport(syncClient, dataRegionId)));
     }
     heartbeatFuture =
-        heartbeatExecutorService.scheduleAtFixedRate(
-            this::heartbeat, 0, SyncConstant.HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
+        ScheduledExecutorUtil.safelyScheduleAtFixedRate(
+            heartbeatExecutorService,
+            this::heartbeat,
+            0,
+            SyncConstant.HEARTBEAT_INTERVAL_SECONDS,
+            TimeUnit.SECONDS);
     isRunning = true;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/sync/transport/client/SyncClientFactory.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/transport/client/SyncClientFactory.java
@@ -57,6 +57,18 @@ public class SyncClientFactory {
     }
   }
 
+  public static ISyncClient createHeartbeatClient(Pipe pipe, PipeSink pipeSink) {
+    switch (pipeSink.getType()) {
+      case IoTDB:
+        IoTDBPipeSink ioTDBPipeSink = (IoTDBPipeSink) pipeSink;
+        return new IoTDBSyncClient(
+            pipe, ioTDBPipeSink.getIp(), ioTDBPipeSink.getPort(), getLocalIP(ioTDBPipeSink));
+      case ExternalPipe:
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
   private static String getLocalIP(IoTDBPipeSink pipeSink) {
     String localIP;
     try {


### PR DESCRIPTION
## Description

https://issues.apache.org/jira/browse/IOTDB-4957

1. Add check for create pipesink. For IoTDBPipeSink, it will response exception if ip address is not standard IPv4 address.
2. To avoid busy waiting and large amount of duplicate logs. I optimize logic of re-connection. If sender lost connection to receiver, it will hang up until scheduled heartbeat task successfully reconnect to receiver. Default interval of heartbeat is 30 seconds. 

<img width="1420" alt="image" src="https://user-images.githubusercontent.com/43774645/202435573-e6831ae7-d11f-4b1a-840c-5d1a2d6b1a9e.png">
