### PR TITLE
[IOTDB-5269] Fix PathPatternTree.getAllDevicePatterns

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -152,6 +152,10 @@ public class PathPatternTree {
         results.add(
             nodes.size() == 1 ? "" : convertNodesToString(nodes.subList(0, nodes.size() - 1)));
       } else {
+        // the device of root.sg.d.** is root.sg.d and root.sg.d.**
+        if (nodes.size() > 2) {
+          results.add(convertNodesToString(nodes.subList(0, nodes.size() - 1)));
+        }
         results.add(convertNodesToString(nodes));
       }
       if (curNode.isLeaf()) {

--- a/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
@@ -174,7 +174,10 @@ public class PathPatternTreeTest {
             new PartialPath("root.sg1.d1.**"),
             new PartialPath("root.sg1.d1.s1")),
         Arrays.asList(new PartialPath("root.sg1.d1"), new PartialPath("root.sg1.d1.**")),
-        Arrays.asList(new PartialPath("root.sg1"), new PartialPath("root.sg1.d1.**")));
+        Arrays.asList(
+            new PartialPath("root.sg1"),
+            new PartialPath("root.sg1.d1"),
+            new PartialPath("root.sg1.d1.**")));
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -160,7 +160,6 @@ import static org.apache.iotdb.commons.conf.IoTDBConstant.ALLOWED_SCHEMA_PROPS;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.DEADBAND;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.LOSS;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.ONE_LEVEL_PATH_WILDCARD;
-import static org.apache.iotdb.db.metadata.MetadataConstant.ALL_RESULT_NODES;
 import static org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant.DEVICE;
 import static org.apache.iotdb.db.mpp.plan.analyze.SelectIntoUtils.constructTargetDevice;
 import static org.apache.iotdb.db.mpp.plan.analyze.SelectIntoUtils.constructTargetMeasurement;
@@ -2294,18 +2293,29 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     Map<String, List<DataPartitionQueryParam>> sgNameToQueryParamsMap = new HashMap<>();
 
-    schemaTree
-        .getMatchedDevices(new PartialPath(ALL_RESULT_NODES))
-        .forEach(
-            deviceSchemaInfo -> {
-              PartialPath devicePath = deviceSchemaInfo.getDevicePath();
-              DataPartitionQueryParam queryParam = new DataPartitionQueryParam();
-              queryParam.setDevicePath(devicePath.getFullPath());
-              sgNameToQueryParamsMap
-                  .computeIfAbsent(
-                      schemaTree.getBelongedDatabase(devicePath), key -> new ArrayList<>())
-                  .add(queryParam);
-            });
+    Set<String> deduplicatedDevicePaths = new HashSet<>();
+
+    for (String devicePattern : patternTree.getAllDevicePatterns()) {
+      try {
+        schemaTree
+            .getMatchedDevices(new PartialPath(devicePattern))
+            .forEach(
+                deviceSchemaInfo -> {
+                  deduplicatedDevicePaths.add(deviceSchemaInfo.getDevicePath().getFullPath());
+                });
+      } catch (IllegalPathException ignored) {
+        // won't happen
+      }
+    }
+
+    deduplicatedDevicePaths.forEach(
+        devicePath -> {
+          DataPartitionQueryParam queryParam = new DataPartitionQueryParam();
+          queryParam.setDevicePath(devicePath);
+          sgNameToQueryParamsMap
+              .computeIfAbsent(schemaTree.getBelongedDatabase(devicePath), key -> new ArrayList<>())
+              .add(queryParam);
+        });
 
     DataPartition dataPartition = partitionFetcher.getDataPartition(sgNameToQueryParamsMap);
     analysis.setDataPartitionInfo(dataPartition);


### PR DESCRIPTION
## Description


### Problem

see https://issues.apache.org/jira/browse/IOTDB-5269

### Solution

Add special judge when encountering \*\* during the process of pattern tree.
