### PR TITLE
[IOTDB-4934]Modify error message of use 'null' directly in SQL

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
@@ -55,7 +55,6 @@ import org.apache.iotdb.db.mpp.plan.expression.binary.MultiplicationExpression;
 import org.apache.iotdb.db.mpp.plan.expression.binary.NonEqualExpression;
 import org.apache.iotdb.db.mpp.plan.expression.binary.SubtractionExpression;
 import org.apache.iotdb.db.mpp.plan.expression.leaf.ConstantOperand;
-import org.apache.iotdb.db.mpp.plan.expression.leaf.NullOperand;
 import org.apache.iotdb.db.mpp.plan.expression.leaf.TimeSeriesOperand;
 import org.apache.iotdb.db.mpp.plan.expression.leaf.TimestampOperand;
 import org.apache.iotdb.db.mpp.plan.expression.multi.FunctionExpression;
@@ -2555,8 +2554,6 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     } else if (constantContext.dateExpression() != null) {
       return new ConstantOperand(
           TSDataType.INT64, String.valueOf(parseDateExpression(constantContext.dateExpression())));
-    } else if (constantContext.NULL_LITERAL() != null) {
-      return new NullOperand();
     } else {
       throw new SQLParserException("Unsupported constant operand: " + text);
     }


### PR DESCRIPTION
The error will be like this:
<img width="719" alt="image" src="https://user-images.githubusercontent.com/60659567/202337280-ee404313-ac39-4501-b87a-214237d4ffd2.png">
<img width="660" alt="image" src="https://user-images.githubusercontent.com/60659567/202336309-5c8667aa-a765-41e5-b504-ec132d24c6a3.png">
