### PR TITLE
[IOTDB-5153] Fix dead lock in confignode

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -171,11 +171,11 @@ public class ConfigPlanExecutor {
     this.authorInfo = authorInfo;
     this.snapshotProcessorList.add(authorInfo);
 
-    this.udfInfo = udfInfo;
-    this.snapshotProcessorList.add(udfInfo);
-
     this.triggerInfo = triggerInfo;
     this.snapshotProcessorList.add(triggerInfo);
+
+    this.udfInfo = udfInfo;
+    this.snapshotProcessorList.add(udfInfo);
 
     this.syncInfo = syncInfo;
     this.snapshotProcessorList.add(syncInfo);
@@ -398,7 +398,7 @@ public class ConfigPlanExecutor {
 
     AtomicBoolean result = new AtomicBoolean(true);
     snapshotProcessorList
-        .parallelStream()
+        .stream()
         .forEach(
             x -> {
               boolean takeSnapshotResult = true;


### PR DESCRIPTION
1. In register datanode, the trigger lock and udf lock are acquired sequentially.
2. In snapshot, this sequential order is not guaranteed. We have to guarantee the order to avoid dead lock.