### PR TITLE
[To rel/1.0] Disable integration-tests and testcontainer in mvn install

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -158,7 +158,6 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <skipTests>false</skipTests>
                             <groups>${integrationTest.includedGroups}</groups>
                             <excludedGroups>${integrationTest.excludedGroups}</excludedGroups>
                             <useSystemClassLoader>false</useSystemClassLoader>
@@ -181,9 +180,6 @@
                         </goals>
                         <configuration>
                             <skipTests>false</skipTests>
-                            <summaryFiles>
-                                <summaryFile>target/failsafe-reports/failsafe-summary-IT.xml</summaryFile>
-                            </summaryFiles>
                         </configuration>
                     </execution>
                 </executions>

--- a/testcontainer/pom.xml
+++ b/testcontainer/pom.xml
@@ -66,7 +66,7 @@
         <profile>
             <id>testcontainer</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>
@@ -164,6 +164,9 @@
         </profile>
         <profile>
             <id>test-sync</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
             <build>
                 <plugins>
                     <!-- before integration test, we build the docker image -->


### PR DESCRIPTION
Currently when user executes `mvn clean install -DskipTests`, the tests in integration-test and testcontainer are still running.  This PR will fix it.