### PR TITLE
[IOTDB-5158] Fix InputStream may skip over some smaller number of bytes 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
@@ -163,11 +163,11 @@ public class DeviceTimeIndex implements ITimeIndex {
    */
   public static Set<String> getDevices(InputStream inputStream) throws IOException {
     int deviceNum = ReadWriteIOUtils.readInt(inputStream);
-    inputStream.skip(2L * deviceNum * ReadWriteIOUtils.LONG_LEN);
+    ReadWriteIOUtils.skip(inputStream, 2L * deviceNum * ReadWriteIOUtils.LONG_LEN);
     Set<String> devices = new HashSet<>();
     for (int i = 0; i < deviceNum; i++) {
       String path = ReadWriteIOUtils.readString(inputStream).intern();
-      inputStream.skip(ReadWriteIOUtils.INT_LEN);
+      ReadWriteIOUtils.skip(inputStream, ReadWriteIOUtils.INT_LEN);
       devices.add(path);
     }
     return devices;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/ChunkHeader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/ChunkHeader.java
@@ -206,7 +206,7 @@ public class ChunkHeader {
   public static Pair<CompressionType, TSEncoding> deserializeCompressionTypeAndEncoding(
       InputStream inputStream) throws IOException {
     ReadWriteForEncodingUtils.readUnsignedVarInt(inputStream);
-    inputStream.skip(Byte.BYTES); // skip Data type
+    ReadWriteIOUtils.skip(inputStream, Byte.BYTES); // skip Data type
     CompressionType type = ReadWriteIOUtils.readCompressionType(inputStream);
     TSEncoding encoding = ReadWriteIOUtils.readEncoding(inputStream);
     return new Pair<>(type, encoding);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
@@ -1059,4 +1059,28 @@ public class ReadWriteIOUtils {
     clone.flip();
     return clone;
   }
+
+  /**
+   * The skip method of will return only if skipping n bytes or reaching end of file.
+   *
+   * @param inputStream the inputSteam to be skipped.
+   * @param n the number of bytes to be skipped.
+   * @throws IOException if the stream does not support seek, or if some other I/O error occurs.
+   */
+  public static void skip(InputStream inputStream, long n) throws IOException {
+    while (n > 0) {
+      long skipN = inputStream.skip(n);
+      if (skipN > 0) {
+        n -= skipN;
+      } else {
+        // read one byte to decide should we retry
+        if (inputStream.read() == -1) {
+          // EOF
+          break;
+        } else {
+          n--;
+        }
+      }
+    }
+  }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtilsTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtilsTest.java
@@ -21,6 +21,8 @@ package org.apache.iotdb.tsfile.utils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -162,5 +164,28 @@ public class ReadWriteIOUtilsTest {
     }
     result = ReadWriteIOUtils.readMap(ByteBuffer.wrap(byteArrayOutputStream.toByteArray()));
     Assert.assertNull(result);
+  }
+
+  @Test
+  public void skipInputStreamTest() {
+    int expectedSkipNum = 9000;
+    int totalNum = 10000;
+    try (BufferedInputStream inputStream =
+        new BufferedInputStream(new ByteArrayInputStream(new byte[totalNum]))) {
+      ReadWriteIOUtils.readByte(inputStream);
+      long skipN = inputStream.skip(expectedSkipNum);
+      Assert.assertNotEquals(expectedSkipNum, skipN);
+      Assert.assertNotEquals(totalNum - expectedSkipNum - 1, inputStream.available());
+    } catch (IOException e) {
+      Assert.fail(e.getMessage());
+    }
+    try (BufferedInputStream inputStream =
+        new BufferedInputStream(new ByteArrayInputStream(new byte[totalNum]))) {
+      ReadWriteIOUtils.readByte(inputStream);
+      ReadWriteIOUtils.skip(inputStream, expectedSkipNum);
+      Assert.assertEquals(totalNum - expectedSkipNum - 1, inputStream.available());
+    } catch (IOException e) {
+      Assert.fail(e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
## Description


`InputStream` may skip over some smaller number of bytes. So I implement a skip method in ReadWriteIOUtils to guarantee skip n bytes or reach end of file.