### PR TITLE
Fix out of bound Segment access in SchemaFile

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/ISchemaPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/ISchemaPage.java
@@ -109,8 +109,6 @@ public interface ISchemaPage {
     return new AliasIndexPage(buffer);
   }
 
-  boolean isCapableForSize(short size);
-
   void syncPageBuffer();
 
   void flushPageToChannel(FileChannel channel) throws IOException;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/ISegmentedPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/ISegmentedPage.java
@@ -64,6 +64,8 @@ public interface ISegmentedPage extends ISchemaPage {
 
   short getSpareSize();
 
+  boolean isCapableForSegSize(short size);
+
   short getSegmentSize(short segId) throws SegmentNotFoundException;
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/InternalPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/InternalPage.java
@@ -79,7 +79,7 @@ public class InternalPage extends SchemaPage implements ISegment<Integer, Intege
   @Override
   public int insertRecord(String key, Integer pointer) throws RecordDuplicatedException {
     // TODO: remove debug parameter INTERNAL_SPLIT_VALVE
-    if (spareSize < 8 + 4 + key.getBytes().length + INTERNAL_SPLIT_VALVE) {
+    if (spareSize < COMPOUND_POINT_LENGTH + 4 + key.getBytes().length + INTERNAL_SPLIT_VALVE) {
       return -1;
     }
 
@@ -267,7 +267,7 @@ public class InternalPage extends SchemaPage implements ISegment<Integer, Intege
       this.pageBuffer.position(this.spareOffset);
       dstBuffer.put(this.pageBuffer);
 
-      // migrate p1 to p_n-1, offset of each pointer has not to be modified
+      // migrate p1 to p_n-1, offset of each pointer shall not be modified
       dstBuffer.position(PAGE_HEADER_SIZE);
       this.pageBuffer.position(PAGE_HEADER_SIZE + COMPOUND_POINT_LENGTH);
       this.pageBuffer.limit(PAGE_HEADER_SIZE + COMPOUND_POINT_LENGTH * this.memberNum);
@@ -344,6 +344,7 @@ public class InternalPage extends SchemaPage implements ISegment<Integer, Intege
       for (int vi = splitPos; vi <= this.memberNum; vi++) {
         if (vi == pos + 1) {
           // directly points to the new key, do nothing
+          // offset of mPtr always be corrected below, MIN_VALUE as placeholder
           mPtr = compoundPointer(pk, Short.MIN_VALUE);
           mKey = key;
         } else {
@@ -351,8 +352,8 @@ public class InternalPage extends SchemaPage implements ISegment<Integer, Intege
           ai = vi > pos ? vi - 1 : vi;
           mPtr = getPointerByIndex(ai);
           mKey = getKeyByIndex(ai);
-          // this.memberNum --;
-          this.spareSize -= COMPOUND_POINT_LENGTH + mKey.getBytes().length + 4;
+          // this.spareSize and this.memNumber will always be corrected below during compaction,
+          //  therefore unnecessary to count here
         }
 
         memberNum++;
@@ -534,8 +535,8 @@ public class InternalPage extends SchemaPage implements ISegment<Integer, Intege
    *
    * <ul>
    *   <li>16 bits: reserved
-   *   <li>32 bits: page index, which indicate segment actually
-   *   <li>16 bits: key offset, which denote keys in corresponding segment
+   *   <li>32 bits: page index, which points to target content
+   *   <li>16 bits: key offset, which denotes where key is in this page/segment.
    * </ul>
    */
   private long compoundPointer(int pageIndex, short offset) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaPage.java
@@ -58,11 +58,6 @@ public abstract class SchemaPage implements ISchemaPage {
   }
 
   @Override
-  public boolean isCapableForSize(short size) {
-    return spareSize >= size;
-  }
-
-  @Override
   public void syncPageBuffer() {
     this.pageBuffer.limit(this.pageBuffer.capacity());
     this.pageBuffer.position(SchemaFileConfig.PAGE_HEADER_INDEX_OFFSET);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SegmentedPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SegmentedPage.java
@@ -172,6 +172,11 @@ public class SegmentedPage extends SchemaPage implements ISegmentedPage {
   }
 
   @Override
+  public boolean isCapableForSegSize(short size) {
+    return spareSize >= size + SchemaFileConfig.SEG_OFF_DIG;
+  }
+
+  @Override
   public short getSegmentSize(short segId) throws SegmentNotFoundException {
     return getSegment(segId).size();
   }
@@ -201,7 +206,7 @@ public class SegmentedPage extends SchemaPage implements ISegmentedPage {
   @Override
   public long transplantSegment(ISegmentedPage srcPage, short segId, short newSegSize)
       throws MetadataException {
-    if (!isCapableForSize(newSegSize)) {
+    if (!isCapableForSegSize(newSegSize)) {
       throw new SchemaPageOverflowException(pageIndex);
     }
     if (maxAppendableSegmentSize() < newSegSize) {
@@ -408,7 +413,8 @@ public class SegmentedPage extends SchemaPage implements ISegmentedPage {
   }
 
   private short maxAppendableSegmentSize() {
-    return (short) (pageBuffer.limit() - 2 * (memberNum + 1) - spareOffset);
+    return (short)
+        (pageBuffer.limit() - SchemaFileConfig.SEG_OFF_DIG * (memberNum + 1) - spareOffset);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
@@ -493,14 +493,14 @@ public abstract class PageManager implements IPageManager {
   protected ISegmentedPage getMinApplSegmentedPageInMem(short size) {
     for (Map.Entry<Integer, ISchemaPage> entry : dirtyPages.entrySet()) {
       if (entry.getValue().getAsSegmentedPage() != null
-          && entry.getValue().isCapableForSize(size)) {
+          && entry.getValue().getAsSegmentedPage().isCapableForSegSize(size)) {
         return dirtyPages.get(entry.getKey()).getAsSegmentedPage();
       }
     }
 
     for (Map.Entry<Integer, ISchemaPage> entry : pageInstCache.entrySet()) {
       if (entry.getValue().getAsSegmentedPage() != null
-          && entry.getValue().isCapableForSize(size)) {
+          && entry.getValue().getAsSegmentedPage().isCapableForSegSize(size)) {
         markDirty(entry.getValue());
         return pageInstCache.get(entry.getKey()).getAsSegmentedPage();
       }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -469,7 +469,9 @@ public abstract class Traverser {
     // if the node is usingTemplate, the upperTemplate won't be null or the upperTemplateId won't be
     // NON_TEMPLATE.
     throw new IllegalStateException(
-        "There should not be no template mounted on any ancestor of a node usingTemplate.");
+        String.format(
+            "There should be a template mounted on any ancestor of the node [%s] usingTemplate.",
+            node.getFullPath()));
   }
 
   public void setTemplateMap(Map<Integer, Template> templateMap) {


### PR DESCRIPTION
## Description
The root of this issue is that `SegmentedPage` missed the width of segments offset when check spare size with the requested segment within method `isCapableFor`(renamed to `isCapableForSegSize` now). It only turns up with the segment size steps implemented by https://github.com/apache/iotdb/pull/7726 which was meant to improve space utilization, and under certain work load where a `SegmentedPage` was requested to allocate a 1020B segment with another fifteen 1020B segment alive along with one invliad segment offset. In the previous implementation, modification to the headmost segment offset will contaminate last few bytes of the last segment thus an **out of bound exception** was buried and will only be exposed as those bytes was accessed.

The exception may come up as any erroneous state of the MTree but could be identified by a negative `spareSize` of the related segment, therefore all other usage of `spareSize` had been checked and corrected. 

A few lines was modified to be more straight forward as well.

It also indicates abstraction among pages within SchemaFile could be improved in further development.