### PR TITLE
Make memory portion take effect after change the default ratio

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1816,6 +1816,7 @@ public class IoTDBConfig {
 
   public void setAllocateMemoryForStorageEngine(long allocateMemoryForStorageEngine) {
     this.allocateMemoryForStorageEngine = allocateMemoryForStorageEngine;
+    this.allocateMemoryForTimePartitionInfo = allocateMemoryForStorageEngine * 50 / 1001;
   }
 
   public long getAllocateMemoryForSchema() {
@@ -1828,6 +1829,10 @@ public class IoTDBConfig {
 
   public void setAllocateMemoryForSchema(long allocateMemoryForSchema) {
     this.allocateMemoryForSchema = allocateMemoryForSchema;
+
+    this.allocateMemoryForSchemaRegion = allocateMemoryForSchema * 8 / 10;
+    this.allocateMemoryForSchemaCache = allocateMemoryForSchema / 10;
+    this.allocateMemoryForLastCache = allocateMemoryForSchema / 10;
   }
 
   public void setAllocateMemoryForConsensus(long allocateMemoryForConsensus) {
@@ -1840,6 +1845,14 @@ public class IoTDBConfig {
 
   void setAllocateMemoryForRead(long allocateMemoryForRead) {
     this.allocateMemoryForRead = allocateMemoryForRead;
+
+    this.allocateMemoryForBloomFilterCache = allocateMemoryForRead / 1001;
+    this.allocateMemoryForTimeSeriesMetaDataCache = allocateMemoryForRead * 200 / 1001;
+    this.allocateMemoryForChunkCache = allocateMemoryForRead * 100 / 1001;
+    this.allocateMemoryForCoordinator = allocateMemoryForRead * 50 / 1001;
+    this.allocateMemoryForOperators = allocateMemoryForRead * 200 / 1001;
+    this.allocateMemoryForDataExchange = allocateMemoryForRead * 200 / 1001;
+    this.allocateMemoryForTimeIndex = allocateMemoryForRead * 200 / 1001;
   }
 
   public long getAllocateMemoryForFree() {

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SinkHandleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SinkHandleTest.java
@@ -113,8 +113,7 @@ public class SinkHandleTest {
     Mockito.verify(mockMemoryPool, Mockito.times(2))
         .reserve(queryId, mockTsBlockSize * numOfMockTsBlock);
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
           .onNewDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -123,7 +122,7 @@ public class SinkHandleTest {
                           && localFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && e.getStartSequenceId() == 0
                           && e.getBlockSizes().size() == numOfMockTsBlock));
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -145,13 +144,8 @@ public class SinkHandleTest {
     Assert.assertTrue(sinkHandle.isFull().isDone());
     Assert.assertFalse(sinkHandle.isFinished());
     Assert.assertFalse(sinkHandle.isAborted());
-    try {
-      Thread.sleep(500L);
-      Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onEndOfBlocks(sinkHandle);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-      Assert.fail();
-    }
+    Mockito.verify(mockSinkHandleListener, Mockito.timeout(10_000).times(1))
+        .onEndOfBlocks(sinkHandle);
 
     // Ack tsblocks.
     sinkHandle.acknowledgeTsBlock(0, numOfMockTsBlock);
@@ -164,8 +158,7 @@ public class SinkHandleTest {
     Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onFinish(sinkHandle);
 
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
           .onEndOfDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -173,7 +166,7 @@ public class SinkHandleTest {
                           && remotePlanNodeId.equals(e.getTargetPlanNodeId())
                           && localFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && numOfMockTsBlock - 1 == e.getLastSequenceId()));
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -249,8 +242,7 @@ public class SinkHandleTest {
     Mockito.verify(mockMemoryPool, Mockito.times(2))
         .reserve(queryId, mockTsBlockSize * numOfMockTsBlock);
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
           .onNewDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -259,7 +251,7 @@ public class SinkHandleTest {
                           && localFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && e.getStartSequenceId() == 0
                           && e.getBlockSizes().size() == numOfMockTsBlock));
-    } catch (TException | InterruptedException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -298,8 +290,7 @@ public class SinkHandleTest {
     Mockito.verify(mockMemoryPool, Mockito.times(3))
         .reserve(queryId, mockTsBlockSize * numOfMockTsBlock);
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
           .onNewDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -308,7 +299,7 @@ public class SinkHandleTest {
                           && localFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && e.getStartSequenceId() == numOfMockTsBlock
                           && e.getBlockSizes().size() == numOfMockTsBlock));
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -317,17 +308,11 @@ public class SinkHandleTest {
     sinkHandle.setNoMoreTsBlocks();
     Assert.assertFalse(sinkHandle.isFinished());
     Assert.assertFalse(sinkHandle.isAborted());
-    try {
-      Thread.sleep(500L);
-      Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onEndOfBlocks(sinkHandle);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-      Assert.fail();
-    }
+    Mockito.verify(mockSinkHandleListener, Mockito.timeout(10_000).times(1))
+        .onEndOfBlocks(sinkHandle);
 
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
           .onEndOfDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -335,7 +320,7 @@ public class SinkHandleTest {
                           && remotePlanNodeId.equals(e.getTargetPlanNodeId())
                           && localFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && numOfMockTsBlock * 2 - 1 == e.getLastSequenceId()));
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -433,8 +418,7 @@ public class SinkHandleTest {
     Mockito.verify(mockMemoryPool, Mockito.times(2))
         .reserve(queryId, mockTsBlockSize * numOfMockTsBlock);
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(SinkHandle.MAX_ATTEMPT_TIMES))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(SinkHandle.MAX_ATTEMPT_TIMES))
           .onNewDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -443,22 +427,18 @@ public class SinkHandleTest {
                           && localFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && e.getStartSequenceId() == 0
                           && e.getBlockSizes().size() == numOfMockTsBlock));
-    } catch (TException | InterruptedException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
-    Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onFailure(sinkHandle, mockException);
+    Mockito.verify(mockSinkHandleListener, Mockito.timeout(10_000).times(1))
+        .onFailure(sinkHandle, mockException);
 
     // Close the SinkHandle.
-    try {
-      sinkHandle.setNoMoreTsBlocks();
-      Assert.assertFalse(sinkHandle.isAborted());
-      Thread.sleep(500L);
-      Mockito.verify(mockSinkHandleListener, Mockito.times(0)).onEndOfBlocks(sinkHandle);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-      Assert.fail();
-    }
+    sinkHandle.setNoMoreTsBlocks();
+    Assert.assertFalse(sinkHandle.isAborted());
+    Mockito.verify(mockSinkHandleListener, Mockito.timeout(10_000).times(0))
+        .onEndOfBlocks(sinkHandle);
 
     // Abort the SinkHandle.
     sinkHandle.abort();

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SinkHandleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SinkHandleTest.java
@@ -110,7 +110,7 @@ public class SinkHandleTest {
         mockTsBlockSize * numOfMockTsBlock + DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES,
         sinkHandle.getBufferRetainedSizeInBytes());
     Assert.assertEquals(numOfMockTsBlock, sinkHandle.getNumOfBufferedTsBlocks());
-    Mockito.verify(mockMemoryPool, Mockito.times(2))
+    Mockito.verify(mockMemoryPool, Mockito.timeout(10_0000).times(2))
         .reserve(queryId, mockTsBlockSize * numOfMockTsBlock);
     try {
       Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
@@ -153,9 +153,9 @@ public class SinkHandleTest {
     Assert.assertTrue(sinkHandle.isFinished());
     Assert.assertFalse(sinkHandle.isAborted());
     Assert.assertEquals(mockTsBlockSize, sinkHandle.getBufferRetainedSizeInBytes());
-    Mockito.verify(mockMemoryPool, Mockito.times(1))
+    Mockito.verify(mockMemoryPool, Mockito.timeout(10_0000).times(1))
         .free(queryId, numOfMockTsBlock * mockTsBlockSize);
-    Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onFinish(sinkHandle);
+    Mockito.verify(mockSinkHandleListener, Mockito.timeout(10_0000).times(1)).onFinish(sinkHandle);
 
     try {
       Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
@@ -239,7 +239,7 @@ public class SinkHandleTest {
         mockTsBlockSize * numOfMockTsBlock + DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES,
         sinkHandle.getBufferRetainedSizeInBytes());
     Assert.assertEquals(numOfMockTsBlock, sinkHandle.getNumOfBufferedTsBlocks());
-    Mockito.verify(mockMemoryPool, Mockito.times(2))
+    Mockito.verify(mockMemoryPool, Mockito.timeout(10_0000).times(2))
         .reserve(queryId, mockTsBlockSize * numOfMockTsBlock);
     try {
       Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
@@ -275,7 +275,7 @@ public class SinkHandleTest {
     Assert.assertFalse(sinkHandle.isAborted());
     Assert.assertEquals(
         DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES, sinkHandle.getBufferRetainedSizeInBytes());
-    Mockito.verify(mockMemoryPool, Mockito.times(1))
+    Mockito.verify(mockMemoryPool, Mockito.timeout(10_0000).times(1))
         .free(queryId, numOfMockTsBlock * mockTsBlockSize);
 
     // Send tsblocks.
@@ -287,7 +287,7 @@ public class SinkHandleTest {
         mockTsBlockSize * numOfMockTsBlock + DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES,
         sinkHandle.getBufferRetainedSizeInBytes());
     Assert.assertEquals(numOfMockTsBlock, sinkHandle.getNumOfBufferedTsBlocks());
-    Mockito.verify(mockMemoryPool, Mockito.times(3))
+    Mockito.verify(mockMemoryPool, Mockito.timeout(10_0000).times(3))
         .reserve(queryId, mockTsBlockSize * numOfMockTsBlock);
     try {
       Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
@@ -342,9 +342,9 @@ public class SinkHandleTest {
     Assert.assertFalse(sinkHandle.isAborted());
     Assert.assertEquals(
         DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES, sinkHandle.getBufferRetainedSizeInBytes());
-    Mockito.verify(mockMemoryPool, Mockito.times(2))
+    Mockito.verify(mockMemoryPool, Mockito.timeout(10_0000).times(2))
         .free(queryId, numOfMockTsBlock * mockTsBlockSize);
-    Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onFinish(sinkHandle);
+    Mockito.verify(mockSinkHandleListener, Mockito.timeout(10_0000).times(1)).onFinish(sinkHandle);
   }
 
   @Test
@@ -415,7 +415,7 @@ public class SinkHandleTest {
         mockTsBlockSize * numOfMockTsBlock + DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES,
         sinkHandle.getBufferRetainedSizeInBytes());
     Assert.assertEquals(numOfMockTsBlock, sinkHandle.getNumOfBufferedTsBlocks());
-    Mockito.verify(mockMemoryPool, Mockito.times(2))
+    Mockito.verify(mockMemoryPool, Mockito.timeout(10_0000).times(2))
         .reserve(queryId, mockTsBlockSize * numOfMockTsBlock);
     try {
       Mockito.verify(mockClient, Mockito.timeout(10_000).times(SinkHandle.MAX_ATTEMPT_TIMES))
@@ -443,8 +443,8 @@ public class SinkHandleTest {
     // Abort the SinkHandle.
     sinkHandle.abort();
     Assert.assertTrue(sinkHandle.isAborted());
-    Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onAborted(sinkHandle);
-    Mockito.verify(mockSinkHandleListener, Mockito.times(0)).onFinish(sinkHandle);
+    Mockito.verify(mockSinkHandleListener, Mockito.timeout(10_0000).times(1)).onAborted(sinkHandle);
+    Mockito.verify(mockSinkHandleListener, Mockito.timeout(10_0000).times(0)).onFinish(sinkHandle);
   }
 
   @Test
@@ -526,7 +526,7 @@ public class SinkHandleTest {
     Assert.assertTrue(sinkHandle.isAborted());
     Assert.assertEquals(0L, sinkHandle.getBufferRetainedSizeInBytes());
     Assert.assertEquals(0, sinkHandle.getNumOfBufferedTsBlocks());
-    Mockito.verify(mockSinkHandleListener, Mockito.times(1)).onAborted(sinkHandle);
+    Mockito.verify(mockSinkHandleListener, Mockito.timeout(10_0000).times(1)).onAborted(sinkHandle);
     Assert.assertEquals(0L, spyMemoryPool.getQueryMemoryReservedBytes(queryId));
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SourceHandleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SourceHandleTest.java
@@ -113,8 +113,7 @@ public class SourceHandleTest {
             .limit(numOfMockTsBlock)
             .collect(Collectors.toList()));
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
           .getDataBlock(
               Mockito.argThat(
                   req ->
@@ -128,7 +127,7 @@ public class SourceHandleTest {
                       remoteFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && 0 == e.getStartSequenceId()
                           && numOfMockTsBlock == e.getEndSequenceId()));
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -229,8 +228,8 @@ public class SourceHandleTest {
             .limit(numOfMockTsBlock)
             .collect(Collectors.toList()));
     try {
-      Thread.sleep(100L);
-      Mockito.verify(spyMemoryPool, Mockito.times(6)).reserve(queryId, mockTsBlockSize);
+      Mockito.verify(spyMemoryPool, Mockito.timeout(10_000).times(6))
+          .reserve(queryId, mockTsBlockSize);
       Mockito.verify(mockClient, Mockito.times(1))
           .getDataBlock(
               Mockito.argThat(
@@ -245,7 +244,7 @@ public class SourceHandleTest {
                       remoteFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && 0 == e.getStartSequenceId()
                           && 5 == e.getEndSequenceId()));
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -259,20 +258,19 @@ public class SourceHandleTest {
       Mockito.verify(spyMemoryPool, Mockito.times(i)).free(queryId, mockTsBlockSize);
       sourceHandle.receive();
       try {
-        Thread.sleep(100L);
         if (i < 5) {
           Assert.assertEquals(
               i == 4 ? 5 * mockTsBlockSize : 6 * mockTsBlockSize,
               sourceHandle.getBufferRetainedSizeInBytes());
           final int startSequenceId = 5 + i;
-          Mockito.verify(mockClient, Mockito.times(1))
+          Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
               .getDataBlock(
                   Mockito.argThat(
                       req ->
                           remoteFragmentInstanceId.equals(req.getSourceFragmentInstanceId())
                               && startSequenceId == req.getStartSequenceId()
                               && startSequenceId + 1 == req.getEndSequenceId()));
-          Mockito.verify(mockClient, Mockito.times(1))
+          Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
               .onAcknowledgeDataBlockEvent(
                   Mockito.argThat(
                       e ->
@@ -284,7 +282,7 @@ public class SourceHandleTest {
               (numOfMockTsBlock - 1 - i) * mockTsBlockSize,
               sourceHandle.getBufferRetainedSizeInBytes());
         }
-      } catch (InterruptedException | TException e) {
+      } catch (TException e) {
         e.printStackTrace();
         Assert.fail();
       }
@@ -372,12 +370,11 @@ public class SourceHandleTest {
             .limit(numOfMockTsBlock)
             .collect(Collectors.toList()));
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(0))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(0))
           .getDataBlock(Mockito.any(TGetDataBlockRequest.class));
       Mockito.verify(mockClient, Mockito.times(0))
           .onAcknowledgeDataBlockEvent(Mockito.any(TAcknowledgeDataBlockEvent.class));
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -392,8 +389,7 @@ public class SourceHandleTest {
             .limit(numOfMockTsBlock)
             .collect(Collectors.toList()));
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
           .getDataBlock(
               Mockito.argThat(
                   req ->
@@ -407,7 +403,7 @@ public class SourceHandleTest {
                       remoteFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && 0 == e.getStartSequenceId()
                           && numOfMockTsBlock * 2 == e.getEndSequenceId()));
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -439,8 +435,7 @@ public class SourceHandleTest {
             .limit(numOfMockTsBlock)
             .collect(Collectors.toList()));
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(1))
           .getDataBlock(
               Mockito.argThat(
                   req ->
@@ -454,7 +449,7 @@ public class SourceHandleTest {
                       remoteFragmentInstanceId.equals(e.getSourceFragmentInstanceId())
                           && numOfMockTsBlock * 2 == e.getStartSequenceId()
                           && numOfMockTsBlock * 3 == e.getEndSequenceId()));
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }
@@ -548,10 +543,9 @@ public class SourceHandleTest {
             .limit(numOfMockTsBlock)
             .collect(Collectors.toList()));
     try {
-      Thread.sleep(100L);
-      Mockito.verify(mockClient, Mockito.times(SourceHandle.MAX_ATTEMPT_TIMES))
+      Mockito.verify(mockClient, Mockito.timeout(10_000).times(SourceHandle.MAX_ATTEMPT_TIMES))
           .getDataBlock(Mockito.any());
-    } catch (InterruptedException | TException e) {
+    } catch (TException e) {
       e.printStackTrace();
       Assert.fail();
     }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SourceHandleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SourceHandleTest.java
@@ -120,7 +120,7 @@ public class SourceHandleTest {
                       remoteFragmentInstanceId.equals(req.getSourceFragmentInstanceId())
                           && 0 == req.getStartSequenceId()
                           && numOfMockTsBlock == req.getEndSequenceId()));
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_0000).times(1))
           .onAcknowledgeDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -158,7 +158,8 @@ public class SourceHandleTest {
     Assert.assertFalse(sourceHandle.isAborted());
     Assert.assertTrue(sourceHandle.isFinished());
     Assert.assertEquals(0L, sourceHandle.getBufferRetainedSizeInBytes());
-    Mockito.verify(mockSourceHandleListener, Mockito.times(1)).onFinished(sourceHandle);
+    Mockito.verify(mockSourceHandleListener, Mockito.timeout(10_0000).times(1))
+        .onFinished(sourceHandle);
   }
 
   @Test
@@ -230,14 +231,14 @@ public class SourceHandleTest {
     try {
       Mockito.verify(spyMemoryPool, Mockito.timeout(10_000).times(6))
           .reserve(queryId, mockTsBlockSize);
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_0000).times(1))
           .getDataBlock(
               Mockito.argThat(
                   req ->
                       remoteFragmentInstanceId.equals(req.getSourceFragmentInstanceId())
                           && 0 == req.getStartSequenceId()
                           && 5 == req.getEndSequenceId()));
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_0000).times(1))
           .onAcknowledgeDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -255,7 +256,8 @@ public class SourceHandleTest {
 
     // The local fragment instance consumes the data blocks.
     for (int i = 0; i < numOfMockTsBlock; i++) {
-      Mockito.verify(spyMemoryPool, Mockito.times(i)).free(queryId, mockTsBlockSize);
+      Mockito.verify(spyMemoryPool, Mockito.timeout(10_0000).times(i))
+          .free(queryId, mockTsBlockSize);
       sourceHandle.receive();
       try {
         if (i < 5) {
@@ -301,7 +303,8 @@ public class SourceHandleTest {
     Assert.assertFalse(sourceHandle.isAborted());
     Assert.assertTrue(sourceHandle.isFinished());
     Assert.assertEquals(0L, sourceHandle.getBufferRetainedSizeInBytes());
-    Mockito.verify(mockSourceHandleListener, Mockito.times(1)).onFinished(sourceHandle);
+    Mockito.verify(mockSourceHandleListener, Mockito.timeout(10_0000).times(1))
+        .onFinished(sourceHandle);
   }
 
   @Test
@@ -372,7 +375,7 @@ public class SourceHandleTest {
     try {
       Mockito.verify(mockClient, Mockito.timeout(10_000).times(0))
           .getDataBlock(Mockito.any(TGetDataBlockRequest.class));
-      Mockito.verify(mockClient, Mockito.times(0))
+      Mockito.verify(mockClient, Mockito.timeout(10_0000).times(0))
           .onAcknowledgeDataBlockEvent(Mockito.any(TAcknowledgeDataBlockEvent.class));
     } catch (TException e) {
       e.printStackTrace();
@@ -396,7 +399,7 @@ public class SourceHandleTest {
                       remoteFragmentInstanceId.equals(req.getSourceFragmentInstanceId())
                           && 0 == req.getStartSequenceId()
                           && numOfMockTsBlock * 2 == req.getEndSequenceId()));
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_0000).times(1))
           .onAcknowledgeDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -442,7 +445,7 @@ public class SourceHandleTest {
                       remoteFragmentInstanceId.equals(req.getSourceFragmentInstanceId())
                           && numOfMockTsBlock * 2 == req.getStartSequenceId()
                           && numOfMockTsBlock * 3 == req.getEndSequenceId()));
-      Mockito.verify(mockClient, Mockito.times(1))
+      Mockito.verify(mockClient, Mockito.timeout(10_0000).times(1))
           .onAcknowledgeDataBlockEvent(
               Mockito.argThat(
                   e ->
@@ -480,7 +483,8 @@ public class SourceHandleTest {
     Assert.assertFalse(sourceHandle.isAborted());
     Assert.assertTrue(sourceHandle.isFinished());
     Assert.assertEquals(0L, sourceHandle.getBufferRetainedSizeInBytes());
-    Mockito.verify(mockSourceHandleListener, Mockito.times(1)).onFinished(sourceHandle);
+    Mockito.verify(mockSourceHandleListener, Mockito.timeout(10_0000).times(1))
+        .onFinished(sourceHandle);
   }
 
   @Test
@@ -550,7 +554,7 @@ public class SourceHandleTest {
       Assert.fail();
     }
 
-    Mockito.verify(mockSourceHandleListener, Mockito.times(1))
+    Mockito.verify(mockSourceHandleListener, Mockito.timeout(10_0000).times(1))
         .onFailure(sourceHandle, mockException);
     Assert.assertFalse(blocked.isDone());
 
@@ -559,7 +563,8 @@ public class SourceHandleTest {
     Assert.assertTrue(sourceHandle.isAborted());
     Assert.assertTrue(blocked.isDone());
     Assert.assertEquals(0L, sourceHandle.getBufferRetainedSizeInBytes());
-    Mockito.verify(mockSourceHandleListener, Mockito.times(1)).onAborted(sourceHandle);
+    Mockito.verify(mockSourceHandleListener, Mockito.timeout(10_0000).times(1))
+        .onAborted(sourceHandle);
   }
 
   @Test
@@ -628,6 +633,7 @@ public class SourceHandleTest {
     Assert.assertTrue(sourceHandle.isAborted());
     Assert.assertFalse(sourceHandle.isFinished());
     Assert.assertEquals(0L, sourceHandle.getBufferRetainedSizeInBytes());
-    Mockito.verify(mockSourceHandleListener, Mockito.times(1)).onAborted(sourceHandle);
+    Mockito.verify(mockSourceHandleListener, Mockito.timeout(10_0000).times(1))
+        .onAborted(sourceHandle);
   }
 }


### PR DESCRIPTION
Currently, if we only change `storage_query_schema_consensus_free_memory_proportion`, it won't successfully change its corresponding children's memory if we don't change `chunk_timeseriesmeta_free_memory_proportion`, because they were already inited at first using default configuration.