### PR TITLE
Fix the bug that the AggregationNode is always Final 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
@@ -397,7 +397,7 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
               rootAggDescriptorList.add(
                   new AggregationDescriptor(
                       descriptor.getAggregationFuncName(),
-                      AggregationStep.FINAL,
+                      context.isRoot ? AggregationStep.FINAL : AggregationStep.INTERMEDIATE,
                       descriptor.getInputExpressions()));
             });
 


### PR DESCRIPTION
## Description
Before this change, if the logical plan contains only 1 series and the series belongs to serval DataRegions, the distribution plan will always set the AggragtionStep to `FINAL`, which is not correct. This PR fixed this issue and add two more unit tests for this scenarios.