### PR TITLE
[To rel/0.13] [IOTDB-4939]remove unsupport compress type

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -972,7 +972,7 @@ public class MManagerBasicTest {
     encodingList.add(Arrays.asList(TSEncoding.RLE, TSEncoding.RLE));
 
     List<List<CompressionType>> compressionTypes = new ArrayList<>();
-    compressionTypes.add(Collections.singletonList(CompressionType.SDT));
+    compressionTypes.add(Collections.singletonList(CompressionType.SNAPPY));
     compressionTypes.add(Collections.singletonList(CompressionType.SNAPPY));
     compressionTypes.add(Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
 
@@ -1103,7 +1103,7 @@ public class MManagerBasicTest {
     encodingList.add(Arrays.asList(TSEncoding.RLE, TSEncoding.RLE));
 
     List<List<CompressionType>> compressionTypes = new ArrayList<>();
-    compressionTypes.add(Collections.singletonList(CompressionType.SDT));
+    compressionTypes.add(Collections.singletonList(CompressionType.SNAPPY));
     compressionTypes.add(Collections.singletonList(CompressionType.SNAPPY));
     compressionTypes.add(Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/CompressionType.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/CompressionType.java
@@ -28,18 +28,6 @@ public enum CompressionType {
   /** GZIP */
   GZIP(".gzip", (byte) 2),
 
-  /** LZO */
-  LZO(".lzo", (byte) 3),
-
-  /** SDT */
-  SDT(".sdt", (byte) 4),
-
-  /** PAA */
-  PAA(".paa", (byte) 5),
-
-  /** PLA */
-  PLA(".pla", (byte) 6),
-
   /** LZ4 */
   LZ4(".lz4", (byte) 7);
 
@@ -65,14 +53,6 @@ public enum CompressionType {
         return CompressionType.SNAPPY;
       case 2:
         return CompressionType.GZIP;
-      case 3:
-        return CompressionType.LZO;
-      case 4:
-        return CompressionType.SDT;
-      case 5:
-        return CompressionType.PAA;
-      case 6:
-        return CompressionType.PLA;
       case 7:
         return CompressionType.LZ4;
       default:


### PR DESCRIPTION
See [IOTDB-4939](https://issues.apache.org/jira/browse/IOTDB-4939)
This pr removes LZO, SDT, PAA, PLA compression.