### PR TITLE
[IOTDB-5429] Disable first election in RatisConsensus UT to avoid inconsistency states

### DIFF
--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.consensus.config.RatisConfig;
 import org.apache.iotdb.consensus.exception.RatisRequestFailedException;
 
 import org.apache.ratis.util.FileUtils;
+import org.apache.ratis.util.TimeDuration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -75,6 +76,13 @@ public class RatisConsensusTest {
                   RatisConfig.Snapshot.newBuilder()
                       .setAutoTriggerThreshold(100)
                       .setCreationGap(10)
+                      .build())
+              .setRpc(
+                  RatisConfig.Rpc.newBuilder()
+                      .setFirstElectionTimeoutMin(TimeDuration.valueOf(1, TimeUnit.SECONDS))
+                      .setFirstElectionTimeoutMax(TimeDuration.valueOf(4, TimeUnit.SECONDS))
+                      .setTimeoutMin(TimeDuration.valueOf(1, TimeUnit.SECONDS))
+                      .setTimeoutMax(TimeDuration.valueOf(4, TimeUnit.SECONDS))
                       .build())
               .setImpl(
                   RatisConfig.Impl.newBuilder()


### PR DESCRIPTION
First election in CI env is causing frequent elections that will interrupt the normal operations of Raft progressing. To make matters worse, together with a recently spotted bug in matchIndex https://github.com/apache/ratis/pull/805, it may cause permanent inconsistency issues.
The erroneous event sequence are as follows,
1. Member 1 becomes the leader.
2. Leader 1 initializes the state, writes the first log (index=0) as an configuration entry.
3. This entry is mistakenly committed and be applied to Leader 1's StateMachine due to incorrect matchIndex.
Before 1 could appendEntries to 2/3, 2 & 3 both timeout and started election.
4. 2‘s requestVote has a higher term and forces Leader 1 down.
5. 2 becomes the new Leader, also writing the first log (index = 0) as an configuration entry.
Inconsistent appendEntries occurred when 2 tries to sync log to 1. And the group cannot automatically recover from this inconsistency. 

NOTICE: Disable first elections will not TOTALLY resolve this CI issue, but to reduce its reproduce possibility to a minimal. The total resolution depends on Ratis new releases.