### PR TITLE
[IOTDB-5323] Extend File related Metrics

### DIFF
--- a/docs/UserGuide/Monitor-Alert/Metric-Tool.md
+++ b/docs/UserGuide/Monitor-Alert/Metric-Tool.md
@@ -91,10 +91,10 @@ Core-level metrics are enabled by default during system operation. The addition 
 
 #### 4.1.1. Cluster
 | Metric      | Tags                                            | Type      | Description                                         |
-|-------------|-------------------------------------------------| --------- | --------------------------------------------------- |
+| ----------- | ----------------------------------------------- | --------- | --------------------------------------------------- |
 | config_node | name="total",status="Registered/Online/Unknown" | AutoGauge | The number of registered/online/unknown confignodes |
 | data_node   | name="total",status="Registered/Online/Unknown" | AutoGauge | The number of registered/online/unknown datanodes   |
-| points      | database="{{database}}", type="flush"           | Gauge     | The point number of last flushed memtable                     |
+| points      | database="{{database}}", type="flush"           | Gauge     | The point number of last flushed memtable           |
 
 #### 4.1.2. IoTDB process
 | Metric            | Tags           | Type      | Description                                            |
@@ -128,7 +128,7 @@ Core-level metrics are enabled by default during system operation. The addition 
 
 #### 4.2.2. Node
 | Metric   | Tags                                       | Type      | Description                                                   |
-|----------|--------------------------------------------|-----------|---------------------------------------------------------------|
+| -------- | ------------------------------------------ | --------- | ------------------------------------------------------------- |
 | quantity | name="database"                            | AutoGauge | The number of database                                        |
 | quantity | name="timeSeries"                          | AutoGauge | The number of timeseries                                      |
 | quantity | name="pointsIn"                            | Counter   | The number of write points                                    |
@@ -182,11 +182,11 @@ Core-level metrics are enabled by default during system operation. The addition 
 
 #### 4.2.6. Memory
 | Metric | Tags                                 | Type      | Description                                                        |
-| ------ |--------------------------------------| --------- | ------------------------------------------------------------------ |
+| ------ | ------------------------------------ | --------- | ------------------------------------------------------------------ |
 | mem    | name="database_{{name}}"             | AutoGauge | The memory usage of DataRegion in DataNode, Unit: byte             |
 | mem    | name="chunkMetaData_{{name}}"        | AutoGauge | The memory usage of chunkMetaData when writting TsFile, Unit: byte |
 | mem    | name="IoTConsensus"                  | AutoGauge | The memory usage of IoTConsensus, Unit: byte                       |
-| mem    | name="schema_region_total_usage"           | AutoGauge | The memory usage of all SchemaRegion, Unit: byte                   |
+| mem    | name="schema_region_total_usage"     | AutoGauge | The memory usage of all SchemaRegion, Unit: byte                   |
 | mem    | name="schema_region_total_remaining" | AutoGauge | The memory remaining for all SchemaRegion, Unit: byte              |
 
 #### 4.2.7. Task
@@ -209,20 +209,21 @@ Core-level metrics are enabled by default during system operation. The addition 
 
 #### 4.2.9. File
 
