### PR TITLE
Fix cluster_name definition conflict

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
@@ -268,28 +268,6 @@ public class IoTDBConstant {
   public static final String WAL_START_SEARCH_INDEX = "startSearchIndex";
   public static final String WAL_STATUS_CODE = "statusCode";
 
-  // show cluster status
-  public static final String NODE_TYPE_CONFIG_NODE = "ConfigNode";
-  public static final String NODE_TYPE_DATA_NODE = "DataNode";
-  public static final String CLUSTER_NAME = "ClusterName";
-  public static final String CONFIG_NODE_CONSENSUS_PROTOCOL_CLASS =
-      "ConfigNodeConsensusProtocolClass";
-  public static final String DATA_REGION_CONSENSUS_PROTOCOL_CLASS =
-      "DataRegionConsensusProtocolClass";
-  public static final String SCHEMA_REGION_CONSENSUS_PROTOCOL_CLASS =
-      "SchemaRegionConsensusProtocolClass";
-  public static final String SERIES_SLOT_NUM = "SeriesSlotNum";
-  public static final String SERIES_SLOT_EXECUTOR_CLASS = "SeriesSlotExecutorClass";
-  public static final String DEFAULT_TTL = "DefaultTTL(ms)";
-  public static final String TIME_PARTITION_INTERVAL = "TimePartitionInterval";
-  public static final String DATA_REPLICATION_FACTOR = "DataReplicationFactor";
-  public static final String SCHEMA_REPLICATION_FACTOR = "SchemaReplicationFactor";
-  public static final String SCHEMA_REGION_PER_DATA_NODE = "SchemaRegionPerDataNode";
-  public static final String DATA_REGION_PER_PROCESSOR = "DataRegionPerProcessor";
-  public static final String READ_CONSISTENCY_LEVEL = "ReadConsistencyLevel";
-  public static final String DISK_SPACE_WARNING_THRESHOLD = "DiskSpaceWarningThreshold";
-  public static final String LEAST_DATA_REGION_GROUP_NUM = "LeastDataRegionGroupNum";
-
   public static final String IOTDB_FOREGROUND = "iotdb-foreground";
   public static final String IOTDB_PIDFILE = "iotdb-pidfile";
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -132,7 +132,6 @@ public class IoTDBStartCheck {
   // endregion
   // region params don't need checking, determined by the system
   private static final String IOTDB_VERSION_STRING = "iotdb_version";
-  private static final String CLUSTER_NAME = "cluster_name";
   private static final String DATA_NODE_ID = "data_node_id";
   private static final String SCHEMA_REGION_CONSENSUS_PROTOCOL = "schema_region_consensus_protocol";
   private static final String DATA_REGION_CONSENSUS_PROTOCOL = "data_region_consensus_protocol";
@@ -408,8 +407,8 @@ public class IoTDBStartCheck {
     }
 
     // load configuration from system properties only when start as Data node
-    if (properties.containsKey(CLUSTER_NAME)) {
-      config.setClusterName(properties.getProperty(CLUSTER_NAME));
+    if (properties.containsKey(IoTDBConstant.CLUSTER_NAME)) {
+      config.setClusterName(properties.getProperty(IoTDBConstant.CLUSTER_NAME));
     }
     if (properties.containsKey(DATA_NODE_ID)) {
       config.setDataNodeId(Integer.parseInt(properties.getProperty(DATA_NODE_ID)));
@@ -454,7 +453,7 @@ public class IoTDBStartCheck {
     reloadProperties();
 
     try (FileOutputStream tmpFOS = new FileOutputStream(tmpPropertiesFile.toString())) {
-      properties.setProperty(CLUSTER_NAME, clusterName);
+      properties.setProperty(IoTDBConstant.CLUSTER_NAME, clusterName);
       properties.setProperty(DATA_NODE_ID, String.valueOf(dataNodeId));
       properties.store(tmpFOS, SYSTEM_PROPERTIES_STRING);
       // serialize finished, delete old system.properties file

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
@@ -93,11 +93,29 @@ public class ColumnHeaderConstant {
   public static final String PATH_PATTERN = "PathPattern";
   public static final String CLASS_NAME = "ClassName";
 
+  // show cluster status
+  public static final String NODE_TYPE_CONFIG_NODE = "ConfigNode";
+  public static final String NODE_TYPE_DATA_NODE = "DataNode";
+  public static final String CLUSTER_NAME = "ClusterName";
+  public static final String CONFIG_NODE_CONSENSUS_PROTOCOL_CLASS =
+      "ConfigNodeConsensusProtocolClass";
+  public static final String DATA_REGION_CONSENSUS_PROTOCOL_CLASS =
+      "DataRegionConsensusProtocolClass";
+  public static final String SCHEMA_REGION_CONSENSUS_PROTOCOL_CLASS =
+      "SchemaRegionConsensusProtocolClass";
+  public static final String SERIES_SLOT_NUM = "SeriesSlotNum";
+  public static final String SERIES_SLOT_EXECUTOR_CLASS = "SeriesSlotExecutorClass";
+  public static final String DEFAULT_TTL = "DefaultTTL(ms)";
+  public static final String SCHEMA_REGION_PER_DATA_NODE = "SchemaRegionPerDataNode";
+  public static final String DATA_REGION_PER_PROCESSOR = "DataRegionPerProcessor";
+  public static final String READ_CONSISTENCY_LEVEL = "ReadConsistencyLevel";
+  public static final String DISK_SPACE_WARNING_THRESHOLD = "DiskSpaceWarningThreshold";
+  public static final String LEAST_DATA_REGION_GROUP_NUM = "LeastDataRegionGroupNum";
+
   // column names for show region statement
   public static final String REGION_ID = "RegionId";
   public static final String TYPE = "Type";
   public static final String DATA_NODE_ID = "DataNodeId";
-  public static final String SERIES_SLOT_NUM = "SeriesSlotNum";
   public static final String TIME_SLOT_NUM = "TimeSlotNum";
   public static final String SERIES_SLOT_ID = "SeriesSlotId";
   public static final String TIME_SLOT_ID = "TimeSlotId";

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
@@ -96,7 +96,7 @@ public class ColumnHeaderConstant {
   // show cluster status
   public static final String NODE_TYPE_CONFIG_NODE = "ConfigNode";
   public static final String NODE_TYPE_DATA_NODE = "DataNode";
-  public static final String CLUSTER_NAME = "ClusterName";
+  public static final String COLUMN_CLUSTER_NAME = "ClusterName";
   public static final String CONFIG_NODE_CONSENSUS_PROTOCOL_CLASS =
       "ConfigNodeConsensusProtocolClass";
   public static final String DATA_REGION_CONSENSUS_PROTOCOL_CLASS =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterDetailsTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterDetailsTask.java
@@ -39,8 +39,8 @@ import com.google.common.util.concurrent.SettableFuture;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.iotdb.commons.conf.IoTDBConstant.NODE_TYPE_CONFIG_NODE;
-import static org.apache.iotdb.commons.conf.IoTDBConstant.NODE_TYPE_DATA_NODE;
+import static org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant.NODE_TYPE_CONFIG_NODE;
+import static org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant.NODE_TYPE_DATA_NODE;
 
 public class ShowClusterDetailsTask implements IConfigTask {
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterParametersTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterParametersTask.java
@@ -64,7 +64,7 @@ public class ShowClusterParametersTask implements IConfigTask {
     TClusterParameters clusterParameters = showClusterParametersResp.getClusterParameters();
     buildTSBlock(
         builder,
-        new Binary(ColumnHeaderConstant.CLUSTER_NAME),
+        new Binary(ColumnHeaderConstant.COLUMN_CLUSTER_NAME),
         new Binary(clusterParameters.getClusterName()));
     buildTSBlock(
         builder,

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterParametersTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterParametersTask.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.mpp.plan.execution.config.metadata;
 
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.confignode.rpc.thrift.TClusterParameters;
 import org.apache.iotdb.confignode.rpc.thrift.TShowClusterParametersResp;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
@@ -65,63 +64,63 @@ public class ShowClusterParametersTask implements IConfigTask {
     TClusterParameters clusterParameters = showClusterParametersResp.getClusterParameters();
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.CLUSTER_NAME),
+        new Binary(ColumnHeaderConstant.CLUSTER_NAME),
         new Binary(clusterParameters.getClusterName()));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.DATA_REPLICATION_FACTOR),
+        new Binary(ColumnHeaderConstant.DATA_REPLICATION_FACTOR),
         new Binary(String.valueOf(clusterParameters.getDataReplicationFactor())));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.SCHEMA_REPLICATION_FACTOR),
+        new Binary(ColumnHeaderConstant.SCHEMA_REPLICATION_FACTOR),
         new Binary(String.valueOf(clusterParameters.getSchemaReplicationFactor())));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.DATA_REGION_CONSENSUS_PROTOCOL_CLASS),
+        new Binary(ColumnHeaderConstant.DATA_REGION_CONSENSUS_PROTOCOL_CLASS),
         new Binary(clusterParameters.getDataRegionConsensusProtocolClass()));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.SCHEMA_REGION_CONSENSUS_PROTOCOL_CLASS),
+        new Binary(ColumnHeaderConstant.SCHEMA_REGION_CONSENSUS_PROTOCOL_CLASS),
         new Binary(clusterParameters.getSchemaRegionConsensusProtocolClass()));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.CONFIG_NODE_CONSENSUS_PROTOCOL_CLASS),
+        new Binary(ColumnHeaderConstant.CONFIG_NODE_CONSENSUS_PROTOCOL_CLASS),
         new Binary(clusterParameters.getConfigNodeConsensusProtocolClass()));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.TIME_PARTITION_INTERVAL),
