### PR TITLE
[To rel/1.0] [IOTDB-4933] More detailed error message for udf/trigger executor and fix typo in udf doc

### DIFF
--- a/docs/UserGuide/Operators-Functions/User-Defined-Function.md
+++ b/docs/UserGuide/Operators-Functions/User-Defined-Function.md
@@ -538,7 +538,7 @@ For more user permissions related content, please refer to [Account Management S
 
 ## Configurable Properties
 
-You can use `trigger_lib_dir` to config trigger lib directory.  
+You can use `udf_lib_dir` to config udf lib directory.  
 When querying by a UDF, IoTDB may prompt that there is insufficient memory. You can resolve the issue by configuring `udf_initial_byte_array_length_for_memory_control`, `udf_memory_budget_in_mb` and `udf_reader_transformer_collector_memory_proportion` in `iotdb-datanode.properties` and restarting the server.
 
 

--- a/docs/zh/UserGuide/Operators-Functions/User-Defined-Function.md
+++ b/docs/zh/UserGuide/Operators-Functions/User-Defined-Function.md
@@ -489,7 +489,7 @@ SHOW FUNCTIONS
 
 ## 配置项
 
-使用配置项 `trigger_lib_dir` 来配置 trigger 的存储目录.  
+使用配置项 `udf_lib_dir` 来配置 udf 的存储目录.  
 在 SQL 语句中使用自定义函数时，可能提示内存不足。这种情况下，您可以通过更改配置文件`iotdb-datanode.properties`中的`udf_initial_byte_array_length_for_memory_control`，`udf_memory_budget_in_mb`和`udf_reader_transformer_collector_memory_proportion`并重启服务来解决此问题。
 
 ## 贡献 UDF

--- a/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/udf/UDTFExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/udf/UDTFExecutor.java
@@ -149,10 +149,13 @@ public class UDTFExecutor {
   }
 
   private void onError(String methodName, Exception e) {
-    LOGGER.warn("Error occurred during executing UDTF", e);
+    LOGGER.warn(
+        "Error occurred during executing UDTF, perhaps need to check whether the implementation of UDF is correct according to the udf-api description.",
+        e);
     throw new RuntimeException(
         String.format(
-                "Error occurred during executing UDTF#%s: %s", methodName, System.lineSeparator())
+                "Error occurred during executing UDTF#%s: %s, perhaps need to check whether the implementation of UDF is correct according to the udf-api description.",
+                methodName, System.lineSeparator())
             + e);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/trigger/executor/TriggerExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/trigger/executor/TriggerExecutor.java
@@ -100,7 +100,7 @@ public class TriggerExecutor {
       throws TriggerExecutionException {
     String errorMessage =
         String.format(
-                "Error occurred during executing Trigger(%s)#%s: %s",
+                "Error occurred during executing Trigger(%s)#%s: %s, perhaps need to check whether the implementation of Trigger is correct according to the trigger-api description.",
                 triggerInformation.getTriggerName(), methodName, System.lineSeparator())
             + t;
     LOGGER.warn(errorMessage);


### PR DESCRIPTION
(cherry picked from commit 11c489bc254d47137e028e8135be10ac7ed0f290)