-| Metric     | Tags         | Type      | Description                                                  |
-| ---------- | ------------ | --------- |--------------------------------------------------------------|
-| file_size  | name="wal"   | AutoGauge | The size of WAL file, Unit: byte                             |
-| file_size  | name="seq"   | AutoGauge | The size of sequence TsFile, Unit: byte                      |
-| file_size  | name="unseq" | AutoGauge | The size of unsequence TsFile, Unit: byte                    |
-| file_count | name="wal"   | AutoGauge | The count of WAL file                                        |
-| file_count | name="seq"   | AutoGauge | The count of sequence TsFile                                 |
-| file_count | name="unseq" | AutoGauge | The count of unsequence TsFile                               |
-| file_count| name="inner-seq-temp-num" | AutoGauge | The count of inner sequence space compaction temporal file   |
-| file_count | name="inner-unseq-temp-num"|AutoGauge| The count of inner unsequence space compaction temporal file |
-| file_count|name="cross-temp-num"|AutoGauge| The count of cross space compaction temporal file            |
-| file_size|name="inner-seq-temp-size" | AutoGauge| The size of inner sequence space compaction temporal file    |
-| file_size|name="inner-unseq-temp-size"|AutoGauge| The size of inner unsequence space compaction temporal file  |
-|file_size|name="cross-temp-size"|AutoGauge|The size of cross space compaction temoporal file|
+| Metric     | Tags                    | Type      | Description                                                        |
+| ---------- | ----------------------- | --------- | ------------------------------------------------------------------ |
+| file_size  | name="wal"              | AutoGauge | The size of WAL file, Unit: byte                                   |
+| file_size  | name="seq"              | AutoGauge | The size of sequence TsFile, Unit: byte                            |
+| file_size  | name="unseq"            | AutoGauge | The size of unsequence TsFile, Unit: byte                          |
+| file_size  | name="inner-seq-temp"   | AutoGauge | The size of inner sequence space compaction temporal file          |
+| file_size  | name="inner-unseq-temp" | AutoGauge | The size of inner unsequence space compaction temporal file        |
+| file_size  | name="cross-temp"       | AutoGauge | The size of cross space compaction temoporal file                  |
+| file_count | name="wal"              | AutoGauge | The count of WAL file                                              |
+| file_count | name="seq"              | AutoGauge | The count of sequence TsFile                                       |
+| file_count | name="unseq"            | AutoGauge | The count of unsequence TsFile                                     |
+| file_count | name="inner-seq-temp"   | AutoGauge | The count of inner sequence space compaction temporal file         |
+| file_count | name="inner-unseq-temp" | AutoGauge | The count of inner unsequence space compaction temporal file       |
+| file_count | name="cross-temp"       | AutoGauge | The count of cross space compaction temporal file                  |
+| file_count | name="open"             | AutoGauge | The count of iotdb process open file, only support linux and macos |
 
 #### 4.2.10. IoTDB Process
 
@@ -515,12 +516,12 @@ data source for Apache IoTDB Dashboard.
 #### 5.3.1. IoTDB mapping relationship of metrics
 > For metrics whose Metric Name is name and Tags are K1=V1, ..., Kn=Vn, the mapping is as follows, taking root.__system.metric.`ip:port` as an example by default
 
-| Metric Type      | Mapping                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Counter          | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| AutoGauge、Gauge | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| Histogram        | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.max <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.sum <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p0 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p25 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p50 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p75 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p100                                                                                                                                                                                                                      |
-| Rate             | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.mean <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m1 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m5 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m15                                                                                                                                                                                                                                                                                                                                                                                      |
+| Metric Type      | Mapping                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Counter          | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| AutoGauge、Gauge | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Histogram        | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.max <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.sum <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p0 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p25 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p50 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p75 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p100                                                                                                                                                                                                                                                              |
+| Rate             | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.mean <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m1 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m5 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m15                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | Timer            | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.max <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.mean <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.sum <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p0 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p25 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p50 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p75 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p100   <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m1 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m5 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m15 |
 
 #### 5.3.2. Obtain metrics

--- a/docs/zh/UserGuide/Monitor-Alert/Metric-Tool.md
+++ b/docs/zh/UserGuide/Monitor-Alert/Metric-Tool.md
@@ -85,10 +85,10 @@ Core 级别的监控指标在系统运行中默认开启，每一个 Core 级别
 #### 4.1.1. 集群运行状态
 
 | Metric      | Tags                                            | Type      | Description                            |
-|-------------|-------------------------------------------------| --------- | -------------------------------------- |
+| ----------- | ----------------------------------------------- | --------- | -------------------------------------- |
 | config_node | name="total",status="Registered/Online/Unknown" | AutoGauge | 已注册/在线/离线 confignode 的节点数量 |
 | data_node   | name="total",status="Registered/Online/Unknown" | AutoGauge | 已注册/在线/离线 datanode 的节点数量   |
-| points      | database="{{database}}", type="flush"           | Gauge     | 最新一个刷盘的memtale的点数        |
+| points      | database="{{database}}", type="flush"           | Gauge     | 最新一个刷盘的memtale的点数            |
 
 #### 4.1.2. IoTDB 进程运行状态
 | Metric            | Tags           | Type      | Description                         |
@@ -123,13 +123,13 @@ Core 级别的监控指标在系统运行中默认开启，每一个 Core 级别
 | cluster_node_status       | name="{{ip}}:{{port}}",type="ConfigNode/DataNode" | Gauge | 节点的状态，0=Unkonwn 1=online |
 
 #### 4.2.2. 节点统计
