### PR TITLE
[IOTDB-4960]SchemaFile implements separate FileChannel for read/write operation

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -559,7 +559,7 @@ public class IoTDBConfig {
   private long cacheFileReaderClearPeriod = 100000;
 
   /** the max executing time of query in ms. Unit: millisecond */
-  private long queryTimeoutThreshold = 60000;
+  private long queryTimeoutThreshold = 5000;
 
   /** the max time to live of a session in ms. Unit: millisecond */
   private int sessionTimeoutThreshold = 0;
@@ -842,7 +842,7 @@ public class IoTDBConfig {
   private boolean enableIDTableLogFile = false;
 
   /** whether to use persistent schema mode */
-  private String schemaEngineMode = "Memory";
+  private String schemaEngineMode = "Schema_File";
 
   /** the memory used for metadata cache when using persistent schema */
   private int cachedMNodeSizeInSchemaFileMode = -1;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -559,7 +559,7 @@ public class IoTDBConfig {
   private long cacheFileReaderClearPeriod = 100000;
 
   /** the max executing time of query in ms. Unit: millisecond */
-  private long queryTimeoutThreshold = 5000;
+  private long queryTimeoutThreshold = 60000;
 
   /** the max time to live of a session in ms. Unit: millisecond */
   private int sessionTimeoutThreshold = 0;
@@ -842,7 +842,7 @@ public class IoTDBConfig {
   private boolean enableIDTableLogFile = false;
 
   /** whether to use persistent schema mode */
-  private String schemaEngineMode = "Schema_File";
+  private String schemaEngineMode = "Memory";
 
   /** the memory used for metadata cache when using persistent schema */
   private int cachedMNodeSizeInSchemaFileMode = -1;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -77,6 +77,7 @@ public class SchemaFile implements ISchemaFile {
   private File pmtFile;
   private FileChannel channel;
 
+  // todo refactor constructor for schema file in Jan.
   private SchemaFile(
       String sgName, int schemaRegionId, boolean override, long ttl, boolean isEntity)
       throws IOException, MetadataException {
@@ -330,7 +331,7 @@ public class SchemaFile implements ISchemaFile {
       ReadWriteIOUtils.write(sgNodeTemplateIdWithState, headerContent);
       ReadWriteIOUtils.write(SchemaFileConfig.SCHEMA_FILE_VERSION, headerContent);
       lastSGAddr = 0L;
-      pageManager = new BTreePageManager(channel, -1, logPath);
+      pageManager = new BTreePageManager(channel, pmtFile, -1, logPath);
     } else {
       channel.read(headerContent);
       headerContent.clear();
@@ -345,7 +346,7 @@ public class SchemaFile implements ISchemaFile {
         throw new MetadataException("SchemaFile with wrong version, please check or upgrade.");
       }
 
-      pageManager = new BTreePageManager(channel, lastPageIndex, logPath);
+      pageManager = new BTreePageManager(channel, pmtFile, lastPageIndex, logPath);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/BTreePageManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/BTreePageManager.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.ISchemaPage;
 import org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.ISegmentedPage;
 import org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFileConfig;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -40,9 +41,9 @@ import static org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.SchemaFil
 
 public class BTreePageManager extends PageManager {
 
-  public BTreePageManager(FileChannel channel, int lastPageIndex, String logPath)
+  public BTreePageManager(FileChannel channel, File pmtFile, int lastPageIndex, String logPath)
       throws IOException, MetadataException {
-    super(channel, lastPageIndex, logPath);
+    super(channel, pmtFile, lastPageIndex, logPath);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
@@ -35,11 +35,13 @@ import org.apache.iotdb.db.metadata.mtree.store.disk.schemafile.log.SchemaFileLo
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -89,10 +91,14 @@ public abstract class PageManager implements IPageManager {
 
   private final FileChannel channel;
 
+  // handle timeout interruption during reading
+  private File pmtFile;
+  private FileChannel readChannel;
+
   private final AtomicInteger logCounter;
   private SchemaFileLogWriter logWriter;
 
-  PageManager(FileChannel channel, int lastPageIndex, String logPath)
+  PageManager(FileChannel channel, File pmtFile, int lastPageIndex, String logPath)
       throws IOException, MetadataException {
     this.pageInstCache = Collections.synchronizedMap(new LinkedHashMap<>(PAGE_CACHE_SIZE, 1, true));
     this.dirtyPages = new ConcurrentHashMap<>();
@@ -102,6 +108,8 @@ public abstract class PageManager implements IPageManager {
         lastPageIndex >= 0 ? new AtomicInteger(lastPageIndex) : new AtomicInteger(0);
     this.treeTrace = new int[16];
     this.channel = channel;
+    this.pmtFile = pmtFile;
+    this.readChannel = FileChannel.open(pmtFile.toPath(), StandardOpenOption.READ);
 
     // recover if log exists
     int pageAcc = (int) recoverFromLog(logPath) / PAGE_LENGTH;
@@ -555,9 +563,12 @@ public abstract class PageManager implements IPageManager {
     return page;
   }
 
-  private int loadFromFile(ByteBuffer dst, int pageIndex) throws IOException {
+  private synchronized int loadFromFile(ByteBuffer dst, int pageIndex) throws IOException {
     dst.clear();
-    return channel.read(dst, getPageAddress(pageIndex));
+    if (!readChannel.isOpen()) {
+      readChannel = FileChannel.open(pmtFile.toPath(), StandardOpenOption.READ);
+    }
+    return readChannel.read(dst, getPageAddress(pageIndex));
   }
 
   private void updateParentalRecord(IMNode parent, String key, long newSegAddr)


### PR DESCRIPTION
This PR bases on the fact that `FileChannel` would be closed if the executing thread was interrupted.
Previously, `SchemaFile`/`PageManager` holds a `FileChannel` variable to read from or write to disk. With high cardinality workload and limited `query_timeout_threshold`, the channel would be interrupted while executing Channel.read(more likely on HDD), which would close the channel and corrupt later access.
After this fix, `SchemaFile` will always check whether the channel is closed and open a new one if so.
Related test figures as below.

For whom may need verify or reproduce, better to test on HDD, lower the query timeout threshold and max heap size.

Before:
![image](https://user-images.githubusercontent.com/22140148/211577030-a2c74c53-9e80-4477-95b2-630e5609240b.png)

After:
![image](https://user-images.githubusercontent.com/22140148/211577078-a564df92-1662-481c-8a5e-422e2bc39b87.png)

Besides, few lines had been fixed for better sync behaviour within SchemaFile write and update methods.

A refactor of constructor of SchemaFile is scheduled before Jan.