### PR TITLE
[IOTDB-5004] [Metrics] Fix the seq file size in grafana is inconsistent with the actual query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/TsFileMetricManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/TsFileMetricManager.java
@@ -48,13 +48,13 @@ public class TsFileMetricManager {
     }
   }
 
-  public void deleteFile(long size, boolean seq) {
+  public void deleteFile(long size, boolean seq, int num) {
     if (seq) {
       seqFileSize.getAndAdd(-size);
-      seqFileNum.getAndAdd(-1);
+      seqFileNum.getAndAdd(-num);
     } else {
       unseqFileSize.getAndAdd(-size);
-      unseqFileNum.getAndAdd(-1);
+      unseqFileNum.getAndAdd(-num);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
@@ -170,8 +170,10 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
 
         long sequenceFileSize = deleteOldFiles(selectedSequenceFiles);
         long unsequenceFileSize = deleteOldFiles(selectedUnsequenceFiles);
-        TsFileMetricManager.getInstance().deleteFile(sequenceFileSize, true);
-        TsFileMetricManager.getInstance().deleteFile(unsequenceFileSize, false);
+        TsFileMetricManager.getInstance()
+            .deleteFile(sequenceFileSize, true, selectedSequenceFiles.size());
+        TsFileMetricManager.getInstance()
+            .deleteFile(unsequenceFileSize, false, selectedUnsequenceFiles.size());
 
         for (TsFileResource targetResource : targetTsfileResourceList) {
           TsFileMetricManager.getInstance().addFile(targetResource.getTsFileSize(), true);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
@@ -168,15 +168,11 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
         releaseReadAndLockWrite(selectedSequenceFiles);
         releaseReadAndLockWrite(selectedUnsequenceFiles);
 
-        deleteOldFiles(selectedSequenceFiles);
-        deleteOldFiles(selectedUnsequenceFiles);
+        long sequenceFileSize = deleteOldFiles(selectedSequenceFiles);
+        long unsequenceFileSize = deleteOldFiles(selectedUnsequenceFiles);
+        TsFileMetricManager.getInstance().deleteFile(sequenceFileSize, true);
+        TsFileMetricManager.getInstance().deleteFile(unsequenceFileSize, false);
 
-        for (TsFileResource seqResource : selectedSequenceFiles) {
-          TsFileMetricManager.getInstance().deleteFile(seqResource.getTsFileSize(), true);
-        }
-        for (TsFileResource unseqResource : selectedUnsequenceFiles) {
-          TsFileMetricManager.getInstance().deleteFile(unseqResource.getTsFileSize(), false);
-        }
         for (TsFileResource targetResource : targetTsfileResourceList) {
           TsFileMetricManager.getInstance().addFile(targetResource.getTsFileSize(), true);
         }
@@ -299,14 +295,17 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
     selectedUnsequenceFiles.forEach(x -> x.setStatus(TsFileResourceStatus.CLOSED));
   }
 
-  private void deleteOldFiles(List<TsFileResource> tsFileResourceList) throws IOException {
+  private long deleteOldFiles(List<TsFileResource> tsFileResourceList) throws IOException {
+    long totalSize = 0;
     for (TsFileResource tsFileResource : tsFileResourceList) {
       FileReaderManager.getInstance().closeFileAndRemoveReader(tsFileResource.getTsFilePath());
+      totalSize += tsFileResource.getTsFileSize();
       tsFileResource.remove();
       LOGGER.info(
           "[CrossSpaceCompaction] Delete TsFile :{}.",
           tsFileResource.getTsFile().getAbsolutePath());
     }
+    return totalSize;
   }
 
   private void releaseReadAndLockWrite(List<TsFileResource> tsFileResourceList) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
@@ -211,7 +211,8 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
       CompactionUtils.deleteModificationForSourceFile(
           selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
-      TsFileMetricManager.getInstance().deleteFile(totalSizeOfDeletedFile, sequence);
+      TsFileMetricManager.getInstance()
+          .deleteFile(totalSizeOfDeletedFile, sequence, selectedTsFileResourceList.size());
       // inner space compaction task has only one target file
       if (targetTsFileList.size() > 0) {
         // if the target tsfile is empty file, it will be removed

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionTask.java
@@ -203,13 +203,15 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           storageGroupName,
           dataRegionId);
       // delete the old files
+      long totalSizeOfDeletedFile = 0L;
+      for (TsFileResource resource : selectedTsFileResourceList) {
+        totalSizeOfDeletedFile += resource.getTsFileSize();
+      }
       CompactionUtils.deleteTsFilesInDisk(
           selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
       CompactionUtils.deleteModificationForSourceFile(
           selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
-      for (TsFileResource resource : selectedTsFileResourceList) {
-        TsFileMetricManager.getInstance().deleteFile(resource.getTsFile().length(), sequence);
-      }
+      TsFileMetricManager.getInstance().deleteFile(totalSizeOfDeletedFile, sequence);
       // inner space compaction task has only one target file
       if (targetTsFileList.size() > 0) {
         // if the target tsfile is empty file, it will be removed


### PR DESCRIPTION
See [IOTDB-5004](https://issues.apache.org/jira/browse/IOTDB-5004).

The reason for this bug is that, when reducing the size of deleted tsfile after compaction, the deleted files return a size of zero. This pr fixes it by calculating the total size of deleted file before they are deleted, and reducing it after deletion of the files.