### PR TITLE
[IOTDB-5398] Handle failure in schema query if there is exception occurs during the iteration

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
@@ -350,7 +350,7 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R>
     this.throwable = e;
   }
 
-  protected Throwable getFailure() {
+  public Throwable getFailure() {
     return throwable;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -999,6 +999,16 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
             collector, showDevicesPlan.getLimit(), showDevicesPlan.getOffset());
     return new ISchemaReader<IDeviceSchemaInfo>() {
       @Override
+      public boolean isSuccess() {
+        return traverser.isSuccess();
+      }
+
+      @Override
+      public Throwable getFailure() {
+        return traverser.getFailure();
+      }
+
+      @Override
       public void close() {
         traverser.close();
       }
@@ -1042,6 +1052,16 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
             collector, showTimeSeriesPlan.getLimit(), showTimeSeriesPlan.getOffset());
     return new ISchemaReader<ITimeSeriesSchemaInfo>() {
       @Override
+      public boolean isSuccess() {
+        return traverser.isSuccess();
+      }
+
+      @Override
+      public Throwable getFailure() {
+        return traverser.getFailure();
+      }
+
+      @Override
       public void close() {
         traverser.close();
       }
@@ -1071,6 +1091,16 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
         };
     collector.setTargetLevel(showNodesPlan.getLevel());
     return new ISchemaReader<INodeSchemaInfo>() {
+      @Override
+      public boolean isSuccess() {
+        return collector.isSuccess();
+      }
+
+      @Override
+      public Throwable getFailure() {
+        return collector.getFailure();
+      }
+
       @Override
       public void close() {
         collector.close();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -883,6 +883,16 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
             collector, showDevicesPlan.getLimit(), showDevicesPlan.getOffset());
     return new ISchemaReader<IDeviceSchemaInfo>() {
       @Override
+      public boolean isSuccess() {
+        return traverser.isSuccess();
+      }
+
+      @Override
+      public Throwable getFailure() {
+        return traverser.getFailure();
+      }
+
+      @Override
       public void close() {
         traverser.close();
       }
@@ -925,6 +935,16 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
             collector, showTimeSeriesPlan.getLimit(), showTimeSeriesPlan.getOffset());
     return new ISchemaReader<ITimeSeriesSchemaInfo>() {
       @Override
+      public boolean isSuccess() {
+        return traverser.isSuccess();
+      }
+
+      @Override
+      public Throwable getFailure() {
+        return traverser.getFailure();
+      }
+
+      @Override
       public void close() {
         traverser.close();
       }
@@ -955,6 +975,16 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
     collector.setTargetLevel(showNodesPlan.getLevel());
 
     return new ISchemaReader<INodeSchemaInfo>() {
+      @Override
+      public boolean isSuccess() {
+        return collector.isSuccess();
+      }
+
+      @Override
+      public Throwable getFailure() {
+        return collector.getFailure();
+      }
+
       @Override
       public void close() {
         collector.close();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/TraverserWithLimitOffsetWrapper.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/TraverserWithLimitOffsetWrapper.java
@@ -74,6 +74,16 @@ public class TraverserWithLimitOffsetWrapper<R> extends Traverser<R> {
   }
 
   @Override
+  public boolean isSuccess() {
+    return traverser.isSuccess();
+  }
+
+  @Override
+  public Throwable getFailure() {
+    return traverser.getFailure();
+  }
+
+  @Override
   protected boolean shouldVisitSubtreeOfInternalMatchedNode(IMNode node) {
     return false;
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/query/reader/ISchemaReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/query/reader/ISchemaReader.java
@@ -23,4 +23,18 @@ import org.apache.iotdb.db.metadata.query.info.ISchemaInfo;
 
 import java.util.Iterator;
 
-public interface ISchemaReader<T extends ISchemaInfo> extends Iterator<T>, AutoCloseable {}
+public interface ISchemaReader<T extends ISchemaInfo> extends Iterator<T>, AutoCloseable {
+  /**
+   * Determines if the iteration is successful when it completes.
+   *
+   * @return False if an exception occurs during the iteration. Otherwise, return true.
+   */
+  boolean isSuccess();
+
+  /**
+   * Get throwable if there is exception occurs during the iteration.
+   *
+   * @return Throwable, null if no exception.
+   */
+  Throwable getFailure();
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -1191,6 +1191,16 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       Iterator<ShowTimeSeriesResult> iterator = showTimeSeriesResultList.iterator();
       return new ISchemaReader<ITimeSeriesSchemaInfo>() {
         @Override
+        public boolean isSuccess() {
+          return true;
+        }
+
+        @Override
+        public Throwable getFailure() {
+          return null;
+        }
+
+        @Override
         public void close() {}
 
         @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -1274,6 +1274,16 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
       Iterator<ShowTimeSeriesResult> iterator = showTimeSeriesResultList.iterator();
       return new ISchemaReader<ITimeSeriesSchemaInfo>() {
         @Override
+        public boolean isSuccess() {
+          return true;
+        }
+
+        @Override
+        public Throwable getFailure() {
+          return null;
+        }
+
+        @Override
         public void close() {}
 
         @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelScanOperator.java
@@ -125,6 +125,9 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
         break;
       }
     }
+    if (!schemaReader.isSuccess()) {
+      throw new RuntimeException(schemaReader.getFailure());
+    }
 
     TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(OUTPUT_DATA_TYPES);
     for (Map.Entry<PartialPath, Long> entry : countMap.entrySet()) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperator.java
@@ -83,6 +83,9 @@ public class SchemaCountOperator<T extends ISchemaInfo> implements SourceOperato
       schemaReader.next();
       count++;
     }
+    if (!schemaReader.isSuccess()) {
+      throw new RuntimeException(schemaReader.getFailure());
+    }
 
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
     tsBlockBuilder.getColumnBuilder(0).writeLong(count);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
@@ -139,6 +139,9 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
         break;
       }
     }
+    if (!schemaReader.isSuccess()) {
+      throw new RuntimeException(schemaReader.getFailure());
+    }
     return tsBlockBuilder.build();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
@@ -75,6 +75,7 @@ public class PathsUsingTemplateSource implements ISchemaSource<IDeviceSchemaInfo
         Iterator<PartialPath> pathPatternIterator, ISchemaRegion schemaRegion) {
       this.pathPatternIterator = pathPatternIterator;
       this.schemaRegion = schemaRegion;
+      this.throwable = null;
     }
 
     @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
@@ -114,5 +114,15 @@ public class PathsUsingTemplateSource implements ISchemaSource<IDeviceSchemaInfo
     public IDeviceSchemaInfo next() {
       return currentDeviceReader.next();
     }
+
+    @Override
+    public boolean isSuccess() {
+      return currentDeviceReader.isSuccess();
+    }
+
+    @Override
+    public Throwable getFailure() {
+      return currentDeviceReader.getFailure();
+    }
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelMergeOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelMergeOperatorTest.java
@@ -158,6 +158,16 @@ public class CountGroupByLevelMergeOperatorTest {
     Iterator<ITimeSeriesSchemaInfo> iterator = timeSeriesSchemaInfoList.iterator();
     return new ISchemaReader<ITimeSeriesSchemaInfo>() {
       @Override
+      public boolean isSuccess() {
+        return true;
+      }
+
+      @Override
+      public Throwable getFailure() {
+        return null;
+      }
+
+      @Override
       public void close() throws Exception {}
 
       @Override

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelMergeOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelMergeOperatorTest.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
-import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
@@ -49,8 +48,10 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.mpp.execution.operator.schema.SchemaOperatorTestUtil.EXCEPTION_MESSAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -82,14 +83,14 @@ public class CountGroupByLevelMergeOperatorTest {
               planNodeId,
               driverContext.getOperatorContexts().get(0),
               2,
-              mockSchemaSource(schemaRegion, new PartialPath(OPERATOR_TEST_SG + ".device2")));
+              mockSchemaSource(schemaRegion, new PartialPath(OPERATOR_TEST_SG + ".device2"), true));
 
       CountGroupByLevelScanOperator<ITimeSeriesSchemaInfo> timeSeriesCountOperator2 =
           new CountGroupByLevelScanOperator<>(
               planNodeId,
               driverContext.getOperatorContexts().get(0),
               2,
-              mockSchemaSource(schemaRegion, new PartialPath(OPERATOR_TEST_SG)));
+              mockSchemaSource(schemaRegion, new PartialPath(OPERATOR_TEST_SG), true));
 
       CountGroupByLevelMergeOperator mergeOperator =
           new CountGroupByLevelMergeOperator(
@@ -132,21 +133,80 @@ public class CountGroupByLevelMergeOperatorTest {
     }
   }
 
+  @Test
+  public void testCountScanOperator() {
+    ExecutorService instanceNotificationExecutor =
+        IoTDBThreadPoolFactory.newFixedThreadPool(1, "test-instance-notification");
+    try {
+      QueryId queryId = new QueryId("stub_query");
+      FragmentInstanceId instanceId =
+          new FragmentInstanceId(new PlanFragmentId(queryId, 0), "stub-instance");
+      FragmentInstanceStateMachine stateMachine =
+          new FragmentInstanceStateMachine(instanceId, instanceNotificationExecutor);
+      FragmentInstanceContext fragmentInstanceContext =
+          createFragmentInstanceContext(instanceId, stateMachine);
+      DriverContext driverContext = new DriverContext(fragmentInstanceContext, 0);
+      PlanNodeId planNodeId = queryId.genPlanNodeId();
+      OperatorContext operatorContext =
+          driverContext.addOperatorContext(
+              1, planNodeId, CountGroupByLevelScanOperator.class.getSimpleName());
+      ISchemaRegion schemaRegion = Mockito.mock(ISchemaRegion.class);
+      operatorContext.setDriverContext(
+          new SchemaDriverContext(fragmentInstanceContext, schemaRegion));
+      CountGroupByLevelScanOperator<ITimeSeriesSchemaInfo> timeSeriesCountOperator =
+          new CountGroupByLevelScanOperator<>(
+              planNodeId,
+              driverContext.getOperatorContexts().get(0),
+              2,
+              mockSchemaSource(schemaRegion, new PartialPath(OPERATOR_TEST_SG), true));
+      TsBlock tsBlock = null;
+      while (timeSeriesCountOperator.hasNext()) {
+        tsBlock = timeSeriesCountOperator.next();
+        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
+          assertEquals(1, tsBlock.getColumn(1).getLong(i));
+        }
+      }
+      assertNotNull(tsBlock);
+
+      // Assert failure if exception occurs
+      CountGroupByLevelScanOperator<ITimeSeriesSchemaInfo> timeSeriesCountOperatorFailure =
+          new CountGroupByLevelScanOperator<>(
+              planNodeId,
+              driverContext.getOperatorContexts().get(0),
+              2,
+              mockSchemaSource(schemaRegion, new PartialPath(OPERATOR_TEST_SG), false));
+      try {
+        while (timeSeriesCountOperatorFailure.hasNext()) {
+          timeSeriesCountOperatorFailure.next();
+        }
+      } catch (RuntimeException e) {
+        Assert.assertTrue(e.getMessage().contains(EXCEPTION_MESSAGE));
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail();
+    } finally {
+      instanceNotificationExecutor.shutdown();
+    }
+  }
+
   private ISchemaSource<ITimeSeriesSchemaInfo> mockSchemaSource(
-      ISchemaRegion schemaRegion, PartialPath path) throws Exception {
+      ISchemaRegion schemaRegion, PartialPath path, boolean success) throws Exception {
     ISchemaSource<ITimeSeriesSchemaInfo> schemaSource = Mockito.mock(ISchemaSource.class);
     if (path.equals(new PartialPath(OPERATOR_TEST_SG + ".device2"))) {
-      ISchemaReader<ITimeSeriesSchemaInfo> schemaReader =
-          mockSchemaReader(10, OPERATOR_TEST_SG + ".device2");
-      Mockito.when(schemaSource.getSchemaReader(schemaRegion)).thenReturn(schemaReader);
+      mockSchemaReader(schemaSource, schemaRegion, 10, OPERATOR_TEST_SG + ".device2", success);
     } else if (path.equals(new PartialPath(OPERATOR_TEST_SG))) {
-      ISchemaReader<ITimeSeriesSchemaInfo> schemaReader = mockSchemaReader(2000, OPERATOR_TEST_SG);
-      Mockito.when(schemaSource.getSchemaReader(schemaRegion)).thenReturn(schemaReader);
+      mockSchemaReader(schemaSource, schemaRegion, 2000, OPERATOR_TEST_SG, success);
     }
     return schemaSource;
   }
 
-  private ISchemaReader<ITimeSeriesSchemaInfo> mockSchemaReader(int expectedNum, String prefix)
+  private void mockSchemaReader(
+      ISchemaSource<ITimeSeriesSchemaInfo> schemaSource,
+      ISchemaRegion schemaRegion,
+      int expectedNum,
+      String prefix,
+      boolean success)
       throws IllegalPathException {
     List<ITimeSeriesSchemaInfo> timeSeriesSchemaInfoList = new ArrayList<>(expectedNum);
     for (int i = 0; i < expectedNum; i++) {
@@ -156,29 +216,6 @@ public class CountGroupByLevelMergeOperatorTest {
       timeSeriesSchemaInfoList.add(timeSeriesSchemaInfo);
     }
     Iterator<ITimeSeriesSchemaInfo> iterator = timeSeriesSchemaInfoList.iterator();
-    return new ISchemaReader<ITimeSeriesSchemaInfo>() {
-      @Override
-      public boolean isSuccess() {
-        return true;
-      }
-
-      @Override
-      public Throwable getFailure() {
-        return null;
-      }
-
-      @Override
-      public void close() throws Exception {}
-
-      @Override
-      public boolean hasNext() {
-        return iterator.hasNext();
-      }
-
-      @Override
-      public ITimeSeriesSchemaInfo next() {
-        return iterator.next();
-      }
-    };
+    SchemaOperatorTestUtil.mockGetSchemaReader(schemaSource, iterator, schemaRegion, success);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperatorTest.java
@@ -85,7 +85,17 @@ public class SchemaCountOperatorTest {
           .thenReturn(
               new ISchemaReader() {
                 @Override
-                public void close() throws Exception {}
+                public boolean isSuccess() {
+                  return true;
+                }
+
+                @Override
+                public Throwable getFailure() {
+                  return null;
+                }
+
+                @Override
+                public void close() {}
 
                 @Override
                 public boolean hasNext() {
@@ -140,7 +150,7 @@ public class SchemaCountOperatorTest {
               driverContext.getOperatorContexts().get(0),
               2,
               mockSchemaSource(schemaRegion));
-      TsBlock tsBlock = null;
+      TsBlock tsBlock;
       List<TsBlock> tsBlockList = collectResult(timeSeriesCountOperator);
       assertEquals(1, tsBlockList.size());
       tsBlock = tsBlockList.get(0);
@@ -203,7 +213,17 @@ public class SchemaCountOperatorTest {
     Iterator<ITimeSeriesSchemaInfo> iterator = timeSeriesSchemaInfoList.iterator();
     return new ISchemaReader<ITimeSeriesSchemaInfo>() {
       @Override
-      public void close() throws Exception {}
+      public boolean isSuccess() {
+        return true;
+      }
+
+      @Override
+      public Throwable getFailure() {
+        return null;
+      }
+
+      @Override
+      public void close() {}
 
       @Override
       public boolean hasNext() {

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperatorTest.java
@@ -19,11 +19,9 @@
 package org.apache.iotdb.db.mpp.execution.operator.schema;
 
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
-import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.query.info.ISchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
-import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
@@ -37,6 +35,7 @@ import org.apache.iotdb.db.mpp.execution.operator.schema.source.ISchemaSource;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -46,6 +45,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.mpp.execution.operator.schema.SchemaOperatorTestUtil.EXCEPTION_MESSAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -74,39 +74,14 @@ public class SchemaCountOperatorTest {
               1, planNodeId, SchemaCountOperator.class.getSimpleName());
       operatorContext.setDriverContext(
           new SchemaDriverContext(fragmentInstanceContext, schemaRegion));
-      ISchemaSource<?> schemaSource = Mockito.mock(ISchemaSource.class);
+      ISchemaSource<ISchemaInfo> schemaSource = Mockito.mock(ISchemaSource.class);
 
       List<ISchemaInfo> schemaInfoList = new ArrayList<>(10);
       for (int i = 0; i < 10; i++) {
         schemaInfoList.add(Mockito.mock(ISchemaInfo.class));
       }
-      Iterator<ISchemaInfo> iterator = schemaInfoList.iterator();
-      Mockito.when(schemaSource.getSchemaReader(schemaRegion))
-          .thenReturn(
-              new ISchemaReader() {
-                @Override
-                public boolean isSuccess() {
-                  return true;
-                }
-
-                @Override
-                public Throwable getFailure() {
-                  return null;
-                }
-
-                @Override
-                public void close() {}
-
-                @Override
-                public boolean hasNext() {
-                  return iterator.hasNext();
-                }
-
-                @Override
-                public ISchemaInfo next() {
-                  return iterator.next();
-                }
-              });
+      SchemaOperatorTestUtil.mockGetSchemaReader(
+          schemaSource, schemaInfoList.iterator(), schemaRegion, true);
 
       SchemaCountOperator<?> schemaCountOperator =
           new SchemaCountOperator<>(
@@ -117,7 +92,22 @@ public class SchemaCountOperatorTest {
         tsBlock = schemaCountOperator.next();
       }
       assertNotNull(tsBlock);
-      assertEquals(tsBlock.getColumn(0).getLong(0), 10);
+      assertEquals(10, tsBlock.getColumn(0).getLong(0));
+
+      // Assert failure if exception occurs
+      SchemaOperatorTestUtil.mockGetSchemaReader(
+          schemaSource, schemaInfoList.iterator(), schemaRegion, false);
+      try {
+        SchemaCountOperator<?> schemaCountOperatorFailure =
+            new SchemaCountOperator<>(
+                planNodeId, driverContext.getOperatorContexts().get(0), schemaSource);
+        while (schemaCountOperatorFailure.hasNext()) {
+          schemaCountOperatorFailure.next();
+        }
+        Assert.fail();
+      } catch (RuntimeException e) {
+        Assert.assertTrue(e.getMessage().contains(EXCEPTION_MESSAGE));
+      }
     } finally {
       instanceNotificationExecutor.shutdown();
     }
@@ -149,7 +139,7 @@ public class SchemaCountOperatorTest {
               planNodeId,
               driverContext.getOperatorContexts().get(0),
               2,
-              mockSchemaSource(schemaRegion));
+              mockSchemaSource(schemaRegion, true));
       TsBlock tsBlock;
       List<TsBlock> tsBlockList = collectResult(timeSeriesCountOperator);
       assertEquals(1, tsBlockList.size());
@@ -166,12 +156,26 @@ public class SchemaCountOperatorTest {
               planNodeId,
               driverContext.getOperatorContexts().get(0),
               1,
-              mockSchemaSource(schemaRegion));
+              mockSchemaSource(schemaRegion, true));
       tsBlockList = collectResult(timeSeriesCountOperator2);
       assertEquals(1, tsBlockList.size());
       tsBlock = tsBlockList.get(0);
 
       assertEquals(100, tsBlock.getColumn(1).getLong(0));
+
+      // Assert failure if exception occurs
+      try {
+        CountGroupByLevelScanOperator<ITimeSeriesSchemaInfo> timeSeriesCountOperatorFailure =
+            new CountGroupByLevelScanOperator<>(
+                planNodeId,
+                driverContext.getOperatorContexts().get(0),
+                1,
+                mockSchemaSource(schemaRegion, false));
+        collectResult(timeSeriesCountOperatorFailure);
+        Assert.fail();
+      } catch (RuntimeException e) {
+        Assert.assertTrue(e.getMessage().contains(EXCEPTION_MESSAGE));
+      }
     } catch (Exception e) {
       e.printStackTrace();
       fail();
@@ -192,15 +196,9 @@ public class SchemaCountOperatorTest {
     return tsBlocks;
   }
 
-  private ISchemaSource<ITimeSeriesSchemaInfo> mockSchemaSource(ISchemaRegion schemaRegion)
-      throws Exception {
+  private ISchemaSource<ITimeSeriesSchemaInfo> mockSchemaSource(
+      ISchemaRegion schemaRegion, boolean success) throws Exception {
     ISchemaSource<ITimeSeriesSchemaInfo> schemaSource = Mockito.mock(ISchemaSource.class);
-    ISchemaReader<ITimeSeriesSchemaInfo> schemaReader = mockSchemaReader();
-    Mockito.when(schemaSource.getSchemaReader(schemaRegion)).thenReturn(schemaReader);
-    return schemaSource;
-  }
-
-  private ISchemaReader<ITimeSeriesSchemaInfo> mockSchemaReader() throws IllegalPathException {
     List<ITimeSeriesSchemaInfo> timeSeriesSchemaInfoList = new ArrayList<>(1000);
     for (int i = 0; i < 10; i++) {
       for (int j = 0; j < 10; j++) {
@@ -211,29 +209,7 @@ public class SchemaCountOperatorTest {
       }
     }
     Iterator<ITimeSeriesSchemaInfo> iterator = timeSeriesSchemaInfoList.iterator();
-    return new ISchemaReader<ITimeSeriesSchemaInfo>() {
-      @Override
-      public boolean isSuccess() {
-        return true;
-      }
-
-      @Override
-      public Throwable getFailure() {
-        return null;
-      }
-
-      @Override
-      public void close() {}
-
-      @Override
-      public boolean hasNext() {
-        return iterator.hasNext();
-      }
-
-      @Override
-      public ITimeSeriesSchemaInfo next() {
-        return iterator.next();
-      }
-    };
+    SchemaOperatorTestUtil.mockGetSchemaReader(schemaSource, iterator, schemaRegion, success);
+    return schemaSource;
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaOperatorTestUtil.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaOperatorTestUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.mpp.execution.operator.schema;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.db.metadata.query.info.ISchemaInfo;
+import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
+import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
+import org.apache.iotdb.db.mpp.execution.operator.schema.source.ISchemaSource;
+
+import org.mockito.Mockito;
+
+import java.util.Iterator;
+
+public class SchemaOperatorTestUtil {
+  public static final String EXCEPTION_MESSAGE = "ExceptionMessage";
+
+  public static <T extends ISchemaInfo> void mockGetSchemaReader(
+      ISchemaSource<T> schemaSource,
+      Iterator<T> iterator,
+      ISchemaRegion schemaRegion,
+      boolean isSuccess) {
+    Mockito.when(schemaSource.getSchemaReader(schemaRegion))
+        .thenReturn(
+            new ISchemaReader<T>() {
+              @Override
+              public boolean isSuccess() {
+                return isSuccess;
+              }
+
+              @Override
+              public Throwable getFailure() {
+                return isSuccess ? null : new MetadataException(EXCEPTION_MESSAGE);
+              }
+
+              @Override
+              public void close() {}
+
+              @Override
+              public boolean hasNext() {
+                return iterator.hasNext();
+              }
+
+              @Override
+              public T next() {
+                return iterator.next();
+              }
+            });
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperatorTest.java
@@ -97,6 +97,16 @@ public class SchemaQueryScanOperatorTest {
           .thenReturn(
               new ISchemaReader<IDeviceSchemaInfo>() {
                 @Override
+                public boolean isSuccess() {
+                  return true;
+                }
+
+                @Override
+                public Throwable getFailure() {
+                  return null;
+                }
+
+                @Override
                 public void close() throws Exception {}
 
                 @Override
@@ -197,6 +207,16 @@ public class SchemaQueryScanOperatorTest {
       Mockito.when(timeSeriesSchemaSource.getSchemaReader(schemaRegion))
           .thenReturn(
               new ISchemaReader<ITimeSeriesSchemaInfo>() {
+                @Override
+                public boolean isSuccess() {
+                  return true;
+                }
+
+                @Override
+                public Throwable getFailure() {
+                  return null;
+                }
+
                 @Override
                 public void close() throws Exception {}
 

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperatorTest.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
-import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
@@ -52,11 +51,11 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.mpp.execution.operator.schema.SchemaOperatorTestUtil.EXCEPTION_MESSAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -88,44 +87,22 @@ public class SchemaQueryScanOperatorTest {
       Mockito.when(deviceSchemaInfo.getFullPath())
           .thenReturn(META_SCAN_OPERATOR_TEST_SG + ".device0");
       Mockito.when(deviceSchemaInfo.isAligned()).thenReturn(false);
-      Iterator<IDeviceSchemaInfo> iterator = Collections.singletonList(deviceSchemaInfo).iterator();
       operatorContext.setDriverContext(
           new SchemaDriverContext(fragmentInstanceContext, schemaRegion));
       ISchemaSource<IDeviceSchemaInfo> deviceSchemaSource =
           SchemaSourceFactory.getDeviceSchemaSource(partialPath, false, 10, 0, true);
-      Mockito.when(deviceSchemaSource.getSchemaReader(schemaRegion))
-          .thenReturn(
-              new ISchemaReader<IDeviceSchemaInfo>() {
-                @Override
-                public boolean isSuccess() {
-                  return true;
-                }
-
-                @Override
-                public Throwable getFailure() {
-                  return null;
-                }
-
-                @Override
-                public void close() throws Exception {}
-
-                @Override
-                public boolean hasNext() {
-                  return iterator.hasNext();
-                }
-
-                @Override
-                public IDeviceSchemaInfo next() {
-                  return iterator.next();
-                }
-              });
-
+      SchemaOperatorTestUtil.mockGetSchemaReader(
+          deviceSchemaSource,
+          Collections.singletonList(deviceSchemaInfo).iterator(),
+          schemaRegion,
+          true);
+      //
       List<ColumnHeader> columns = deviceSchemaSource.getInfoQueryColumnHeaders();
 
       SchemaQueryScanOperator<IDeviceSchemaInfo> devicesSchemaScanOperator =
           new SchemaQueryScanOperator<>(
               planNodeId, driverContext.getOperatorContexts().get(0), deviceSchemaSource);
-
+      //
       while (devicesSchemaScanOperator.hasNext()) {
         TsBlock tsBlock = devicesSchemaScanOperator.next();
         assertEquals(3, tsBlock.getValueColumnCount());
@@ -152,6 +129,23 @@ public class SchemaQueryScanOperatorTest {
             }
           }
         }
+      }
+      // Assert failure if exception occurs
+      SchemaOperatorTestUtil.mockGetSchemaReader(
+          deviceSchemaSource,
+          Collections.singletonList(deviceSchemaInfo).iterator(),
+          schemaRegion,
+          false);
+      try {
+        SchemaQueryScanOperator<IDeviceSchemaInfo> devicesSchemaScanOperatorFailure =
+            new SchemaQueryScanOperator<>(
+                planNodeId, driverContext.getOperatorContexts().get(0), deviceSchemaSource);
+        while (devicesSchemaScanOperatorFailure.hasNext()) {
+          devicesSchemaScanOperatorFailure.next();
+        }
+        Assert.fail();
+      } catch (RuntimeException e) {
+        Assert.assertTrue(e.getMessage().contains(EXCEPTION_MESSAGE));
       }
     } catch (MetadataException e) {
       e.printStackTrace();
@@ -194,7 +188,6 @@ public class SchemaQueryScanOperatorTest {
         Mockito.when(timeSeriesSchemaInfo.getAttributes()).thenReturn(null);
         showTimeSeriesResults.add(timeSeriesSchemaInfo);
       }
-      Iterator<ITimeSeriesSchemaInfo> iterator = showTimeSeriesResults.iterator();
 
       ISchemaRegion schemaRegion = Mockito.mock(ISchemaRegion.class);
       Mockito.when(schemaRegion.getStorageGroupFullPath()).thenReturn(META_SCAN_OPERATOR_TEST_SG);
@@ -204,32 +197,8 @@ public class SchemaQueryScanOperatorTest {
       ISchemaSource<ITimeSeriesSchemaInfo> timeSeriesSchemaSource =
           SchemaSourceFactory.getTimeSeriesSchemaSource(
               partialPath, false, 10, 0, null, null, false, Collections.emptyMap());
-      Mockito.when(timeSeriesSchemaSource.getSchemaReader(schemaRegion))
-          .thenReturn(
-              new ISchemaReader<ITimeSeriesSchemaInfo>() {
-                @Override
-                public boolean isSuccess() {
-                  return true;
-                }
-
-                @Override
-                public Throwable getFailure() {
-                  return null;
-                }
-
-                @Override
-                public void close() throws Exception {}
-
-                @Override
-                public boolean hasNext() {
-                  return iterator.hasNext();
-                }
-
-                @Override
-                public ITimeSeriesSchemaInfo next() {
-                  return iterator.next();
-                }
-              });
+      SchemaOperatorTestUtil.mockGetSchemaReader(
+          timeSeriesSchemaSource, showTimeSeriesResults.iterator(), schemaRegion, true);
 
       SchemaQueryScanOperator<ITimeSeriesSchemaInfo> timeSeriesMetaScanOperator =
           new SchemaQueryScanOperator<>(
@@ -273,6 +242,20 @@ public class SchemaQueryScanOperatorTest {
             }
           }
         }
+      }
+      // Assert failure if exception occurs
+      SchemaOperatorTestUtil.mockGetSchemaReader(
+          timeSeriesSchemaSource, showTimeSeriesResults.iterator(), schemaRegion, false);
+      try {
+        SchemaQueryScanOperator<ITimeSeriesSchemaInfo> timeSeriesMetaScanOperatorFailure =
+            new SchemaQueryScanOperator<>(
+                planNodeId, driverContext.getOperatorContexts().get(0), timeSeriesSchemaSource);
+        while (timeSeriesMetaScanOperatorFailure.hasNext()) {
+          timeSeriesMetaScanOperatorFailure.next();
+        }
+        Assert.fail();
+      } catch (RuntimeException e) {
+        Assert.assertTrue(e.getMessage().contains(EXCEPTION_MESSAGE));
       }
     } catch (MetadataException e) {
       e.printStackTrace();


### PR DESCRIPTION
## Description

* Handle failure in schema query if there is exception occurs during the iteration.
* Add UT to mock exception and check whether Operator throws runtime exception correctlly.