### PR TITLE
[IOTDB-5026] Improve last query on aligned timeseries

### DIFF
--- a/.github/workflows/main-unix.yml
+++ b/.github/workflows/main-unix.yml
@@ -37,7 +37,7 @@ jobs:
       max-parallel: 20
       matrix:
         java: [ 8, 11, 17 ]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
         include:
           - java: 8
             os: macos-latest

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/AlignedPath.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/AlignedPath.java
@@ -92,6 +92,12 @@ public class AlignedPath extends PartialPath {
     measurementList.add(subSensor);
   }
 
+  public AlignedPath(PartialPath vectorPath) {
+    super(vectorPath.getNodes());
+    measurementList = new ArrayList<>();
+    schemaList = new ArrayList<>();
+  }
+
   public AlignedPath(MeasurementPath path) {
     super(path.getDevicePath().getNodes());
     measurementList = new ArrayList<>();
@@ -155,6 +161,18 @@ public class AlignedPath extends PartialPath {
       schemaList = new ArrayList<>();
     }
     schemaList.add(measurementPath.getMeasurementSchema());
+  }
+
+  public void addMeasurement(String measurement, IMeasurementSchema measurementSchema) {
+    if (measurementList == null) {
+      measurementList = new ArrayList<>();
+    }
+    measurementList.add(measurement);
+
+    if (schemaList == null) {
+      schemaList = new ArrayList<>();
+    }
+    schemaList.add(measurementSchema);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/last/AbstractUpdateLastCacheOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/last/AbstractUpdateLastCacheOperator.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.execution.operator.process.last;
+
+import org.apache.iotdb.db.metadata.cache.DataNodeSchemaCache;
+import org.apache.iotdb.db.mpp.execution.driver.DataDriverContext;
+import org.apache.iotdb.db.mpp.execution.operator.Operator;
+import org.apache.iotdb.db.mpp.execution.operator.OperatorContext;
+import org.apache.iotdb.db.mpp.execution.operator.process.ProcessOperator;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+public abstract class AbstractUpdateLastCacheOperator implements ProcessOperator {
+  protected static final TsBlock LAST_QUERY_EMPTY_TSBLOCK =
+      new TsBlockBuilder(ImmutableList.of(TSDataType.TEXT, TSDataType.TEXT, TSDataType.TEXT))
+          .build();
+
+  protected OperatorContext operatorContext;
+
+  protected Operator child;
+
+  protected DataNodeSchemaCache lastCache;
+
+  protected boolean needUpdateCache;
+
+  protected TsBlockBuilder tsBlockBuilder;
+
+  protected String databaseName;
+
+  public AbstractUpdateLastCacheOperator(
+      OperatorContext operatorContext,
+      Operator child,
+      DataNodeSchemaCache dataNodeSchemaCache,
+      boolean needUpdateCache) {
+    this.operatorContext = operatorContext;
+    this.child = child;
+    this.lastCache = dataNodeSchemaCache;
+    this.needUpdateCache = needUpdateCache;
+    this.tsBlockBuilder = LastQueryUtil.createTsBlockBuilder(1);
+  }
+
+  @Override
+  public OperatorContext getOperatorContext() {
+    return operatorContext;
+  }
+
+  @Override
+  public ListenableFuture<?> isBlocked() {
+    return child.isBlocked();
+  }
+
+  protected String getDatabaseName() {
+    if (databaseName == null) {
+      databaseName =
+          ((DataDriverContext) operatorContext.getInstanceContext().getDriverContext())
+              .getDataRegion()
+              .getStorageGroupName();
+    }
+    return databaseName;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return child.hasNext();
+  }
+
+  @Override
+  public boolean isFinished() {
+    return child.isFinished();
+  }
+
+  @Override
+  public void close() throws Exception {
+    child.close();
+  }
+
+  @Override
+  public long calculateMaxPeekMemory() {
+    return child.calculateMaxPeekMemory();
+  }
+
+  @Override
+  public long calculateMaxReturnSize() {
+    return child.calculateMaxReturnSize();
+  }
+
+  @Override
+  public long calculateRetainedSizeAfterCallingNext() {
+    return child.calculateRetainedSizeAfterCallingNext();
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/last/LastQueryOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/last/LastQueryOperator.java
@@ -43,7 +43,7 @@ public class LastQueryOperator implements ProcessOperator {
 
   private final OperatorContext operatorContext;
 
-  private final List<UpdateLastCacheOperator> children;
+  private final List<AbstractUpdateLastCacheOperator> children;
 
   private final int inputOperatorsCount;
 
@@ -53,7 +53,7 @@ public class LastQueryOperator implements ProcessOperator {
 
   public LastQueryOperator(
       OperatorContext operatorContext,
-      List<UpdateLastCacheOperator> children,
+      List<AbstractUpdateLastCacheOperator> children,
       TsBlockBuilder builder) {
     this.operatorContext = operatorContext;
     this.children = children;
@@ -109,7 +109,7 @@ public class LastQueryOperator implements ProcessOperator {
         if (tsBlock == null) {
           return null;
         } else if (!tsBlock.isEmpty()) {
-          LastQueryUtil.appendLastValue(tsBlockBuilder, tsBlock, 0);
+          LastQueryUtil.appendLastValue(tsBlockBuilder, tsBlock);
         }
       }
       currentIndex++;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/last/LastQuerySortOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/last/LastQuerySortOperator.java
@@ -55,7 +55,7 @@ public class LastQuerySortOperator implements ProcessOperator {
   private int cachedTsBlockRowIndex;
 
   // we must make sure that Operator in children has already been sorted
-  private final List<UpdateLastCacheOperator> children;
+  private final List<AbstractUpdateLastCacheOperator> children;
 
   private final OperatorContext operatorContext;
 
@@ -73,7 +73,7 @@ public class LastQuerySortOperator implements ProcessOperator {
   public LastQuerySortOperator(
       OperatorContext operatorContext,
       TsBlock cachedTsBlock,
-      List<UpdateLastCacheOperator> children,
+      List<AbstractUpdateLastCacheOperator> children,
       Comparator<Binary> timeSeriesComparator) {
     this.cachedTsBlock = cachedTsBlock;
     this.cachedTsBlockSize = cachedTsBlock.getPositionCount();
@@ -117,7 +117,7 @@ public class LastQuerySortOperator implements ProcessOperator {
         if (canUseDataFromCachedTsBlock(previousTsBlock)) {
           LastQueryUtil.appendLastValue(tsBlockBuilder, cachedTsBlock, cachedTsBlockRowIndex++);
         } else {
-          LastQueryUtil.appendLastValue(tsBlockBuilder, previousTsBlock, 0);
+          LastQueryUtil.appendLastValue(tsBlockBuilder, previousTsBlock);
           previousTsBlock = null;
         }
       }
@@ -144,7 +144,7 @@ public class LastQuerySortOperator implements ProcessOperator {
         if (canUseDataFromCachedTsBlock(previousTsBlock)) {
           LastQueryUtil.appendLastValue(tsBlockBuilder, cachedTsBlock, cachedTsBlockRowIndex++);
         } else {
-          LastQueryUtil.appendLastValue(tsBlockBuilder, previousTsBlock, 0);
+          LastQueryUtil.appendLastValue(tsBlockBuilder, previousTsBlock);
           previousTsBlock = null;
         }
       } else {
@@ -157,7 +157,8 @@ public class LastQuerySortOperator implements ProcessOperator {
               LastQueryUtil.appendLastValue(tsBlockBuilder, cachedTsBlock, cachedTsBlockRowIndex++);
               previousTsBlock = tsBlock;
             } else {
-              LastQueryUtil.appendLastValue(tsBlockBuilder, tsBlock, 0);
+              // it is safe to append the whole TsBlock
+              LastQueryUtil.appendLastValue(tsBlockBuilder, tsBlock);
             }
           }
         }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/last/LastQueryUtil.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/last/LastQueryUtil.java
@@ -140,6 +140,24 @@ public class LastQueryUtil {
     return aggregators;
   }
 
+  public static List<Aggregator> createAggregators(TSDataType dataType, int valueColumnIndex) {
+    // max_time, last_value
+    List<Aggregator> aggregators = new ArrayList<>(2);
+    aggregators.add(
+        new Aggregator(
+            new MaxTimeDescAccumulator(),
+            AggregationStep.SINGLE,
+            Collections.singletonList(
+                new InputLocation[] {new InputLocation(0, valueColumnIndex)})));
+    aggregators.add(
+        new Aggregator(
+            new LastValueDescAccumulator(dataType),
+            AggregationStep.SINGLE,
+            Collections.singletonList(
+                new InputLocation[] {new InputLocation(0, valueColumnIndex)})));
+    return aggregators;
+  }
+
   public static boolean needUpdateCache(Filter timeFilter) {
     // Update the cache only when, the filter is gt (greater than) or ge (greater than or equal to)
     return CACHE_ENABLED && (timeFilter == null || timeFilter instanceof GtEq)

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -350,7 +350,6 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
               .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    sourceExpressions.forEach(expression -> analyzeExpression(analysis, expression));
     analysis.setSourceExpressions(sourceExpressions);
 
     analysis.setRespDatasetHeader(DatasetHeaderFactory.getLastQueryHeader());

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
@@ -82,6 +82,8 @@ import org.apache.iotdb.db.mpp.execution.operator.process.join.merge.MultiColumn
 import org.apache.iotdb.db.mpp.execution.operator.process.join.merge.NonOverlappedMultiColumnMerger;
 import org.apache.iotdb.db.mpp.execution.operator.process.join.merge.SingleColumnMerger;
 import org.apache.iotdb.db.mpp.execution.operator.process.join.merge.TimeComparator;
+import org.apache.iotdb.db.mpp.execution.operator.process.last.AbstractUpdateLastCacheOperator;
+import org.apache.iotdb.db.mpp.execution.operator.process.last.AlignedUpdateLastCacheOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.last.LastQueryCollectOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.last.LastQueryMergeOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.last.LastQueryOperator;
@@ -1704,34 +1706,46 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
   @Override
   public Operator visitAlignedLastQueryScan(
       AlignedLastQueryScanNode node, LocalExecutionPlanContext context) {
-    PartialPath seriesPath = node.getSeriesPath().transformToPartialPath();
-    TimeValuePair timeValuePair = DATA_NODE_SCHEMA_CACHE.getLastCache(seriesPath);
-    if (timeValuePair == null) { // last value is not cached
-      return createUpdateLastCacheOperator(
-          node, context, node.getSeriesPath().getMeasurementPath());
-    } else if (!LastQueryUtil.satisfyFilter(
-        updateFilterUsingTTL(context.getLastQueryTimeFilter(), context.getDataRegionTTL()),
-        timeValuePair)) { // cached last value is not satisfied
+    AlignedPath alignedPath = node.getSeriesPath();
+    PartialPath devicePath = alignedPath.getDevicePath();
+    // get series under aligned entity that has not been cached
+    List<Integer> unCachedMeasurementIndexes = new ArrayList<>();
+    List<String> measurementList = alignedPath.getMeasurementList();
+    for (int i = 0; i < measurementList.size(); i++) {
+      PartialPath measurementPath = devicePath.concatNode(measurementList.get(i));
+      TimeValuePair timeValuePair = DATA_NODE_SCHEMA_CACHE.getLastCache(measurementPath);
+      if (timeValuePair == null) { // last value is not cached
+        unCachedMeasurementIndexes.add(i);
+      } else if (!LastQueryUtil.satisfyFilter(
+          updateFilterUsingTTL(context.getLastQueryTimeFilter(), context.getDataRegionTTL()),
+          timeValuePair)) { // cached last value is not satisfied
 
-      boolean isFilterGtOrGe =
-          (context.getLastQueryTimeFilter() instanceof Gt
-              || context.getLastQueryTimeFilter() instanceof GtEq);
-      // time filter is not > or >=, we still need to read from disk
-      if (!isFilterGtOrGe) {
-        return createUpdateLastCacheOperator(
-            node, context, node.getSeriesPath().getMeasurementPath());
-      } else { // otherwise, we just ignore it and return null
-        return null;
+        boolean isFilterGtOrGe =
+            (context.getLastQueryTimeFilter() instanceof Gt
+                || context.getLastQueryTimeFilter() instanceof GtEq);
+        // time filter is not > or >=, we still need to read from disk
+        if (!isFilterGtOrGe) {
+          unCachedMeasurementIndexes.add(i);
+        }
+      } else { //  cached last value is satisfied, put it into LastCacheScanOperator
+        context.addCachedLastValue(timeValuePair, measurementPath.getFullPath());
       }
-    } else { //  cached last value is satisfied, put it into LastCacheScanOperator
-      context.addCachedLastValue(timeValuePair, seriesPath.getFullPath());
+    }
+    if (unCachedMeasurementIndexes.isEmpty()) {
       return null;
+    } else {
+      AlignedPath unCachedPath = new AlignedPath(alignedPath.getDevicePath());
+      for (int i : unCachedMeasurementIndexes) {
+        unCachedPath.addMeasurement(measurementList.get(i), alignedPath.getSchemaList().get(i));
+      }
+      return createAlignedUpdateLastCacheOperator(node, unCachedPath, context);
     }
   }
 
-  private UpdateLastCacheOperator createUpdateLastCacheOperator(
-      AlignedLastQueryScanNode node, LocalExecutionPlanContext context, MeasurementPath fullPath) {
-    AlignedSeriesAggregationScanOperator lastQueryScan = createLastQueryScanOperator(node, context);
+  private AlignedUpdateLastCacheOperator createAlignedUpdateLastCacheOperator(
+      AlignedLastQueryScanNode node, AlignedPath unCachedPath, LocalExecutionPlanContext context) {
+    AlignedSeriesAggregationScanOperator lastQueryScan =
+        createLastQueryScanOperator(node, unCachedPath, context);
 
     OperatorContext operatorContext =
         context
@@ -1739,20 +1753,18 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
             .addOperatorContext(
                 context.getNextOperatorId(),
                 node.getPlanNodeId(),
-                UpdateLastCacheOperator.class.getSimpleName());
+                AlignedUpdateLastCacheOperator.class.getSimpleName());
     context.getTimeSliceAllocator().recordExecutionWeight(operatorContext, 1);
-    return new UpdateLastCacheOperator(
+    return new AlignedUpdateLastCacheOperator(
         operatorContext,
         lastQueryScan,
-        fullPath,
-        node.getSeriesPath().getSchemaList().get(0).getType(),
+        unCachedPath,
         DATA_NODE_SCHEMA_CACHE,
         context.isNeedUpdateLastCache());
   }
 
   private AlignedSeriesAggregationScanOperator createLastQueryScanOperator(
-      AlignedLastQueryScanNode node, LocalExecutionPlanContext context) {
-    AlignedPath seriesPath = node.getSeriesPath();
+      AlignedLastQueryScanNode node, AlignedPath unCachedPath, LocalExecutionPlanContext context) {
     OperatorContext operatorContext =
         context
             .getInstanceContext()
@@ -1762,17 +1774,18 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
                 AlignedSeriesAggregationScanOperator.class.getSimpleName());
 
     // last_time, last_value
-    List<Aggregator> aggregators =
-        LastQueryUtil.createAggregators(seriesPath.getSchemaList().get(0).getType());
+    List<Aggregator> aggregators = new ArrayList<>();
+    for (int i = 0; i < unCachedPath.getMeasurementList().size(); i++) {
+      aggregators.addAll(
+          LastQueryUtil.createAggregators(unCachedPath.getSchemaList().get(i).getType(), i));
+    }
     ITimeRangeIterator timeRangeIterator = initTimeRangeIterator(null, false, false);
-    long maxReturnSize =
-        calculateMaxAggregationResultSizeForLastQuery(
-            aggregators, seriesPath.transformToPartialPath());
+    long maxReturnSize = calculateMaxAggregationResultSizeForLastQuery(aggregators, unCachedPath);
 
     AlignedSeriesAggregationScanOperator seriesAggregationScanOperator =
         new AlignedSeriesAggregationScanOperator(
             node.getPlanNodeId(),
-            seriesPath,
+            unCachedPath,
             operatorContext,
             aggregators,
             timeRangeIterator,
@@ -1781,7 +1794,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
             null,
             maxReturnSize);
     context.addSourceOperator(seriesAggregationScanOperator);
-    context.addPath(seriesPath);
+    context.addPath(unCachedPath);
     context.getTimeSliceAllocator().recordExecutionWeight(operatorContext, aggregators.size());
     return seriesAggregationScanOperator;
   }
@@ -1798,11 +1811,11 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
     context.setLastQueryTimeFilter(node.getTimeFilter());
     context.setNeedUpdateLastCache(LastQueryUtil.needUpdateCache(node.getTimeFilter()));
 
-    List<UpdateLastCacheOperator> operatorList =
+    List<AbstractUpdateLastCacheOperator> operatorList =
         node.getChildren().stream()
             .map(child -> child.accept(this, context))
             .filter(Objects::nonNull)
-            .map(o -> (UpdateLastCacheOperator) o)
+            .map(o -> (AbstractUpdateLastCacheOperator) o)
             .collect(Collectors.toList());
 
     List<Pair<TimeValuePair, Binary>> cachedLastValueAndPathList =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/SubPlanTypeExtractor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/SubPlanTypeExtractor.java
@@ -27,7 +27,12 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.AggregationNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByLevelNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByTagNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggregationNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryCollectNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryMergeNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedLastQueryScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.AlignedSeriesAggregationScanNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.LastQueryScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.SeriesAggregationScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.AggregationDescriptor;
 
@@ -104,6 +109,30 @@ public class SubPlanTypeExtractor {
           .forEach(this::updateTypeProviderByAggregationDescriptor);
       return visitPlan(node, context);
     }
+
+    // region PlanNode of last query
+    // No need to deal with type of last query
+    public Void visitLastQueryScan(LastQueryScanNode node, Void context) {
+      return null;
+    }
+
+    public Void visitAlignedLastQueryScan(AlignedLastQueryScanNode node, Void context) {
+      return null;
+    }
+
+    public Void visitLastQuery(LastQueryNode node, Void context) {
+      return null;
+    }
+
+    public Void visitLastQueryMerge(LastQueryMergeNode node, Void context) {
+      return null;
+    }
+
+    public Void visitLastQueryCollect(LastQueryCollectNode node, Void context) {
+      return null;
+    }
+
+    // end region PlanNode of last query
 
     private void updateTypeProviderByAggregationDescriptor(
         List<? extends AggregationDescriptor> aggregationDescriptorList) {

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/OperatorMemoryTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/OperatorMemoryTest.java
@@ -47,6 +47,7 @@ import org.apache.iotdb.db.mpp.execution.operator.process.fill.linear.LinearFill
 import org.apache.iotdb.db.mpp.execution.operator.process.join.RowBasedTimeJoinOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.join.TimeJoinOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.join.merge.TimeComparator;
+import org.apache.iotdb.db.mpp.execution.operator.process.last.AbstractUpdateLastCacheOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.last.LastQueryCollectOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.last.LastQueryMergeOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.last.LastQueryOperator;
@@ -325,7 +326,7 @@ public class OperatorMemoryTest {
   public void lastQueryOperatorTest() {
     TsBlockBuilder builder = Mockito.mock(TsBlockBuilder.class);
     Mockito.when(builder.getRetainedSizeInBytes()).thenReturn(1024L);
-    List<UpdateLastCacheOperator> children = new ArrayList<>(4);
+    List<AbstractUpdateLastCacheOperator> children = new ArrayList<>(4);
     long expectedMaxReturnSize = DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
     for (int i = 0; i < 4; i++) {
       UpdateLastCacheOperator child = Mockito.mock(UpdateLastCacheOperator.class);
@@ -355,7 +356,7 @@ public class OperatorMemoryTest {
     TsBlock tsBlock = Mockito.mock(TsBlock.class);
     Mockito.when(tsBlock.getRetainedSizeInBytes()).thenReturn(16 * 1024L);
     Mockito.when(tsBlock.getPositionCount()).thenReturn(16);
-    List<UpdateLastCacheOperator> children = new ArrayList<>(4);
+    List<AbstractUpdateLastCacheOperator> children = new ArrayList<>(4);
 
     for (int i = 0; i < 4; i++) {
       UpdateLastCacheOperator child = Mockito.mock(UpdateLastCacheOperator.class);


### PR DESCRIPTION
Previously, we construct a PlanNode for every measurement of an AlignedPath which is unnecessary. This PR aims to reduce the cost of construcing unnecessary PlanNode for last query on aligned timeseries.