### PR TITLE
update nodenames if necessary in ClientRpcServiceImpl

### DIFF
--- a/client-cpp/pom.xml
+++ b/client-cpp/pom.xml
@@ -121,8 +121,8 @@
                 <cmake.root.dir>${project.parent.basedir}/compile-tools/thrift/target/cmake-${cmake-version}-win64-x64/</cmake.root.dir>
                 <thrift.exec.absolute.path>${project.parent.basedir}/compile-tools/thrift/target/build/compiler/cpp/bin/${cmake.build.type}/thrift.exe</thrift.exec.absolute.path>
                 <iotdb.server.script>start-server.bat</iotdb.server.script>
-                <boost.include.dir />
-                <boost.library.dir />
+                <boost.include.dir/>
+                <boost.library.dir/>
             </properties>
         </profile>
         <profile>

--- a/compile-tools/pom.xml
+++ b/compile-tools/pom.xml
@@ -35,7 +35,7 @@
         <cmake-version>3.17.3</cmake-version>
         <openssl.include.dir>-Dtrue1=true1</openssl.include.dir>
         <bison.executable.dir>-Dtrue1=true1</bison.executable.dir>
-        <cmake.build.type />
+        <cmake.build.type/>
     </properties>
     <modules>
         <module>thrift</module>
@@ -138,8 +138,8 @@
                 <thrift.make.executable>make</thrift.make.executable>
                 <thrift.compiler.executable>thrift.exe</thrift.compiler.executable>
                 <gradlew.executable>gradlew.bat</gradlew.executable>
-                <boost.include.dir />
-                <boost.library.dir />
+                <boost.include.dir/>
+                <boost.library.dir/>
             </properties>
         </profile>
     </profiles>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -29,7 +29,7 @@
     </parent>
     <artifactId>iotdb-distribution</artifactId>
     <name>IoTDB Distribution</name>
-    <modules />
+    <modules/>
     <build>
         <plugins>
             <plugin>

--- a/example/client-cpp-example/pom.xml
+++ b/example/client-cpp-example/pom.xml
@@ -84,7 +84,7 @@
             <properties>
                 <cmake.generator>Visual Studio 16 2019</cmake.generator>
                 <cmake.root.dir>${project.parent.basedir}/../compile-tools/thrift/target/cmake-${cmake-version}-win64-x64/</cmake.root.dir>
-                <boost.include.dir />
+                <boost.include.dir/>
             </properties>
         </profile>
         <profile>

--- a/example/trigger/pom.xml
+++ b/example/trigger/pom.xml
@@ -123,7 +123,7 @@
                                 <importOrder>
                                     <order>org.apache.iotdb,,javax,java,\#</order>
                                 </importOrder>
-                                <removeUnusedImports />
+                                <removeUnusedImports/>
                             </java>
                         </configuration>
                         <executions>

--- a/example/udf/pom.xml
+++ b/example/udf/pom.xml
@@ -117,7 +117,7 @@
                                 <importOrder>
                                     <order>org.apache.iotdb,,javax,java,\#</order>
                                 </importOrder>
-                                <removeUnusedImports />
+                                <removeUnusedImports/>
                             </java>
                         </configuration>
                         <executions>

--- a/grafana-connector/pom.xml
+++ b/grafana-connector/pom.xml
@@ -170,7 +170,7 @@
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                         <resource>META-INF/spring.schemas</resource>
                                     </transformer>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <mainClass>${start-class}</mainClass>
                                     </transformer>

--- a/grafana-plugin/pom.xml
+++ b/grafana-plugin/pom.xml
@@ -123,16 +123,16 @@
                                 <configuration>
                                     <tasks>
                                         <condition property="osFamily" value="windows">
-                                            <os family="windows" />
+                                            <os family="windows"/>
                                         </condition>
                                         <condition property="osFamily" value="unix">
-                                            <os family="unix" />
+                                            <os family="unix"/>
                                         </condition>
                                         <exec executable="C:\\Windows\\System32\\cmd.exe" osfamily="windows">
-                                            <arg line="/c backend-compile.bat" />
+                                            <arg line="/c backend-compile.bat"/>
                                         </exec>
                                         <exec executable="/bin/bash" osfamily="unix">
-                                            <arg line="-c ./backend-compile.sh" />
+                                            <arg line="-c ./backend-compile.sh"/>
                                         </exec>
                                     </tasks>
                                 </configuration>

