### PR TITLE
[IOTDB-5061] Add message in RatisRequestFailed

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/exception/RatisRequestFailedException.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/exception/RatisRequestFailedException.java
@@ -18,9 +18,14 @@
  */
 package org.apache.iotdb.consensus.exception;
 
+import java.util.Optional;
+
 public class RatisRequestFailedException extends ConsensusException {
 
   public RatisRequestFailedException(Exception cause) {
-    super("Ratis request failed", cause);
+    super(
+        "Ratis request failed "
+            + Optional.ofNullable(cause).map(Exception::getMessage).orElse("Unknown"),
+        cause);
   }
 }


### PR DESCRIPTION
Currently cause is not serialized and returned to confignode. Add detailed message so that the cause is contained in the error message.