### PR TITLE
[IOTDB-5208]Fix file handles increase when TsFileResource is degraded and compacted with fast performer

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/CompactionUtils.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
-import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
@@ -177,24 +176,13 @@ public class CompactionUtils {
     logger.info("{} [Compaction] Compaction starts to delete real file ", storageGroupName);
     boolean result = true;
     for (TsFileResource mergeTsFile : mergeTsFiles) {
-      if (!deleteTsFile(mergeTsFile)) {
+      if (!mergeTsFile.remove()) {
         result = false;
       }
       logger.info(
           "{} [Compaction] delete TsFile {}", storageGroupName, mergeTsFile.getTsFilePath());
     }
     return result;
-  }
-
-  public static boolean deleteTsFile(TsFileResource seqFile) {
-    try {
-      FileReaderManager.getInstance().closeFileAndRemoveReader(seqFile.getTsFilePath());
-      seqFile.remove();
-    } catch (IOException e) {
-      logger.error(e.getMessage(), e);
-      return false;
-    }
-    return true;
   }
 
   /** Delete all modification files for source files */

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionTask.java
@@ -34,7 +34,6 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
-import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.db.rescon.SystemInfo;
 
 import org.apache.commons.io.FileUtils;
@@ -331,7 +330,6 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
   private long deleteOldFiles(List<TsFileResource> tsFileResourceList) throws IOException {
     long totalSize = 0;
     for (TsFileResource tsFileResource : tsFileResourceList) {
-      FileReaderManager.getInstance().closeFileAndRemoveReader(tsFileResource.getTsFilePath());
       totalSize += tsFileResource.getTsFileSize();
       tsFileResource.remove();
       LOGGER.info(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/FastCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/performer/impl/FastCompactionPerformer.java
@@ -115,7 +115,7 @@ public class FastCompactionPerformer
             new MultiTsFileDeviceIterator(seqFiles, unseqFiles, readerCacheMap);
         AbstractCompactionWriter compactionWriter =
             isCrossCompaction
-                ? new FastCrossCompactionWriter(targetFiles, seqFiles)
+                ? new FastCrossCompactionWriter(targetFiles, seqFiles, readerCacheMap)
                 : new FastInnerCompactionWriter(targetFiles.get(0))) {
       while (deviceIterator.hasNextDevice()) {
         checkThreadInterrupted();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/FastCrossCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/FastCrossCompactionWriter.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.tsfile.exception.write.PageException;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.Chunk;
 import org.apache.iotdb.tsfile.read.common.block.column.Column;
 import org.apache.iotdb.tsfile.read.common.block.column.TimeColumn;
@@ -32,13 +33,17 @@ import org.apache.iotdb.tsfile.write.chunk.ChunkWriterImpl;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 
 public class FastCrossCompactionWriter extends AbstractCrossCompactionWriter {
 
   public FastCrossCompactionWriter(
-      List<TsFileResource> targetResources, List<TsFileResource> seqSourceResources)
+      List<TsFileResource> targetResources,
+      List<TsFileResource> seqSourceResources,
+      Map<TsFileResource, TsFileSequenceReader> readerMap)
       throws IOException {
     super(targetResources, seqSourceResources);
+    this.readerMap = readerMap;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/FastCrossCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/FastCrossCompactionWriter.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 
 public class FastCrossCompactionWriter extends AbstractCrossCompactionWriter {
+  // Only used for fast compaction performer
+  protected Map<TsFileResource, TsFileSequenceReader> readerMap;
 
   public FastCrossCompactionWriter(
       List<TsFileResource> targetResources,
@@ -50,6 +52,11 @@ public class FastCrossCompactionWriter extends AbstractCrossCompactionWriter {
   public void write(TimeColumn timestamps, Column[] columns, int subTaskId, int batchSize)
       throws IOException {
     throw new RuntimeException("Does not support this method in FastCrossCompactionWriter");
+  }
+
+  @Override
+  protected TsFileSequenceReader getFileReader(TsFileResource resource) {
+    return readerMap.get(resource);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/ReadPointCrossCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/writer/ReadPointCrossCompactionWriter.java
@@ -19,9 +19,11 @@
 package org.apache.iotdb.db.engine.compaction.writer;
 
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.Chunk;
 import org.apache.iotdb.tsfile.read.common.block.column.Column;
 import org.apache.iotdb.tsfile.read.common.block.column.TimeColumn;
@@ -59,6 +61,11 @@ public class ReadPointCrossCompactionWriter extends AbstractCrossCompactionWrite
     isDeviceExistedInTargetFiles[seqFileIndexArray[subTaskId]] = true;
     isEmptyFile[seqFileIndexArray[subTaskId]] = false;
     lastTime[subTaskId] = timestamps.getEndTime();
+  }
+
+  @Override
+  protected TsFileSequenceReader getFileReader(TsFileResource resource) throws IOException {
+    return FileReaderManager.getInstance().get(resource.getTsFilePath(), true);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.query.control;
 
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
@@ -251,6 +252,16 @@ public class FileReaderManager {
     for (Map.Entry<String, AtomicInteger> entry : unclosedReferenceMap.entrySet()) {
       DEBUG_LOGGER.info(String.format("\t%s: %d", entry.getKey(), entry.getValue().get()));
     }
+  }
+
+  @TestOnly
+  public Map<String, TsFileSequenceReader> getClosedFileReaderMap() {
+    return closedFileReaderMap;
+  }
+
+  @TestOnly
+  public Map<String, TsFileSequenceReader> getUnclosedFileReaderMap() {
+    return unclosedFileReaderMap;
   }
 
   private static class FileReaderManagerHelper {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastCrossCompactionPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastCrossCompactionPerformerTest.java
@@ -139,10 +139,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     tsBlockReader =
@@ -253,10 +256,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -448,10 +454,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -640,10 +649,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -822,10 +834,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     targetResources.removeIf(resource -> resource == null);
@@ -997,10 +1012,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     Assert.assertEquals(4, targetResources.size());
@@ -1130,6 +1148,8 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
           new FastCompactionPerformer(seqResources, unseqResources, targetResources);
       performer.setSummary(new CompactionTaskSummary());
       performer.perform();
+      Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+      Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
       CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
       Assert.assertEquals(4, targetResources.size());
@@ -1205,6 +1225,8 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
           new FastCompactionPerformer(seqResources, unseqResources, targetResources);
       performer.setSummary(new CompactionTaskSummary());
       performer.perform();
+      Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+      Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
       CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
       Assert.assertEquals(2, targetResources.size());
@@ -1339,10 +1361,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     tsBlockReader =
@@ -1467,10 +1492,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     for (int i = TsFileGeneratorUtils.getAlignDeviceOffset();
@@ -1669,10 +1697,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     Assert.assertEquals(4, targetResources.size());
@@ -1906,10 +1937,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
     targetResources.removeIf(resource -> resource == null);
 
@@ -2021,10 +2055,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
     targetResources.removeIf(resource -> resource == null);
     Assert.assertEquals(2, targetResources.size());
@@ -2147,10 +2184,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -2286,10 +2326,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -2404,10 +2447,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -2539,10 +2585,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -2696,10 +2745,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
     targetResources.removeIf(resource -> resource == null);
     Assert.assertEquals(3, targetResources.size());
@@ -2939,10 +2991,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -3207,10 +3262,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -3397,10 +3455,13 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
 
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
 
     List<String> deviceIdList = new ArrayList<>();
@@ -3711,12 +3772,16 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
       }
     }
 
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     targetResources.addAll(
         CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
     performer.setSummary(new CompactionTaskSummary());
     performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
     targetResources.removeIf(resource -> resource == null);
 
@@ -3782,6 +3847,199 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
         } else if ((i == TsFileGeneratorUtils.getAlignDeviceOffset() + 1 && j == 4)) {
           assertEquals(600, count);
         } else if (i < TsFileGeneratorUtils.getAlignDeviceOffset() + 3 && j < 4) {
+          assertEquals(1200, count);
+        } else {
+          assertEquals(600, count);
+        }
+      }
+    }
+  }
+
+  /**
+   * Total 4 seq files and 5 unseq files, each file has different nonAligned timeseries.
+   *
+   * <p>Seq files<br>
+   * first and second file has d0 ~ d1 and s0 ~ s2, time range is 0 ~ 299 and 350 ~ 649, value range
+   * is 0 ~ 299 and 350 ~ 649.<br>
+   * third and forth file has d0 ~ d3 and s0 ~ S4,time range is 700 ~ 999 and 1050 ~ 1349, value
+   * range is 700 ~ 999 and 1050 ~ 1349.<br>
+   *
+   * <p>UnSeq files<br>
+   * first, second and third file has d0 ~ d2 and s0 ~ s3, time range is 20 ~ 219, 250 ~ 449 and 480
+   * ~ 679, value range is 10020 ~ 10219, 10250 ~ 10449 and 10480 ~ 10679.<br>
+   * forth and fifth file has d0 and s0 ~ s4, time range is 450 ~ 549 and 550 ~ 649, value range is
+   * 20450 ~ 20549 and 20550 ~ 20649.
+   */
+  @Test
+  public void testCrossSpaceCompactionWithFileTimeIndex() throws Exception {
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
+    registerTimeseriesInMManger(4, 5, false);
+    createFiles(2, 2, 3, 300, 0, 0, 50, 50, false, true);
+    createFiles(2, 4, 5, 300, 700, 700, 50, 50, false, true);
+    createFiles(3, 3, 4, 200, 20, 10020, 30, 30, false, false);
+    createFiles(2, 1, 5, 100, 450, 20450, 0, 0, false, false);
+
+    for (int i = 0; i < 4; i++) {
+      for (int j = 0; j < 5; j++) {
+        PartialPath path =
+            new MeasurementPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
+                "s" + j,
+                new MeasurementSchema("s" + j, TSDataType.INT64));
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
+                path,
+                TSDataType.INT64,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
+                seqResources,
+                unseqResources,
+                true);
+        int count = 0;
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            if (i == 0
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
+            } else if ((i < 3 && j < 4)
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
+            } else {
+              assertEquals(iterator.currentTime(), iterator.currentValue());
+            }
+            count++;
+            iterator.next();
+          }
+        }
+        tsBlockReader.close();
+        if (i < 2 && j < 3) {
+          assertEquals(1280, count);
+        } else if (i < 1 && j < 4) {
+          assertEquals(1230, count);
+        } else if (i == 0) {
+          assertEquals(800, count);
+        } else if ((i == 1 && j == 4)) {
+          assertEquals(600, count);
+        } else if (i < 3 && j < 4) {
+          assertEquals(1200, count);
+        } else {
+          assertEquals(600, count);
+        }
+      }
+    }
+
+    // degrade time index
+    for (TsFileResource resource : seqResources) {
+      resource.degradeTimeIndex();
+    }
+    for (TsFileResource resource : unseqResources) {
+      resource.degradeTimeIndex();
+    }
+
+    targetResources.addAll(
+        CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources));
+    FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
+    ICompactionPerformer performer =
+        new FastCompactionPerformer(seqResources, unseqResources, targetResources);
+    performer.setSummary(new CompactionTaskSummary());
+    performer.perform();
+    Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
+    Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
+    CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+
+    List<String> deviceIdList = new ArrayList<>();
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1");
+    for (int i = 0; i < 2; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertFalse(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2");
+    deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3");
+    for (int i = 2; i < 4; i++) {
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d1"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d2"));
+      Assert.assertTrue(
+          targetResources.get(i).isDeviceIdExist(COMPACTION_TEST_SG + PATH_SEPARATOR + "d3"));
+      check(targetResources.get(i), deviceIdList);
+    }
+
+    Map<String, Long> measurementMaxTime = new HashMap<>();
+
+    for (int i = 0; i < 4; i++) {
+      for (int j = 0; j < 5; j++) {
+        measurementMaxTime.putIfAbsent(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
+            Long.MIN_VALUE);
+        PartialPath path =
+            new MeasurementPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
+                "s" + j,
+                new MeasurementSchema("s" + j, TSDataType.INT64));
+        IDataBlockReader tsBlockReader =
+            new SeriesDataBlockReader(
+                path,
+                TSDataType.INT64,
+                FragmentInstanceContext.createFragmentInstanceContextForCompaction(
+                    EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
+                targetResources,
+                new ArrayList<>(),
+                true);
+        int count = 0;
+        while (tsBlockReader.hasNextBatch()) {
+          TsBlock block = tsBlockReader.nextBatch();
+          IBatchDataIterator iterator = block.getTsBlockSingleColumnIterator();
+          while (iterator.hasNext()) {
+            if (measurementMaxTime.get(
+                    COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j)
+                >= iterator.currentTime()) {
+              Assert.fail();
+            }
+            measurementMaxTime.put(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
+                iterator.currentTime());
+            if (i == 0
+                && ((450 <= iterator.currentTime() && iterator.currentTime() < 550)
+                    || (550 <= iterator.currentTime() && iterator.currentTime() < 650))) {
+              assertEquals(iterator.currentTime() + 20000, iterator.currentValue());
+            } else if ((i < 3 && j < 4)
+                && ((20 <= iterator.currentTime() && iterator.currentTime() < 220)
+                    || (250 <= iterator.currentTime() && iterator.currentTime() < 450)
+                    || (480 <= iterator.currentTime() && iterator.currentTime() < 680))) {
+              assertEquals(iterator.currentTime() + 10000, iterator.currentValue());
+            } else {
+              assertEquals(iterator.currentTime(), iterator.currentValue());
+            }
+            count++;
+            iterator.next();
+          }
+        }
+        tsBlockReader.close();
+        if (i < 2 && j < 3) {
+          assertEquals(1280, count);
+        } else if (i < 1 && j < 4) {
+          assertEquals(1230, count);
+        } else if (i == 0) {
+          assertEquals(800, count);
+        } else if ((i == 1 && j == 4)) {
+          assertEquals(600, count);
+        } else if (i < 3 && j < 4) {
           assertEquals(1200, count);
         } else {
           assertEquals(600, count);


### PR DESCRIPTION
**Description**
If TsFileResource is degraded to FileTimeIndex and then compacted with fast performer, it will create more file handles. To solve this problem, we should remove the usage of FileReaderManager in fast compaction.