### PR TITLE
[IOTDB-4975] Explain support last query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanGraphPrinter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanGraphPrinter.java
@@ -39,9 +39,14 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggre
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SortNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TimeJoinNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TransformNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryCollectNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryMergeNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.sink.FragmentSinkNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedLastQueryScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedSeriesAggregationScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedSeriesScanNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.LastQueryScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.SeriesAggregationScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.SeriesScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.AggregationDescriptor;
@@ -343,6 +348,50 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
                   ? "[ALIGNED]"
                   : ""));
     }
+  }
+
+  @Override
+  public List<String> visitLastQueryScan(LastQueryScanNode node, GraphContext context) {
+    List<String> boxValue = new ArrayList<>();
+    boxValue.add(String.format("LastQueryScan-%s", node.getPlanNodeId().getId()));
+    boxValue.add(String.format("Series: %s", node.getSeriesPath()));
+    boxValue.add(printRegion(node.getRegionReplicaSet()));
+    return render(node, boxValue, context);
+  }
+
+  @Override
+  public List<String> visitAlignedLastQueryScan(
+      AlignedLastQueryScanNode node, GraphContext context) {
+    List<String> boxValue = new ArrayList<>();
+    boxValue.add(String.format("AlignedLastQueryScan-%s", node.getPlanNodeId().getId()));
+    boxValue.add(
+        String.format(
+            "Series: %s%s",
+            node.getSeriesPath().getDevice(), node.getSeriesPath().getMeasurementList()));
+    boxValue.add(printRegion(node.getRegionReplicaSet()));
+    return render(node, boxValue, context);
+  }
+
+  @Override
+  public List<String> visitLastQuery(LastQueryNode node, GraphContext context) {
+    List<String> boxValue = new ArrayList<>();
+    boxValue.add(String.format("LastQuery-%s", node.getPlanNodeId().getId()));
+    boxValue.add(String.format("TimeFilter: %s", node.getTimeFilter()));
+    return render(node, boxValue, context);
+  }
+
+  @Override
+  public List<String> visitLastQueryMerge(LastQueryMergeNode node, GraphContext context) {
+    List<String> boxValue = new ArrayList<>();
+    boxValue.add(String.format("LastQueryMerge-%s", node.getPlanNodeId().getId()));
+    return render(node, boxValue, context);
+  }
+
+  @Override
+  public List<String> visitLastQueryCollect(LastQueryCollectNode node, GraphContext context) {
+    List<String> boxValue = new ArrayList<>();
+    boxValue.add(String.format("LastQueryCollect-%s", node.getPlanNodeId().getId()));
+    return render(node, boxValue, context);
   }
 
   private String printRegion(TRegionReplicaSet regionReplicaSet) {


### PR DESCRIPTION
This PR has:
- [x] been self-reviewed.
- [x] been tested in a test IoTDB cluster.
<img width="473" alt="image" src="https://user-images.githubusercontent.com/60659567/202612397-93690a61-fbf0-4c9d-b440-b5e4dee512bf.png">
<img width="693" alt="image" src="https://user-images.githubusercontent.com/60659567/202618038-cf0465e1-408b-468d-a6ac-dc46b14c2dd9.png">

