### PR TITLE
[IOTDB-5288][IOTDB-5163] Fix the file metrics is wrong

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -205,10 +205,6 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
         }
 
         // update the metrics finally in case of any exception occurs
-        TsFileMetricManager.getInstance()
-            .deleteFile(sequenceFileSize, true, selectedSequenceFiles.size());
-        TsFileMetricManager.getInstance()
-            .deleteFile(unsequenceFileSize, false, selectedUnsequenceFiles.size());
         for (TsFileResource targetResource : targetTsfileResourceList) {
           if (targetResource != null) {
             TsFileMetricManager.getInstance().addFile(targetResource.getTsFileSize(), true);
@@ -217,6 +213,10 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
             targetResource.setStatus(TsFileResourceStatus.CLOSED);
           }
         }
+        TsFileMetricManager.getInstance()
+            .deleteFile(sequenceFileSize, true, selectedSequenceFiles.size());
+        TsFileMetricManager.getInstance()
+            .deleteFile(unsequenceFileSize, false, selectedUnsequenceFiles.size());
         long costTime = (System.currentTimeMillis() - startTime) / 1000;
         LOGGER.info(
             "{}-{} [Compaction] CrossSpaceCompaction task finishes successfully, time cost is {} s, compaction speed is {} MB/s",

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -184,19 +184,6 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
 
         long sequenceFileSize = deleteOldFiles(selectedSequenceFiles);
         long unsequenceFileSize = deleteOldFiles(selectedUnsequenceFiles);
-        TsFileMetricManager.getInstance()
-            .deleteFile(sequenceFileSize, true, selectedSequenceFiles.size());
-        TsFileMetricManager.getInstance()
-            .deleteFile(unsequenceFileSize, false, selectedUnsequenceFiles.size());
-
-        for (TsFileResource targetResource : targetTsfileResourceList) {
-          if (targetResource != null) {
-            TsFileMetricManager.getInstance().addFile(targetResource.getTsFileSize(), true);
-
-            // set target resources to CLOSED, so that they can be selected to compact
-            targetResource.setStatus(TsFileResourceStatus.CLOSED);
-          }
-        }
 
         CompactionUtils.deleteCompactionModsFile(selectedSequenceFiles, selectedUnsequenceFiles);
 
@@ -215,6 +202,20 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
               subTaskSummary.PAGE_NONE_OVERLAP_BUT_DESERIALIZE,
               subTaskSummary.PAGE_OVERLAP_OR_MODIFIED,
               subTaskSummary.PAGE_FAKE_OVERLAP);
+        }
+
+        // update the metrics finally in case of any exception occurs
+        TsFileMetricManager.getInstance()
+            .deleteFile(sequenceFileSize, true, selectedSequenceFiles.size());
+        TsFileMetricManager.getInstance()
+            .deleteFile(unsequenceFileSize, false, selectedUnsequenceFiles.size());
+        for (TsFileResource targetResource : targetTsfileResourceList) {
+          if (targetResource != null) {
+            TsFileMetricManager.getInstance().addFile(targetResource.getTsFileSize(), true);
+
+            // set target resources to CLOSED, so that they can be selected to compact
+            targetResource.setStatus(TsFileResourceStatus.CLOSED);
+          }
         }
         long costTime = (System.currentTimeMillis() - startTime) / 1000;
         LOGGER.info(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -223,16 +223,6 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
       CompactionUtils.deleteModificationForSourceFile(
           selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
-      TsFileMetricManager.getInstance()
-          .deleteFile(totalSizeOfDeletedFile, sequence, selectedTsFileResourceList.size());
-      // inner space compaction task has only one target file
-      if (targetTsFileList.get(0) != null) {
-        TsFileMetricManager.getInstance()
-            .addFile(targetTsFileList.get(0).getTsFile().length(), sequence);
-
-        // set target resources to CLOSED, so that they can be selected to compact
-        targetTsFileList.get(0).setStatus(TsFileResourceStatus.CLOSED);
-      }
 
       if (performer instanceof FastCompactionPerformer) {
         SubCompactionTaskSummary subTaskSummary =
@@ -248,6 +238,21 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
             subTaskSummary.PAGE_FAKE_OVERLAP);
       }
 
+      if (logFile.exists()) {
+        FileUtils.delete(logFile);
+      }
+
+      // inner space compaction task has only one target file
+      if (targetTsFileList.get(0) != null) {
+        TsFileMetricManager.getInstance()
+            .addFile(targetTsFileList.get(0).getTsFile().length(), sequence);
+
+        // set target resources to CLOSED, so that they can be selected to compact
+        targetTsFileList.get(0).setStatus(TsFileResourceStatus.CLOSED);
+      }
+      TsFileMetricManager.getInstance()
+          .deleteFile(totalSizeOfDeletedFile, sequence, selectedTsFileResourceList.size());
+
       double costTime = (System.currentTimeMillis() - startTime) / 1000.0d;
       LOGGER.info(
           "{}-{} [Compaction] InnerSpaceCompaction task finishes successfully, target file is {},"
@@ -257,10 +262,6 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           targetTsFileResource.getTsFile().getName(),
           costTime,
           selectedFileSize / 1024.0d / 1024.0d / costTime);
-
-      if (logFile.exists()) {
-        FileUtils.delete(logFile);
-      }
     } catch (Throwable throwable) {
       // catch throwable to handle OOM errors
       if (!(throwable instanceof InterruptedException)) {


### PR DESCRIPTION
See [IOTDB-5288](https://issues.apache.org/jira/browse/IOTDB-5288), [IOTDB-5163](https://issues.apache.org/jira/browse/IOTDB-5163).

This PR moves the edition of metrics to the end of compaction, in case of any exception occurs after the metrics is editted.