### PR TITLE
[IOTDB-5011] Fix session connection failure when start datanode using iotdb reporter

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -159,6 +159,9 @@ public class DataNode implements DataNodeMBean {
       active();
       // setup rpc service
       setUpRPCService();
+      registerManager.register(MetricService.getInstance());
+      // bind predefined metrics
+      DataNodeMetricsHelper.bind();
       logger.info("IoTDB configuration: " + config.getConfigMessage());
       logger.info("Congratulation, IoTDB DataNode is set up successfully. Now, enjoy yourself!");
     } catch (StartupException e) {
@@ -366,10 +369,7 @@ public class DataNode implements DataNodeMBean {
     // start region migrate service
     registerManager.register(RegionMigrateService.getInstance());
 
-    registerManager.register(MetricService.getInstance());
     registerManager.register(CompactionTaskManager.getInstance());
-    // bind predefined metrics
-    DataNodeMetricsHelper.bind();
   }
 
   /** set up RPC and protocols after DataNode is available */


### PR DESCRIPTION
When use iotdb reporter in metric module, there are session connection failure because the start of reporter is earlier than the set up of RPC service