### PR TITLE
[To rel/1.0][IOTDB-5130]Accelerate the compaction of nonOverlap points in overlap…

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/utils/PointElement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/utils/PointElement.java
@@ -38,7 +38,7 @@ public class PointElement {
     } else {
       this.pointReader = pageElement.batchData.getTsBlockAlignedRowIterator();
     }
-    this.timeValuePair = pointReader.currentTimeValuePair();
+    this.timeValuePair = pointReader.nextTimeValuePair();
     this.timestamp = timeValuePair.getTimestamp();
     this.priority = pageElement.priority;
   }


### PR DESCRIPTION
In the fast compaction, the overlapping pages will be put into the pointPriorityReader, and the points are spit out in order. Every time a point is spit out, an element must be popped out from the priority queue, and then added into the queue. When the points do not overlap, it will cause a lot of invalid heap sort, which will reduce the compaction rate. For example: there are two pages, the time ranges are 1-500, 400-900, the actual overlapping part is only 400-500, and the rest of the points can be spit out directly, instead of adding into the queue and popping them out every time.