### PR TITLE
Make simple consensuse as default for confignode

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigNodeRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigNodeRegionStateMachine.java
@@ -69,7 +69,7 @@ public class ConfigNodeRegionStateMachine
   private int endIndex;
 
   private static final String currentFileDir =
-      CONF.getConsensusDir() + File.separator + "standalone" + File.separator + "current";
+      CONF.getConsensusDir() + File.separator + "simple" + File.separator + "current";
   private static final String progressFilePath =
       currentFileDir + File.separator + "log_inprogress_";
   private static final String filePath = currentFileDir + File.separator + "log_";

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -23,9 +23,10 @@
 # ConfigNode consensus protocol type.
 # This parameter is unmodifiable after ConfigNode starts for the first time.
 # These consensus protocols are currently supported:
-# 1. org.apache.iotdb.consensus.ratis.RatisConsensus
+# 1. org.apache.iotdb.consensus.simple.SimpleConsensus
+# 2. org.apache.iotdb.consensus.ratis.RatisConsensus
 # Datatype: string
-# config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
+# config_node_consensus_protocol_class=org.apache.iotdb.consensus.simple.SimpleConsensus
 
 # Default number of schema replicas
 # Can not be changed after the first start


### PR DESCRIPTION
## Description

Make simple consensuse as default for confignode.

1. The file structure is as shown below:
![image](https://user-images.githubusercontent.com/6756545/203973408-b9bb8902-bdd6-4cef-a683-3efa6a7c7a8e.png)

2. The performance of simple is better than ratis 1 replica(DEVICE_NUMBER=5, SENSOR_NUMBER=10, GROUP_NUMBER=5). 

test result of simple
![image](https://user-images.githubusercontent.com/6756545/203973629-1210de07-c264-471b-a7e1-f233bee1fc11.png)

test result of ratis 1 replica
![image](https://user-images.githubusercontent.com/6756545/203973733-7a7c3c6d-7c6c-45e8-b00d-9563bf64a1a3.png)
