### PR TITLE
[To rel/1.0][IOTDB-5105] Remove least_data_region_group_num check when register Non-Seed-ConfigNode

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -786,9 +786,6 @@ public class ConfigManager implements IManager {
         != CommonDescriptor.getInstance().getConfig().getDiskSpaceWarningThreshold()) {
       return errorStatus.setMessage(errorPrefix + "disk_space_warning_threshold" + errorSuffix);
     }
-    if (req.getLeastDataRegionGroupNum() != conf.getLeastDataRegionGroupNum()) {
-      return errorStatus.setMessage(errorPrefix + "least_data_region_group_num" + errorSuffix);
-    }
     return null;
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -259,6 +259,10 @@ public class ConfigNode implements ConfigNodeMBean {
       }
 
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        if (resp == null) {
+          LOGGER.error("The result of register ConfigNode is empty!");
+          throw new StartupException("The result of register ConfigNode is empty!");
+        }
         /* Always set ConfigNodeId before initConsensusManager */
         CONF.setConfigNodeId(resp.getConfigNodeId());
         configManager.initConsensusManager();


### PR DESCRIPTION
Create more databases to adjust The least number of DataRegionGroups per Database:
![image](https://user-images.githubusercontent.com/6756545/205038074-0092181e-c179-445f-9397-f3d473f2eb7c.png)

Add new ConfigNode:
![image](https://user-images.githubusercontent.com/6756545/205038142-320f1700-39e2-4075-a70f-722e214a599e.png)
