### PR TITLE
[To rel/1.0][IOTDB-5118] FileMetric opens too many file descriptors

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ProcedureInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ProcedureInfo.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 public class ProcedureInfo {
 
@@ -49,10 +50,8 @@ public class ProcedureInfo {
   private final ConcurrentHashMap<Long, ProcedureWAL> procWALMap = new ConcurrentHashMap<>();
 
   public void load(List<Procedure> procedureList) {
-    try {
-      Files.list(Paths.get(procedureWalDir))
-          .filter(
-              path -> path.getFileName().toString().endsWith(ProcedureStore.PROCEDURE_WAL_SUFFIX))
+    try (Stream<Path> s = Files.list(Paths.get(procedureWalDir))) {
+      s.filter(path -> path.getFileName().toString().endsWith(ProcedureStore.PROCEDURE_WAL_SUFFIX))
           .sorted(
               (p1, p2) ->
                   Long.compareUnsigned(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureStore.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureStore.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 public class ProcedureStore implements IProcedureStore {
 
@@ -79,9 +80,8 @@ public class ProcedureStore implements IProcedureStore {
    * @param procedureList procedureList
    */
   public void load(List<Procedure> procedureList) {
-    try {
-      Files.list(Paths.get(procedureWalDir))
-          .filter(path -> path.getFileName().toString().endsWith(PROCEDURE_WAL_SUFFIX))
+    try (Stream<Path> s = Files.list(Paths.get(procedureWalDir))) {
+      s.filter(path -> path.getFileName().toString().endsWith(PROCEDURE_WAL_SUFFIX))
           .sorted(
               (p1, p2) ->
                   Long.compareUnsigned(

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.db.service.metrics;
 
 import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
-import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.service.metric.enums.Metric;
 import org.apache.iotdb.commons.service.metric.enums.Tag;
 import org.apache.iotdb.db.engine.TsFileMetricManager;
@@ -34,13 +33,10 @@ import org.apache.iotdb.metrics.utils.MetricType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.UncheckedIOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 public class FileMetrics implements IMetricSet {
   private static final Logger logger = LoggerFactory.getLogger(FileMetrics.class);
@@ -135,41 +131,10 @@ public class FileMetrics implements IMetricSet {
   }
 
   private void collect() {
-    String[] walDirs = CommonDescriptor.getInstance().getConfig().getWalDirs();
     walFileTotalSize = WALManager.getInstance().getTotalDiskUsage();
     sequenceFileTotalSize = TsFileMetricManager.getInstance().getFileSize(true);
     unsequenceFileTotalSize = TsFileMetricManager.getInstance().getFileSize(false);
-    walFileTotalCount =
-        Stream.of(walDirs)
-            .mapToLong(
-                dir -> {
-                  File walFolder = new File(dir);
-                  if (walFolder.exists()) {
-                    File[] walNodeFolders = walFolder.listFiles(File::isDirectory);
-                    long result = 0L;
-                    if (null != walNodeFolders) {
-                      for (File walNodeFolder : walNodeFolders) {
-                        if (walNodeFolder.exists() && walNodeFolder.isDirectory()) {
-                          try {
-                            result +=
-                                org.apache.commons.io.FileUtils.listFiles(walFolder, null, true)
-                                    .size();
-                          } catch (UncheckedIOException exception) {
-                            // do nothing
-                            logger.debug(
-                                "Failed when count wal folder {}: ",
-                                walNodeFolder.getName(),
-                                exception);
-                          }
-                        }
-                      }
-                    }
-                    return result;
-                  } else {
-                    return 0L;
-                  }
-                })
-            .sum();
+    walFileTotalCount = WALManager.getInstance().getTotalFileNum();
     sequenceFileTotalCount = TsFileMetricManager.getInstance().getFileNum(true);
     unsequenceFileTotalCount = TsFileMetricManager.getInstance().getFileNum(false);
   }

--- a/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
@@ -59,6 +59,8 @@ public class WALManager implements IService {
   private ScheduledExecutorService walDeleteThread;
   /** total disk usage of wal files */
   private final AtomicLong totalDiskUsage = new AtomicLong();
+  /** total number of wal files */
+  private final AtomicLong totalFileNum = new AtomicLong();
 
   private WALManager() {
     if (config.isClusterMode()
@@ -197,6 +199,18 @@ public class WALManager implements IService {
 
   public void subtractTotalDiskUsage(long size) {
     totalDiskUsage.accumulateAndGet(size, (x, y) -> x - y);
+  }
+
+  public long getTotalFileNum() {
+    return totalFileNum.get();
+  }
+
+  public void addTotalFileNum(long size) {
+    totalFileNum.accumulateAndGet(size, Long::sum);
+  }
+
+  public void subtractTotalFileNum(long size) {
+    totalFileNum.accumulateAndGet(size, (x, y) -> x - y);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/AbstractWALBuffer.java
@@ -84,6 +84,7 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
     String currentName = currentFile.getName();
     currentWALFileWriter.close();
     WALManager.getInstance().addTotalDiskUsage(currentWALFileWriter.size());
+    WALManager.getInstance().addTotalFileNum(1);
     if (WALFileUtils.parseStatusCode(currentName) != fileStatus) {
       String targetName =
           WALFileUtils.getLogFileName(

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -285,11 +285,12 @@ public class WALNode implements IWALNode {
       }
       // delete files
       int deletedFilesNum = 0;
+      long deletedFilesSize = 0;
       for (int i = 0; i < endFileIndex; ++i) {
         long fileSize = filesToDelete[i].length();
         if (filesToDelete[i].delete()) {
           deletedFilesNum++;
-          WALManager.getInstance().subtractTotalDiskUsage(fileSize);
+          deletedFilesSize += fileSize;
         } else {
           logger.info(
               "Fail to delete outdated wal file {} of wal node-{}.", filesToDelete[i], identifier);
@@ -301,6 +302,8 @@ public class WALNode implements IWALNode {
           totalCostOfFlushedMemTables.addAndGet(-memTableRamCostSum);
         }
       }
+      WALManager.getInstance().subtractTotalDiskUsage(deletedFilesSize);
+      WALManager.getInstance().subtractTotalFileNum(deletedFilesNum);
       logger.debug(
           "Successfully delete {} outdated wal files for wal node-{}.",
           deletedFilesNum,

--- a/server/src/main/java/org/apache/iotdb/db/wal/recover/WALNodeRecoverTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/recover/WALNodeRecoverTask.java
@@ -111,9 +111,10 @@ public class WALNodeRecoverTask implements Runnable {
       long lastVersionId = indexInfo[0];
       long lastSearchIndex = indexInfo[1];
       // update disk usage
-      long totalSize =
-          Arrays.stream(WALFileUtils.listAllWALFiles(logDirectory)).mapToLong(File::length).sum();
-      WALManager.getInstance().addTotalDiskUsage(totalSize);
+      File[] walFiles = WALFileUtils.listAllWALFiles(logDirectory);
+      WALManager.getInstance()
+          .addTotalDiskUsage(Arrays.stream(walFiles).mapToLong(File::length).sum());
+      WALManager.getInstance().addTotalFileNum(walFiles.length);
       // register wal node
       WALManager.getInstance()
           .registerWALNode(


### PR DESCRIPTION
FileUtils.listFiles in the commons io doesn't use Files.walk with try-with-resources contract, this error is same as [JDK-8250785](https://bugs.openjdk.org/browse/JDK-8250785)