### PR TITLE
Better schema file printer, not limited by length anymore

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/AliasIndexPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/AliasIndexPage.java
@@ -389,7 +389,7 @@ public class AliasIndexPage extends SchemaPage implements ISegment<String, Strin
     for (int i = 0; i < memberNum; i++) {
       builder.append(String.format("(%s, %s),", getKeyByIndex(i), getNameByIndex(i)));
     }
-    builder.append("]");
+    builder.append("]\n");
     return builder.toString();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/InternalPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/InternalPage.java
@@ -431,7 +431,7 @@ public class InternalPage extends SchemaPage implements ISegment<Integer, Intege
               "(%s, %s, %s),",
               getKeyByIndex(i), keyOffset(getPointerByIndex(i)), pageIndex(getPointerByIndex(i))));
     }
-    builder.append("]");
+    builder.append("]\n");
     return builder.toString();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -273,22 +274,29 @@ public class SchemaFile implements ISchemaFile {
   }
 
   public String inspect() throws MetadataException, IOException {
-    StringBuilder builder =
-        new StringBuilder(
-            String.format(
-                "=============================\n"
-                    + "== Schema File Sketch Tool ==\n"
-                    + "=============================\n"
-                    + "== Notice: \n"
-                    + "==  Internal/Entity presents as (name, is_aligned, child_segment_address)\n"
-                    + "==  Measurement presents as (name, data_type, encoding, compressor, alias_if_exist)\n"
-                    + "=============================\n"
-                    + "Belong to StorageGroup: [%s], segment of SG:%s, total pages:%d\n",
-                storageGroupName == null ? "NOT SPECIFIED" : storageGroupName,
-                Long.toHexString(lastSGAddr),
-                lastPageIndex + 1));
+    return inspect(null);
+  }
 
-    return pageManager.inspect(builder).toString();
+  public String inspect(PrintWriter pw) throws MetadataException, IOException {
+    String header =
+        String.format(
+            "=============================\n"
+                + "== Schema File Sketch Tool ==\n"
+                + "=============================\n"
+                + "== Notice: \n"
+                + "==  Internal/Entity presents as (name, is_aligned, child_segment_address)\n"
+                + "==  Measurement presents as (name, data_type, encoding, compressor, alias_if_exist)\n"
+                + "=============================\n"
+                + "Belong to StorageGroup: [%s], segment of SG:%s, total pages:%d\n",
+            storageGroupName == null ? "NOT SPECIFIED" : storageGroupName,
+            Long.toHexString(lastSGAddr),
+            lastPageIndex + 1);
+    if (pw == null) {
+      pw = new PrintWriter(System.out);
+    }
+    pw.print(header);
+    pageManager.inspect(pw);
+    return String.format("SchemaFile[%s] had been inspected.", this.filePath);
   }
   // endregion
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/IPageManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/IPageManager.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFile;
 import org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaPage;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Iterator;
 
 /**
@@ -55,7 +56,5 @@ public interface IPageManager {
 
   int getLastPageIndex();
 
-  @Deprecated
-  StringBuilder inspect(StringBuilder builder)
-      throws IOException, MetadataException; // TODO: shift to use stream
+  void inspect(PrintWriter pw) throws IOException, MetadataException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
@@ -428,11 +429,14 @@ public abstract class PageManager implements IPageManager {
   }
 
   @Override
-  public StringBuilder inspect(StringBuilder builder) throws IOException, MetadataException {
+  public void inspect(PrintWriter pw) throws IOException, MetadataException {
+    String pageContent;
     for (int i = 0; i <= lastPageIndex.get(); i++) {
-      builder.append(String.format("---------------------\n%s\n", getPageInstance(i).inspect()));
+      pageContent = getPageInstance(i).inspect();
+      pw.print("---------------------\n");
+      pw.print(pageContent);
+      pw.print("\n");
     }
-    return builder;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/tools/schema/SchemaFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/schema/SchemaFileSketchTool.java
@@ -154,9 +154,8 @@ public class SchemaFileSketchTool {
     pw = new PrintWriter(new FileWriter(outputFile, false));
     ISchemaFile sf = SchemaFile.loadSchemaFile(SystemFileFactory.INSTANCE.getFile(inputFile));
     try {
-      String res = ((SchemaFile) sf).inspect();
+      String res = ((SchemaFile) sf).inspect(pw);
       System.out.println(res);
-      pw.print(res);
     } finally {
       sf.close();
       pw.close();

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
@@ -101,7 +101,6 @@ public class SchemaFileTest {
         sf.writeMNode(curNode);
       }
     }
-    System.out.println(((SchemaFile) sf).inspect());
 
     ICachedMNodeContainer.getCachedMNodeContainer(int0).getNewChildBuffer().clear();
     addNodeToUpdateBuffer(int0, getMeasurementNode(int0, "mint1", "alas99999"));
@@ -844,7 +843,7 @@ public class SchemaFileTest {
   // region Quick Print
 
   private void printSF(ISchemaFile file) throws IOException, MetadataException {
-    System.out.println(((SchemaFile) file).inspect());
+    ((SchemaFile) file).inspect();
   }
 
   public static void print(Object o) {

--- a/server/src/test/java/org/apache/iotdb/db/tools/SchemaFileSketchTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/tools/SchemaFileSketchTest.java
@@ -43,6 +43,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Iterator;
@@ -106,10 +108,14 @@ public class SchemaFileSketchTest {
 
     SchemaFileSketchTool.sketchFile(file.getAbsolutePath(), sketchFile.getAbsolutePath());
     ISchemaFile sf = SchemaFile.loadSchemaFile(file);
-    String sketchString = ((SchemaFile) sf).inspect();
-    Assert.assertEquals(
-        sketchString, new String(Files.readAllBytes(Paths.get(sketchFile.getAbsolutePath()))));
-    sf.close();
+    try {
+      StringWriter sw = new StringWriter();
+      ((SchemaFile) sf).inspect(new PrintWriter(sw));
+      Assert.assertEquals(
+          sw.toString(), new String(Files.readAllBytes(Paths.get(sketchFile.getAbsolutePath()))));
+    } finally {
+      sf.close();
+    }
   }
 
   private Iterator<IMNode> getTreeBFT(IMNode root) {


### PR DESCRIPTION
## Description
Previously SchemaFile provide a sketch method by building all text content into one single String, which may take unnecessary memory overhead. Now SchemaFile will flush sketched text into a PrintWriter in a page by page way so that even huge SchemaFile could be handled with a limited memory resource.