### PR TITLE
[To rel/0.13][IOTDB-5307] Failed to get TsFile input of file: NoSuchFileException

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/RewriteCrossSpaceCompactionSelector.java
@@ -30,13 +30,11 @@ import org.apache.iotdb.db.engine.compaction.inner.utils.InnerSpaceCompactionUti
 import org.apache.iotdb.db.engine.compaction.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
-import org.apache.iotdb.db.exception.MergeException;
 import org.apache.iotdb.db.rescon.SystemInfo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -137,7 +135,7 @@ public class RewriteCrossSpaceCompactionSelector extends AbstractCrossSpaceCompa
             mergeResource.getUnseqFiles().size());
       }
 
-    } catch (MergeException | IOException | InterruptedException e) {
+    } catch (Exception e) {
       LOGGER.error("{} cannot select file for cross space compaction", logicalStorageGroupName, e);
     }
   }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/FileInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/FileInputFactory.java
@@ -21,7 +21,9 @@ package org.apache.iotdb.tsfile.fileSystem.fileInputFactory;
 
 import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 
+import java.io.IOException;
+
 public interface FileInputFactory {
 
-  TsFileInput getTsFileInput(String filePath);
+  TsFileInput getTsFileInput(String filePath) throws IOException;
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/HDFSInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/HDFSInputFactory.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
@@ -44,15 +45,15 @@ public class HDFSInputFactory implements FileInputFactory {
   }
 
   @Override
-  public TsFileInput getTsFileInput(String filePath) {
+  public TsFileInput getTsFileInput(String filePath) throws IOException {
     try {
       return (TsFileInput) constructor.newInstance(filePath);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get TsFile input of file: {}. Please check your dependency of Hadoop module.",
-          filePath,
+      throw new IOException(
+          String.format(
+              "Failed to get TsFile input of file: %s. Please check your dependency of Hadoop module.",
+              filePath),
           e);
-      return null;
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/LocalFSInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/LocalFSInputFactory.java
@@ -22,23 +22,13 @@ package org.apache.iotdb.tsfile.fileSystem.fileInputFactory;
 import org.apache.iotdb.tsfile.read.reader.LocalTsFileInput;
 import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.file.Paths;
 
 public class LocalFSInputFactory implements FileInputFactory {
 
-  private static final Logger logger = LoggerFactory.getLogger(LocalFSInputFactory.class);
-
   @Override
-  public TsFileInput getTsFileInput(String filePath) {
-    try {
-      return new LocalTsFileInput(Paths.get(filePath));
-    } catch (IOException e) {
-      logger.error("Failed to get TsFile input of file: {}, ", filePath, e);
-      return null;
-    }
+  public TsFileInput getTsFileInput(String filePath) throws IOException {
+    return new LocalTsFileInput(Paths.get(filePath));
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -134,6 +134,9 @@ public class TsFileSequenceReader implements AutoCloseable {
     }
     this.file = file;
     tsFileInput = FSFactoryProducer.getFileInputFactory().getTsFileInput(file);
+    if (tsFileInput == null) {
+      throw new IOException("Failed to get TsFile input of file: tsFileInput is null");
+    }
     try {
       if (loadMetadataSize) {
         loadMetadataSize();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -134,9 +134,6 @@ public class TsFileSequenceReader implements AutoCloseable {
     }
     this.file = file;
     tsFileInput = FSFactoryProducer.getFileInputFactory().getTsFileInput(file);
-    if (tsFileInput == null) {
-      throw new IOException("Failed to get TsFile input of file: tsFileInput is null");
-    }
     try {
       if (loadMetadataSize) {
         loadMetadataSize();


### PR DESCRIPTION
## Description
因TsFileResource状态修改存在并发问题，导致ttl删除文件和合并冲突，最终导致合并定时任务卡死，原因是未捕获到npe异常

当前PR实现内容：
1、捕获文件不存在异常
2、捕获跨区合并Exception异常

未解决内容：
修改TsFileResource状态时需要增加并发控制

