### PR TITLE
[To rel/1.0][IOTDB-5333] Fix a typo of max_tsblock_line_number in iotdb-common.properties

### DIFF
--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -401,7 +401,7 @@
 
 # The max number of lines in a single TsBlock
 # Datatype: int
-# max_tsblock_line_numbers=1000
+# max_tsblock_line_number=1000
 
 # Time cost(ms) threshold for slow query
 # Datatype: long


### PR DESCRIPTION
A cherry pick of #8705 