### PR TITLE
[IOTDB-5135] Sync snapshot fails when sync file is empty.

### DIFF
--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/ClusterSyncInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/ClusterSyncInfoTest.java
@@ -82,10 +82,24 @@ public class ClusterSyncInfoTest {
   }
 
   @Test
-  public void testSnapshot() throws Exception {
-    prepareClusterSyncInfo();
+  public void testEmptySnapshot() throws Exception {
+    // test empty snapshot
+    Assert.assertTrue(clusterSyncInfo.processTakeSnapshot(snapshotDir));
+    ClusterSyncInfo clusterSyncInfo2 = new ClusterSyncInfo();
+    clusterSyncInfo2.processLoadSnapshot(snapshotDir);
 
-    clusterSyncInfo.processTakeSnapshot(snapshotDir);
+    List<PipeSink> expectedPipeSink =
+        clusterSyncInfo.getPipeSink(new GetPipeSinkPlan()).getPipeSinkList();
+    List<PipeSink> actualPipeSink =
+        clusterSyncInfo2.getPipeSink(new GetPipeSinkPlan()).getPipeSinkList();
+    Assert.assertEquals(expectedPipeSink, actualPipeSink);
+  }
+
+  @Test
+  public void testSnapshot() throws Exception {
+    // test snapshot with data
+    prepareClusterSyncInfo();
+    Assert.assertTrue(clusterSyncInfo.processTakeSnapshot(snapshotDir));
     ClusterSyncInfo clusterSyncInfo2 = new ClusterSyncInfo();
     clusterSyncInfo2.processLoadSnapshot(snapshotDir);
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/metadata/SyncMetadata.java
@@ -200,6 +200,7 @@ public class SyncMetadata implements SnapshotProcessor {
     }
     File tmpFile = new File(snapshotFile.getAbsolutePath() + "-" + UUID.randomUUID());
     try (SyncLogWriter writer = new SyncLogWriter(snapshotDir, tmpFile.getName())) {
+      writer.initOutputStream();
       for (PipeSink pipeSink : pipeSinks.values()) {
         writer.addPipeSink(pipeSink);
       }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/sync/persistence/SyncLogWriter.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/sync/persistence/SyncLogWriter.java
@@ -49,9 +49,8 @@ public class SyncLogWriter implements AutoCloseable {
     this.fileName = fileName;
   }
 
-  public void getOutputStream() throws IOException {
+  public void initOutputStream() throws IOException {
     if (outputStream == null) {
-      //      File logFile = new File(SyncPathUtil.getSysDir(), SyncConstant.SYNC_LOG_NAME);
       File logFile = new File(dir, fileName);
       if (!logFile.getParentFile().exists()) {
         logFile.getParentFile().mkdirs();
@@ -61,26 +60,26 @@ public class SyncLogWriter implements AutoCloseable {
   }
 
   public synchronized void addPipeSink(PipeSink pipeSink) throws IOException {
-    getOutputStream();
+    initOutputStream();
     ReadWriteIOUtils.write((byte) SyncOperation.CREATE_PIPESINK.ordinal(), outputStream);
     pipeSink.serialize(outputStream);
   }
 
   public synchronized void dropPipeSink(String pipeSinkName) throws IOException {
-    getOutputStream();
+    initOutputStream();
     ReadWriteIOUtils.write((byte) SyncOperation.DROP_PIPESINK.ordinal(), outputStream);
     ReadWriteIOUtils.write(pipeSinkName, outputStream);
   }
 
   public synchronized void addPipe(PipeInfo pipeInfo) throws IOException {
-    getOutputStream();
+    initOutputStream();
     ReadWriteIOUtils.write((byte) SyncOperation.CREATE_PIPE.ordinal(), outputStream);
     pipeInfo.serialize(outputStream);
   }
 
   public synchronized void operatePipe(String pipeName, SyncOperation syncOperation)
       throws IOException {
-    getOutputStream();
+    initOutputStream();
     ReadWriteIOUtils.write((byte) syncOperation.ordinal(), outputStream);
     ReadWriteIOUtils.write(pipeName, outputStream);
   }


### PR DESCRIPTION
## Description

This problem is caused by the fact that when `ClusterSyncInfo` is empty, `SyncLogWriter` will not generate a tmpFile and `tmpFile.renameTo(snapshotFile)` will return false.

## Solution

Force the file to be initialised when taking a snapshot.