--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSyntaxConventionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSyntaxConventionIT.java
@@ -109,6 +109,7 @@ public class IoTDBSessionSyntaxConventionIT {
       measurements.add("`a“（Φ）”b`");
       measurements.add("`a>b`");
       measurements.add("`\\\"a`");
+      measurements.add("`aaa`");
       List<String> values = new ArrayList<>();
 
       for (int i = 0; i < measurements.size(); i++) {
@@ -125,6 +126,7 @@ public class IoTDBSessionSyntaxConventionIT {
       assertTrue(session.checkTimeseriesExists("root.sg1.d1.`a“（Φ）”b`"));
       assertTrue(session.checkTimeseriesExists("root.sg1.d1.`a>b`"));
       assertTrue(session.checkTimeseriesExists("root.sg1.d1.`\\\"a`"));
+      assertTrue(session.checkTimeseriesExists("root.sg1.d1.aaa"));
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -85,7 +85,7 @@
             <id>LocalStandalone</id>
             <properties>
                 <test.includedGroups>org.apache.iotdb.itbase.category.LocalStandaloneTest</test.includedGroups>
-                <test.excludedGroups />
+                <test.excludedGroups/>
             </properties>
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -147,7 +147,7 @@
             <id>Remote</id>
             <properties>
                 <test.includedGroups>org.apache.iotdb.itbase.category.RemoteTest</test.includedGroups>
-                <test.excludedGroups />
+                <test.excludedGroups/>
             </properties>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -211,7 +211,7 @@
             <id>Cluster</id>
             <properties>
                 <test.includedGroups>org.apache.iotdb.itbase.category.ClusterTest</test.includedGroups>
-                <test.excludedGroups />
+                <test.excludedGroups/>
             </properties>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -206,7 +206,7 @@
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>
-                                                <ignore />
+                                                <ignore/>
                                             </action>
                                         </pluginExecution>
                                     </pluginExecutions>

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/PathUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/PathUtils.java
@@ -27,9 +27,9 @@ import org.apache.iotdb.tsfile.read.common.parser.PathNodesGenerator;
 import org.apache.iotdb.tsfile.read.common.parser.PathVisitor;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 public class PathUtils {
 
@@ -66,11 +66,11 @@ public class PathUtils {
     if (measurementLists == null) {
       return null;
     }
-    // use set to skip checking duplicated measurements
-    Set<String> measurementSet = new HashSet<>();
+    // skip checking duplicated measurements
+    Map<String, String> checkedMeasurements = new HashMap<>();
     List<List<String>> res = new ArrayList<>();
     for (List<String> measurements : measurementLists) {
-      res.add(checkLegalSingleMeasurementsAndSkipDuplicate(measurements, measurementSet));
+      res.add(checkLegalSingleMeasurementsAndSkipDuplicate(measurements, checkedMeasurements));
     }
     return res;
   }
@@ -80,7 +80,7 @@ public class PathUtils {
    * single node name, use set to skip checking duplicated measurements
    */
   public static List<String> checkLegalSingleMeasurementsAndSkipDuplicate(
-      List<String> measurements, Set<String> measurementSet) throws MetadataException {
+      List<String> measurements, Map<String, String> checkedMeasurements) throws MetadataException {
     if (measurements == null) {
       return null;
     }
@@ -90,12 +90,12 @@ public class PathUtils {
         res.add(null);
         continue;
       }
-      if (measurementSet.contains(measurement)) {
-        res.add(measurement);
+      if (checkedMeasurements.get(measurement) != null) {
+        res.add(checkedMeasurements.get(measurement));
         continue;
       }
       String checked = checkAndReturnSingleMeasurement(measurement);
-      measurementSet.add(checked);
+      checkedMeasurements.put(measurement, checked);
       res.add(checked);
     }
     return res;

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <sonar.junit.reportPaths>target/surefire-reports,target/failsafe-reports</sonar.junit.reportPaths>
         <!-- By default, the argLine is empty-->
         <gson.version>2.8.9</gson.version>
-        <argLine />
+        <argLine/>
         <!-- whether enable compiling the cpp client-->
         <client-cpp>false</client-cpp>
         <!-- disable enforcer by default-->
@@ -800,7 +800,7 @@
                             <importOrder>
                                 <order>org.apache.iotdb,,javax,java,\#</order>
                             </importOrder>
-                            <removeUnusedImports />
+                            <removeUnusedImports/>
                         </java>
                         <lineEndings>UNIX</lineEndings>
                     </configuration>
@@ -878,7 +878,7 @@
                         <phase>validate</phase>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                         <goals>
@@ -924,7 +924,7 @@
                                 </requireJavaVersion>
                                 <!-- Disabled for now as it breaks the ability to build single modules -->
                                 <!--reactorModuleConvergence/-->
-                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies" />
+                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
                             </rules>
                         </configuration>
                     </execution>

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
@@ -1539,12 +1539,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     }
     if (nodeName.startsWith(TsFileConstant.BACK_QUOTE_STRING)
         && nodeName.endsWith(TsFileConstant.BACK_QUOTE_STRING)) {
-      String unWrapped = nodeName.substring(1, nodeName.length() - 1);
-      if (PathUtils.isRealNumber(unWrapped)
-          || !TsFileConstant.IDENTIFIER_PATTERN.matcher(unWrapped).matches()) {
-        return nodeName;
-      }
-      return unWrapped;
+      return PathUtils.removeBackQuotesIfNecessary(nodeName);
     }
     checkNodeName(nodeName);
     return nodeName;
@@ -1556,12 +1551,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     }
     if (nodeName.startsWith(TsFileConstant.BACK_QUOTE_STRING)
         && nodeName.endsWith(TsFileConstant.BACK_QUOTE_STRING)) {
-      String unWrapped = nodeName.substring(1, nodeName.length() - 1);
-      if (PathUtils.isRealNumber(unWrapped)
-          || !TsFileConstant.IDENTIFIER_PATTERN.matcher(unWrapped).matches()) {
-        return nodeName;
-      }
-      return unWrapped;
+      return PathUtils.removeBackQuotesIfNecessary(nodeName);
     }
     checkNodeNameInIntoPath(nodeName);
     return nodeName;

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -599,7 +599,10 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // measurementAlias is also a nodeName
-      PathUtils.isLegalSingleMeasurements(Collections.singletonList(req.getMeasurementAlias()));
+      req.setMeasurementAlias(
+          PathUtils.checkIsLegalSingleMeasurementsAndUpdate(
+                  Collections.singletonList(req.getMeasurementAlias()))
+              .get(0));
       // Step 1: transfer from TSCreateTimeseriesReq to Statement
       CreateTimeSeriesStatement statement =
           (CreateTimeSeriesStatement) StatementGenerator.createStatement(req);
@@ -647,9 +650,10 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurements(req.getMeasurementAlias());
+      req.setMeasurementAlias(
+          PathUtils.checkIsLegalSingleMeasurementsAndUpdate(req.getMeasurementAlias()));
 
-      PathUtils.isLegalSingleMeasurements(req.getMeasurements());
+      req.setMeasurements(PathUtils.checkIsLegalSingleMeasurementsAndUpdate(req.getMeasurements()));
 
       // Step 1: transfer from CreateAlignedTimeSeriesReq to Statement
       CreateAlignedTimeSeriesStatement statement =
@@ -698,7 +702,8 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurements(req.getMeasurementAliasList());
+      req.setMeasurementAliasList(
+          PathUtils.checkIsLegalSingleMeasurementsAndUpdate(req.getMeasurementAliasList()));
 
       // Step 1: transfer from CreateMultiTimeSeriesReq to Statement
       CreateMultiTimeSeriesStatement statement =
@@ -951,7 +956,8 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      req.setMeasurementsList(
+          PathUtils.checkIsLegalSingleMeasurementListsAndUpdate(req.getMeasurementsList()));
 
       // Step 1:  transfer from TSInsertRecordsReq to Statement
       InsertRowsStatement statement = (InsertRowsStatement) StatementGenerator.createStatement(req);
@@ -1006,7 +1012,8 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      req.setMeasurementsList(
+          PathUtils.checkIsLegalSingleMeasurementListsAndUpdate(req.getMeasurementsList()));
 
       // Step 1: transfer from TSInsertRecordsOfOneDeviceReq to Statement
       InsertRowsOfOneDeviceStatement statement =
@@ -1062,7 +1069,8 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      req.setMeasurementsList(
+          PathUtils.checkIsLegalSingleMeasurementListsAndUpdate(req.getMeasurementsList()));
 
       // Step 1: transfer from TSInsertStringRecordsOfOneDeviceReq to Statement
       InsertRowsOfOneDeviceStatement statement =
@@ -1119,7 +1127,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
           req.getTimestamp());
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurements(req.getMeasurements());
+      req.setMeasurements(PathUtils.checkIsLegalSingleMeasurementsAndUpdate(req.getMeasurements()));
 
       InsertRowStatement statement = (InsertRowStatement) StatementGenerator.createStatement(req);
       // return success when this statement is empty because server doesn't need to execute it
@@ -1164,7 +1172,8 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
         return getNotLoggedInStatus();
       }
 
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      req.setMeasurementsList(
+          PathUtils.checkIsLegalSingleMeasurementListsAndUpdate(req.getMeasurementsList()));
 
       // Step 1: transfer from TSInsertTabletsReq to Statement
       InsertMultiTabletsStatement statement =
@@ -1212,7 +1221,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurements(req.getMeasurements());
+      req.setMeasurements(PathUtils.checkIsLegalSingleMeasurementsAndUpdate(req.getMeasurements()));
       // Step 1: transfer from TSInsertTabletReq to Statement
       InsertTabletStatement statement =
           (InsertTabletStatement) StatementGenerator.createStatement(req);
@@ -1267,7 +1276,8 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurementLists(req.getMeasurementsList());
+      req.setMeasurementsList(
+          PathUtils.checkIsLegalSingleMeasurementListsAndUpdate(req.getMeasurementsList()));
 
       InsertRowsStatement statement = (InsertRowsStatement) StatementGenerator.createStatement(req);
       // return success when this statement is empty because server doesn't need to execute it
@@ -1731,7 +1741,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
           req.getTimestamp());
 
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalSingleMeasurements(req.getMeasurements());
+      req.setMeasurements(PathUtils.checkIsLegalSingleMeasurementsAndUpdate(req.getMeasurements()));
 
       InsertRowStatement statement = (InsertRowStatement) StatementGenerator.createStatement(req);
 

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -122,7 +122,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -599,10 +598,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // measurementAlias is also a nodeName
-      req.setMeasurementAlias(
-          PathUtils.checkIsLegalSingleMeasurementsAndUpdate(
-                  Collections.singletonList(req.getMeasurementAlias()))
-              .get(0));
+      req.setMeasurementAlias(PathUtils.checkAndReturnSingleMeasurement(req.getMeasurementAlias()));
       // Step 1: transfer from TSCreateTimeseriesReq to Statement
       CreateTimeSeriesStatement statement =
           (CreateTimeSeriesStatement) StatementGenerator.createStatement(req);

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -1042,7 +1042,8 @@ public class TSServiceImpl implements IClientRPCServiceWithHandler {
       }
 
       // measurementAlias is also a nodeName
-      PathUtils.isLegalSingleMeasurements(Collections.singletonList(req.getMeasurementAlias()));
+      PathUtils.checkIsLegalSingleMeasurementsAndUpdate(
+          Collections.singletonList(req.getMeasurementAlias()));
       CreateTimeSeriesPlan plan =
           new CreateTimeSeriesPlan(
               new PartialPath(req.path),
@@ -1072,9 +1073,9 @@ public class TSServiceImpl implements IClientRPCServiceWithHandler {
 
       // check whether measurement is legal according to syntax convention
 
-      PathUtils.isLegalSingleMeasurements(req.getMeasurements());
+      PathUtils.checkIsLegalSingleMeasurementsAndUpdate(req.getMeasurements());
 
-      PathUtils.isLegalSingleMeasurements(req.getMeasurementAlias());
+      PathUtils.checkIsLegalSingleMeasurementsAndUpdate(req.getMeasurementAlias());
 
       if (AUDIT_LOGGER.isDebugEnabled()) {
         AUDIT_LOGGER.debug(
@@ -1135,7 +1136,7 @@ public class TSServiceImpl implements IClientRPCServiceWithHandler {
 
       // measurementAlias is also a nodeName
 
-      PathUtils.isLegalSingleMeasurements(req.measurementAliasList);
+      PathUtils.checkIsLegalSingleMeasurementsAndUpdate(req.measurementAliasList);
 
       CreateMultiTimeSeriesPlan multiPlan = new CreateMultiTimeSeriesPlan();
       List<PartialPath> paths = new ArrayList<>(req.paths.size());
@@ -1255,7 +1256,7 @@ public class TSServiceImpl implements IClientRPCServiceWithHandler {
       ByteBuffer buffer = ByteBuffer.wrap(req.getSerializedTemplate());
       plan = CreateTemplatePlan.deserializeFromReq(buffer);
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalMeasurementLists(plan.getMeasurements());
+      PathUtils.checkIsLegalMeasurementListsAndUpdate(plan.getMeasurements());
       TSStatus status = SESSION_MANAGER.checkAuthority(plan, SESSION_MANAGER.getCurrSession());
 
       return status != null ? status : executeNonQueryPlan(plan);
@@ -1271,7 +1272,7 @@ public class TSServiceImpl implements IClientRPCServiceWithHandler {
   public TSStatus appendSchemaTemplate(TSAppendSchemaTemplateReq req) {
     try {
       // check whether measurement is legal according to syntax convention
-      PathUtils.isLegalMeasurements(req.getMeasurements());
+      PathUtils.checkIsLegalMeasurementsAndUpdate(req.getMeasurements());
     } catch (IoTDBException e) {
       onIoTDBException(e, OperationType.EXECUTE_NON_QUERY_PLAN, e.getErrorCode());
     }


### PR DESCRIPTION
 Previously we forget to update the checked measurements as node name  like \`aa\` should be stored as aa.