### PR TITLE
[To rel/1.0] [IOTDB-5125] Change default port and stop the process when port is already in use

### DIFF
--- a/confignode/src/assembly/resources/sbin/start-confignode.bat
+++ b/confignode/src/assembly/resources/sbin/start-confignode.bat
@@ -75,8 +75,61 @@ for %%i in (%*) do (
 IF EXIST "%CONFIGNODE_CONF%\confignode-env.bat" (
     CALL "%CONFIGNODE_CONF%\confignode-env.bat" %1
     ) ELSE (
-    echo "can't find %CONFIGNODE_CONF%\confignode-env.bat"
+    echo "Can't find %CONFIGNODE_CONF%\confignode-env.bat"
     )
+
+@REM CHECK THE PORT USAGES
+IF EXIST "%CONFIGNODE_CONF%\iotdb-confignode.properties" (
+  for /f  "eol=# tokens=2 delims==" %%i in ('findstr /i "^cn_internal_port"
+    %CONFIGNODE_CONF%\iotdb-confignode.properties') do (
+      set cn_internal_port=%%i
+  )
+  for /f  "eol=# tokens=2 delims==" %%i in ('findstr /i "^cn_consensus_port"
+    %CONFIGNODE_CONF%\iotdb-confignode.properties') do (
+      set cn_consensus_port=%%i
+  )
+) ELSE IF EXIST "%CONFIGNODE_HOME%\conf\iotdb-confignode.properties" (
+  for /f  "eol=# tokens=2 delims==" %%i in ('findstr /i "^cn_internal_port"
+      %CONFIGNODE_HOME%\conf\iotdb-confignode.properties') do (
+        set cn_internal_port=%%i
+  )
+  for /f  "eol=# tokens=2 delims==" %%i in ('findstr /i "^cn_consensus_port"
+      %CONFIGNODE_HOME%\conf\iotdb-confignode.properties') do (
+        set cn_consensus_port=%%i
+  )
+) ELSE (
+  echo "Can't find iotdb-confignode.properties, check the default ports"
+  set cn_internal_port=22277
+  set cn_consensus_port=22278
+)
+
+echo Check whether the ports are occupied....
+set occupied=0
+set cn_internal_port_occupied=0
+set cn_consensus_port_occupied=0
+for /f  "tokens=1,3,7 delims=: " %%i in ('netstat /ano') do (
+    if %%i==TCP (
+       if %%j==%cn_internal_port% (
+         if !cn_internal_port_occupied!==0 (
+           echo The cn_internal_port %cn_internal_port% is already occupied, pid:%%k
+           set occupied=1
+           set cn_internal_port_occupied=1
+         )
+       ) else if %%j==%cn_consensus_port% (
+         if !cn_consensus_port_occupied!==0 (
+           echo The cn_consensus_port %cn_consensus_port% is already occupied, pid:%%k
+           set occupied=1
+           set cn_consensus_port_occupied=1
+         )
+       )
+    )
+)
+
+if %occupied%==1 (
+  echo There exists occupied port, please change the configuration.
+  TIMEOUT /T 10 /NOBREAK
+  exit 0
+)
 
 set CONF_PARAMS=-s
 if NOT DEFINED MAIN_CLASS set MAIN_CLASS=org.apache.iotdb.confignode.service.ConfigNode

--- a/confignode/src/assembly/resources/sbin/stop-confignode.sh
+++ b/confignode/src/assembly/resources/sbin/stop-confignode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -19,12 +19,12 @@
 #
 
 CONFIGNODE_CONF="$(dirname "$0")/../conf"
-cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' ${CONFIGNODE_CONF}/iotdb-confignode.properties)
+cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-confignode.properties)
 
-echo "check whether the internal_port is used..., port is" $cn_internal_port
+echo Check whether the internal_port is used..., port is "$cn_internal_port"
 
 if type lsof >/dev/null 2>&1; then
-  PID=$(lsof -t -i:${cn_internal_port} -sTCP:LISTEN)
+  PID=$(lsof -t -i:"${cn_internal_port}" -sTCP:LISTEN)
 elif type netstat >/dev/null 2>&1; then
   PID=$(netstat -anp 2>/dev/null | grep ":${cn_internal_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g")
 else
@@ -34,10 +34,17 @@ else
   exit 1
 fi
 
+PID_VERIFY=$(ps ax | grep -i 'ConfigNode' | grep java | grep -v grep | awk '{print $1}')
 if [ -z "$PID" ]; then
   echo "No ConfigNode to stop"
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Maybe you can try to run in sudo mode to detect the process."
+  fi
   exit 1
