### PR TITLE
[IOTDB-4973] add a copy of time instead of calling getTimestamp

### DIFF
--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -62,6 +62,7 @@ public class IoTDBRpcDataSet {
   public long sessionId;
   public long queryId;
   public long statementId;
+  public long time;
   public boolean ignoreTimeStamp;
   // indicates that there is still more data in server side and we can call fetchResult to get more
   public boolean moreData;
@@ -331,6 +332,7 @@ public class IoTDBRpcDataSet {
   public void constructOneRow() {
     tsBlockIndex++;
     hasCachedRecord = true;
+    time = curTsBlock.getTimeColumn().getLong(tsBlockIndex);
   }
 
   public void constructOneTsBlock() {

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -499,10 +499,6 @@ public class IoTDBRpcDataSet {
     return getTimestamp(findColumn(columnName));
   }
 
-  public Timestamp getTimestamp() throws StatementExecutionException {
-    return new Timestamp(curTsBlock.getTimeByIndex(tsBlockIndex));
-  }
-
   public int findColumn(String columnName) {
     return columnOrdinalMap.get(columnName);
   }
@@ -551,10 +547,6 @@ public class IoTDBRpcDataSet {
       return null;
     }
     lastReadWasNull = false;
-    return getObject(index, columnTypeDeduplicatedList.get(index));
-  }
-
-  public Object getObject(int index, TSDataType tsDataType) {
     return curTsBlock.getColumn(index).getObject(tsBlockIndex);
   }
 

--- a/session/src/main/java/org/apache/iotdb/session/SessionDataSet.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionDataSet.java
@@ -173,7 +173,7 @@ public class SessionDataSet implements AutoCloseable {
       }
       outFields.add(field);
     }
-    return new RowRecord(ioTDBRpcDataSet.getTimestamp().getTime(), outFields);
+    return new RowRecord(ioTDBRpcDataSet.time, outFields);
   }
 
   public RowRecord next() throws StatementExecutionException, IoTDBConnectionException {


### PR DESCRIPTION
The curves show the cost of time in constructRowRecordFromValueArray() method comparing with version 0.13
### Before:
![image](https://user-images.githubusercontent.com/51467236/202488512-ea9e3be5-2515-4277-bfcb-37fe94423f30.png)
### After:
![image](https://user-images.githubusercontent.com/51467236/202488741-3e646c60-8c11-4baf-b44c-ca2ba7d05731.png)