### PR TITLE
[IOTDB-5226] Correct the style and reliance of schema operator UT

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowDevicesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowDevicesPlan.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Objects;
 
 public class ShowDevicesPlan extends ShowPlan {
 
@@ -51,5 +52,18 @@ public class ShowDevicesPlan extends ShowPlan {
 
   public boolean hasSgCol() {
     return hasSgCol;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ShowDevicesPlan that = (ShowDevicesPlan) o;
+    return hasSgCol == that.hasSgCol;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hasSgCol);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowTimeSeriesPlan.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.metadata.template.Template;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 public class ShowTimeSeriesPlan extends ShowPlan {
 
@@ -117,5 +118,22 @@ public class ShowTimeSeriesPlan extends ShowPlan {
     outputStream.writeInt(offset);
     outputStream.writeBoolean(orderByHeat);
     outputStream.writeLong(index);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ShowTimeSeriesPlan that = (ShowTimeSeriesPlan) o;
+    return isContains == that.isContains
+        && orderByHeat == that.orderByHeat
+        && Objects.equals(key, that.key)
+        && Objects.equals(value, that.value)
+        && Objects.equals(relatedTemplate, that.relatedTemplate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(isContains, key, value, orderByHeat, relatedTemplate);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountMergeOperatorTest.java
@@ -21,10 +21,7 @@ package org.apache.iotdb.db.mpp.execution.operator.schema;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
-import org.apache.iotdb.db.localconfignode.LocalConfigNode;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
-import org.apache.iotdb.db.metadata.schemaregion.SchemaEngine;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.common.QueryId;
@@ -33,22 +30,16 @@ import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceStateMachine;
 import org.apache.iotdb.db.mpp.execution.operator.OperatorContext;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
-import org.apache.iotdb.db.query.reader.series.SeriesReaderTestUtil;
-import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
-import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.Mockito;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
@@ -58,87 +49,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Ignore
 public class CountMergeOperatorTest {
   private static final String COUNT_MERGE_OPERATOR_TEST_SG = "root.CountMergeOperatorTest";
-  private final List<String> deviceIds = new ArrayList<>();
-  private final List<MeasurementSchema> measurementSchemas = new ArrayList<>();
-
-  private final List<TsFileResource> seqResources = new ArrayList<>();
-  private final List<TsFileResource> unSeqResources = new ArrayList<>();
-
-  @Before
-  public void setUp() throws MetadataException, IOException, WriteProcessException {
-    SeriesReaderTestUtil.setUp(
-        measurementSchemas, deviceIds, seqResources, unSeqResources, COUNT_MERGE_OPERATOR_TEST_SG);
-  }
-
-  @After
-  public void tearDown() throws IOException {
-    SeriesReaderTestUtil.tearDown(seqResources, unSeqResources);
-  }
-
-  @Test
-  public void testTimeSeriesCountOperator() {
-    ExecutorService instanceNotificationExecutor =
-        IoTDBThreadPoolFactory.newFixedThreadPool(1, "test-instance-notification");
-    try {
-      QueryId queryId = new QueryId("stub_query");
-      FragmentInstanceId instanceId =
-          new FragmentInstanceId(new PlanFragmentId(queryId, 0), "stub-instance");
-      FragmentInstanceStateMachine stateMachine =
-          new FragmentInstanceStateMachine(instanceId, instanceNotificationExecutor);
-      FragmentInstanceContext fragmentInstanceContext =
-          createFragmentInstanceContext(instanceId, stateMachine);
-      PlanNodeId planNodeId = queryId.genPlanNodeId();
-      OperatorContext operatorContext =
-          fragmentInstanceContext.addOperatorContext(
-              1, planNodeId, TimeSeriesCountOperator.class.getSimpleName());
-      PartialPath partialPath = new PartialPath(COUNT_MERGE_OPERATOR_TEST_SG);
-      ISchemaRegion schemaRegion =
-          SchemaEngine.getInstance()
-              .getSchemaRegion(
-                  LocalConfigNode.getInstance().getBelongedSchemaRegionId(partialPath));
-      operatorContext
-          .getInstanceContext()
-          .setDriverContext(new SchemaDriverContext(fragmentInstanceContext, schemaRegion));
-      TimeSeriesCountOperator timeSeriesCountOperator =
-          new TimeSeriesCountOperator(
-              planNodeId,
-              fragmentInstanceContext.getOperatorContexts().get(0),
-              partialPath,
-              true,
-              null,
-              null,
-              false,
-              Collections.emptyMap());
-      TsBlock tsBlock = null;
-      while (timeSeriesCountOperator.hasNext()) {
-        tsBlock = timeSeriesCountOperator.next();
-      }
-      assertNotNull(tsBlock);
-      assertEquals(100, tsBlock.getColumn(0).getLong(0));
-      TimeSeriesCountOperator timeSeriesCountOperator2 =
-          new TimeSeriesCountOperator(
-              planNodeId,
-              fragmentInstanceContext.getOperatorContexts().get(0),
-              new PartialPath(COUNT_MERGE_OPERATOR_TEST_SG + ".device1.*"),
-              false,
-              null,
-              null,
-              false,
-              Collections.emptyMap());
-      tsBlock = timeSeriesCountOperator2.next();
-      assertFalse(timeSeriesCountOperator2.hasNext());
-      assertTrue(timeSeriesCountOperator2.isFinished());
-      assertEquals(10, tsBlock.getColumn(0).getLong(0));
-    } catch (MetadataException e) {
-      e.printStackTrace();
-      fail();
-    } finally {
-      instanceNotificationExecutor.shutdown();
-    }
-  }
 
   @Test
   public void testCountMergeOperator() {
@@ -156,11 +68,21 @@ public class CountMergeOperatorTest {
       OperatorContext operatorContext =
           fragmentInstanceContext.addOperatorContext(
               1, planNodeId, LevelTimeSeriesCountOperator.class.getSimpleName());
-      ISchemaRegion schemaRegion =
-          SchemaEngine.getInstance()
-              .getSchemaRegion(
-                  LocalConfigNode.getInstance()
-                      .getBelongedSchemaRegionId(new PartialPath(COUNT_MERGE_OPERATOR_TEST_SG)));
+      ISchemaRegion schemaRegion = Mockito.mock(ISchemaRegion.class);
+      Map<PartialPath, Long> sgResult = new HashMap<>();
+      for (int i = 0; i < 10; i++) {
+        sgResult.put(new PartialPath(COUNT_MERGE_OPERATOR_TEST_SG + ".device" + i), 10L);
+      }
+      Mockito.when(
+              schemaRegion.getMeasurementCountGroupByLevel(
+                  new PartialPath(COUNT_MERGE_OPERATOR_TEST_SG), 2, true))
+          .thenReturn(sgResult);
+      Mockito.when(
+              schemaRegion.getMeasurementCountGroupByLevel(
+                  new PartialPath(COUNT_MERGE_OPERATOR_TEST_SG + ".device2"), 2, true))
+          .thenReturn(
+              Collections.singletonMap(
+                  new PartialPath(COUNT_MERGE_OPERATOR_TEST_SG + ".device2"), 10L));
       operatorContext
           .getInstanceContext()
           .setDriverContext(new SchemaDriverContext(fragmentInstanceContext, schemaRegion));


### PR DESCRIPTION
## Description

Use Mockito to mock schemaRegion rather than rely on SchemaEngine or LocalConfigNode.