### PR TITLE
[To rel/1.0][IOTDB-5093]Fix compaction selector bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/CrossSpaceCompactionResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/CrossSpaceCompactionResource.java
@@ -23,9 +23,7 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * CrossSpaceCompactionResource manages files and caches of readers to avoid unnecessary object
@@ -39,13 +37,8 @@ public class CrossSpaceCompactionResource {
 
   public CrossSpaceCompactionResource(
       List<TsFileResource> seqFiles, List<TsFileResource> unseqFiles) {
-    this.seqFiles = seqFiles.stream().filter(this::filterSeqResource).collect(Collectors.toList());
+    this.seqFiles = seqFiles;
     filterUnseqResource(unseqFiles);
-  }
-
-  /** Fitler the seq files into the compaction. Seq files should be not deleted or over ttl. */
-  private boolean filterSeqResource(TsFileResource res) {
-    return !res.isDeleted() && res.stillLives(ttlLowerBound);
   }
 
   /**
@@ -65,9 +58,9 @@ public class CrossSpaceCompactionResource {
   }
 
   public CrossSpaceCompactionResource(
-      Collection<TsFileResource> seqFiles, List<TsFileResource> unseqFiles, long ttlLowerBound) {
+      List<TsFileResource> seqFiles, List<TsFileResource> unseqFiles, long ttlLowerBound) {
     this.ttlLowerBound = ttlLowerBound;
-    this.seqFiles = seqFiles.stream().filter(this::filterSeqResource).collect(Collectors.toList());
+    this.seqFiles = seqFiles;
     filterUnseqResource(unseqFiles);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.engine.compaction.task.ICompactionSelector;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.MergeException;
 import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.tsfile.utils.Pair;
@@ -262,9 +263,7 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
    */
   private boolean checkIsSeqFilesValid() {
     for (Integer seqIdx : tmpSelectedSeqFiles) {
-      if (resource.getSeqFiles().get(seqIdx).isCompactionCandidate()
-          || resource.getSeqFiles().get(seqIdx).isCompacting()
-          || !resource.getSeqFiles().get(seqIdx).isClosed()
+      if (resource.getSeqFiles().get(seqIdx).getStatus() != TsFileResourceStatus.CLOSED
           || !resource.getSeqFiles().get(seqIdx).getTsFile().exists()) {
         return false;
       }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.engine.compaction.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.RewriteCrossSpaceCompactionSelector;
 import org.apache.iotdb.db.engine.compaction.performer.impl.ReadChunkCompactionPerformer;
+import org.apache.iotdb.db.engine.compaction.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
@@ -2223,6 +2224,8 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
     registerTimeseriesInMManger(5, 10, true);
     createFiles(5, 10, 5, 1000, 0, 0, 100, 100, false, true);
     createFiles(1, 5, 10, 4500, 500, 500, 0, 100, false, false);
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
 
     // seq file 3 and 4 are being compacted by inner space compaction
     List<TsFileResource> sourceFiles = new ArrayList<>();
@@ -2232,6 +2235,7 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
         CompactionFileGeneratorUtils.getInnerCompactionTargetTsFileResources(sourceFiles, true);
     ReadChunkCompactionPerformer performer = new ReadChunkCompactionPerformer(sourceFiles);
     performer.setTargetFiles(targetResources);
+    performer.setSummary(new CompactionTaskSummary());
     performer.perform();
 
     CompactionUtils.moveTargetFile(targetResources, true, COMPACTION_TEST_SG + "-" + "0");

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
@@ -22,8 +22,11 @@ package org.apache.iotdb.db.engine.compaction.cross;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.AbstractCompactionTest;
+import org.apache.iotdb.db.engine.compaction.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.RewriteCrossSpaceCompactionSelector;
+import org.apache.iotdb.db.engine.compaction.performer.impl.ReadChunkCompactionPerformer;
+import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
@@ -41,6 +44,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -2204,5 +2209,47 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
         .doCompaction();
 
     validateSeqFiles(true);
+  }
+
+  /**
+   * Cross space compaction select 1, 2, 3, 4, 5 seq file, but file 3 and 4 are being compacted and
+   * being deleted by other inner compaction task. Cross space compaction selector should abort this
+   * task.
+   */
+  @Test
+  public void testSelectingFilesWhenSomeFilesBeingDeleted()
+      throws MetadataException, IOException, WriteProcessException, StorageEngineException,
+          InterruptedException, MergeException {
+    registerTimeseriesInMManger(5, 10, true);
+    createFiles(5, 10, 5, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 5, 10, 4500, 500, 500, 0, 100, false, false);
+
+    // seq file 3 and 4 are being compacted by inner space compaction
+    List<TsFileResource> sourceFiles = new ArrayList<>();
+    sourceFiles.add(seqResources.get(2));
+    sourceFiles.add(seqResources.get(3));
+    List<TsFileResource> targetResources =
+        CompactionFileGeneratorUtils.getInnerCompactionTargetTsFileResources(sourceFiles, true);
+    ReadChunkCompactionPerformer performer = new ReadChunkCompactionPerformer(sourceFiles);
+    performer.setTargetFiles(targetResources);
+    performer.perform();
+
+    CompactionUtils.moveTargetFile(targetResources, true, COMPACTION_TEST_SG + "-" + "0");
+    CompactionUtils.combineModsInInnerCompaction(sourceFiles, targetResources.get(0));
+    tsFileManager.replace(sourceFiles, Collections.emptyList(), targetResources, 0, true);
+    CompactionUtils.deleteTsFilesInDisk(sourceFiles, COMPACTION_TEST_SG + "-" + "0");
+
+    // start selecting files and then start a cross space compaction task
+    ICrossSpaceSelector selector =
+        IoTDBDescriptor.getInstance()
+            .getConfig()
+            .getCrossCompactionSelector()
+            .createInstance(COMPACTION_TEST_SG, "0", 0, tsFileManager);
+    // In the process of getting the file list and starting to select files, the file list is
+    // updated (the file is deleted or the status is updated)
+    List<Pair<List<TsFileResource>, List<TsFileResource>>> selected =
+        selector.selectCrossSpaceTask(seqResources, unseqResources);
+
+    Assert.assertEquals(0, selected.size());
   }
 }


### PR DESCRIPTION
**Description**
target file overlap with previous file 

**Reason**
In the process of getting the file list and starting to select files, the file list is updated (the file is deleted or the status is updated). When a seq file is occupied and deleted by other compaction thread, and it happens to select files in cross space compaction, the deleted file will be filtered out, resulting in an overlap target file.

**Solution**
Do not filter out any seq files before selecting the files. After selecting the files, judge whether the seq files have been deleted or being compacted. If there are any, the task will be discarded.