### PR TITLE
[IOTDB-5050] Try to make TsBlock returned by ScanOperator larger

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
@@ -502,13 +502,13 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
    */
   public void forceDeregisterFragmentInstance(TFragmentInstanceId fragmentInstanceId) {
     logger.debug("[StartForceReleaseFIDataExchangeResource]");
-    if (sinkHandles.containsKey(fragmentInstanceId)) {
-      ISinkHandle sinkHandle = sinkHandles.get(fragmentInstanceId);
+    ISinkHandle sinkHandle = sinkHandles.get(fragmentInstanceId);
+    if (sinkHandle != null) {
       sinkHandle.abort();
       sinkHandles.remove(fragmentInstanceId);
     }
-    if (sourceHandles.containsKey(fragmentInstanceId)) {
-      Map<String, ISourceHandle> planNodeIdToSourceHandle = sourceHandles.get(fragmentInstanceId);
+    Map<String, ISourceHandle> planNodeIdToSourceHandle = sourceHandles.get(fragmentInstanceId);
+    if (planNodeIdToSourceHandle != null) {
       for (Entry<String, ISourceHandle> entry : planNodeIdToSourceHandle.entrySet()) {
         logger.debug("[CloseSourceHandle] {}", entry.getKey());
         entry.getValue().abort();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/AlignedSeriesScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/AlignedSeriesScanOperator.java
@@ -180,15 +180,24 @@ public class AlignedSeriesScanOperator implements DataSourceOperator {
     for (int i = 0; i < size; i++) {
       timeColumnBuilder.writeLong(timeColumn.getLong(i));
       builder.declarePosition();
-      ;
     }
     for (int columnIndex = 0, columnSize = tsBlock.getValueColumnCount();
         columnIndex < columnSize;
         columnIndex++) {
       ColumnBuilder columnBuilder = builder.getColumnBuilder(columnIndex);
       Column column = tsBlock.getColumn(columnIndex);
-      for (int i = 0; i < size; i++) {
-        columnBuilder.write(column, i);
+      if (column.mayHaveNull()) {
+        for (int i = 0; i < size; i++) {
+          if (column.isNull(i)) {
+            columnBuilder.appendNull();
+          } else {
+            columnBuilder.write(column, i);
+          }
+        }
+      } else {
+        for (int i = 0; i < size; i++) {
+          columnBuilder.write(column, i);
+        }
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/AlignedSeriesScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/AlignedSeriesScanOperator.java
@@ -179,6 +179,8 @@ public class AlignedSeriesScanOperator implements DataSourceOperator {
     TimeColumn timeColumn = tsBlock.getTimeColumn();
     for (int i = 0; i < size; i++) {
       timeColumnBuilder.writeLong(timeColumn.getLong(i));
+      builder.declarePosition();
+      ;
     }
     for (int columnIndex = 0, columnSize = tsBlock.getValueColumnCount();
         columnIndex < columnSize;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanOperator.java
@@ -184,6 +184,7 @@ public class SeriesScanOperator implements DataSourceOperator {
     for (int i = 0, size = tsBlock.getPositionCount(); i < size; i++) {
       timeColumnBuilder.writeLong(timeColumn.getLong(i));
       columnBuilder.write(column, i);
+      builder.declarePosition();
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanOperator.java
@@ -181,10 +181,22 @@ public class SeriesScanOperator implements DataSourceOperator {
     ColumnBuilder columnBuilder = builder.getColumnBuilder(0);
     Column column = tsBlock.getColumn(0);
 
-    for (int i = 0, size = tsBlock.getPositionCount(); i < size; i++) {
-      timeColumnBuilder.writeLong(timeColumn.getLong(i));
-      columnBuilder.write(column, i);
-      builder.declarePosition();
+    if (column.mayHaveNull()) {
+      for (int i = 0, size = tsBlock.getPositionCount(); i < size; i++) {
+        timeColumnBuilder.writeLong(timeColumn.getLong(i));
+        if (column.isNull(i)) {
+          columnBuilder.appendNull();
+        } else {
+          columnBuilder.write(column, i);
+        }
+        builder.declarePosition();
+      }
+    } else {
+      for (int i = 0, size = tsBlock.getPositionCount(); i < size; i++) {
+        timeColumnBuilder.writeLong(timeColumn.getLong(i));
+        columnBuilder.write(column, i);
+        builder.declarePosition();
+      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/SeriesScanOperator.java
@@ -25,18 +25,24 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
+import org.apache.iotdb.tsfile.read.common.block.column.Column;
+import org.apache.iotdb.tsfile.read.common.block.column.ColumnBuilder;
+import org.apache.iotdb.tsfile.read.common.block.column.TimeColumn;
+import org.apache.iotdb.tsfile.read.common.block.column.TimeColumnBuilder;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class SeriesScanOperator implements DataSourceOperator {
 
   private final OperatorContext operatorContext;
   private final SeriesScanUtil seriesScanUtil;
   private final PlanNodeId sourceId;
-  private TsBlock tsBlock;
-  private boolean hasCachedTsBlock = false;
+  private final TsBlockBuilder builder;
+
   private boolean finished = false;
 
   private final long maxReturnSize;
@@ -62,6 +68,7 @@ public class SeriesScanOperator implements DataSourceOperator {
             valueFilter,
             ascending);
     this.maxReturnSize = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
+    this.builder = new TsBlockBuilder(seriesScanUtil.getTsDataTypeList());
   }
 
   @Override
@@ -71,49 +78,48 @@ public class SeriesScanOperator implements DataSourceOperator {
 
   @Override
   public TsBlock next() {
-    if (hasCachedTsBlock || hasNext()) {
-      hasCachedTsBlock = false;
-      TsBlock res = tsBlock;
-      tsBlock = null;
-      return res;
-    }
-    throw new IllegalStateException("no next batch");
+    TsBlock block = builder.build();
+    builder.reset();
+    return block;
   }
 
   @Override
   public boolean hasNext() {
-
     try {
-      if (hasCachedTsBlock) {
-        return true;
-      }
 
-      /*
-       * consume page data firstly
-       */
-      if (readPageData()) {
-        hasCachedTsBlock = true;
-        return true;
-      }
+      // start stopwatch
+      long maxRuntime = operatorContext.getMaxRunTime().roundTo(TimeUnit.NANOSECONDS);
+      long start = System.nanoTime();
 
-      /*
-       * consume chunk data secondly
-       */
-      if (readChunkData()) {
-        hasCachedTsBlock = true;
-        return true;
-      }
-
-      /*
-       * consume next file finally
-       */
-      while (seriesScanUtil.hasNextFile()) {
-        if (readChunkData()) {
-          hasCachedTsBlock = true;
-          return true;
+      // here use do-while to promise doing this at least once
+      do {
+        /*
+         * consume page data firstly
+         */
+        if (readPageData()) {
+          continue;
         }
-      }
-      return hasCachedTsBlock;
+
+        /*
+         * consume chunk data secondly
+         */
+        if (readChunkData()) {
+          continue;
+        }
+
+        /*
+         * consume next file finally
+         */
+        if (readFileData()) {
+          continue;
+        }
+        break;
+
+      } while (System.nanoTime() - start < maxRuntime && !builder.isFull());
+
+      finished = builder.isEmpty();
+
+      return !finished;
     } catch (IOException e) {
       throw new RuntimeException("Error happened while scanning the file", e);
     }
@@ -121,7 +127,7 @@ public class SeriesScanOperator implements DataSourceOperator {
 
   @Override
   public boolean isFinished() {
-    return finished || (finished = !hasNext());
+    return finished;
   }
 
   @Override
@@ -139,6 +145,15 @@ public class SeriesScanOperator implements DataSourceOperator {
     return 0L;
   }
 
+  private boolean readFileData() throws IOException {
+    while (seriesScanUtil.hasNextFile()) {
+      if (readChunkData()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private boolean readChunkData() throws IOException {
     while (seriesScanUtil.hasNextChunk()) {
       if (readPageData()) {
@@ -150,12 +165,26 @@ public class SeriesScanOperator implements DataSourceOperator {
 
   private boolean readPageData() throws IOException {
     while (seriesScanUtil.hasNextPage()) {
-      tsBlock = seriesScanUtil.nextPage();
+      TsBlock tsBlock = seriesScanUtil.nextPage();
+
       if (!isEmpty(tsBlock)) {
+        appendToBuilder(tsBlock);
         return true;
       }
     }
     return false;
+  }
+
+  private void appendToBuilder(TsBlock tsBlock) {
+    TimeColumnBuilder timeColumnBuilder = builder.getTimeColumnBuilder();
+    TimeColumn timeColumn = tsBlock.getTimeColumn();
+    ColumnBuilder columnBuilder = builder.getColumnBuilder(0);
+    Column column = tsBlock.getColumn(0);
+
+    for (int i = 0, size = tsBlock.getPositionCount(); i < size; i++) {
+      timeColumnBuilder.writeLong(timeColumn.getLong(i));
+      columnBuilder.write(column, i);
+    }
   }
 
   private boolean isEmpty(TsBlock tsBlock) {

--- a/server/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
@@ -85,9 +85,9 @@ public class ErrorHandlingUtils {
             String.format(
                 "Status code: %s, Query Statement: %s failed", status.getCode(), operation);
         if (status.getCode() == TSStatusCode.SQL_PARSE_ERROR.getStatusCode()) {
-          LOGGER.error(message);
+          LOGGER.warn(message);
         } else {
-          LOGGER.error(message, e);
+          LOGGER.warn(message, e);
         }
       }
       return status;

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/AlignedSeriesScanOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/AlignedSeriesScanOperatorTest.java
@@ -51,6 +51,7 @@ import org.apache.iotdb.tsfile.read.common.block.column.LongColumn;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
+import io.airlift.units.Duration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,6 +63,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
@@ -124,6 +126,10 @@ public class AlignedSeriesScanOperatorTest {
               null,
               true);
       seriesScanOperator.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       int count = 0;
       while (seriesScanOperator.hasNext()) {
         TsBlock tsBlock = seriesScanOperator.next();
@@ -135,29 +141,26 @@ public class AlignedSeriesScanOperatorTest {
         assertTrue(tsBlock.getColumn(4) instanceof DoubleColumn);
         assertTrue(tsBlock.getColumn(5) instanceof BinaryColumn);
 
-        assertEquals(20, tsBlock.getPositionCount());
-        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
-          long expectedTime = i + 20L * count;
-          assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
+        for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
+          assertEquals(count, tsBlock.getTimeByIndex(i));
           int delta = 0;
-          if (expectedTime < 200) {
+          if ((long) count < 200) {
             delta = 20000;
-          } else if (expectedTime < 260
-              || (expectedTime >= 300 && expectedTime < 380)
-              || expectedTime >= 400) {
+          } else if ((long) count < 260
+              || ((long) count >= 300 && (long) count < 380)
+              || (long) count >= 400) {
             delta = 10000;
           }
-          assertEquals((delta + expectedTime) % 2 == 0, tsBlock.getColumn(0).getBoolean(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(1).getInt(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(2).getLong(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(3).getFloat(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(4).getDouble(i), DELTA);
+          assertEquals((delta + (long) count) % 2 == 0, tsBlock.getColumn(0).getBoolean(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(1).getInt(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(2).getLong(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(3).getFloat(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(4).getDouble(i), DELTA);
           assertEquals(
-              String.valueOf(delta + expectedTime), tsBlock.getColumn(5).getBinary(i).toString());
+              String.valueOf(delta + (long) count), tsBlock.getColumn(5).getBinary(i).toString());
         }
-        count++;
       }
-      assertEquals(25, count);
+      assertEquals(500, count);
     } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();
@@ -222,6 +225,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               true);
       seriesScanOperator1.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       AlignedPath alignedPath2 =
           new AlignedPath(
@@ -241,6 +247,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               true);
       seriesScanOperator2.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator2
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       Set<String> allSensors = new HashSet<>();
       allSensors.add("sensor0");
@@ -264,6 +273,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               true);
       seriesScanOperator3.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator3
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath4 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor1", TSDataType.INT32);
@@ -278,6 +290,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               true);
       seriesScanOperator4.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator4
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath5 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor2", TSDataType.INT64);
@@ -292,6 +307,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               true);
       seriesScanOperator5.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator5
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath6 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor3", TSDataType.FLOAT);
@@ -306,6 +324,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               true);
       seriesScanOperator6.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator6
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath7 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor4", TSDataType.DOUBLE);
@@ -320,6 +341,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               true);
       seriesScanOperator7.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator7
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath8 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor5", TSDataType.DOUBLE);
@@ -334,6 +358,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               true);
       seriesScanOperator8.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator8
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       TimeJoinOperator timeJoinOperator =
           new TimeJoinOperator(
@@ -410,43 +437,40 @@ public class AlignedSeriesScanOperatorTest {
         assertTrue(tsBlock.getColumn(16) instanceof DoubleColumn);
         assertTrue(tsBlock.getColumn(17) instanceof BinaryColumn);
 
-        assertEquals(20, tsBlock.getPositionCount());
-        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
-          long expectedTime = i + 20L * count;
-          assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
+        for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
+          assertEquals(count, tsBlock.getTimeByIndex(i));
           int delta = 0;
-          if (expectedTime < 200) {
+          if ((long) count < 200) {
             delta = 20000;
-          } else if (expectedTime < 260
-              || (expectedTime >= 300 && expectedTime < 380)
-              || expectedTime >= 400) {
+          } else if ((long) count < 260
+              || ((long) count >= 300 && (long) count < 380)
+              || (long) count >= 400) {
             delta = 10000;
           }
-          assertEquals((delta + expectedTime) % 2 == 0, tsBlock.getColumn(0).getBoolean(i));
-          assertEquals((delta + expectedTime) % 2 == 0, tsBlock.getColumn(6).getBoolean(i));
-          assertEquals((delta + expectedTime) % 2 == 0, tsBlock.getColumn(12).getBoolean(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(1).getInt(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(7).getInt(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(13).getInt(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(2).getLong(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(8).getLong(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(14).getLong(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(3).getFloat(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(9).getFloat(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(15).getFloat(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(4).getDouble(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(10).getDouble(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(16).getDouble(i), DELTA);
+          assertEquals((delta + (long) count) % 2 == 0, tsBlock.getColumn(0).getBoolean(i));
+          assertEquals((delta + (long) count) % 2 == 0, tsBlock.getColumn(6).getBoolean(i));
+          assertEquals((delta + (long) count) % 2 == 0, tsBlock.getColumn(12).getBoolean(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(1).getInt(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(7).getInt(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(13).getInt(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(2).getLong(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(8).getLong(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(14).getLong(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(3).getFloat(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(9).getFloat(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(15).getFloat(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(4).getDouble(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(10).getDouble(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(16).getDouble(i), DELTA);
           assertEquals(
-              String.valueOf(delta + expectedTime), tsBlock.getColumn(5).getBinary(i).toString());
+              String.valueOf(delta + (long) count), tsBlock.getColumn(5).getBinary(i).toString());
           assertEquals(
-              String.valueOf(delta + expectedTime), tsBlock.getColumn(11).getBinary(i).toString());
+              String.valueOf(delta + (long) count), tsBlock.getColumn(11).getBinary(i).toString());
           assertEquals(
-              String.valueOf(delta + expectedTime), tsBlock.getColumn(17).getBinary(i).toString());
+              String.valueOf(delta + (long) count), tsBlock.getColumn(17).getBinary(i).toString());
         }
-        count++;
       }
-      assertEquals(25, count);
+      assertEquals(500, count);
     } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();
@@ -512,6 +536,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               false);
       seriesScanOperator1.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       AlignedPath alignedPath2 =
           new AlignedPath(
@@ -531,6 +558,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               false);
       seriesScanOperator2.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator2
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       Set<String> allSensors = new HashSet<>();
       allSensors.add("sensor0");
@@ -554,6 +584,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               false);
       seriesScanOperator3.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator3
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath4 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor1", TSDataType.INT32);
@@ -568,6 +601,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               false);
       seriesScanOperator4.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator4
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath5 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor2", TSDataType.INT64);
@@ -582,6 +618,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               false);
       seriesScanOperator5.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator5
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath6 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor3", TSDataType.FLOAT);
@@ -596,6 +635,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               false);
       seriesScanOperator6.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator6
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath7 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor4", TSDataType.DOUBLE);
@@ -610,6 +652,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               false);
       seriesScanOperator7.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator7
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath8 =
           new MeasurementPath(SERIES_SCAN_OPERATOR_TEST_SG + ".device2.sensor5", TSDataType.DOUBLE);
@@ -624,6 +669,9 @@ public class AlignedSeriesScanOperatorTest {
               null,
               false);
       seriesScanOperator8.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator8
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       TimeJoinOperator timeJoinOperator =
           new TimeJoinOperator(
@@ -678,7 +726,7 @@ public class AlignedSeriesScanOperatorTest {
                   new SingleColumnMerger(new InputLocation(7, 0), new DescTimeComparator())),
               new DescTimeComparator());
 
-      int count = 25;
+      int count = 499;
       while (timeJoinOperator.hasNext()) {
         TsBlock tsBlock = timeJoinOperator.next();
         assertEquals(18, tsBlock.getValueColumnCount());
@@ -701,43 +749,40 @@ public class AlignedSeriesScanOperatorTest {
         assertTrue(tsBlock.getColumn(16) instanceof DoubleColumn);
         assertTrue(tsBlock.getColumn(17) instanceof BinaryColumn);
 
-        assertEquals(20, tsBlock.getPositionCount());
-        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
-          long expectedTime = tsBlock.getPositionCount() - i - 1 + 20L * (count - 1);
-          assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
+        for (int i = 0; i < tsBlock.getPositionCount(); i++, count--) {
+          assertEquals(count, tsBlock.getTimeByIndex(i));
           int delta = 0;
-          if (expectedTime < 200) {
+          if ((long) count < 200) {
             delta = 20000;
-          } else if (expectedTime < 260
-              || (expectedTime >= 300 && expectedTime < 380)
-              || expectedTime >= 400) {
+          } else if ((long) count < 260
+              || ((long) count >= 300 && (long) count < 380)
+              || (long) count >= 400) {
             delta = 10000;
           }
-          assertEquals((delta + expectedTime) % 2 == 0, tsBlock.getColumn(0).getBoolean(i));
-          assertEquals((delta + expectedTime) % 2 == 0, tsBlock.getColumn(6).getBoolean(i));
-          assertEquals((delta + expectedTime) % 2 == 0, tsBlock.getColumn(12).getBoolean(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(1).getInt(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(7).getInt(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(13).getInt(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(2).getLong(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(8).getLong(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(14).getLong(i));
-          assertEquals(delta + expectedTime, tsBlock.getColumn(3).getFloat(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(9).getFloat(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(15).getFloat(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(4).getDouble(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(10).getDouble(i), DELTA);
-          assertEquals(delta + expectedTime, tsBlock.getColumn(16).getDouble(i), DELTA);
+          assertEquals((delta + (long) count) % 2 == 0, tsBlock.getColumn(0).getBoolean(i));
+          assertEquals((delta + (long) count) % 2 == 0, tsBlock.getColumn(6).getBoolean(i));
+          assertEquals((delta + (long) count) % 2 == 0, tsBlock.getColumn(12).getBoolean(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(1).getInt(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(7).getInt(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(13).getInt(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(2).getLong(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(8).getLong(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(14).getLong(i));
+          assertEquals(delta + (long) count, tsBlock.getColumn(3).getFloat(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(9).getFloat(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(15).getFloat(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(4).getDouble(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(10).getDouble(i), DELTA);
+          assertEquals(delta + (long) count, tsBlock.getColumn(16).getDouble(i), DELTA);
           assertEquals(
-              String.valueOf(delta + expectedTime), tsBlock.getColumn(5).getBinary(i).toString());
+              String.valueOf(delta + (long) count), tsBlock.getColumn(5).getBinary(i).toString());
           assertEquals(
-              String.valueOf(delta + expectedTime), tsBlock.getColumn(11).getBinary(i).toString());
+              String.valueOf(delta + (long) count), tsBlock.getColumn(11).getBinary(i).toString());
           assertEquals(
-              String.valueOf(delta + expectedTime), tsBlock.getColumn(17).getBinary(i).toString());
+              String.valueOf(delta + (long) count), tsBlock.getColumn(17).getBinary(i).toString());
         }
-        count--;
       }
-      assertEquals(0, count);
+      assertEquals(-1, count);
     } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/DeviceMergeOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/DeviceMergeOperatorTest.java
@@ -42,6 +42,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
+import io.airlift.units.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.junit.Assert.assertEquals;
@@ -133,6 +135,10 @@ public class DeviceMergeOperatorTest {
               null,
               true);
       seriesScanOperator1.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       DeviceViewOperator deviceViewOperator1 =
           new DeviceViewOperator(
               fragmentInstanceContext.getOperatorContexts().get(2),
@@ -154,6 +160,10 @@ public class DeviceMergeOperatorTest {
               null,
               true);
       seriesScanOperator2.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator2
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       DeviceViewOperator deviceViewOperator2 =
           new DeviceViewOperator(
               fragmentInstanceContext.getOperatorContexts().get(3),
@@ -184,12 +194,11 @@ public class DeviceMergeOperatorTest {
           continue;
         }
         assertEquals(3, tsBlock.getValueColumnCount());
-        assertEquals(20, tsBlock.getPositionCount());
-        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
-          long expectedTime = i + 20L * (count % 25);
+        for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
+          long expectedTime = count % 500;
           assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
           assertEquals(
-              count < 25
+              count < 500
                   ? DEVICE_MERGE_OPERATOR_TEST_SG + ".device0"
                   : DEVICE_MERGE_OPERATOR_TEST_SG + ".device1",
               tsBlock.getColumn(0).getBinary(i).getStringValue());
@@ -218,9 +227,8 @@ public class DeviceMergeOperatorTest {
             }
           }
         }
-        count++;
       }
-      assertEquals(50, count);
+      assertEquals(1000, count);
     } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();
@@ -291,6 +299,10 @@ public class DeviceMergeOperatorTest {
       unSeqResources1.add(unSeqResources.get(3));
       unSeqResources1.add(unSeqResources.get(5));
       seriesScanOperator1.initQueryDataSource(new QueryDataSource(seqResources1, unSeqResources1));
+      seriesScanOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       DeviceViewOperator deviceViewOperator1 =
           new DeviceViewOperator(
               fragmentInstanceContext.getOperatorContexts().get(2),
@@ -309,6 +321,10 @@ public class DeviceMergeOperatorTest {
               null,
               null,
               true);
+      seriesScanOperator2
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       List<TsFileResource> seqResources2 = new ArrayList<>();
       List<TsFileResource> unSeqResources2 = new ArrayList<>();
       seqResources2.add(seqResources.get(2));
@@ -345,26 +361,23 @@ public class DeviceMergeOperatorTest {
           continue;
         }
         assertEquals(2, tsBlock.getValueColumnCount());
-        assertEquals(20, tsBlock.getPositionCount());
-        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
-          long expectedTime = i + 20L * (count % 25);
-          assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
+        for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
+          assertEquals(count, tsBlock.getTimeByIndex(i));
           assertEquals(
               DEVICE_MERGE_OPERATOR_TEST_SG + ".device0",
               tsBlock.getColumn(0).getBinary(i).getStringValue());
-          if (expectedTime < 200) {
-            assertEquals(20000 + expectedTime, tsBlock.getColumn(1).getInt(i));
-          } else if (expectedTime < 260
-              || (expectedTime >= 300 && expectedTime < 380)
-              || expectedTime >= 400) {
-            assertEquals(10000 + expectedTime, tsBlock.getColumn(1).getInt(i));
+          if ((long) count < 200) {
+            assertEquals(20000 + (long) count, tsBlock.getColumn(1).getInt(i));
+          } else if ((long) count < 260
+              || ((long) count >= 300 && (long) count < 380)
+              || (long) count >= 400) {
+            assertEquals(10000 + (long) count, tsBlock.getColumn(1).getInt(i));
           } else {
-            assertEquals(expectedTime, tsBlock.getColumn(1).getInt(i));
+            assertEquals(count, tsBlock.getColumn(1).getInt(i));
           }
         }
-        count++;
       }
-      assertEquals(25, count);
+      assertEquals(500, count);
     } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();
@@ -437,6 +450,10 @@ public class DeviceMergeOperatorTest {
       unSeqResources1.add(unSeqResources.get(3));
       unSeqResources1.add(unSeqResources.get(5));
       seriesScanOperator1.initQueryDataSource(new QueryDataSource(seqResources1, unSeqResources1));
+      seriesScanOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       MeasurementPath measurementPath2 =
           new MeasurementPath(DEVICE_MERGE_OPERATOR_TEST_SG + ".device1.sensor1", TSDataType.INT32);
       SeriesScanOperator seriesScanOperator2 =
@@ -450,6 +467,10 @@ public class DeviceMergeOperatorTest {
               null,
               true);
       seriesScanOperator2.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator2
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       List<String> devices = new ArrayList<>();
       devices.add(DEVICE_MERGE_OPERATOR_TEST_SG + ".device0");
       devices.add(DEVICE_MERGE_OPERATOR_TEST_SG + ".device1");
@@ -477,6 +498,10 @@ public class DeviceMergeOperatorTest {
               null,
               null,
               true);
+      seriesScanOperator3
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       List<TsFileResource> seqResources2 = new ArrayList<>();
       List<TsFileResource> unSeqResources2 = new ArrayList<>();
       seqResources2.add(seqResources.get(2));
@@ -511,12 +536,11 @@ public class DeviceMergeOperatorTest {
           continue;
         }
         assertEquals(3, tsBlock.getValueColumnCount());
-        assertEquals(20, tsBlock.getPositionCount());
-        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
-          long expectedTime = i + 20L * (count % 25);
+        for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
+          long expectedTime = count % 500;
           assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
           assertEquals(
-              count < 25
+              count < 500
                   ? DEVICE_MERGE_OPERATOR_TEST_SG + ".device0"
                   : DEVICE_MERGE_OPERATOR_TEST_SG + ".device1",
               tsBlock.getColumn(0).getBinary(i).getStringValue());
@@ -545,9 +569,8 @@ public class DeviceMergeOperatorTest {
             }
           }
         }
-        count++;
       }
-      assertEquals(50, count);
+      assertEquals(1000, count);
     } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/LimitOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/LimitOperatorTest.java
@@ -44,6 +44,7 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.common.block.column.IntColumn;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
+import io.airlift.units.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,6 +56,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.junit.Assert.assertEquals;
@@ -119,6 +121,9 @@ public class LimitOperatorTest {
               null,
               true);
       seriesScanOperator1.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       MeasurementPath measurementPath2 =
           new MeasurementPath(TIME_JOIN_OPERATOR_TEST_SG + ".device0.sensor1", TSDataType.INT32);
@@ -133,6 +138,9 @@ public class LimitOperatorTest {
               null,
               true);
       seriesScanOperator2.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
+      seriesScanOperator2
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       TimeJoinOperator timeJoinOperator =
           new TimeJoinOperator(
@@ -154,30 +162,24 @@ public class LimitOperatorTest {
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
-        if (count < 12) {
-          assertEquals(20, tsBlock.getPositionCount());
-        } else {
-          assertEquals(10, tsBlock.getPositionCount());
-        }
-        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
-          long expectedTime = i + 20L * count;
-          assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
-          if (expectedTime < 200) {
-            assertEquals(20000 + expectedTime, tsBlock.getColumn(0).getInt(i));
-            assertEquals(20000 + expectedTime, tsBlock.getColumn(1).getInt(i));
-          } else if (expectedTime < 260
-              || (expectedTime >= 300 && expectedTime < 380)
-              || expectedTime >= 400) {
-            assertEquals(10000 + expectedTime, tsBlock.getColumn(0).getInt(i));
-            assertEquals(10000 + expectedTime, tsBlock.getColumn(1).getInt(i));
+
+        for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
+          assertEquals(count, tsBlock.getTimeByIndex(i));
+          if ((long) count < 200) {
+            assertEquals(20000 + (long) count, tsBlock.getColumn(0).getInt(i));
+            assertEquals(20000 + (long) count, tsBlock.getColumn(1).getInt(i));
+          } else if ((long) count < 260
+              || ((long) count >= 300 && (long) count < 380)
+              || (long) count >= 400) {
+            assertEquals(10000 + (long) count, tsBlock.getColumn(0).getInt(i));
+            assertEquals(10000 + (long) count, tsBlock.getColumn(1).getInt(i));
           } else {
-            assertEquals(expectedTime, tsBlock.getColumn(0).getInt(i));
-            assertEquals(expectedTime, tsBlock.getColumn(1).getInt(i));
+            assertEquals(count, tsBlock.getColumn(0).getInt(i));
+            assertEquals(count, tsBlock.getColumn(1).getInt(i));
           }
         }
-        count++;
       }
-      assertEquals(13, count);
+      assertEquals(250, count);
     } catch (IllegalPathException e) {
       e.printStackTrace();
       fail();

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/RawDataAggregationOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/RawDataAggregationOperatorTest.java
@@ -232,16 +232,17 @@ public class RawDataAggregationOperatorTest {
       if (resultTsBlock == null) {
         continue;
       }
-      assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(0));
-      for (int i = 0; i < 2; i++) {
-        assertEquals(result[0][count], resultTsBlock.getColumn(6 * i).getLong(0));
-        assertEquals(result[1][count], resultTsBlock.getColumn(6 * i + 1).getDouble(0), 0.0001);
-        assertEquals(result[2][count], resultTsBlock.getColumn(6 * i + 2).getLong(0));
-        assertEquals(result[3][count], resultTsBlock.getColumn(6 * i + 3).getLong(0));
-        assertEquals(result[4][count], resultTsBlock.getColumn(6 * i + 4).getInt(0));
-        assertEquals(result[5][count], resultTsBlock.getColumn(6 * i + 5).getInt(0));
+      for (int row = 0; row < resultTsBlock.getPositionCount(); row++, count++) {
+        assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(row));
+        for (int i = 0; i < 2; i++) {
+          assertEquals(result[0][count], resultTsBlock.getColumn(6 * i).getLong(row));
+          assertEquals(result[1][count], resultTsBlock.getColumn(6 * i + 1).getDouble(row), 0.0001);
+          assertEquals(result[2][count], resultTsBlock.getColumn(6 * i + 2).getLong(row));
+          assertEquals(result[3][count], resultTsBlock.getColumn(6 * i + 3).getLong(row));
+          assertEquals(result[4][count], resultTsBlock.getColumn(6 * i + 4).getInt(row));
+          assertEquals(result[5][count], resultTsBlock.getColumn(6 * i + 5).getInt(row));
+        }
       }
-      count++;
     }
     assertEquals(4, count);
   }
@@ -284,17 +285,19 @@ public class RawDataAggregationOperatorTest {
       if (resultTsBlock == null) {
         continue;
       }
-      assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(0));
-      for (int i = 0; i < 2; i++) {
-        assertEquals(result[0][count], resultTsBlock.getColumn(i).getDouble(0), 0.001);
+
+      for (int row = 0; row < resultTsBlock.getPositionCount(); row++, count++) {
+        assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(row));
+        for (int i = 0; i < 2; i++) {
+          assertEquals(result[0][count], resultTsBlock.getColumn(i).getDouble(row), 0.001);
+        }
+        for (int i = 2; i < 4; i++) {
+          assertEquals((int) result[1][count], resultTsBlock.getColumn(i).getInt(row));
+        }
+        for (int i = 4; i < 6; i++) {
+          assertEquals((int) result[2][count], resultTsBlock.getColumn(i).getInt(row));
+        }
       }
-      for (int i = 2; i < 4; i++) {
-        assertEquals((int) result[1][count], resultTsBlock.getColumn(i).getInt(0));
-      }
-      for (int i = 4; i < 6; i++) {
-        assertEquals((int) result[2][count], resultTsBlock.getColumn(i).getInt(0));
-      }
-      count++;
     }
     assertEquals(4, count);
   }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/BinaryColumn.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/BinaryColumn.java
@@ -82,7 +82,6 @@ public class BinaryColumn implements Column {
 
   @Override
   public Binary getBinary(int position) {
-    checkReadablePosition(position);
     return values[position + arrayOffset];
   }
 
@@ -98,7 +97,6 @@ public class BinaryColumn implements Column {
 
   @Override
   public TsPrimitiveType getTsPrimitiveType(int position) {
-    checkReadablePosition(position);
     return new TsPrimitiveType.TsBinary(getBinary(position));
   }
 
@@ -109,7 +107,6 @@ public class BinaryColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    checkReadablePosition(position);
     return valueIsNull != null && valueIsNull[position + arrayOffset];
   }
 
@@ -161,12 +158,6 @@ public class BinaryColumn implements Column {
         valueIsNull[i] = valueIsNull[j];
         valueIsNull[j] = isNullTmp;
       }
-    }
-  }
-
-  private void checkReadablePosition(int position) {
-    if (position < 0 || position >= getPositionCount()) {
-      throw new IllegalArgumentException("position is not valid");
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/BooleanColumn.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/BooleanColumn.java
@@ -81,7 +81,6 @@ public class BooleanColumn implements Column {
 
   @Override
   public boolean getBoolean(int position) {
-    checkReadablePosition(position);
     return values[position + arrayOffset];
   }
 
@@ -97,7 +96,6 @@ public class BooleanColumn implements Column {
 
   @Override
   public TsPrimitiveType getTsPrimitiveType(int position) {
-    checkReadablePosition(position);
     return new TsPrimitiveType.TsBoolean(getBoolean(position));
   }
 
@@ -108,7 +106,6 @@ public class BooleanColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    checkReadablePosition(position);
     return valueIsNull != null && valueIsNull[position + arrayOffset];
   }
 
@@ -160,12 +157,6 @@ public class BooleanColumn implements Column {
         valueIsNull[i] = valueIsNull[j];
         valueIsNull[j] = isNullTmp;
       }
-    }
-  }
-
-  private void checkReadablePosition(int position) {
-    if (position < 0 || position >= getPositionCount()) {
-      throw new IllegalArgumentException("position is not valid");
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnBuilder.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnBuilder.java
@@ -67,6 +67,8 @@ public interface ColumnBuilder {
   /**
    * Write value at index of passing column
    *
+   * <p>Caller should make sure that value at index is not null
+   *
    * @param column source column whose type should be same as ColumnBuilder
    * @param index index of source column to read from
    */

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/DoubleColumn.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/DoubleColumn.java
@@ -81,7 +81,6 @@ public class DoubleColumn implements Column {
 
   @Override
   public double getDouble(int position) {
-    checkReadablePosition(position);
     return values[position + arrayOffset];
   }
 
@@ -97,7 +96,6 @@ public class DoubleColumn implements Column {
 
   @Override
   public TsPrimitiveType getTsPrimitiveType(int position) {
-    checkReadablePosition(position);
     return new TsPrimitiveType.TsDouble(getDouble(position));
   }
 
@@ -108,7 +106,6 @@ public class DoubleColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    checkReadablePosition(position);
     return valueIsNull != null && valueIsNull[position + arrayOffset];
   }
 
@@ -160,12 +157,6 @@ public class DoubleColumn implements Column {
         valueIsNull[i] = valueIsNull[j];
         valueIsNull[j] = isNullTmp;
       }
-    }
-  }
-
-  private void checkReadablePosition(int position) {
-    if (position < 0 || position >= getPositionCount()) {
-      throw new IllegalArgumentException("position is not valid");
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/FloatColumn.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/FloatColumn.java
@@ -80,7 +80,6 @@ public class FloatColumn implements Column {
 
   @Override
   public float getFloat(int position) {
-    checkReadablePosition(position);
     return values[position + arrayOffset];
   }
 
@@ -96,7 +95,6 @@ public class FloatColumn implements Column {
 
   @Override
   public TsPrimitiveType getTsPrimitiveType(int position) {
-    checkReadablePosition(position);
     return new TsPrimitiveType.TsFloat(getFloat(position));
   }
 
@@ -107,7 +105,6 @@ public class FloatColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    checkReadablePosition(position);
     return valueIsNull != null && valueIsNull[position + arrayOffset];
   }
 
@@ -158,12 +155,6 @@ public class FloatColumn implements Column {
         valueIsNull[i] = valueIsNull[j];
         valueIsNull[j] = isNullTmp;
       }
-    }
-  }
-
-  private void checkReadablePosition(int position) {
-    if (position < 0 || position >= getPositionCount()) {
-      throw new IllegalArgumentException("position is not valid");
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/IntColumn.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/IntColumn.java
@@ -80,7 +80,6 @@ public class IntColumn implements Column {
 
   @Override
   public int getInt(int position) {
-    checkReadablePosition(position);
     return values[position + arrayOffset];
   }
 
@@ -96,7 +95,6 @@ public class IntColumn implements Column {
 
   @Override
   public TsPrimitiveType getTsPrimitiveType(int position) {
-    checkReadablePosition(position);
     return new TsPrimitiveType.TsInt(getInt(position));
   }
 
@@ -107,7 +105,6 @@ public class IntColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    checkReadablePosition(position);
     return valueIsNull != null && valueIsNull[position + arrayOffset];
   }
 
@@ -158,12 +155,6 @@ public class IntColumn implements Column {
         valueIsNull[i] = valueIsNull[j];
         valueIsNull[j] = isNullTmp;
       }
-    }
-  }
-
-  private void checkReadablePosition(int position) {
-    if (position < 0 || position >= getPositionCount()) {
-      throw new IllegalArgumentException("position is not valid");
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/LongColumn.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/LongColumn.java
@@ -80,7 +80,6 @@ public class LongColumn implements Column {
 
   @Override
   public long getLong(int position) {
-    checkReadablePosition(position);
     return values[position + arrayOffset];
   }
 
@@ -96,7 +95,6 @@ public class LongColumn implements Column {
 
   @Override
   public TsPrimitiveType getTsPrimitiveType(int position) {
-    checkReadablePosition(position);
     return new TsPrimitiveType.TsLong(getLong(position));
   }
 
@@ -107,7 +105,6 @@ public class LongColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    checkReadablePosition(position);
     return valueIsNull != null && valueIsNull[position + arrayOffset];
   }
 
@@ -158,12 +155,6 @@ public class LongColumn implements Column {
         valueIsNull[i] = valueIsNull[j];
         valueIsNull[j] = isNullTmp;
       }
-    }
-  }
-
-  private void checkReadablePosition(int position) {
-    if (position < 0 || position >= getPositionCount()) {
-      throw new IllegalArgumentException("position is not valid");
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/RunLengthEncodedColumn.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/RunLengthEncodedColumn.java
@@ -76,43 +76,36 @@ public class RunLengthEncodedColumn implements Column {
 
   @Override
   public boolean getBoolean(int position) {
-    checkReadablePosition(position);
     return value.getBoolean(0);
   }
 
   @Override
   public int getInt(int position) {
-    checkReadablePosition(position);
     return value.getInt(0);
   }
 
   @Override
   public long getLong(int position) {
-    checkReadablePosition(position);
     return value.getLong(0);
   }
 
   @Override
   public float getFloat(int position) {
-    checkReadablePosition(position);
     return value.getFloat(0);
   }
 
   @Override
   public double getDouble(int position) {
-    checkReadablePosition(position);
     return value.getDouble(0);
   }
 
   @Override
   public Binary getBinary(int position) {
-    checkReadablePosition(position);
     return value.getBinary(0);
   }
 
   @Override
   public Object getObject(int position) {
-    checkReadablePosition(position);
     return value.getObject(0);
   }
 
@@ -167,7 +160,6 @@ public class RunLengthEncodedColumn implements Column {
 
   @Override
   public TsPrimitiveType getTsPrimitiveType(int position) {
-    checkReadablePosition(position);
     return value.getTsPrimitiveType(0);
   }
 
@@ -178,7 +170,6 @@ public class RunLengthEncodedColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    checkReadablePosition(position);
     return value.isNull(0);
   }
 
@@ -216,11 +207,5 @@ public class RunLengthEncodedColumn implements Column {
   @Override
   public void reverse() {
     // do nothing because the underlying column has only one value
-  }
-
-  private void checkReadablePosition(int position) {
-    if (position < 0 || position >= positionCount) {
-      throw new IllegalArgumentException("position is not valid");
-    }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/TimeColumn.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/TimeColumn.java
@@ -71,7 +71,6 @@ public class TimeColumn implements Column {
 
   @Override
   public long getLong(int position) {
-    checkReadablePosition(position);
     return values[position + arrayOffset];
   }
 
@@ -142,11 +141,5 @@ public class TimeColumn implements Column {
 
   public long[] getTimes() {
     return values;
-  }
-
-  private void checkReadablePosition(int position) {
-    if (position < 0 || position >= getPositionCount()) {
-      throw new IllegalArgumentException("position is not valid");
-    }
   }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/common/block/NullColumnUnitTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/common/block/NullColumnUnitTest.java
@@ -36,11 +36,6 @@ public class NullColumnUnitTest {
     Assert.assertTrue(nullColumn.mayHaveNull());
     Assert.assertTrue(nullColumn.isNull(0));
     Assert.assertTrue(nullColumn.isNull(9));
-    try {
-      nullColumn.isNull(10);
-      Assert.fail();
-    } catch (IllegalArgumentException ignored) {
-    }
   }
 
   @Test
@@ -51,11 +46,6 @@ public class NullColumnUnitTest {
     Assert.assertTrue(nullColumn.mayHaveNull());
     Assert.assertTrue(nullColumn.isNull(0));
     Assert.assertTrue(nullColumn.isNull(9));
-    try {
-      nullColumn.isNull(10);
-      Assert.fail();
-    } catch (IllegalArgumentException ignored) {
-    }
   }
 
   @Test
@@ -66,11 +56,6 @@ public class NullColumnUnitTest {
     Assert.assertTrue(nullColumn.mayHaveNull());
     Assert.assertTrue(nullColumn.isNull(0));
     Assert.assertTrue(nullColumn.isNull(9));
-    try {
-      nullColumn.isNull(10);
-      Assert.fail();
-    } catch (IllegalArgumentException ignored) {
-    }
   }
 
   @Test
@@ -81,11 +66,6 @@ public class NullColumnUnitTest {
     Assert.assertTrue(nullColumn.mayHaveNull());
     Assert.assertTrue(nullColumn.isNull(0));
     Assert.assertTrue(nullColumn.isNull(9));
-    try {
-      nullColumn.isNull(10);
-      Assert.fail();
-    } catch (IllegalArgumentException ignored) {
-    }
   }
 
   @Test
@@ -96,11 +76,6 @@ public class NullColumnUnitTest {
     Assert.assertTrue(nullColumn.mayHaveNull());
     Assert.assertTrue(nullColumn.isNull(0));
     Assert.assertTrue(nullColumn.isNull(9));
-    try {
-      nullColumn.isNull(10);
-      Assert.fail();
-    } catch (IllegalArgumentException ignored) {
-    }
   }
 
   @Test
@@ -111,10 +86,5 @@ public class NullColumnUnitTest {
     Assert.assertTrue(nullColumn.mayHaveNull());
     Assert.assertTrue(nullColumn.isNull(0));
     Assert.assertTrue(nullColumn.isNull(9));
-    try {
-      nullColumn.isNull(10);
-      Assert.fail();
-    } catch (IllegalArgumentException ignored) {
-    }
   }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/common/ColumnTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/common/ColumnTest.java
@@ -52,28 +52,11 @@ public class ColumnTest {
     Assert.assertEquals(5, timeColumn.getPositionCount());
     Assert.assertEquals(5, timeColumn.getLong(0));
     Assert.assertEquals(9, timeColumn.getLong(4));
-    try {
-      timeColumn.getLong(5);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
+
     timeColumn = (TimeColumn) timeColumn.subColumn(3);
     Assert.assertEquals(2, timeColumn.getPositionCount());
     Assert.assertEquals(8, timeColumn.getLong(0));
     Assert.assertEquals(9, timeColumn.getLong(1));
-    try {
-      timeColumn.getLong(2);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
-    try {
-      timeColumn.subColumn(3);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("fromIndex is not valid"));
-    }
   }
 
   @Test
@@ -87,28 +70,11 @@ public class ColumnTest {
     Assert.assertEquals(5, binaryColumn.getPositionCount());
     Assert.assertEquals("5", binaryColumn.getBinary(0).toString());
     Assert.assertEquals("9", binaryColumn.getBinary(4).toString());
-    try {
-      binaryColumn.getBinary(5);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
+
     binaryColumn = (BinaryColumn) binaryColumn.subColumn(3);
     Assert.assertEquals(2, binaryColumn.getPositionCount());
     Assert.assertEquals("8", binaryColumn.getBinary(0).toString());
     Assert.assertEquals("9", binaryColumn.getBinary(1).toString());
-    try {
-      binaryColumn.getBinary(2);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
-    try {
-      binaryColumn.subColumn(3);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("fromIndex is not valid"));
-    }
   }
 
   @Test
@@ -123,28 +89,11 @@ public class ColumnTest {
     Assert.assertEquals(5, booleanColumn.getPositionCount());
     Assert.assertFalse(booleanColumn.getBoolean(0));
     Assert.assertFalse(booleanColumn.getBoolean(4));
-    try {
-      booleanColumn.getBoolean(5);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
+
     booleanColumn = (BooleanColumn) booleanColumn.subColumn(3);
     Assert.assertEquals(2, booleanColumn.getPositionCount());
     Assert.assertTrue(booleanColumn.getBoolean(0));
     Assert.assertFalse(booleanColumn.getBoolean(1));
-    try {
-      booleanColumn.getBoolean(2);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
-    try {
-      booleanColumn.subColumn(3);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("fromIndex is not valid"));
-    }
   }
 
   @Test
@@ -158,28 +107,11 @@ public class ColumnTest {
     Assert.assertEquals(5, doubleColumn.getPositionCount());
     Assert.assertEquals(5.0, doubleColumn.getDouble(0), 0.001);
     Assert.assertEquals(9.0, doubleColumn.getDouble(4), 0.001);
-    try {
-      doubleColumn.getDouble(5);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
+
     doubleColumn = (DoubleColumn) doubleColumn.subColumn(3);
     Assert.assertEquals(2, doubleColumn.getPositionCount());
     Assert.assertEquals(8.0, doubleColumn.getDouble(0), 0.001);
     Assert.assertEquals(9.0, doubleColumn.getDouble(1), 0.001);
-    try {
-      doubleColumn.getDouble(2);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
-    try {
-      doubleColumn.subColumn(3);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("fromIndex is not valid"));
-    }
   }
 
   @Test
@@ -193,28 +125,11 @@ public class ColumnTest {
     Assert.assertEquals(5, floatColumn.getPositionCount());
     Assert.assertEquals(5.0, floatColumn.getFloat(0), 0.001);
     Assert.assertEquals(9.0, floatColumn.getFloat(4), 0.001);
-    try {
-      floatColumn.getFloat(5);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
+
     floatColumn = (FloatColumn) floatColumn.subColumn(3);
     Assert.assertEquals(2, floatColumn.getPositionCount());
     Assert.assertEquals(8.0, floatColumn.getFloat(0), 0.001);
     Assert.assertEquals(9.0, floatColumn.getFloat(1), 0.001);
-    try {
-      floatColumn.getFloat(2);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
-    try {
-      floatColumn.subColumn(3);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("fromIndex is not valid"));
-    }
   }
 
   @Test
@@ -228,28 +143,11 @@ public class ColumnTest {
     Assert.assertEquals(5, intColumn.getPositionCount());
     Assert.assertEquals(5, intColumn.getInt(0));
     Assert.assertEquals(9, intColumn.getInt(4));
-    try {
-      intColumn.getInt(5);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
+
     intColumn = (IntColumn) intColumn.subColumn(3);
     Assert.assertEquals(2, intColumn.getPositionCount());
     Assert.assertEquals(8, intColumn.getInt(0));
     Assert.assertEquals(9, intColumn.getInt(1));
-    try {
-      intColumn.getInt(2);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
-    try {
-      intColumn.subColumn(3);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("fromIndex is not valid"));
-    }
   }
 
   @Test
@@ -263,28 +161,11 @@ public class ColumnTest {
     Assert.assertEquals(5, longColumn.getPositionCount());
     Assert.assertEquals(5, longColumn.getLong(0));
     Assert.assertEquals(9, longColumn.getLong(4));
-    try {
-      longColumn.getLong(5);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
+
     longColumn = (LongColumn) longColumn.subColumn(3);
     Assert.assertEquals(2, longColumn.getPositionCount());
     Assert.assertEquals(8, longColumn.getLong(0));
     Assert.assertEquals(9, longColumn.getLong(1));
-    try {
-      longColumn.getLong(2);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
-    try {
-      longColumn.subColumn(3);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("fromIndex is not valid"));
-    }
   }
 
   @Test
@@ -296,27 +177,10 @@ public class ColumnTest {
     Assert.assertEquals(5, column.getPositionCount());
     Assert.assertEquals(1, column.getLong(0));
     Assert.assertEquals(1, column.getLong(4));
-    try {
-      column.getLong(5);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
+
     column = (RunLengthEncodedColumn) column.subColumn(3);
     Assert.assertEquals(2, column.getPositionCount());
     Assert.assertEquals(1, column.getLong(0));
     Assert.assertEquals(1, column.getLong(1));
-    try {
-      column.getLong(2);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("position is not valid"));
-    }
-    try {
-      column.subColumn(3);
-      Assert.fail();
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("fromIndex is not valid"));
-    }
   }
 }


### PR DESCRIPTION
We do improvements in this pr:

1. make TsBlock returned by ScanOperator larger
2. fix a bug in MultiColumnMerger if there exist timestamp belonging to more than one DataRegion, currently we simply choose the first values as the final value
3. turn query error log to warn level
4. delete useless safety check in Column