### PR TITLE
[To rel/0.13][IOTDB-5311]Fix RunTimeException and NoSuchFile Exception when selecting files causing compaction scheduled thread to get stuck

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/VirtualStorageGroupProcessor.java
@@ -2217,13 +2217,17 @@ public class VirtualStorageGroupProcessor {
   }
 
   private void executeCompaction() {
-    List<Long> timePartitions = new ArrayList<>(tsFileManager.getTimePartitions());
-    // sort the time partition from largest to smallest
-    timePartitions.sort((o1, o2) -> (int) (o2 - o1));
-    for (long timePartition : timePartitions) {
-      CompactionScheduler.scheduleCompaction(tsFileManager, timePartition);
+    try {
+      List<Long> timePartitions = new ArrayList<>(tsFileManager.getTimePartitions());
+      // sort the time partition from largest to smallest
+      timePartitions.sort((o1, o2) -> (int) (o2 - o1));
+      for (long timePartition : timePartitions) {
+        CompactionScheduler.scheduleCompaction(tsFileManager, timePartition);
+      }
+      CompactionTaskManager.getInstance().submitTaskFromTaskQueue();
+    } catch (Throwable e) {
+      logger.error("Meet error in compaction schedule.", e);
     }
-    CompactionTaskManager.getInstance().submitTaskFromTaskQueue();
   }
 
   /**


### PR DESCRIPTION
**Description**
The process of compaction selecting files may throws No Such File exception and RunTimeException, causing compaction schedule thread to get stuck.
 
**Reason**
The process of selecting file does not add read locks of the source files. Assuming that the file was not deleted at the moment the deleted file was filtered, but was later deleted, No such file exception would be thrown when the reader for the file was built, and a RunTimeException would be thrown when the state was set to CompactionCandidate. Among them, the fix scheduled thread of compaction stops on 0.13, but not on master and 1.0.
 
**Solution**
Do an exception catch in compaction schedule method.
When building a reader for a file, throw IOException instead of NPE if the file does not exist.