### PR TITLE
[IOTDB-5160] [Metric] Fix the file count of datanode become negative number

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -452,10 +452,14 @@ public class DataRegion implements IDataRegionForQuery {
       List<WALRecoverListener> recoverListeners = new ArrayList<>();
       for (List<TsFileResource> value : partitionTmpSeqTsFiles.values()) {
         // tsFiles without resource file are unsealed
+        for (TsFileResource resource : value) {
+          if (resource.resourceFileExists()) {
+            TsFileMetricManager.getInstance().addFile(resource.getTsFile().length(), true);
+          }
+        }
         while (!value.isEmpty()) {
           TsFileResource tsFileResource = value.get(value.size() - 1);
           if (tsFileResource.resourceFileExists()) {
-            TsFileMetricManager.getInstance().addFile(tsFileResource.getTsFile().length(), true);
             break;
           } else {
             value.remove(value.size() - 1);
@@ -469,10 +473,14 @@ public class DataRegion implements IDataRegionForQuery {
       }
       for (List<TsFileResource> value : partitionTmpUnseqTsFiles.values()) {
         // tsFiles without resource file are unsealed
+        for (TsFileResource resource : value) {
+          if (resource.resourceFileExists()) {
+            TsFileMetricManager.getInstance().addFile(resource.getTsFile().length(), false);
+          }
+        }
         while (!value.isEmpty()) {
           TsFileResource tsFileResource = value.get(value.size() - 1);
           if (tsFileResource.resourceFileExists()) {
-            TsFileMetricManager.getInstance().addFile(tsFileResource.getTsFile().length(), false);
             break;
           } else {
             value.remove(value.size() - 1);


### PR DESCRIPTION
See [IOTDB-5160](https://issues.apache.org/jira/browse/IOTDB-5160), [IOTDB-5279](https://issues.apache.org/jira/browse/IOTDB-5279).

The reason for this bug is the program fails to traverse the whole file list in recovering. As a result, the number and size of the files in metrics are smaller than the actual value.