### PR TITLE
[IOTDB-5023] Improve Schema Count operation to return long

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeactivateTemplateProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeactivateTemplateProcedure.java
@@ -131,7 +131,7 @@ public class DeactivateTemplateProcedure
   }
 
   // return the total num of timeseries in schema black list
-  private int constructBlackList(ConfigNodeProcedureEnv env) {
+  private long constructBlackList(ConfigNodeProcedureEnv env) {
     Map<TConsensusGroupId, TRegionReplicaSet> targetSchemaRegionGroup =
         env.getConfigManager().getRelatedSchemaRegionGroup(timeSeriesPatternTree);
     if (targetSchemaRegionGroup.isEmpty()) {
@@ -172,10 +172,10 @@ public class DeactivateTemplateProcedure
       return 0;
     }
 
-    int preDeletedNum = 0;
+    long preDeletedNum = 0;
     for (List<TSStatus> respList : constructBlackListTask.getResponseMap().values()) {
       for (TSStatus resp : respList) {
-        preDeletedNum += Integer.parseInt(resp.getMessage());
+        preDeletedNum += Long.parseLong(resp.getMessage());
       }
     }
     return preDeletedNum;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteTimeSeriesProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteTimeSeriesProcedure.java
@@ -132,7 +132,7 @@ public class DeleteTimeSeriesProcedure
   }
 
   // return the total num of timeseries in schema black list
-  private int constructBlackList(ConfigNodeProcedureEnv env) {
+  private long constructBlackList(ConfigNodeProcedureEnv env) {
     Map<TConsensusGroupId, TRegionReplicaSet> targetSchemaRegionGroup =
         env.getConfigManager().getRelatedSchemaRegionGroup(patternTree);
     if (targetSchemaRegionGroup.isEmpty()) {
@@ -172,10 +172,10 @@ public class DeleteTimeSeriesProcedure
       return 0;
     }
 
-    int preDeletedNum = 0;
+    long preDeletedNum = 0;
     for (List<TSStatus> respList : constructBlackListTask.getResponseMap().values()) {
       for (TSStatus resp : respList) {
-        preDeletedNum += Integer.parseInt(resp.getMessage());
+        preDeletedNum += Long.parseLong(resp.getMessage());
       }
     }
     return preDeletedNum;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/UnsetTemplateProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/UnsetTemplateProcedure.java
@@ -178,7 +178,7 @@ public class UnsetTemplateProcedure
     }
   }
 
-  private int checkDataNodeTemplateActivation(ConfigNodeProcedureEnv env) {
+  private long checkDataNodeTemplateActivation(ConfigNodeProcedureEnv env) {
     PathPatternTree patternTree = new PathPatternTree();
     patternTree.appendPathPattern(path);
     patternTree.appendPathPattern(path.concatNode(MULTI_LEVEL_PATH_WILDCARD));
@@ -256,7 +256,7 @@ public class UnsetTemplateProcedure
       return 0;
     }
 
-    int result = 0;
+    long result = 0;
     Map<Integer, List<TCountPathsUsingTemplateResp>> dataNodeResponseMap =
         regionTask.getResponseMap();
     for (List<TCountPathsUsingTemplateResp> respList : dataNodeResponseMap.values()) {

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBCreateTimeseriesIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBCreateTimeseriesIT.java
@@ -158,7 +158,7 @@ public class IoTDBCreateTimeseriesIT {
         Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery("count timeseries root.sg.**")) {
       while (resultSet.next()) {
-        int count = resultSet.getInt(1);
+        long count = resultSet.getLong(1);
         Assert.assertEquals(timeSeriesArray.length, count);
       }
     }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBMetadataFetchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBMetadataFetchIT.java
@@ -483,7 +483,7 @@ public class IoTDBMetadataFetchIT {
         Set<String> standard = standards[n];
         try (ResultSet resultSet = statement.executeQuery(sql)) {
           while (resultSet.next()) {
-            String string = resultSet.getString(1) + "," + resultSet.getInt(2) + ",";
+            String string = resultSet.getString(1) + "," + resultSet.getLong(2) + ",";
             Assert.assertTrue(standard.contains(string));
             standard.remove(string);
           }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -129,7 +129,7 @@ public class IoTDBSchemaTemplateIT {
 
     try (ResultSet resultSet = statement.executeQuery("COUNT TIMESERIES root.sg1.**")) {
       resultSet.next();
-      Assert.assertEquals(4, resultSet.getInt(1));
+      Assert.assertEquals(4, resultSet.getLong(1));
     }
 
     expectedResult = new HashSet<>(Arrays.asList("root.sg1.d1,false", "root.sg1.d2,true"));
@@ -207,7 +207,7 @@ public class IoTDBSchemaTemplateIT {
 
     try (ResultSet resultSet = statement.executeQuery("COUNT TIMESERIES root.sg1.**")) {
       resultSet.next();
-      Assert.assertEquals(4, resultSet.getInt(1));
+      Assert.assertEquals(4, resultSet.getLong(1));
     }
 
     expectedResult = new HashSet<>(Arrays.asList("root.sg1.d1,false", "root.sg1.d2,true"));

--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -681,7 +681,7 @@ public class RSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
+  public long constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
     throw new UnsupportedOperationException();
   }
 
@@ -1811,7 +1811,7 @@ public class RSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
+  public long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException {
     throw new UnsupportedOperationException();
   }
@@ -1828,7 +1828,7 @@ public class RSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
+  public long countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
       throws MetadataException {
     throw new UnsupportedOperationException();
   }

--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -864,32 +864,27 @@ public class RSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     return getCountByNodeType(new Character[] {NODE_TYPE_MEASUREMENT}, pathPattern.getNodes());
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean isPrefixMatch)
       throws MetadataException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, boolean isPrefixMatch, String key, String value, boolean isContains)
       throws MetadataException {
     return getMatchedMeasurementPathWithTags(pathPattern.getNodes()).size();
   }
 
-  @TestOnly
-  public int getAllTimeseriesCount(PartialPath pathPattern) throws MetadataException {
-    return getAllTimeseriesCount(pathPattern, false);
-  }
-
   @Override
-  public int getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     return getCountByNodeType(new Character[] {NODE_TYPE_ENTITY}, pathPattern.getNodes());
   }
@@ -906,9 +901,9 @@ public class RSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
-    Map<PartialPath, Integer> result = new ConcurrentHashMap<>();
+    Map<PartialPath, Long> result = new ConcurrentHashMap<>();
     BiFunction<byte[], byte[], Boolean> function =
         (a, b) -> {
           String key = new String(a);
@@ -920,7 +915,7 @@ public class RSchemaRegion implements ISchemaRegion {
             } catch (IllegalPathException e) {
               logger.warn(e.getMessage());
             }
-            result.putIfAbsent(path, 0);
+            result.putIfAbsent(path, 0L);
             result.put(path, result.get(path) + 1);
           }
           return true;
@@ -932,7 +927,7 @@ public class RSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern,
       int level,
       boolean isPrefixMatch,
@@ -940,7 +935,7 @@ public class RSchemaRegion implements ISchemaRegion {
       String value,
       boolean isContains)
       throws MetadataException {
-    Map<PartialPath, Integer> result = new ConcurrentHashMap<>();
+    Map<PartialPath, Long> result = new ConcurrentHashMap<>();
     Map<MeasurementPath, Pair<Map<String, String>, Map<String, String>>> measurementPathsAndTags =
         getMatchedMeasurementPathWithTags(pathPattern.getNodes());
     BiFunction<byte[], byte[], Boolean> function;
@@ -959,7 +954,7 @@ public class RSchemaRegion implements ISchemaRegion {
               if (!measurementPathsAndTags.keySet().contains(partialName)) {
                 result.put(path, result.get(path));
               } else {
-                result.putIfAbsent(path, 0);
+                result.putIfAbsent(path, 0L);
                 result.put(path, result.get(path) + 1);
               }
             }
@@ -977,7 +972,7 @@ public class RSchemaRegion implements ISchemaRegion {
               } catch (IllegalPathException e) {
                 logger.warn(e.getMessage());
               }
-              result.putIfAbsent(path, 0);
+              result.putIfAbsent(path, 0L);
             }
             return true;
           };

--- a/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
+++ b/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
@@ -353,7 +353,7 @@ public class TagSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     int res = 0;
     List<IDeviceID> deviceIDs = getDeviceIdFromInvertedIndex(pathPattern);
@@ -369,27 +369,27 @@ public class TagSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean isPrefixMatch)
       throws MetadataException {
     throw new UnsupportedOperationException("getAllTimeseriesCount");
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, boolean isPrefixMatch, String key, String value, boolean isContains)
       throws MetadataException {
     throw new UnsupportedOperationException("getAllTimeseriesCount");
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
     throw new UnsupportedOperationException("getMeasurementCountGroupByLevel");
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern,
       int level,
       boolean isPrefixMatch,
@@ -401,7 +401,7 @@ public class TagSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     synchronized (idTableWithDeviceIDList) {
       if (pathPattern.getFullPath().length() <= storageGroupFullPath.length()) {

--- a/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
+++ b/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
@@ -327,7 +327,7 @@ public class TagSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
+  public long constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
     throw new UnsupportedOperationException("constructSchemaBlackList");
   }
 
@@ -804,7 +804,7 @@ public class TagSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
+  public long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException {
     throw new UnsupportedOperationException("constructSchemaBlackListWithTemplate");
   }
@@ -821,7 +821,7 @@ public class TagSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public int countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
+  public long countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
       throws MetadataException {
     return 0;
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaProcessor.java
@@ -59,7 +59,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -408,23 +407,6 @@ public class LocalSchemaProcessor {
   public int getNodesCountInGivenLevel(PartialPath pathPattern, int level, boolean isPrefixMatch)
       throws MetadataException {
     return getNodesListInGivenLevel(pathPattern, level, isPrefixMatch).size();
-  }
-
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
-      PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
-    Map<PartialPath, Integer> result = new HashMap<>();
-    Map<PartialPath, Integer> sgResult;
-    for (ISchemaRegion schemaRegion : getInvolvedSchemaRegions(pathPattern, isPrefixMatch)) {
-      sgResult = schemaRegion.getMeasurementCountGroupByLevel(pathPattern, level, isPrefixMatch);
-      for (PartialPath path : sgResult.keySet()) {
-        if (result.containsKey(path)) {
-          result.put(path, result.get(path) + sgResult.get(path));
-        } else {
-          result.put(path, sgResult.get(path));
-        }
-      }
-    }
-    return result;
   }
 
   // endregion

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/ConfigMTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/ConfigMTree.java
@@ -321,7 +321,7 @@ public class ConfigMTree {
     CounterTraverser counter = new StorageGroupCounter(root, pathPattern, store);
     counter.setPrefixMatch(isPrefixMatch);
     counter.traverse();
-    return counter.getCount();
+    return (int) counter.getCount();
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
@@ -246,7 +246,7 @@ public interface IMTreeBelowSG {
    * @param pathPattern a path pattern or a full path, may contain wildcard
    * @param isPrefixMatch if true, the path pattern is used to match prefix path
    */
-  int getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
+  long getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException;
 
   /**
@@ -256,7 +256,7 @@ public interface IMTreeBelowSG {
    * @param templateMap <TemplateId, Template>
    * @param isPrefixMatch if true, the path pattern is used to match prefix path
    */
-  int getAllTimeseriesCount(
+  long getAllTimeseriesCount(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean isPrefixMatch)
       throws MetadataException;
 
@@ -265,14 +265,14 @@ public interface IMTreeBelowSG {
    *
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
-  int getAllTimeseriesCount(PartialPath pathPattern) throws MetadataException;
+  long getAllTimeseriesCount(PartialPath pathPattern) throws MetadataException;
 
   /**
    * Get the count of timeseries matching the given path by tag.
    *
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
-  int getAllTimeseriesCount(
+  long getAllTimeseriesCount(
       PartialPath pathPattern, boolean isPrefixMatch, List<String> timeseries, boolean hasTag)
       throws MetadataException;
 
@@ -283,27 +283,27 @@ public interface IMTreeBelowSG {
    * @param pathPattern a path pattern or a full path, may contain wildcard
    * @param isPrefixMatch if true, the path pattern is used to match prefix path
    */
-  int getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException;
+  long getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException;
 
   /**
    * Get the count of devices matching the given path.
    *
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
-  int getDevicesNum(PartialPath pathPattern) throws MetadataException;
+  long getDevicesNum(PartialPath pathPattern) throws MetadataException;
 
   /**
    * Get the count of nodes in the given level matching the given path. If using prefix match, the
    * path pattern is used to match prefix path. All timeseries start with the matched prefix path
    * will be counted.
    */
-  int getNodesCountInGivenLevel(PartialPath pathPattern, int level, boolean isPrefixMatch)
+  long getNodesCountInGivenLevel(PartialPath pathPattern, int level, boolean isPrefixMatch)
       throws MetadataException;
 
-  Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException;
 
-  Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern,
       int level,
       boolean isPrefixMatch,
@@ -336,5 +336,5 @@ public interface IMTreeBelowSG {
   List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
       throws MetadataException;
 
-  int countPathsUsingTemplate(PartialPath pathPattern, int templateId) throws MetadataException;
+  long countPathsUsingTemplate(PartialPath pathPattern, int templateId) throws MetadataException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -983,7 +983,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
   @Override
-  public int getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     CounterTraverser counter = new MeasurementCounter(storageGroupMNode, pathPattern, store);
     counter.setPrefixMatch(isPrefixMatch);
@@ -992,7 +992,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean isPrefixMatch)
       throws MetadataException {
     CounterTraverser counter = new MeasurementCounter(storageGroupMNode, pathPattern, store);
@@ -1008,12 +1008,12 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
   @Override
-  public int getAllTimeseriesCount(PartialPath pathPattern) throws MetadataException {
+  public long getAllTimeseriesCount(PartialPath pathPattern) throws MetadataException {
     return getAllTimeseriesCount(pathPattern, false);
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, boolean isPrefixMatch, List<String> timeseries, boolean hasTag)
       throws MetadataException {
     CounterTraverser counter =
@@ -1031,7 +1031,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
    * @param isPrefixMatch if true, the path pattern is used to match prefix path
    */
   @Override
-  public int getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     CounterTraverser counter = new EntityCounter(storageGroupMNode, pathPattern, store);
     counter.setPrefixMatch(isPrefixMatch);
@@ -1045,7 +1045,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
   @Override
-  public int getDevicesNum(PartialPath pathPattern) throws MetadataException {
+  public long getDevicesNum(PartialPath pathPattern) throws MetadataException {
     return getDevicesNum(pathPattern, false);
   }
 
@@ -1055,7 +1055,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
    * will be counted.
    */
   @Override
-  public int getNodesCountInGivenLevel(PartialPath pathPattern, int level, boolean isPrefixMatch)
+  public long getNodesCountInGivenLevel(PartialPath pathPattern, int level, boolean isPrefixMatch)
       throws MetadataException {
     MNodeLevelCounter counter = new MNodeLevelCounter(storageGroupMNode, pathPattern, store, level);
     counter.setPrefixMatch(isPrefixMatch);
@@ -1064,7 +1064,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
     MeasurementGroupByLevelCounter counter =
         new MeasurementGroupByLevelCounter(storageGroupMNode, pathPattern, store, level);
@@ -1074,7 +1074,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern,
       int level,
       boolean isPrefixMatch,
@@ -1360,7 +1360,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
   }
 
   @Override
-  public int countPathsUsingTemplate(PartialPath pathPattern, int templateId)
+  public long countPathsUsingTemplate(PartialPath pathPattern, int templateId)
       throws MetadataException {
     CounterTraverser counterTraverser =
         new CounterTraverser(storageGroupMNode, pathPattern, store) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -924,7 +924,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
   @Override
-  public int getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     CounterTraverser counter = new MeasurementCounter(storageGroupMNode, pathPattern, store);
     counter.setPrefixMatch(isPrefixMatch);
@@ -933,7 +933,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean isPrefixMatch)
       throws MetadataException {
     CounterTraverser counter = new MeasurementCounter(storageGroupMNode, pathPattern, store);
@@ -949,12 +949,12 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
   @Override
-  public int getAllTimeseriesCount(PartialPath pathPattern) throws MetadataException {
+  public long getAllTimeseriesCount(PartialPath pathPattern) throws MetadataException {
     return getAllTimeseriesCount(pathPattern, false);
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, boolean isPrefixMatch, List<String> timeseries, boolean hasTag)
       throws MetadataException {
     CounterTraverser counter =
@@ -972,7 +972,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
    * @param isPrefixMatch if true, the path pattern is used to match prefix path
    */
   @Override
-  public int getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     CounterTraverser counter = new EntityCounter(storageGroupMNode, pathPattern, store);
     counter.setPrefixMatch(isPrefixMatch);
@@ -986,7 +986,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
    * @param pathPattern a path pattern or a full path, may contain wildcard
    */
   @Override
-  public int getDevicesNum(PartialPath pathPattern) throws MetadataException {
+  public long getDevicesNum(PartialPath pathPattern) throws MetadataException {
     return getDevicesNum(pathPattern, false);
   }
 
@@ -996,7 +996,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
    * will be counted.
    */
   @Override
-  public int getNodesCountInGivenLevel(PartialPath pathPattern, int level, boolean isPrefixMatch)
+  public long getNodesCountInGivenLevel(PartialPath pathPattern, int level, boolean isPrefixMatch)
       throws MetadataException {
     MNodeLevelCounter counter = new MNodeLevelCounter(storageGroupMNode, pathPattern, store, level);
     counter.setPrefixMatch(isPrefixMatch);
@@ -1005,7 +1005,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
     MeasurementGroupByLevelCounter counter =
         new MeasurementGroupByLevelCounter(storageGroupMNode, pathPattern, store, level);
@@ -1015,7 +1015,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern,
       int level,
       boolean isPrefixMatch,
@@ -1232,7 +1232,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
   }
 
   @Override
-  public int countPathsUsingTemplate(PartialPath pathPattern, int templateId)
+  public long countPathsUsingTemplate(PartialPath pathPattern, int templateId)
       throws MetadataException {
     CounterTraverser counterTraverser =
         new CounterTraverser(storageGroupMNode, pathPattern, store) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/CounterTraverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/CounterTraverser.java
@@ -27,14 +27,14 @@ import org.apache.iotdb.db.metadata.mtree.traverser.Traverser;
 // This class define the count as traversal result.
 public abstract class CounterTraverser extends Traverser {
 
-  protected int count;
+  protected long count;
 
   public CounterTraverser(IMNode startNode, PartialPath path, IMTreeStore store)
       throws MetadataException {
     super(startNode, path, store);
   }
 
-  public int getCount() {
+  public long getCount() {
     return count;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MeasurementGroupByLevelCounter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/counter/MeasurementGroupByLevelCounter.java
@@ -34,7 +34,7 @@ public class MeasurementGroupByLevelCounter extends Traverser {
   // level query option
   private int groupByLevel;
 
-  private Map<PartialPath, Integer> result = new HashMap<>();
+  private Map<PartialPath, Long> result = new HashMap<>();
   private List<String> timeseries = new ArrayList<>();
   private boolean hasTag = false;
 
@@ -78,7 +78,7 @@ public class MeasurementGroupByLevelCounter extends Traverser {
       level--;
       if (level == groupByLevel) {
         path = parent.getPartialPath();
-        result.putIfAbsent(path, 0);
+        result.putIfAbsent(path, 0L);
         break;
       }
       parent = parent.getParent();
@@ -90,7 +90,7 @@ public class MeasurementGroupByLevelCounter extends Traverser {
       throws MetadataException {
     if (level == groupByLevel) {
       path = node.getPartialPath();
-      result.putIfAbsent(path, 0);
+      result.putIfAbsent(path, 0L);
     }
     return false;
   }
@@ -100,7 +100,7 @@ public class MeasurementGroupByLevelCounter extends Traverser {
       throws MetadataException {
     if (level == groupByLevel) {
       path = node.getPartialPath();
-      result.putIfAbsent(path, 0);
+      result.putIfAbsent(path, 0L);
     }
     if (!node.isMeasurement()) {
       return false;
@@ -116,11 +116,11 @@ public class MeasurementGroupByLevelCounter extends Traverser {
     return true;
   }
 
-  public Map<PartialPath, Integer> getResult() {
+  public Map<PartialPath, Long> getResult() {
     return result;
   }
 
-  public void setResult(Map<PartialPath, Integer> result) {
+  public void setResult(Map<PartialPath, Long> result) {
     this.result = result;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -125,7 +125,7 @@ public interface ISchemaRegion {
    * @param patternTree
    * @throws MetadataException
    */
-  int constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException;
+  long constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException;
 
   /**
    * Rollback schema black list via setting matched timeseries to not pre deleted.
@@ -379,7 +379,7 @@ public interface ISchemaRegion {
   List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
       throws MetadataException;
 
-  int constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
+  long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException;
 
   void rollbackSchemaBlackListWithTemplate(IRollbackPreDeactivateTemplatePlan plan)
@@ -387,7 +387,8 @@ public interface ISchemaRegion {
 
   void deactivateTemplateInBlackList(IDeactivateTemplatePlan plan) throws MetadataException;
 
-  int countPathsUsingTemplate(int templateId, PathPatternTree patternTree) throws MetadataException;
+  long countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
+      throws MetadataException;
 
   // endregion
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -160,22 +160,22 @@ public interface ISchemaRegion {
    * path, may contain wildcard. If using prefix match, the path pattern is used to match prefix
    * path. All timeseries start with the matched prefix path will be counted.
    */
-  int getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
+  long getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException;
 
-  int getAllTimeseriesCount(
+  long getAllTimeseriesCount(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean isPrefixMatch)
       throws MetadataException;
 
-  int getAllTimeseriesCount(
+  long getAllTimeseriesCount(
       PartialPath pathPattern, boolean isPrefixMatch, String key, String value, boolean isContains)
       throws MetadataException;
 
   // The measurements will be grouped by the node in given level and then counted for each group.
-  Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException;
 
-  Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern,
       int level,
       boolean isPrefixMatch,
@@ -189,7 +189,7 @@ public interface ISchemaRegion {
    * pattern is used to match prefix path. All timeseries start with the matched prefix path will be
    * counted.
    */
-  int getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException;
+  long getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException;
   // endregion
 
   // region Interfaces for level Node info Query

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -1729,7 +1729,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   @Override
   public long countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
       throws MetadataException {
-    int result = 0;
+    long result = 0;
     for (PartialPath pathPattern : patternTree.getAllPathPatterns()) {
       result += mtree.countPathsUsingTemplate(pathPattern, templateId);
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -769,8 +769,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   }
 
   @Override
-  public int constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
-    int preDeletedNum = 0;
+  public long constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
+    long preDeletedNum = 0;
     for (PartialPath pathPattern : patternTree.getAllPathPatterns()) {
       for (IMeasurementMNode measurementMNode : mtree.getMatchedMeasurementMNode(pathPattern)) {
         // Given pathPatterns may match one timeseries multi times, which may results in the
@@ -1657,9 +1657,9 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   }
 
   @Override
-  public int constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
+  public long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException {
-    int preDeactivateNum = 0;
+    long preDeactivateNum = 0;
     Map<PartialPath, List<Integer>> templateSetInfo = plan.getTemplateSetInfo();
     for (Map.Entry<PartialPath, List<Integer>> entry : templateSetInfo.entrySet()) {
       for (IEntityMNode entityMNode :
@@ -1727,7 +1727,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   }
 
   @Override
-  public int countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
+  public long countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
       throws MetadataException {
     int result = 0;
     for (PartialPath pathPattern : patternTree.getAllPathPatterns()) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -962,20 +962,20 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
    * path. All timeseries start with the matched prefix path will be counted.
    */
   @Override
-  public int getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     return mtree.getAllTimeseriesCount(pathPattern, isPrefixMatch);
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean isPrefixMatch)
       throws MetadataException {
     return mtree.getAllTimeseriesCount(pathPattern, templateMap, isPrefixMatch);
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, boolean isPrefixMatch, String key, String value, boolean isContains)
       throws MetadataException {
     return mtree.getAllTimeseriesCount(
@@ -991,24 +991,19 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
    * counted.
    */
   @Override
-  public int getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     return mtree.getDevicesNum(pathPattern, isPrefixMatch);
   }
 
-  /** To calculate the count of devices for given path pattern. */
-  public int getDevicesNum(PartialPath pathPattern) throws MetadataException {
-    return getDevicesNum(pathPattern, false);
-  }
-
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
     return mtree.getMeasurementCountGroupByLevel(pathPattern, level, isPrefixMatch);
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern,
       int level,
       boolean isPrefixMatch,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -1055,20 +1055,20 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
    * path. All timeseries start with the matched prefix path will be counted.
    */
   @Override
-  public int getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getAllTimeseriesCount(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     return mtree.getAllTimeseriesCount(pathPattern, isPrefixMatch);
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean isPrefixMatch)
       throws MetadataException {
     return mtree.getAllTimeseriesCount(pathPattern, templateMap, isPrefixMatch);
   }
 
   @Override
-  public int getAllTimeseriesCount(
+  public long getAllTimeseriesCount(
       PartialPath pathPattern, boolean isPrefixMatch, String key, String value, boolean isContains)
       throws MetadataException {
     return mtree.getAllTimeseriesCount(
@@ -1084,24 +1084,19 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
    * counted.
    */
   @Override
-  public int getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
+  public long getDevicesNum(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     return mtree.getDevicesNum(pathPattern, isPrefixMatch);
   }
 
-  /** To calculate the count of devices for given path pattern. */
-  public int getDevicesNum(PartialPath pathPattern) throws MetadataException {
-    return getDevicesNum(pathPattern, false);
-  }
-
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern, int level, boolean isPrefixMatch) throws MetadataException {
     return mtree.getMeasurementCountGroupByLevel(pathPattern, level, isPrefixMatch);
   }
 
   @Override
-  public Map<PartialPath, Integer> getMeasurementCountGroupByLevel(
+  public Map<PartialPath, Long> getMeasurementCountGroupByLevel(
       PartialPath pathPattern,
       int level,
       boolean isPrefixMatch,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -848,8 +848,8 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   }
 
   @Override
-  public int constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
-    int preDeletedNum = 0;
+  public long constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
+    long preDeletedNum = 0;
     for (PartialPath pathPattern : patternTree.getAllPathPatterns()) {
       List<IMeasurementMNode> measurementMNodeList = mtree.getMatchedMeasurementMNode(pathPattern);
       try {
@@ -1695,7 +1695,7 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   }
 
   @Override
-  public int constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
+  public long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException {
     Map<PartialPath, List<Integer>> resultTemplateSetInfo =
         mtree.constructSchemaBlackListWithTemplate(plan.getTemplateSetInfo());
@@ -1732,9 +1732,9 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   }
 
   @Override
-  public int countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
+  public long countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
       throws MetadataException {
-    int result = 0;
+    long result = 0;
     for (PartialPath pathPattern : patternTree.getAllPathPatterns()) {
       result += mtree.countPathsUsingTemplate(pathPattern, templateId);
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/visitor/SchemaExecutionVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/visitor/SchemaExecutionVisitor.java
@@ -293,7 +293,7 @@ public class SchemaExecutionVisitor extends PlanVisitor<TSStatus, ISchemaRegion>
   public TSStatus visitConstructSchemaBlackList(
       ConstructSchemaBlackListNode node, ISchemaRegion schemaRegion) {
     try {
-      int preDeletedNum = schemaRegion.constructSchemaBlackList(node.getPatternTree());
+      long preDeletedNum = schemaRegion.constructSchemaBlackList(node.getPatternTree());
       return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS, String.valueOf(preDeletedNum));
     } catch (MetadataException e) {
       logger.error(e.getMessage(), e);
@@ -328,7 +328,7 @@ public class SchemaExecutionVisitor extends PlanVisitor<TSStatus, ISchemaRegion>
   public TSStatus visitPreDeactivateTemplate(
       PreDeactivateTemplateNode node, ISchemaRegion schemaRegion) {
     try {
-      int preDeactivateNum = schemaRegion.constructSchemaBlackListWithTemplate(node);
+      long preDeactivateNum = schemaRegion.constructSchemaBlackListWithTemplate(node);
       return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS, String.valueOf(preDeactivateNum));
     } catch (MetadataException e) {
       logger.error(e.getMessage(), e);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
@@ -196,18 +196,18 @@ public class ColumnHeaderConstant {
       ImmutableList.of(new ColumnHeader(PATHS, TSDataType.TEXT));
 
   public static final List<ColumnHeader> countDevicesColumnHeaders =
-      ImmutableList.of(new ColumnHeader(COUNT_DEVICES, TSDataType.INT32));
+      ImmutableList.of(new ColumnHeader(COUNT_DEVICES, TSDataType.INT64));
 
   public static final List<ColumnHeader> countNodesColumnHeaders =
-      ImmutableList.of(new ColumnHeader(COUNT_NODES, TSDataType.INT32));
+      ImmutableList.of(new ColumnHeader(COUNT_NODES, TSDataType.INT64));
 
   public static final List<ColumnHeader> countLevelTimeSeriesColumnHeaders =
       ImmutableList.of(
           new ColumnHeader(COLUMN, TSDataType.TEXT),
-          new ColumnHeader(COUNT_TIMESERIES, TSDataType.INT32));
+          new ColumnHeader(COUNT_TIMESERIES, TSDataType.INT64));
 
   public static final List<ColumnHeader> countTimeSeriesColumnHeaders =
-      ImmutableList.of(new ColumnHeader(COUNT_TIMESERIES, TSDataType.INT32));
+      ImmutableList.of(new ColumnHeader(COUNT_TIMESERIES, TSDataType.INT64));
 
   public static final List<ColumnHeader> countStorageGroupColumnHeaders =
       ImmutableList.of(new ColumnHeader(COUNT_DATABASE, TSDataType.INT32));

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperator.java
@@ -124,35 +124,35 @@ public class CountMergeOperator implements ProcessOperator {
   }
 
   private void generateResultWithoutGroupByLevel() {
-    int totalCount = 0;
+    long totalCount = 0;
     for (TsBlock tsBlock : childrenTsBlocks) {
-      int count = tsBlock.getColumn(0).getInt(0);
+      long count = tsBlock.getColumn(0).getLong(0);
       totalCount += count;
     }
-    TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(Collections.singletonList(TSDataType.INT32));
+    TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(Collections.singletonList(TSDataType.INT64));
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-    tsBlockBuilder.getColumnBuilder(0).writeInt(totalCount);
+    tsBlockBuilder.getColumnBuilder(0).writeLong(totalCount);
     tsBlockBuilder.declarePosition();
     this.resultTsBlockList = Collections.singletonList(tsBlockBuilder.build());
   }
 
   private void generateResultWithGroupByLevel() {
-    Map<String, Integer> countMap = new HashMap<>();
+    Map<String, Long> countMap = new HashMap<>();
     for (TsBlock tsBlock : childrenTsBlocks) {
       for (int i = 0; i < tsBlock.getPositionCount(); i++) {
         String columnName = tsBlock.getColumn(0).getBinary(i).getStringValue();
-        int count = tsBlock.getColumn(1).getInt(i);
-        countMap.put(columnName, countMap.getOrDefault(columnName, 0) + count);
+        long count = tsBlock.getColumn(1).getLong(i);
+        countMap.put(columnName, countMap.getOrDefault(columnName, 0L) + count);
       }
     }
     this.resultTsBlockList =
         SchemaTsBlockUtil.transferSchemaResultToTsBlockList(
             countMap.entrySet().iterator(),
-            Arrays.asList(TSDataType.TEXT, TSDataType.INT32),
+            Arrays.asList(TSDataType.TEXT, TSDataType.INT64),
             (entry, tsBlockBuilder) -> {
               tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
               tsBlockBuilder.getColumnBuilder(0).writeBinary(new Binary(entry.getKey()));
-              tsBlockBuilder.getColumnBuilder(1).writeInt(entry.getValue());
+              tsBlockBuilder.getColumnBuilder(1).writeLong(entry.getValue());
               tsBlockBuilder.declarePosition();
             });
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/DevicesCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/DevicesCountOperator.java
@@ -73,7 +73,7 @@ public class DevicesCountOperator implements SourceOperator {
   public TsBlock next() {
     isFinished = true;
     TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
-    int count = 0;
+    long count = 0;
     try {
       count =
           ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
@@ -83,7 +83,7 @@ public class DevicesCountOperator implements SourceOperator {
       throw new RuntimeException(e.getMessage(), e);
     }
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-    tsBlockBuilder.getColumnBuilder(0).writeInt(count);
+    tsBlockBuilder.getColumnBuilder(0).writeLong(count);
     tsBlockBuilder.declarePosition();
     return tsBlockBuilder.build();
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/LevelTimeSeriesCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/LevelTimeSeriesCountOperator.java
@@ -105,7 +105,7 @@ public class LevelTimeSeriesCountOperator implements SourceOperator {
   }
 
   public void createTsBlockList() {
-    Map<PartialPath, Integer> countMap;
+    Map<PartialPath, Long> countMap;
     try {
       if (key != null && value != null) {
         countMap =
@@ -133,7 +133,7 @@ public class LevelTimeSeriesCountOperator implements SourceOperator {
               tsBlockBuilder
                   .getColumnBuilder(0)
                   .writeBinary(new Binary(entry.getKey().getFullPath()));
-              tsBlockBuilder.getColumnBuilder(1).writeInt(entry.getValue());
+              tsBlockBuilder.getColumnBuilder(1).writeLong(entry.getValue());
               tsBlockBuilder.declarePosition();
             });
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/NodePathsCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/NodePathsCountOperator.java
@@ -85,7 +85,7 @@ public class NodePathsCountOperator implements ProcessOperator {
     TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
 
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-    tsBlockBuilder.getColumnBuilder(0).writeInt(nodePaths.size());
+    tsBlockBuilder.getColumnBuilder(0).writeLong(nodePaths.size());
     tsBlockBuilder.declarePosition();
     return tsBlockBuilder.build();
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/TimeSeriesCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/TimeSeriesCountOperator.java
@@ -87,7 +87,7 @@ public class TimeSeriesCountOperator implements SourceOperator {
   public TsBlock next() {
     isFinished = true;
     TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
-    int count = 0;
+    long count = 0;
     try {
       if (key != null && value != null) {
         count =
@@ -104,7 +104,7 @@ public class TimeSeriesCountOperator implements SourceOperator {
       throw new RuntimeException(e.getMessage(), e);
     }
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-    tsBlockBuilder.getColumnBuilder(0).writeInt(count);
+    tsBlockBuilder.getColumnBuilder(0).writeLong(count);
     tsBlockBuilder.declarePosition();
     return tsBlockBuilder.build();
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/memory/StatementMemorySourceVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/memory/StatementMemorySourceVisitor.java
@@ -187,7 +187,7 @@ public class StatementMemorySourceVisitor
             .map(TSchemaNode::getNodeName)
             .collect(Collectors.toSet());
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-    tsBlockBuilder.getColumnBuilder(0).writeInt(matchedChildNodes.size());
+    tsBlockBuilder.getColumnBuilder(0).writeLong(matchedChildNodes.size());
     tsBlockBuilder.declarePosition();
     return new StatementMemorySource(
         tsBlockBuilder.build(), context.getAnalysis().getRespDatasetHeader());
@@ -202,7 +202,7 @@ public class StatementMemorySourceVisitor
             .collect(Collectors.toList());
     TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-    tsBlockBuilder.getColumnBuilder(0).writeInt(0);
+    tsBlockBuilder.getColumnBuilder(0).writeLong(0);
     tsBlockBuilder.declarePosition();
     return new StatementMemorySource(
         tsBlockBuilder.build(), context.getAnalysis().getRespDatasetHeader());
@@ -217,7 +217,7 @@ public class StatementMemorySourceVisitor
             .collect(Collectors.toList());
     TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-    tsBlockBuilder.getColumnBuilder(0).writeInt(0);
+    tsBlockBuilder.getColumnBuilder(0).writeLong(0);
     tsBlockBuilder.declarePosition();
     return new StatementMemorySource(
         tsBlockBuilder.build(), context.getAnalysis().getRespDatasetHeader());

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -102,7 +102,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
@@ -289,24 +288,9 @@ public class PlanExecutor implements IPlanExecutor {
   }
 
   private QueryDataSet processCountNodeTimeSeries(CountPlan countPlan) throws MetadataException {
-    Map<PartialPath, Integer> countResults = getTimeseriesCountGroupByLevel(countPlan);
-    ListDataSet listDataSet =
-        new ListDataSet(
-            Arrays.asList(
-                new PartialPath(COLUMN_COLUMN, false), new PartialPath(COLUMN_COUNT, false)),
-            Arrays.asList(TSDataType.TEXT, TSDataType.INT32));
-    for (PartialPath columnPath : countResults.keySet()) {
-      RowRecord record = new RowRecord(0);
-      Field field = new Field(TSDataType.TEXT);
-      field.setBinaryV(new Binary(columnPath.getFullPath()));
-      Field field1 = new Field(TSDataType.INT32);
-      // get the count of every group
-      field1.setIntV(countResults.get(columnPath));
-      record.addField(field);
-      record.addField(field1);
-      listDataSet.putRecord(record);
-    }
-    return listDataSet;
+    return new ListDataSet(
+        Arrays.asList(new PartialPath(COLUMN_COLUMN, false), new PartialPath(COLUMN_COUNT, false)),
+        Arrays.asList(TSDataType.TEXT, TSDataType.INT32));
   }
 
   private QueryDataSet processCountDevices(CountPlan countPlan) throws MetadataException {
@@ -372,12 +356,6 @@ public class PlanExecutor implements IPlanExecutor {
 
   protected List<MeasurementPath> getPathsName(PartialPath path) throws MetadataException {
     return IoTDB.schemaProcessor.getMeasurementPaths(path);
-  }
-
-  private Map<PartialPath, Integer> getTimeseriesCountGroupByLevel(CountPlan countPlan)
-      throws MetadataException {
-    return IoTDB.schemaProcessor.getMeasurementCountGroupByLevel(
-        countPlan.getPath(), countPlan.getLevel(), countPlan.isPrefixMatch());
   }
 
   private QueryDataSet processCountTimeSeries(CountPlan countPlan) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -736,7 +736,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
       throws TException {
     PathPatternTree patternTree = PathPatternTree.deserialize(req.patternTree);
     TCountPathsUsingTemplateResp resp = new TCountPathsUsingTemplateResp();
-    int result = 0;
+    long result = 0;
     for (TConsensusGroupId consensusGroupId : req.getSchemaRegionIdList()) {
       // todo implement as consensus layer read request
       ReadWriteLock readWriteLock =

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
@@ -778,18 +778,17 @@ public abstract class MTreeBelowSGTest {
         null);
 
     PartialPath pattern = new PartialPath("root.sg.**");
-    Map<PartialPath, Integer> result =
-        storageGroup.getMeasurementCountGroupByLevel(pattern, 2, false);
+    Map<PartialPath, Long> result = storageGroup.getMeasurementCountGroupByLevel(pattern, 2, false);
     assertEquals(2, result.size());
-    assertEquals(3, (int) result.get(new PartialPath("root.sg.a1")));
-    assertEquals(2, (int) result.get(new PartialPath("root.sg.a2")));
+    assertEquals(3, (long) result.get(new PartialPath("root.sg.a1")));
+    assertEquals(2, (long) result.get(new PartialPath("root.sg.a2")));
 
     result = storageGroup.getMeasurementCountGroupByLevel(pattern, 3, false);
     assertEquals(4, result.size());
-    assertEquals(1, (int) result.get(new PartialPath("root.sg.a1.s1")));
-    assertEquals(2, (int) result.get(new PartialPath("root.sg.a1.d1")));
-    assertEquals(1, (int) result.get(new PartialPath("root.sg.a2.s1")));
-    assertEquals(1, (int) result.get(new PartialPath("root.sg.a2.d1")));
+    assertEquals(1, (long) result.get(new PartialPath("root.sg.a1.s1")));
+    assertEquals(2, (long) result.get(new PartialPath("root.sg.a1.d1")));
+    assertEquals(1, (long) result.get(new PartialPath("root.sg.a2.s1")));
+    assertEquals(1, (long) result.get(new PartialPath("root.sg.a2.d1")));
 
     result = storageGroup.getMeasurementCountGroupByLevel(pattern, 5, false);
     assertEquals(0, result.size());
@@ -797,14 +796,14 @@ public abstract class MTreeBelowSGTest {
     pattern = new PartialPath("root.**.s1");
     result = storageGroup.getMeasurementCountGroupByLevel(pattern, 2, false);
     assertEquals(2, result.size());
-    assertEquals(2, (int) result.get(new PartialPath("root.sg.a1")));
-    assertEquals(2, (int) result.get(new PartialPath("root.sg.a2")));
+    assertEquals(2, (long) result.get(new PartialPath("root.sg.a1")));
+    assertEquals(2, (long) result.get(new PartialPath("root.sg.a2")));
 
     result = storageGroup.getMeasurementCountGroupByLevel(pattern, 3, false);
     assertEquals(4, result.size());
-    assertEquals(1, (int) result.get(new PartialPath("root.sg.a1.s1")));
-    assertEquals(1, (int) result.get(new PartialPath("root.sg.a1.d1")));
-    assertEquals(1, (int) result.get(new PartialPath("root.sg.a2.s1")));
-    assertEquals(1, (int) result.get(new PartialPath("root.sg.a2.d1")));
+    assertEquals(1, (long) result.get(new PartialPath("root.sg.a1.s1")));
+    assertEquals(1, (long) result.get(new PartialPath("root.sg.a1.d1")));
+    assertEquals(1, (long) result.get(new PartialPath("root.sg.a2.s1")));
+    assertEquals(1, (long) result.get(new PartialPath("root.sg.a2.d1")));
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperatorTest.java
@@ -115,7 +115,7 @@ public class CountMergeOperatorTest {
         tsBlock = timeSeriesCountOperator.next();
       }
       assertNotNull(tsBlock);
-      assertEquals(100, tsBlock.getColumn(0).getInt(0));
+      assertEquals(100, tsBlock.getColumn(0).getLong(0));
       TimeSeriesCountOperator timeSeriesCountOperator2 =
           new TimeSeriesCountOperator(
               planNodeId,
@@ -129,7 +129,7 @@ public class CountMergeOperatorTest {
       tsBlock = timeSeriesCountOperator2.next();
       assertFalse(timeSeriesCountOperator2.hasNext());
       assertTrue(timeSeriesCountOperator2.isFinished());
-      assertEquals(10, tsBlock.getColumn(0).getInt(0));
+      assertEquals(10, tsBlock.getColumn(0).getLong(0));
     } catch (MetadataException e) {
       e.printStackTrace();
       fail();
@@ -200,9 +200,9 @@ public class CountMergeOperatorTest {
         String path = tsBlock.getColumn(0).getBinary(i).getStringValue();
         assertTrue(path.startsWith(COUNT_MERGE_OPERATOR_TEST_SG + ".device"));
         if (path.equals(COUNT_MERGE_OPERATOR_TEST_SG + ".device2")) {
-          assertEquals(20, tsBlock.getColumn(1).getInt(i));
+          assertEquals(20, tsBlock.getColumn(1).getLong(i));
         } else {
-          assertEquals(10, tsBlock.getColumn(1).getInt(i));
+          assertEquals(10, tsBlock.getColumn(1).getLong(i));
         }
       }
     } catch (MetadataException e) {

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperatorTest.java
@@ -106,7 +106,7 @@ public class SchemaCountOperatorTest {
         tsBlock = devicesCountOperator.next();
       }
       assertNotNull(tsBlock);
-      assertEquals(tsBlock.getColumn(0).getInt(0), 10);
+      assertEquals(tsBlock.getColumn(0).getLong(0), 10);
     } catch (MetadataException e) {
       e.printStackTrace();
       fail();
@@ -154,7 +154,7 @@ public class SchemaCountOperatorTest {
         tsBlock = timeSeriesCountOperator.next();
       }
       assertNotNull(tsBlock);
-      assertEquals(100, tsBlock.getColumn(0).getInt(0));
+      assertEquals(100, tsBlock.getColumn(0).getLong(0));
       TimeSeriesCountOperator timeSeriesCountOperator2 =
           new TimeSeriesCountOperator(
               planNodeId,
@@ -168,7 +168,7 @@ public class SchemaCountOperatorTest {
       tsBlock = timeSeriesCountOperator2.next();
       assertFalse(timeSeriesCountOperator2.hasNext());
       assertTrue(timeSeriesCountOperator2.isFinished());
-      assertEquals(10, tsBlock.getColumn(0).getInt(0));
+      assertEquals(10, tsBlock.getColumn(0).getLong(0));
     } catch (MetadataException e) {
       e.printStackTrace();
       fail();
@@ -221,7 +221,7 @@ public class SchemaCountOperatorTest {
       for (int i = 0; i < 10; i++) {
         String path = tsBlock.getColumn(0).getBinary(i).getStringValue();
         assertTrue(path.startsWith(SCHEMA_COUNT_OPERATOR_TEST_SG + ".device"));
-        assertEquals(10, tsBlock.getColumn(1).getInt(i));
+        assertEquals(10, tsBlock.getColumn(1).getLong(i));
       }
 
       LevelTimeSeriesCountOperator timeSeriesCountOperator2 =
@@ -238,7 +238,7 @@ public class SchemaCountOperatorTest {
         tsBlock = timeSeriesCountOperator2.next();
       }
       assertNotNull(tsBlock);
-      assertEquals(100, tsBlock.getColumn(1).getInt(0));
+      assertEquals(100, tsBlock.getColumn(1).getLong(0));
     } catch (MetadataException e) {
       e.printStackTrace();
       fail();

--- a/thrift/src/main/thrift/datanode.thrift
+++ b/thrift/src/main/thrift/datanode.thrift
@@ -321,7 +321,7 @@ struct TCountPathsUsingTemplateReq{
 
 struct TCountPathsUsingTemplateResp{
   1: required common.TSStatus status
-  2: optional i32 count
+  2: optional i64 count
 }
 
 struct TCreatePipeOnDataNodeReq{


### PR DESCRIPTION
## Description


### Motivation

Since we want to use iotdb cluster to manage 10 billion timeseries, which far exceeds the MAX_VALUE of int, we cannot use int as the format of schema statistic result.

### Modification

1. Make the schema count operation return long, including:
    1. count timeseries
    2. count timeseries group by level
    3. count device
    4. count nodes 
2. Make the internal schema statistics method return long, including:
    1. timeseries statistic used in delete timeseries
    2. device statistic used in deactivate timeseries
    3. device statistic used in unset timeseries


