### PR TITLE
[To rel/1.0][IOTDB-5390] Keep mqtt_host being same with rpc_address

### DIFF
--- a/docs/UserGuide/API/Programming-MQTT.md
+++ b/docs/UserGuide/API/Programming-MQTT.md
@@ -63,14 +63,14 @@ The IoTDB MQTT service load configurations from `${IOTDB_HOME}/${IOTDB_CONF}/iot
 
 Configurations are as follows:
 
-| NAME        | DESCRIPTION           | DEFAULT  |
-| ------------- |:-------------:|:------:|
-| enable_mqtt_service      | whether to enable the mqtt service | false |
-| mqtt_host      | the mqtt service binding host | 0.0.0.0 |
-| mqtt_port      | the mqtt service binding port    |   1883 |
-| mqtt_handler_pool_size | the handler pool size for handing the mqtt messages      |    1 |
-| mqtt_payload_formatter | the mqtt message payload formatter     |    json |
-| mqtt_max_message_size | the max mqtt message size in byte|   1048576 |
+| NAME        | DESCRIPTION           |  DEFAULT  |
+| ------------- |:-------------:|:---------:|
+| enable_mqtt_service      | whether to enable the mqtt service |   false   |
+| mqtt_host      | the mqtt service binding host | 127.0.0.1 |
+| mqtt_port      | the mqtt service binding port    |   1883    |
+| mqtt_handler_pool_size | the handler pool size for handing the mqtt messages      |     1     |
+| mqtt_payload_formatter | the mqtt message payload formatter     |   json    |
+| mqtt_max_message_size | the max mqtt message size in byte|  1048576  |
 
 
 ### Coding Examples

--- a/docs/zh/UserGuide/API/Programming-MQTT.md
+++ b/docs/zh/UserGuide/API/Programming-MQTT.md
@@ -67,7 +67,7 @@ MQTT 主题与 IoTDB 时间序列相对应。
 | 名称      | 描述         | 默认 |
 | ------------- |:-------------:|:------:|
 | enable_mqtt_service      | 是否启用 mqtt 服务 | false |
-| mqtt_host      | mqtt 服务绑定主机 | 0.0.0.0 |
+| mqtt_host      | mqtt 服务绑定主机 | 127.0.0.1 |
 | mqtt_port      | mqtt 服务绑定端口 |   1883 |
 | mqtt_handler_pool_size | 处理 mqtt 消息的处理程序池大小 |    1 |
 | mqtt_payload_formatter | mqtt 消息有效负载格式化程序 |    json |

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -1011,7 +1011,7 @@ cluster_name=defaultCluster
 
 # the mqtt service binding host.
 # Datatype: String
-# mqtt_host=0.0.0.0
+# mqtt_host=127.0.0.1
 
 # the mqtt service binding port.
 # Datatype: int

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -90,7 +90,7 @@ public class IoTDBConfig {
   private boolean enableMQTTService = false;
 
   /** the mqtt service binding host. */
-  private String mqttHost = "0.0.0.0";
+  private String mqttHost = "127.0.0.1";
 
   /** the mqtt service binding port. */
   private int mqttPort = 1883;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -90,7 +90,7 @@ public class IoTDBConfig {
   private boolean enableMQTTService = false;
 
   /** the mqtt service binding host. */
-  private String mqttHost = "127.0.0.1";
+  private String mqttHost = "0.0.0.0";
 
   /** the mqtt service binding port. */
   private int mqttPort = 1883;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1298,6 +1298,10 @@ public class IoTDBDescriptor {
 
     if (properties.getProperty(IoTDBConstant.MQTT_HOST_NAME) != null) {
       conf.setMqttHost(properties.getProperty(IoTDBConstant.MQTT_HOST_NAME));
+    } else {
+      logger.info("MQTT host is not configured, will use dn_rpc_address.");
+      conf.setMqttHost(
+          properties.getProperty(IoTDBConstant.DN_RPC_ADDRESS, conf.getRpcAddress().trim()));
     }
 
     if (properties.getProperty(IoTDBConstant.MQTT_PORT_NAME) != null) {


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/IOTDB-5390

Set the default mqtt host to be the same as dn_rpc_address, so the mqtt client on other devices can connect to iotdb without setting the mqtt_host config.