-| Metric   | Tags                                       | Type      | Description              |
-| -------- | ------------------------------------------ | --------- |--------------------------|
-| quantity | name="database"                            | AutoGauge | 系统数据库数量                  |
-| quantity | name="timeSeries"                          | AutoGauge | 系统时间序列数量                 |
-| quantity | name="pointsIn"                            | Counter   | 系统累计写入点数                 |
-| region   | name="total",type="SchemaRegion"           | AutoGauge | 分区表中 SchemaRegion 总数量    |
-| region   | name="total",type="DataRegion"             | AutoGauge | 分区表中 DataRegion 总数量      |
+| Metric   | Tags                                       | Type      | Description                          |
+| -------- | ------------------------------------------ | --------- | ------------------------------------ |
+| quantity | name="database"                            | AutoGauge | 系统数据库数量                       |
+| quantity | name="timeSeries"                          | AutoGauge | 系统时间序列数量                     |
+| quantity | name="pointsIn"                            | Counter   | 系统累计写入点数                     |
+| region   | name="total",type="SchemaRegion"           | AutoGauge | 分区表中 SchemaRegion 总数量         |
+| region   | name="total",type="DataRegion"             | AutoGauge | 分区表中 DataRegion 总数量           |
 | region   | name="{{ip}}:{{port}}",type="SchemaRegion" | Gauge     | 分区表中对应节点上 DataRegion 总数量 |
 | region   | name="{{ip}}:{{port}}",type="DataRegion"   | Gauge     | 分区表中对应节点上 DataRegion 总数量 |
 
@@ -178,12 +178,12 @@ Core 级别的监控指标在系统运行中默认开启，每一个 Core 级别
 
 #### 4.2.6. 内存统计
 | Metric | Tags                                 | Type      | Description                                       |
-| ------ |--------------------------------------| --------- | ------------------------------------------------- |
+| ------ | ------------------------------------ | --------- | ------------------------------------------------- |
 | mem    | name="database_{{name}}"             | AutoGauge | DataNode内对应DataRegion的内存占用，单位为byte    |
 | mem    | name="chunkMetaData_{{name}}"        | AutoGauge | 写入TsFile时的ChunkMetaData的内存占用，单位为byte |
 | mem    | name="IoTConsensus"                  | AutoGauge | IoT共识协议的内存占用，单位为byte                 |
-| mem    | name="schema_region_total_usage"           | AutoGauge | 所有SchemaRegion的总内存占用，单位为byte         |
-| mem    | name="schema_region_total_remaining" | AutoGauge | 所有SchemaRegion的总内存剩余，单位为byte         |
+| mem    | name="schema_region_total_usage"     | AutoGauge | 所有SchemaRegion的总内存占用，单位为byte          |
+| mem    | name="schema_region_total_remaining" | AutoGauge | 所有SchemaRegion的总内存剩余，单位为byte          |
 
 #### 4.2.7. 任务统计
 | Metric    | Tags                                              | Type      | Description        |
@@ -205,20 +205,21 @@ Core 级别的监控指标在系统运行中默认开启，每一个 Core 级别
 
 #### 4.2.9. 文件统计信息
 
