### PR TITLE
[IOTDB-5245] Fix bug in last query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/utils/MetaUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/utils/MetaUtils.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.LOSS;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.SDT_PARAMETERS;
@@ -118,15 +117,12 @@ public class MetaUtils {
 
   public static List<PartialPath> groupAlignedSeriesWithOrder(
       List<PartialPath> fullPaths, OrderByParameter orderByParameter) {
-    fullPaths.sort(
+    List<PartialPath> res = groupAlignedSeries(fullPaths, new HashMap<>());
+    res.sort(
         orderByParameter.getSortItemList().get(0).getOrdering() == Ordering.ASC
             ? Comparator.naturalOrder()
             : Comparator.reverseOrder());
-    Map<String, AlignedPath> deviceToAlignedPathMap =
-        orderByParameter.getSortItemList().get(0).getOrdering() == Ordering.ASC
-            ? new TreeMap<>()
-            : new TreeMap<>(Collections.reverseOrder());
-    return groupAlignedSeries(fullPaths, deviceToAlignedPathMap);
+    return res;
   }
 
   private static List<PartialPath> groupAlignedSeries(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
@@ -2013,7 +2013,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
             .addOperatorContext(
                 context.getNextOperatorId(),
                 node.getPlanNodeId(),
-                TimeJoinOperator.class.getSimpleName());
+                LastQueryMergeOperator.class.getSimpleName());
 
     List<SortItem> items = node.getMergeOrderParameter().getSortItemList();
     Comparator<Binary> comparator =
@@ -2038,7 +2038,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
             .addOperatorContext(
                 context.getNextOperatorId(),
                 node.getPlanNodeId(),
-                TimeJoinOperator.class.getSimpleName());
+                LastQueryCollectOperator.class.getSimpleName());
 
     context.getTimeSliceAllocator().recordExecutionWeight(operatorContext, 1);
     return new LastQueryCollectOperator(operatorContext, children);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
@@ -546,18 +546,19 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
     if (root instanceof LastQueryNode) {
       LastQueryNode lastQueryNode = (LastQueryNode) root;
       lastQueryNode.setMergeOrderParameter(orderByParameter);
+      // sort children node
       lastQueryNode.setChildren(
           lastQueryNode.getChildren().stream()
               .sorted(
                   Comparator.comparing(
                       child -> {
-                        String device = "";
+                        String fullPath = "";
                         if (child instanceof LastQueryScanNode) {
-                          device = ((LastQueryScanNode) child).getSeriesPath().getDevice();
+                          fullPath = ((LastQueryScanNode) child).getSeriesPath().getFullPath();
                         } else if (child instanceof AlignedLastQueryScanNode) {
-                          device = ((AlignedLastQueryScanNode) child).getSeriesPath().getDevice();
+                          fullPath = ((AlignedLastQueryScanNode) child).getSeriesPath().getDevice();
                         }
-                        return device;
+                        return fullPath;
                       }))
               .collect(Collectors.toList()));
     } else {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
@@ -543,7 +543,9 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
   }
 
   private void addSortForEachLastQueryNode(PlanNode root, OrderByParameter orderByParameter) {
-    if (root instanceof LastQueryNode) {
+    if (root instanceof LastQueryNode
+        && (root.getChildren().get(0) instanceof LastQueryScanNode
+            || root.getChildren().get(0) instanceof AlignedLastQueryScanNode)) {
       LastQueryNode lastQueryNode = (LastQueryNode) root;
       lastQueryNode.setMergeOrderParameter(orderByParameter);
       // sort children node

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/process/last/LastQueryNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/process/last/LastQueryNode.java
@@ -44,7 +44,7 @@ public class LastQueryNode extends MultiChildProcessNode {
 
   // The result output order, which could sort by sensor and time.
   // The size of this list is 2 and the first SortItem in this list has higher priority.
-  private final OrderByParameter mergeOrderParameter;
+  private OrderByParameter mergeOrderParameter;
 
   public LastQueryNode(PlanNodeId id, Filter timeFilter, OrderByParameter mergeOrderParameter) {
     super(id);
@@ -163,5 +163,9 @@ public class LastQueryNode extends MultiChildProcessNode {
 
   public OrderByParameter getMergeOrderParameter() {
     return mergeOrderParameter;
+  }
+
+  public void setMergeOrderParameter(OrderByParameter mergeOrderParameter) {
+    this.mergeOrderParameter = mergeOrderParameter;
   }
 }


### PR DESCRIPTION
While there exist multi data regions for one series slot, we will add LastMergeSortNode to merge all last query result from different data regions, it will select max time for the same time-series.
However, if so, we still need to add default order by parameter for each LastQueryNode in each DataRegion and sort its children by timeseries asc, because `LastQueryMergeOperator` will assume that all its children returning TsBlock has already been sorted.