### PR TITLE
[To rel/1.0][IOTDB-5429] Disable first election in RatisConsensus UT to avoid inconsistency states

### DIFF
--- a/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.consensus.config.RatisConfig;
 import org.apache.iotdb.consensus.exception.RatisRequestFailedException;
 
 import org.apache.ratis.util.FileUtils;
+import org.apache.ratis.util.TimeDuration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -75,6 +76,13 @@ public class RatisConsensusTest {
                   RatisConfig.Snapshot.newBuilder()
                       .setAutoTriggerThreshold(100)
                       .setCreationGap(10)
+                      .build())
+              .setRpc(
+                  RatisConfig.Rpc.newBuilder()
+                      .setFirstElectionTimeoutMin(TimeDuration.valueOf(1, TimeUnit.SECONDS))
+                      .setFirstElectionTimeoutMax(TimeDuration.valueOf(4, TimeUnit.SECONDS))
+                      .setTimeoutMin(TimeDuration.valueOf(1, TimeUnit.SECONDS))
+                      .setTimeoutMax(TimeDuration.valueOf(4, TimeUnit.SECONDS))
                       .build())
               .setImpl(
                   RatisConfig.Impl.newBuilder()


### PR DESCRIPTION
cherry pick of https://github.com/apache/iotdb/pull/8896