### PR TITLE
[IOTDB-4972] Fix NPE when validate schema without auto create schema

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertNode.java
@@ -248,10 +248,9 @@ public abstract class InsertNode extends WritePlanNode {
   /** Check whether data types are matched with measurement schemas */
   protected void selfCheckDataTypes() throws DataTypeMismatchException {
     for (int i = 0; i < measurementSchemas.length; i++) {
-      if (dataTypes[i] != measurementSchemas[i].getType()) {
-        if (checkAndCastDataType(i, measurementSchemas[i].getType())) {
-          continue;
-        }
+      if (measurementSchemas[i] == null
+          || (dataTypes[i] != measurementSchemas[i].getType()
+              && !checkAndCastDataType(i, measurementSchemas[i].getType()))) {
         if (!IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
           throw new DataTypeMismatchException(
               devicePath.getFullPath(),


### PR DESCRIPTION
## Description

When the auto create schema is closing, some schema of target measurement may be missing in fetched schema tree, which results in the npe when trying to get dataType from fetched schema.
