### PR TITLE
[To rel/1.0][IOTDB-5269] Fix PathPatternTree.getAllDevicePatterns bug

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -152,6 +152,10 @@ public class PathPatternTree {
         results.add(
             nodes.size() == 1 ? "" : convertNodesToString(nodes.subList(0, nodes.size() - 1)));
       } else {
+        // the device of root.sg.d.** is root.sg.d and root.sg.d.**
+        if (nodes.size() > 2) {
+          results.add(convertNodesToString(nodes.subList(0, nodes.size() - 1)));
+        }
         results.add(convertNodesToString(nodes));
       }
       if (curNode.isLeaf()) {

--- a/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
@@ -174,7 +174,10 @@ public class PathPatternTreeTest {
             new PartialPath("root.sg1.d1.**"),
             new PartialPath("root.sg1.d1.s1")),
         Arrays.asList(new PartialPath("root.sg1.d1"), new PartialPath("root.sg1.d1.**")),
-        Arrays.asList(new PartialPath("root.sg1"), new PartialPath("root.sg1.d1.**")));
+        Arrays.asList(
+            new PartialPath("root.sg1"),
+            new PartialPath("root.sg1.d1"),
+            new PartialPath("root.sg1.d1.**")));
   }
 
   /**


### PR DESCRIPTION
## Description


### Problem

see https://issues.apache.org/jira/browse/IOTDB-5269

### Solution

Add special judge when encountering \*\* during the process of pattern tree.
