### PR TITLE
[To rel/1.0] [IOTDB-5059] Remove redundant database check in SchemaEngine

### DIFF
--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -44,7 +44,6 @@ import org.apache.iotdb.db.metadata.idtable.IDTable;
 import org.apache.iotdb.db.metadata.idtable.IDTableManager;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
-import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
 import org.apache.iotdb.db.metadata.mnode.MNodeType;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IActivateTemplateInClusterPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.ICreateAlignedTimeSeriesPlan;
@@ -144,7 +143,6 @@ public class RSchemaRegion implements ISchemaRegion {
   private String schemaRegionDirPath;
   private String storageGroupFullPath;
   private SchemaRegionId schemaRegionId;
-  private IStorageGroupMNode storageGroupMNode;
   private int storageGroupPathLevel;
 
   public RSchemaRegion() throws MetadataException {
@@ -157,14 +155,10 @@ public class RSchemaRegion implements ISchemaRegion {
   }
 
   public RSchemaRegion(
-      PartialPath storageGroup,
-      SchemaRegionId schemaRegionId,
-      IStorageGroupMNode storageGroupMNode,
-      RSchemaConfLoader rSchemaConfLoader)
+      PartialPath storageGroup, SchemaRegionId schemaRegionId, RSchemaConfLoader rSchemaConfLoader)
       throws MetadataException {
     this.schemaRegionId = schemaRegionId;
     storageGroupFullPath = storageGroup.getFullPath();
-    this.storageGroupMNode = storageGroupMNode;
     init();
     try {
       readWriteHandler = new RSchemaReadWriteHandler(schemaRegionDirPath, rSchemaConfLoader);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -118,28 +118,38 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
 
   // region MTree initialization, clear and serialization
   public MTreeBelowSGCachedImpl(
-      IStorageGroupMNode storageGroupMNode,
+      PartialPath storageGroupPath,
       Function<IMeasurementMNode, Map<String, String>> tagGetter,
       int schemaRegionId)
       throws MetadataException, IOException {
     this.tagGetter = tagGetter;
-    PartialPath storageGroup = storageGroupMNode.getPartialPath();
-    store = new CachedMTreeStore(storageGroup, schemaRegionId);
+    store = new CachedMTreeStore(storageGroupPath, schemaRegionId);
     this.storageGroupMNode = store.getRoot().getAsStorageGroupMNode();
-    this.storageGroupMNode.setParent(storageGroupMNode.getParent());
-    levelOfSG = storageGroup.getNodeLength() - 1;
+
+    this.storageGroupMNode.setParent(generatePrefix(storageGroupPath));
+    levelOfSG = storageGroupPath.getNodeLength() - 1;
+  }
+
+  // generate the ancestor nodes of storageGroupNode
+  private IMNode generatePrefix(PartialPath storageGroupPath) {
+    String[] nodes = storageGroupPath.getNodes();
+    IMNode cur = null;
+    for (int i = 0; i < nodes.length - 1; i++) {
+      cur = new InternalMNode(cur, nodes[i]);
+    }
+    return cur;
   }
 
   /** Only used for load snapshot */
   private MTreeBelowSGCachedImpl(
+      PartialPath storageGroupPath,
       CachedMTreeStore store,
-      IStorageGroupMNode storageGroupMNode,
       Consumer<IMeasurementMNode> measurementProcess,
       Function<IMeasurementMNode, Map<String, String>> tagGetter)
       throws MetadataException {
     this.store = store;
     this.storageGroupMNode = store.getRoot().getAsStorageGroupMNode();
-    this.storageGroupMNode.setParent(storageGroupMNode.getParent());
+    this.storageGroupMNode.setParent(generatePrefix(storageGroupPath));
     levelOfSG = storageGroupMNode.getPartialPath().getNodeLength() - 1;
     this.tagGetter = tagGetter;
 
@@ -169,15 +179,14 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
 
   public static MTreeBelowSGCachedImpl loadFromSnapshot(
       File snapshotDir,
-      IStorageGroupMNode storageGroupMNode,
+      String storageGroupFullPath,
       int schemaRegionId,
       Consumer<IMeasurementMNode> measurementProcess,
       Function<IMeasurementMNode, Map<String, String>> tagGetter)
       throws IOException, MetadataException {
     return new MTreeBelowSGCachedImpl(
-        CachedMTreeStore.loadFromSnapshot(
-            snapshotDir, storageGroupMNode.getFullPath(), schemaRegionId),
-        storageGroupMNode,
+        new PartialPath(storageGroupFullPath),
+        CachedMTreeStore.loadFromSnapshot(snapshotDir, storageGroupFullPath, schemaRegionId),
         measurementProcess,
         tagGetter);
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -133,9 +133,13 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
   // generate the ancestor nodes of storageGroupNode
   private IMNode generatePrefix(PartialPath storageGroupPath) {
     String[] nodes = storageGroupPath.getNodes();
-    IMNode cur = null;
-    for (int i = 0; i < nodes.length - 1; i++) {
-      cur = new InternalMNode(cur, nodes[i]);
+    // nodes[0] must be root
+    IMNode cur = new InternalMNode(null, nodes[0]);
+    IMNode child;
+    for (int i = 1; i < nodes.length - 1; i++) {
+      child = new InternalMNode(cur, nodes[i]);
+      cur.addChild(nodes[i], child);
+      cur = child;
     }
     return cur;
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -144,9 +144,13 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
   // generate the ancestor nodes of storageGroupNode
   private IMNode generatePrefix(PartialPath storageGroupPath) {
     String[] nodes = storageGroupPath.getNodes();
-    IMNode cur = null;
-    for (int i = 0; i < nodes.length - 1; i++) {
-      cur = new InternalMNode(cur, nodes[i]);
+    // nodes[0] must be root
+    IMNode cur = new InternalMNode(null, nodes[0]);
+    IMNode child;
+    for (int i = 1; i < nodes.length - 1; i++) {
+      child = new InternalMNode(cur, nodes[i]);
+      cur.addChild(nodes[i], child);
+      cur = child;
     }
     return cur;
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/RSchemaRegionLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/RSchemaRegionLoader.java
@@ -20,7 +20,6 @@ package org.apache.iotdb.db.metadata.schemaregion;
 
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,11 +52,9 @@ public class RSchemaRegionLoader {
    *
    * @param storageGroup
    * @param schemaRegionId
-   * @param node
    * @return
    */
-  public ISchemaRegion loadRSchemaRegion(
-      PartialPath storageGroup, SchemaRegionId schemaRegionId, IStorageGroupMNode node) {
+  public ISchemaRegion loadRSchemaRegion(PartialPath storageGroup, SchemaRegionId schemaRegionId) {
     ISchemaRegion region = null;
     LOGGER.info("Creating instance for schema-engine-rocksdb");
     try {
@@ -66,14 +63,9 @@ public class RSchemaRegionLoader {
       Class<?> classForRSchemaConfLoader = urlClassLoader.loadClass(RSCHEMA_CONF_LOADER_CLASS_NAME);
       Constructor<?> constructor =
           classForRSchemaRegion.getConstructor(
-              PartialPath.class,
-              SchemaRegionId.class,
-              IStorageGroupMNode.class,
-              classForRSchemaConfLoader);
+              PartialPath.class, SchemaRegionId.class, classForRSchemaConfLoader);
       Object rSchemaLoader = classForRSchemaConfLoader.getConstructor().newInstance();
-      region =
-          (ISchemaRegion)
-              constructor.newInstance(storageGroup, schemaRegionId, node, rSchemaLoader);
+      region = (ISchemaRegion) constructor.newInstance(storageGroup, schemaRegionId, rSchemaLoader);
     } catch (ClassNotFoundException
         | NoSuchMethodException
         | InvocationTargetException

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaEngine.java
@@ -30,10 +30,6 @@ import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.exception.metadata.StorageGroupAlreadySetException;
-import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
-import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
-import org.apache.iotdb.db.metadata.mtree.ConfigMTree;
 import org.apache.iotdb.db.metadata.rescon.SchemaResourceManager;
 import org.apache.iotdb.db.metadata.visitor.SchemaExecutionVisitor;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
@@ -63,8 +59,6 @@ public class SchemaEngine {
   private static final Logger logger = LoggerFactory.getLogger(SchemaEngine.class);
 
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
-
-  private ConfigMTree sharedPrefixTree;
 
   private Map<SchemaRegionId, ISchemaRegion> schemaRegionMap;
   private SchemaEngineMode schemaRegionStoredMode;
@@ -122,7 +116,6 @@ public class SchemaEngine {
     SchemaResourceManager.initSchemaResource();
 
     schemaRegionMap = new ConcurrentHashMap<>();
-    sharedPrefixTree = new ConfigMTree();
 
     Map<PartialPath, List<SchemaRegionId>> schemaRegionInfo = initSchemaRegion();
 
@@ -243,11 +236,6 @@ public class SchemaEngine {
       schemaRegionMap.clear();
       schemaRegionMap = null;
     }
-
-    if (sharedPrefixTree != null) {
-      sharedPrefixTree.clear();
-      sharedPrefixTree = null;
-    }
   }
 
   public ISchemaRegion getSchemaRegion(SchemaRegionId regionId) {
@@ -306,22 +294,16 @@ public class SchemaEngine {
   private ISchemaRegion createSchemaRegionWithoutExistenceCheck(
       PartialPath storageGroup, SchemaRegionId schemaRegionId) throws MetadataException {
     ISchemaRegion schemaRegion;
-    IStorageGroupMNode storageGroupMNode = ensureStorageGroupByStorageGroupPath(storageGroup);
     switch (this.schemaRegionStoredMode) {
       case Memory:
-        schemaRegion =
-            new SchemaRegionMemoryImpl(
-                storageGroup, schemaRegionId, storageGroupMNode, seriesNumerMonitor);
+        schemaRegion = new SchemaRegionMemoryImpl(storageGroup, schemaRegionId, seriesNumerMonitor);
         break;
       case Schema_File:
         schemaRegion =
-            new SchemaRegionSchemaFileImpl(
-                storageGroup, schemaRegionId, storageGroupMNode, seriesNumerMonitor);
+            new SchemaRegionSchemaFileImpl(storageGroup, schemaRegionId, seriesNumerMonitor);
         break;
       case Rocksdb_based:
-        schemaRegion =
-            new RSchemaRegionLoader()
-                .loadRSchemaRegion(storageGroup, schemaRegionId, storageGroupMNode);
+        schemaRegion = new RSchemaRegionLoader().loadRSchemaRegion(storageGroup, schemaRegionId);
         break;
       default:
         throw new UnsupportedOperationException(
@@ -330,29 +312,6 @@ public class SchemaEngine {
                 schemaRegionStoredMode));
     }
     return schemaRegion;
-  }
-
-  private IStorageGroupMNode ensureStorageGroupByStorageGroupPath(PartialPath storageGroup)
-      throws MetadataException {
-    try {
-      return sharedPrefixTree.getStorageGroupNodeByStorageGroupPath(storageGroup);
-    } catch (StorageGroupNotSetException e) {
-      try {
-        sharedPrefixTree.setStorageGroup(storageGroup);
-      } catch (StorageGroupAlreadySetException storageGroupAlreadySetException) {
-        // do nothing
-        // concurrent timeseries creation may result concurrent ensureStorageGroup
-        // it's ok that the storageGroup has already been set
-
-        if (storageGroupAlreadySetException.isHasChild()) {
-          // if setStorageGroup failure is because of child, the deviceNode should not be created.
-          // Timeseries can't be created under a deviceNode without storageGroup.
-          throw storageGroupAlreadySetException;
-        }
-      }
-
-      return sharedPrefixTree.getStorageGroupNodeByStorageGroupPath(storageGroup);
-    }
   }
 
   public synchronized void deleteSchemaRegion(SchemaRegionId schemaRegionId)
@@ -382,7 +341,6 @@ public class SchemaEngine {
       if (sgDir.exists()) {
         FileUtils.deleteDirectory(sgDir);
       }
-      sharedPrefixTree.deleteStorageGroup(new PartialPath(schemaRegion.getStorageGroupFullPath()));
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
@@ -91,11 +91,9 @@ public abstract class MTreeBelowSGTest {
       IMTreeBelowSG mtree;
       if (SchemaEngineMode.valueOf(IoTDBDescriptor.getInstance().getConfig().getSchemaEngineMode())
           .equals(SchemaEngineMode.Schema_File)) {
-        mtree =
-            new MTreeBelowSGCachedImpl(root.getStorageGroupNodeByStorageGroupPath(path), null, 0);
+        mtree = new MTreeBelowSGCachedImpl(path, null, 0);
       } else {
-        mtree =
-            new MTreeBelowSGMemoryImpl(root.getStorageGroupNodeByStorageGroupPath(path), null, 0);
+        mtree = new MTreeBelowSGMemoryImpl(path, null, 0);
       }
       usedMTree.add(mtree);
       return mtree;


### PR DESCRIPTION
## Description

Since the database name has already been checked on configNode when creating database, there's no need to check it again in SchemaEngine. We suppose all the internal requests are legal and SchemaEngine only need to execute them.

The async physical deletion of schemaRegion affects the creation of new region of new database with nested name, e.g. old db is root.udf and new db is root.udf.load, which results in the creation failure of new region and this shall not happen. 
