### PR TITLE
[IOTDB-4959] Remove createPeer state when confignode restart

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.consensus.ConfigNodeRegionId;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
-import org.apache.iotdb.commons.exception.BadNodeUrlException;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
@@ -181,14 +180,8 @@ public class ConsensusManager {
     }
     consensusImpl.start();
     if (SystemPropertiesUtils.isRestarted()) {
-      try {
-        // TODO: Check and notify if current ConfigNode's ip or port has changed
-        LOGGER.info(
-            "Init ConsensusManager successfully when restarted, configNodeList: {}",
-            SystemPropertiesUtils.loadConfigNodeList());
-      } catch (BadNodeUrlException e) {
-        throw new IOException(e);
-      }
+      // TODO: Check and notify if current ConfigNode's ip or port has changed
+      LOGGER.info("Init ConsensusManager successfully when restarted");
     } else if (ConfigNodeDescriptor.getInstance().isSeedConfigNode()) {
       // Create ConsensusGroup that contains only itself
       // if the current ConfigNode is Seed-ConfigNode

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConsensusManager.java
@@ -182,9 +182,10 @@ public class ConsensusManager {
     consensusImpl.start();
     if (SystemPropertiesUtils.isRestarted()) {
       try {
-        // Create ConsensusGroup from confignode-system.properties file when restart
         // TODO: Check and notify if current ConfigNode's ip or port has changed
-        createPeerForConsensusGroup(SystemPropertiesUtils.loadConfigNodeList());
+        LOGGER.info(
+            "Init ConsensusManager successfully when restarted, configNodeList: {}",
+            SystemPropertiesUtils.loadConfigNodeList());
       } catch (BadNodeUrlException e) {
         throw new IOException(e);
       }


### PR DESCRIPTION
## Description

Remove createPeer process when confignode restart to remove this ERROR as the screenshot.
![image](https://user-images.githubusercontent.com/6756545/202678072-0695e47c-202a-4741-860e-b47551ee5aea.png)

