### PR TITLE
Update SchemaFile to be compatible with MeasurementSchema.props

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/RecordUtilTests.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/RecordUtilTests.java
@@ -37,6 +37,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RecordUtilTests {
 
@@ -65,8 +67,13 @@ public class RecordUtilTests {
 
   @Test
   public void measurementTest() throws MetadataException {
+    Map<String, String> props = new HashMap<>();
+    props.put("ka", "va");
+    props.put("kb", "vb");
+
     IMeasurementSchema schema =
-        new MeasurementSchema("amn", TSDataType.FLOAT, TSEncoding.BITMAP, CompressionType.GZIP);
+        new MeasurementSchema(
+            "amn", TSDataType.FLOAT, TSEncoding.BITMAP, CompressionType.GZIP, props);
     IMNode amn = MeasurementMNode.getMeasurementMNode(null, "amn", schema, "anothername");
 
     ByteBuffer tBuf = RecordUtils.node2Buffer(amn);
@@ -89,5 +96,6 @@ public class RecordUtilTests {
     Assert.assertEquals(
         node2.getAsMeasurementMNode().getAlias(), amn.getAsMeasurementMNode().getAlias());
     Assert.assertEquals(true, node2.getAsMeasurementMNode().isPreDeleted());
+    Assert.assertEquals(props, node2.getAsMeasurementMNode().getSchema().getProps());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
@@ -671,7 +671,7 @@ public class SchemaFileTest {
     sf.writeMNode(ent2);
 
     Assert.assertEquals(
-        getSegAddr(sf, getSegAddrInContainer(ent2), "e2m0") + 1,
+        getSegAddr(sf, getSegAddrInContainer(ent2), "e2m0") + 65536,
         getSegAddr(sf, getSegAddrInContainer(ent3), "e3m0"));
     Assert.assertEquals(
         getSegAddr(sf, getSegAddrInContainer(ent2), "e2m0") + 2,


### PR DESCRIPTION
Previously, `SchemaFile` did not store `MeasurementSchema.Props` as it is a variable length and relatively less efficient field to store into persistent media. To support full capability of metadata under high cardinality circumstance, `SchemaFile` will store/restore this `Map<String, String>` after then.

This update will cost at least 4 bytes more per measurement record in `SchemaFile`, and malicious long property key or value may cause overflow exception withou decent guradian statements for property's assignment. Well-optimized access methods for constrained property set is expected in further development.