### PR TITLE
add instruction about how to allow large java file generated by Thrift in IDEA

### DIFF
--- a/docs/Development/ContributeGuide.md
+++ b/docs/Development/ContributeGuide.md
@@ -191,7 +191,7 @@ import -> Maven -> Existing Maven Projects
 
 # Frequent Questions When Compiling the Source Code
 
-I could not download thrift-* tools, like `Could not get content
+>Q: I could not download thrift-* tools, like `Could not get content
 org.apache.maven.wagon.TransferFailedException: Transfer failed for https://github.com/apache/iotdb-bin-resources/blob/main/compile-tools/thrift-0.14-ubuntu`
 
  It is due to some network problems (especially in China), you can:
@@ -204,6 +204,18 @@ org.apache.maven.wagon.TransferFailedException: Transfer failed for https://gith
  * Put the file to thrift/target/tools/
 
  * Re-run maven command like `mvn compile`
+
+ 
+ >Q: IConfigNodeRPCService class is unrecognized (IDEA can not find the class even though we have generated it)
+
+ It is because Thrift generate the file too large, which exceeds the lines that IDEA can parse by default. You can find that file and then you will see IDEA claims that. To make it work, you can:
+ 
+ * Click "Help" menu of IDEA
+ * Choose "Edit Customed Properties"
+ * On the opened file (`idea.properties`), add: `idea.max.intellisense.filesize=9000`
+ * Restart IDEA
+ 
+ 
 
 
 ## Recommended Debug Tool 


### PR DESCRIPTION
this PR only modifies a doc.