-| Metric     | Tags                         | Type      | Description          |
-| ---------- |------------------------------| --------- |----------------------|
-| file_size  | name="wal"                   | AutoGauge | 写前日志总大小，单位为byte      |
-| file_size  | name="seq"                   | AutoGauge | 顺序TsFile总大小，单位为byte  |
-| file_size  | name="unseq"                 | AutoGauge | 乱序TsFile总大小，单位为byte  |
-| file_count | name="wal"                   | AutoGauge | 写前日志文件个数             |
-| file_count | name="seq"                   | AutoGauge | 顺序TsFile文件个数         |
-| file_count | name="unseq"                 | AutoGauge | 乱序TsFile文件个数         |
-| file_count| name="inner-seq-file-num"    |AutoGauge| 顺序空间内合并临时文件个数        |
-| file_count| name="inner-unseq-file-num"  |AutoGauge| 乱序空间内合并临时文件个数        |
-| file_count| name="cross-file-num"        |AutoGauge| 跨空间合并临时文件个数          |
-| file_count| name="inner-seq-file-size"   |AutoGauge| 顺序空间内合并临时文件大小，单位为byte |
-| file_count| name="inner-unseq-file-size" |AutoGauge| 乱序空间内合并临时文件大小，单位为byte |
-| file_count| name="cross-file-size"       |AutoGauge| 跨空间合并临时文件大小，单位为byte  |
+| Metric     | Tags                    | Type      | Description                              |
+| ---------- | ----------------------- | --------- | ---------------------------------------- |
+| file_size  | name="wal"              | AutoGauge | 写前日志总大小，单位为byte               |
+| file_size  | name="seq"              | AutoGauge | 顺序TsFile总大小，单位为byte             |
+| file_size  | name="unseq"            | AutoGauge | 乱序TsFile总大小，单位为byte             |
+| file_size  | name="inner-seq-temp"   | AutoGauge | 顺序空间内合并临时文件大小，单位为byte   |
+| file_size  | name="inner-unseq-temp" | AutoGauge | 乱序空间内合并临时文件大小，单位为byte   |
+| file_size  | name="cross-temp"       | AutoGauge | 跨空间合并临时文件大小，单位为byte       |
+| file_count | name="wal"              | AutoGauge | 写前日志文件个数                         |
+| file_count | name="seq"              | AutoGauge | 顺序TsFile文件个数                       |
+| file_count | name="unseq"            | AutoGauge | 乱序TsFile文件个数                       |
+| file_count | name="inner-seq-temp"   | AutoGauge | 顺序空间内合并临时文件个数               |
+| file_count | name="inner-unseq-temp" | AutoGauge | 乱序空间内合并临时文件个数               |
+| file_count | name="cross-temp"       | AutoGauge | 跨空间合并临时文件个数                   |
+| file_count | name="open"             | AutoGauge | IoTDB 进程打开文件数，仅支持Linux和MacOS |
 
 #### 4.2.10. IoTDB 进程统计
 | Metric                | Tags           | Type      | Description                          |
@@ -278,8 +279,8 @@ Core 级别的监控指标在系统运行中默认开启，每一个 Core 级别
 ### 4.3. Normal 级别监控指标
 
 #### 4.3.1. 集群
-| Metric | Tags                                                           | Type      | Description                                                        |
-| ------ | -------------------------------------------------------------- | --------- | ------------------------------------------------------------------ |
+| Metric | Tags                                                           | Type      | Description                                             |
+| ------ | -------------------------------------------------------------- | --------- | ------------------------------------------------------- |
 | region | name="{{DatabaseName}}",type="SchemaRegion/DataRegion"         | AutoGauge | 特定节点上不同 Database 的 DataRegion/SchemaRegion 个数 |
 | slot   | name="{{DatabaseName}}",type="schemaSlotNumber/dataSlotNumber" | AutoGauge | 特定节点上不同 Database 的 DataSlot/SchemaSlot 个数     |
 
@@ -488,12 +489,12 @@ static_configs:
 #### 5.3.1. 监控指标的 IoTDB 映射关系
 > 对于 Metric Name 为 name, Tags 为 K1=V1, ..., Kn=Vn 的监控指标有如下映射，以默认写到 root.__system.metric.`ip:port` 为例
 
-| 监控指标类型     | 映射关系                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Counter          | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| AutoGauge、Gauge | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| Histogram        | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.max <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.sum <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p0 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p25 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p50 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p75 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p100                                                                                                                                                                                                                      |
-| Rate             | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.mean <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m1 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m5 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m15                                                                                                                                                                                                                                                                                                                                                                                      |
+| 监控指标类型     | 映射关系                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Counter          | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| AutoGauge、Gauge | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Histogram        | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.max <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.sum <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p0 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p25 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p50 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p75 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p100                                                                                                                                                                                                                                                              |
+| Rate             | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.mean <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m1 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m5 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m15                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | Timer            | root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.count <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.max <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.mean <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.sum <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p0 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p25 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p50 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p75 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.p100   <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m1 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m5 <br> root.__system.metric.`ip:port`.name.`K1=V1`...`Kn=Vn`.m15 |
 
 #### 5.3.2. 获取监控指标

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
@@ -23,13 +23,17 @@ import org.apache.iotdb.metrics.utils.InternalReporterType;
 import org.apache.iotdb.metrics.utils.MetricFrameType;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.ReporterType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public class MetricConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MetricConfig.class);
   /** The type of the implementation of metric framework. */
   private MetricFrameType metricFrameType = MetricFrameType.MICROMETER;
 
