### PR TITLE
[IOTDB-5228]NPE if the file does not exist when create TsFileSequenceR…

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/FileInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/FileInputFactory.java
@@ -21,7 +21,9 @@ package org.apache.iotdb.tsfile.fileSystem.fileInputFactory;
 
 import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 
+import java.io.IOException;
+
 public interface FileInputFactory {
 
-  TsFileInput getTsFileInput(String filePath);
+  TsFileInput getTsFileInput(String filePath) throws IOException;
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/HDFSInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/HDFSInputFactory.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
@@ -44,15 +45,15 @@ public class HDFSInputFactory implements FileInputFactory {
   }
 
   @Override
-  public TsFileInput getTsFileInput(String filePath) {
+  public TsFileInput getTsFileInput(String filePath) throws IOException {
     try {
       return (TsFileInput) constructor.newInstance(filePath);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get TsFile input of file: {}. Please check your dependency of Hadoop module.",
-          filePath,
+      throw new IOException(
+          String.format(
+              "Failed to get TsFile input of file: %s. Please check your dependency of Hadoop module.",
+              filePath),
           e);
-      return null;
     }
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/LocalFSInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/fileInputFactory/LocalFSInputFactory.java
@@ -22,23 +22,13 @@ package org.apache.iotdb.tsfile.fileSystem.fileInputFactory;
 import org.apache.iotdb.tsfile.read.reader.LocalTsFileInput;
 import org.apache.iotdb.tsfile.read.reader.TsFileInput;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.file.Paths;
 
 public class LocalFSInputFactory implements FileInputFactory {
 
-  private static final Logger logger = LoggerFactory.getLogger(LocalFSInputFactory.class);
-
   @Override
-  public TsFileInput getTsFileInput(String filePath) {
-    try {
-      return new LocalTsFileInput(Paths.get(filePath));
-    } catch (IOException e) {
-      logger.error("Failed to get TsFile input of file: {}, ", filePath, e);
-      return null;
-    }
+  public TsFileInput getTsFileInput(String filePath) throws IOException {
+    return new LocalTsFileInput(Paths.get(filePath));
   }
 }


### PR DESCRIPTION
## Description
NPE if the file does not exist when create TsFileSequenceReader instance

When create a TsFileSequenceReader, an exception will be thrown if the file does not exist, and the reason of the exception can not be caught.

 

Current TsFileSequenceReader:

public TsFileSequenceReader(String file, boolean loadMetadataSize) throws IOException {
  if (resourceLogger.isDebugEnabled()) {
    resourceLogger.debug("{} reader is opened. {}", file, getClass().getName());
  }
  this.file = file;
  tsFileInput = FSFactoryProducer.getFileInputFactory().getTsFileInput(file);
  try {
    if (loadMetadataSize) {
      loadMetadataSize();
    }
  } catch (Throwable e) {
    tsFileInput.close();
    throw e;
  }
} 
 

while TsFileInput:

public TsFileInput getTsFileInput(String filePath) {
  try {
    return new LocalTsFileInput(Paths.get(filePath));
  } catch (IOException e) {
    logger.error("Failed to get TsFile input of file: {}, ", filePath, e);
    return null;
  }
} 
 

exception example:

private static QueryDataSet readTsFile(String path) throws IOException {
  try (TsFileSequenceReader reader = new TsFileSequenceReader(path);
      TsFileReader readTsFile = new TsFileReader(reader)) {
    ArrayList<Path> paths = new ArrayList<>();
    paths.add(new Path("root.test.t2", "c1", true));
    paths.add(new Path("root.test.t2", "c2", true));
    paths.add(new Path("root.test.t2", "c3", true));
    QueryExpression queryExpression = QueryExpression.create(paths, null);
    return readTsFile.query(queryExpression);
  }
} 
java.lang.NullPointerException: Cannot invoke "org.apache.iotdb.tsfile.read.reader.TsFileInput.close()" because "this.tsFileInput" is null    at org.apache.iotdb.tsfile.read.TsFileSequenceReader.<init>(TsFileSequenceReader.java:143)
    at org.apache.iotdb.tsfile.read.TsFileSequenceReader.<init>(TsFileSequenceReader.java:123)
    at org.apache.iotdb.cross.tests.tools.tsfile.ExportTsFileTestIT.readTsFile(ExportTsFileTestIT.java:89)
    at org.apache.iotdb.cross.tests.tools.tsfile.ExportTsFileTestIT.testExport(ExportTsFileTestIT.java:78)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:568)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
    at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
    at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
    at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
    at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
    at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
    at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
    at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
    at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
    at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
    at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54) 
 