+        new Binary(ColumnHeaderConstant.TIME_PARTITION_INTERVAL),
         new Binary(String.valueOf(clusterParameters.getTimePartitionInterval())));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.DEFAULT_TTL),
+        new Binary(ColumnHeaderConstant.DEFAULT_TTL),
         new Binary(String.valueOf(clusterParameters.getDefaultTTL())));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.READ_CONSISTENCY_LEVEL),
+        new Binary(ColumnHeaderConstant.READ_CONSISTENCY_LEVEL),
         new Binary(String.valueOf(clusterParameters.getReadConsistencyLevel())));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.SCHEMA_REGION_PER_DATA_NODE),
+        new Binary(ColumnHeaderConstant.SCHEMA_REGION_PER_DATA_NODE),
         new Binary(String.valueOf(clusterParameters.getSchemaRegionPerDataNode())));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.DATA_REGION_PER_PROCESSOR),
+        new Binary(ColumnHeaderConstant.DATA_REGION_PER_PROCESSOR),
         new Binary(String.valueOf(clusterParameters.getDataRegionPerProcessor())));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.LEAST_DATA_REGION_GROUP_NUM),
+        new Binary(ColumnHeaderConstant.LEAST_DATA_REGION_GROUP_NUM),
         new Binary(String.valueOf(clusterParameters.getLeastDataRegionGroupNum())));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.SERIES_SLOT_NUM),