@@ -55,6 +59,17 @@ public class MetricConfig {
   private String rpcAddress = "0.0.0.0";
   /** The port of iotdb instance that is monitored. */
   private Integer rpcPort = 6667;
+  /** The pid of iotdb instance. */
+  private String pid = "";
+
+  public MetricConfig() {
+    // try to get pid of iotdb instance
+    try {
+      pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
+    } catch (Exception e) {
+      LOGGER.error("Failed to get pid, because ", e);
+    }
+  }
 
   public MetricFrameType getMetricFrameType() {
     return metricFrameType;
@@ -119,6 +134,10 @@ public class MetricConfig {
 
   public Integer getRpcPort() {
     return rpcPort;
+  }
+
+  public String getPid() {
+    return pid;
   }
 
   /** Update rpc address and rpc port of monitored node. */

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
@@ -19,10 +19,8 @@
 
 package org.apache.iotdb.metrics.config;
 
-import org.apache.iotdb.metrics.utils.InternalReporterType;
-import org.apache.iotdb.metrics.utils.MetricFrameType;
-import org.apache.iotdb.metrics.utils.MetricLevel;
-import org.apache.iotdb.metrics.utils.ReporterType;
+import org.apache.iotdb.metrics.utils.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +59,8 @@ public class MetricConfig {
   private Integer rpcPort = 6667;
   /** The pid of iotdb instance. */
   private String pid = "";
+  /** The running system of iotdb instance */
+  private final SystemType systemType = SystemType.getSystemType();
 
   public MetricConfig() {
     // try to get pid of iotdb instance
@@ -138,6 +138,10 @@ public class MetricConfig {
 
   public String getPid() {
     return pid;
+  }
+
+  public SystemType getSystemType() {
+    return systemType;
   }
 
   /** Update rpc address and rpc port of monitored node. */

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/SystemType.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/SystemType.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.metrics.utils;
+
+public enum SystemType {
+  WINDOWS,
+  LINUX,
+  MAC,
+  OTHER;
+
+  public static SystemType getSystemType() {
+    String system = System.getProperty("os.name").toLowerCase();
+    if (system.contains("windows")) {
+      return SystemType.WINDOWS;
+    } else if (system.contains("linux")) {
+      return SystemType.LINUX;
+    } else if (system.contains("mac")) {
+      return SystemType.MAC;
+    } else {
+      return SystemType.OTHER;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return name();
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/TsFileMetricManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/TsFileMetricManager.java
@@ -96,19 +96,19 @@ public class TsFileMetricManager {
     }
   }
 
-  public long getCompactionTempFileSize(boolean innerSpace, boolean seq) {
-    if (innerSpace) {
-      return seq ? innerSeqCompactionTempFileSize.get() : innerUnseqCompactionTempFileSize.get();
-    } else {
-      return crossCompactionTempFileSize.get();
-    }
+  public long getInnerCompactionTempFileSize(boolean seq) {
+    return seq ? innerSeqCompactionTempFileSize.get() : innerUnseqCompactionTempFileSize.get();
   }
 
-  public int getCompactionTempFileNum(boolean innerSpace, boolean seq) {
-    if (innerSpace) {
-      return seq ? innerSeqCompactionTempFileNum.get() : innerUnseqCompactionTempFileNum.get();
-    } else {
-      return crossCompactionTempFileNum.get();
-    }
+  public long getCrossCompactionTempFileSize() {
+    return crossCompactionTempFileSize.get();
+  }
+
+  public long getInnerCompactionTempFileNum(boolean seq) {
+    return seq ? innerSeqCompactionTempFileNum.get() : innerUnseqCompactionTempFileNum.get();
+  }
+
+  public long getCrossCompactionTempFileNum() {
+    return crossCompactionTempFileNum.get();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
@@ -25,19 +25,31 @@ import org.apache.iotdb.commons.service.metric.enums.Tag;
 import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.wal.WALManager;
 import org.apache.iotdb.metrics.AbstractMetricService;
+import org.apache.iotdb.metrics.config.MetricConfig;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.metricsets.IMetricSet;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.MetricType;
+import org.apache.iotdb.metrics.utils.SystemType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class FileMetrics implements IMetricSet {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileMetrics.class);
+  private static final MetricConfig METRIC_CONFIG =
+      MetricConfigDescriptor.getInstance().getMetricConfig();
   private Future<?> currentServiceFuture;
   private final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+  private final Runtime runtime = Runtime.getRuntime();
   private long walFileTotalSize = 0L;
   private long walFileTotalCount = 0L;
   private long sequenceFileTotalSize = 0L;
@@ -52,15 +64,30 @@ public class FileMetrics implements IMetricSet {
   private long innerUnseqCompactionTempFileNum = 0L;
   private long crossCompactionTempFileNum = 0L;
 
+  private long openFileNumbers = 0L;
+  private String[] getOpenFileNumberCommand;
+
   @Override
   public void bindTo(AbstractMetricService metricService) {
-    metricService.createAutoGauge(
-        Metric.FILE_SIZE.toString(),
-        MetricLevel.IMPORTANT,
-        this,
-        FileMetrics::getWalFileTotalSize,
-        Tag.NAME.toString(),
-        "wal");
+    bindTsFileMetrics(metricService);
+    bindWalFileMetrics(metricService);
+    bindCompactionFileMetrics(metricService);
+    bindSystemRelatedMetrics(metricService);
+    // finally start to update the value of some metrics in async way
+    if (null == currentServiceFuture) {
+      currentServiceFuture =
+          ScheduledExecutorUtil.safelyScheduleAtFixedRate(
+              service,
+              this::collect,
+              1,
+              MetricConfigDescriptor.getInstance()
+                  .getMetricConfig()
+                  .getAsyncCollectPeriodInSecond(),
+              TimeUnit.SECONDS);
+    }
+  }
+
+  private void bindTsFileMetrics(AbstractMetricService metricService) {
     metricService.createAutoGauge(
         Metric.FILE_SIZE.toString(),
         MetricLevel.IMPORTANT,
@@ -79,13 +106,6 @@ public class FileMetrics implements IMetricSet {
         Metric.FILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
         this,
-        FileMetrics::getWalFileTotalCount,
-        Tag.NAME.toString(),
-        "wal");
-    metricService.createAutoGauge(
-        Metric.FILE_COUNT.toString(),
-        MetricLevel.IMPORTANT,
-        this,
         FileMetrics::getSequenceFileTotalCount,
         Tag.NAME.toString(),
         "seq");
@@ -96,60 +116,85 @@ public class FileMetrics implements IMetricSet {
         FileMetrics::getUnsequenceFileTotalCount,
         Tag.NAME.toString(),
         "unseq");
+  }
+
+  private void bindWalFileMetrics(AbstractMetricService metricService) {
+    metricService.createAutoGauge(
+        Metric.FILE_SIZE.toString(),
+        MetricLevel.IMPORTANT,
+        this,
+        FileMetrics::getWalFileTotalSize,
+        Tag.NAME.toString(),
+        "wal");
+    metricService.createAutoGauge(
+        Metric.FILE_COUNT.toString(),
+        MetricLevel.IMPORTANT,
+        this,
+        FileMetrics::getWalFileTotalCount,
+        Tag.NAME.toString(),
+        "wal");
+  }
+
+  private void bindCompactionFileMetrics(AbstractMetricService metricService) {
     metricService.createAutoGauge(
         Metric.FILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
         this,
         FileMetrics::getInnerSeqCompactionTempFileNum,
         Tag.NAME.toString(),
-        "inner-seq-temp-num");
+        "inner-seq-temp");
     metricService.createAutoGauge(
         Metric.FILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
         this,
         FileMetrics::getInnerUnseqCompactionTempFileNum,
         Tag.NAME.toString(),
-        "inner-unseq-temp-num");
+        "inner-unseq-temp");
     metricService.createAutoGauge(
         Metric.FILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
         this,
         FileMetrics::getCrossCompactionTempFileNum,
         Tag.NAME.toString(),
-        "cross-temp-num");
+        "cross-temp");
     metricService.createAutoGauge(
         Metric.FILE_SIZE.toString(),
         MetricLevel.IMPORTANT,
         this,
         FileMetrics::getInnerSeqCompactionTempFileSize,
         Tag.NAME.toString(),
-        "inner-seq-temp-size");
+        "inner-seq-temp");
     metricService.createAutoGauge(
         Metric.FILE_SIZE.toString(),
         MetricLevel.IMPORTANT,
         this,
         FileMetrics::getInnerUnseqCompactionTempFileSize,
         Tag.NAME.toString(),
-        "inner-unseq-temp-size");
+        "inner-unseq-temp");
     metricService.createAutoGauge(
         Metric.FILE_SIZE.toString(),
         MetricLevel.IMPORTANT,
         this,
         FileMetrics::getCrossCompactionTempFileSize,
         Tag.NAME.toString(),
-        "cross-temp-size");
+        "cross-temp");
+  }
 
-    // finally start to update the value of some metrics in async way
-    if (null == currentServiceFuture) {
-      currentServiceFuture =
-          ScheduledExecutorUtil.safelyScheduleAtFixedRate(
-              service,
-              this::collect,
-              1,
-              MetricConfigDescriptor.getInstance()
-                  .getMetricConfig()
-                  .getAsyncCollectPeriodInSecond(),
-              TimeUnit.SECONDS);
+  private void bindSystemRelatedMetrics(AbstractMetricService metricService) {
+    if ((METRIC_CONFIG.getSystemType() == SystemType.LINUX
+            || METRIC_CONFIG.getSystemType() == SystemType.MAC)
+        && METRIC_CONFIG.getPid().length() != 0) {
+      this.getOpenFileNumberCommand =
+          new String[] {
+            "/bin/sh", "-c", String.format("lsof -p %s | wc -l", METRIC_CONFIG.getPid())
+          };
+      metricService.createAutoGauge(
+          Metric.FILE_COUNT.toString(),
+          MetricLevel.IMPORTANT,
+          this,
+          FileMetrics::getOpenFileNumbers,
+          Tag.NAME.toString(),
+          "open");
     }
   }
 
@@ -160,52 +205,96 @@ public class FileMetrics implements IMetricSet {
       currentServiceFuture.cancel(true);
       currentServiceFuture = null;
     }
+    unbindTsFileMetrics(metricService);
+    unbindWalMetrics(metricService);
+    unbindCompactionMetrics(metricService);
+    unbindSystemRelatedMetrics(metricService);
+  }
 
-    metricService.remove(
-        MetricType.AUTO_GAUGE, Metric.FILE_SIZE.toString(), Tag.NAME.toString(), "wal");
+  private void unbindTsFileMetrics(AbstractMetricService metricService) {
     metricService.remove(
         MetricType.AUTO_GAUGE, Metric.FILE_SIZE.toString(), Tag.NAME.toString(), "seq");
     metricService.remove(
         MetricType.AUTO_GAUGE, Metric.FILE_SIZE.toString(), Tag.NAME.toString(), "unseq");
     metricService.remove(
-        MetricType.AUTO_GAUGE, Metric.FILE_COUNT.toString(), Tag.NAME.toString(), "wal");
-    metricService.remove(
         MetricType.AUTO_GAUGE, Metric.FILE_COUNT.toString(), Tag.NAME.toString(), "seq");
     metricService.remove(
         MetricType.AUTO_GAUGE, Metric.FILE_COUNT.toString(), Tag.NAME.toString(), "unseq");
+  }
+
+  private void unbindWalMetrics(AbstractMetricService metricService) {
+    metricService.remove(
+        MetricType.AUTO_GAUGE, Metric.FILE_SIZE.toString(), Tag.NAME.toString(), "wal");
+    metricService.remove(
+        MetricType.AUTO_GAUGE, Metric.FILE_COUNT.toString(), Tag.NAME.toString(), "wal");
+  }
+
+  private void unbindCompactionMetrics(AbstractMetricService metricService) {
+    metricService.remove(
+        MetricType.AUTO_GAUGE, Metric.FILE_COUNT.toString(), Tag.NAME.toString(), "inner-seq-temp");
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.FILE_COUNT.toString(),
         Tag.NAME.toString(),
-        "inner-seq-temp-num");
+        "inner-unseq-temp");
     metricService.remove(
-        MetricType.AUTO_GAUGE,
-        Metric.FILE_COUNT.toString(),
-        Tag.NAME.toString(),
-        "inner-unseq-temp-num");
+        MetricType.AUTO_GAUGE, Metric.FILE_COUNT.toString(), Tag.NAME.toString(), "cross-temp");
     metricService.remove(
-        MetricType.AUTO_GAUGE, Metric.FILE_COUNT.toString(), Tag.NAME.toString(), "cross-temp-num");
+        MetricType.AUTO_GAUGE, Metric.FILE_SIZE.toString(), Tag.NAME.toString(), "inner-seq-temp");
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.FILE_SIZE.toString(),
         Tag.NAME.toString(),
-        "inner-seq-temp-size");
+        "inner-unseq-temp");
     metricService.remove(
-        MetricType.AUTO_GAUGE,
-        Metric.FILE_SIZE.toString(),
-        Tag.NAME.toString(),
-        "inner-unseq-temp-size");
-    metricService.remove(
-        MetricType.AUTO_GAUGE, Metric.FILE_SIZE.toString(), Tag.NAME.toString(), "cross-temp-size");
+        MetricType.AUTO_GAUGE, Metric.FILE_SIZE.toString(), Tag.NAME.toString(), "cross-temp");
+  }
+
+  private void unbindSystemRelatedMetrics(AbstractMetricService metricService) {
+    if ((METRIC_CONFIG.getSystemType() == SystemType.LINUX
+            || METRIC_CONFIG.getSystemType() == SystemType.MAC)
+        && METRIC_CONFIG.getPid().length() != 0) {
+      metricService.remove(
+          MetricType.AUTO_GAUGE, Metric.FILE_COUNT.toString(), Tag.NAME.toString(), "open");
+    }
   }
 
   private void collect() {
+    // update TsFile Metrics
+    TsFileMetricManager tsFileMetricManager = TsFileMetricManager.getInstance();
+    sequenceFileTotalSize = tsFileMetricManager.getFileSize(true);
+    unsequenceFileTotalSize = tsFileMetricManager.getFileSize(false);
+    sequenceFileTotalCount = tsFileMetricManager.getFileNum(true);
+    unsequenceFileTotalCount = tsFileMetricManager.getFileNum(false);
+    // update wal Metrics
     walFileTotalSize = WALManager.getInstance().getTotalDiskUsage();
-    sequenceFileTotalSize = TsFileMetricManager.getInstance().getFileSize(true);
-    unsequenceFileTotalSize = TsFileMetricManager.getInstance().getFileSize(false);
     walFileTotalCount = WALManager.getInstance().getTotalFileNum();
-    sequenceFileTotalCount = TsFileMetricManager.getInstance().getFileNum(true);
-    unsequenceFileTotalCount = TsFileMetricManager.getInstance().getFileNum(false);
+    // update compaction Metrics
+    innerSeqCompactionTempFileSize = tsFileMetricManager.getInnerCompactionTempFileSize(true);
+    innerUnseqCompactionTempFileSize = tsFileMetricManager.getInnerCompactionTempFileSize(false);
+    crossCompactionTempFileSize = tsFileMetricManager.getCrossCompactionTempFileSize();
+    innerSeqCompactionTempFileNum = tsFileMetricManager.getInnerCompactionTempFileNum(true);
+    innerUnseqCompactionTempFileNum = tsFileMetricManager.getInnerCompactionTempFileNum(false);
+    crossCompactionTempFileNum = tsFileMetricManager.getCrossCompactionTempFileNum();
+    // update open file number
+    try {
+      if ((METRIC_CONFIG.getSystemType() == SystemType.LINUX
+              || METRIC_CONFIG.getSystemType() == SystemType.MAC)
+          && METRIC_CONFIG.getPid().length() != 0) {
+        Process process = runtime.exec(getOpenFileNumberCommand);
+        StringBuilder result = new StringBuilder();
+        try (BufferedReader input =
+            new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+          String line = "";
+          while ((line = input.readLine()) != null) {
+            result.append(line);
+          }
+        }
+        openFileNumbers = Long.parseLong(result.toString());
+      }
+    } catch (IOException e) {
+      LOGGER.error("Failed to get open file number, because ", e);
+    }
   }
 
   public long getWalFileTotalSize() {
@@ -254,5 +343,9 @@ public class FileMetrics implements IMetricSet {
 
   public long getCrossCompactionTempFileNum() {
     return crossCompactionTempFileNum;
+  }
+
+  public long getOpenFileNumbers() {
+    return openFileNumbers;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
@@ -290,7 +290,7 @@ public class FileMetrics implements IMetricSet {
             result.append(line);
           }
         }
-        openFileNumbers = Long.parseLong(result.toString());
+        openFileNumbers = Long.parseLong(result.toString().trim());
       }
     } catch (IOException e) {
       LOGGER.error("Failed to get open file number, because ", e);


### PR DESCRIPTION
1. Fix the update logic of compaction related file metrics
2. Add open file number metrics(now support macOs and Linux)
3. Add `pid` and `systemType` into MetricConfig