### PR TITLE
[IOTDB-5054] Fix errors in IoTDBPipeIT

### DIFF
--- a/integration-test/import-control.xml
+++ b/integration-test/import-control.xml
@@ -22,6 +22,7 @@
   <disallow class="java.sql.DriverManager"/>
   <disallow class="javax.sql.DataSource"/>
   <allow class="java.security.SecureRandom" />
+  <allow class="org.awaitility.Awaitility"/>
   <allow pkg="org\.junit.*" regex="true"/>
   <allow pkg="java.io" />
   <allow pkg="java.nio"/>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>rewrite-tsfile-tool</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
@@ -37,7 +37,9 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.iotdb.db.it.utils.TestUtils.assertResultSetEqual;
+import static org.awaitility.Awaitility.await;
 
 @RunWith(IoTDBTestRunner.class)
 @Category({LocalStandaloneIT.class, ClusterIT.class})
@@ -110,6 +112,18 @@ public class IoTDBPipeIT {
         assertResultSetEqual(resultSet, SHOW_PIPE_HEADER, expectedRetSet);
       }
       statement.execute("START PIPE p1;");
+      await()
+          .atMost(5, SECONDS)
+          .until(
+              () -> {
+                try (ResultSet resultSet = statement.executeQuery("SHOW PIPE")) {
+                  int cnt = 0;
+                  while (resultSet.next()) {
+                    cnt++;
+                  }
+                  return cnt == 2;
+                }
+              });
       try (ResultSet resultSet = statement.executeQuery("SHOW PIPE")) {
         String[] expectedRetSet =
             new String[] {

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/sync/IoTDBPipeIT.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
 import org.apache.commons.lang3.StringUtils;
+import org.awaitility.Awaitility;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -39,7 +40,6 @@ import java.sql.Statement;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.iotdb.db.it.utils.TestUtils.assertResultSetEqual;
-import static org.awaitility.Awaitility.await;
 
 @RunWith(IoTDBTestRunner.class)
 @Category({LocalStandaloneIT.class, ClusterIT.class})
@@ -112,7 +112,7 @@ public class IoTDBPipeIT {
         assertResultSetEqual(resultSet, SHOW_PIPE_HEADER, expectedRetSet);
       }
       statement.execute("START PIPE p1;");
-      await()
+      Awaitility.await()
           .atMost(5, SECONDS)
           .until(
               () -> {


### PR DESCRIPTION
## Description

Fix errors in IoTDBPipeIT.

This error may be caused by an asynchronous operation that has not completed. According to the writing specification., I use `Awaitility.await` to avoid this error.