### PR TITLE
[To rel/0.13][IOTDB-5293]fix npe

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -693,11 +693,19 @@ public class TSServiceImpl implements TSIService.Iface {
       Thread.currentThread().interrupt();
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(
-              e, "\"" + req.getStatement() + "\". " + OperationType.EXECUTE_QUERY_STATEMENT));
+              e,
+              "\""
+                  + (req == null ? null : req.getStatement())
+                  + "\". "
+                  + OperationType.EXECUTE_QUERY_STATEMENT));
     } catch (Exception e) {
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(
-              e, "\"" + req.getStatement() + "\". " + OperationType.EXECUTE_QUERY_STATEMENT));
+              e,
+              "\""
+                  + (req == null ? null : req.getStatement())
+                  + "\". "
+                  + OperationType.EXECUTE_QUERY_STATEMENT));
     }
   }
 


### PR DESCRIPTION
## Description
fix npe
ERROR o.a.t.ProcessFunction:47 - Internal error processing executeQueryStatement 
java.lang.NullPointerException: null
        at org.apache.iotdb.db.service.thrift.impl.TSServiceImpl.executeQueryStatement(TSServiceImpl.java:684)
        at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$executeQueryStatement.getResult(TSIService.java:3151)
        at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$executeQueryStatement.getResult(TSIService.java:3131)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.iotdb.db.service.thrift.ProcessorWithMetrics.process(ProcessorWithMetrics.java:64)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
