### PR TITLE
[IOTDB-5025][To rel/0.13] Fix the tag of metrics in 0.13 version

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionMetricsManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionMetricsManager.java
@@ -154,7 +154,7 @@ public class CompactionMetricsManager {
                   Tag.NAME.toString(),
                   "cross_compaction_count",
                   Tag.TYPE.toString(),
-                  "total");
+                  "cross");
         }
         break;
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionMetricsManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionMetricsManager.java
@@ -52,9 +52,7 @@ public class CompactionMetricsManager {
             Tag.NAME.toString(),
             compactionType.toString(),
             Tag.TYPE.toString(),
-            aligned ? "ALIGNED" : "NOT_ALIGNED",
-            Tag.TYPE.toString(),
-            processChunkType.toString());
+            (aligned ? "ALIGNED" : "NOT_ALIGNED") + "_" + processChunkType.toString());
     MetricService.getInstance()
         .count(
             byteNum / 1024L,
@@ -134,9 +132,7 @@ public class CompactionMetricsManager {
                 Metric.COST_TASK.toString(),
                 MetricLevel.IMPORTANT,
                 Tag.NAME.toString(),
-                "compaction",
-                Tag.NAME.toString(),
-                isInnerTask ? "inner" : "cross");
+                (isInnerTask ? "inner" : "cross") + "_compaction");
         if (isInnerTask) {
           MetricService.getInstance()
               .count(
@@ -156,7 +152,9 @@ public class CompactionMetricsManager {
                   Metric.COMPACTION_TASK_COUNT.toString(),
                   MetricLevel.IMPORTANT,
                   Tag.NAME.toString(),
-                  "cross_compaction_count");
+                  "cross_compaction_count",
+                  Tag.TYPE.toString(),
+                  "total");
         }
         break;
     }


### PR DESCRIPTION
1. `data_written`, `cost_task` metrics has same tag keys which is not recommend.
2. `cross_compaction_count` metrics has different tag keys in specific metrics.