### PR TITLE
[IOTDB-5373] Eliminate stale code in LocalConfigNode and LocalSchemaProcessor to simplify interfaces of ISchemaRegion

### DIFF
--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -946,14 +946,6 @@ public class RSchemaRegion implements ISchemaRegion {
     return result;
   }
 
-  @Override
-  public Set<PartialPath> getMatchedDevices(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    Set<PartialPath> allPath = new HashSet<>();
-    getMatchedPathByNodeType(pathPattern.getNodes(), new Character[] {NODE_TYPE_ENTITY}, allPath);
-    return allPath;
-  }
-
   private void getMatchedPathByNodeType(
       String[] nodes, Character[] nodetype, Collection<PartialPath> collection)
       throws IllegalPathException {

--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -574,7 +574,6 @@ public class RSchemaRegion implements ISchemaRegion {
     }
   }
 
-  @Override
   public Pair<Integer, Set<String>> deleteTimeseries(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
     try {

--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -985,7 +985,6 @@ public class RSchemaRegion implements ISchemaRegion {
     return res;
   }
 
-  @Override
   public List<MeasurementPath> getMeasurementPaths(
       PartialPath pathPattern, boolean isPrefixMath, boolean withTags) throws MetadataException {
     if (withTags) {
@@ -1006,14 +1005,6 @@ public class RSchemaRegion implements ISchemaRegion {
         pathPattern.getNodes(), MAX_PATH_DEPTH, function, new Character[] {NODE_TYPE_MEASUREMENT});
 
     return allResult;
-  }
-
-  @Override
-  public Pair<List<MeasurementPath>, Integer> getMeasurementPathsWithAlias(
-      PartialPath pathPattern, int limit, int offset, boolean isPrefixMatch, boolean withTags)
-      throws MetadataException {
-    // todo page query
-    return new Pair<>(getMeasurementPaths(pathPattern, false, withTags), offset + limit);
   }
 
   @Override
@@ -1054,7 +1045,8 @@ public class RSchemaRegion implements ISchemaRegion {
               measurementPath.getMeasurementAlias(),
               (MeasurementSchema) measurementPath.getMeasurementSchema(),
               entry.getValue().left,
-              entry.getValue().right));
+              entry.getValue().right,
+              measurementPath.isUnderAlignedEntity()));
     }
 
     return res;

--- a/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
+++ b/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
@@ -438,7 +438,6 @@ public class TagSchemaRegion implements ISchemaRegion {
     throw new UnsupportedOperationException("getMatchedDevices");
   }
 
-  @Override
   public List<MeasurementPath> getMeasurementPaths(
       PartialPath pathPattern, boolean isPrefixMatch, boolean withTags) throws MetadataException {
     PartialPath devicePath = pathPattern.getDevicePath();
@@ -447,15 +446,6 @@ public class TagSchemaRegion implements ISchemaRegion {
     } else {
       return getMeasurementPathsWithPointQuery(devicePath, isPrefixMatch);
     }
-  }
-
-  @Override
-  public Pair<List<MeasurementPath>, Integer> getMeasurementPathsWithAlias(
-      PartialPath pathPattern, int limit, int offset, boolean isPrefixMatch, boolean withTags)
-      throws MetadataException {
-    List<MeasurementPath> res = getMeasurementPaths(pathPattern, isPrefixMatch, false);
-    Pair<List<MeasurementPath>, Integer> result = new Pair<>(res, 0);
-    return result;
   }
 
   @Override

--- a/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
+++ b/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
@@ -69,7 +69,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -345,27 +344,6 @@ public class TagSchemaRegion implements ISchemaRegion {
   public Set<TSchemaNode> getChildNodePathInNextLevel(PartialPath pathPattern)
       throws MetadataException {
     throw new UnsupportedOperationException("getChildNodePathInNextLevel");
-  }
-
-  @Override
-  public Set<PartialPath> getMatchedDevices(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    List<IDeviceID> deviceIDs = getDeviceIdFromInvertedIndex(pathPattern);
-    Set<PartialPath> matchedDevices = new HashSet<>();
-    String devicePath = pathPattern.getFullPath();
-    // exact query
-    if (!devicePath.endsWith(TAIL) && !devicePath.equals(storageGroupFullPath)) {
-      DeviceEntry deviceEntry = idTableWithDeviceIDList.getDeviceEntry(devicePath);
-      if (deviceEntry != null) {
-        matchedDevices.add(pathPattern);
-      }
-      return matchedDevices;
-    }
-    List<String> devicePaths = getDevicePaths(deviceIDs);
-    for (String path : devicePaths) {
-      matchedDevices.add(new PartialPath(path));
-    }
-    return matchedDevices;
   }
 
   private List<String> getDevicePaths(List<IDeviceID> deviceIDS) {

--- a/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
+++ b/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
@@ -61,7 +61,6 @@ import org.apache.iotdb.external.api.ISeriesNumerMonitor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
-import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -305,12 +304,6 @@ public class TagSchemaRegion implements ISchemaRegion {
     plan.setDataTypes(tmpDataTypes);
     plan.setEncodings(tmpEncodings);
     plan.setCompressors(tmpCompressors);
-  }
-
-  @Override
-  public Pair<Integer, Set<String>> deleteTimeseries(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    throw new UnsupportedOperationException("deleteTimeseries");
   }
 
   @Override

--- a/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/utils/ShowTimeSeriesResultUtils.java
+++ b/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/utils/ShowTimeSeriesResultUtils.java
@@ -49,7 +49,8 @@ public class ShowTimeSeriesResultUtils {
             schemaEntry.getTSEncoding(),
             schemaEntry.getCompressionType()),
         new HashMap<>(),
-        new HashMap<>());
+        new HashMap<>(),
+        false);
   }
 
   /**
@@ -72,7 +73,8 @@ public class ShowTimeSeriesResultUtils {
               schemaEntry.getTSEncoding(),
               schemaEntry.getCompressionType()),
           new HashMap<>(),
-          new HashMap<>());
+          new HashMap<>(),
+          false);
     } catch (IllegalPathException e) {
       throw new RuntimeException(e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalConfigNode.java
@@ -19,92 +19,42 @@
 
 package org.apache.iotdb.db.localconfignode;
 
-import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
-import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
-import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
-import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TFlushReq;
-import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.common.rpc.thrift.TSchemaNode;
-import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
-import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
-import org.apache.iotdb.commons.auth.AuthException;
-import org.apache.iotdb.commons.auth.authorizer.BasicAuthorizer;
-import org.apache.iotdb.commons.auth.authorizer.IAuthorizer;
-import org.apache.iotdb.commons.auth.entity.PathPrivilege;
-import org.apache.iotdb.commons.auth.entity.PrivilegeType;
-import org.apache.iotdb.commons.auth.entity.Role;
-import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.cluster.NodeStatus;
-import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
-import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.consensus.DataRegionId;
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.commons.exception.MetadataException;
-import org.apache.iotdb.commons.exception.sync.PipeException;
-import org.apache.iotdb.commons.exception.sync.PipeSinkException;
 import org.apache.iotdb.commons.file.SystemFileFactory;
-import org.apache.iotdb.commons.partition.DataPartition;
-import org.apache.iotdb.commons.partition.DataPartitionQueryParam;
-import org.apache.iotdb.commons.partition.executor.SeriesPartitionExecutor;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.commons.path.PathPatternTree;
-import org.apache.iotdb.commons.sync.pipesink.PipeSink;
-import org.apache.iotdb.commons.utils.AuthUtils;
-import org.apache.iotdb.commons.utils.StatusUtils;
-import org.apache.iotdb.confignode.rpc.thrift.TShowPipeInfo;
-import org.apache.iotdb.confignode.rpc.thrift.TShowPipeResp;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.cache.BloomFilterCache;
 import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
-import org.apache.iotdb.db.engine.storagegroup.DataRegion;
-import org.apache.iotdb.db.exception.DataRegionException;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupAlreadySetException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
-import org.apache.iotdb.db.exception.sql.StatementAnalyzeException;
-import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.metadata.schemaregion.SchemaEngine;
 import org.apache.iotdb.db.metadata.storagegroup.IStorageGroupSchemaManager;
 import org.apache.iotdb.db.metadata.storagegroup.StorageGroupSchemaManager;
 import org.apache.iotdb.db.metadata.utils.MetaUtils;
-import org.apache.iotdb.db.mpp.common.DataNodeEndPoints;
-import org.apache.iotdb.db.mpp.plan.statement.AuthorType;
-import org.apache.iotdb.db.mpp.plan.statement.sys.AuthorStatement;
-import org.apache.iotdb.db.mpp.plan.statement.sys.sync.CreatePipeSinkStatement;
-import org.apache.iotdb.db.mpp.plan.statement.sys.sync.CreatePipeStatement;
 import org.apache.iotdb.db.rescon.MemTableManager;
-import org.apache.iotdb.db.sync.SyncService;
-import org.apache.iotdb.db.utils.sync.SyncPipeUtil;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
-import org.apache.iotdb.tsfile.utils.Pair;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * This class simulates the behaviour of configNode to manage the configs locally. The schema
@@ -116,10 +66,7 @@ public class LocalConfigNode {
   private static final Logger logger = LoggerFactory.getLogger(LocalConfigNode.class);
 
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
-  public static final long STANDALONE_MOCK_TIME_SLOT_START_TIME = 0L;
   private volatile boolean initialized = false;
-
-  private ScheduledExecutorService timedForceMLogThread;
 
   private final IStorageGroupSchemaManager storageGroupSchemaManager =
       StorageGroupSchemaManager.getInstance();
@@ -131,14 +78,6 @@ public class LocalConfigNode {
 
   private final LocalDataPartitionInfo dataPartitionInfo = LocalDataPartitionInfo.getInstance();
 
-  private final SeriesPartitionExecutor executor =
-      SeriesPartitionExecutor.getSeriesPartitionExecutor(
-          config.getSeriesPartitionExecutorClass(), config.getSeriesPartitionSlotNum());
-
-  private final SyncService syncService = SyncService.getInstance();
-
-  private IAuthorizer iAuthorizer;
-
   private LocalConfigNode() {
     String schemaDir = config.getSchemaDir();
     File schemaFolder = SystemFileFactory.INSTANCE.getFile(schemaDir);
@@ -148,11 +87,6 @@ public class LocalConfigNode {
       } else {
         logger.error("create system folder {} failed.", schemaFolder.getAbsolutePath());
       }
-    }
-    try {
-      iAuthorizer = BasicAuthorizer.getInstance();
-    } catch (AuthException e) {
-      logger.error(e.getMessage());
     }
   }
 
@@ -182,18 +116,6 @@ public class LocalConfigNode {
           schemaEngine.initForLocalConfigNode();
       schemaPartitionTable.init(recoveredLocalSchemaRegionInfo);
 
-      if (config.getSyncMlogPeriodInMs() != 0) {
-        timedForceMLogThread =
-            IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(
-                "LocalConfigNode-TimedForceMLog-Thread");
-        ScheduledExecutorUtil.unsafelyScheduleAtFixedRate(
-            timedForceMLogThread,
-            this::forceMlog,
-            config.getSyncMlogPeriodInMs(),
-            config.getSyncMlogPeriodInMs(),
-            TimeUnit.MILLISECONDS);
-      }
-
       // TODO: the judgment should be removed after old standalone removed
       if (!config.isClusterMode()) {
         Map<String, List<DataRegionId>> recoveredLocalDataRegionInfo =
@@ -215,11 +137,6 @@ public class LocalConfigNode {
 
     try {
 
-      if (timedForceMLogThread != null) {
-        timedForceMLogThread.shutdown();
-        timedForceMLogThread = null;
-      }
-
       schemaPartitionTable.clear();
       schemaEngine.clear();
       storageGroupSchemaManager.clear();
@@ -231,14 +148,6 @@ public class LocalConfigNode {
     }
 
     initialized = false;
-  }
-
-  public synchronized void forceMlog() {
-    if (!initialized) {
-      return;
-    }
-
-    storageGroupSchemaManager.forceLog();
   }
 
   // endregion
@@ -260,62 +169,6 @@ public class LocalConfigNode {
 
     if (!config.isEnableMemControl()) {
       MemTableManager.getInstance().addOrDeleteStorageGroup(1);
-    }
-  }
-
-  public void deleteStorageGroup(PartialPath storageGroup) throws MetadataException {
-
-    if (!config.isClusterMode()) {
-      deleteDataRegionsInStorageGroup(
-          dataPartitionInfo.getDataRegionIdsByStorageGroup(storageGroup));
-      dataPartitionInfo.deleteStorageGroup(storageGroup);
-    }
-
-    deleteSchemaRegionsInStorageGroup(
-        storageGroup, schemaPartitionTable.getSchemaRegionIdsByStorageGroup(storageGroup));
-
-    if (!config.isEnableMemControl()) {
-      MemTableManager.getInstance().addOrDeleteStorageGroup(-1);
-    }
-
-    schemaPartitionTable.deleteStorageGroup(storageGroup);
-
-    // delete database after all related resources have been cleared
-    storageGroupSchemaManager.deleteStorageGroup(storageGroup);
-  }
-
-  private void deleteSchemaRegionsInStorageGroup(
-      PartialPath storageGroup, List<SchemaRegionId> schemaRegionIdSet) throws MetadataException {
-    for (SchemaRegionId schemaRegionId : schemaRegionIdSet) {
-      schemaEngine.deleteSchemaRegion(schemaRegionId);
-    }
-
-    File sgDir = new File(config.getSchemaDir() + File.separator + storageGroup.getFullPath());
-    if (sgDir.delete()) {
-      logger.info("delete database folder {}", sgDir.getAbsolutePath());
-    } else {
-      if (sgDir.exists()) {
-        logger.info("delete database folder {} failed.", sgDir.getAbsolutePath());
-        throw new MetadataException(
-            String.format("Failed to delete database folder %s", sgDir.getAbsolutePath()));
-      }
-    }
-  }
-
-  private void deleteDataRegionsInStorageGroup(List<DataRegionId> dataRegionIdSet) {
-    for (DataRegionId dataRegionId : dataRegionIdSet) {
-      storageEngine.deleteDataRegion(dataRegionId);
-    }
-  }
-
-  /**
-   * Delete databases of given paths from MTree.
-   *
-   * @param storageGroups list of paths to be deleted.
-   */
-  public void deleteStorageGroups(List<PartialPath> storageGroups) throws MetadataException {
-    for (PartialPath storageGroup : storageGroups) {
-      deleteStorageGroup(storageGroup);
     }
   }
 
