### PR TITLE
[IOTDB-5174] Use filename format such as NodeID-Index rather than Endpoint-Index to track follower sync progress

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexController.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexController.java
@@ -40,7 +40,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @ThreadSafe
 public class IndexController {
 
-  public static final String separator = "-";
+  public static final String SEPARATOR = "-";
 
   private final Logger logger = LoggerFactory.getLogger(IndexController.class);
 
@@ -60,7 +60,7 @@ public class IndexController {
   public IndexController(String storageDir, Peer peer, long initialIndex, long checkpointGap) {
     this.storageDir = storageDir;
     this.peer = peer;
-    this.prefix = peer.getNodeId() + separator;
+    this.prefix = peer.getNodeId() + SEPARATOR;
     this.checkpointGap = checkpointGap;
     this.initialIndex = initialIndex;
     // This is because we changed the name of the version file in version 1.0.1. In order to ensure
@@ -139,14 +139,14 @@ public class IndexController {
 
   private void upgrade() {
     File directory = new File(storageDir);
-    String oldPrefix = Utils.fromTEndPointToString(peer.getEndpoint()) + separator;
+    String oldPrefix = Utils.fromTEndPointToString(peer.getEndpoint()) + SEPARATOR;
     Optional.ofNullable(directory.listFiles((dir, name) -> name.startsWith(oldPrefix)))
         .ifPresent(
             files ->
                 Arrays.stream(files)
                     .forEach(
                         oldFile -> {
-                          String[] splits = oldFile.getName().split(separator);
+                          String[] splits = oldFile.getName().split(SEPARATOR);
                           long fileVersion = Long.parseLong(splits[splits.length - 1]);
                           File newFile = new File(storageDir, prefix + fileVersion);
                           try {
@@ -169,7 +169,7 @@ public class IndexController {
       long maxVersion = 0;
       int maxVersionIndex = 0;
       for (int i = 0; i < versionFiles.length; i++) {
-        long fileVersion = Long.parseLong(versionFiles[i].getName().split(separator)[1]);
+        long fileVersion = Long.parseLong(versionFiles[i].getName().split(SEPARATOR)[1]);
         if (fileVersion > maxVersion) {
           maxVersion = fileVersion;
           maxVersionIndex = i;

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexController.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexController.java
@@ -40,6 +40,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @ThreadSafe
 public class IndexController {
 
+  public static final String separator = "-";
+
   private final Logger logger = LoggerFactory.getLogger(IndexController.class);
 
   private long lastFlushedIndex;
@@ -58,7 +60,7 @@ public class IndexController {
   public IndexController(String storageDir, Peer peer, long initialIndex, long checkpointGap) {
     this.storageDir = storageDir;
     this.peer = peer;
-    this.prefix = peer.getNodeId() + "-";
+    this.prefix = peer.getNodeId() + separator;
     this.checkpointGap = checkpointGap;
     this.initialIndex = initialIndex;
     // This is because we changed the name of the version file in version 1.0.1. In order to ensure
@@ -137,14 +139,15 @@ public class IndexController {
 
   private void upgrade() {
     File directory = new File(storageDir);
-    String oldPrefix = Utils.fromTEndPointToString(peer.getEndpoint()) + "-";
+    String oldPrefix = Utils.fromTEndPointToString(peer.getEndpoint()) + separator;
     Optional.ofNullable(directory.listFiles((dir, name) -> name.startsWith(oldPrefix)))
         .ifPresent(
             files ->
                 Arrays.stream(files)
                     .forEach(
                         oldFile -> {
-                          long fileVersion = Long.parseLong(oldFile.getName().split("-")[1]);
+                          String[] splits = oldFile.getName().split(separator);
+                          long fileVersion = Long.parseLong(splits[splits.length - 1]);
                           File newFile = new File(storageDir, prefix + fileVersion);
                           try {
                             logger.info(
@@ -166,7 +169,7 @@ public class IndexController {
       long maxVersion = 0;
       int maxVersionIndex = 0;
       for (int i = 0; i < versionFiles.length; i++) {
-        long fileVersion = Long.parseLong(versionFiles[i].getName().split("-")[1]);
+        long fileVersion = Long.parseLong(versionFiles[i].getName().split(separator)[1]);
         if (fileVersion > maxVersion) {
           maxVersion = fileVersion;
           maxVersionIndex = i;

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -35,7 +35,6 @@ import org.apache.iotdb.consensus.iot.thrift.TLogBatch;
 import org.apache.iotdb.consensus.iot.thrift.TSyncLogReq;
 import org.apache.iotdb.consensus.iot.wal.ConsensusReqReader;
 import org.apache.iotdb.consensus.iot.wal.GetConsensusReqReaderPlan;
-import org.apache.iotdb.consensus.ratis.Utils;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 
 import org.apache.thrift.TException;
@@ -204,7 +203,7 @@ public class LogDispatcher {
       this.controller =
           new IndexController(
               impl.getStorageDir(),
-              Utils.fromTEndPointToString(peer.getEndpoint()),
+              peer,
               initialSyncIndex,
               config.getReplication().getCheckpointGap());
       this.syncStatus = new SyncStatus(controller, config);

--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexControllerTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexControllerTest.java
@@ -39,7 +39,7 @@ public class IndexControllerTest {
   private static final File storageDir = new File("target" + java.io.File.separator + "test");
 
   private static final Peer peer =
-      new Peer(new DataRegionId(1), 2, new TEndPoint("127.0.0.1", 6667));
+      new Peer(new DataRegionId(1), 2, new TEndPoint("datanode-1.datanode-svc", 6667));
 
   private static final long CHECK_POINT_GAP = 500;
 
@@ -93,14 +93,16 @@ public class IndexControllerTest {
   @Test
   public void testUpgrade() throws IOException {
     File oldFile =
-        new File(storageDir, Utils.fromTEndPointToString(peer.getEndpoint()) + "-" + 100);
+        new File(
+            storageDir,
+            Utils.fromTEndPointToString(peer.getEndpoint()) + IndexController.separator + 100);
     Files.createFile(oldFile.toPath());
 
     IndexController controller =
         new IndexController(storageDir.getAbsolutePath(), peer, 0, CHECK_POINT_GAP);
     Assert.assertEquals(100, controller.getCurrentIndex());
 
-    File newFile = new File(storageDir, peer.getNodeId() + "-" + 100);
+    File newFile = new File(storageDir, peer.getNodeId() + IndexController.separator + 100);
     Assert.assertTrue(newFile.exists());
   }
 }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexControllerTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexControllerTest.java
@@ -95,14 +95,14 @@ public class IndexControllerTest {
     File oldFile =
         new File(
             storageDir,
-            Utils.fromTEndPointToString(peer.getEndpoint()) + IndexController.separator + 100);
+            Utils.fromTEndPointToString(peer.getEndpoint()) + IndexController.SEPARATOR + 100);
     Files.createFile(oldFile.toPath());
 
     IndexController controller =
         new IndexController(storageDir.getAbsolutePath(), peer, 0, CHECK_POINT_GAP);
     Assert.assertEquals(100, controller.getCurrentIndex());
 
-    File newFile = new File(storageDir, peer.getNodeId() + IndexController.separator + 100);
+    File newFile = new File(storageDir, peer.getNodeId() + IndexController.SEPARATOR + 100);
     Assert.assertTrue(newFile.exists());
   }
 }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatusTest.java
@@ -19,6 +19,9 @@
 
 package org.apache.iotdb.consensus.iot.logdispatcher;
 
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+import org.apache.iotdb.commons.consensus.DataRegionId;
+import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.config.IoTConsensusConfig;
 import org.apache.iotdb.consensus.iot.thrift.TLogBatch;
 
@@ -38,7 +41,9 @@ import java.util.concurrent.ExecutionException;
 public class SyncStatusTest {
 
   private static final File storageDir = new File("target" + java.io.File.separator + "test");
-  private static final String prefix = "version";
+
+  private static final Peer peer =
+      new Peer(new DataRegionId(1), 2, new TEndPoint("127.0.0.1", 6667));
   private static final IoTConsensusConfig config = new IoTConsensusConfig.Builder().build();
   private static final long CHECK_POINT_GAP = 500;
 
@@ -56,7 +61,7 @@ public class SyncStatusTest {
   @Test
   public void sequenceTest() throws InterruptedException {
     IndexController controller =
-        new IndexController(storageDir.getAbsolutePath(), prefix, 0, CHECK_POINT_GAP);
+        new IndexController(storageDir.getAbsolutePath(), peer, 0, CHECK_POINT_GAP);
     Assert.assertEquals(0, controller.getCurrentIndex());
 
     SyncStatus status = new SyncStatus(controller, config);
@@ -86,7 +91,7 @@ public class SyncStatusTest {
   @Test
   public void reverseTest() throws InterruptedException {
     IndexController controller =
-        new IndexController(storageDir.getAbsolutePath(), prefix, 0, CHECK_POINT_GAP);
+        new IndexController(storageDir.getAbsolutePath(), peer, 0, CHECK_POINT_GAP);
     Assert.assertEquals(0, controller.getCurrentIndex());
     Assert.assertEquals(0, controller.getLastFlushedIndex());
 
@@ -123,7 +128,7 @@ public class SyncStatusTest {
   @Test
   public void mixedTest() throws InterruptedException {
     IndexController controller =
-        new IndexController(storageDir.getAbsolutePath(), prefix, 0, CHECK_POINT_GAP);
+        new IndexController(storageDir.getAbsolutePath(), peer, 0, CHECK_POINT_GAP);
     Assert.assertEquals(0, controller.getCurrentIndex());
     Assert.assertEquals(0, controller.getLastFlushedIndex());
 
@@ -172,7 +177,7 @@ public class SyncStatusTest {
   @Test
   public void waitTest() throws InterruptedException, ExecutionException {
     IndexController controller =
-        new IndexController(storageDir.getAbsolutePath(), prefix, 0, CHECK_POINT_GAP);
+        new IndexController(storageDir.getAbsolutePath(), peer, 0, CHECK_POINT_GAP);
     Assert.assertEquals(0, controller.getCurrentIndex());
 
     SyncStatus status = new SyncStatus(controller, config);


### PR DESCRIPTION
see [jira5174](https://issues.apache.org/jira/browse/IOTDB-5174)