### PR TITLE
Fix testGetSlots IT bug

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionGetterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionGetterIT.java
@@ -94,7 +94,7 @@ public class IoTDBPartitionGetterIT {
       ConfigFactory.getConfig().getTimePartitionInterval();
 
   protected static int originalLeastDataRegionGroupNum;
-  private static final int testLeastDataRegionGroupNum = 3;
+  private static final int testLeastDataRegionGroupNum = 5;
 
   private static final String sg = "root.sg";
   private static final int storageGroupNum = 2;


### PR DESCRIPTION
Modify a test configuration to avoid local test bug. Since our local computers always have sufficient CPUs, this IT will create DataRegionGroups for each StorageGroups that more than expected(leastDataRegionGroupNum).