### PR TITLE
Set namespace to generated go files

### DIFF
--- a/thrift-commons/src/main/thrift/common.thrift
+++ b/thrift-commons/src/main/thrift/common.thrift
@@ -19,6 +19,7 @@
 
 namespace java org.apache.iotdb.common.rpc.thrift
 namespace py iotdb.thrift.common
+namespace go common
 
 // Define a set of ip:port address
 struct TEndPoint {

--- a/thrift/src/main/thrift/client.thrift
+++ b/thrift/src/main/thrift/client.thrift
@@ -20,6 +20,7 @@
 include "common.thrift"
 namespace java org.apache.iotdb.service.rpc.thrift
 namespace py iotdb.thrift.rpc
+namespace go rpc
 
 struct TSQueryDataSet{
   // ByteBuffer for time column


### PR DESCRIPTION
No the generated go files have their packages.
However as the stupid plugin we used to generate thrift codes, we can't specify the parameter to generate with  full import path, which results the package `rpc` imports `common` but can't be used in iotdb-client-go directly, we should just change the import path manually as a workaround.
![image](https://user-images.githubusercontent.com/3821212/203500916-948102f4-ecef-4830-a01c-1c54666b5c58.png)
