### PR TITLE
[IOTDB-5358][To rel/1.0]dn_data_dir failed to be effectively set when executing load

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1278,6 +1278,7 @@ public class IoTDBConfig {
 
   public void setDataDirs(String[] dataDirs) {
     this.dataDirs = dataDirs;
+    setLoadTsFileDir(dataDirs[0] + File.separator + IoTDBConstant.LOAD_TSFILE_FOLDER_NAME);
   }
 
   public String getRpcAddress() {


### PR DESCRIPTION
When the user defines the dn_data_dir, this option will not take effect for the load folder