### PR TITLE
[IOTDB-5256] Modify the default value of `iot_consensus_cache_window_time_in_ms`

### DIFF
--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -703,7 +703,7 @@
 # iot_consensus_throttle_threshold_in_byte=53687091200
 
 # Maximum wait time of write cache in IoTConsensus
-# If this value is less than or equal to 0, use the default value Long.MAX_VALUE.
+# If this value is less than or equal to 0, use the default value 10 * 1000 ms (10s)
 # Datatype: long
 # iot_consensus_cache_window_time_in_ms=-1
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1004,7 +1004,7 @@ public class IoTDBConfig {
   private long throttleThreshold = 50 * 1024 * 1024 * 1024L;
 
   /** Maximum wait time of write cache in IoTConsensus. Unit: ms */
-  private long cacheWindowTimeInMs = 60 * 1000;
+  private long cacheWindowTimeInMs = 10 * 1000;
 
   private long dataRatisConsensusLogAppenderBufferSizeMax = 4 * 1024 * 1024L;
   private long schemaRatisConsensusLogAppenderBufferSizeMax = 4 * 1024 * 1024L;


### PR DESCRIPTION
Modify the default value of `iot_consensus_cache_window_time_in_ms` to 10*1000 which is 10s