### PR TITLE
[To rel/1.0][IOTDB-5250] Unify the address or port of metric module in DataNode (#8541)

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -188,7 +188,7 @@ public class IoTDBDescriptor {
         MetricConfigDescriptor.getInstance().loadProps(commonProperties);
         MetricConfigDescriptor.getInstance()
             .getMetricConfig()
-            .updateRpcInstance(conf.getRpcAddress(), conf.getRpcPort());
+            .updateRpcInstance(conf.getInternalAddress(), conf.getInternalPort());
       }
     } else {
       logger.warn(


### PR DESCRIPTION
Use internal address and port which is consistent with confignode
(cherry picked from commit 47aac84dc9c51cf6e68ea053f8bfe0e4c185f59d)
