### PR TITLE
Use gitbox thrift url instead of github to avoid download issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1180,8 +1180,8 @@
             </activation>
             <properties>
                 <os.classifier>linux-x86_64</os.classifier>
-                <thrift.download-url>https://github.com/apache/iotdb-bin-resources/raw/main/compile-tools/thrift-0.14-ubuntu</thrift.download-url>
-                <thrift.executable>thrift_0.14.1_linux.exe</thrift.executable>
+                <thrift.download-url>https://gitbox.apache.org/repos/asf?p=iotdb-bin-resources.git;a=blob_plain;f=compile-tools/thrift-0.14-ubuntu;hb=HEAD</thrift.download-url>
+                <thrift.executable>thrift_0.14.1_linux</thrift.executable>
                 <thrift.skip-making-executable>false</thrift.skip-making-executable>
                 <thrift.exec-cmd.executable>chmod</thrift.exec-cmd.executable>
                 <thrift.exec-cmd.args>+x ${project.build.directory}/tools/${thrift.executable}</thrift.exec-cmd.args>
@@ -1196,8 +1196,8 @@
             </activation>
             <properties>
                 <os.classifier>mac-x86_64</os.classifier>
-                <thrift.download-url>https://github.com/apache/iotdb-bin-resources/raw/main/compile-tools/thrift-0.14-MacOS</thrift.download-url>
-                <thrift.executable>thrift_0.14.1_mac.exe</thrift.executable>
+                <thrift.download-url>https://gitbox.apache.org/repos/asf?p=iotdb-bin-resources.git;a=blob_plain;f=compile-tools/thrift-0.14-MacOS;hb=HEAD</thrift.download-url>
+                <thrift.executable>thrift_0.14.1_mac</thrift.executable>
                 <thrift.skip-making-executable>false</thrift.skip-making-executable>
                 <thrift.exec-cmd.executable>chmod</thrift.exec-cmd.executable>
                 <thrift.exec-cmd.args>+x ${project.build.directory}/tools/${thrift.executable}</thrift.exec-cmd.args>


### PR DESCRIPTION
## Description

Users in China may have trouble to download thrift compile tool due to the github download url. 
<img width="901" alt="image" src="https://user-images.githubusercontent.com/25913899/215302713-c8d6b1f3-cbee-4fb0-97ee-9ad786f0849b.png">

This PR change the url to the gitbox one.