### PR TITLE
[IOTDB-5068] Fix ComapctionSchedulerTest

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionSchedulerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionSchedulerTest.java
@@ -429,7 +429,6 @@ public class CompactionSchedulerTest {
           e.printStackTrace();
         }
       }
-      assertEquals(0, tsFileManager.getTsFileList(false).size());
       totalWaitingTime = 0;
       while (tsFileManager.getTsFileList(false).size() > 0) {
         try {


### PR DESCRIPTION
See [IOTDB-5068](https://issues.apache.org/jira/browse/IOTDB-5068).

The assertion at line 432 is not reasonable. Before this assertion, the test waits for all sequence space compaction task finish. After that, it asserts all unsequence files is compacted to sequence space, which doesn't have to happend, so it may fail some times.  We don't need this assertion, just remove it and the test has already assertted the num of sequence files and unsequence files in the end of the test.