### PR TITLE
[To rel/1.0][IOTDB-5277] SchemaRegion throws NPE when loading snapshot

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MetadataConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MetadataConstant.java
@@ -85,4 +85,8 @@ public class MetadataConstant {
         throw new RuntimeException("Undefined MNode type " + type);
     }
   }
+
+  public static boolean isStorageGroupType(byte type) {
+    return type == STORAGE_GROUP_MNODE_TYPE || type == STORAGE_GROUP_ENTITY_MNODE_TYPE;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/snapshot/MemMTreeSnapshotUtil.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/snapshot/MemMTreeSnapshotUtil.java
@@ -57,6 +57,7 @@ import static org.apache.iotdb.db.metadata.MetadataConstant.INTERNAL_MNODE_TYPE;
 import static org.apache.iotdb.db.metadata.MetadataConstant.MEASUREMENT_MNODE_TYPE;
 import static org.apache.iotdb.db.metadata.MetadataConstant.STORAGE_GROUP_ENTITY_MNODE_TYPE;
 import static org.apache.iotdb.db.metadata.MetadataConstant.STORAGE_GROUP_MNODE_TYPE;
+import static org.apache.iotdb.db.metadata.MetadataConstant.isStorageGroupType;
 
 public class MemMTreeSnapshotUtil {
 
@@ -220,7 +221,8 @@ public class MemMTreeSnapshotUtil {
       ancestors.peek().addChild(node);
     }
 
-    if (childrenNum > 0) {
+    //     Storage type means current node is root node, so it must be returned.
+    if (childrenNum > 0 || isStorageGroupType(type)) {
       ancestors.push(node);
       restChildrenNum.push(childrenNum);
     }


### PR DESCRIPTION
## Description

This problem is caused by loading empty storage group snaptshot. 

When the `childrenNum` of root node is 0, it still needs to be added into `ancestors` and processed by `inorderDeserialize`. Otherwise the root node returned would be null.

```
  private static IMNode inorderDeserialize(
      InputStream inputStream, Consumer<IMeasurementMNode> measurementProcess) throws IOException {
    MNodeDeserializer deserializer = new MNodeDeserializer();
    Deque<IMNode> ancestors = new ArrayDeque<>();
    Deque<Integer> restChildrenNum = new ArrayDeque<>();
    deserializeMNode(ancestors, restChildrenNum, deserializer, inputStream, measurementProcess);
    int childrenNum;
    IMNode root = ancestors.peek();
    while (!ancestors.isEmpty()) {
      childrenNum = restChildrenNum.pop();
      if (childrenNum == 0) {
        ancestors.pop();
      } else {
        restChildrenNum.push(childrenNum - 1);
        deserializeMNode(ancestors, restChildrenNum, deserializer, inputStream, measurementProcess);
      }
    }
    return root;
  }
```