### PR TITLE
[To rel/0.13][IOTDB-5281]Fix selecting deleted files in 0.13

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/manage/CrossSpaceCompactionResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/manage/CrossSpaceCompactionResource.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.engine.compaction.cross.rewrite.manage;
 
 import org.apache.iotdb.db.engine.modification.Modification;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.utils.Pair;
@@ -80,9 +81,9 @@ public class CrossSpaceCompactionResource {
    */
   private void filterUnseqResource(List<TsFileResource> unseqResources) {
     for (TsFileResource resource : unseqResources) {
-      if (resource.isCompacting() || resource.isCompactionCandidate() || !resource.isClosed()) {
+      if (resource.getStatus() != TsFileResourceStatus.CLOSED || !resource.getTsFile().exists()) {
         return;
-      } else if (!resource.isDeleted() && resource.stillLives(ttlLowerBound)) {
+      } else if (resource.stillLives(ttlLowerBound)) {
         this.unseqFiles.add(resource);
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.MergeException;
 
 import org.slf4j.Logger;
@@ -256,9 +257,8 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
    */
   private boolean checkIsSeqFilesValid() {
     for (Integer seqIdx : tmpSelectedSeqFiles) {
-      if (resource.getSeqFiles().get(seqIdx).isCompactionCandidate()
-          || resource.getSeqFiles().get(seqIdx).isCompacting()
-          || !resource.getSeqFiles().get(seqIdx).isClosed()) {
+      if (resource.getSeqFiles().get(seqIdx).getStatus() != TsFileResourceStatus.CLOSED
+          || !resource.getSeqFiles().get(seqIdx).getTsFile().exists()) {
         return false;
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionSelector.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.slf4j.Logger;
@@ -124,9 +125,7 @@ public class SizeTieredCompactionSelector extends AbstractInnerSpaceCompactionSe
       TsFileNameGenerator.TsFileName currentName =
           TsFileNameGenerator.getTsFileName(currentFile.getTsFile().getName());
       if (currentName.getInnerCompactionCnt() != level
-          || currentFile.isCompactionCandidate()
-          || currentFile.isCompacting()
-          || !currentFile.isClosed()) {
+          || currentFile.getStatus() != TsFileResourceStatus.CLOSED) {
         selectedFileList.clear();
         selectedFileSize = 0L;
         continue;

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -623,6 +623,10 @@ public class TsFileResource {
     return this.status == TsFileResourceStatus.COMPACTION_CANDIDATE;
   }
 
+  public TsFileResourceStatus getStatus() {
+    return this.status;
+  }
+
   public void setStatus(TsFileResourceStatus status) {
     switch (status) {
       case CLOSED:

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -901,4 +901,40 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
         .getConfig()
         .setMaxCrossCompactionCandidateFileNum(maxCrossFilesNum);
   }
+
+  /** Test selecting with deleted files. */
+  @Test
+  public void testSelectionWithFileBeingDeleted() throws MergeException, IOException {
+    // cross select files with the last unseq file being deleted
+    unseqResources.get(unseqResources.size() - 1).setStatus(TsFileResourceStatus.DELETED);
+    CrossSpaceCompactionResource resource =
+        new CrossSpaceCompactionResource(seqResources, unseqResources);
+    assertEquals(5, resource.getSeqFiles().size());
+    assertEquals(5, resource.getUnseqFiles().size());
+    ICrossSpaceMergeFileSelector mergeFileSelector =
+        new RewriteCompactionFileSelector(resource, Long.MAX_VALUE);
+    List[] result = mergeFileSelector.select();
+    List<TsFileResource> seqSelected = result[0];
+    List<TsFileResource> unseqSelected = result[1];
+
+    assertEquals(5, seqSelected.size());
+    assertEquals(5, unseqSelected.size());
+    assertEquals(seqResources, seqSelected);
+    assertEquals(resource.getUnseqFiles(), unseqSelected);
+    resource.clear();
+
+    // cross select files with the last unseq file and the last seq file being deleted
+    seqResources.get(seqResources.size() - 1).setStatus(TsFileResourceStatus.DELETED);
+    resource = new CrossSpaceCompactionResource(seqResources, unseqResources);
+    assertEquals(4, resource.getSeqFiles().size());
+    assertEquals(5, resource.getUnseqFiles().size());
+    result = mergeFileSelector.select();
+
+    assertEquals(4, result[0].size());
+    assertEquals(4, result[1].size());
+
+    resource.getUnseqFiles().remove(resource.getUnseqFiles().size() - 1);
+    assertEquals(resource.getSeqFiles(), result[0]);
+    assertEquals(resource.getUnseqFiles(), result[1]);
+  }
 }


### PR DESCRIPTION
**Description**
Throw RunTimeException during selecting files in compaction: Cannot set the status of TsFileResource to COMPACTION_ CANDIDATE while its status is DELETED.
**Solution**
Filter out the deleted file when selecting files.