### PR TITLE
[IOTDB-5061] Add initialize state check when create snapshot

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -439,7 +439,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   public synchronized boolean createSnapshot(File snapshotDir) {
     if (!initialized) {
       logger.warn(
-          "Failed to create snapshot of schemaRegion {}, because thi schemaRegion has not been initialized.",
+          "Failed to create snapshot of schemaRegion {}, because the schemaRegion has not been initialized.",
           schemaRegionId);
       return false;
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -437,6 +437,12 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   // currently, this method is only used for cluster-ratis mode
   @Override
   public synchronized boolean createSnapshot(File snapshotDir) {
+    if (!initialized) {
+      logger.info(
+          "Failed to create snapshot of schemaRegion {}, because thi schemaRegion has not been initialized.",
+          schemaRegionId);
+      return false;
+    }
     logger.info("Start create snapshot of schemaRegion {}", schemaRegionId);
     boolean isSuccess = true;
     long startTime = System.currentTimeMillis();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -438,7 +438,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   @Override
   public synchronized boolean createSnapshot(File snapshotDir) {
     if (!initialized) {
-      logger.info(
+      logger.warn(
           "Failed to create snapshot of schemaRegion {}, because thi schemaRegion has not been initialized.",
           schemaRegionId);
       return false;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -426,7 +426,7 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   public boolean createSnapshot(File snapshotDir) {
     if (!initialized) {
       logger.warn(
-          "Failed to create snapshot of schemaRegion {}, because thi schemaRegion has not been initialized.",
+          "Failed to create snapshot of schemaRegion {}, because the schemaRegion has not been initialized.",
           schemaRegionId);
       return false;
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -424,6 +424,12 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
 
   @Override
   public boolean createSnapshot(File snapshotDir) {
+    if (!initialized) {
+      logger.info(
+          "Failed to create snapshot of schemaRegion {}, because thi schemaRegion has not been initialized.",
+          schemaRegionId);
+      return false;
+    }
     logger.info("Start create snapshot of schemaRegion {}", schemaRegionId);
     boolean isSuccess = true;
     long startTime = System.currentTimeMillis();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -425,7 +425,7 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   @Override
   public boolean createSnapshot(File snapshotDir) {
     if (!initialized) {
-      logger.info(
+      logger.warn(
           "Failed to create snapshot of schemaRegion {}, because thi schemaRegion has not been initialized.",
           schemaRegionId);
       return false;


### PR DESCRIPTION
## Description

When the schemaRegion is not initialized or has been cleared, the create snapshot operation may result in NPE.
