### PR TITLE
[IOTDB-5034] Change log level

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -673,17 +673,17 @@ class RatisConsensus implements IConsensus {
   }
 
   private ConsensusGenericResponse failed(ConsensusException e) {
-    logger.error("{} request failed with exception {}", this, e);
+    logger.debug("{} request failed with exception {}", this, e);
     return ConsensusGenericResponse.newBuilder().setSuccess(false).setException(e).build();
   }
 
   private ConsensusWriteResponse failedWrite(ConsensusException e) {
-    logger.error("{} write request failed with exception {}", this, e);
+    logger.debug("{} write request failed with exception {}", this, e);
     return ConsensusWriteResponse.newBuilder().setException(e).build();
   }
 
   private ConsensusReadResponse failedRead(ConsensusException e) {
-    logger.error("{} read request failed with exception {}", this, e);
+    logger.debug("{} read request failed with exception {}", this, e);
     return ConsensusReadResponse.newBuilder().setException(e).build();
   }
 


### PR DESCRIPTION
# Why change log level

Currently RatisConsensus treats failed consensus operations all as error level. However, some failures are expected and can be retries by caller. So I changed the level to INFO, leaving the ERROR/WARN decision to caller.