@@ -345,52 +198,9 @@ public class LocalConfigNode {
     }
   }
 
-  public void setTTL(PartialPath storageGroup, long dataTTL) throws MetadataException, IOException {
-    if (!config.isClusterMode()) {
-      storageEngine.setTTL(dataPartitionInfo.getDataRegionIdsByStorageGroup(storageGroup), dataTTL);
-    }
-    storageGroupSchemaManager.setTTL(storageGroup, dataTTL);
-  }
-
   // endregion
 
   // region Interfaces for database info query
-
-  /**
-   * Check if the given path is database or not.
-   *
-   * @param path Format: root.node.(node)*
-   */
-  public boolean isStorageGroup(PartialPath path) {
-    return storageGroupSchemaManager.isStorageGroup(path);
-  }
-
-  /** Check whether the given path contains a database */
-  public boolean checkStorageGroupByPath(PartialPath path) {
-    return storageGroupSchemaManager.checkStorageGroupByPath(path);
-  }
-
-  /**
-   * Check whether the database of given path is set. The path may be a prefix path of some
-   * database. Besides, the given path may be also beyond the MTreeAboveSG scope, then return true
-   * if the covered part exists, which means there's database on this path. The rest part will be
-   * checked by certain database subTree.
-   *
-   * @param path a full path or a prefix path
-   */
-  public boolean isStorageGroupAlreadySet(PartialPath path) {
-    return storageGroupSchemaManager.isStorageGroupAlreadySet(path);
-  }
-
-  /**
-   * To calculate the count of database for given path pattern. If using prefix match, the path
-   * pattern is used to match prefix path. All timeseries start with the matched prefix path will be
-   * counted.
-   */
-  public int getStorageGroupNum(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    return storageGroupSchemaManager.getStorageGroupNum(pathPattern, isPrefixMatch);
-  }
 
   /**
    * Get database name by path
@@ -404,160 +214,11 @@ public class LocalConfigNode {
     return storageGroupSchemaManager.getBelongedStorageGroup(path);
   }
 
-  /**
-   * Get the database that given path pattern matches or belongs to.
-   *
-   * <p>Suppose we have (root.sg1.d1.s1, root.sg2.d2.s2), refer the following cases: 1. given path
-   * "root.sg1", ("root.sg1") will be returned. 2. given path "root.*", ("root.sg1", "root.sg2")
-   * will be returned. 3. given path "root.*.d1.s1", ("root.sg1", "root.sg2") will be returned.
-   *
-   * @param pathPattern a path pattern or a full path
-   * @return a list contains all databases related to given path pattern
-   */
-  public List<PartialPath> getBelongedStorageGroups(PartialPath pathPattern)
-      throws MetadataException {
-    return storageGroupSchemaManager.getBelongedStorageGroups(pathPattern);
-  }
-
-  /**
-   * Get all database matching given path pattern. If using prefix match, the path pattern is used
-   * to match prefix path. All timeseries start with the matched prefix path will be collected.
-   *
-   * @param pathPattern a pattern of a full path
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   * @return A ArrayList instance which stores database paths matching given path pattern.
-   */
-  public List<PartialPath> getMatchedStorageGroups(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    return storageGroupSchemaManager.getMatchedStorageGroups(pathPattern, isPrefixMatch);
-  }
-
-  /** Get all database paths */
-  public List<PartialPath> getAllStorageGroupPaths() {
-    return storageGroupSchemaManager.getAllStorageGroupPaths();
-  }
-
-  /**
-   * get all storageGroups ttl
-   *
-   * @return key-> storageGroupPath, value->ttl
-   */
-  public Map<PartialPath, Long> getStorageGroupsTTL() {
-    Map<PartialPath, Long> storageGroupsTTL = new HashMap<>();
-    for (IStorageGroupMNode storageGroupMNode : getAllStorageGroupNodes()) {
-      storageGroupsTTL.put(storageGroupMNode.getPartialPath(), storageGroupMNode.getDataTTL());
-    }
-    return storageGroupsTTL;
-  }
-
-  /**
-   * To collect nodes in the given level for given path pattern. If using prefix match, the path
-   * pattern is used to match prefix path. All nodes start with the matched prefix path will be
-   * collected. This method only count in nodes above database. Nodes below database, including
-   * database node will be collected by certain SchemaRegion. The involved databases will be
-   * collected to fetch schemaRegion.
-   *
-   * @param pathPattern a path pattern or a full path
-   * @param nodeLevel the level should match the level of the path
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  public Pair<List<PartialPath>, Set<PartialPath>> getNodesListInGivenLevel(
-      PartialPath pathPattern, int nodeLevel, boolean isPrefixMatch) throws MetadataException {
-    return storageGroupSchemaManager.getNodesListInGivenLevel(
-        pathPattern, nodeLevel, isPrefixMatch);
-  }
-
-  /**
-   * Get child node path in the next level of the given path pattern. This method only count in
-   * nodes above database. Nodes below database, including database node will be counted by certain
-   * database.
-   *
-   * <p>give pathPattern and the child nodes is those matching pathPattern.*
-   *
-   * <p>e.g., MTree has [root.a.sg1.d1.s1, root.b.sg1.d1.s2, root.c.sg1.d2.s1] given path = root
-   * return [root.a, root.b]
-   *
-   * @param pathPattern The given path
-   * @return All child nodes' seriesPath(s) of given seriesPath.
-   */
-  public Pair<Set<TSchemaNode>, Set<PartialPath>> getChildNodePathInNextLevel(
-      PartialPath pathPattern) throws MetadataException {
-    return storageGroupSchemaManager.getChildNodePathInNextLevel(pathPattern);
-  }
-
-  /**
-   * Get child node path in the next level of the given path pattern. This method only count in
-   * nodes above database. Nodes below database, including database node will be counted by certain
-   * database.
-   *
-   * <p>give pathPattern and the child nodes is those matching pathPattern.*
-   *
-   * <p>e.g., MTree has [root.a.sg1.d1.s1, root.b.sg1.d1.s2, root.c.sg1.d2.s1] given path = root
-   * return [a, b]
-   *
-   * @param pathPattern The given path
-   * @return All child nodes' seriesPath(s) of given seriesPath.
-   */
-  public Pair<Set<String>, Set<PartialPath>> getChildNodeNameInNextLevel(PartialPath pathPattern)
-      throws MetadataException {
-    return storageGroupSchemaManager.getChildNodeNameInNextLevel(pathPattern);
-  }
-
-  // endregion
-
-  // region Interfaces for StorageGroupMNode Query
-
-  /** Get database node by path. the give path don't need to be database path. */
-  public IStorageGroupMNode getStorageGroupNodeByPath(PartialPath path) throws MetadataException {
-    // used for storage engine auto create database
-    ensureStorageGroup(path);
-    return storageGroupSchemaManager.getStorageGroupNodeByPath(path);
-  }
-
-  /** Get all database MNodes */
-  public List<IStorageGroupMNode> getAllStorageGroupNodes() {
-    return storageGroupSchemaManager.getAllStorageGroupNodes();
-  }
-
   // endregion
 
   // endregion
 
   // region Interfaces for SchemaRegionId Management
-
-  /**
-   * Get the target SchemaRegionIds, which the given path belongs to. The path must be a fullPath
-   * without wildcards, * or **. This method is the first step when there's a task on one certain
-   * path, e.g., root.sg1 is a database and path = root.sg1.d1, return SchemaRegionId of root.sg1.
-   * If there's no database on the given path, StorageGroupNotSetException will be thrown.
-   */
-  public SchemaRegionId getBelongedSchemaRegionId(PartialPath path) throws MetadataException {
-    PartialPath storageGroup = storageGroupSchemaManager.getBelongedStorageGroup(path);
-    SchemaRegionId schemaRegionId = schemaPartitionTable.getSchemaRegionId(storageGroup, path);
-    // Since the creation of storageGroup, schemaRegionId and schemaRegion is not atomic or locked,
-    // any access concurrent with this creation may get null.
-    // Thread A: create sg, allocate schemaRegionId, create schemaRegion
-    // Thread B: access sg, access partitionTable to get schemaRegionId, access schemaEngine to get
-    // schemaRegion
-    // When A and B are running concurrently, B may get null while getting schemaRegionId or
-    // schemaRegion. This means B must run after A ends.
-    // To avoid this exception, please invoke getBelongedSchemaRegionIdWithAutoCreate according to
-    // the scenario.
-    if (schemaRegionId == null) {
-      throw new MetadataException(
-          String.format(
-              "database %s has not been prepared well. Schema region for %s has not been allocated or is not initialized.",
-              storageGroup, path));
-    }
-    ISchemaRegion schemaRegion = schemaEngine.getSchemaRegion(schemaRegionId);
-    if (schemaRegion == null) {
-      throw new MetadataException(
-          String.format(
-              "database [%s] has not been prepared well. Schema region [%s] is not initialized.",
-              storageGroup, schemaRegionId));
-    }
-    return schemaRegionId;
-  }
 
   // This interface involves database and schema region auto creation
   public SchemaRegionId getBelongedSchemaRegionIdWithAutoCreate(PartialPath path)
