### PR TITLE
[IOTDB-5316] fix bug that Session.setFetchSize is not used in the following fetch requests

### DIFF
--- a/isession/src/main/java/org/apache/iotdb/isession/SessionDataSet.java
+++ b/isession/src/main/java/org/apache/iotdb/isession/SessionDataSet.java
@@ -100,6 +100,37 @@ public class SessionDataSet implements AutoCloseable {
             timeout);
   }
 
+  public SessionDataSet(
+      String sql,
+      List<String> columnNameList,
+      List<String> columnTypeList,
+      Map<String, Integer> columnNameIndex,
+      long queryId,
+      long statementId,
+      IClientRPCService.Iface client,
+      long sessionId,
+      List<ByteBuffer> queryResult,
+      boolean ignoreTimeStamp,
+      long timeout,
+      boolean moreData,
+      int fetchSize) {
+    this.ioTDBRpcDataSet =
+        new IoTDBRpcDataSet(
+            sql,
+            columnNameList,
+            columnTypeList,
+            columnNameIndex,
+            ignoreTimeStamp,
+            moreData,
+            queryId,
+            statementId,
+            client,
+            sessionId,
+            queryResult,
+            fetchSize,
+            timeout);
+  }
+
   public int getFetchSize() {
     return ioTDBRpcDataSet.fetchSize;
   }

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -381,7 +381,8 @@ public class SessionConnection {
         execResp.queryResult,
         execResp.isIgnoreTimeStamp(),
         timeout,
-        execResp.moreData);
+        execResp.moreData,
+        session.fetchSize);
   }
 
   protected void executeNonQueryStatement(String sql)


### PR DESCRIPTION
Session.setFetchSize only applies for the first query execution request and the following fetch request uses the default fetch size 5000. The reason is that the construction method of SessionDataSet in `SessionConnection.executeQueryStatement` uses `SessionConfig.DEFAULT_FETCH_SIZE` instead of the actual `session.fetchSize`. So this pr fixes this bug.