### PR TITLE
[To Rel/1.0][Metrics][IOTDB-5288][IOTDB-5163] Fix the file metrics is wrong

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -184,19 +184,6 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
 
         long sequenceFileSize = deleteOldFiles(selectedSequenceFiles);
         long unsequenceFileSize = deleteOldFiles(selectedUnsequenceFiles);
-        TsFileMetricManager.getInstance()
-            .deleteFile(sequenceFileSize, true, selectedSequenceFiles.size());
-        TsFileMetricManager.getInstance()
-            .deleteFile(unsequenceFileSize, false, selectedUnsequenceFiles.size());
-
-        for (TsFileResource targetResource : targetTsfileResourceList) {
-          if (targetResource != null) {
-            TsFileMetricManager.getInstance().addFile(targetResource.getTsFileSize(), true);
-
-            // set target resources to CLOSED, so that they can be selected to compact
-            targetResource.setStatus(TsFileResourceStatus.CLOSED);
-          }
-        }
 
         CompactionUtils.deleteCompactionModsFile(selectedSequenceFiles, selectedUnsequenceFiles);
 
@@ -216,6 +203,20 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
               subTaskSummary.PAGE_OVERLAP_OR_MODIFIED,
               subTaskSummary.PAGE_FAKE_OVERLAP);
         }
+
+        // update the metrics finally in case of any exception occurs
+        for (TsFileResource targetResource : targetTsfileResourceList) {
+          if (targetResource != null) {
+            TsFileMetricManager.getInstance().addFile(targetResource.getTsFileSize(), true);
+
+            // set target resources to CLOSED, so that they can be selected to compact
+            targetResource.setStatus(TsFileResourceStatus.CLOSED);
+          }
+        }
+        TsFileMetricManager.getInstance()
+            .deleteFile(sequenceFileSize, true, selectedSequenceFiles.size());
+        TsFileMetricManager.getInstance()
+            .deleteFile(unsequenceFileSize, false, selectedUnsequenceFiles.size());
         long costTime = (System.currentTimeMillis() - startTime) / 1000;
         LOGGER.info(
             "{}-{} [Compaction] CrossSpaceCompaction task finishes successfully, time cost is {} s, compaction speed is {} MB/s",

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -256,7 +256,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           dataRegionId,
           targetTsFileResource.getTsFile().getName(),
           costTime,
-          ((double) selectedFileSize) / 1024.0d / 1024.0d / costTime);
+          selectedFileSize / 1024.0d / 1024.0d / costTime);
 
       if (logFile.exists()) {
         FileUtils.delete(logFile);


### PR DESCRIPTION
See [IOTDB-5288](https://issues.apache.org/jira/browse/IOTDB-5288), [IOTDB-5163](https://issues.apache.org/jira/browse/IOTDB-5163).

This PR moves the edition of metrics to the end of compaction, in case of any exception occurs after the metrics is editted.