### PR TITLE
[IOTDB-5412]Print Help Message when loading empty tsfile

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -1742,6 +1742,13 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     // analyze tsfile metadata
     for (File tsFile : loadTsFileStatement.getTsFiles()) {
+      if (tsFile.length() == 0) {
+        logger.warn(String.format("TsFile %s is empty.", tsFile.getPath()));
+        throw new SemanticException(
+            String.format(
+                "TsFile %s is empty, please check it be flushed to disk correctly.",
+                tsFile.getPath()));
+      }
       try {
         TsFileResource resource =
             analyzeTsFile(
@@ -1752,6 +1759,13 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
                 device2Schemas,
                 device2IsAligned);
         loadTsFileStatement.addTsFileResource(resource);
+      } catch (IllegalArgumentException e) {
+        logger.warn(
+            String.format(
+                "Parse file %s to resource error, this TsFile maybe empty.", tsFile.getPath()),
+            e);
+        throw new SemanticException(
+            String.format("TsFile %s is empty or incomplete.", tsFile.getPath()));
       } catch (Exception e) {
         logger.warn(String.format("Parse file %s to resource error.", tsFile.getPath()), e);
         throw new SemanticException(


### PR DESCRIPTION
Print Help Message when loading empty tsfile

when tsfile is empty
Msg: 701: TsFile E:\IoTDB\data\load\mpp_load\[IOTDB-5412](https://issues.apache.org/jira/browse/IOTDB-5412)\1-0-0-0.tsfile is empty, please check it be flushed to disk correctly.

when tsfile is incomplete.
Msg: 701: TsFile E:\IoTDB\data\load\mpp_load\[IOTDB-5412](https://issues.apache.org/jira/browse/IOTDB-5412)\1-0-0-0.tsfile is empty or incomplete.