### PR TITLE
[IOTDB-5045] Add concurrent control to database create and drop operation

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -426,7 +426,7 @@ public class ConfigManager implements IManager {
   }
 
   @Override
-  public TSStatus setStorageGroup(SetStorageGroupPlan setStorageGroupPlan) {
+  public synchronized TSStatus setStorageGroup(SetStorageGroupPlan setStorageGroupPlan) {
     TSStatus status = confirmLeader();
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       return clusterSchemaManager.setStorageGroup(setStorageGroupPlan);
@@ -436,7 +436,7 @@ public class ConfigManager implements IManager {
   }
 
   @Override
-  public TSStatus deleteStorageGroups(List<String> deletedPaths) {
+  public synchronized TSStatus deleteStorageGroups(List<String> deletedPaths) {
     TSStatus status = confirmLeader();
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       // remove wild


### PR DESCRIPTION
## Description

The problem described in IOTDB-5045 is mostly derived by concurrent operations on databases, thus add concurrent control.

Since database is a global heavy management unit, the sequence operation on it is fine.
