### PR TITLE
[To rel/1.0][IOTDB-5389] Cause DataNode startup to fail when wal_mode is disabled in IoTConsensus

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -303,6 +303,12 @@ public class IoTDBStartCheck {
         systemProperties.forEach((k, v) -> properties.setProperty(k, v.get()));
         properties.store(outputStream, SYSTEM_PROPERTIES_STRING);
       }
+      if (config.isClusterMode()
+          && config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
+          && config.getWalMode().equals(WALMode.DISABLE)) {
+        throw new ConfigurationException(
+            "Configuring the WALMode as disable is not supported under IoTConsensus");
+      }
     } else {
       // check whether upgrading from <=v0.9
       if (!properties.containsKey(IOTDB_VERSION_STRING)) {


### PR DESCRIPTION
cherry-pick [pull/8798](https://github.com/apache/iotdb/pull/8798)