+elif [[ "${PID_VERIFY}" =~ ${PID} ]]; then
+  kill -s TERM "$PID"
+  echo "Close ConfigNode, PID:" "$PID"
 else
-  kill -s TERM $PID
-  echo "close ConfigNode, PID:" $PID
+  echo "No ConfigNode to stop"
+  exit 1
 fi

--- a/node-commons/src/assembly/resources/sbin/iotdb-common.sh
+++ b/node-commons/src/assembly/resources/sbin/iotdb-common.sh
@@ -150,6 +150,143 @@ checkAllConfigNodeVariables()
   fi
 }
 
+checkDataNodePortUsages () {
+  echo "Checking whether the ports are already occupied..."
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Warning: If you do not use sudo, the checking may not detect all the occupied ports."
+  fi
+  occupied=false
+  if [ -f "$IOTDB_CONF/iotdb-datanode.properties" ]; then
+    dn_rpc_port=$(sed '/^dn_rpc_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
+    dn_internal_port=$(sed '/^dn_internal_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
+    dn_mpp_data_exchange_port=$(sed '/^dn_mpp_data_exchange_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
+    dn_schema_region_consensus_port=$(sed '/^dn_schema_region_consensus_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
+    dn_data_region_consensus_port=$(sed '/^dn_data_region_consensus_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
+  elif [ -f "$IOTDB_HOME/conf/iotdb-datanode.properties" ]; then
+    dn_rpc_port=$(sed '/^dn_rpc_port=/!d;s/.*=//' "${IOTDB_HOME}"/conf/iotdb-datanode.properties)
+    dn_internal_port=$(sed '/^dn_internal_port=/!d;s/.*=//' "${IOTDB_HOME}"/conf/iotdb-datanode.properties)
+    dn_mpp_data_exchange_port=$(sed '/^dn_mpp_data_exchange_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
+    dn_schema_region_consensus_port=$(sed '/^dn_schema_region_consensus_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
+    dn_data_region_consensus_port=$(sed '/^dn_data_region_consensus_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
+  else
+    echo "Warning: cannot find iotdb-datanode.properties, check the default configuration"
+    dn_rpc_port=6667
+    dn_internal_port=9003
+    dn_mpp_data_exchange_port=8777
+    dn_schema_region_consensus_port=50010
+    dn_data_region_consensus_port=40010
+  fi
+  if type lsof >/dev/null 2>&1; then
+    PID=$(lsof -t -i:"${dn_rpc_port}" -sTCP:LISTEN)
+    if [ -n "$PID" ]; then
+      echo "The dn_rpc_port" "$dn_rpc_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(lsof -t -i:"${dn_internal_port}" -sTCP:LISTEN)
+    if [ -n "$PID" ]; then
+      echo "The dn_internal_port" "$dn_internal_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(lsof -t -i:"${dn_mpp_data_exchange_port}" -sTCP:LISTEN)
+    if [ -n "$PID" ]; then
+      echo "The dn_mpp_data_exchange_port" "$dn_mpp_data_exchange_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(lsof -t -i:"${dn_schema_region_consensus_port}" -sTCP:LISTEN)
+    if [ -n "$PID" ]; then
+      echo "The dn_schema_region_consensus_port" "$dn_schema_region_consensus_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(lsof -t -i:"${dn_data_region_consensus_port}" -sTCP:LISTEN)
+    if [ -n "$PID" ]; then
+      echo "The dn_data_region_consensus_port" "$dn_data_region_consensus_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+  elif type netstat >/dev/null 2>&1; then
+    PID=$(netstat -anp 2>/dev/null | grep ":${dn_rpc_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g")
+    if [ -n "$PID" ]; then
+      echo "The dn_rpc_port" "$dn_rpc_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(netstat -anp 2>/dev/null | grep ":${dn_internal_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g")
+    if [ -n "$PID" ]; then
+      echo "The dn_internal_port" "$dn_internal_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(netstat -anp 2>/dev/null | grep ":${dn_mpp_data_exchange_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g")
+    if [ -n "$PID" ]; then
+      echo "The dn_mpp_data_exchange_port" "$dn_mpp_data_exchange_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(netstat -anp 2>/dev/null | grep ":${dn_schema_region_consensus_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g")
+    if [ -n "$PID" ]; then
+      echo "The dn_schema_region_consensus_port" "$dn_schema_region_consensus_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(netstat -anp 2>/dev/null | grep ":${dn_data_region_consensus_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g")
+    if [ -n "$PID" ]; then
+      echo "The dn_data_region_consensus_port" "$dn_data_region_consensus_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+  else
+    echo " Error: No necessary tool to check whether given port is occupied, stop ports checking"
+    echo " Please install 'lsof' or 'netstat'."
+  fi
+  if [ $occupied = true ]; then
+    echo "Exit because there are occupied ports."
+    exit 0
+  fi
+}
+
+checkConfigNodePortUsages () {
+  echo "Checking whether the ports are already occupied..."
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Warning: If you do not use sudo, the checking may not detect all the occupied ports."
+  fi
+  occupied=false
+  if [ -f "$CONFIGNODE_CONF/iotdb-confignode.properties" ]; then
+    cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-confignode.properties)
+    cn_consensus_port=$(sed '/^cn_consensus_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-confignode.properties)
+  elif [ -f "$CONFIGNODE_HOME/conf/iotdb-confignode.properties" ]; then
+    cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' "${CONFIGNODE_HOME}"/conf/iotdb-confignode.properties)
+    cn_consensus_port=$(sed '/^cn_consensus_port=/!d;s/.*=//' "${CONFIGNODE_HOME}"/conf/iotdb-confignode.properties)
+  else
+    echo "Cannot find iotdb-confignode.properties, check the default configuration"
+    cn_internal_port=22277
+    cn_consensus_port=22278
+  fi
+  if type lsof >/dev/null 2>&1; then
+    PID=$(lsof -t -i:"${cn_internal_port}" -sTCP:LISTEN)
+    if [ -n "$PID" ]; then
+      echo "The cn_internal_port" "$cn_internal_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(lsof -t -i:"${cn_consensus_port}" -sTCP:LISTEN)
+    if [ -n "$PID" ]; then
+      echo "The cn_consensus_port" "$cn_consensus_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+  elif type netstat >/dev/null 2>&1; then
+    PID=$(netstat -anp 2>/dev/null | grep ":${cn_internal_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g")
+    if [ -n "$PID" ]; then
+      echo "The cn_internal_port" "$cn_internal_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+    PID=$(netstat -anp 2>/dev/null | grep ":${cn_consensus_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g")
+    if [ -n "$PID" ]; then
+      echo "The cn_consensus_port" "$cn_consensus_port" "is already occupied, PID:" "$PID"
+      occupied=true
+    fi
+  else
+    echo " Error: No necessary tool to check whether given port is occupied, stop ports checking"
+    echo " Please install 'lsof' or 'netstat'."
+  fi
+  if [ $occupied = true ]; then
+    echo "Exit because there are occupied ports."
+    exit 0
+  fi
+}
+
 initEnv() {
   if [ -f "$IOTDB_CONF/datanode-env.sh" ]; then
       if [ "x$PRINT_GC" != "x" ]; then

--- a/node-commons/src/assembly/resources/sbin/start-standalone.bat
+++ b/node-commons/src/assembly/resources/sbin/start-standalone.bat
@@ -17,6 +17,8 @@
 @REM under the License.
 @REM
 
+@echo off
+
 pushd %~dp0..
 if NOT DEFINED IOTDB_HOME set IOTDB_HOME=%cd%
 popd
@@ -40,3 +42,4 @@ TIMEOUT /T 5 /NOBREAK
 start cmd /c %DATANODE_START_PATH%
 
 echo "Execute start-standalone.sh finished, you can see more details in the logs of confignode and datanode"
+exit 0

--- a/node-commons/src/assembly/resources/sbin/stop-standalone.bat
+++ b/node-commons/src/assembly/resources/sbin/stop-standalone.bat
@@ -17,6 +17,8 @@
 @REM under the License.
 @REM
 
+@echo off
+
 pushd %~dp0..
 if NOT DEFINED IOTDB_HOME set IOTDB_HOME=%cd%
 popd
@@ -38,3 +40,4 @@ IF EXIST "%IOTDB_HOME%\sbin\stop-datanode.bat" (
 start cmd /c %CONFIGNODE_STOP_PATH%
 TIMEOUT /T 3 /NOBREAK
 start cmd /c %DATANODE_STOP_PATH%
+exit 0

--- a/server/src/assembly/resources/sbin/start-datanode.sh
+++ b/server/src/assembly/resources/sbin/start-datanode.sh
@@ -26,7 +26,10 @@ foreground="yes"
 
 IOTDB_HEAP_DUMP_COMMAND=""
 
-echo "all parameters are $*"
+if [ $# -ne 0 ]; then
+  echo "All parameters are $*"
+fi
+
 while true; do
     case "$1" in
         -c)
@@ -60,7 +63,7 @@ while true; do
         -D)
             IOTDB_JVM_OPTS="$IOTDB_JVM_OPTS -D$2"
             #checkEnvVariables is in iotdb-common.sh
-            checkEnvVariables $2
+            checkEnvVariables "$2"
             shift 2
         ;;
         -X)
@@ -95,11 +98,18 @@ while true; do
     esac
 done
 
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Notice: in some systems, DataNode must run in sudo mode to write data. The process may fail."
+fi
+
 #checkAllVariables is in iotdb-common.sh
 checkAllVariables
 
+#checkDataNodePortUsages is in iotdb-common.sh
+checkDataNodePortUsages
+
 CLASSPATH=""
-for f in ${IOTDB_HOME}/lib/*.jar; do
+for f in "${IOTDB_HOME}"/lib/*.jar; do
   CLASSPATH=${CLASSPATH}":"$f
 done
 
@@ -212,7 +222,7 @@ get_real_path() {
   echo "${real_path}"
 }
 
-# check whether same directory's IotDB node process has been running
+# check whether same directory's IoTDB node process has been running
 check_running_process() {
   check_tool_env
 
@@ -245,7 +255,7 @@ check_running_process() {
 
 
 check_tool_env
-# If needed tool is ready, check whether same directory's IotDB node is running
+# If needed tool is ready, check whether same directory's IoTDB node is running
 if [ $? -eq 0 ]; then
   check_running_process
 fi

--- a/server/src/assembly/resources/sbin/stop-datanode.bat
+++ b/server/src/assembly/resources/sbin/stop-datanode.bat
@@ -22,20 +22,20 @@
 set current_dir=%~dp0
 set superior_dir=%current_dir%\..\
 
-for /f  "eol=; tokens=2,2 delims==" %%i in ('findstr /i "^dn_rpc_port"
+for /f  "eol=# tokens=2 delims==" %%i in ('findstr /i "^dn_rpc_port"
 %superior_dir%\conf\iotdb-datanode.properties') do (
   set dn_rpc_port=%%i
 )
 
-echo "check whether the rpc_port is used..., port is " %dn_rpc_port%
+echo Check whether the rpc_port is used..., port is %dn_rpc_port%
 
-for /f  "eol=; tokens=2,2 delims==" %%i in ('findstr /i "dn_rpc_address"
+for /f  "eol=# tokens=2 delims==" %%i in ('findstr /i "dn_rpc_address"
 %superior_dir%\conf\iotdb-datanode.properties') do (
   set dn_rpc_address=%%i
 )
 
 for /f "tokens=5" %%a in ('netstat /ano ^| findstr %dn_rpc_address%:%dn_rpc_port%') do (
   taskkill /f /pid %%a
-  echo "close DataNode, PID:" %%a
+  echo Close DataNode, PID: %%a
 )
 rem ps ax | grep -i 'iotdb.DataNode' | grep -v grep | awk '{print $1}' | xargs kill -SIGTERM

--- a/server/src/assembly/resources/sbin/stop-datanode.sh
+++ b/server/src/assembly/resources/sbin/stop-datanode.sh
@@ -24,7 +24,7 @@ dn_rpc_port=`sed '/^dn_rpc_port=/!d;s/.*=//' ${DATANODE_CONF}/iotdb-datanode.pro
 echo "check whether the rpc_port is used..., port is" $dn_rpc_port
 
 if  type lsof > /dev/null 2>&1 ; then
-  PID=$(lsof -t -i:${dn_rpc_port} -sTCP:LISTEN)
+  PID=$(lsof -t -i:"${dn_rpc_port}" -sTCP:LISTEN)
 elif type netstat > /dev/null 2>&1 ; then
   PID=$(netstat -anp 2>/dev/null | grep ":${dn_rpc_port} " | grep ' LISTEN ' | awk '{print $NF}' | sed "s|/.*||g" )
 else
@@ -34,18 +34,18 @@ else
   exit 1
 fi
 
-PIDS=$(ps ax | grep -i 'DataNode' | grep java | grep -v grep | awk '{print $1}')
+PID_VERIFY=$(ps ax | grep -i 'DataNode' | grep java | grep -v grep | awk '{print $1}')
 if [ -z "$PID" ]; then
   echo "No DataNode to stop"
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Maybe you can try to run in sudo mode to detect the process."
+  fi
   exit 1
-elif [[ "${PIDS}" =~ "${PID}" ]]; then
-  kill -s TERM $PID
-  echo "Stop DataNode, PID:" $PID
+elif [[ "${PID_VERIFY}" =~ ${PID} ]]; then
+  kill -s TERM "$PID"
+  echo "Stop DataNode, PID:" "$PID"
 else
   echo "No DataNode to stop"
   exit 1
 fi
-
-
-
 


### PR DESCRIPTION
## IOTDB-5125
As the title said


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