+        new Binary(ColumnHeaderConstant.SERIES_SLOT_NUM),
         new Binary(String.valueOf(clusterParameters.getSeriesPartitionSlotNum())));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.SERIES_SLOT_EXECUTOR_CLASS),
+        new Binary(ColumnHeaderConstant.SERIES_SLOT_EXECUTOR_CLASS),
         new Binary(clusterParameters.getSeriesPartitionExecutorClass()));
     buildTSBlock(
         builder,
-        new Binary(IoTDBConstant.DISK_SPACE_WARNING_THRESHOLD),
+        new Binary(ColumnHeaderConstant.DISK_SPACE_WARNING_THRESHOLD),
         new Binary(String.valueOf(clusterParameters.getDiskSpaceWarningThreshold())));
 
     DatasetHeader datasetHeader = DatasetHeaderFactory.getShowClusterParametersHeader();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowClusterTask.java
@@ -39,8 +39,8 @@ import com.google.common.util.concurrent.SettableFuture;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.iotdb.commons.conf.IoTDBConstant.NODE_TYPE_CONFIG_NODE;
-import static org.apache.iotdb.commons.conf.IoTDBConstant.NODE_TYPE_DATA_NODE;
+import static org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant.NODE_TYPE_CONFIG_NODE;
+import static org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant.NODE_TYPE_DATA_NODE;
 
 public class ShowClusterTask implements IConfigTask {
 


### PR DESCRIPTION
Changes:

1. Remove `CLUSTER_NAME` definition in IoTDBStartupCheck.
2. Definition `CLUSTER_NAME = "cluster_name"` is in IoTDBConstant, which will be used for reading configuration files.
3. Definition `COLUMN_CLUSTER_NAME = "ClusterName"` is in ColumnHeaderConstant, which will be used for indicating a row result of SQL: `SHOW VARIABLES`.