### PR TITLE
[IOTDB-5333] Fix a typo of max_tsblock_line_number in iotdb-common.properties

### DIFF
--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -396,7 +396,7 @@
 
 # The max number of lines in a single TsBlock
 # Datatype: int
-# max_tsblock_line_numbers=1000
+# max_tsblock_line_number=1000
 
 # Time cost(ms) threshold for slow query
 # Datatype: long


### PR DESCRIPTION
The Java code:
![image](https://user-images.githubusercontent.com/3821212/210293085-c85defc1-c5f5-420a-b8ce-6d9acdd4c7ad.png)
