### PR TITLE
[To rel/1.0] [IOTDB-5090] Add npe check in DataNode

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -670,8 +670,12 @@ public class DataNode implements DataNodeMBean {
 
     try {
       MetricService.getInstance().stop();
-      SchemaRegionConsensusImpl.getInstance().stop();
-      DataRegionConsensusImpl.getInstance().stop();
+      if (SchemaRegionConsensusImpl.getInstance() != null) {
+        SchemaRegionConsensusImpl.getInstance().stop();
+      }
+      if (DataRegionConsensusImpl.getInstance() != null) {
+        DataRegionConsensusImpl.getInstance().stop();
+      }
     } catch (Exception e) {
       logger.error("Stop data node error", e);
     }


### PR DESCRIPTION
When fail to start a Datanode, `SchemaRegionConsensusImpl` and `DataRegionConsensusImpl` will  be null instead of being init , so need to add a check whether they are nullpoints when stop the datanode.