@@ -581,443 +242,17 @@ public class LocalConfigNode {
    * multiple paths represented by the given pathPattern. If isPrefixMatch, all databases under the
    * prefixPath that matches the given pathPattern will be collected.
    */
-  public List<SchemaRegionId> getInvolvedSchemaRegionIds(
-      PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException {
+  public List<SchemaRegionId> getInvolvedSchemaRegionIds(PartialPath pathPattern)
+      throws MetadataException {
     List<SchemaRegionId> result = new ArrayList<>();
     for (PartialPath storageGroup :
-        storageGroupSchemaManager.getInvolvedStorageGroups(pathPattern, isPrefixMatch)) {
-      result.addAll(
-          schemaPartitionTable.getInvolvedSchemaRegionIds(
-              storageGroup, pathPattern, isPrefixMatch));
+        storageGroupSchemaManager.getInvolvedStorageGroups(pathPattern)) {
+      result.addAll(schemaPartitionTable.getInvolvedSchemaRegionIds(storageGroup, pathPattern));
     }
     return result;
   }
 
-  public List<SchemaRegionId> getSchemaRegionIdsByStorageGroup(PartialPath storageGroup) {
-    return schemaPartitionTable.getSchemaRegionIdsByStorageGroup(storageGroup);
-  }
-
   // endregion
-
-  // region Interfaces for DataRegionId Management
-
-  /**
-   * Get the target DataRegionIds, which the given path belongs to. The path must be a fullPath
-   * without wildcards, * or **. This method is the first step when there's a task on one certain
-   * path, e.g., root.sg1 is a database and path = root.sg1.d1, return DataRegionId of root.sg1. If
-   * there's no database on the given path, StorageGroupNotSetException will be thrown.
-   */
-  public DataRegionId getBelongedDataRegionId(PartialPath path)
-      throws MetadataException, DataRegionException {
-    PartialPath storageGroup = storageGroupSchemaManager.getBelongedStorageGroup(path);
-    DataRegionId dataRegionId = dataPartitionInfo.getDataRegionId(storageGroup, path);
-    if (dataRegionId == null) {
-      return null;
-    }
-    DataRegion dataRegion = storageEngine.getDataRegion(dataRegionId);
-    if (dataRegion == null) {
-      throw new DataRegionException(
-          String.format(
-              "Database %s has not been prepared well. Data region for %s is not initialized.",
-              storageGroup, path));
-    }
-    return dataRegionId;
-  }
-
-  // This interface involves database and data region auto creation
-  public DataRegionId getBelongedDataRegionIdWithAutoCreate(PartialPath devicePath)
-      throws MetadataException, DataRegionException {
-    PartialPath storageGroup = storageGroupSchemaManager.getBelongedStorageGroup(devicePath);
-    DataRegionId dataRegionId = dataPartitionInfo.getDataRegionId(storageGroup, devicePath);
-    if (dataRegionId == null) {
-      dataPartitionInfo.registerStorageGroup(storageGroup);
-      dataRegionId = dataPartitionInfo.allocateDataRegionForNewSlot(storageGroup, devicePath);
-    }
-    DataRegion dataRegion = storageEngine.getDataRegion(dataRegionId);
-    if (dataRegion == null) {
-      storageEngine.createDataRegion(dataRegionId, storageGroup.getFullPath(), Long.MAX_VALUE);
-    }
-    return dataRegionId;
-  }
-
-  public Map<String, Map<TSeriesPartitionSlot, TRegionReplicaSet>> getSchemaPartition(
-      PathPatternTree patternTree) {
-
-    Map<String, Map<TSeriesPartitionSlot, TRegionReplicaSet>> partitionSlotsMap = new HashMap<>();
-    patternTree.constructTree();
-    List<PartialPath> partialPathList = patternTree.getAllPathPatterns();
-    try {
-      for (PartialPath path : partialPathList) {
-        List<PartialPath> storageGroups = getBelongedStorageGroups(path);
-        for (PartialPath storageGroupPath : storageGroups) {
-          String storageGroup = storageGroupPath.getFullPath();
-          SchemaRegionId schemaRegionId = getBelongedSchemaRegionId(storageGroupPath);
-          ISchemaRegion schemaRegion = schemaEngine.getSchemaRegion(schemaRegionId);
-          Set<PartialPath> devices = schemaRegion.getMatchedDevices(storageGroupPath, true);
-          for (PartialPath device : devices) {
-            partitionSlotsMap
-                .computeIfAbsent(storageGroup, key -> new HashMap<>())
-                .put(
-                    executor.getSeriesPartitionSlot(device.getFullPath()),
-                    genStandaloneRegionReplicaSet(
-                        TConsensusGroupType.SchemaRegion, schemaRegionId.getId()));
-          }
-        }
-      }
-      return partitionSlotsMap;
-    } catch (MetadataException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public Map<String, Map<TSeriesPartitionSlot, TRegionReplicaSet>> getOrCreateSchemaPartition(
-      PathPatternTree patternTree) {
-    List<String> devicePaths = patternTree.getAllDevicePatterns();
-    Map<String, Map<TSeriesPartitionSlot, TRegionReplicaSet>> partitionSlotsMap = new HashMap<>();
-
-    try {
-      for (String devicePath : devicePaths) {
-        // Only check devicePaths that without "*"
-        if (!devicePath.contains("*")) {
-          PartialPath device = new PartialPath(devicePath);
-          PartialPath storageGroup = ensureStorageGroup(device);
-          SchemaRegionId schemaRegionId = getBelongedSchemaRegionIdWithAutoCreate(device);
-          partitionSlotsMap
-              .computeIfAbsent(storageGroup.getFullPath(), key -> new HashMap<>())
-              .put(
-                  executor.getSeriesPartitionSlot(devicePath),
-                  genStandaloneRegionReplicaSet(
-                      TConsensusGroupType.SchemaRegion, schemaRegionId.getId()));
-        }
-      }
-    } catch (MetadataException e) {
-      throw new StatementAnalyzeException(
-          "An error occurred when executing getOrCreateSchemaPartition():" + e.getMessage());
-    }
-    return partitionSlotsMap;
-  }
-
-  // region Interfaces for StandalonePartitionFetcher
-  public DataPartition getDataPartition(
-      Map<String, List<DataPartitionQueryParam>> sgNameToQueryParamsMap)
-      throws MetadataException, DataRegionException {
-    Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>>
-        dataPartitionMap = new HashMap<>();
-    for (Map.Entry<String, List<DataPartitionQueryParam>> sgEntry :
-        sgNameToQueryParamsMap.entrySet()) {
-      // for each sg
-      String storageGroupName = sgEntry.getKey();
-      List<DataPartitionQueryParam> dataPartitionQueryParams = sgEntry.getValue();
-      Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>
-          deviceToRegionsMap = new HashMap<>();
-      for (DataPartitionQueryParam dataPartitionQueryParam : dataPartitionQueryParams) {
-        String deviceId = dataPartitionQueryParam.getDevicePath();
-        DataRegionId dataRegionId = getBelongedDataRegionId(new PartialPath(deviceId));
-        // dataRegionId is null means the DataRegion is not created,
-        // use an empty dataPartitionMap to init DataPartition
-        if (dataRegionId != null) {
-          Map<TTimePartitionSlot, List<TRegionReplicaSet>> timePartitionToRegionsMap =
-              deviceToRegionsMap.getOrDefault(
-                  executor.getSeriesPartitionSlot(deviceId), new HashMap<>());
-          timePartitionToRegionsMap.put(
-              new TTimePartitionSlot(STANDALONE_MOCK_TIME_SLOT_START_TIME),
-              Collections.singletonList(
-                  genStandaloneRegionReplicaSet(
-                      TConsensusGroupType.DataRegion, dataRegionId.getId())));
-          deviceToRegionsMap.put(
-              executor.getSeriesPartitionSlot(deviceId), timePartitionToRegionsMap);
-        }
-      }
-      if (!deviceToRegionsMap.isEmpty()) {
-        dataPartitionMap.put(storageGroupName, deviceToRegionsMap);
-      }
-    }
-    return new DataPartition(
-        dataPartitionMap,
-        IoTDBDescriptor.getInstance().getConfig().getSeriesPartitionExecutorClass(),
-        IoTDBDescriptor.getInstance().getConfig().getSeriesPartitionSlotNum());
-  }
-
-  private TRegionReplicaSet genStandaloneRegionReplicaSet(TConsensusGroupType type, int id) {
-    TRegionReplicaSet regionReplicaSet = new TRegionReplicaSet();
-    regionReplicaSet.setRegionId(new TConsensusGroupId(type, id));
-    regionReplicaSet.setDataNodeLocations(
-        Collections.singletonList(
-            new TDataNodeLocation(
-                IoTDBDescriptor.getInstance().getConfig().getDataNodeId(),
-                new TEndPoint(),
-                DataNodeEndPoints.LOCAL_HOST_INTERNAL_ENDPOINT,
-                DataNodeEndPoints.LOCAL_HOST_DATA_BLOCK_ENDPOINT,
-                new TEndPoint(),
-                new TEndPoint())));
-    return regionReplicaSet;
-  }
-
-  public DataPartition getOrCreateDataPartition(
-      Map<String, List<DataPartitionQueryParam>> sgNameToQueryParamsMap)
-      throws MetadataException, DataRegionException {
-    Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>>
-        dataPartitionMap = new HashMap<>();
-    for (Map.Entry<String, List<DataPartitionQueryParam>> sgEntry :
-        sgNameToQueryParamsMap.entrySet()) {
-      // for each sg
-      String storageGroupName = sgEntry.getKey();
-      List<DataPartitionQueryParam> dataPartitionQueryParams = sgEntry.getValue();
-      Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>
-          deviceToRegionsMap = new HashMap<>();
-      for (DataPartitionQueryParam dataPartitionQueryParam : dataPartitionQueryParams) {
-        // for each device
-        String deviceId = dataPartitionQueryParam.getDevicePath();
-        List<TTimePartitionSlot> timePartitionSlotList =
-            dataPartitionQueryParam.getTimePartitionSlotList();
-        for (TTimePartitionSlot timePartitionSlot : timePartitionSlotList) {
-          DataRegionId dataRegionId =
-              getBelongedDataRegionIdWithAutoCreate(new PartialPath(deviceId));
-          Map<TTimePartitionSlot, List<TRegionReplicaSet>> timePartitionToRegionsMap =
-              deviceToRegionsMap.getOrDefault(
-                  executor.getSeriesPartitionSlot(deviceId), new HashMap<>());
-          timePartitionToRegionsMap.put(
-              timePartitionSlot,
-              Collections.singletonList(
-                  genStandaloneRegionReplicaSet(
-                      TConsensusGroupType.DataRegion, dataRegionId.getId())));
-          deviceToRegionsMap.put(
-              executor.getSeriesPartitionSlot(deviceId), timePartitionToRegionsMap);
-        }
-      }
-      dataPartitionMap.put(storageGroupName, deviceToRegionsMap);
-    }
-    return new DataPartition(
-        dataPartitionMap,
-        IoTDBDescriptor.getInstance().getConfig().getSeriesPartitionExecutorClass(),
-        IoTDBDescriptor.getInstance().getConfig().getSeriesPartitionSlotNum());
-  }
-
-  // endregion
-
-  // author
-  public void operatorPermission(AuthorStatement authorStatement) throws AuthException {
-    AuthorType authorType = AuthorType.values()[authorStatement.getAuthorType().ordinal()];
-    String userName = authorStatement.getUserName();
-    String roleName = authorStatement.getRoleName();
-    String password = authorStatement.getPassWord();
-    String newPassword = authorStatement.getNewPassword();
-    Set<Integer> permissions = AuthUtils.strToPermissions(authorStatement.getPrivilegeList());
-    List<String> nodeNameList =
-        authorStatement.getNodeNameList().stream()
-            .map(PartialPath::getFullPath)
-            .collect(Collectors.toList());
-    switch (authorType) {
-      case UPDATE_USER:
-        iAuthorizer.updateUserPassword(userName, newPassword);
-        break;
-      case CREATE_USER:
-        iAuthorizer.createUser(userName, password);
-        break;
-      case CREATE_ROLE:
-        iAuthorizer.createRole(roleName);
-        break;
-      case DROP_USER:
-        iAuthorizer.deleteUser(userName);
-        break;
-      case DROP_ROLE:
-        iAuthorizer.deleteRole(roleName);
-        break;
-      case GRANT_ROLE:
-        for (int i : permissions) {
-          for (String path : nodeNameList) {
-            iAuthorizer.grantPrivilegeToRole(roleName, path, i);
-          }
-        }
-        break;
-      case GRANT_USER:
-        for (int i : permissions) {
-          for (String path : nodeNameList) {
-            iAuthorizer.grantPrivilegeToUser(userName, path, i);
-          }
-        }
-        break;
-      case GRANT_USER_ROLE:
-        iAuthorizer.grantRoleToUser(roleName, userName);
-        break;
-      case REVOKE_USER:
-        for (int i : permissions) {
-          for (String path : nodeNameList) {
-            iAuthorizer.revokePrivilegeFromUser(userName, path, i);
-          }
-        }
-        break;
-      case REVOKE_ROLE:
-        for (int i : permissions) {
-          for (String path : nodeNameList) {
-            iAuthorizer.revokePrivilegeFromRole(roleName, path, i);
-          }
-        }
-        break;
-      case REVOKE_USER_ROLE:
-        iAuthorizer.revokeRoleFromUser(roleName, userName);
-        break;
-      default:
-        throw new AuthException(
-            TSStatusCode.UNSUPPORTED_AUTH_OPERATION, "Unsupported operation " + authorType);
-    }
-  }
-
-  public Map<String, List<String>> queryPermission(AuthorStatement authorStatement)
-      throws AuthException {
-    AuthorType authorType = AuthorType.values()[authorStatement.getAuthorType().ordinal()];
-    switch (authorType) {
-      case LIST_USER:
-        return executeListRoleUsers(authorStatement);
-      case LIST_ROLE:
-        return executeListRoles(authorStatement);
-      case LIST_USER_PRIVILEGE:
-        return executeListUserPrivileges(authorStatement);
-      case LIST_ROLE_PRIVILEGE:
-        return executeListRolePrivileges(authorStatement);
-      default:
-        throw new AuthException(
-            TSStatusCode.UNSUPPORTED_AUTH_OPERATION, "Unsupported operation " + authorType);
-    }
-  }
-
-  public Map<String, List<String>> executeListRoleUsers(AuthorStatement authorStatement)
-      throws AuthException {
-    List<String> userList = iAuthorizer.listAllUsers();
-    if (authorStatement.getRoleName() != null && !authorStatement.getRoleName().isEmpty()) {
-      Role role = iAuthorizer.getRole(authorStatement.getRoleName());
-      if (role == null) {
-        throw new AuthException(
-            TSStatusCode.ROLE_NOT_EXIST, "No such role : " + authorStatement.getRoleName());
-      }
-      Iterator<String> itr = userList.iterator();
-      while (itr.hasNext()) {
-        User userObj = iAuthorizer.getUser(itr.next());
-        if (userObj == null || !userObj.hasRole(authorStatement.getRoleName())) {
-          itr.remove();
-        }
-      }
-    }
-
-    Map<String, List<String>> permissionInfo = new HashMap<>();
-    permissionInfo.put(IoTDBConstant.COLUMN_USER, userList);
-    return permissionInfo;
-  }
-
-  public Map<String, List<String>> executeListRoles(AuthorStatement authorStatement)
-      throws AuthException {
-    List<String> roleList = new ArrayList<>();
-    if (authorStatement.getUserName() == null || authorStatement.getUserName().isEmpty()) {
-      roleList.addAll(iAuthorizer.listAllRoles());
-    } else {
-      User user = iAuthorizer.getUser(authorStatement.getUserName());
-      if (user == null) {
-        throw new AuthException(
-            TSStatusCode.USER_NOT_EXIST, "No such user : " + authorStatement.getUserName());
-      }
-      roleList.addAll(user.getRoleList());
-    }
-
-    Map<String, List<String>> permissionInfo = new HashMap<>();
-    permissionInfo.put(IoTDBConstant.COLUMN_ROLE, roleList);
-    return permissionInfo;
-  }
-
-  public Map<String, List<String>> executeListRolePrivileges(AuthorStatement authorStatement)
-      throws AuthException {
-    Map<String, List<String>> permissionInfo = new HashMap<>();
-    Role role = iAuthorizer.getRole(authorStatement.getRoleName());
-    if (role == null) {
-      throw new AuthException(
-          TSStatusCode.ROLE_NOT_EXIST, "No such role : " + authorStatement.getRoleName());
-    }
-    Set<String> rolePrivilegeSet = new HashSet<>();
-    for (PathPrivilege pathPrivilege : role.getPrivilegeList()) {
-      if (authorStatement.getNodeNameList().isEmpty()) {
-        rolePrivilegeSet.add(pathPrivilege.toString());
-        continue;
-      }
-      for (PartialPath path : authorStatement.getNodeNameList()) {
-        if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path.getFullPath())) {
-          rolePrivilegeSet.add(pathPrivilege.toString());
-        }
-      }
-    }
-
-    permissionInfo.put(IoTDBConstant.COLUMN_PRIVILEGE, new ArrayList<>(rolePrivilegeSet));
-    return permissionInfo;
-  }
-
-  public Map<String, List<String>> executeListUserPrivileges(AuthorStatement authorStatement)
-      throws AuthException {
-    Map<String, List<String>> permissionInfo = new HashMap<>();
-    User user = iAuthorizer.getUser(authorStatement.getUserName());
-    if (user == null) {
-      throw new AuthException(
-          TSStatusCode.USER_NOT_EXIST, "No such user : " + authorStatement.getUserName());
-    }
-    List<String> userPrivilegesList = new ArrayList<>();
-
-    if (IoTDBConstant.PATH_ROOT.equals(authorStatement.getUserName())) {
-      for (PrivilegeType privilegeType : PrivilegeType.values()) {
-        userPrivilegesList.add(privilegeType.toString());
-      }
-    } else {
-      List<String> rolePrivileges = new ArrayList<>();
-      Set<String> userPrivilegeSet = new HashSet<>();
-      for (PathPrivilege pathPrivilege : user.getPrivilegeList()) {
-        if (authorStatement.getNodeNameList().isEmpty()
-            && !userPrivilegeSet.contains(pathPrivilege.toString())) {
-          rolePrivileges.add("");
-          userPrivilegeSet.add(pathPrivilege.toString());
-          continue;
-        }
-        for (PartialPath path : authorStatement.getNodeNameList()) {
-          if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path.getFullPath())
-              && !userPrivilegeSet.contains(pathPrivilege.toString())) {
-            rolePrivileges.add("");
-            userPrivilegeSet.add(pathPrivilege.toString());
-          }
-        }
-      }
-      userPrivilegesList.addAll(userPrivilegeSet);
-      for (String roleN : user.getRoleList()) {
-        Role role = iAuthorizer.getRole(roleN);
-        if (roleN == null) {
-          continue;
-        }
-        Set<String> rolePrivilegeSet = new HashSet<>();
-        for (PathPrivilege pathPrivilege : role.getPrivilegeList()) {
-          if (authorStatement.getNodeNameList().isEmpty()
-              && !rolePrivilegeSet.contains(pathPrivilege.toString())) {
-            rolePrivileges.add(roleN);
-            rolePrivilegeSet.add(pathPrivilege.toString());
-            continue;
-          }
-          for (PartialPath path : authorStatement.getNodeNameList()) {
-            if (AuthUtils.pathBelongsTo(pathPrivilege.getPath(), path.getFullPath())
-                && !rolePrivilegeSet.contains(pathPrivilege.toString())) {
-              rolePrivileges.add(roleN);
-              rolePrivilegeSet.add(pathPrivilege.toString());
-            }
-          }
-        }
-        userPrivilegesList.addAll(rolePrivilegeSet);
-      }
-      permissionInfo.put(IoTDBConstant.COLUMN_ROLE, rolePrivileges);
-    }
-    permissionInfo.put(IoTDBConstant.COLUMN_PRIVILEGE, userPrivilegesList);
-    return permissionInfo;
-  }
-
-  public boolean login(String username, String password) throws AuthException {
-    return iAuthorizer.login(username, password);
-  }
-
-  public boolean checkUserPrivileges(String username, String path, int permission)
-      throws AuthException {
-    return iAuthorizer.checkUserPrivileges(username, path, permission);
-  }
 
   public TSStatus executeMergeOperation() {
     try {
@@ -1055,75 +290,5 @@ public class LocalConfigNode {
       return RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, e.getMessage());
     }
     return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
-  }
-
-  public TSStatus createPipeSink(CreatePipeSinkStatement createPipeSinkStatement) {
-    try {
-      syncService.addPipeSink(createPipeSinkStatement);
-    } catch (PipeSinkException e) {
-      return RpcUtils.getStatus(TSStatusCode.CREATE_PIPE_SINK_ERROR, e.getMessage());
-    }
-    return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
-  }
-
-  public TSStatus dropPipeSink(String pipeSinkName) {
-    try {
-      syncService.dropPipeSink(pipeSinkName);
-    } catch (PipeSinkException e) {
-      return RpcUtils.getStatus(TSStatusCode.CREATE_PIPE_SINK_ERROR, e.getMessage());
-    }
-    return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
-  }
-
-  public List<PipeSink> showPipeSink(String pipeSinkName) throws PipeSinkException {
-    boolean showAll = StringUtils.isEmpty(pipeSinkName);
-    if (showAll) {
-      return syncService.getAllPipeSink();
-    } else {
-      return Collections.singletonList(syncService.getPipeSink(pipeSinkName));
-    }
-  }
-
-  public TSStatus createPipe(CreatePipeStatement createPipeStatement) {
-    try {
-      syncService.addPipe(
-          SyncPipeUtil.parseCreatePipeStatementAsPipeInfo(
-              createPipeStatement, System.currentTimeMillis()));
-    } catch (PipeException e) {
-      return RpcUtils.getStatus(TSStatusCode.PIPE_ERROR, e.getMessage());
-    }
-    return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
-  }
-
-  public TSStatus startPipe(String pipeName) {
-    try {
-      syncService.startPipe(pipeName);
-    } catch (PipeException e) {
-      return RpcUtils.getStatus(TSStatusCode.PIPE_ERROR, e.getMessage());
-    }
-    return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
-  }
-
-  public TSStatus stopPipe(String pipeName) {
-    try {
-      syncService.stopPipe(pipeName);
-    } catch (PipeException e) {
-      return RpcUtils.getStatus(TSStatusCode.PIPE_ERROR, e.getMessage());
-    }
-    return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
-  }
-
-  public TSStatus dropPipe(String pipeName) {
-    try {
-      syncService.dropPipe(pipeName);
-    } catch (PipeException e) {
-      return RpcUtils.getStatus(TSStatusCode.PIPE_ERROR, e.getMessage());
-    }
-    return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
-  }
-
-  public TShowPipeResp showPipe(String pipeName) {
-    List<TShowPipeInfo> pipeInfos = SyncService.getInstance().showPipe(pipeName);
-    return new TShowPipeResp().setPipeInfoList(pipeInfos).setStatus(StatusUtils.OK);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalSchemaPartitionTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/localconfignode/LocalSchemaPartitionTable.java
@@ -88,7 +88,7 @@ public class LocalSchemaPartitionTable {
   }
 
   public List<SchemaRegionId> getInvolvedSchemaRegionIds(
-      PartialPath storageGroup, PartialPath pathPattern, boolean isPrefixMatch) {
+      PartialPath storageGroup, PartialPath pathPattern) {
     List<SchemaRegionId> result = new ArrayList<>();
     if (table.containsKey(storageGroup)) {
       result.addAll(table.get(storageGroup));

--- a/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/LocalSchemaProcessor.java
@@ -29,7 +29,10 @@ import org.apache.iotdb.db.exception.metadata.MeasurementAlreadyExistException;
 import org.apache.iotdb.db.exception.metadata.PathAlreadyExistException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
 import org.apache.iotdb.db.localconfignode.LocalConfigNode;
+import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWritePlanFactory;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
+import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.metadata.schemaregion.SchemaEngine;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -122,10 +125,9 @@ public class LocalSchemaProcessor {
    * paths represented by the given pathPattern. If isPrefixMatch, all databases under the
    * prefixPath that matches the given pathPattern will be collected.
    */
-  private List<ISchemaRegion> getInvolvedSchemaRegions(
-      PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException {
-    List<SchemaRegionId> schemaRegionIds =
-        configManager.getInvolvedSchemaRegionIds(pathPattern, isPrefixMatch);
+  private List<ISchemaRegion> getInvolvedSchemaRegions(PartialPath pathPattern)
+      throws MetadataException {
+    List<SchemaRegionId> schemaRegionIds = configManager.getInvolvedSchemaRegionIds(pathPattern);
     List<ISchemaRegion> schemaRegions = new ArrayList<>();
     for (SchemaRegionId schemaRegionId : schemaRegionIds) {
       schemaRegions.add(schemaEngine.getSchemaRegion(schemaRegionId));
@@ -190,7 +192,7 @@ public class LocalSchemaProcessor {
    * @return deletion failed Timeseries
    */
   public String deleteTimeseries(PartialPath pathPattern) throws MetadataException {
-    List<ISchemaRegion> schemaRegions = getInvolvedSchemaRegions(pathPattern, false);
+    List<ISchemaRegion> schemaRegions = getInvolvedSchemaRegions(pathPattern);
     if (schemaRegions.isEmpty()) {
       // In the cluster mode, the deletion of a timeseries will be forwarded to all the nodes. For
       // nodes that do not have the metadata of the timeseries, the coordinator expects a
@@ -233,40 +235,27 @@ public class LocalSchemaProcessor {
   // region Interfaces for metadata info Query
 
   // region Interfaces for timeseries, measurement and schema info Query
-  /**
-   * Similar to method getMeasurementPaths(), but return Path with alias and filter the result by
-   * limit and offset. If using prefix match, the path pattern is used to match prefix path. All
-   * timeseries start with the matched prefix path will be collected.
-   *
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  public Pair<List<MeasurementPath>, Integer> getMeasurementPathsWithAlias(
-      PartialPath pathPattern, int limit, int offset, boolean isPrefixMatch, boolean withTags)
+
+  public List<MeasurementPath> getMeasurementPathsWithAlias(PartialPath pathPattern)
       throws MetadataException {
     List<MeasurementPath> measurementPaths = new LinkedList<>();
-    Pair<List<MeasurementPath>, Integer> result;
-    int resultOffset = 0;
 
-    int tmpLimit = limit;
-    int tmpOffset = offset;
-
-    for (ISchemaRegion schemaRegion : getInvolvedSchemaRegions(pathPattern, isPrefixMatch)) {
-      if (limit != 0 && tmpLimit == 0) {
-        break;
-      }
-      result =
-          schemaRegion.getMeasurementPathsWithAlias(
-              pathPattern, tmpLimit, tmpOffset, isPrefixMatch, withTags);
-      measurementPaths.addAll(result.left);
-      resultOffset += result.right;
-      if (limit != 0) {
-        tmpOffset = Math.max(0, tmpOffset - result.right);
-        tmpLimit -= result.left.size();
+    for (ISchemaRegion schemaRegion : getInvolvedSchemaRegions(pathPattern)) {
+      ISchemaReader<ITimeSeriesSchemaInfo> timeSeriesReader =
+          schemaRegion.getTimeSeriesReader(
+              SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(pathPattern));
+      while (timeSeriesReader.hasNext()) {
+        ITimeSeriesSchemaInfo timeSeriesSchemaInfo = timeSeriesReader.next();
+        MeasurementPath measurementPath =
+            new MeasurementPath(
+                timeSeriesSchemaInfo.getPartialPath(), timeSeriesSchemaInfo.getSchema());
+        measurementPath.setMeasurementAlias(timeSeriesSchemaInfo.getAlias());
+        measurementPath.setUnderAlignedEntity(timeSeriesSchemaInfo.isUnderAlignedDevice());
+        measurementPaths.add(measurementPath);
       }
     }
 
-    result = new Pair<>(measurementPaths, resultOffset);
-    return result;
+    return measurementPaths;
   }
   // endregion
   // endregion

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/ConfigMTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/ConfigMTree.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.metadata.mtree;
 
 import org.apache.iotdb.common.rpc.thrift.TSchemaNode;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
@@ -160,48 +159,6 @@ public class ConfigMTree {
   }
 
   /**
-   * Check whether path is database or not
-   *
-   * <p>e.g., path = root.a.b.sg. if nor a and b is StorageGroupMNode and sg is a StorageGroupMNode
-   * path is a database
-   *
-   * @param path path
-   * @apiNote :for cluster
-   */
-  public boolean isStorageGroup(PartialPath path) {
-    String[] nodeNames = path.getNodes();
-    if (nodeNames.length <= 1 || !nodeNames[0].equals(IoTDBConstant.PATH_ROOT)) {
-      return false;
-    }
-    IMNode cur = root;
-    int i = 1;
-    while (i < nodeNames.length - 1) {
-      cur = cur.getChild(nodeNames[i]);
-      if (cur == null || cur.isStorageGroup()) {
-        return false;
-      }
-      i++;
-    }
-    cur = cur.getChild(nodeNames[i]);
-    return cur != null && cur.isStorageGroup();
-  }
-
-  /** Check whether the given path contains a database */
-  public boolean checkStorageGroupByPath(PartialPath path) {
-    String[] nodes = path.getNodes();
-    IMNode cur = root;
-    for (int i = 1; i < nodes.length; i++) {
-      cur = cur.getChild(nodes[i]);
-      if (cur == null) {
-        return false;
-      } else if (cur.isStorageGroup()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Get database path by path
    *
    * <p>e.g., root.sg1 is database, path is root.sg1.d1, return root.sg1
@@ -289,27 +246,6 @@ public class ConfigMTree {
   }
 
   /**
-   * Resolve the path or path pattern into StorageGroupName-FullPath pairs. Try determining the
-   * database using the children of a mNode. If one child is a database node, put a
-   * storageGroupName-fullPath pair into paths.
-   */
-  public Map<String, List<PartialPath>> groupPathByStorageGroup(PartialPath path)
-      throws MetadataException {
-    Map<String, List<PartialPath>> result = new HashMap<>();
-    StorageGroupCollector<Map<String, String>> collector =
-        new StorageGroupCollector<Map<String, String>>(root, path, store) {
-          @Override
-          protected void collectStorageGroup(IStorageGroupMNode node) {
-            PartialPath sgPath = node.getPartialPath();
-            result.put(sgPath.getFullPath(), path.alterPrefixPath(sgPath));
-          }
-        };
-    collector.setCollectInternal(true);
-    collector.traverse();
-    return result;
-  }
-
-  /**
    * Get the count of database matching the given path. If using prefix match, the path pattern is
    * used to match prefix path. All timeseries start with the matched prefix path will be counted.
    *
@@ -376,38 +312,6 @@ public class ConfigMTree {
       }
     }
     throw new StorageGroupNotSetException(path.getFullPath());
-  }
-
-  public List<PartialPath> getInvolvedStorageGroupNodes(
-      PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException {
-    List<PartialPath> result = new ArrayList<>();
-    StorageGroupCollector<List<PartialPath>> collector =
-        new StorageGroupCollector<List<PartialPath>>(root, pathPattern, store) {
-          @Override
-          protected void collectStorageGroup(IStorageGroupMNode node) {
-            result.add(node.getPartialPath());
-          }
-        };
-    collector.setCollectInternal(true);
-    collector.setPrefixMatch(isPrefixMatch);
-    collector.traverse();
-    return result;
-  }
-
-  /** Get all database MNodes */
-  public List<IStorageGroupMNode> getAllStorageGroupNodes() {
-    List<IStorageGroupMNode> ret = new ArrayList<>();
-    Deque<IMNode> nodeStack = new ArrayDeque<>();
-    nodeStack.add(root);
-    while (!nodeStack.isEmpty()) {
-      IMNode current = nodeStack.pop();
-      if (current.isStorageGroup()) {
-        ret.add(current.getAsStorageGroupMNode());
-      } else {
-        nodeStack.addAll(current.getChildren().values());
-      }
-    }
-    return ret;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
@@ -151,23 +151,6 @@ public interface IMTreeBelowSG {
       throws MetadataException;
 
   /**
-   * Get all measurement paths matching the given path pattern If using prefix match, the path
-   * pattern is used to match prefix path. All timeseries start with the matched prefix path will be
-   * collected and return.
-   *
-   * @param pathPattern a path pattern or a full path, may contain wildcard
-   * @param limit the limit of query result.
-   * @param offset the offset.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   * @param withTags whether returns all the tags of each timeseries as well.
-   * @return Pair.left contains all the satisfied path Pair.right means the current offset or zero
-   *     if we don't set offset.
-   */
-  Pair<List<MeasurementPath>, Integer> getMeasurementPathsWithAlias(
-      PartialPath pathPattern, int limit, int offset, boolean isPrefixMatch, boolean withTags)
-      throws MetadataException;
-
-  /**
    * Fetch all measurement path
    *
    * @param pathPattern a path pattern or a full path, may contain wildcard

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
@@ -131,17 +131,6 @@ public interface IMTreeBelowSG {
   List<ShowDevicesResult> getDevices(IShowDevicesPlan plan) throws MetadataException;
 
   /**
-   * Get all measurement paths matching the given path pattern. If using prefix match, the path
-   * pattern is used to match prefix path. All timeseries start with the matched prefix path will be
-   * collected and return.
-   *
-   * @param pathPattern a path pattern or a full path, may contain wildcard.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  List<MeasurementPath> getMeasurementPaths(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException;
-
-  /**
    * Fetch all measurement path
    *
    * @param pathPattern a path pattern or a full path, may contain wildcard

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
@@ -128,15 +128,6 @@ public interface IMTreeBelowSG {
    */
   IMNode getDeviceNodeWithAutoCreating(PartialPath deviceId) throws MetadataException;
 
-  /**
-   * Get all devices matching the given path pattern. If isPrefixMatch, then the devices under the
-   * paths matching given path pattern will be collected too.
-   *
-   * @return a list contains all distinct devices names
-   */
-  Set<PartialPath> getDevices(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException;
-
   List<ShowDevicesResult> getDevices(IShowDevicesPlan plan) throws MetadataException;
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -653,27 +653,6 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
   // region Interfaces and Implementation for metadata info Query
 
   // region Interfaces for Device info Query
-  /**
-   * Get all devices matching the given path pattern. If isPrefixMatch, then the devices under the
-   * paths matching given path pattern will be collected too.
-   *
-   * @return a list contains all distinct devices names
-   */
-  @Override
-  public Set<PartialPath> getDevices(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    Set<PartialPath> result = new TreeSet<>();
-    EntityCollector<Set<PartialPath>> collector =
-        new EntityCollector<Set<PartialPath>>(storageGroupMNode, pathPattern, store) {
-          @Override
-          protected void collectEntity(IEntityMNode node) {
-            result.add(getCurrentPartialPath(node));
-          }
-        };
-    collector.setPrefixMatch(isPrefixMatch);
-    collector.traverse();
-    return result;
-  }
 
   @Override
   public List<ShowDevicesResult> getDevices(IShowDevicesPlan plan) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -709,27 +709,9 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
   @Override
   public List<MeasurementPath> getMeasurementPaths(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
-    return getMeasurementPathsWithAlias(pathPattern, 0, 0, isPrefixMatch, false).left;
-  }
-
-  /**
-   * Get all measurement paths matching the given path pattern If using prefix match, the path
-   * pattern is used to match prefix path. All timeseries start with the matched prefix path will be
-   * collected and return.
-   *
-   * @param pathPattern a path pattern or a full path, may contain wildcard
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   * @return Pair.left contains all the satisfied paths Pair.right means the current offset or zero
-   *     if we don't set offset.
-   */
-  @Override
-  public Pair<List<MeasurementPath>, Integer> getMeasurementPathsWithAlias(
-      PartialPath pathPattern, int limit, int offset, boolean isPrefixMatch, boolean withTags)
-      throws MetadataException {
     List<MeasurementPath> result = new LinkedList<>();
     MeasurementCollector<List<PartialPath>> collector =
-        new MeasurementCollector<List<PartialPath>>(
-            storageGroupMNode, pathPattern, store, limit, offset) {
+        new MeasurementCollector<List<PartialPath>>(storageGroupMNode, pathPattern, store) {
           @Override
           protected void collectMeasurement(IMeasurementMNode node) {
             MeasurementPath path = getCurrentMeasurementPathInTraverse(node);
@@ -737,16 +719,13 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
               // only when user query with alias, the alias in path will be set
               path.setMeasurementAlias(node.getAlias());
             }
-            if (withTags) {
-              path.setTagMap(tagGetter.apply(node));
-            }
+
             result.add(path);
           }
         };
     collector.setPrefixMatch(isPrefixMatch);
     collector.traverse();
-    offset = collector.getCurOffset() + 1;
-    return new Pair<>(result, offset);
+    return result;
   }
 
   public List<ShowTimeSeriesResult> getAllMeasurementSchema(
@@ -769,7 +748,8 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
                     node.getAlias(),
                     (MeasurementSchema) node.getSchema(),
                     tagAndAttribute.left,
-                    tagAndAttribute.right));
+                    tagAndAttribute.right,
+                    node.getParent().isAligned()));
           }
         };
     collector.setPrefixMatch(plan.isPrefixMatch());

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -677,35 +677,6 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
   // endregion
 
   // region Interfaces for timeseries, measurement and schema info Query
-  /**
-   * Get all measurement paths matching the given path pattern. If using prefix match, the path
-   * pattern is used to match prefix path. All timeseries start with the matched prefix path will be
-   * collected and return.
-   *
-   * @param pathPattern a path pattern or a full path, may contain wildcard.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  @Override
-  public List<MeasurementPath> getMeasurementPaths(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    List<MeasurementPath> result = new LinkedList<>();
-    MeasurementCollector<List<PartialPath>> collector =
-        new MeasurementCollector<List<PartialPath>>(storageGroupMNode, pathPattern, store) {
-          @Override
-          protected void collectMeasurement(IMeasurementMNode node) {
-            MeasurementPath path = getCurrentMeasurementPathInTraverse(node);
-            if (nodes[nodes.length - 1].equals(node.getAlias())) {
-              // only when user query with alias, the alias in path will be set
-              path.setMeasurementAlias(node.getAlias());
-            }
-
-            result.add(path);
-          }
-        };
-    collector.setPrefixMatch(isPrefixMatch);
-    collector.traverse();
-    return result;
-  }
 
   public List<ShowTimeSeriesResult> getAllMeasurementSchema(
       IShowTimeSeriesPlan plan,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -699,7 +699,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
                     (MeasurementSchema) node.getSchema(),
                     tagAndAttribute.left,
                     tagAndAttribute.right,
-                    node.getParent().isAligned()));
+                    getCurrentNodeParent().getAsEntityMNode().isAligned()));
           }
         };
     collector.setPrefixMatch(plan.isPrefixMatch());

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -643,7 +643,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
                     (MeasurementSchema) node.getSchema(),
                     tagAndAttribute.left,
                     tagAndAttribute.right,
-                    node.getParent().isAligned()));
+                    getCurrentNodeParent().getAsEntityMNode().isAligned()));
           }
         };
     collector.setPrefixMatch(plan.isPrefixMatch());

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -595,35 +595,6 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
   // endregion
 
   // region Interfaces for timeseries, measurement and schema info Query
-  /**
-   * Get all measurement paths matching the given path pattern. If using prefix match, the path
-   * pattern is used to match prefix path. All timeseries start with the matched prefix path will be
-   * collected and return.
-   *
-   * @param pathPattern a path pattern or a full path, may contain wildcard.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  @Override
-  public List<MeasurementPath> getMeasurementPaths(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    List<MeasurementPath> result = new LinkedList<>();
-    MeasurementCollector<List<PartialPath>> collector =
-        new MeasurementCollector<List<PartialPath>>(storageGroupMNode, pathPattern, store) {
-          @Override
-          protected void collectMeasurement(IMeasurementMNode node) {
-            MeasurementPath path = getCurrentMeasurementPathInTraverse(node);
-            if (nodes[nodes.length - 1].equals(node.getAlias())) {
-              // only when user query with alias, the alias in path will be set
-              path.setMeasurementAlias(node.getAlias());
-            }
-
-            result.add(path);
-          }
-        };
-    collector.setPrefixMatch(isPrefixMatch);
-    collector.traverse();
-    return result;
-  }
 
   @Override
   public List<MeasurementPath> fetchSchema(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -627,27 +627,9 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
   @Override
   public List<MeasurementPath> getMeasurementPaths(PartialPath pathPattern, boolean isPrefixMatch)
       throws MetadataException {
-    return getMeasurementPathsWithAlias(pathPattern, 0, 0, isPrefixMatch, false).left;
-  }
-
-  /**
-   * Get all measurement paths matching the given path pattern If using prefix match, the path
-   * pattern is used to match prefix path. All timeseries start with the matched prefix path will be
-   * collected and return.
-   *
-   * @param pathPattern a path pattern or a full path, may contain wildcard
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   * @return Pair.left contains all the satisfied paths Pair.right means the current offset or zero
-   *     if we don't set offset.
-   */
-  @Override
-  public Pair<List<MeasurementPath>, Integer> getMeasurementPathsWithAlias(
-      PartialPath pathPattern, int limit, int offset, boolean isPrefixMatch, boolean withTags)
-      throws MetadataException {
     List<MeasurementPath> result = new LinkedList<>();
     MeasurementCollector<List<PartialPath>> collector =
-        new MeasurementCollector<List<PartialPath>>(
-            storageGroupMNode, pathPattern, store, limit, offset) {
+        new MeasurementCollector<List<PartialPath>>(storageGroupMNode, pathPattern, store) {
           @Override
           protected void collectMeasurement(IMeasurementMNode node) {
             MeasurementPath path = getCurrentMeasurementPathInTraverse(node);
@@ -655,16 +637,13 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
               // only when user query with alias, the alias in path will be set
               path.setMeasurementAlias(node.getAlias());
             }
-            if (withTags) {
-              path.setTagMap(tagGetter.apply(node));
-            }
+
             result.add(path);
           }
         };
     collector.setPrefixMatch(isPrefixMatch);
     collector.traverse();
-    offset = collector.getCurOffset() + 1;
-    return new Pair<>(result, offset);
+    return result;
   }
 
   @Override
@@ -713,7 +692,8 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
                     node.getAlias(),
                     (MeasurementSchema) node.getSchema(),
                     tagAndAttribute.left,
-                    tagAndAttribute.right));
+                    tagAndAttribute.right,
+                    node.getParent().isAligned()));
           }
         };
     collector.setPrefixMatch(plan.isPrefixMatch());

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -571,27 +571,6 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
   // region Interfaces and Implementation for metadata info Query
 
   // region Interfaces for Device info Query
-  /**
-   * Get all devices matching the given path pattern. If isPrefixMatch, then the devices under the
-   * paths matching given path pattern will be collected too.
-   *
-   * @return a list contains all distinct devices names
-   */
-  @Override
-  public Set<PartialPath> getDevices(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    Set<PartialPath> result = new TreeSet<>();
-    EntityCollector<Set<PartialPath>> collector =
-        new EntityCollector<Set<PartialPath>>(storageGroupMNode, pathPattern, store) {
-          @Override
-          protected void collectEntity(IEntityMNode node) {
-            result.add(getCurrentPartialPath(node));
-          }
-        };
-    collector.setPrefixMatch(isPrefixMatch);
-    collector.traverse();
-    return result;
-  }
 
   @Override
   public List<ShowDevicesResult> getDevices(IShowDevicesPlan plan) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -515,18 +515,7 @@ public abstract class Traverser {
     return nodeNames.toArray(new String[0]);
   }
 
-  /** @return the database node in the traverse path */
-  protected IMNode getStorageGroupNodeInTraversePath(IMNode currentNode) {
-    if (currentNode.isStorageGroup()) {
-      return currentNode;
-    }
-    Iterator<IMNode> nodes = traverseContext.iterator();
-    while (nodes.hasNext()) {
-      IMNode node = nodes.next();
-      if (node.isStorageGroup()) {
-        return node;
-      }
-    }
-    return null;
+  protected IMNode getCurrentNodeParent() {
+    return traverseContext.peek();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/result/ShowTimeSeriesResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/result/ShowTimeSeriesResult.java
@@ -37,17 +37,21 @@ public class ShowTimeSeriesResult extends ShowSchemaResult implements ITimeSerie
   private Map<String, String> tags;
   private Map<String, String> attributes;
 
+  private boolean isUnderAlignedDevice;
+
   public ShowTimeSeriesResult(
       String name,
       String alias,
       MeasurementSchema measurementSchema,
       Map<String, String> tags,
-      Map<String, String> attributes) {
+      Map<String, String> attributes,
+      boolean isUnderAlignedDevice) {
     super(name);
     this.alias = alias;
     this.measurementSchema = measurementSchema;
     this.tags = tags;
     this.attributes = attributes;
+    this.isUnderAlignedDevice = isUnderAlignedDevice;
   }
 
   public ShowTimeSeriesResult() {
@@ -66,6 +70,11 @@ public class ShowTimeSeriesResult extends ShowSchemaResult implements ITimeSerie
   @Override
   public Pair<Map<String, String>, Map<String, String>> getTagAndAttribute() {
     return new Pair<>(tags, attributes);
+  }
+
+  @Override
+  public boolean isUnderAlignedDevice() {
+    return isUnderAlignedDevice;
   }
 
   public TSDataType getDataType() {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/query/info/ITimeSeriesSchemaInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/query/info/ITimeSeriesSchemaInfo.java
@@ -31,4 +31,6 @@ public interface ITimeSeriesSchemaInfo extends ISchemaInfo {
   MeasurementSchema getSchema();
 
   Pair<Map<String, String>, Map<String, String>> getTagAndAttribute();
+
+  boolean isUnderAlignedDevice();
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -203,18 +203,6 @@ public interface ISchemaRegion {
   // region Interfaces for Entity/Device info Query
 
   /**
-   * Get all device paths matching the path pattern. If using prefix match, the path pattern is used
-   * to match prefix path. All timeseries start with the matched prefix path will be collected.
-   *
-   * @param pathPattern the pattern of the target devices.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path.
-   * @return A HashSet instance which stores devices paths matching the given path pattern.
-   */
-  @Deprecated
-  Set<PartialPath> getMatchedDevices(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException;
-
-  /**
    * Get all device paths and corresponding database paths as ShowDevicesResult.
    *
    * @param plan ShowDevicesPlan which contains the path pattern and restriction params.

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -39,7 +39,6 @@ import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.template.Template;
-import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.io.File;
 import java.io.IOException;
@@ -122,19 +121,6 @@ public interface ISchemaRegion {
    */
   Map<Integer, MetadataException> checkMeasurementExistence(
       PartialPath devicePath, List<String> measurementList, List<String> aliasList);
-
-  /**
-   * Delete all timeseries matching the given path pattern. If using prefix match, the path pattern
-   * is used to match prefix path. All timeseries start with the matched prefix path will be
-   * deleted.
-   *
-   * @param pathPattern path to be deleted
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   * @return deletion failed Timeseries
-   */
-  @Deprecated
-  Pair<Integer, Set<String>> deleteTimeseries(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException;
 
   /**
    * Construct schema black list via setting matched timeseries to pre deleted.

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -224,31 +224,6 @@ public interface ISchemaRegion {
   // endregion
 
   // region Interfaces for timeseries, measurement and schema info Query
-  /**
-   * Return all measurement paths for given path if the path is abstract. Or return the path itself.
-   * Regular expression in this method is formed by the amalgamation of seriesPath and the character
-   * '*'. If using prefix match, the path pattern is used to match prefix path. All timeseries start
-   * with the matched prefix path will be collected.
-   *
-   * @param pathPattern can be a pattern or a full path of timeseries.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   * @param withTags whether returns tag kvs in the result list.
-   */
-  @Deprecated
-  List<MeasurementPath> getMeasurementPaths(
-      PartialPath pathPattern, boolean isPrefixMatch, boolean withTags) throws MetadataException;
-
-  /**
-   * Similar to method getMeasurementPaths(), but return Path with alias and filter the result by
-   * limit and offset. If using prefix match, the path pattern is used to match prefix path. All
-   * timeseries start with the matched prefix path will be collected.
-   *
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  @Deprecated
-  Pair<List<MeasurementPath>, Integer> getMeasurementPathsWithAlias(
-      PartialPath pathPattern, int limit, int offset, boolean isPrefixMatch, boolean withTags)
-      throws MetadataException;
 
   List<MeasurementPath> fetchSchema(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -696,33 +696,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
     return mtree.checkMeasurementExistence(devicePath, measurementList, aliasList);
   }
 
-  /**
-   * Delete all timeseries matching the given path pattern. If using prefix match, the path pattern
-   * is used to match prefix path. All timeseries start with the matched prefix path will be
-   * deleted.
-   *
-   * @param pathPattern path to be deleted
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   * @return deletion failed Timeseries
-   */
-  @Override
-  public synchronized Pair<Integer, Set<String>> deleteTimeseries(
-      PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException {
-    try {
-      List<MeasurementPath> allTimeseries = mtree.getMeasurementPaths(pathPattern, isPrefixMatch);
-
-      Set<String> failedNames = new HashSet<>();
-      int deletedNum = 0;
-      for (PartialPath p : allTimeseries) {
-        deleteSingleTimeseriesInternal(p);
-        deletedNum++;
-      }
-      return new Pair<>(deletedNum, failedNames);
-    } catch (IOException e) {
-      throw new MetadataException(e.getMessage());
-    }
-  }
-
   @Override
   public long constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
     long preDeletedNum = 0;
@@ -811,17 +784,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   private void recoverRollbackPreDeleteTimeseries(PartialPath path) throws MetadataException {
     IMeasurementMNode measurementMNode = mtree.getMeasurementMNode(path);
     measurementMNode.setPreDeleted(false);
-  }
-
-  /**
-   * Delete all timeseries matching the given path pattern
-   *
-   * @param pathPattern path to be deleted
-   * @return deletion failed Timeseries
-   */
-  public Pair<Integer, Set<String>> deleteTimeseries(PartialPath pathPattern)
-      throws MetadataException {
-    return deleteTimeseries(pathPattern, false);
   }
 
   private void deleteSingleTimeseriesInternal(PartialPath p) throws MetadataException, IOException {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -935,35 +935,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
 
   // region Interfaces for timeseries, measurement and schema info Query
 
-  /**
-   * Return all measurement paths for given path if the path is abstract. Or return the path itself.
-   * Regular expression in this method is formed by the amalgamation of seriesPath and the character
-   * '*'. If using prefix match, the path pattern is used to match prefix path. All timeseries start
-   * with the matched prefix path will be collected.
-   *
-   * @param pathPattern can be a pattern or a full path of timeseries.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  @Override
-  public List<MeasurementPath> getMeasurementPaths(
-      PartialPath pathPattern, boolean isPrefixMatch, boolean withTags) throws MetadataException {
-    return getMeasurementPathsWithAlias(pathPattern, 0, 0, isPrefixMatch, withTags).left;
-  }
-
-  /**
-   * Similar to method getMeasurementPaths(), but return Path with alias and filter the result by
-   * limit and offset. If using prefix match, the path pattern is used to match prefix path. All
-   * timeseries start with the matched prefix path will be collected.
-   *
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  @Override
-  public Pair<List<MeasurementPath>, Integer> getMeasurementPathsWithAlias(
-      PartialPath pathPattern, int limit, int offset, boolean isPrefixMatch, boolean withTags)
-      throws MetadataException {
-    return mtree.getMeasurementPathsWithAlias(pathPattern, limit, offset, isPrefixMatch, withTags);
-  }
-
   @Override
   public List<MeasurementPath> fetchSchema(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
@@ -1014,7 +985,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
                   leaf.getAlias(),
                   (MeasurementSchema) leaf.getSchema(),
                   tagAndAttributePair.left,
-                  tagAndAttributePair.right));
+                  tagAndAttributePair.right,
+                  leaf.getParent().isAligned()));
           if (limit != 0) {
             count++;
           }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -908,20 +908,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   // region Interfaces for Entity/Device info Query
 
   /**
-   * Get all device paths matching the path pattern. If using prefix match, the path pattern is used
-   * to match prefix path. All timeseries start with the matched prefix path will be collected.
-   *
-   * @param pathPattern the pattern of the target devices.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path.
-   * @return A HashSet instance which stores devices paths matching the given path pattern.
-   */
-  @Override
-  public Set<PartialPath> getMatchedDevices(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    return mtree.getDevices(pathPattern, isPrefixMatch);
-  }
-
-  /**
    * Get all device paths and according database paths as ShowDevicesResult.
    *
    * @param plan ShowDevicesPlan which contains the path pattern and restriction params.

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -967,20 +967,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   // region Interfaces for Entity/Device info Query
 
   /**
-   * Get all device paths matching the path pattern. If using prefix match, the path pattern is used
-   * to match prefix path. All timeseries start with the matched prefix path will be collected.
-   *
-   * @param pathPattern the pattern of the target devices.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path.
-   * @return A HashSet instance which stores devices paths matching the given path pattern.
-   */
-  @Override
-  public Set<PartialPath> getMatchedDevices(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    return mtree.getDevices(pathPattern, isPrefixMatch);
-  }
-
-  /**
    * Get all device paths and according database paths as ShowDevicesResult.
    *
    * @param plan ShowDevicesPlan which contains the path pattern and restriction params.

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -752,33 +752,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
     return mtree.checkMeasurementExistence(devicePath, measurementList, aliasList);
   }
 
-  /**
-   * Delete all timeseries matching the given path pattern. If using prefix match, the path pattern
-   * is used to match prefix path. All timeseries start with the matched prefix path will be
-   * deleted.
-   *
-   * @param pathPattern path to be deleted
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   * @return deletion failed Timeseries
-   */
-  @Override
-  public synchronized Pair<Integer, Set<String>> deleteTimeseries(
-      PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException {
-    try {
-      List<MeasurementPath> allTimeseries = mtree.getMeasurementPaths(pathPattern, isPrefixMatch);
-
-      Set<String> failedNames = new HashSet<>();
-      int deletedNum = 0;
-      for (PartialPath p : allTimeseries) {
-        deleteSingleTimeseriesInternal(p);
-        deletedNum++;
-      }
-      return new Pair<>(deletedNum, failedNames);
-    } catch (IOException e) {
-      throw new MetadataException(e.getMessage());
-    }
-  }
-
   @Override
   public long constructSchemaBlackList(PathPatternTree patternTree) throws MetadataException {
     long preDeletedNum = 0;
@@ -869,17 +842,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
     if (seriesNumerMonitor != null) {
       seriesNumerMonitor.deleteTimeSeries(1);
     }
-  }
-
-  /**
-   * Delete all timeseries matching the given path pattern
-   *
-   * @param pathPattern path to be deleted
-   * @return deletion failed Timeseries
-   */
-  public Pair<Integer, Set<String>> deleteTimeseries(PartialPath pathPattern)
-      throws MetadataException {
-    return deleteTimeseries(pathPattern, false);
   }
 
   private void deleteSingleTimeseriesInternal(PartialPath p) throws MetadataException, IOException {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -994,35 +994,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
 
   // region Interfaces for timeseries, measurement and schema info Query
 
-  /**
-   * Return all measurement paths for given path if the path is abstract. Or return the path itself.
-   * Regular expression in this method is formed by the amalgamation of seriesPath and the character
-   * '*'. If using prefix match, the path pattern is used to match prefix path. All timeseries start
-   * with the matched prefix path will be collected.
-   *
-   * @param pathPattern can be a pattern or a full path of timeseries.
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  @Override
-  public List<MeasurementPath> getMeasurementPaths(
-      PartialPath pathPattern, boolean isPrefixMatch, boolean withTags) throws MetadataException {
-    return getMeasurementPathsWithAlias(pathPattern, 0, 0, isPrefixMatch, withTags).left;
-  }
-
-  /**
-   * Similar to method getMeasurementPaths(), but return Path with alias and filter the result by
-   * limit and offset. If using prefix match, the path pattern is used to match prefix path. All
-   * timeseries start with the matched prefix path will be collected.
-   *
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  @Override
-  public Pair<List<MeasurementPath>, Integer> getMeasurementPathsWithAlias(
-      PartialPath pathPattern, int limit, int offset, boolean isPrefixMatch, boolean withTags)
-      throws MetadataException {
-    return mtree.getMeasurementPathsWithAlias(pathPattern, limit, offset, isPrefixMatch, withTags);
-  }
-
   @Override
   public List<MeasurementPath> fetchSchema(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
@@ -1076,7 +1047,8 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
                   leaf.getAlias(),
                   (MeasurementSchema) leaf.getSchema(),
                   tagAndAttributePair.left,
-                  tagAndAttributePair.right));
+                  tagAndAttributePair.right,
+                  leaf.getParent().isAligned()));
           if (limit != 0) {
             count++;
           }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/IStorageGroupSchemaManager.java
@@ -18,24 +18,17 @@
  */
 package org.apache.iotdb.db.metadata.storagegroup;
 
-import org.apache.iotdb.common.rpc.thrift.TSchemaNode;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
-import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
-import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 // This class declares all the interfaces for database management.
 public interface IStorageGroupSchemaManager {
 
   void init() throws MetadataException, IOException;
-
-  void forceLog();
 
   void clear() throws IOException;
 
@@ -45,17 +38,6 @@ public interface IStorageGroupSchemaManager {
    * @param path database path
    */
   void setStorageGroup(PartialPath path) throws MetadataException;
-
-  /** Delete databases of given paths from MTree. Log format: "delete_storage_group,sg1,sg2,sg3" */
-  void deleteStorageGroup(PartialPath storageGroup) throws MetadataException;
-
-  void setTTL(PartialPath storageGroup, long dataTTL) throws MetadataException, IOException;
-
-  /** Check if the given path is database or not. */
-  boolean isStorageGroup(PartialPath path);
-
-  /** Check whether the given path contains a database */
-  boolean checkStorageGroupByPath(PartialPath path);
 
   /**
    * Get database name by path
@@ -67,138 +49,5 @@ public interface IStorageGroupSchemaManager {
    */
   PartialPath getBelongedStorageGroup(PartialPath path) throws StorageGroupNotSetException;
 
-  /**
-   * Get the database that given path pattern matches or belongs to.
-   *
-   * <p>Suppose we have (root.sg1.d1.s1, root.sg2.d2.s2), refer the following cases: 1. given path
-   * "root.sg1", ("root.sg1") will be returned. 2. given path "root.*", ("root.sg1", "root.sg2")
-   * will be returned. 3. given path "root.*.d1.s1", ("root.sg1", "root.sg2") will be returned.
-   *
-   * @param pathPattern a path pattern or a full path
-   * @return a list contains all databases related to given path pattern
-   */
-  List<PartialPath> getBelongedStorageGroups(PartialPath pathPattern) throws MetadataException;
-
-  List<PartialPath> getInvolvedStorageGroups(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException;
-
-  /**
-   * Get all database matching given path pattern. If using prefix match, the path pattern is used
-   * to match prefix path. All timeseries start with the matched prefix path will be collected.
-   *
-   * @param pathPattern a pattern of a full path
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   * @return A ArrayList instance which stores database paths matching given path pattern.
-   */
-  List<PartialPath> getMatchedStorageGroups(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException;
-
-  /** Get all database paths */
-  List<PartialPath> getAllStorageGroupPaths();
-
-  /**
-   * For a path, infer all databases it may belong to. The path can have wildcards. Resolve the path
-   * or path pattern into StorageGroupName-FullPath pairs that FullPath matches the given path.
-   *
-   * <p>Consider the path into two parts: (1) the sub path which can not contain a database name and
-   * (2) the sub path which is substring that begin after the database name.
-   *
-   * <p>(1) Suppose the part of the path can not contain a database name (e.g.,
-   * "root".contains("root.sg") == false), then: For each one level wildcard *, only one level will
-   * be inferred and the wildcard will be removed. For each multi level wildcard **, then the
-   * inference will go on until the databases are found and the wildcard will be kept. (2) Suppose
-   * the part of the path is a substring that begin after the database name. (e.g., For
-   * "root.*.sg1.a.*.b.*" and "root.x.sg1" is a database, then this part is "a.*.b.*"). For this
-   * part, keep what it is.
-   *
-   * <p>Assuming we have three SGs: root.group1, root.group2, root.area1.group3 Eg1: for input
-   * "root.**", returns ("root.group1", "root.group1.**"), ("root.group2", "root.group2.**")
-   * ("root.area1.group3", "root.area1.group3.**") Eg2: for input "root.*.s1", returns
-   * ("root.group1", "root.group1.s1"), ("root.group2", "root.group2.s1")
-   *
-   * <p>Eg3: for input "root.area1.**", returns ("root.area1.group3", "root.area1.group3.**")
-   *
-   * @param path can be a path pattern or a full path.
-   * @return StorageGroupName-FullPath pairs
-   * @apiNote :for cluster
-   */
-  Map<String, List<PartialPath>> groupPathByStorageGroup(PartialPath path) throws MetadataException;
-
-  /**
-   * To calculate the count of database for given path pattern. If using prefix match, the path
-   * pattern is used to match prefix path. All timeseries start with the matched prefix path will be
-   * counted.
-   */
-  int getStorageGroupNum(PartialPath pathPattern, boolean isPrefixMatch) throws MetadataException;
-
-  /** Get database node by path. the give path don't need to be database path. */
-  IStorageGroupMNode getStorageGroupNodeByPath(PartialPath path) throws MetadataException;
-
-  /** Get all database MNodes */
-  List<IStorageGroupMNode> getAllStorageGroupNodes();
-
-  /**
-   * Different with LocalConfigNode.ensureStorageGroup, this method won't init storageGroup
-   * resources and the input is the target database path.
-   *
-   * @param storageGroup database path
-   */
-  IStorageGroupMNode ensureStorageGroupByStorageGroupPath(PartialPath storageGroup)
-      throws MetadataException;
-
-  /**
-   * Check whether the database of given path is set. The path may be a prefix path of some
-   * database. Besides, the given path may be also beyond the MTreeAboveSG scope, then return true
-   * if the covered part exists, which means there's database on this path. The rest part will be
-   * checked by certain database subTree.
-   *
-   * @param path a full path or a prefix path
-   */
-  boolean isStorageGroupAlreadySet(PartialPath path);
-
-  /**
-   * To collect nodes in the given level for given path pattern. If using prefix match, the path
-   * pattern is used to match prefix path. All nodes start with the matched prefix path will be
-   * collected. This method only count in nodes above database. Nodes below database, including
-   * database node will be collected by certain SchemaRegion. The involved storage groups will be
-   * collected to fetch schemaRegion.
-   *
-   * @param pathPattern a path pattern or a full path
-   * @param nodeLevel the level should match the level of the path
-   * @param isPrefixMatch if true, the path pattern is used to match prefix path
-   */
-  Pair<List<PartialPath>, Set<PartialPath>> getNodesListInGivenLevel(
-      PartialPath pathPattern, int nodeLevel, boolean isPrefixMatch) throws MetadataException;
-
-  /**
-   * Get child node path in the next level of the given path pattern. This method only count in
-   * nodes above database. Nodes below database, including database node will be counted by certain
-   * database.
-   *
-   * <p>give pathPattern and the child nodes is those matching pathPattern.*
-   *
-   * <p>e.g., MTree has [root.a.sg1.d1.s1, root.b.sg1.d1.s2, root.c.sg1.d2.s1] given path = root
-   * return [root.a, root.b]
-   *
-   * @param pathPattern The given path
-   * @return All child nodes' seriesPath(s) of given seriesPath.
-   */
-  Pair<Set<TSchemaNode>, Set<PartialPath>> getChildNodePathInNextLevel(PartialPath pathPattern)
-      throws MetadataException;
-
-  /**
-   * Get child node path in the next level of the given path pattern. This method only count in
-   * nodes above database. Nodes below database, including database node will be counted by certain
-   * database.
-   *
-   * <p>give pathPattern and the child nodes is those matching pathPattern.*
-   *
-   * <p>e.g., MTree has [root.a.sg1.d1.s1, root.b.sg1.d1.s2, root.c.sg1.d2.s1] given path = root
-   * return [a, b]
-   *
-   * @param pathPattern The given path
-   * @return All child nodes' seriesPath(s) of given seriesPath.
-   */
-  Pair<Set<String>, Set<PartialPath>> getChildNodeNameInNextLevel(PartialPath pathPattern)
-      throws MetadataException;
+  List<PartialPath> getInvolvedStorageGroups(PartialPath pathPattern) throws MetadataException;
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/storagegroup/StorageGroupSchemaManager.java
@@ -19,19 +19,13 @@
 
 package org.apache.iotdb.db.metadata.storagegroup;
 
-import org.apache.iotdb.common.rpc.thrift.TSchemaNode;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.exception.metadata.StorageGroupAlreadySetException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
-import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
 import org.apache.iotdb.db.metadata.mtree.ConfigMTree;
-import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 // Never support restart
 // This class implements all the interfaces for database management. The MTreeAboveSg is used
@@ -57,47 +51,7 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
   public synchronized void init() throws MetadataException, IOException {
 
     mtree = new ConfigMTree();
-
-    //    recoverLog();
   }
-
-  public void recoverLog() throws IOException {
-    //    File logFile = new File(config.getSchemaDir(), STORAGE_GROUP_LOG);
-    //    if (!logFile.exists()) {
-    //      return;
-    //    }
-    //    try (StorageGroupLogReader logReader =
-    //        new StorageGroupLogReader(config.getSchemaDir(), STORAGE_GROUP_LOG)) {
-    //      PhysicalPlan plan;
-    //      while (logReader.hasNext()) {
-    //        plan = logReader.next();
-    //        try {
-    //          switch (plan.getOperatorType()) {
-    //            case SET_STORAGE_GROUP:
-    //              SetStorageGroupPlan setStorageGroupPlan = (SetStorageGroupPlan) plan;
-    //              setStorageGroup(setStorageGroupPlan.getPath());
-    //              break;
-    //            case DELETE_STORAGE_GROUP:
-    //              DeleteStorageGroupPlan deleteStorageGroupPlan = (DeleteStorageGroupPlan) plan;
-    //              deleteStorageGroup(deleteStorageGroupPlan.getPaths().get(0));
-    //              break;
-    //            case TTL:
-    //              SetTTLPlan setTTLPlan = (SetTTLPlan) plan;
-    //              setTTL(setTTLPlan.getStorageGroup(), setTTLPlan.getDataTTL());
-    //              break;
-    //            default:
-    //              logger.error("Unrecognizable command {}", plan.getOperatorType());
-    //          }
-    //        } catch (MetadataException | IOException e) {
-    //          logger.error("Error occurred while redo database log", e);
-    //        }
-    //      }
-    //    }
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void forceLog() {}
 
   public synchronized void clear() throws IOException {
 
@@ -112,119 +66,13 @@ public class StorageGroupSchemaManager implements IStorageGroupSchemaManager {
   }
 
   @Override
-  public IStorageGroupMNode ensureStorageGroupByStorageGroupPath(PartialPath storageGroup)
-      throws MetadataException {
-    try {
-      return mtree.getStorageGroupNodeByStorageGroupPath(storageGroup);
-    } catch (StorageGroupNotSetException e) {
-      try {
-        setStorageGroup(storageGroup);
-      } catch (StorageGroupAlreadySetException storageGroupAlreadySetException) {
-        // do nothing
-        // concurrent timeseries creation may result concurrent ensureStorageGroup
-        // it's ok that the storageGroup has already been set
-
-        if (storageGroupAlreadySetException.isHasChild()) {
-          // if setStorageGroup failure is because of child, the deviceNode should not be created.
-          // Timeseries can't be created under a deviceNode without storageGroup.
-          throw storageGroupAlreadySetException;
-        }
-      }
-
-      return mtree.getStorageGroupNodeByStorageGroupPath(storageGroup);
-    }
-  }
-
-  @Override
-  public synchronized void deleteStorageGroup(PartialPath storageGroup) throws MetadataException {
-    mtree.deleteStorageGroup(storageGroup);
-  }
-
-  @Override
-  public void setTTL(PartialPath storageGroup, long dataTTL) throws MetadataException, IOException {
-    mtree.getStorageGroupNodeByStorageGroupPath(storageGroup).setDataTTL(dataTTL);
-  }
-
-  @Override
-  public boolean isStorageGroup(PartialPath path) {
-    return mtree.isStorageGroup(path);
-  }
-
-  @Override
-  public boolean checkStorageGroupByPath(PartialPath path) {
-    return mtree.checkStorageGroupByPath(path);
-  }
-
-  @Override
   public PartialPath getBelongedStorageGroup(PartialPath path) throws StorageGroupNotSetException {
     return mtree.getBelongedStorageGroup(path);
   }
 
   @Override
-  public List<PartialPath> getBelongedStorageGroups(PartialPath pathPattern)
+  public List<PartialPath> getInvolvedStorageGroups(PartialPath pathPattern)
       throws MetadataException {
     return mtree.getBelongedStorageGroups(pathPattern);
-  }
-
-  @Override
-  public List<PartialPath> getInvolvedStorageGroups(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    return mtree.getInvolvedStorageGroupNodes(pathPattern, isPrefixMatch);
-  }
-
-  @Override
-  public List<PartialPath> getMatchedStorageGroups(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    return mtree.getMatchedStorageGroups(pathPattern, isPrefixMatch);
-  }
-
-  @Override
-  public List<PartialPath> getAllStorageGroupPaths() {
-    return mtree.getAllStorageGroupPaths();
-  }
-
-  @Override
-  public Map<String, List<PartialPath>> groupPathByStorageGroup(PartialPath path)
-      throws MetadataException {
-    return mtree.groupPathByStorageGroup(path);
-  }
-
-  @Override
-  public int getStorageGroupNum(PartialPath pathPattern, boolean isPrefixMatch)
-      throws MetadataException {
-    return mtree.getStorageGroupNum(pathPattern, isPrefixMatch);
-  }
-
-  @Override
-  public IStorageGroupMNode getStorageGroupNodeByPath(PartialPath path) throws MetadataException {
-    return mtree.getStorageGroupNodeByPath(path);
-  }
-
-  @Override
-  public List<IStorageGroupMNode> getAllStorageGroupNodes() {
-    return mtree.getAllStorageGroupNodes();
-  }
-
-  @Override
-  public boolean isStorageGroupAlreadySet(PartialPath path) {
-    return mtree.isStorageGroupAlreadySet(path);
-  }
-
-  @Override
-  public Pair<List<PartialPath>, Set<PartialPath>> getNodesListInGivenLevel(
-      PartialPath pathPattern, int nodeLevel, boolean isPrefixMatch) throws MetadataException {
-    return mtree.getNodesListInGivenLevel(pathPattern, nodeLevel, isPrefixMatch);
-  }
-
-  @Override
-  public Pair<Set<TSchemaNode>, Set<PartialPath>> getChildNodePathInNextLevel(
-      PartialPath pathPattern) throws MetadataException {
-    return mtree.getChildNodePathInNextLevel(pathPattern);
-  }
-
-  @Override
-  public Pair<Set<String>, Set<PartialPath>> getChildNodeNameInNextLevel(PartialPath pathPattern)
-      throws MetadataException {
-    return mtree.getChildNodeNameInNextLevel(pathPattern);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/ConfigMTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/ConfigMTreeTest.java
@@ -124,12 +124,10 @@ public class ConfigMTreeTest {
     try {
       root.setStorageGroup(new PartialPath("root.laptop.d1"));
       assertTrue(root.isStorageGroupAlreadySet(new PartialPath("root.laptop.d1")));
-      assertTrue(root.checkStorageGroupByPath(new PartialPath("root.laptop.d1")));
       assertEquals(
           "root.laptop.d1",
           root.getBelongedStorageGroup(new PartialPath("root.laptop.d1")).getFullPath());
       assertTrue(root.isStorageGroupAlreadySet(new PartialPath("root.laptop.d1.s1")));
-      assertTrue(root.checkStorageGroupByPath(new PartialPath("root.laptop.d1.s1")));
       assertEquals(
           "root.laptop.d1",
           root.getBelongedStorageGroup(new PartialPath("root.laptop.d1.s1")).getFullPath());
@@ -158,31 +156,6 @@ public class ConfigMTreeTest {
     assertFalse(root.isStorageGroupAlreadySet(new PartialPath("root.laptop.d1")));
     assertTrue(root.isStorageGroupAlreadySet(new PartialPath("root.laptop")));
     assertTrue(root.isStorageGroupAlreadySet(new PartialPath("root.laptop.d2")));
-  }
-
-  @Test
-  public void testCheckStorageGroup() {
-    try {
-      assertFalse(root.isStorageGroup(new PartialPath("root")));
-      assertFalse(root.isStorageGroup(new PartialPath("root1.laptop.d2")));
-
-      root.setStorageGroup(new PartialPath("root.laptop.d1"));
-      assertTrue(root.isStorageGroup(new PartialPath("root.laptop.d1")));
-      assertFalse(root.isStorageGroup(new PartialPath("root.laptop.d2")));
-      assertFalse(root.isStorageGroup(new PartialPath("root.laptop")));
-      assertFalse(root.isStorageGroup(new PartialPath("root.laptop.d1.s1")));
-
-      root.setStorageGroup(new PartialPath("root.laptop.d2"));
-      assertTrue(root.isStorageGroup(new PartialPath("root.laptop.d1")));
-      assertTrue(root.isStorageGroup(new PartialPath("root.laptop.d2")));
-      assertFalse(root.isStorageGroup(new PartialPath("root.laptop.d3")));
-
-      root.setStorageGroup(new PartialPath("root.`1`"));
-      assertTrue(root.isStorageGroup(new PartialPath("root.`1`")));
-    } catch (MetadataException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
   }
 
   @Test
@@ -315,7 +288,6 @@ public class ConfigMTreeTest {
     newTree.deserialize(inputStream);
 
     for (int i = 0; i < pathList.length; i++) {
-      newTree.isStorageGroup(pathList[i]);
       TStorageGroupSchema storageGroupSchema =
           newTree.getStorageGroupNodeByStorageGroupPath(pathList[i]).getStorageGroupSchema();
       Assert.assertEquals(i, storageGroupSchema.getTTL());

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
@@ -32,7 +32,6 @@ import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
-import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -132,7 +131,6 @@ public abstract class MTreeBelowSGTest {
   public void testAddAndQueryPath() {
     try {
       assertFalse(root.isStorageGroupAlreadySet(new PartialPath("root.a")));
-      assertFalse(root.checkStorageGroupByPath(new PartialPath("root.a")));
       storageGroup = getStorageGroup(new PartialPath("root.a"));
 
       storageGroup.createTimeseries(
@@ -198,7 +196,6 @@ public abstract class MTreeBelowSGTest {
   public void testAddAndQueryPathWithAlias() {
     try {
       assertFalse(root.isStorageGroupAlreadySet(new PartialPath("root.a")));
-      assertFalse(root.checkStorageGroupByPath(new PartialPath("root.a")));
       storageGroup = getStorageGroup(new PartialPath("root.a"));
 
       storageGroup.createTimeseries(
@@ -260,9 +257,7 @@ public abstract class MTreeBelowSGTest {
       assertEquals("root.a.d1.s0", result.get(1).getFullPath());
 
       List<MeasurementPath> result2 =
-          storageGroup.getMeasurementPathsWithAlias(
-                  new PartialPath("root.a.*.s0"), 0, 0, false, false)
-              .left;
+          storageGroup.getMeasurementPaths(new PartialPath("root.a.*.s0"), false);
       result2.sort(Comparator.comparing(MeasurementPath::getFullPath));
       assertEquals(2, result2.size());
       assertEquals("root.a.d0.s0", result2.get(0).getFullPath());
@@ -270,20 +265,11 @@ public abstract class MTreeBelowSGTest {
       assertEquals("root.a.d1.s0", result2.get(1).getFullPath());
       assertFalse(result2.get(1).isMeasurementAliasExists());
 
-      result2 =
-          storageGroup.getMeasurementPathsWithAlias(
-                  new PartialPath("root.a.*.temperature"), 0, 0, false, false)
-              .left;
+      result2 = storageGroup.getMeasurementPaths(new PartialPath("root.a.*.temperature"), false);
       result2.sort(Comparator.comparing(MeasurementPath::getFullPath));
       assertEquals(2, result2.size());
       assertEquals("root.a.d0.temperature", result2.get(0).getFullPathWithAlias());
       assertEquals("root.a.d1.temperature", result2.get(1).getFullPathWithAlias());
-
-      Pair<List<MeasurementPath>, Integer> result3 =
-          storageGroup.getMeasurementPathsWithAlias(
-              new PartialPath("root.a.**"), 2, 0, false, false);
-      assertEquals(2, result3.left.size());
-      assertEquals(2, result3.right.intValue());
 
     } catch (MetadataException e) {
       e.printStackTrace();
@@ -296,11 +282,9 @@ public abstract class MTreeBelowSGTest {
     try {
       storageGroup = getStorageGroup(new PartialPath("root.laptop.d1"));
       assertTrue(root.isStorageGroupAlreadySet(new PartialPath("root.laptop.d1")));
-      assertTrue(root.checkStorageGroupByPath(new PartialPath("root.laptop.d1")));
       assertEquals(
           "root.laptop.d1",
           root.getBelongedStorageGroup(new PartialPath("root.laptop.d1")).getFullPath());
-      assertTrue(root.checkStorageGroupByPath(new PartialPath("root.laptop.d1.s1")));
       assertEquals(
           "root.laptop.d1",
           root.getBelongedStorageGroup(new PartialPath("root.laptop.d1.s1")).getFullPath());
@@ -379,12 +363,7 @@ public abstract class MTreeBelowSGTest {
 
     assertEquals(2, storageGroup.getDevices(new PartialPath("root"), true).size());
     assertEquals(2, storageGroup.getDevices(new PartialPath("root.**"), false).size());
-    assertEquals(
-        2,
-        storageGroup
-            .getMeasurementPathsWithAlias(new PartialPath("root.**"), 0, 0, false, false)
-            .left
-            .size());
+    assertEquals(2, storageGroup.getMeasurementPaths(new PartialPath("root.**"), false).size());
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
@@ -361,8 +361,6 @@ public abstract class MTreeBelowSGTest {
         Collections.emptyMap(),
         null);
 
-    assertEquals(2, storageGroup.getDevices(new PartialPath("root"), true).size());
-    assertEquals(2, storageGroup.getDevices(new PartialPath("root.**"), false).size());
     assertEquals(2, storageGroup.getMeasurementPaths(new PartialPath("root.**"), false).size());
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
@@ -19,7 +19,6 @@
 package org.apache.iotdb.db.metadata.mtree;
 
 import org.apache.iotdb.commons.exception.MetadataException;
-import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.metadata.AliasAlreadyExistException;
@@ -40,14 +39,11 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -128,156 +124,6 @@ public abstract class MTreeBelowSGTest {
   }
 
   @Test
-  public void testAddAndQueryPath() {
-    try {
-      assertFalse(root.isStorageGroupAlreadySet(new PartialPath("root.a")));
-      storageGroup = getStorageGroup(new PartialPath("root.a"));
-
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.d0.s0"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          null);
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.d0.s1"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          null);
-
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.d1.s0"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          null);
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.d1.s1"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          null);
-
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.b.d0.s0"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          null);
-
-    } catch (MetadataException e1) {
-      e1.printStackTrace();
-    }
-
-    try {
-      assertNotNull(storageGroup);
-      List<MeasurementPath> result =
-          storageGroup.getMeasurementPaths(new PartialPath("root.a.*.s0"), false);
-      result.sort(Comparator.comparing(MeasurementPath::getFullPath));
-      assertEquals(2, result.size());
-      assertEquals("root.a.d0.s0", result.get(0).getFullPath());
-      assertEquals("root.a.d1.s0", result.get(1).getFullPath());
-
-      result = storageGroup.getMeasurementPaths(new PartialPath("root.a.*.*.s0"), false);
-      assertEquals("root.a.b.d0.s0", result.get(0).getFullPath());
-    } catch (MetadataException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
-  }
-
-  @Test
-  public void testAddAndQueryPathWithAlias() {
-    try {
-      assertFalse(root.isStorageGroupAlreadySet(new PartialPath("root.a")));
-      storageGroup = getStorageGroup(new PartialPath("root.a"));
-
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.d0.s0"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          "temperature");
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.d0.s1"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          "status");
-
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.d1.s0"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          "temperature");
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.d1.s1"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          null);
-
-      storageGroup.createTimeseries(
-          new PartialPath("root.a.b.d0.s0"),
-          TSDataType.INT32,
-          TSEncoding.RLE,
-          TSFileDescriptor.getInstance().getConfig().getCompressor(),
-          Collections.emptyMap(),
-          null);
-
-    } catch (MetadataException e1) {
-      e1.printStackTrace();
-    }
-
-    try {
-      assertNotNull(storageGroup);
-
-      List<MeasurementPath> result =
-          storageGroup.getMeasurementPaths(new PartialPath("root.a.*.s0"), false);
-      result.sort(Comparator.comparing(MeasurementPath::getFullPath));
-      assertEquals(2, result.size());
-      assertEquals("root.a.d0.s0", result.get(0).getFullPath());
-      assertEquals("root.a.d1.s0", result.get(1).getFullPath());
-
-      result = storageGroup.getMeasurementPaths(new PartialPath("root.a.*.temperature"), false);
-      result.sort(Comparator.comparing(MeasurementPath::getFullPath));
-      assertEquals(2, result.size());
-      assertEquals("root.a.d0.s0", result.get(0).getFullPath());
-      assertEquals("root.a.d1.s0", result.get(1).getFullPath());
-
-      List<MeasurementPath> result2 =
-          storageGroup.getMeasurementPaths(new PartialPath("root.a.*.s0"), false);
-      result2.sort(Comparator.comparing(MeasurementPath::getFullPath));
-      assertEquals(2, result2.size());
-      assertEquals("root.a.d0.s0", result2.get(0).getFullPath());
-      assertFalse(result2.get(0).isMeasurementAliasExists());
-      assertEquals("root.a.d1.s0", result2.get(1).getFullPath());
-      assertFalse(result2.get(1).isMeasurementAliasExists());
-
-      result2 = storageGroup.getMeasurementPaths(new PartialPath("root.a.*.temperature"), false);
-      result2.sort(Comparator.comparing(MeasurementPath::getFullPath));
-      assertEquals(2, result2.size());
-      assertEquals("root.a.d0.temperature", result2.get(0).getFullPathWithAlias());
-      assertEquals("root.a.d1.temperature", result2.get(1).getFullPathWithAlias());
-
-    } catch (MetadataException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
-  }
-
-  @Test
   public void testSetStorageGroup() throws MetadataException {
     try {
       storageGroup = getStorageGroup(new PartialPath("root.laptop.d1"));
@@ -341,27 +187,6 @@ public abstract class MTreeBelowSGTest {
     assertFalse(root.isStorageGroupAlreadySet(new PartialPath("root.laptop.d1.s1")));
     assertFalse(root.isStorageGroupAlreadySet(new PartialPath("root.laptop.d1")));
     assertFalse(root.isStorageGroupAlreadySet(new PartialPath("root.laptop")));
-  }
-
-  @Test
-  public void testAddSubDevice() throws MetadataException {
-    storageGroup = getStorageGroup(new PartialPath("root.laptop"));
-    storageGroup.createTimeseries(
-        new PartialPath("root.laptop.d1.s1"),
-        TSDataType.INT32,
-        TSEncoding.RLE,
-        TSFileDescriptor.getInstance().getConfig().getCompressor(),
-        Collections.emptyMap(),
-        null);
-    storageGroup.createTimeseries(
-        new PartialPath("root.laptop.d1.s2.b"),
-        TSDataType.INT32,
-        TSEncoding.RLE,
-        TSFileDescriptor.getInstance().getConfig().getCompressor(),
-        Collections.emptyMap(),
-        null);
-
-    assertEquals(2, storageGroup.getMeasurementPaths(new PartialPath("root.**"), false).size());
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/tools/MLogParserTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/tools/MLogParserTest.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.tools;
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.metadata.MetadataConstant;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWritePlanFactory;
@@ -60,7 +61,7 @@ public class MLogParserTest {
    * There' still 1 CreateTemplatePlan in template_log.bin
    *
    * */
-  private int[] mlogLineNum = new int[] {50, 53, 0};
+  private int[] mlogLineNum = new int[] {50, 54, 0};
 
   @Before
   public void setUp() {
@@ -110,9 +111,11 @@ public class MLogParserTest {
     }
 
     try {
-      schemaEngine
-          .getSchemaRegion(new SchemaRegionId(1))
-          .deleteTimeseries(new PartialPath("root.sg1.device1.s1"), false);
+      PathPatternTree patternTree = new PathPatternTree();
+      patternTree.appendPathPattern(new PartialPath("root.sg1.device1.s1"));
+      patternTree.constructTree();
+      schemaEngine.getSchemaRegion(new SchemaRegionId(1)).constructSchemaBlackList(patternTree);
+      schemaEngine.getSchemaRegion(new SchemaRegionId(1)).deleteTimeseriesInBlackList(patternTree);
       Map<String, String> tags = new HashMap<String, String>();
       tags.put("tag1", "value1");
       schemaEngine

--- a/server/src/test/java/org/apache/iotdb/db/utils/SchemaTestUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/SchemaTestUtils.java
@@ -33,9 +33,7 @@ public class SchemaTestUtils {
       throws MetadataException {
     PartialPath pathPattern = new PartialPath(pathPatternString);
     List<MeasurementPath> measurementPaths =
-        LocalSchemaProcessor.getInstance()
-            .getMeasurementPathsWithAlias(pathPattern, 0, 0, false, false)
-            .left;
+        LocalSchemaProcessor.getInstance().getMeasurementPathsWithAlias(pathPattern);
     assertFalse(measurementPaths.isEmpty());
     return measurementPaths.get(0);
   }


### PR DESCRIPTION
## Description


### Motivation

see IOTDB-5373

There're some interfaces and methods in SchemaRegion only used by LocalConfigNode and LocalSchemaProcessor, which are all deprecated. The stale code will bring burdens to the future refactor in SchemaRegion (see [IOTDB-4982](https://issues.apache.org/jira/browse/IOTDB-4982)).

### Modification

1. Delete useless code in LocalConfigNode and ConfigMTree
2. Refactor some implementations of LocalSchemaProcessor methods, which are still used for UT, for example delete and query timeseries.
3. Remove deprecated interfaces and implementations in SchemaRegion
