### PR TITLE
[IOTDB-5426] Cannot trigger flush for sequence file when timed flush enabled

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -132,7 +132,6 @@ public class SystemInfo {
     if (reportedStorageGroupMemCostMap.containsKey(dataRegionInfo)) {
       delta = reportedStorageGroupMemCostMap.get(dataRegionInfo) - dataRegionInfo.getMemCost();
       this.totalStorageGroupMemCost -= delta;
-      dataRegionInfo.setLastReportedSize(dataRegionInfo.getMemCost());
       reportedStorageGroupMemCostMap.put(dataRegionInfo, dataRegionInfo.getMemCost());
     }
 


### PR DESCRIPTION
This bug occurs when there are few insert operations and the timed flush memtable is open. The lastReportedSize is reset by the timed flush operation and needToReportToSystem method always return false, because the memtable flush are caused by the time threshold rather than the memory threshold and the memory cost increase cannot reach storageGroupSizeReportThreshold before next timed flush.
<img width="955" alt="截屏2023-01-30 10 42 05" src="https://user-images.githubusercontent.com/43991780/215376442-d1d1b9bd-2eba-4755-a408-e6e867a79b6b.png">
To solve this problem, we @HTHou  decide to delete setLastReportedSize when resetStorageGroupStatus.