### PR TITLE
[IOTDB-3671] Make thread group of ProcedureExecutor warn

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -865,10 +865,9 @@ public class ProcedureExecutor<Env> {
     try {
       threadGroup.destroy();
     } catch (IllegalThreadStateException e) {
-      LOG.error(
-          "ThreadGroup {} contains running threads; {}: See STDOUT",
-          this.threadGroup,
-          e.getMessage());
+      LOG.warn(
+          "ProcedureExecutor threadGroup {} contains running threads which are used by non-procedure module.",
+          this.threadGroup);
       this.threadGroup.list();
     }
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -342,15 +342,22 @@ public class ConfigNodeProcedureEnv {
   public void broadCastTheLatestConfigNodeGroup() {
     List<TConfigNodeLocation> registeredConfigNodes =
         configManager.getNodeManager().getRegisteredConfigNodes();
+    Map<Integer, TDataNodeLocation> registeredDataNodes =
+        configManager.getNodeManager().getRegisteredDataNodeLocations();
     AsyncClientHandler<TUpdateConfigNodeGroupReq, TSStatus> clientHandler =
         new AsyncClientHandler<>(
             DataNodeRequestType.BROADCAST_LATEST_CONFIG_NODE_GROUP,
             new TUpdateConfigNodeGroupReq(registeredConfigNodes),
-            configManager.getNodeManager().getRegisteredDataNodeLocations());
+            registeredDataNodes);
 
-    LOG.info("Begin to broadcast the latest configNodeGroup: {}", registeredConfigNodes);
-    AsyncDataNodeClientPool.getInstance().sendAsyncRequestToDataNodeWithRetry(clientHandler);
-    LOG.info("Broadcast the latest configNodeGroup finished.");
+    if (registeredDataNodes.size() > 0) {
+      LOG.info(
+          "Begin to broadcast the latest configNodeGroup to DataNodes, ConfigNodeGroups: {}, DataNodes: {}",
+          registeredConfigNodes,
+          registeredDataNodes.values());
+      AsyncDataNodeClientPool.getInstance().sendAsyncRequestToDataNodeWithRetry(clientHandler);
+      LOG.info("Broadcast the latest configNodeGroup to DataNodes finished.");
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Make the log level of `thread group in ProcedureExecutor` as warn.
These threads cannot be stopped may be used by other module such as ASyncClientManger, and it's no need to destroy it.

