### PR TITLE
[IOTDB-5031] Make snapshot taking in shutdown hook parallel

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -56,8 +56,7 @@ public class IoTDBShutdownHook extends Thread {
     if (IoTDBDescriptor.getInstance().getConfig().isClusterMode()) {
       // This setting ensures that compaction work is not discarded
       // even if there are frequent restarts
-      DataRegionConsensusImpl.getInstance()
-          .getAllConsensusGroupIds()
+      DataRegionConsensusImpl.getInstance().getAllConsensusGroupIds().parallelStream()
           .forEach(id -> DataRegionConsensusImpl.getInstance().triggerSnapshot(id));
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -56,7 +56,9 @@ public class IoTDBShutdownHook extends Thread {
     if (IoTDBDescriptor.getInstance().getConfig().isClusterMode()) {
       // This setting ensures that compaction work is not discarded
       // even if there are frequent restarts
-      DataRegionConsensusImpl.getInstance().getAllConsensusGroupIds().parallelStream()
+      DataRegionConsensusImpl.getInstance()
+          .getAllConsensusGroupIds()
+          .parallelStream()
           .forEach(id -> DataRegionConsensusImpl.getInstance().triggerSnapshot(id));
     }
 


### PR DESCRIPTION
See [IOTDB-5031](https://issues.apache.org/jira/browse/IOTDB-5031).

Trigger a snapshot when shutting down IoTDB could help reserve the compaction result, this pr makes it parallel to accelerate thisp process.