### PR TITLE
Change config in SourceHandleTest according to IoTDBDescriptor

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.conf;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.property.ClientPoolProperty.DefaultProperty;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.db.audit.AuditLogOperation;
 import org.apache.iotdb.db.audit.AuditLogStorage;
@@ -511,6 +512,9 @@ public class IoTDBConfig {
 
   /** Memory allocated for operators */
   private long allocateMemoryForDataExchange = allocateMemoryForRead * 200 / 1001;
+
+  /** Max bytes of each FragmentInstance for DataExchange */
+  private long maxBytesPerFragmentInstance = allocateMemoryForDataExchange / queryThreadCount;
 
   /** Memory allocated proportion for timeIndex */
   private long allocateMemoryForTimeIndex = allocateMemoryForRead * 200 / 1001;
@@ -1529,7 +1533,12 @@ public class IoTDBConfig {
   }
 
   public long getMaxBytesPerFragmentInstance() {
-    return allocateMemoryForDataExchange / queryThreadCount;
+    return maxBytesPerFragmentInstance;
+  }
+
+  @TestOnly
+  public void setMaxBytesPerFragmentInstance(long maxBytesPerFragmentInstance) {
+    this.maxBytesPerFragmentInstance = maxBytesPerFragmentInstance;
   }
 
   public int getRawQueryBlockingQueueCapacity() {

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SourceHandleTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/exchange/SourceHandleTest.java
@@ -217,7 +217,11 @@ public class SourceHandleTest {
             mockTsBlockSerde,
             mockSourceHandleListener,
             mockClientManager);
-    sourceHandle.setMaxBytesCanReserve(5 * mockTsBlockSize);
+    long maxBytesCanReserve =
+        Math.min(
+            5 * mockTsBlockSize,
+            IoTDBDescriptor.getInstance().getConfig().getMaxBytesPerFragmentInstance());
+    sourceHandle.setMaxBytesCanReserve(maxBytesCanReserve);
     Assert.assertFalse(sourceHandle.isBlocked().isDone());
     Assert.assertFalse(sourceHandle.isAborted());
     Assert.assertFalse(sourceHandle.isFinished());
@@ -236,7 +240,7 @@ public class SourceHandleTest {
               localFragmentInstanceId.getInstanceId(),
               localPlanNodeId,
               mockTsBlockSize,
-              5 * mockTsBlockSize);
+              maxBytesCanReserve);
       Mockito.verify(mockClient, Mockito.timeout(10_0000).times(1))
           .getDataBlock(
               Mockito.argThat(


### PR DESCRIPTION
Before this pr, maxBytesCanReserve of SourceHandle is a constant in SourceHandleTest. When calling sourceHandle.setMaxBytesCanReserve(5 * mockTsBlockSize), if IoTDBDescriptor.getInstance().getConfig().getMaxBytesPerFragmentInstance() is less than 5 * mockTsBlockSize, it will set maxBytesCanReserve of SourceHandle to IoTDBDescriptor.getInstance().getConfig().getMaxBytesPerFragmentInstance() instead of wanted 5 * mockTsBlockSiz, which could lead to UT error.