### PR TITLE
[To rel/1.0][IOTDB-5311]Fix RunTimeException and NoSuchFile Exception when selecting files causing compaction scheduled thread to get stuck

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -2129,11 +2129,15 @@ public class DataRegion implements IDataRegionForQuery {
   }
 
   private void executeCompaction() {
-    List<Long> timePartitions = new ArrayList<>(tsFileManager.getTimePartitions());
-    // sort the time partition from largest to smallest
-    timePartitions.sort((o1, o2) -> (int) (o2 - o1));
-    for (long timePartition : timePartitions) {
-      CompactionScheduler.scheduleCompaction(tsFileManager, timePartition);
+    try {
+      List<Long> timePartitions = new ArrayList<>(tsFileManager.getTimePartitions());
+      // sort the time partition from largest to smallest
+      timePartitions.sort((o1, o2) -> (int) (o2 - o1));
+      for (long timePartition : timePartitions) {
+        CompactionScheduler.scheduleCompaction(tsFileManager, timePartition);
+      }
+    } catch (Throwable e) {
+      logger.error("Meet error in compaction schedule.", e);
     }
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/FileInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/FileInputFactory.java
@@ -21,7 +21,9 @@ package org.apache.iotdb.tsfile.fileSystem.fileInputFactory;
 
 import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 
+import java.io.IOException;
+
 public interface FileInputFactory {
 
-  TsFileInput getTsFileInput(String filePath);
+  TsFileInput getTsFileInput(String filePath) throws IOException;
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/HDFSInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/HDFSInputFactory.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
@@ -44,15 +45,15 @@ public class HDFSInputFactory implements FileInputFactory {
   }
 
   @Override
-  public TsFileInput getTsFileInput(String filePath) {
+  public TsFileInput getTsFileInput(String filePath) throws IOException {
     try {
       return (TsFileInput) constructor.newInstance(filePath);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get TsFile input of file: {}. Please check your dependency of Hadoop module.",
-          filePath,
+      throw new IOException(
+          String.format(
+              "Failed to get TsFile input of file: %s. Please check your dependency of Hadoop module.",
+              filePath),
           e);
-      return null;
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/LocalFSInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/LocalFSInputFactory.java
@@ -22,23 +22,13 @@ package org.apache.iotdb.tsfile.fileSystem.fileInputFactory;
 import org.apache.iotdb.tsfile.read.reader.LocalTsFileInput;
 import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.file.Paths;
 
 public class LocalFSInputFactory implements FileInputFactory {
 
-  private static final Logger logger = LoggerFactory.getLogger(LocalFSInputFactory.class);
-
   @Override
-  public TsFileInput getTsFileInput(String filePath) {
-    try {
-      return new LocalTsFileInput(Paths.get(filePath));
-    } catch (IOException e) {
-      logger.error("Failed to get TsFile input of file: {}, ", filePath, e);
-      return null;
-    }
+  public TsFileInput getTsFileInput(String filePath) throws IOException {
+    return new LocalTsFileInput(Paths.get(filePath));
   }
 }


### PR DESCRIPTION
**Description**
The process of compaction selecting files may throws No Such File exception and RunTimeException, causing compaction schedule thread to get stuck.

**Reason**
The process of selecting file does not add read locks of the source files. Assuming that the file was not deleted at the moment the deleted file was filtered, but was later deleted, No such file exception would be thrown when the reader for the file was built, and a RunTimeException would be thrown when the state was set to CompactionCandidate. Among them, the fix scheduled thread of compaction stops on 0.13, but not on master and 1.0.

**Solution**
Do an exception catch in compaction schedule method.
When building a reader for a file, throw IOException instead of NPE if the file does not exist.