### PR TITLE
Fix an issue regarding to data partition update

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/cache/PartitionCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/cache/PartitionCache.java
@@ -749,9 +749,9 @@ public class PartitionCache {
         String storageGroupName = entry1.getKey();
         if (null != storageGroupName) {
           DataPartitionTable result = dataPartitionCache.getIfPresent(storageGroupName);
-          if (null == result) {
+          boolean needToUpdateCache = (null == result);
+          if (needToUpdateCache) {
             result = new DataPartitionTable();
-            dataPartitionCache.put(storageGroupName, result);
           }
           Map<TSeriesPartitionSlot, SeriesPartitionTable>
               seriesPartitionSlotSeriesPartitionTableMap = result.getDataPartitionMap();
@@ -774,6 +774,9 @@ public class PartitionCache {
                 result3.putAll(entry2.getValue());
               }
             }
+          }
+          if (needToUpdateCache) {
+            dataPartitionCache.put(storageGroupName, result);
           }
         }
       }


### PR DESCRIPTION
## Description
The `dataPartitionCache` is a multiple level data structure. Its value is also a collection which may need to be updated during maintaining the cache. 
If we put the value into the Cache at the beginning without finishing its value's maintenance, the subsequent request may fetch an incomplete data partition result, which may lead to an error.

The error message is like:
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/18027703/211971695-a87cf743-7bd8-4844-828b-39e7ffe7e2de.png">
