### PR TITLE
[IOTDB-5199]fix NPE in StorageExector inLoading process

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/ExecutorType.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/ExecutorType.java
@@ -33,8 +33,4 @@ public interface ExecutorType {
   default TRegionReplicaSet getRegionReplicaSet() {
     throw new UnsupportedOperationException(getClass().getName());
   }
-
-  default void setRegionReplicaSet(TRegionReplicaSet regionReplicaSet) {
-    throw new UnsupportedOperationException(getClass().getName());
-  }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/StorageExecutor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/StorageExecutor.java
@@ -22,21 +22,20 @@ package org.apache.iotdb.commons.partition;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 
+import javax.annotation.Nonnull;
+
 import java.util.Objects;
 
 /** StorageExecutor indicates execution of this query need data from StorageEngine */
 public class StorageExecutor implements ExecutorType {
-  private TRegionReplicaSet regionReplicaSet;
+  private final TRegionReplicaSet regionReplicaSet;
 
-  public StorageExecutor(TRegionReplicaSet regionReplicaSet) {
+  public StorageExecutor(@Nonnull TRegionReplicaSet regionReplicaSet) {
     this.regionReplicaSet = regionReplicaSet;
   }
 
   @Override
   public TDataNodeLocation getDataNodeLocation() {
-    if (regionReplicaSet == null || regionReplicaSet.getDataNodeLocations() == null) {
-      return null;
-    }
     return regionReplicaSet.getDataNodeLocations().get(0);
   }
 
@@ -48,11 +47,6 @@ public class StorageExecutor implements ExecutorType {
   @Override
   public TRegionReplicaSet getRegionReplicaSet() {
     return regionReplicaSet;
-  }
-
-  @Override
-  public void setRegionReplicaSet(TRegionReplicaSet regionReplicaSet) {
-    this.regionReplicaSet = regionReplicaSet;
   }
 
   @Override

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/StorageExecutor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/StorageExecutor.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.commons.partition;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 
-import java.util.List;
 import java.util.Objects;
 
 /** StorageExecutor indicates execution of this query need data from StorageEngine */
@@ -35,8 +34,7 @@ public class StorageExecutor implements ExecutorType {
 
   @Override
   public TDataNodeLocation getDataNodeLocation() {
-    List<TDataNodeLocation> dataNodeLocations = regionReplicaSet.getDataNodeLocations();
-    if (dataNodeLocations == null) {
+    if (regionReplicaSet == null || regionReplicaSet.getDataNodeLocations() == null) {
       return null;
     }
     return regionReplicaSet.getDataNodeLocations().get(0);

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/StorageExecutor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/StorageExecutor.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.commons.partition;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 
+import java.util.List;
 import java.util.Objects;
 
 /** StorageExecutor indicates execution of this query need data from StorageEngine */
@@ -34,6 +35,10 @@ public class StorageExecutor implements ExecutorType {
 
   @Override
   public TDataNodeLocation getDataNodeLocation() {
+    List<TDataNodeLocation> dataNodeLocations = regionReplicaSet.getDataNodeLocations();
+    if (dataNodeLocations == null) {
+      return null;
+    }
     return regionReplicaSet.getDataNodeLocations().get(0);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/WriteFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/WriteFragmentParallelPlanner.java
@@ -65,7 +65,9 @@ public class WriteFragmentParallelPlanner implements IFragmentParallelPlaner {
               queryContext.getQueryType(),
               queryContext.getTimeOut(),
               queryContext.getSession());
-      instance.setExecutorAndHost(new StorageExecutor(split.getRegionReplicaSet()));
+      if (split.getRegionReplicaSet() != null) {
+        instance.setExecutorAndHost(new StorageExecutor(split.getRegionReplicaSet()));
+      }
       ret.add(instance);
     }
     return ret;


### PR DESCRIPTION
cause: The `RegionReplicset` of `StorageExecutor` may be null.