### PR TITLE
Catch Throwable in DataNodeInternalService to avoid ambiguous TException

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
@@ -80,7 +80,6 @@ public class RegionWriteExecutor {
 
   public RegionExecutionResult execute(ConsensusGroupId groupId, PlanNode planNode) {
     try {
-
       WritePlanNodeExecutionContext context =
           new WritePlanNodeExecutionContext(groupId, REGION_MANAGER.getRegionLock(groupId));
       WritePlanNodeExecutionVisitor executionVisitor = new WritePlanNodeExecutionVisitor();


### PR DESCRIPTION
## Description

When there's some internal runtime error, not caught, thrift will return an TException to the client and miss the meaningless message.