### PR TITLE
[IOTDB-5304] Adjust the column header's order of show cluster details

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
@@ -267,9 +267,9 @@ public class ColumnHeaderConstant {
           new ColumnHeader(CONFIG_CONSENSUS_PORT, TSDataType.TEXT),
           new ColumnHeader(RPC_ADDRESS, TSDataType.TEXT),
           new ColumnHeader(RPC_PORT, TSDataType.TEXT),
-          new ColumnHeader(DATA_CONSENSUS_PORT, TSDataType.TEXT),
+          new ColumnHeader(MPP_PORT, TSDataType.TEXT),
           new ColumnHeader(SCHEMA_CONSENSUS_PORT, TSDataType.TEXT),
-          new ColumnHeader(MPP_PORT, TSDataType.TEXT));
+          new ColumnHeader(DATA_CONSENSUS_PORT, TSDataType.TEXT));
 
   public static final List<ColumnHeader> showFunctionsColumnHeaders =
       ImmutableList.of(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterDetailsTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterDetailsTask.java
@@ -134,9 +134,9 @@ public class ShowClusterDetailsTask implements IConfigTask {
                     e.getInternalEndPoint().getPort(),
                     e.getClientRpcEndPoint().getIp(),
                     e.getClientRpcEndPoint().getPort(),
-                    e.getDataRegionConsensusEndPoint().getPort(),
+                    e.getMPPDataExchangeEndPoint().getPort(),
                     e.getSchemaRegionConsensusEndPoint().getPort(),
-                    e.getMPPDataExchangeEndPoint().getPort()));
+                    e.getDataRegionConsensusEndPoint().getPort()));
 
     DatasetHeader datasetHeader = DatasetHeaderFactory.getShowClusterDetailsHeader();
     future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS, builder.build(), datasetHeader));


### PR DESCRIPTION
adjust the column header's order of `show cluster details` command from DataConsensusPort|SchemaConsensusPort|MppPort into MppPort|SchemaConsensusPort|DataConsensusPort|

![7a8ba4b0b1c996bd5b9586f4f6abe21](https://user-images.githubusercontent.com/42286868/209756549-5198a10a-6c75-46c1-bc99-de76729fba67.png)
