### PR TITLE
[IOTDB-5391] Implement SchemaReader using iterative Traverser

### DIFF
--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -46,7 +46,6 @@ import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowNodesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IActivateTemplateInClusterPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.ICreateAlignedTimeSeriesPlan;
@@ -54,7 +53,9 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.write.ICreateTimeSeriesPla
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IDeactivateTemplatePlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IPreDeactivateTemplatePlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IRollbackPreDeactivateTemplatePlan;
+import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.metadata.schemaregion.SchemaRegionUtils;
@@ -912,57 +913,10 @@ public class RSchemaRegion implements ISchemaRegion {
   }
 
   @Override
-  public List<ShowDevicesResult> getMatchedDevices(IShowDevicesPlan plan) throws MetadataException {
-    List<ShowDevicesResult> res = Collections.synchronizedList(new ArrayList<>());
-    BiFunction<byte[], byte[], Boolean> function =
-        (a, b) -> {
-          String fullPath = RSchemaUtils.getPathByInnerName(new String(a));
-          res.add(new ShowDevicesResult(fullPath, RSchemaUtils.isAligned(b)));
-          return true;
-        };
-    traverseOutcomeBasins(
-        plan.getPath().getNodes(), MAX_PATH_DEPTH, function, new Character[] {NODE_TYPE_ENTITY});
-
-    return res;
-  }
-
-  public List<MeasurementPath> getMeasurementPaths(
-      PartialPath pathPattern, boolean isPrefixMath, boolean withTags) throws MetadataException {
-    if (withTags) {
-      Map<MeasurementPath, Pair<Map<String, String>, Map<String, String>>> results =
-          getMatchedMeasurementPathWithTags(pathPattern.getNodes());
-      return new ArrayList<>(results.keySet());
-    }
-    List<MeasurementPath> allResult = Collections.synchronizedList(new ArrayList<>());
-    BiFunction<byte[], byte[], Boolean> function =
-        (a, b) -> {
-          allResult.add(
-              new RMeasurementMNode(
-                      RSchemaUtils.getPathByInnerName(new String(a)), b, readWriteHandler)
-                  .getMeasurementPath());
-          return true;
-        };
-    traverseOutcomeBasins(
-        pathPattern.getNodes(), MAX_PATH_DEPTH, function, new Character[] {NODE_TYPE_MEASUREMENT});
-
-    return allResult;
-  }
-
-  @Override
   public List<MeasurementPath> fetchSchema(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
       throws MetadataException {
     throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public List<ShowTimeSeriesResult> showTimeseries(IShowTimeSeriesPlan plan)
-      throws MetadataException {
-    if (plan.getKey() != null && plan.getValue() != null) {
-      return showTimeseriesWithIndex(plan);
-    } else {
-      return showTimeseriesWithoutIndex(plan);
-    }
   }
 
   private List<ShowTimeSeriesResult> showTimeseriesWithIndex(IShowTimeSeriesPlan plan) {
@@ -1545,6 +1499,18 @@ public class RSchemaRegion implements ISchemaRegion {
   @Override
   public long countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
       throws MetadataException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ISchemaReader<IDeviceSchemaInfo> getDeviceReader(IShowDevicesPlan showDevicesPlan)
+      throws MetadataException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(
+      IShowTimeSeriesPlan showTimeSeriesPlan) throws MetadataException {
     throw new UnsupportedOperationException();
   }
 

--- a/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
+++ b/schema-engine-tag/src/main/java/org/apache/iotdb/db/metadata/tagSchemaRegion/TagSchemaRegion.java
@@ -41,7 +41,6 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWri
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowNodesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IActivateTemplateInClusterPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.ICreateAlignedTimeSeriesPlan;
@@ -49,7 +48,9 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.write.ICreateTimeSeriesPla
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IDeactivateTemplatePlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IPreDeactivateTemplatePlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IRollbackPreDeactivateTemplatePlan;
+import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.metadata.schemaregion.SchemaRegionUtils;
@@ -394,11 +395,6 @@ public class TagSchemaRegion implements ISchemaRegion {
     return measurementPaths;
   }
 
-  @Override
-  public List<ShowDevicesResult> getMatchedDevices(IShowDevicesPlan plan) throws MetadataException {
-    throw new UnsupportedOperationException("getMatchedDevices");
-  }
-
   public List<MeasurementPath> getMeasurementPaths(
       PartialPath pathPattern, boolean isPrefixMatch, boolean withTags) throws MetadataException {
     PartialPath devicePath = pathPattern.getDevicePath();
@@ -437,34 +433,6 @@ public class TagSchemaRegion implements ISchemaRegion {
       PartialPath devicePath, boolean isPrefixMatch) throws MetadataException {
     List<IDeviceID> deviceIDs = getDeviceIdFromInvertedIndex(devicePath);
     return getMeasurementPaths(deviceIDs);
-  }
-
-  @Override
-  public List<ShowTimeSeriesResult> showTimeseries(IShowTimeSeriesPlan plan)
-      throws MetadataException {
-    List<ShowTimeSeriesResult> showTimeSeriesResults = new ArrayList<>();
-    String path = plan.getPath().getFullPath();
-    // point query
-    if (!path.endsWith(TAIL)) {
-      path = PathTagConverterUtils.pathToTagsSortPath(storageGroupFullPath, path);
-      DeviceEntry deviceEntry = idTableWithDeviceIDList.getDeviceEntry(path);
-      if (deviceEntry != null) {
-        Map<String, SchemaEntry> measurementMap = deviceEntry.getMeasurementMap();
-        for (String m : measurementMap.keySet()) {
-          SchemaEntry schemaEntry = measurementMap.get(m);
-          showTimeSeriesResults.add(
-              ShowTimeSeriesResultUtils.generateShowTimeSeriesResult(
-                  storageGroupFullPath, path, m, schemaEntry));
-        }
-      }
-      return showTimeSeriesResults;
-    }
-    // batch query
-    List<IDeviceID> deviceIDs = getDeviceIdFromInvertedIndex(plan.getPath());
-    for (IDeviceID deviceID : deviceIDs) {
-      getTimeSeriesResultOfDeviceFromIDTable(showTimeSeriesResults, deviceID);
-    }
-    return showTimeSeriesResults;
   }
 
   private void getTimeSeriesResultOfDeviceFromIDTable(
@@ -583,6 +551,18 @@ public class TagSchemaRegion implements ISchemaRegion {
   public long countPathsUsingTemplate(int templateId, PathPatternTree patternTree)
       throws MetadataException {
     return 0;
+  }
+
+  @Override
+  public ISchemaReader<IDeviceSchemaInfo> getDeviceReader(IShowDevicesPlan showDevicesPlan)
+      throws MetadataException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(
+      IShowTimeSeriesPlan showTimeSeriesPlan) throws MetadataException {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/IMTreeBelowSG.java
@@ -23,8 +23,6 @@ import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
 import org.apache.iotdb.db.metadata.mnode.IMeasurementMNode;
-import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -142,8 +140,6 @@ public interface IMTreeBelowSG {
    * <p>e.g., get root.sg.d1, get or create all internal nodes and return the node of d1
    */
   IMNode getDeviceNodeWithAutoCreating(PartialPath deviceId) throws MetadataException;
-
-  List<ShowDevicesResult> getDevices(IShowDevicesPlan plan) throws MetadataException;
 
   /**
    * Fetch all measurement path

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -55,7 +55,9 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowNodesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
+import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.utils.MetaFormatUtils;
@@ -94,10 +96,6 @@ import java.util.function.Function;
  *   <li>Timeseries operation, including create and delete
  *   <li>Entity/Device operation
  *   <li>Interfaces and Implementation for metadata info Query
- *       <ol>
- *         <li>Interfaces for Device info Query
- *         <li>Interfaces for timeseries, measurement and schema info Query
- *       </ol>
  *   <li>Interfaces and Implementation for MNode Query
  *   <li>Interfaces and Implementation for Template check
  * </ol>
@@ -705,68 +703,35 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
 
   // region Interfaces and Implementation for metadata info Query
 
-  // region Interfaces for Device info Query
-
   @Override
-  public List<ShowDevicesResult> getDevices(IShowDevicesPlan plan) throws MetadataException {
-    List<ShowDevicesResult> res = new ArrayList<>();
-    try (EntityCollector<ShowDevicesResult> collector =
-        new EntityCollector<ShowDevicesResult>(
-            rootNode, plan.getPath(), store, plan.isPrefixMatch()) {
-          @Override
-          protected ShowDevicesResult collectEntity(IEntityMNode node) {
-            PartialPath device = getPartialPathFromRootToNode(node);
-            return new ShowDevicesResult(device.getFullPath(), node.isAligned());
-          }
-        }) {
-      if (plan.usingSchemaTemplate()) {
-        collector.setSchemaTemplateFilter(plan.getSchemaTemplateId());
-      }
-      TraverserWithLimitOffsetWrapper<ShowDevicesResult> traverser =
-          new TraverserWithLimitOffsetWrapper<>(collector, plan.getLimit(), plan.getOffset());
-      while (traverser.hasNext()) {
-        res.add(traverser.next());
-      }
-    }
-
-    return res;
-  }
-  // endregion
-
-  // region Interfaces for timeseries, measurement and schema info Query
-
-  public List<ShowTimeSeriesResult> getAllMeasurementSchema(
-      IShowTimeSeriesPlan plan,
-      Function<Long, Pair<Map<String, String>, Map<String, String>>> tagAndAttributeProvider)
+  public List<MeasurementPath> fetchSchema(
+      PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
       throws MetadataException {
-    List<ShowTimeSeriesResult> result = new LinkedList<>();
-    try (MeasurementCollector<ShowTimeSeriesResult> collector =
-        new MeasurementCollector<ShowTimeSeriesResult>(
-            rootNode, plan.getPath(), store, plan.isPrefixMatch()) {
+    List<MeasurementPath> result = new LinkedList<>();
+    try (MeasurementCollector<Void> collector =
+        new MeasurementCollector<Void>(rootNode, pathPattern, store, false) {
           @Override
-          protected ShowTimeSeriesResult collectMeasurement(IMeasurementMNode node) {
-            Pair<Map<String, String>, Map<String, String>> tagAndAttribute =
-                tagAndAttributeProvider.apply(node.getOffset());
-            return new ShowTimeSeriesResult(
-                getPartialPathFromRootToNode(node).getFullPath(),
-                node.getAlias(),
-                (MeasurementSchema) node.getSchema(),
-                tagAndAttribute.left,
-                tagAndAttribute.right,
-                getParentOfNextMatchedNode().getAsEntityMNode().isAligned());
+          protected Void collectMeasurement(IMeasurementMNode node) {
+            if (node.isPreDeleted()) {
+              return null;
+            }
+            MeasurementPath path = getCurrentMeasurementPathInTraverse(node);
+            if (nodes[nodes.length - 1].equals(node.getAlias())) {
+              // only when user query with alias, the alias in path will be set
+              path.setMeasurementAlias(node.getAlias());
+            }
+            if (withTags) {
+              path.setTagMap(tagGetter.apply(node));
+            }
+            result.add(path);
+            return null;
           }
         }) {
-      collector.setTemplateMap(plan.getRelatedTemplate());
-      TraverserWithLimitOffsetWrapper<ShowTimeSeriesResult> traverser =
-          new TraverserWithLimitOffsetWrapper<>(collector, plan.getLimit(), plan.getOffset());
-      while (traverser.hasNext()) {
-        result.add(traverser.next());
-      }
+      collector.setTemplateMap(templateMap);
+      collector.traverse();
     }
     return result;
   }
-
-  // endregion
 
   // endregion
 
@@ -812,36 +777,6 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
       throw new MNodeTypeMismatchException(
           path.getFullPath(), MetadataConstant.MEASUREMENT_MNODE_TYPE);
     }
-  }
-
-  @Override
-  public List<MeasurementPath> fetchSchema(
-      PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
-      throws MetadataException {
-    List<MeasurementPath> result = new LinkedList<>();
-    try (MeasurementCollector<Void> collector =
-        new MeasurementCollector<Void>(rootNode, pathPattern, store, false) {
-          @Override
-          protected Void collectMeasurement(IMeasurementMNode node) {
-            if (node.isPreDeleted()) {
-              return null;
-            }
-            MeasurementPath path = getCurrentMeasurementPathInTraverse(node);
-            if (nodes[nodes.length - 1].equals(node.getAlias())) {
-              // only when user query with alias, the alias in path will be set
-              path.setMeasurementAlias(node.getAlias());
-            }
-            if (withTags) {
-              path.setTagMap(tagGetter.apply(node));
-            }
-            result.add(path);
-            return null;
-          }
-        }) {
-      collector.setTemplateMap(templateMap);
-      collector.traverse();
-    }
-    return result;
   }
 
   @Override
@@ -1045,6 +980,84 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
   // endregion
 
   // region Interfaces for schema reader
+  public ISchemaReader<IDeviceSchemaInfo> getDeviceReader(IShowDevicesPlan showDevicesPlan)
+      throws MetadataException {
+    EntityCollector<IDeviceSchemaInfo> collector =
+        new EntityCollector<IDeviceSchemaInfo>(
+            rootNode, showDevicesPlan.getPath(), store, showDevicesPlan.isPrefixMatch()) {
+          @Override
+          protected IDeviceSchemaInfo collectEntity(IEntityMNode node) {
+            PartialPath device = getPartialPathFromRootToNode(node);
+            return new ShowDevicesResult(device.getFullPath(), node.isAligned());
+          }
+        };
+    if (showDevicesPlan.usingSchemaTemplate()) {
+      collector.setSchemaTemplateFilter(showDevicesPlan.getSchemaTemplateId());
+    }
+    TraverserWithLimitOffsetWrapper<IDeviceSchemaInfo> traverser =
+        new TraverserWithLimitOffsetWrapper<>(
+            collector, showDevicesPlan.getLimit(), showDevicesPlan.getOffset());
+    return new ISchemaReader<IDeviceSchemaInfo>() {
+      @Override
+      public void close() {
+        traverser.close();
+      }
+
+      @Override
+      public boolean hasNext() {
+        return traverser.hasNext();
+      }
+
+      @Override
+      public IDeviceSchemaInfo next() {
+        return traverser.next();
+      }
+    };
+  }
+
+  public ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(
+      IShowTimeSeriesPlan showTimeSeriesPlan,
+      Function<Long, Pair<Map<String, String>, Map<String, String>>> tagAndAttributeProvider)
+      throws MetadataException {
+    MeasurementCollector<ITimeSeriesSchemaInfo> collector =
+        new MeasurementCollector<ITimeSeriesSchemaInfo>(
+            rootNode, showTimeSeriesPlan.getPath(), store, showTimeSeriesPlan.isPrefixMatch()) {
+          @Override
+          protected ITimeSeriesSchemaInfo collectMeasurement(IMeasurementMNode node) {
+            Pair<Map<String, String>, Map<String, String>> tagAndAttribute =
+                tagAndAttributeProvider.apply(node.getOffset());
+            return new ShowTimeSeriesResult(
+                getPartialPathFromRootToNode(node).getFullPath(),
+                node.getAlias(),
+                (MeasurementSchema) node.getSchema(),
+                tagAndAttribute.left,
+                tagAndAttribute.right,
+                getParentOfNextMatchedNode().getAsEntityMNode().isAligned());
+          }
+        };
+
+    collector.setTemplateMap(showTimeSeriesPlan.getRelatedTemplate());
+    TraverserWithLimitOffsetWrapper<ITimeSeriesSchemaInfo> traverser =
+        new TraverserWithLimitOffsetWrapper<>(
+            collector, showTimeSeriesPlan.getLimit(), showTimeSeriesPlan.getOffset());
+    return new ISchemaReader<ITimeSeriesSchemaInfo>() {
+      @Override
+      public void close() {
+        traverser.close();
+      }
+
+      @Override
+      public boolean hasNext() {
+        return traverser.hasNext();
+      }
+
+      @Override
+      public ITimeSeriesSchemaInfo next() {
+        return traverser.next();
+      }
+    };
+  }
+
   public ISchemaReader<INodeSchemaInfo> getNodeReader(IShowNodesPlan showNodesPlan)
       throws MetadataException {
     MNodeCollector<INodeSchemaInfo> collector =

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -104,7 +104,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
 
   private final CachedMTreeStore store;
   private volatile IStorageGroupMNode storageGroupMNode;
-  private volatile IMNode rootNode;
+  private final IMNode rootNode;
   private final Function<IMeasurementMNode, Map<String, String>> tagGetter;
   private final int levelOfSG;
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -55,7 +55,9 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowNodesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
+import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.utils.MetaFormatUtils;
@@ -94,10 +96,6 @@ import java.util.function.Function;
  *   <li>Timeseries operation, including create and delete
  *   <li>Entity/Device operation
  *   <li>Interfaces and Implementation for metadata info Query
- *       <ol>
- *         <li>Interfaces for Device info Query
- *         <li>Interfaces for timeseries, measurement and schema info Query
- *       </ol>
  *   <li>Interfaces and Implementation for MNode Query
  *   <li>Interfaces and Implementation for Template check
  * </ol>
@@ -623,35 +621,6 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
 
   // region Interfaces and Implementation for metadata info Query
 
-  // region Interfaces for Device info Query
-
-  @Override
-  public List<ShowDevicesResult> getDevices(IShowDevicesPlan plan) throws MetadataException {
-    List<ShowDevicesResult> res = new ArrayList<>();
-    try (EntityCollector<ShowDevicesResult> collector =
-        new EntityCollector<ShowDevicesResult>(
-            rootNode, plan.getPath(), store, plan.isPrefixMatch()) {
-          @Override
-          protected ShowDevicesResult collectEntity(IEntityMNode node) {
-            PartialPath device = getPartialPathFromRootToNode(node);
-            return new ShowDevicesResult(device.getFullPath(), node.isAligned());
-          }
-        }) {
-      if (plan.usingSchemaTemplate()) {
-        collector.setSchemaTemplateFilter(plan.getSchemaTemplateId());
-      }
-      TraverserWithLimitOffsetWrapper<ShowDevicesResult> traverser =
-          new TraverserWithLimitOffsetWrapper<>(collector, plan.getLimit(), plan.getOffset());
-      while (traverser.hasNext()) {
-        res.add(traverser.next());
-      }
-    }
-    return res;
-  }
-  // endregion
-
-  // region Interfaces for timeseries, measurement and schema info Query
-
   @Override
   public List<MeasurementPath> fetchSchema(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
@@ -679,39 +648,6 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
     }
     return result;
   }
-
-  public List<ShowTimeSeriesResult> getAllMeasurementSchema(
-      IShowTimeSeriesPlan plan,
-      Function<Long, Pair<Map<String, String>, Map<String, String>>> tagAndAttributeProvider)
-      throws MetadataException {
-    List<ShowTimeSeriesResult> result = new LinkedList<>();
-    try (MeasurementCollector<ShowTimeSeriesResult> collector =
-        new MeasurementCollector<ShowTimeSeriesResult>(
-            rootNode, plan.getPath(), store, plan.isPrefixMatch()) {
-          @Override
-          protected ShowTimeSeriesResult collectMeasurement(IMeasurementMNode node) {
-            Pair<Map<String, String>, Map<String, String>> tagAndAttribute =
-                tagAndAttributeProvider.apply(node.getOffset());
-            return new ShowTimeSeriesResult(
-                getPartialPathFromRootToNode(node).getFullPath(),
-                node.getAlias(),
-                (MeasurementSchema) node.getSchema(),
-                tagAndAttribute.left,
-                tagAndAttribute.right,
-                getParentOfNextMatchedNode().getAsEntityMNode().isAligned());
-          }
-        }) {
-      collector.setTemplateMap(plan.getRelatedTemplate());
-      TraverserWithLimitOffsetWrapper<ShowTimeSeriesResult> traverser =
-          new TraverserWithLimitOffsetWrapper<>(collector, plan.getLimit(), plan.getOffset());
-      while (traverser.hasNext()) {
-        result.add(traverser.next());
-      }
-    }
-    return result;
-  }
-
-  // endregion
 
   // endregion
 
@@ -927,6 +863,84 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
   // endregion
 
   // region Interfaces for schema reader
+
+  public ISchemaReader<IDeviceSchemaInfo> getDeviceReader(IShowDevicesPlan showDevicesPlan)
+      throws MetadataException {
+    EntityCollector<IDeviceSchemaInfo> collector =
+        new EntityCollector<IDeviceSchemaInfo>(
+            rootNode, showDevicesPlan.getPath(), store, showDevicesPlan.isPrefixMatch()) {
+          @Override
+          protected IDeviceSchemaInfo collectEntity(IEntityMNode node) {
+            PartialPath device = getPartialPathFromRootToNode(node);
+            return new ShowDevicesResult(device.getFullPath(), node.isAligned());
+          }
+        };
+    if (showDevicesPlan.usingSchemaTemplate()) {
+      collector.setSchemaTemplateFilter(showDevicesPlan.getSchemaTemplateId());
+    }
+    TraverserWithLimitOffsetWrapper<IDeviceSchemaInfo> traverser =
+        new TraverserWithLimitOffsetWrapper<>(
+            collector, showDevicesPlan.getLimit(), showDevicesPlan.getOffset());
+    return new ISchemaReader<IDeviceSchemaInfo>() {
+      @Override
+      public void close() {
+        traverser.close();
+      }
+
+      @Override
+      public boolean hasNext() {
+        return traverser.hasNext();
+      }
+
+      @Override
+      public IDeviceSchemaInfo next() {
+        return traverser.next();
+      }
+    };
+  }
+
+  public ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(
+      IShowTimeSeriesPlan showTimeSeriesPlan,
+      Function<Long, Pair<Map<String, String>, Map<String, String>>> tagAndAttributeProvider)
+      throws MetadataException {
+    MeasurementCollector<ITimeSeriesSchemaInfo> collector =
+        new MeasurementCollector<ITimeSeriesSchemaInfo>(
+            rootNode, showTimeSeriesPlan.getPath(), store, showTimeSeriesPlan.isPrefixMatch()) {
+          @Override
+          protected ITimeSeriesSchemaInfo collectMeasurement(IMeasurementMNode node) {
+            Pair<Map<String, String>, Map<String, String>> tagAndAttribute =
+                tagAndAttributeProvider.apply(node.getOffset());
+            return new ShowTimeSeriesResult(
+                getPartialPathFromRootToNode(node).getFullPath(),
+                node.getAlias(),
+                (MeasurementSchema) node.getSchema(),
+                tagAndAttribute.left,
+                tagAndAttribute.right,
+                getParentOfNextMatchedNode().getAsEntityMNode().isAligned());
+          }
+        };
+    collector.setTemplateMap(showTimeSeriesPlan.getRelatedTemplate());
+    TraverserWithLimitOffsetWrapper<ITimeSeriesSchemaInfo> traverser =
+        new TraverserWithLimitOffsetWrapper<>(
+            collector, showTimeSeriesPlan.getLimit(), showTimeSeriesPlan.getOffset());
+    return new ISchemaReader<ITimeSeriesSchemaInfo>() {
+      @Override
+      public void close() {
+        traverser.close();
+      }
+
+      @Override
+      public boolean hasNext() {
+        return traverser.hasNext();
+      }
+
+      @Override
+      public ITimeSeriesSchemaInfo next() {
+        return traverser.next();
+      }
+    };
+  }
+
   public ISchemaReader<INodeSchemaInfo> getNodeReader(IShowNodesPlan showNodesPlan)
       throws MetadataException {
     MNodeCollector<INodeSchemaInfo> collector =

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -103,11 +103,11 @@ import java.util.function.Function;
 public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
 
   // this implementation is based on memory, thus only MTree write operation must invoke MTreeStore
-  private MemMTreeStore store;
+  private final MemMTreeStore store;
   private volatile IStorageGroupMNode storageGroupMNode;
-  private volatile IMNode rootNode;
+  private final IMNode rootNode;
   private final Function<IMeasurementMNode, Map<String, String>> tagGetter;
-  private int levelOfSG;
+  private final int levelOfSG;
 
   // region MTree initialization, clear and serialization
   public MTreeBelowSGMemoryImpl(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/result/ShowTimeSeriesResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/result/ShowTimeSeriesResult.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import java.util.Map;
@@ -68,8 +67,13 @@ public class ShowTimeSeriesResult extends ShowSchemaResult implements ITimeSerie
   }
 
   @Override
-  public Pair<Map<String, String>, Map<String, String>> getTagAndAttribute() {
-    return new Pair<>(tags, attributes);
+  public Map<String, String> getTags() {
+    return tags;
+  }
+
+  @Override
+  public Map<String, String> getAttributes() {
+    return attributes;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/query/info/ITimeSeriesSchemaInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/query/info/ITimeSeriesSchemaInfo.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.metadata.query.info;
 
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import java.util.Map;
@@ -30,7 +29,9 @@ public interface ITimeSeriesSchemaInfo extends ISchemaInfo {
 
   MeasurementSchema getSchema();
 
-  Pair<Map<String, String>, Map<String, String>> getTagAndAttribute();
+  Map<String, String> getTags();
+
+  Map<String, String> getAttributes();
 
   boolean isUnderAlignedDevice();
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -27,8 +27,6 @@ import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowNodesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IActivateTemplateInClusterPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.ICreateAlignedTimeSeriesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.ICreateTimeSeriesPlan;
@@ -43,7 +41,6 @@ import org.apache.iotdb.db.metadata.template.Template;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -159,30 +156,12 @@ public interface ISchemaRegion {
 
   // region Interfaces for metadata info Query
 
-  // region Interfaces for Entity/Device info Query
-
-  /**
-   * Get all device paths and corresponding database paths as ShowDevicesResult.
-   *
-   * @param plan ShowDevicesPlan which contains the path pattern and restriction params.
-   * @return ShowDevicesResult
-   */
-  List<ShowDevicesResult> getMatchedDevices(IShowDevicesPlan plan) throws MetadataException;
-  // endregion
-
   // region Interfaces for timeseries, measurement and schema info Query
 
   List<MeasurementPath> fetchSchema(
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
       throws MetadataException;
 
-  /**
-   * Show timeseries.
-   *
-   * @param plan
-   * @throws MetadataException
-   */
-  List<ShowTimeSeriesResult> showTimeseries(IShowTimeSeriesPlan plan) throws MetadataException;
   // endregion
   // endregion
 
@@ -276,45 +255,11 @@ public interface ISchemaRegion {
 
   // region Interfaces for SchemaReader
 
-  default ISchemaReader<IDeviceSchemaInfo> getDeviceReader(IShowDevicesPlan showDevicesPlan)
-      throws MetadataException {
-    List<ShowDevicesResult> showDevicesResultList = getMatchedDevices(showDevicesPlan);
-    Iterator<ShowDevicesResult> iterator = showDevicesResultList.iterator();
-    return new ISchemaReader<IDeviceSchemaInfo>() {
-      @Override
-      public void close() throws Exception {}
+  ISchemaReader<IDeviceSchemaInfo> getDeviceReader(IShowDevicesPlan showDevicesPlan)
+      throws MetadataException;
 
-      @Override
-      public boolean hasNext() {
-        return iterator.hasNext();
-      }
-
-      @Override
-      public IDeviceSchemaInfo next() {
-        return iterator.next();
-      }
-    };
-  }
-
-  default ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(
-      IShowTimeSeriesPlan showTimeSeriesPlan) throws MetadataException {
-    List<ShowTimeSeriesResult> showTimeSeriesResultList = showTimeseries(showTimeSeriesPlan);
-    Iterator<ShowTimeSeriesResult> iterator = showTimeSeriesResultList.iterator();
-    return new ISchemaReader<ITimeSeriesSchemaInfo>() {
-      @Override
-      public void close() throws Exception {}
-
-      @Override
-      public boolean hasNext() {
-        return iterator.hasNext();
-      }
-
-      @Override
-      public ITimeSeriesSchemaInfo next() {
-        return iterator.next();
-      }
-    };
-  }
+  ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(IShowTimeSeriesPlan showTimeSeriesPlan)
+      throws MetadataException;
 
   ISchemaReader<INodeSchemaInfo> getNodeReader(IShowNodesPlan showNodesPlan)
       throws MetadataException;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -786,14 +786,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
     measurementMNode.setPreDeleted(false);
   }
 
-  private void deleteSingleTimeseriesInternal(PartialPath p) throws MetadataException, IOException {
-    deleteOneTimeseriesUpdateStatistics(p);
-    if (!isRecovering) {
-      writeToMLog(
-          SchemaRegionWritePlanFactory.getDeleteTimeSeriesPlan(Collections.singletonList(p)));
-    }
-  }
-
   /**
    * @param path full path from root to leaf node
    * @return After delete if the schema region is empty, return its path, otherwise return null
@@ -1194,13 +1186,12 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   public ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(
       IShowTimeSeriesPlan showTimeSeriesPlan) throws MetadataException {
     if (showTimeSeriesPlan.getKey() != null && showTimeSeriesPlan.getValue() != null) {
-      // TODO
       List<ShowTimeSeriesResult> showTimeSeriesResultList =
           showTimeseriesWithIndex(showTimeSeriesPlan);
       Iterator<ShowTimeSeriesResult> iterator = showTimeSeriesResultList.iterator();
       return new ISchemaReader<ITimeSeriesSchemaInfo>() {
         @Override
-        public void close() throws Exception {}
+        public void close() {}
 
         @Override
         public boolean hasNext() {
@@ -1213,23 +1204,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
         }
       };
     } else {
-      //      List<ShowTimeSeriesResult> showTimeSeriesResultList =
-      //              showTimeseriesWithoutIndex(showTimeSeriesPlan);
-      //      Iterator<ShowTimeSeriesResult> iterator = showTimeSeriesResultList.iterator();
-      //      return new ISchemaReader<ITimeSeriesSchemaInfo>() {
-      //        @Override
-      //        public void close() throws Exception {}
-      //
-      //        @Override
-      //        public boolean hasNext() {
-      //          return iterator.hasNext();
-      //        }
-      //
-      //        @Override
-      //        public ITimeSeriesSchemaInfo next() {
-      //          return iterator.next();
-      //        }
-      //      };
       return mtree.getTimeSeriesReader(
           showTimeSeriesPlan,
           offset -> {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -50,7 +50,6 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWri
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowNodesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IActivateTemplateInClusterPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IAutoCreateDeviceMNodePlan;
@@ -64,7 +63,9 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.write.IPreDeactivateTempla
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IPreDeleteTimeSeriesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IRollbackPreDeactivateTemplatePlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IRollbackPreDeleteTimeSeriesPlan;
+import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.rescon.MemoryStatistics;
 import org.apache.iotdb.db.metadata.rescon.SchemaStatisticsManager;
@@ -85,6 +86,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -842,18 +844,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
 
   // region Interfaces for Entity/Device info Query
 
-  /**
-   * Get all device paths and according database paths as ShowDevicesResult.
-   *
-   * @param plan ShowDevicesPlan which contains the path pattern and restriction params.
-   * @return ShowDevicesResult and the current offset of this region after traverse.
-   */
-  @Override
-  public List<ShowDevicesResult> getMatchedDevices(IShowDevicesPlan plan) throws MetadataException {
-    return mtree.getDevices(plan);
-  }
-  // endregion
-
   // region Interfaces for timeseries, measurement and schema info Query
 
   @Override
@@ -861,17 +851,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
       throws MetadataException {
     return mtree.fetchSchema(pathPattern, templateMap, withTags);
-  }
-
-  @Override
-  public List<ShowTimeSeriesResult> showTimeseries(IShowTimeSeriesPlan plan)
-      throws MetadataException {
-    // show timeseries with index
-    if (plan.getKey() != null && plan.getValue() != null) {
-      return showTimeseriesWithIndex(plan);
-    } else {
-      return showTimeseriesWithoutIndex(plan);
-    }
   }
 
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
@@ -921,24 +900,6 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
     return res;
   }
 
-  /**
-   * Get the result of ShowTimeseriesPlan
-   *
-   * @param plan show time series query plan
-   */
-  private List<ShowTimeSeriesResult> showTimeseriesWithoutIndex(IShowTimeSeriesPlan plan)
-      throws MetadataException {
-    return mtree.getAllMeasurementSchema(
-        plan,
-        offset -> {
-          try {
-            return tagManager.readTagFile(offset);
-          } catch (IOException e) {
-            logger.error("Failed to read tag and attribute info because {}", e.getMessage(), e);
-            return new Pair<>(Collections.emptyMap(), Collections.emptyMap());
-          }
-        });
-  }
   // endregion
   // endregion
 
@@ -1221,6 +1182,65 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       result += mtree.countPathsUsingTemplate(pathPattern, templateId);
     }
     return result;
+  }
+
+  @Override
+  public ISchemaReader<IDeviceSchemaInfo> getDeviceReader(IShowDevicesPlan showDevicesPlan)
+      throws MetadataException {
+    return mtree.getDeviceReader(showDevicesPlan);
+  }
+
+  @Override
+  public ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(
+      IShowTimeSeriesPlan showTimeSeriesPlan) throws MetadataException {
+    if (showTimeSeriesPlan.getKey() != null && showTimeSeriesPlan.getValue() != null) {
+      // TODO
+      List<ShowTimeSeriesResult> showTimeSeriesResultList =
+          showTimeseriesWithIndex(showTimeSeriesPlan);
+      Iterator<ShowTimeSeriesResult> iterator = showTimeSeriesResultList.iterator();
+      return new ISchemaReader<ITimeSeriesSchemaInfo>() {
+        @Override
+        public void close() throws Exception {}
+
+        @Override
+        public boolean hasNext() {
+          return iterator.hasNext();
+        }
+
+        @Override
+        public ITimeSeriesSchemaInfo next() {
+          return iterator.next();
+        }
+      };
+    } else {
+      //      List<ShowTimeSeriesResult> showTimeSeriesResultList =
+      //              showTimeseriesWithoutIndex(showTimeSeriesPlan);
+      //      Iterator<ShowTimeSeriesResult> iterator = showTimeSeriesResultList.iterator();
+      //      return new ISchemaReader<ITimeSeriesSchemaInfo>() {
+      //        @Override
+      //        public void close() throws Exception {}
+      //
+      //        @Override
+      //        public boolean hasNext() {
+      //          return iterator.hasNext();
+      //        }
+      //
+      //        @Override
+      //        public ITimeSeriesSchemaInfo next() {
+      //          return iterator.next();
+      //        }
+      //      };
+      return mtree.getTimeSeriesReader(
+          showTimeSeriesPlan,
+          offset -> {
+            try {
+              return tagManager.readTagFile(offset);
+            } catch (IOException e) {
+              logger.error("Failed to read tag and attribute info because {}", e.getMessage(), e);
+              return new Pair<>(Collections.emptyMap(), Collections.emptyMap());
+            }
+          });
+    }
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -834,14 +834,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
     }
   }
 
-  private void deleteSingleTimeseriesInternal(PartialPath p) throws MetadataException, IOException {
-    deleteOneTimeseriesUpdateStatistics(p);
-    if (!isRecovering) {
-      writeToMLog(
-          SchemaRegionWritePlanFactory.getDeleteTimeSeriesPlan(Collections.singletonList(p)));
-    }
-  }
-
   /**
    * @param path full path from root to leaf node
    * @return After delete if the schema region is empty, return its path, otherwise return null
@@ -1277,13 +1269,12 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   public ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(
       IShowTimeSeriesPlan showTimeSeriesPlan) throws MetadataException {
     if (showTimeSeriesPlan.getKey() != null && showTimeSeriesPlan.getValue() != null) {
-      // TODO
       List<ShowTimeSeriesResult> showTimeSeriesResultList =
           showTimeseriesWithIndex(showTimeSeriesPlan);
       Iterator<ShowTimeSeriesResult> iterator = showTimeSeriesResultList.iterator();
       return new ISchemaReader<ITimeSeriesSchemaInfo>() {
         @Override
-        public void close() throws Exception {}
+        public void close() {}
 
         @Override
         public boolean hasNext() {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -48,7 +48,6 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWri
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowNodesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IActivateTemplateInClusterPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IAutoCreateDeviceMNodePlan;
@@ -60,20 +59,20 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.write.IDeactivateTemplateP
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IDeleteTimeSeriesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IPreDeactivateTemplatePlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.write.IRollbackPreDeactivateTemplatePlan;
+import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.rescon.MemoryStatistics;
 import org.apache.iotdb.db.metadata.rescon.SchemaStatisticsManager;
 import org.apache.iotdb.db.metadata.tag.TagManager;
 import org.apache.iotdb.db.metadata.template.Template;
-import org.apache.iotdb.db.metadata.utils.MetaUtils;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.external.api.ISeriesNumerMonitor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.utils.Pair;
-import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.slf4j.Logger;
@@ -84,6 +83,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +111,6 @@ import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARA
  *   <li>Interfaces for auto create device
  *   <li>Interfaces for metadata info Query
  *       <ol>
- *         <li>Interfaces for Entity/Device info Query
  *         <li>Interfaces for timeseries, measurement and schema info Query
  *       </ol>
  *   <li>Interfaces for alias and tag/attribute operations
@@ -892,20 +891,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
 
   // region Interfaces for metadata info Query
 
-  // region Interfaces for Entity/Device info Query
-
-  /**
-   * Get all device paths and according database paths as ShowDevicesResult.
-   *
-   * @param plan ShowDevicesPlan which contains the path pattern and restriction params.
-   * @return ShowDevicesResult and the current offset of this region after traverse.
-   */
-  @Override
-  public List<ShowDevicesResult> getMatchedDevices(IShowDevicesPlan plan) throws MetadataException {
-    return mtree.getDevices(plan);
-  }
-  // endregion
-
   // region Interfaces for timeseries, measurement and schema info Query
 
   @Override
@@ -913,17 +898,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
       PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
       throws MetadataException {
     return mtree.fetchSchema(pathPattern, templateMap, withTags);
-  }
-
-  @Override
-  public List<ShowTimeSeriesResult> showTimeseries(IShowTimeSeriesPlan plan)
-      throws MetadataException {
-    // show timeseries with index
-    if (plan.getKey() != null && plan.getValue() != null) {
-      return showTimeseriesWithIndex(plan);
-    } else {
-      return showTimeseriesWithoutIndex(plan);
-    }
   }
 
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
@@ -952,9 +926,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
         try {
           Pair<Map<String, String>, Map<String, String>> tagAndAttributePair =
               tagManager.readTagFile(leaf.getOffset());
-          IMeasurementSchema measurementSchema = leaf.getSchema();
-          Pair<String, String> deadbandInfo =
-              MetaUtils.parseDeadbandInfo(measurementSchema.getProps());
           res.add(
               new ShowTimeSeriesResult(
                   leaf.getFullPath(),
@@ -974,25 +945,6 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
     }
 
     return res;
-  }
-
-  /**
-   * Get the result of ShowTimeseriesPlan
-   *
-   * @param plan show time series query plan
-   */
-  private List<ShowTimeSeriesResult> showTimeseriesWithoutIndex(IShowTimeSeriesPlan plan)
-      throws MetadataException {
-    return mtree.getAllMeasurementSchema(
-        plan,
-        offset -> {
-          try {
-            return tagManager.readTagFile(offset);
-          } catch (IOException e) {
-            logger.error("Failed to read tag and attribute info because {}", e.getMessage(), e);
-            return new Pair<>(Collections.emptyMap(), Collections.emptyMap());
-          }
-        });
   }
   // endregion
   // endregion
@@ -1313,6 +1265,48 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
       result += mtree.countPathsUsingTemplate(pathPattern, templateId);
     }
     return result;
+  }
+
+  @Override
+  public ISchemaReader<IDeviceSchemaInfo> getDeviceReader(IShowDevicesPlan showDevicesPlan)
+      throws MetadataException {
+    return mtree.getDeviceReader(showDevicesPlan);
+  }
+
+  @Override
+  public ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(
+      IShowTimeSeriesPlan showTimeSeriesPlan) throws MetadataException {
+    if (showTimeSeriesPlan.getKey() != null && showTimeSeriesPlan.getValue() != null) {
+      // TODO
+      List<ShowTimeSeriesResult> showTimeSeriesResultList =
+          showTimeseriesWithIndex(showTimeSeriesPlan);
+      Iterator<ShowTimeSeriesResult> iterator = showTimeSeriesResultList.iterator();
+      return new ISchemaReader<ITimeSeriesSchemaInfo>() {
+        @Override
+        public void close() throws Exception {}
+
+        @Override
+        public boolean hasNext() {
+          return iterator.hasNext();
+        }
+
+        @Override
+        public ITimeSeriesSchemaInfo next() {
+          return iterator.next();
+        }
+      };
+    } else {
+      return mtree.getTimeSeriesReader(
+          showTimeSeriesPlan,
+          offset -> {
+            try {
+              return tagManager.readTagFile(offset);
+            } catch (IOException e) {
+              logger.error("Failed to read tag and attribute info because {}", e.getMessage(), e);
+              return new Pair<>(Collections.emptyMap(), Collections.emptyMap());
+            }
+          });
+    }
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/tag/TagManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/tag/TagManager.java
@@ -193,8 +193,7 @@ public class TagManager {
     return timeseries;
   }
 
-  public List<IMeasurementMNode> getMatchedTimeseriesInIndex(IShowTimeSeriesPlan plan)
-      throws MetadataException {
+  public List<IMeasurementMNode> getMatchedTimeseriesInIndex(IShowTimeSeriesPlan plan) {
     if (!tagIndex.containsKey(plan.getKey())) {
       return Collections.emptyList();
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
@@ -91,7 +91,6 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
   @Override
   public void transformToTsBlockColumns(
       ITimeSeriesSchemaInfo series, TsBlockBuilder builder, String database) {
-    Pair<Map<String, String>, Map<String, String>> tagAndAttribute = series.getTagAndAttribute();
     Pair<String, String> deadbandInfo = MetaUtils.parseDeadbandInfo(series.getSchema().getProps());
     builder.getTimeColumnBuilder().writeLong(0);
     builder.writeNullableText(0, series.getFullPath());
@@ -100,8 +99,8 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
     builder.writeNullableText(3, series.getSchema().getType().toString());
     builder.writeNullableText(4, series.getSchema().getEncodingType().toString());
     builder.writeNullableText(5, series.getSchema().getCompressor().toString());
-    builder.writeNullableText(6, mapToString(tagAndAttribute.left));
-    builder.writeNullableText(7, mapToString(tagAndAttribute.right));
+    builder.writeNullableText(6, mapToString(series.getTags()));
+    builder.writeNullableText(7, mapToString(series.getAttributes()));
     builder.writeNullableText(8, deadbandInfo.left);
     builder.writeNullableText(9, deadbandInfo.right);
     builder.declarePosition();

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionAliasAndTagTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionAliasAndTagTest.java
@@ -22,7 +22,7 @@ package org.apache.iotdb.db.metadata.schemaRegion;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-// todo add alias and tag test
 public class SchemaRegionAliasAndTagTest extends AbstractSchemaRegionTest {
 
   private static final Logger logger = LoggerFactory.getLogger(SchemaRegionAliasAndTagTest.class);
@@ -144,14 +143,15 @@ public class SchemaRegionAliasAndTagTest extends AbstractSchemaRegionTest {
   private void checkAliasAndTagsAndAttributes(
       String fullPath, String alias, Map<String, String> tags, Map<String, String> attributes) {
     try {
-      List<ShowTimeSeriesResult> result =
-          schemaRegion.showTimeseries(
+      List<ITimeSeriesSchemaInfo> result =
+          SchemaRegionTestUtil.showTimeseries(
+              schemaRegion,
               SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(new PartialPath(fullPath)));
       Assert.assertEquals(1, result.size());
-      Assert.assertEquals(fullPath, result.get(0).getPath());
+      Assert.assertEquals(fullPath, result.get(0).getFullPath());
       Assert.assertEquals(alias, result.get(0).getAlias());
-      Assert.assertEquals(tags, result.get(0).getTag());
-      Assert.assertEquals(attributes, result.get(0).getAttribute());
+      Assert.assertEquals(tags, result.get(0).getTags());
+      Assert.assertEquals(attributes, result.get(0).getAttributes());
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
       Assert.fail(e.getMessage());
@@ -160,12 +160,13 @@ public class SchemaRegionAliasAndTagTest extends AbstractSchemaRegionTest {
 
   private void checkAttributes(String fullPath, Map<String, String> attributes) {
     try {
-      List<ShowTimeSeriesResult> result =
-          schemaRegion.showTimeseries(
+      List<ITimeSeriesSchemaInfo> result =
+          SchemaRegionTestUtil.showTimeseries(
+              schemaRegion,
               SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(new PartialPath(fullPath)));
       Assert.assertEquals(1, result.size());
-      Assert.assertEquals(fullPath, result.get(0).getPath());
-      Assert.assertEquals(attributes, result.get(0).getAttribute());
+      Assert.assertEquals(fullPath, result.get(0).getFullPath());
+      Assert.assertEquals(attributes, result.get(0).getAttributes());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -174,12 +175,13 @@ public class SchemaRegionAliasAndTagTest extends AbstractSchemaRegionTest {
 
   private void checkTags(String fullPath, Map<String, String> tags) {
     try {
-      List<ShowTimeSeriesResult> result =
-          schemaRegion.showTimeseries(
+      List<ITimeSeriesSchemaInfo> result =
+          SchemaRegionTestUtil.showTimeseries(
+              schemaRegion,
               SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(new PartialPath(fullPath)));
       Assert.assertEquals(1, result.size());
-      Assert.assertEquals(fullPath, result.get(0).getPath());
-      Assert.assertEquals(tags, result.get(0).getTag());
+      Assert.assertEquals(fullPath, result.get(0).getFullPath());
+      Assert.assertEquals(tags, result.get(0).getTags());
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
       Assert.fail(e.getMessage());

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
@@ -30,7 +30,8 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionRead
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWritePlanFactory;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowNodesResult;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
+import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -618,38 +619,44 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
 
     Assert.assertEquals(
         Collections.emptyList(),
-        schemaRegion.getMatchedDevices(
+        SchemaRegionTestUtil.getMatchedDevices(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowDevicesPlan(new PartialPath("root.laptop.d0"))));
     Assert.assertEquals(
         Collections.singletonList(new ShowDevicesResult("root.laptop.d1", false)),
-        schemaRegion.getMatchedDevices(
+        SchemaRegionTestUtil.getMatchedDevices(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowDevicesPlan(new PartialPath("root.laptop.d1"))));
     Assert.assertEquals(
         Collections.singletonList(new ShowDevicesResult("root.laptop.d2", false)),
-        schemaRegion.getMatchedDevices(
+        SchemaRegionTestUtil.getMatchedDevices(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowDevicesPlan(new PartialPath("root.laptop.d2"))));
     Assert.assertEquals(
         Collections.singletonList(new ShowDevicesResult("root.laptop", false)),
-        schemaRegion.getMatchedDevices(
+        SchemaRegionTestUtil.getMatchedDevices(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowDevicesPlan(new PartialPath("root.laptop"))));
     Assert.assertEquals(
         Collections.singletonList(new ShowDevicesResult("root.laptop", false)),
-        schemaRegion.getMatchedDevices(
+        SchemaRegionTestUtil.getMatchedDevices(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowDevicesPlan(new PartialPath("root.*"))));
 
-    List<ShowDevicesResult> expectedList =
+    List<IDeviceSchemaInfo> expectedList =
         Arrays.asList(
             new ShowDevicesResult("root.laptop", false),
             new ShowDevicesResult("root.laptop.d1", false),
             new ShowDevicesResult("root.laptop.d2", false),
             new ShowDevicesResult("root.laptop.d1.s2", false));
 
-    List<ShowDevicesResult> actualResult =
-        schemaRegion.getMatchedDevices(
+    List<IDeviceSchemaInfo> actualResult =
+        SchemaRegionTestUtil.getMatchedDevices(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowDevicesPlan(new PartialPath("root.**")));
     // Compare hash sets because the order does not matter.
-    HashSet<ShowDevicesResult> expectedHashset = new HashSet<>(expectedList);
-    HashSet<ShowDevicesResult> actualHashset = new HashSet<>(actualResult);
+    HashSet<IDeviceSchemaInfo> expectedHashset = new HashSet<>(expectedList);
+    HashSet<IDeviceSchemaInfo> actualHashset = new HashSet<>(actualResult);
     Assert.assertEquals(expectedHashset, actualHashset);
 
     expectedList =
@@ -658,7 +665,8 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
             new ShowDevicesResult("root.laptop.d2", false));
 
     actualResult =
-        schemaRegion.getMatchedDevices(
+        SchemaRegionTestUtil.getMatchedDevices(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowDevicesPlan(new PartialPath("root.**.d*")));
     // Compare hash sets because the order does not matter.
     expectedHashset = new HashSet<>(expectedList);
@@ -681,8 +689,10 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
             "root.laptop.d2.s2"));
 
     // case 01: all timeseries
-    List<ShowTimeSeriesResult> result =
-        schemaRegion.showTimeseries(
+
+    List<ITimeSeriesSchemaInfo> result =
+        SchemaRegionTestUtil.showTimeseries(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(new PartialPath("root.**")));
     HashSet<String> expectedPathList =
         new HashSet<>(
@@ -697,13 +707,14 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
     Assert.assertEquals(expectedSize, result.size());
     HashSet<String> actualPathList = new HashSet<>();
     for (int index = 0; index < expectedSize; index++) {
-      actualPathList.add(result.get(index).getPath());
+      actualPathList.add(result.get(index).getFullPath());
     }
     Assert.assertEquals(expectedPathList, actualPathList);
 
     // case 02: some timeseries, pattern "root.**.s*"
     result =
-        schemaRegion.showTimeseries(
+        SchemaRegionTestUtil.showTimeseries(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(new PartialPath("root.**.s*")));
     expectedPathList =
         new HashSet<>(
@@ -716,7 +727,7 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
     Assert.assertEquals(expectedSize, result.size());
     actualPathList = new HashSet<>();
     for (int index = 0; index < expectedSize; index++) {
-      actualPathList.add(result.get(index).getPath());
+      actualPathList.add(result.get(index).getFullPath());
     }
     Assert.assertEquals(expectedPathList, actualPathList);
   }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionManagementTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionManagementTest.java
@@ -28,7 +28,8 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.metadata.MetadataConstant;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWritePlanFactory;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
+import org.apache.iotdb.db.metadata.query.info.ISchemaInfo;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -41,6 +42,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,14 +96,16 @@ public class SchemaRegionManagementTest extends AbstractSchemaRegionTest {
 
       schemaRegion.loadSnapshot(snapshotDir);
 
-      List<ShowTimeSeriesResult> result =
-          schemaRegion.showTimeseries(
+      List<ITimeSeriesSchemaInfo> result =
+          SchemaRegionTestUtil.showTimeseries(
+              schemaRegion,
               SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
                   new PartialPath("root.sg.**"), false, "tag-key", "tag-value"));
 
-      ShowTimeSeriesResult seriesResult = result.get(0);
-      Assert.assertEquals(new PartialPath("root.sg.d1.s1").getFullPath(), seriesResult.getPath());
-      Map<String, String> resultTagMap = seriesResult.getTag();
+      ITimeSeriesSchemaInfo seriesResult = result.get(0);
+      Assert.assertEquals(
+          new PartialPath("root.sg.d1.s1").getFullPath(), seriesResult.getFullPath());
+      Map<String, String> resultTagMap = seriesResult.getTags();
       Assert.assertEquals(1, resultTagMap.size());
       Assert.assertEquals("tag-value", resultTagMap.get("tag-key"));
 
@@ -110,24 +114,29 @@ public class SchemaRegionManagementTest extends AbstractSchemaRegionTest {
       ISchemaRegion newSchemaRegion = getSchemaRegion("root.sg", 0);
       newSchemaRegion.loadSnapshot(snapshotDir);
       result =
-          newSchemaRegion.showTimeseries(
+          SchemaRegionTestUtil.showTimeseries(
+              newSchemaRegion,
               SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
                   new PartialPath("root.sg.**"), false, "tag-key", "tag-value"));
 
       seriesResult = result.get(0);
-      Assert.assertEquals(new PartialPath("root.sg.d1.s1").getFullPath(), seriesResult.getPath());
-      resultTagMap = seriesResult.getTag();
+      Assert.assertEquals(
+          new PartialPath("root.sg.d1.s1").getFullPath(), seriesResult.getFullPath());
+      resultTagMap = seriesResult.getTags();
       Assert.assertEquals(1, resultTagMap.size());
       Assert.assertEquals("tag-value", resultTagMap.get("tag-key"));
 
       result =
-          newSchemaRegion.showTimeseries(
+          SchemaRegionTestUtil.showTimeseries(
+              newSchemaRegion,
               SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
                   new PartialPath("root.sg.*.s1"),
                   Collections.singletonMap(template.getId(), template)));
-      result.sort(ShowTimeSeriesResult::compareTo);
-      Assert.assertEquals(new PartialPath("root.sg.d1.s1").getFullPath(), result.get(0).getPath());
-      Assert.assertEquals(new PartialPath("root.sg.d2.s1").getFullPath(), result.get(1).getPath());
+      result.sort(Comparator.comparing(ISchemaInfo::getFullPath));
+      Assert.assertEquals(
+          new PartialPath("root.sg.d1.s1").getFullPath(), result.get(0).getFullPath());
+      Assert.assertEquals(
+          new PartialPath("root.sg.d2.s1").getFullPath(), result.get(1).getFullPath());
 
     } finally {
       config.setSchemaRegionConsensusProtocolClass(schemaRegionConsensusProtocolClass);
@@ -167,8 +176,9 @@ public class SchemaRegionManagementTest extends AbstractSchemaRegionTest {
 
       schemaRegion.loadSnapshot(snapshotDir);
 
-      List<ShowTimeSeriesResult> result =
-          schemaRegion.showTimeseries(
+      List<ITimeSeriesSchemaInfo> result =
+          SchemaRegionTestUtil.showTimeseries(
+              schemaRegion,
               SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
                   new PartialPath("root.sg.**"), false, "tag-key", "tag-value"));
 
@@ -179,7 +189,8 @@ public class SchemaRegionManagementTest extends AbstractSchemaRegionTest {
       ISchemaRegion newSchemaRegion = getSchemaRegion("root.sg", 0);
       newSchemaRegion.loadSnapshot(snapshotDir);
       result =
-          newSchemaRegion.showTimeseries(
+          SchemaRegionTestUtil.showTimeseries(
+              newSchemaRegion,
               SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
                   new PartialPath("root.sg.**"), false, "tag-key", "tag-value"));
 

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
@@ -24,7 +24,8 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWritePlanFactory;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
+import org.apache.iotdb.db.metadata.query.info.ISchemaInfo;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -232,11 +233,12 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
     }
 
     // check show timeseries
-    List<ShowTimeSeriesResult> result =
-        schemaRegion.showTimeseries(
+    List<ITimeSeriesSchemaInfo> result =
+        SchemaRegionTestUtil.showTimeseries(
+            schemaRegion,
             SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
                 new PartialPath("root.**"), templateMap));
-    result.sort(ShowTimeSeriesResult::compareTo);
+    result.sort(Comparator.comparing(ISchemaInfo::getFullPath));
     for (int i = 0; i < result.size(); i++) {
       Assert.assertEquals(expectedTimeseries.get(i), result.get(i).getFullPath());
     }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
@@ -22,6 +22,8 @@ import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWritePlanFactory;
+import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
+import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
 import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
@@ -215,8 +217,7 @@ public class SchemaRegionTestUtil {
   }
 
   public static List<String> getPathsUsingTemplate(
-      ISchemaRegion schemaRegion, PartialPath pathPattern, int templateId)
-      throws MetadataException {
+      ISchemaRegion schemaRegion, PartialPath pathPattern, int templateId) {
     List<String> result = new ArrayList<>();
     try (ISchemaReader<IDeviceSchemaInfo> deviceReader =
         schemaRegion.getDeviceReader(
@@ -232,8 +233,7 @@ public class SchemaRegionTestUtil {
   }
 
   public static List<PartialPath> getNodesListInGivenLevel(
-      ISchemaRegion schemaRegion, PartialPath pathPattern, int nodeLevel, boolean isPrefixMatch)
-      throws MetadataException {
+      ISchemaRegion schemaRegion, PartialPath pathPattern, int nodeLevel, boolean isPrefixMatch) {
     List<PartialPath> result = new ArrayList<>();
     try (ISchemaReader<INodeSchemaInfo> nodeReader =
         schemaRegion.getNodeReader(
@@ -248,7 +248,7 @@ public class SchemaRegionTestUtil {
   }
 
   public static Set<INodeSchemaInfo> getChildNodePathInNextLevel(
-      ISchemaRegion schemaRegion, PartialPath pathPattern) throws MetadataException {
+      ISchemaRegion schemaRegion, PartialPath pathPattern) {
     Set<INodeSchemaInfo> result = new HashSet<>();
     try (ISchemaReader<INodeSchemaInfo> nodeReader =
         schemaRegion.getNodeReader(
@@ -256,6 +256,32 @@ public class SchemaRegionTestUtil {
                 pathPattern.concatNode(ONE_LEVEL_PATH_WILDCARD)))) {
       while (nodeReader.hasNext()) {
         result.add(nodeReader.next());
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+
+  public static List<ITimeSeriesSchemaInfo> showTimeseries(
+      ISchemaRegion schemaRegion, IShowTimeSeriesPlan plan) {
+    List<ITimeSeriesSchemaInfo> result = new ArrayList<>();
+    try (ISchemaReader<ITimeSeriesSchemaInfo> reader = schemaRegion.getTimeSeriesReader(plan)) {
+      while (reader.hasNext()) {
+        result.add(reader.next());
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+
+  public static List<IDeviceSchemaInfo> getMatchedDevices(
+      ISchemaRegion schemaRegion, IShowDevicesPlan plan) {
+    List<IDeviceSchemaInfo> result = new ArrayList<>();
+    try (ISchemaReader<IDeviceSchemaInfo> reader = schemaRegion.getDeviceReader(plan)) {
+      while (reader.hasNext()) {
+        result.add(reader.next());
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperatorTest.java
@@ -44,7 +44,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.common.block.column.BinaryColumn;
 import org.apache.iotdb.tsfile.utils.Binary;
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.junit.Assert;
@@ -181,7 +180,8 @@ public class SchemaQueryScanOperatorTest {
             .thenReturn(
                 new MeasurementSchema(
                     "s" + i, TSDataType.INT32, TSEncoding.PLAIN, CompressionType.UNCOMPRESSED));
-        Mockito.when(timeSeriesSchemaInfo.getTagAndAttribute()).thenReturn(new Pair<>(null, null));
+        Mockito.when(timeSeriesSchemaInfo.getTags()).thenReturn(null);
+        Mockito.when(timeSeriesSchemaInfo.getAttributes()).thenReturn(null);
         showTimeSeriesResults.add(timeSeriesSchemaInfo);
       }
       Iterator<ITimeSeriesSchemaInfo> iterator = showTimeSeriesResults.iterator();


### PR DESCRIPTION
## Description

The current SchemaReader uses the result set returned from the original SchemaRegion to generate an iterator; however, the new Traverser supports the iterator pattern, allowing the SchemaReader to be implemented using an iterative Traverser, avoiding the overhead of repeated traversals.