### PR TITLE
[IOTDB-4809] Broadcast the RegionRouteMap to all DataNodes except the unknown ones

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
@@ -284,8 +284,9 @@ public class LoadManager {
   public void broadcastLatestRegionRouteMap() {
     Map<TConsensusGroupId, TRegionReplicaSet> latestRegionRouteMap = getLatestRegionRouteMap();
     Map<Integer, TDataNodeLocation> dataNodeLocationMap = new ConcurrentHashMap<>();
+    // Broadcast the RegionRouteMap to all DataNodes except the unknown ones
     getNodeManager()
-        .filterDataNodeThroughStatus(NodeStatus.Running)
+        .filterDataNodeThroughStatus(NodeStatus.Running, NodeStatus.Removing, NodeStatus.ReadOnly)
         .forEach(
             onlineDataNode ->
                 dataNodeLocationMap.put(


### PR DESCRIPTION
Fix bug that the Removing and ReadOnly DataNodes can't receive the latest RegionRouteMap