### PR TITLE
[IOTDB-5414] Timeseries with alias deleted success but can still be queried by alias

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -523,7 +523,7 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
     // delete the last node of path
     store.deleteChild(parent, path.getMeasurement());
     if (deletedNode.getAlias() != null) {
-      parent.addAlias(deletedNode.getAlias(), deletedNode);
+      parent.deleteAliasChild(deletedNode.getAlias());
     }
     return new Pair<>(deleteEmptyInternalMNodeAndReturnEmptyStorageGroup(parent), deletedNode);
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -466,7 +466,7 @@ public class MTreeBelowSGMemoryImpl implements IMTreeBelowSG {
     // delete the last node of path
     store.deleteChild(parent, path.getMeasurement());
     if (deletedNode.getAlias() != null) {
-      parent.addAlias(deletedNode.getAlias(), deletedNode);
+      parent.deleteAliasChild(deletedNode.getAlias());
     }
     return new Pair<>(deleteEmptyInternalMNodeAndReturnEmptyStorageGroup(parent), deletedNode);
   }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionAliasAndTagTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionAliasAndTagTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.metadata.schemaRegion;
 
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
@@ -521,6 +522,34 @@ public class SchemaRegionAliasAndTagTest extends AbstractSchemaRegionTest {
               put("newTag1", "t1");
             }
           });
+    } catch (Exception e) {
+      logger.error(e.getMessage(), e);
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testDeleteAndQueryByAlias() {
+    try {
+      prepareTimeseries();
+      List<ITimeSeriesSchemaInfo> result =
+          SchemaRegionTestUtil.showTimeseries(
+              schemaRegion,
+              SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
+                  new PartialPath("root.sg.wf01.wt01.v1.temp")));
+      Assert.assertEquals(1, result.size());
+      // delete timeseries
+      PathPatternTree patternTree = new PathPatternTree();
+      patternTree.appendFullPath(new PartialPath("root.sg.wf01.wt01.v1.temp"));
+      patternTree.constructTree();
+      Assert.assertTrue(schemaRegion.constructSchemaBlackList(patternTree) >= 1);
+      schemaRegion.deleteTimeseriesInBlackList(patternTree);
+      result =
+          SchemaRegionTestUtil.showTimeseries(
+              schemaRegion,
+              SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
+                  new PartialPath("root.sg.wf01.wt01.v1.temp")));
+      Assert.assertEquals(0, result.size());
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
       Assert.fail(e.getMessage());


### PR DESCRIPTION
## Description

* Cause by delete alias child incorrectly.
* Fix and add UT.

Reproduce Step:
```
IoTDB> create timeseries root.turbine.d1.s1(temprature) with datatype=FLOAT, encoding=RLE, compression=SNAPPY
Msg: The statement is executed successfully.
IoTDB> create timeseries root.turbine.d1.s2 with datatype=FLOAT, encoding=RLE, compression=SNAPPY
Msg: The statement is executed successfully.
IoTDB> SHOW TIMESERIES root.**
+------------------+----------+------------+--------+--------+-----------+----+----------+--------+------------------+
|        Timeseries|     Alias|    Database|DataType|Encoding|Compression|Tags|Attributes|Deadband|DeadbandParameters|
+------------------+----------+------------+--------+--------+-----------+----+----------+--------+------------------+
|root.turbine.d1.s1|temprature|root.turbine|   FLOAT|     RLE|     SNAPPY|null|      null|    null|              null|
|root.turbine.d1.s2|      null|root.turbine|   FLOAT|     RLE|     SNAPPY|null|      null|    null|              null|
+------------------+----------+------------+--------+--------+-----------+----+----------+--------+------------------+
Total line number = 2
It costs 0.109s
IoTDB> delete timeseries root.turbine.d1.s1
Msg: The statement is executed successfully.
IoTDB> SHOW TIMESERIES root.**
+------------------+-----+------------+--------+--------+-----------+----+----------+--------+------------------+
|        Timeseries|Alias|    Database|DataType|Encoding|Compression|Tags|Attributes|Deadband|DeadbandParameters|
+------------------+-----+------------+--------+--------+-----------+----+----------+--------+------------------+
|root.turbine.d1.s2| null|root.turbine|   FLOAT|     RLE|     SNAPPY|null|      null|    null|              null|
+------------------+-----+------------+--------+--------+-----------+----+----------+--------+------------------+
Total line number = 1
It costs 0.022s
IoTDB> SHOW TIMESERIES root.turbine.d1.temprature
+------------------+----------+------------+--------+--------+-----------+----+----------+--------+------------------+
|        Timeseries|     Alias|    Database|DataType|Encoding|Compression|Tags|Attributes|Deadband|DeadbandParameters|
+------------------+----------+------------+--------+--------+-----------+----+----------+--------+------------------+
|root.turbine.d1.s1|temprature|root.turbine|   FLOAT|     RLE|     SNAPPY|null|      null|    null|              null|
+------------------+----------+------------+--------+--------+-----------+----+----------+--------+------------------+
Total line number = 1
It costs 0.019s 
```
