### PR TITLE
[IOTDB-5417] Fix missing hasNext() before next() in TagAggregationOperator

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/TagAggregationOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/TagAggregationOperator.java
@@ -122,7 +122,7 @@ public class TagAggregationOperator implements ProcessOperator {
         continue;
       }
 
-      if (!canCallNext[i]) {
+      if (!canCallNext[i] || !children.get(i).hasNextWithTimer()) {
         return false;
       }
 


### PR DESCRIPTION
See JIRA: https://issues.apache.org/jira/browse/IOTDB-5417