### PR TITLE
[IOTDB-5024] Fix same tag keys in metrics

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/CompactionMetricsRecorder.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/CompactionMetricsRecorder.java
@@ -48,9 +48,7 @@ public class CompactionMetricsRecorder {
             Tag.NAME.toString(),
             compactionType.toString(),
             Tag.TYPE.toString(),
-            aligned ? "ALIGNED" : "NOT_ALIGNED",
-            Tag.TYPE.toString(),
-            processChunkType.toString());
+            (aligned ? "ALIGNED" : "NOT_ALIGNED") + "_" + processChunkType.toString());
     MetricService.getInstance()
         .count(
             byteNum / 1024L,


### PR DESCRIPTION
When I check metrics, I find `data_written` metrics has same tag keys which is not recommend.