### PR TITLE
add back the M4 doc temporarily

### DIFF
--- a/docs/UserGuide/UDF-Library/M4.md
+++ b/docs/UserGuide/UDF-Library/M4.md
@@ -1,0 +1,26 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# M4
+
+## M4
+
+The documentation of M4 UDF has been moved to [Operators and Functions->Sample->M4 Function](../Operators-Functions/Sample.md).


### PR DESCRIPTION
Valid the reference link used in a paper for some time.
Afterwards I'll remove this doc.