### PR TITLE
[To rel/0.13][IOTDB-5355]Log RewriteCrossSpaceCompactionTask increase process

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
@@ -168,13 +168,22 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
       compactionLogger.logFiles(selectedUnSeqTsFileResourceList, STR_SOURCE_FILES);
       compactionLogger.logFiles(targetTsfileResourceList, STR_TARGET_FILES);
       // indicates that the cross compaction is complete and the result can be reused during a
+      logger.info("{} [Compaction] Close the logger", fullStorageGroupName);
       // restart recovery
       compactionLogger.close();
+      logger.info(
+          "{} [Compaction] compaction with seqFiles:{}, unSeqFiles:{}, target:{}",
+          fullStorageGroupName,
+          selectedSeqTsFileResourceList,
+          selectedUnSeqTsFileResourceList,
+          targetTsfileResourceList);
 
       CompactionUtils.compact(
           selectedSeqTsFileResourceList, selectedUnSeqTsFileResourceList, targetTsfileResourceList);
 
       CompactionUtils.moveTargetFile(targetTsfileResourceList, false, fullStorageGroupName);
+
+      logger.info("{} [Compaction] start to rename mods file", fullStorageGroupName);
       CompactionUtils.combineModsInCompaction(
           selectedSeqTsFileResourceList, selectedUnSeqTsFileResourceList, targetTsfileResourceList);
 
@@ -185,6 +194,10 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
           targetTsfileResourceList,
           timePartition,
           true);
+
+      logger.info(
+          "{} [Compaction] Compacted target files, try to get the write lock of source files",
+          fullStorageGroupName);
 
       releaseReadAndLockWrite(selectedSeqTsFileResourceList);
       releaseReadAndLockWrite(selectedUnSeqTsFileResourceList);


### PR DESCRIPTION
## Description
Log RewriteCrossSpaceCompactionTask increase process

When the interzone compaction task is slow and after the merge process restarts, it is difficult to locate the problem through the logs