### PR TITLE
[IOTDB-5347] Implement iterating query for devices and timeseries schema query

### DIFF
--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -1660,12 +1660,6 @@ public class RSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
-      throws MetadataException {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException {
     throw new UnsupportedOperationException();

--- a/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
+++ b/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
@@ -656,12 +656,6 @@ public class TagSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
-      throws MetadataException {
-    throw new UnsupportedOperationException("getPathsUsingTemplate");
-  }
-
-  @Override
   public long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException {
     throw new UnsupportedOperationException("constructSchemaBlackListWithTemplate");

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
@@ -267,8 +267,5 @@ public interface IMTreeBelowSG {
 
   void activateTemplate(PartialPath activatePath, Template template) throws MetadataException;
 
-  List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
-      throws MetadataException;
-
   long countPathsUsingTemplate(PartialPath pathPattern, int templateId) throws MetadataException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -688,14 +688,13 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
           @Override
           protected void collectEntity(IEntityMNode node) {
             PartialPath device = getCurrentPartialPath(node);
-            if (plan.hasSgCol()) {
-              res.add(new ShowDevicesResult(device.getFullPath(), node.isAligned()));
-            } else {
-              res.add(new ShowDevicesResult(device.getFullPath(), node.isAligned()));
-            }
+            res.add(new ShowDevicesResult(device.getFullPath(), node.isAligned()));
           }
         };
     collector.setPrefixMatch(plan.isPrefixMatch());
+    if (plan.usingSchemaTemplate()) {
+      collector.setSchemaTemplateFilter(plan.getSchemaTemplateId());
+    }
     collector.traverse();
 
     return res;
@@ -1104,24 +1103,6 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
     } finally {
       unPinPath(cur);
     }
-  }
-
-  @Override
-  public List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
-      throws MetadataException {
-    Set<String> result = new HashSet<>();
-
-    EntityCollector<Set<String>> collector =
-        new EntityCollector<Set<String>>(storageGroupMNode, pathPattern, store) {
-          @Override
-          protected void collectEntity(IEntityMNode node) {
-            if (node.getSchemaTemplateId() == templateId) {
-              result.add(node.getFullPath());
-            }
-          }
-        };
-    collector.traverse();
-    return new ArrayList<>(result);
   }
 
   public Map<PartialPath, List<Integer>> constructSchemaBlackListWithTemplate(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -606,14 +606,13 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
           @Override
           protected void collectEntity(IEntityMNode node) {
             PartialPath device = getCurrentPartialPath(node);
-            if (plan.hasSgCol()) {
-              res.add(new ShowDevicesResult(device.getFullPath(), node.isAligned()));
-            } else {
-              res.add(new ShowDevicesResult(device.getFullPath(), node.isAligned()));
-            }
+            res.add(new ShowDevicesResult(device.getFullPath(), node.isAligned()));
           }
         };
     collector.setPrefixMatch(plan.isPrefixMatch());
+    if (plan.usingSchemaTemplate()) {
+      collector.setSchemaTemplateFilter(plan.getSchemaTemplateId());
+    }
     collector.traverse();
 
     return res;
@@ -1012,24 +1011,6 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
     }
     entityMNode.setUseTemplate(true);
     entityMNode.setSchemaTemplateId(templateId);
