### PR TITLE
[IOTDB-4971] Print status code name when dispatch failed

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -171,8 +171,9 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           TSendPlanNodeResp sendPlanNodeResp = client.sendPlanNode(sendPlanNodeReq);
           if (!sendPlanNodeResp.accepted) {
             logger.error(
-                "dispatch write failed. status: {}, message: {}, node {}",
+                "dispatch write failed. status: {}, code: {}, message: {}, node {}",
                 sendPlanNodeResp.status,
+                TSStatusCode.representOf(sendPlanNodeResp.status.code),
                 sendPlanNodeResp.message,
                 endPoint);
             if (sendPlanNodeResp.getStatus() == null) {


### PR DESCRIPTION
## Description
Currently the error message only contains the int value of the statusCode, which is not very clear for operators.