### PR TITLE
Optimize insert statement generate

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/StatementGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/StatementGenerator.java
@@ -232,9 +232,12 @@ public class StatementGenerator {
     // construct insert statement
     InsertMultiTabletsStatement insertStatement = new InsertMultiTabletsStatement();
     List<InsertTabletStatement> insertTabletStatementList = new ArrayList<>();
+    Map<String, PartialPath> devicePathMap = new HashMap<>();
     for (int i = 0; i < req.prefixPaths.size(); i++) {
       InsertTabletStatement insertTabletStatement = new InsertTabletStatement();
-      insertTabletStatement.setDevicePath(new PartialPath(req.prefixPaths.get(i)));
+      insertTabletStatement.setDevicePath(
+          devicePathMap.putIfAbsent(
+              req.getPrefixPaths().get(i), new PartialPath(req.getPrefixPaths().get(i))));
       insertTabletStatement.setMeasurements(req.measurementsList.get(i).toArray(new String[0]));
       insertTabletStatement.setTimes(
           QueryDataSetUtils.readTimesFromBuffer(req.timestampsList.get(i), req.sizeList.get(i)));
@@ -270,9 +273,12 @@ public class StatementGenerator {
     // construct insert statement
     InsertRowsStatement insertStatement = new InsertRowsStatement();
     List<InsertRowStatement> insertRowStatementList = new ArrayList<>();
+    Map<String, PartialPath> devicePathMap = new HashMap<>();
     for (int i = 0; i < req.prefixPaths.size(); i++) {
       InsertRowStatement statement = new InsertRowStatement();
-      statement.setDevicePath(new PartialPath(req.getPrefixPaths().get(i)));
+      statement.setDevicePath(
+          devicePathMap.putIfAbsent(
+              req.getPrefixPaths().get(i), new PartialPath(req.getPrefixPaths().get(i))));
       statement.setMeasurements(req.getMeasurementsList().get(i).toArray(new String[0]));
       statement.setTime(req.getTimestamps().get(i));
       statement.fillValues(req.valuesList.get(i));
@@ -292,9 +298,12 @@ public class StatementGenerator {
     // construct insert statement
     InsertRowsStatement insertStatement = new InsertRowsStatement();
     List<InsertRowStatement> insertRowStatementList = new ArrayList<>();
+    Map<String, PartialPath> devicePathMap = new HashMap<>();
     for (int i = 0; i < req.prefixPaths.size(); i++) {
       InsertRowStatement statement = new InsertRowStatement();
-      statement.setDevicePath(new PartialPath(req.getPrefixPaths().get(i)));
+      statement.setDevicePath(
+          devicePathMap.putIfAbsent(
+              req.getPrefixPaths().get(i), new PartialPath(req.getPrefixPaths().get(i))));
       addMeasurementAndValue(
           statement, req.getMeasurementsList().get(i), req.getValuesList().get(i));
       statement.setDataTypes(new TSDataType[statement.getMeasurements().length]);


### PR DESCRIPTION
## Description

Optimize tsbs insert performance.
set wal_mode=DISABLE
Before:
```
Summary:
loaded 78537600 metrics in 75.496sec with 1 workers (mean rate 1040289.76 metrics/sec)
loaded 6998400 rows in 75.496sec with 1 workers (mean rate 92699.09 rows/sec)
```
After
```
Summary:
loaded 78537600 metrics in 29.084sec with 1 workers (mean rate 2700401.36 metrics/sec)
loaded 6998400 rows in 29.084sec with 1 workers (mean rate 240629.82 rows/sec)
```