### PR TITLE
[IOTDB-5390] Keep mqtt_host same with rpc_address

### DIFF
--- a/docs/UserGuide/API/Programming-MQTT.md
+++ b/docs/UserGuide/API/Programming-MQTT.md
@@ -66,7 +66,7 @@ Configurations are as follows:
 | NAME        | DESCRIPTION           | DEFAULT  |
 | ------------- |:-------------:|:------:|
 | enable_mqtt_service      | whether to enable the mqtt service | false |
-| mqtt_host      | the mqtt service binding host | 0.0.0.0 |
+| mqtt_host      | the mqtt service binding host | 127.0.0.1 |
 | mqtt_port      | the mqtt service binding port    |   1883 |
 | mqtt_handler_pool_size | the handler pool size for handing the mqtt messages      |    1 |
 | mqtt_payload_formatter | the mqtt message payload formatter     |    json |

--- a/docs/zh/UserGuide/API/Programming-MQTT.md
+++ b/docs/zh/UserGuide/API/Programming-MQTT.md
@@ -67,7 +67,7 @@ MQTT 主题与 IoTDB 时间序列相对应。
 | 名称      | 描述         | 默认 |
 | ------------- |:-------------:|:------:|
 | enable_mqtt_service      | 是否启用 mqtt 服务 | false |
-| mqtt_host      | mqtt 服务绑定主机 | 0.0.0.0 |
+| mqtt_host      | mqtt 服务绑定主机 | 127.0.0.1 |
 | mqtt_port      | mqtt 服务绑定端口 |   1883 |
 | mqtt_handler_pool_size | 处理 mqtt 消息的处理程序池大小 |    1 |
 | mqtt_payload_formatter | mqtt 消息有效负载格式化程序 |    json |

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -1006,7 +1006,7 @@ cluster_name=defaultCluster
 
 # the mqtt service binding host.
 # Datatype: String
-# mqtt_host=0.0.0.0
+# mqtt_host=127.0.0.1
 
 # the mqtt service binding port.
 # Datatype: int

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1291,6 +1291,11 @@ public class IoTDBDescriptor {
     if (properties.getProperty(IoTDBConstant.MQTT_HOST_NAME) != null) {
       conf.setMqttHost(properties.getProperty(IoTDBConstant.MQTT_HOST_NAME));
     }
+    else {
+      logger.info("MQTT host is not configured, will use dn_rpc_address.");
+      conf.setMqttHost(
+          properties.getProperty(IoTDBConstant.DN_RPC_ADDRESS, conf.getRpcAddress().trim()));
+    }
 
     if (properties.getProperty(IoTDBConstant.MQTT_PORT_NAME) != null) {
       conf.setMqttPort(Integer.parseInt(properties.getProperty(IoTDBConstant.MQTT_PORT_NAME)));

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1290,8 +1290,7 @@ public class IoTDBDescriptor {
 
     if (properties.getProperty(IoTDBConstant.MQTT_HOST_NAME) != null) {
       conf.setMqttHost(properties.getProperty(IoTDBConstant.MQTT_HOST_NAME));
-    }
-    else {
+    } else {
       logger.info("MQTT host is not configured, will use dn_rpc_address.");
       conf.setMqttHost(
           properties.getProperty(IoTDBConstant.DN_RPC_ADDRESS, conf.getRpcAddress().trim()));


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/IOTDB-5390

Set the default mqtt host to be the same as dn_rpc_address, so the mqtt client on other devices can connect to iotdb without setting the mqtt_host config.