### PR TITLE
[IOTDB-5435] Add close method for logWriter of ConfigNodeRegionStateMachine

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigNodeRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigNodeRegionStateMachine.java
@@ -297,6 +297,7 @@ public class ConfigNodeRegionStateMachine
       // The method logWriter.write will execute flip() firstly, so we must make position==limit
       buffer.position(buffer.limit());
       logWriter.write(buffer);
+      logWriter.close();
       endIndex = endIndex + 1;
       File tmpLogFile = new File(PROGRESS_FILE_PATH + endIndex);
       Files.move(logFile.toPath(), tmpLogFile.toPath(), StandardCopyOption.ATOMIC_MOVE);


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/6756545/215309786-734086a3-c7cb-4c77-8c54-e3a4258641a3.png)

**Test in windows environment:**
before:
![image](https://user-images.githubusercontent.com/6756545/215317064-29031a71-918b-40c7-b11b-ed93a11df927.png)


after:
![image](https://user-images.githubusercontent.com/6756545/215317849-9415b5ec-30be-404c-ba0e-3009b5cd9026.png)