-  }
-
-  @Override
-  public List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
-      throws MetadataException {
-    Set<String> result = new HashSet<>();
-
-    EntityCollector<Set<String>> collector =
-        new EntityCollector<Set<String>>(storageGroupMNode, pathPattern, store) {
-          @Override
-          protected void collectEntity(IEntityMNode node) {
-            if (node.getSchemaTemplateId() == templateId) {
-              result.add(node.getFullPath());
-            }
-          }
-        };
-    collector.traverse();
-    return new ArrayList<>(result);
   }
 
   public List<IEntityMNode> getDeviceMNodeUsingTargetTemplate(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/EntityCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/EntityCollector.java
@@ -27,6 +27,9 @@ import org.apache.iotdb.db.metadata.mtree.store.IMTreeStore;
 // This class defines EntityMNode as target node and defines the Entity process framework.
 public abstract class EntityCollector<T> extends CollectorTraverser<T> {
 
+  private boolean usingTemplate = false;
+  private int schemaTemplateId = -1;
+
   public EntityCollector(IMNode startNode, PartialPath path, IMTreeStore store)
       throws MetadataException {
     super(startNode, path, store);
@@ -47,6 +50,9 @@ public abstract class EntityCollector<T> extends CollectorTraverser<T> {
   protected boolean processFullMatchedMNode(IMNode node, int idx, int level)
       throws MetadataException {
     if (node.isEntity()) {
+      if (usingTemplate && schemaTemplateId != node.getSchemaTemplateId()) {
+        return false;
+      }
       if (hasLimit) {
         curOffset += 1;
         if (curOffset < offset) {
@@ -59,6 +65,11 @@ public abstract class EntityCollector<T> extends CollectorTraverser<T> {
       }
     }
     return false;
+  }
+
+  public void setSchemaTemplateFilter(int schemaTemplateId) {
+    this.usingTemplate = true;
+    this.schemaTemplateId = schemaTemplateId;
   }
 
   protected abstract void collectEntity(IEntityMNode node) throws MetadataException;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/impl/read/SchemaRegionReadPlanFactory.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/impl/read/SchemaRegionReadPlanFactory.java
@@ -32,12 +32,17 @@ public class SchemaRegionReadPlanFactory {
   private SchemaRegionReadPlanFactory() {}
 
   public static IShowDevicesPlan getShowDevicesPlan(PartialPath path) {
-    return new ShowDevicesPlanImpl(path, 0, 0, false, false);
+    return new ShowDevicesPlanImpl(path, 0, 0, false, -1);
   }
 
   public static IShowDevicesPlan getShowDevicesPlan(
-      PartialPath path, int limit, int offset, boolean hasSgCol, boolean isPrefixMatch) {
-    return new ShowDevicesPlanImpl(path, limit, offset, hasSgCol, isPrefixMatch);
+      PartialPath path, int limit, int offset, boolean isPrefixMatch) {
+    return new ShowDevicesPlanImpl(path, limit, offset, isPrefixMatch, -1);
+  }
+
+  public static IShowDevicesPlan getShowDevicesPlan(
+      PartialPath path, int limit, int offset, boolean isPrefixMatch, int templateId) {
+    return new ShowDevicesPlanImpl(path, limit, offset, isPrefixMatch, templateId);
   }
 
   public static IShowTimeSeriesPlan getShowTimeSeriesPlan(PartialPath path) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/impl/read/ShowDevicesPlanImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/impl/read/ShowDevicesPlanImpl.java
@@ -23,6 +23,8 @@ package org.apache.iotdb.db.metadata.plan.schemaregion.impl.read;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
 
+import java.util.Objects;
+
 public class ShowDevicesPlanImpl extends AbstractShowSchemaPlanImpl implements IShowDevicesPlan {
 
   // templateId > -1 means the device should use template with given templateId
@@ -42,5 +44,19 @@ public class ShowDevicesPlanImpl extends AbstractShowSchemaPlanImpl implements I
   @Override
   public int getSchemaTemplateId() {
     return schemaTemplateId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    ShowDevicesPlanImpl that = (ShowDevicesPlanImpl) o;
+    return schemaTemplateId == that.schemaTemplateId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), schemaTemplateId);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/impl/read/ShowDevicesPlanImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/impl/read/ShowDevicesPlanImpl.java
@@ -23,34 +23,24 @@ package org.apache.iotdb.db.metadata.plan.schemaregion.impl.read;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
 
-import java.util.Objects;
-
 public class ShowDevicesPlanImpl extends AbstractShowSchemaPlanImpl implements IShowDevicesPlan {
 
-  private final boolean hasSgCol;
+  // templateId > -1 means the device should use template with given templateId
+  private final int schemaTemplateId;
 
   ShowDevicesPlanImpl(
-      PartialPath path, int limit, int offset, boolean hasSgCol, boolean isPrefixMatch) {
+      PartialPath path, int limit, int offset, boolean isPrefixMatch, int schemaTemplateId) {
     super(path, limit, offset, isPrefixMatch);
-    this.hasSgCol = hasSgCol;
+    this.schemaTemplateId = schemaTemplateId;
   }
 
   @Override
-  public boolean hasSgCol() {
-    return hasSgCol;
+  public boolean usingSchemaTemplate() {
+    return schemaTemplateId != -1;
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    ShowDevicesPlanImpl that = (ShowDevicesPlanImpl) o;
-    return hasSgCol == that.hasSgCol;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), hasSgCol);
+  public int getSchemaTemplateId() {
+    return schemaTemplateId;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/read/IShowDevicesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/read/IShowDevicesPlan.java
@@ -22,5 +22,7 @@ package org.apache.iotdb.db.metadata.plan.schemaregion.read;
 
 public interface IShowDevicesPlan extends IShowSchemaPlan {
 
-  boolean hasSgCol();
+  boolean usingSchemaTemplate();
+
+  int getSchemaTemplateId();
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -388,9 +388,6 @@ public interface ISchemaRegion {
   void activateSchemaTemplate(IActivateTemplateInClusterPlan plan, Template template)
       throws MetadataException;
 
-  List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
-      throws MetadataException;
-
   long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException;
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -1339,12 +1339,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   }
 
   @Override
-  public List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
-      throws MetadataException {
-    return mtree.getPathsUsingTemplate(pathPattern, templateId);
-  }
-
-  @Override
   public long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException {
     long preDeactivateNum = 0;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -1441,12 +1441,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   }
 
   @Override
-  public List<String> getPathsUsingTemplate(PartialPath pathPattern, int templateId)
-      throws MetadataException {
-    return mtree.getPathsUsingTemplate(pathPattern, templateId);
-  }
-
-  @Override
   public long constructSchemaBlackListWithTemplate(IPreDeactivateTemplatePlan plan)
       throws MetadataException {
     Map<PartialPath, List<Integer>> resultTemplateSetInfo =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/DevicesSchemaScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/DevicesSchemaScanOperator.java
@@ -22,22 +22,19 @@ import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
+import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.db.mpp.execution.driver.SchemaDriverContext;
 import org.apache.iotdb.db.mpp.execution.operator.OperatorContext;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.Binary;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
-public class DevicesSchemaScanOperator extends SchemaQueryScanOperator {
+public class DevicesSchemaScanOperator extends SchemaQueryScanOperator<IDeviceSchemaInfo> {
   private final boolean hasSgCol;
-  private final List<TSDataType> outputDataTypes;
 
   public DevicesSchemaScanOperator(
       PlanNodeId sourceId,
@@ -47,32 +44,34 @@ public class DevicesSchemaScanOperator extends SchemaQueryScanOperator {
       PartialPath partialPath,
       boolean isPrefixPath,
       boolean hasSgCol) {
-    super(sourceId, operatorContext, limit, offset, partialPath, isPrefixPath);
-    this.hasSgCol = hasSgCol;
-    this.outputDataTypes =
+    super(
+        sourceId,
+        operatorContext,
+        limit,
+        offset,
+        partialPath,
+        isPrefixPath,
         (hasSgCol
                 ? ColumnHeaderConstant.showDevicesWithSgColumnHeaders
                 : ColumnHeaderConstant.showDevicesColumnHeaders)
-            .stream().map(ColumnHeader::getColumnType).collect(Collectors.toList());
+            .stream().map(ColumnHeader::getColumnType).collect(Collectors.toList()));
+    this.hasSgCol = hasSgCol;
   }
 
   @Override
-  protected List<TsBlock> createTsBlockList() {
+  protected ISchemaReader<IDeviceSchemaInfo> createSchemaReader() {
     try {
-      return SchemaTsBlockUtil.transferSchemaResultToTsBlockList(
-          ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
-              .getSchemaRegion()
-              .getDeviceReader(
-                  SchemaRegionReadPlanFactory.getShowDevicesPlan(
-                      partialPath, limit, offset, hasSgCol, false)),
-          outputDataTypes,
-          this::setColumns);
+      return ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
+          .getSchemaRegion()
+          .getDeviceReader(
+              SchemaRegionReadPlanFactory.getShowDevicesPlan(partialPath, limit, offset, false));
     } catch (MetadataException e) {
-      throw new RuntimeException(e.getMessage(), e);
+      throw new RuntimeException(e);
     }
   }
 
-  private void setColumns(IDeviceSchemaInfo device, TsBlockBuilder builder) {
+  @Override
+  protected void setColumns(IDeviceSchemaInfo device, TsBlockBuilder builder) {
     builder.getTimeColumnBuilder().writeLong(0L);
     builder.getColumnBuilder(0).writeBinary(new Binary(device.getFullPath()));
     if (hasSgCol) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/DevicesSchemaScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/DevicesSchemaScanOperator.java
@@ -66,7 +66,7 @@ public class DevicesSchemaScanOperator extends SchemaQueryScanOperator<IDeviceSc
           .getDeviceReader(
               SchemaRegionReadPlanFactory.getShowDevicesPlan(partialPath, limit, offset, false));
     } catch (MetadataException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException(e.getMessage(), e);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/PathsUsingTemplateScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/PathsUsingTemplateScanOperator.java
@@ -69,7 +69,7 @@ public class PathsUsingTemplateScanOperator extends SchemaQueryScanOperator<IDev
               SchemaRegionReadPlanFactory.getShowDevicesPlan(
                   partialPath, limit, offset, false, templateId));
     } catch (MetadataException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException(e.getMessage(), e);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/PathsUsingTemplateScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/PathsUsingTemplateScanOperator.java
@@ -21,57 +21,63 @@ package org.apache.iotdb.db.mpp.execution.operator.schema;
 
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
+import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
+import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.db.mpp.execution.driver.SchemaDriverContext;
 import org.apache.iotdb.db.mpp.execution.operator.OperatorContext;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.Binary;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class PathsUsingTemplateScanOperator extends SchemaQueryScanOperator {
+public class PathsUsingTemplateScanOperator extends SchemaQueryScanOperator<IDeviceSchemaInfo> {
 
   private final List<PartialPath> pathPatternList;
 
   private final int templateId;
-
-  private final List<TSDataType> outputDataTypes;
 
   public PathsUsingTemplateScanOperator(
       PlanNodeId planNodeId,
       OperatorContext context,
       List<PartialPath> pathPatternList,
       int templateId) {
-    super(planNodeId, context, 0, 0, null, false);
-    this.pathPatternList = pathPatternList;
-    this.templateId = templateId;
-    this.outputDataTypes =
+    super(
+        planNodeId,
+        context,
+        0,
+        0,
+        null,
+        false,
         ColumnHeaderConstant.showPathsUsingTemplateHeaders.stream()
             .map(ColumnHeader::getColumnType)
-            .collect(Collectors.toList());
+            .collect(Collectors.toList()));
+    this.pathPatternList = pathPatternList;
+    this.templateId = templateId;
   }
 
   @Override
-  protected List<TsBlock> createTsBlockList() {
+  protected ISchemaReader<IDeviceSchemaInfo> createSchemaReader() {
     try {
-      List<String> schemaRegionResult = new LinkedList<>();
-      for (PartialPath pathPattern : pathPatternList) {
-        schemaRegionResult.addAll(
-            ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
-                .getSchemaRegion()
-                .getPathsUsingTemplate(pathPattern, templateId));
-      }
-      return SchemaTsBlockUtil.transferSchemaResultToTsBlockList(
-          schemaRegionResult.iterator(), outputDataTypes, this::setColumns);
+      return ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
+          .getSchemaRegion()
+          .getDeviceReader(
+              SchemaRegionReadPlanFactory.getShowDevicesPlan(
+                  partialPath, limit, offset, false, templateId));
     } catch (MetadataException e) {
-      throw new RuntimeException(e.getMessage(), e);
+      throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  protected void setColumns(IDeviceSchemaInfo device, TsBlockBuilder builder) {
+    builder.getTimeColumnBuilder().writeLong(0L);
+    builder.getColumnBuilder(0).writeBinary(new Binary(device.getFullPath()));
+    builder.declarePosition();
   }
 
   private void setColumns(String path, TsBlockBuilder builder) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
@@ -19,22 +19,26 @@
 package org.apache.iotdb.db.mpp.execution.operator.schema;
 
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.metadata.query.info.ISchemaInfo;
+import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.mpp.execution.driver.SchemaDriverContext;
 import org.apache.iotdb.db.mpp.execution.operator.OperatorContext;
 import org.apache.iotdb.db.mpp.execution.operator.source.SourceOperator;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 
 import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.apache.iotdb.tsfile.read.common.block.TsBlockBuilderStatus.DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
 
-public abstract class SchemaQueryScanOperator implements SourceOperator {
+public abstract class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOperator {
+
+  private static final long MAX_SIZE = DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
 
   protected OperatorContext operatorContext;
-  protected List<TsBlock> tsBlockList;
-  protected int currentIndex = 0;
 
   protected int limit;
   protected int offset;
@@ -45,22 +49,30 @@ public abstract class SchemaQueryScanOperator implements SourceOperator {
 
   private String database;
 
+  private final List<TSDataType> outputDataTypes;
+
+  private ISchemaReader<T> schemaReader;
+
   protected SchemaQueryScanOperator(
       PlanNodeId sourceId,
       OperatorContext operatorContext,
       int limit,
       int offset,
       PartialPath partialPath,
-      boolean isPrefixPath) {
+      boolean isPrefixPath,
+      List<TSDataType> outputDataTypes) {
     this.operatorContext = operatorContext;
     this.limit = limit;
     this.offset = offset;
     this.partialPath = partialPath;
     this.isPrefixPath = isPrefixPath;
     this.sourceId = sourceId;
+    this.outputDataTypes = outputDataTypes;
   }
 
-  protected abstract List<TsBlock> createTsBlockList();
+  protected abstract ISchemaReader<T> createSchemaReader();
+
+  protected abstract void setColumns(T element, TsBlockBuilder builder);
 
   public PartialPath getPartialPath() {
     return partialPath;
@@ -96,16 +108,24 @@ public abstract class SchemaQueryScanOperator implements SourceOperator {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
-    currentIndex++;
-    return tsBlockList.get(currentIndex - 1);
+    TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
+    T element;
+    while (schemaReader.hasNext()) {
+      element = schemaReader.next();
+      setColumns(element, tsBlockBuilder);
+      if (tsBlockBuilder.getRetainedSizeInBytes() >= MAX_SIZE) {
+        break;
+      }
+    }
+    return tsBlockBuilder.build();
   }
 
   @Override
   public boolean hasNext() {
-    if (tsBlockList == null) {
-      tsBlockList = createTsBlockList();
+    if (schemaReader == null) {
+      schemaReader = createSchemaReader();
     }
-    return currentIndex < tsBlockList.size();
+    return schemaReader.hasNext();
   }
 
   @Override
@@ -141,5 +161,10 @@ public abstract class SchemaQueryScanOperator implements SourceOperator {
               .getStorageGroupFullPath();
     }
     return database;
+  }
+
+  @Override
+  public void close() throws Exception {
+    schemaReader.close();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/TimeSeriesSchemaScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/TimeSeriesSchemaScanOperator.java
@@ -91,7 +91,7 @@ public class TimeSeriesSchemaScanOperator extends SchemaQueryScanOperator<ITimeS
               SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
                   partialPath, templateMap, isContains, key, value, limit, offset, false));
     } catch (MetadataException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException(e.getMessage(), e);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/TimeSeriesSchemaScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/TimeSeriesSchemaScanOperator.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
+import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.utils.MetaUtils;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
@@ -29,26 +30,18 @@ import org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.db.mpp.execution.driver.SchemaDriverContext;
 import org.apache.iotdb.db.mpp.execution.operator.OperatorContext;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.Pair;
 
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class TimeSeriesSchemaScanOperator extends SchemaQueryScanOperator {
+public class TimeSeriesSchemaScanOperator extends SchemaQueryScanOperator<ITimeSeriesSchemaInfo> {
   private final String key;
   private final String value;
   private final boolean isContains;
 
-  // if is true, the result will be sorted according to the inserting frequency of the timeseries
-  private final boolean orderByHeat;
-
   private final Map<Integer, Template> templateMap;
-
-  private final List<TSDataType> outputDataTypes;
 
   public TimeSeriesSchemaScanOperator(
       PlanNodeId planNodeId,
@@ -59,19 +52,22 @@ public class TimeSeriesSchemaScanOperator extends SchemaQueryScanOperator {
       String key,
       String value,
       boolean isContains,
-      boolean orderByHeat,
       boolean isPrefixPath,
       Map<Integer, Template> templateMap) {
-    super(planNodeId, operatorContext, limit, offset, partialPath, isPrefixPath);
+    super(
+        planNodeId,
+        operatorContext,
+        limit,
+        offset,
+        partialPath,
+        isPrefixPath,
+        ColumnHeaderConstant.showTimeSeriesColumnHeaders.stream()
+            .map(ColumnHeader::getColumnType)
+            .collect(Collectors.toList()));
     this.isContains = isContains;
     this.key = key;
     this.value = value;
-    this.orderByHeat = orderByHeat;
     this.templateMap = templateMap;
-    this.outputDataTypes =
-        ColumnHeaderConstant.showTimeSeriesColumnHeaders.stream()
-            .map(ColumnHeader::getColumnType)
-            .collect(Collectors.toList());
   }
 
   public String getKey() {
@@ -86,27 +82,21 @@ public class TimeSeriesSchemaScanOperator extends SchemaQueryScanOperator {
     return isContains;
   }
 
-  public boolean isOrderByHeat() {
-    return orderByHeat;
-  }
-
   @Override
-  protected List<TsBlock> createTsBlockList() {
+  protected ISchemaReader<ITimeSeriesSchemaInfo> createSchemaReader() {
     try {
-      return SchemaTsBlockUtil.transferSchemaResultToTsBlockList(
-          ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
-              .getSchemaRegion()
-              .getTimeSeriesReader(
-                  SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
-                      partialPath, templateMap, isContains, key, value, limit, offset, false)),
-          outputDataTypes,
-          this::setColumns);
+      return ((SchemaDriverContext) operatorContext.getInstanceContext().getDriverContext())
+          .getSchemaRegion()
+          .getTimeSeriesReader(
+              SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
+                  partialPath, templateMap, isContains, key, value, limit, offset, false));
     } catch (MetadataException e) {
-      throw new RuntimeException(e.getMessage(), e);
+      throw new RuntimeException(e);
     }
   }
 
-  private void setColumns(ITimeSeriesSchemaInfo series, TsBlockBuilder builder) {
+  @Override
+  protected void setColumns(ITimeSeriesSchemaInfo series, TsBlockBuilder builder) {
     Pair<Map<String, String>, Map<String, String>> tagAndAttribute = series.getTagAndAttribute();
     Pair<String, String> deadbandInfo = MetaUtils.parseDeadbandInfo(series.getSchema().getProps());
     builder.getTimeColumnBuilder().writeLong(0);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
@@ -482,7 +482,6 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
         node.getValue(),
         node.isContains(),
         node.isOrderByHeat(),
-        node.isPrefixPath(),
         node.getTemplateMap());
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.iotdb.db.metadata.schemaRegion.SchemaRegionTestUtil.getPathsUsingTemplate;
+
 public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
 
   public SchemaRegionTemplateTest(SchemaRegionTestParams testParams) {
@@ -85,7 +87,7 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
         template);
     Set<String> expectedPaths = new HashSet<>(Arrays.asList("root.sg.wf01.wt01", "root.sg.wf02"));
     Set<String> pathsUsingTemplate =
-        new HashSet<>(schemaRegion.getPathsUsingTemplate(new PartialPath("root.**"), templateId));
+        new HashSet<>(getPathsUsingTemplate(schemaRegion, new PartialPath("root.**"), templateId));
     Assert.assertEquals(expectedPaths, pathsUsingTemplate);
     PathPatternTree allPatternTree = new PathPatternTree();
     allPatternTree.appendPathPattern(new PartialPath("root.**"));
@@ -97,14 +99,14 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
     Assert.assertEquals(1, schemaRegion.countPathsUsingTemplate(templateId, wf01PatternTree));
     Assert.assertEquals(
         "root.sg.wf01.wt01",
-        schemaRegion.getPathsUsingTemplate(new PartialPath("root.sg.wf01.*"), templateId).get(0));
+        getPathsUsingTemplate(schemaRegion, new PartialPath("root.sg.wf01.*"), templateId).get(0));
     PathPatternTree wf02PatternTree = new PathPatternTree();
     wf02PatternTree.appendPathPattern(new PartialPath("root.sg.wf02"));
     wf02PatternTree.constructTree();
     Assert.assertEquals(1, schemaRegion.countPathsUsingTemplate(templateId, wf02PatternTree));
     Assert.assertEquals(
         "root.sg.wf02",
-        schemaRegion.getPathsUsingTemplate(new PartialPath("root.sg.wf02"), templateId).get(0));
+        getPathsUsingTemplate(schemaRegion, new PartialPath("root.sg.wf02"), templateId).get(0));
   }
 
   /**
@@ -169,7 +171,7 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
     // check using getPathsUsingTemplate
     List<String> expectedPaths = Collections.singletonList("root.sg.wf02");
     List<String> pathsUsingTemplate =
-        schemaRegion.getPathsUsingTemplate(new PartialPath("root.**"), templateId);
+        getPathsUsingTemplate(schemaRegion, new PartialPath("root.**"), templateId);
     Assert.assertEquals(expectedPaths, pathsUsingTemplate);
     // check using countPathsUsingTemplate
     PathPatternTree allPatternTree = new PathPatternTree();

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
@@ -20,12 +20,16 @@ package org.apache.iotdb.db.metadata.schemaRegion;
 
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWritePlanFactory;
+import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
+import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -135,5 +139,22 @@ public class SchemaRegionTestUtil {
     for (String path : pathList) {
       SchemaRegionTestUtil.createSimpleTimeSeriesInt64(schemaRegion, path);
     }
+  }
+
+  public static List<String> getPathsUsingTemplate(
+      ISchemaRegion schemaRegion, PartialPath pathPattern, int templateId)
+      throws MetadataException {
+    List<String> result = new ArrayList<>();
+    try (ISchemaReader<IDeviceSchemaInfo> deviceReader =
+        schemaRegion.getDeviceReader(
+            SchemaRegionReadPlanFactory.getShowDevicesPlan(
+                pathPattern, 0, 0, false, templateId)); ) {
+      while (deviceReader.hasNext()) {
+        result.add(deviceReader.next().getFullPath());
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return result;
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/OperatorMemoryTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/OperatorMemoryTest.java
@@ -695,7 +695,6 @@ public class OperatorMemoryTest {
               null,
               false,
               false,
-              false,
               null);
 
       assertEquals(DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES, operator.calculateMaxPeekMemory());

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperatorTest.java
@@ -92,7 +92,7 @@ public class SchemaQueryScanOperatorTest {
       Iterator<IDeviceSchemaInfo> iterator = Collections.singletonList(deviceSchemaInfo).iterator();
       Mockito.when(
               schemaRegion.getDeviceReader(
-                  SchemaRegionReadPlanFactory.getShowDevicesPlan(partialPath, 10, 0, true, false)))
+                  SchemaRegionReadPlanFactory.getShowDevicesPlan(partialPath, 10, 0, false)))
           .thenReturn(
               new ISchemaReader<IDeviceSchemaInfo>() {
                 @Override
@@ -222,7 +222,6 @@ public class SchemaQueryScanOperatorTest {
               partialPath,
               null,
               null,
-              false,
               false,
               false,
               Collections.emptyMap());


### PR DESCRIPTION
## Description


### Motivation

The origin implementation for devices and timeseries schema query may cost huge memory peak occupation, since all the results should be retrieved and temporarily cached.

### Modification

Implement iterating query based on schema reader in DeviceSchemaScanOperator, TimeSeriesSchemaScanOperator and PathsUsingTemplateScanOperator.
