### PR TITLE
[To rel/1.0][IOTDB-5294] WAL Node close method blocks

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/buffer/WALBuffer.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/buffer/WALBuffer.java
@@ -269,6 +269,7 @@ public class WALBuffer extends AbstractWALBuffer {
           if (dataExists) {
             fsyncWorkingBuffer(currentSearchIndex, currentFileStatus, info);
           }
+          isClosed = true;
           return dataExists;
         default:
           return false;
@@ -511,7 +512,6 @@ public class WALBuffer extends AbstractWALBuffer {
 
   @Override
   public void close() {
-    isClosed = true;
     // first waiting serialize and sync tasks finished, then release all resources
     if (serializeThread != null) {
       // add close signal WALEntry to notify serializeThread
@@ -520,6 +520,7 @@ public class WALBuffer extends AbstractWALBuffer {
       } catch (InterruptedException e) {
         logger.error("Fail to put CLOSE_SIGNAL to walEntries.", e);
       }
+      isClosed = true;
       shutdownThread(serializeThread, ThreadName.WAL_SERIALIZE);
     }
     if (syncBufferThread != null) {


### PR DESCRIPTION
This bug is caused by isClosed flag. After isClosed is set to true, the wal node won‘t submmit serialize task any more, and close method will block at the put method when the walEntries queue is full. So, we should set isClosed to true after the put method.