### PR TITLE
[IOTDB-5109][to rel/1.0] Fix the load of role snapshot

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -178,7 +178,7 @@ public class ConfigPlanExecutor {
     this.snapshotProcessorList.add(triggerInfo);
 
     this.syncInfo = syncInfo;
-    this.snapshotProcessorList.add(triggerInfo);
+    this.snapshotProcessorList.add(syncInfo);
 
     this.cqInfo = cqInfo;
     this.snapshotProcessorList.add(cqInfo);

--- a/docs/UserGuide/QuickStart/QuickStart.md
+++ b/docs/UserGuide/QuickStart/QuickStart.md
@@ -220,6 +220,19 @@ The server can be stopped with ctrl-C or the following script:
 Note: In Linux, please add the "sudo" as far as possible, or else the stopping process may fail.
 More explanations are in Cluster/Cluster-setup.md.
 
+### Administration management
+
+There is a default user in IoTDB after the initial installation: root, and the default password is root. This user is an administrator user, who cannot be deleted and has all the privileges. Neither can new privileges be granted to the root user nor can privileges owned by the root user be deleted.
+
+You can alter the password of root using the following command：
+```
+ALTER USER <username> SET PASSWORD <password>;
+Example: IoTDB > ALTER USER root SET PASSWORD 'newpwd';
+```
+
+More about administration management：[Administration Management](https://iotdb.apache.org/UserGuide/V1.0.x/Administration-Management/Administration.html)
+
+
 ## Basic configuration
 
 The configuration files is in the `conf` folder, includes:

--- a/docs/zh/UserGuide/QuickStart/QuickStart.md
+++ b/docs/zh/UserGuide/QuickStart/QuickStart.md
@@ -251,6 +251,18 @@ Windows 系统停止命令如下：
 ```
 注意：在 Linux 下，执行停止脚本时，请尽量加上 sudo 语句，不然停止可能会失败。更多的解释在分布式/分布式部署中。
 
+### IoTDB 的权限管理
+
+初始安装后的 IoTDB 中有一个默认用户：root，默认密码为 root。该用户为管理员用户，固定拥有所有权限，无法被赋予、撤销权限，也无法被删除。
+
+您可以通过以下命令修改其密码：
+```
+ALTER USER <username> SET PASSWORD <password>;
+Example: IoTDB > ALTER USER root SET PASSWORD 'newpwd';
+```
+
+权限管理的具体内容可以参考：[权限管理](https://iotdb.apache.org/zh/UserGuide/V1.0.x/Administration-Management/Administration.html)
+
 ## 基础配置
 
 配置文件在"conf"文件夹下，包括：


### PR DESCRIPTION
In ratis, it will not copy empty directory through snapshot which may cause NullPointerException when load.
Now, we temporarily check whether the folder is emty