### PR TITLE
[To rel/0.13] Fix the issue that the TimeIndex may not be accurate for one device when selecting cross space compaction task

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/TsFileDeviceInfoStore.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/TsFileDeviceInfoStore.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.engine.compaction.cross.rewrite;
+
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.timeindex.DeviceTimeIndex;
+import org.apache.iotdb.db.engine.storagegroup.timeindex.TimeIndexLevel;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TsFileDeviceInfoStore {
+
+  private Map<TsFileResource, TsFileDeviceInfo> cache;
+
+  public TsFileDeviceInfoStore() {
+    cache = new HashMap<>();
+  }
+
+  public TsFileDeviceInfo get(TsFileResource tsFileResource) {
+    return cache.computeIfAbsent(tsFileResource, TsFileDeviceInfo::new);
+  }
+
+  public static class TsFileDeviceInfo {
+    public TsFileResource resource;
+    private Map<String, DeviceInfo> deviceInfoMap;
+
+    public TsFileDeviceInfo(TsFileResource tsFileResource) {
+      this.resource = tsFileResource;
+    }
+
+    private void prepareDeviceInfos() throws IOException {
+      if (deviceInfoMap != null) {
+        return;
+      }
+      deviceInfoMap = new LinkedHashMap<>();
+      if (TimeIndexLevel.valueOf(resource.getTimeIndexType()) == TimeIndexLevel.FILE_TIME_INDEX) {
+        DeviceTimeIndex timeIndex = resource.buildDeviceTimeIndex();
+        for (String deviceId : timeIndex.getDevices()) {
+          deviceInfoMap.put(
+              deviceId,
+              new DeviceInfo(
+                  deviceId, timeIndex.getStartTime(deviceId), timeIndex.getEndTime(deviceId)));
+        }
+      } else {
+        for (String deviceId : resource.getDevices()) {
+          deviceInfoMap.put(
+              deviceId,
+              new DeviceInfo(
+                  deviceId, resource.getStartTime(deviceId), resource.getEndTime(deviceId)));
+        }
+      }
+    }
+
+    public List<DeviceInfo> getDevices() throws IOException {
+      prepareDeviceInfos();
+      return new ArrayList<>(deviceInfoMap.values());
+    }
+
+    public DeviceInfo getDeviceInfoById(String deviceId) throws IOException {
+      prepareDeviceInfos();
+      return deviceInfoMap.get(deviceId);
+    }
+
+    public boolean containsDevice(String deviceId) throws IOException {
+      prepareDeviceInfos();
+      return deviceInfoMap.containsKey(deviceId);
+    }
+  }
+
+  public static class DeviceInfo {
+    public String deviceId;
+    public long startTime;
+    public long endTime;
+
+    public DeviceInfo(String deviceId, long startTime, long endTime) {
+      this.deviceId = deviceId;
+      this.startTime = startTime;
+      this.endTime = endTime;
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -20,6 +20,9 @@
 package org.apache.iotdb.db.engine.compaction.cross.rewrite.selector;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.TsFileDeviceInfoStore;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.TsFileDeviceInfoStore.DeviceInfo;
+import org.apache.iotdb.db.engine.compaction.cross.rewrite.TsFileDeviceInfoStore.TsFileDeviceInfo;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceCompactionResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
@@ -75,6 +78,10 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
 
   private AbstractCompactionEstimator compactionEstimator;
 
+  // Cache the DeviceInfos for used seqFiles to avoid loading DeviceTimeIndex more than 1 times from
+  // disk for each seqFile because each seqFile may be scanned more than 1 time in each selector
+  private final TsFileDeviceInfoStore deviceInfoStore;
+
   public RewriteCompactionFileSelector(CrossSpaceCompactionResource resource, long memoryBudget) {
     this.resource = resource;
     this.memoryBudget = memoryBudget;
@@ -83,6 +90,7 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
     this.maxCrossCompactionFileSize =
         IoTDBDescriptor.getInstance().getConfig().getMaxCrossCompactionCandidateFileSize();
     this.compactionEstimator = new RewriteCrossCompactionEstimator();
+    this.deviceInfoStore = new TsFileDeviceInfoStore();
   }
 
   /**
@@ -274,16 +282,21 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
    *
    * @param unseqFile the tsFileResource of unseqFile to be compacted
    */
-  private void selectOverlappedSeqFiles(TsFileResource unseqFile) {
+  private void selectOverlappedSeqFiles(TsFileResource unseqFile) throws IOException {
     final int SELECT_WARN_THRESHOLD = 10;
-    for (String deviceId : unseqFile.getDevices()) {
-      long unseqStartTime = unseqFile.getStartTime(deviceId);
-      long unseqEndTime = unseqFile.getEndTime(deviceId);
+    // It is unnecessary to cache DeviceInfo for unseqFile into store because it is only be used
+    // once in every selector.
+    TsFileDeviceInfo unseqFileDeviceInfo = new TsFileDeviceInfo(unseqFile);
+    for (DeviceInfo deviceInfo : unseqFileDeviceInfo.getDevices()) {
+      String deviceId = deviceInfo.deviceId;
+      long unseqStartTime = deviceInfo.startTime;
+      long unseqEndTime = deviceInfo.endTime;
 
       boolean noMoreOverlap = false;
       for (int i = 0; i < resource.getSeqFiles().size() && !noMoreOverlap; i++) {
         TsFileResource seqFile = resource.getSeqFiles().get(i);
-        if (!seqFile.mayContainsDevice(deviceId)) {
+        TsFileDeviceInfo seqFileDeviceInfo = deviceInfoStore.get(seqFile);
+        if (!seqFileDeviceInfo.containsDevice(deviceId)) {
           continue;
         }
         int crossSpaceCompactionTimes = 0;
@@ -295,8 +308,8 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
           logger.warn("Meets IOException when selecting files for cross space compaction", e);
         }
 
-        long seqEndTime = seqFile.getEndTime(deviceId);
-        long seqStartTime = seqFile.getStartTime(deviceId);
+        long seqEndTime = seqFileDeviceInfo.getDeviceInfoById(deviceId).endTime;
+        long seqStartTime = seqFileDeviceInfo.getDeviceInfoById(deviceId).startTime;
         if (!seqFile.isClosed()) {
           // for unclosed file, only select those that overlap with the unseq file
           if (unseqEndTime >= seqStartTime) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -79,7 +79,7 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
   private AbstractCompactionEstimator compactionEstimator;
 
   // Cache the DeviceInfos for used seqFiles to avoid loading DeviceTimeIndex more than 1 times from
-  // disk for each seqFile because each seqFile may be scanned more than 1 time in each selector
+  // disk for each seqFile because each seqFile may be scanned more than 1 times in each selector
   private final TsFileDeviceInfoStore deviceInfoStore;
 
   public RewriteCompactionFileSelector(CrossSpaceCompactionResource resource, long memoryBudget) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -317,6 +317,25 @@ public class TsFileResource {
     }
   }
 
+  public DeviceTimeIndex buildDeviceTimeIndex() throws IOException {
+    readLock();
+    try (InputStream inputStream =
+        FSFactoryProducer.getFSFactory()
+            .getBufferedInputStream(file.getPath() + TsFileResource.RESOURCE_SUFFIX)) {
+      ReadWriteIOUtils.readByte(inputStream);
+      ITimeIndex timeIndexFromResourceFile = ITimeIndex.createTimeIndex(inputStream);
+      if (!(timeIndexFromResourceFile instanceof DeviceTimeIndex)) {
+        throw new IOException("cannot build DeviceTimeIndex from resource " + file.getPath());
+      }
+      return (DeviceTimeIndex) timeIndexFromResourceFile;
+    } catch (Exception e) {
+      throw new IOException(
+          "Can't read file " + file.getPath() + TsFileResource.RESOURCE_SUFFIX + " from disk", e);
+    } finally {
+      readUnlock();
+    }
+  }
+
   public void updateStartTime(String device, long time) {
     timeIndex.updateStartTime(device, time);
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/DeviceTimeIndex.java
@@ -150,6 +150,10 @@ public class DeviceTimeIndex implements ITimeIndex {
     return deviceToIndex.keySet();
   }
 
+  public Set<String> getDevices() {
+    return deviceToIndex.keySet();
+  }
+
   @Override
   public boolean endTimeEmpty() {
     for (long endTime : endTimes) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/ITimeIndex.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/timeindex/ITimeIndex.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.engine.storagegroup.timeindex;
 
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.PartitionViolationException;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -186,4 +187,12 @@ public interface ITimeIndex {
    * it may or may not contain this device
    */
   boolean mayContainsDevice(String device);
+
+  static ITimeIndex createTimeIndex(InputStream inputStream) throws IOException {
+    byte timeIndexType = ReadWriteIOUtils.readByte(inputStream);
+    if (timeIndexType == -1) {
+      throw new IOException("The end of stream has been reached");
+    }
+    return TimeIndexLevel.valueOf(timeIndexType).getTimeIndex().deserialize(inputStream);
+  }
 }


### PR DESCRIPTION
## Description
Before this change, the FileTimeIndex may be used to judge the overlap of one device between two TsFiles when selecting cross space compaction task, which is not accurate and may lead to omission of related `seqFile`s.

This PR will use the DeviceTimeIndex in force when doing the selection and will load the DeviceTimeIndex from resource file for one TsFile if its DeviceTimeIndex is not cached in memory.

We use a `deviceInfoStore` to cache all DeviceTimeIndex for seq files.

## Notes
In this PR, we follow the principle to keep the original code logic as much as possible to avoid new bugs introduced

## Tests
1. basic test
    <img width="1461" alt="image" src="https://user-images.githubusercontent.com/18027703/210122101-8304a0d4-83fe-4451-b299-d27183426e2d.png">

2. local debug test
    <img width="1206" alt="image" src="https://user-images.githubusercontent.com/18027703/210122183-bffbc4bd-b2c1-446f-b789-5f882c648139.png">
    From the local debug case, we make the TimeIndex load from resource file in force. And we can see that the method can load the DeviceTimeIndex successfully.

     
   <img width="1462" alt="image" src="https://user-images.githubusercontent.com/18027703/210122237-184dc6f8-e999-4754-97b0-451b570c645d.png">
    The compaction task can be selected successfully

3. E2E test
   We run the cross space compaction locally and to see whether the unseq files can be merged totally or not.

   Before compaction, the files in unsequence folder is:
    <img width="915" alt="image" src="https://user-images.githubusercontent.com/18027703/210122312-7342b51e-e502-49c8-974f-c0d77bceb550.png">

   After compaction, the folder is empty
   <img width="772" alt="image" src="https://user-images.githubusercontent.com/18027703/210122333-5a2197b4-b554-4528-a29a-b992223e6c66.png">



