### PR TITLE
[IOTDB-5300] Added check in migrate Region sql

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -21,8 +21,10 @@ package org.apache.iotdb.confignode.manager;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
+import org.apache.iotdb.common.rpc.thrift.TDataNodeConfiguration;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.cluster.NodeStatus;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.exception.sync.PipeException;
@@ -87,8 +89,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class ProcedureManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcedureManager.class);
@@ -363,7 +367,10 @@ public class ProcedureManager {
           "Submit RegionMigrateProcedure failed, because no region Group "
               + migrateRegionReq.getRegionId());
       return status;
-    } else if (originalDataNode == null) {
+    }
+    Set<Integer> DataNodesInRegion =
+        regionReplicaMap.get(regionId.get()).getStatistics().getRegionStatisticsMap().keySet();
+    if (originalDataNode == null) {
       LOGGER.warn(
           "Submit RegionMigrateProcedure failed, because no original DataNode {}",
           migrateRegionReq.getFromId());
@@ -381,11 +388,7 @@ public class ProcedureManager {
           "Submit RegionMigrateProcedure failed, because no target DataNode "
               + migrateRegionReq.getToId());
       return status;
-    } else if (!regionReplicaMap
-        .get(regionId.get())
-        .getStatistics()
-        .getRegionStatisticsMap()
-        .containsKey(migrateRegionReq.getFromId())) {
+    } else if (!DataNodesInRegion.contains(migrateRegionReq.getFromId())) {
       LOGGER.warn(
           "Submit RegionMigrateProcedure failed, because the original DataNode {} doesn't contain Region {}",
           migrateRegionReq.getFromId(),
@@ -397,11 +400,7 @@ public class ProcedureManager {
               + " doesn't contain Region "
               + migrateRegionReq.getRegionId());
       return status;
-    } else if (regionReplicaMap
-        .get(regionId.get())
-        .getStatistics()
-        .getRegionStatisticsMap()
-        .containsKey(migrateRegionReq.getToId())) {
+    } else if (DataNodesInRegion.contains(migrateRegionReq.getToId())) {
       LOGGER.warn(
           "Submit RegionMigrateProcedure failed, because the target DataNode {} already contains Region {}",
           migrateRegionReq.getToId(),
@@ -412,6 +411,25 @@ public class ProcedureManager {
               + migrateRegionReq.getToId()
               + " already contains Region "
               + migrateRegionReq.getRegionId());
+      return status;
+    }
+    // Here we only check Running DataNode to implement migration, because removing nodes may not
+    // exist when add peer is performing
+    Set<Integer> aliveDataNodes =
+        configManager.getNodeManager().filterDataNodeThroughStatus(NodeStatus.Running).stream()
+            .map(TDataNodeConfiguration::getLocation)
+            .map(TDataNodeLocation::getDataNodeId)
+            .collect(Collectors.toSet());
+    DataNodesInRegion.retainAll(aliveDataNodes);
+    if (DataNodesInRegion.isEmpty()) {
+      LOGGER.warn(
+          "Submit RegionMigrateProcedure failed, because all of the DataNodes in Region Group {} is unavailable.",
+          migrateRegionReq.getRegionId());
+      TSStatus status = new TSStatus(TSStatusCode.MIGRATE_REGION_ERROR.getStatusCode());
+      status.setMessage(
+          "Submit RegionMigrateProcedure failed, because all of the DataNodes in Region Group "
+              + migrateRegionReq.getRegionId()
+              + " is unavailable.");
       return status;
     }
     this.executor.submitProcedure(


### PR DESCRIPTION
## IOTDB-5300
Now if the region group doesn't contain any running nodes, reject the migration sql.

Future changes:
Support rollback in migrating, delete the statistics of the new region if failure encountered.
Get the region's snapshot resource occupation, and tell if any node can take the snapshot and transmit it to the new region. 
Explore other strategy of migrating when taking snapshot is infeasible.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
