### PR TITLE
[To rel/0.13][IOTDB-5296]fix close session npe when session is null

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
@@ -160,6 +160,11 @@ public class SessionManager implements SessionManagerMBean {
    * @return true if releasing successfully, false otherwise (e.g., the session does not exist)
    */
   public boolean releaseSessionResource(IClientSession session) {
+
+    if (session == null) {
+      LOGGER.error("Error occurred while releasing session resource: session is null");
+      return false;
+    }
     Set<Long> statementIdSet = session.getStatementIds();
     if (statementIdSet != null) {
       for (Long statementId : statementIdSet) {


### PR DESCRIPTION
## Description
2022-12-10 00:00:25,353 [pool-16-IoTDB-RPC-Client-2074] ERROR o.a.t.ProcessFunction:47 - Internal error processing closeSession 
java.lang.NullPointerException: null
        at org.apache.iotdb.db.service.thrift.impl.TSServiceImpl.closeSession(TSServiceImpl.java:343)
        at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$closeSession.getResult(TSIService.java:3076)
        at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$closeSession.getResult(TSIService.java:3056)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.iotdb.db.service.thrift.ProcessorWithMetrics.process(ProcessorWithMetrics.java:64)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
2022-12-10 00:00:25,353 [pool-16-IoTDB-RPC-Client-2074] ERROR o.a.t.s.TThreadPoolServer$WorkerProcess:258 - Thrift Error occurred during processing of message. 
org.apache.thrift.transport.TTransportException: Read a negative frame size (-2147418111)!
        at org.apache.iotdb.rpc.TElasticFramedTransport.readFrame(TElasticFramedTransport.java:117)
        at org.apache.iotdb.rpc.TElasticFramedTransport.read(TElasticFramedTransport.java:107)
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:109)
        at org.apache.thrift.protocol.TBinaryProtocol.readStringBody(TBinaryProtocol.java:416)
        at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:255)
        at org.apache.iotdb.db.service.thrift.ProcessorWithMetrics.process(ProcessorWithMetrics.java:50)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
