### PR TITLE
Start ConfigNode and DataNode successfully when cluster_name is missed

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -31,8 +31,8 @@ import java.io.File;
 
 public class ConfigNodeConfig {
 
-  /** ClusterId, the default value "testCluster" will be changed after join cluster */
-  private volatile String clusterName = "testCluster";
+  /** ClusterId, the default value "defaultCluster" will be changed after join cluster */
+  private volatile String clusterName = "defaultCluster";
 
   /** ConfigNodeId, the default value -1 will be changed after join cluster */
   private volatile int configNodeId = -1;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
@@ -260,9 +260,10 @@ public class SystemPropertiesUtils {
     Properties systemProperties = getSystemProperties();
     String clusterName = systemProperties.getProperty("cluster_name", null);
     if (clusterName == null) {
-      throw new IOException(
-          "The parameter cluster_name doesn't exist in data/confignode/system/confignode-system.properties. "
-              + "Please delete data dir data/confignode and restart again");
+      LOGGER.warn(
+          "Lack cluster_name field in data/confignode/system/confignode-system.properties, set it as defaultCluster");
+      systemProperties.setProperty("cluster_name", "defaultCluster");
+      return systemProperties.getProperty("cluster_name", null);
     }
     return clusterName;
   }
@@ -295,7 +296,13 @@ public class SystemPropertiesUtils {
   public static boolean isSeedConfigNode() {
     try {
       Properties systemProperties = getSystemProperties();
-      return Boolean.parseBoolean(systemProperties.getProperty("is_seed_config_node", null));
+      boolean isSeedConfigNode =
+          Boolean.parseBoolean(systemProperties.getProperty("is_seed_config_node", null));
+      if (isSeedConfigNode) {
+        return true;
+      } else {
+        return ConfigNodeDescriptor.getInstance().isSeedConfigNode();
+      }
     } catch (IOException ignore) {
       return false;
     }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/cluster/IoTDBClusterNodeErrorStartUpIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/cluster/IoTDBClusterNodeErrorStartUpIT.java
@@ -67,7 +67,7 @@ public class IoTDBClusterNodeErrorStartUpIT {
   protected static String originalConfigNodeConsensusProtocolClass;
   private static final String testConsensusProtocolClass = ConsensusFactory.RATIS_CONSENSUS;
 
-  private static final String TEST_CLUSTER_NAME = "testCluster";
+  private static final String TEST_CLUSTER_NAME = "defaultCluster";
   private static final String ERROR_CLUSTER_NAME = "errorCluster";
 
   @Before

--- a/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
@@ -138,7 +138,7 @@ public class ConfigNodeClient
   private static final int RETRY_NUM = 5;
 
   public static final String MSG_RECONNECTION_FAIL =
-      "Fail to connect to any config node. Please check server status";
+      "Fail to connect to any config node. Please check status of ConfigNodes";
 
   private static final int retryIntervalMs = 1000;
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -571,10 +571,10 @@ public class IoTDBConfig {
   private boolean isClusterMode = false;
 
   /**
-   * The cluster name that this DataNode joined in the cluster mode. The default value "testCluster"
-   * will be changed after join cluster
+   * The cluster name that this DataNode joined in the cluster mode. The default value
+   * "defaultCluster" will be changed after join cluster
    */
-  private String clusterName = "testCluster";
+  private String clusterName = "defaultCluster";
 
   /**
    * The DataNodeId of this DataNode for cluster mode. The default value -1 will be changed after

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -393,7 +393,8 @@ public class DataNode implements DataNodeMBean {
     /* Send restart request */
     int retry = DEFAULT_RETRY;
     TDataNodeRestartReq req = new TDataNodeRestartReq();
-    req.setClusterName(config.getClusterName());
+    req.setClusterName(
+        config.getClusterName() == null ? "defaultCluster" : config.getClusterName());
     req.setDataNodeConfiguration(generateDataNodeConfiguration());
     TDataNodeRestartResp dataNodeRestartResp = null;
     while (retry > 0) {


### PR DESCRIPTION
I have test the upgrate from 1.0 to master.

system file of 1.0

![image](https://user-images.githubusercontent.com/6756545/208712197-a10f5bd1-db24-4cc9-b00f-b873edaa642d.png)

![image](https://user-images.githubusercontent.com/6756545/208712271-7ccfb46e-56ef-4865-84c0-91173f5aac77.png)
