### PR TITLE
[IOTDB-5140][To Rel/1.0] Add metrics for compaction deserializing pages or writing chunks

### DIFF
--- a/docs/UserGuide/Monitor-Alert/Apache-IoTDB-DataNode-Dashboard.json
+++ b/docs/UserGuide/Monitor-Alert/Apache-IoTDB-DataNode-Dashboard.json
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "8.4.6"
+      "version": "8.4.2"
     },
     {
       "type": "datasource",
@@ -63,7 +63,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1669708594135,
+  "iteration": 1675061569475,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1614,6 +1614,204 @@
       "type": "timeseries"
     },
     {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(Compacted_Chunk_Num_total{instance=~\"$instance\"}[1m]))*60",
+          "interval": "",
+          "legendFormat": "Compacted Chunk Num Per Min",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(Deserialized_Chunk_Num_total{instance=~\"$instance\"}[1m]))*60",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Deserialized Chunk Num Per Min",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(Directly_Flush_Chunk_Num_total{instance=~\"$instance\"}[1m]))*60",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Directly Flush Chunk Per Min",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(Merged_Chunk_Num_total{instance=~\"$instance\"}[1m]))*60",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Merged Chunk Per Min",
+          "refId": "D"
+        }
+      ],
+      "title": "Compaction Process Chunk Status",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 51
+      },
+      "id": 58,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(Compacted_Point_Num_total{instance=~\"$instance\"}[1m]))*60",
+          "interval": "",
+          "legendFormat": "Compacted Point Num Per Min",
+          "refId": "A"
+        }
+      ],
+      "title": "Compacted Point Num",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
@@ -1623,7 +1821,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 59
       },
       "id": 20,
       "panels": [],
@@ -1695,7 +1893,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 52
+        "y": 60
       },
       "id": 21,
       "options": {
@@ -1788,7 +1986,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 52
+        "y": 60
       },
       "id": 22,
       "options": {
@@ -1878,7 +2076,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 52
+        "y": 60
       },
       "id": 23,
       "options": {
@@ -1983,7 +2181,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 60
+        "y": 68
       },
       "id": 24,
       "options": {
@@ -2073,7 +2271,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 60
+        "y": 68
       },
       "id": 25,
       "options": {
@@ -2188,7 +2386,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 60
+        "y": 68
       },
       "id": 26,
       "options": {
@@ -2281,7 +2479,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "id": 27,
       "options": {
@@ -2374,7 +2572,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 68
+        "y": 76
       },
       "id": 28,
       "options": {
@@ -2463,7 +2661,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 68
+        "y": 76
       },
       "id": 29,
       "options": {
@@ -2553,7 +2751,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 76
+        "y": 84
       },
       "id": 30,
       "options": {
@@ -2645,7 +2843,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 76
+        "y": 84
       },
       "id": 31,
       "options": {
@@ -2738,7 +2936,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 76
+        "y": 84
       },
       "id": 32,
       "options": {
@@ -2784,7 +2982,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 84
+        "y": 92
       },
       "id": 33,
       "panels": [],
@@ -2828,7 +3026,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 85
+        "y": 93
       },
       "id": 34,
       "options": {
@@ -2845,7 +3043,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.6",
+      "pluginVersion": "8.4.2",
       "targets": [
         {
           "datasource": {
@@ -2922,7 +3120,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 85
+        "y": 93
       },
       "id": 35,
       "options": {
@@ -3025,7 +3223,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 85
+        "y": 93
       },
       "id": 40,
       "options": {
@@ -3116,7 +3314,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 93
+        "y": 101
       },
       "id": 41,
       "options": {
@@ -3231,7 +3429,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 93
+        "y": 101
       },
       "id": 42,
       "options": {
@@ -3334,7 +3532,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 93
+        "y": 101
       },
       "id": 43,
       "options": {
@@ -3447,7 +3645,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 101
+        "y": 109
       },
       "id": 44,
       "options": {
@@ -3545,7 +3743,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 101
+        "y": 109
       },
       "id": 45,
       "options": {
@@ -3645,7 +3843,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 101
+        "y": 109
       },
       "id": 46,
       "options": {
@@ -3747,7 +3945,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 109
+        "y": 117
       },
       "id": 47,
       "options": {
@@ -3848,7 +4046,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 109
+        "y": 117
       },
       "id": 48,
       "options": {
@@ -3946,7 +4144,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 109
+        "y": 117
       },
       "id": 49,
       "options": {
@@ -4045,7 +4243,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 116
+        "y": 124
       },
       "id": 50,
       "options": {
@@ -4180,7 +4378,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 116
+        "y": 124
       },
       "id": 51,
       "options": {
@@ -4313,7 +4511,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 116
+        "y": 124
       },
       "id": 52,
       "options": {
@@ -4403,7 +4601,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 124
+        "y": 132
       },
       "id": 53,
       "options": {
@@ -4493,7 +4691,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 124
+        "y": 132
       },
       "id": 54,
       "options": {
@@ -4539,7 +4737,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": "15s",
   "schemaVersion": 35,
   "style": "dark",
   "tags": [
@@ -4596,8 +4794,8 @@
     ]
   },
   "time": {
-    "from": "now-30m",
-    "to": "now"
+    "from": "2023-01-30T05:44:55.019Z",
+    "to": "2023-01-30T07:44:55.023Z"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -4612,6 +4810,6 @@
   "timezone": "browser",
   "title": "Apache IoTDB DataNode Dashboard",
   "uid": "TbEVYRw7A",
-  "version": 18,
+  "version": 2,
   "weekStart": ""
 }

--- a/rewrite-tsfile-tool/src/main/java/org/apache/iotdb/RewriteTsFileTool.java
+++ b/rewrite-tsfile-tool/src/main/java/org/apache/iotdb/RewriteTsFileTool.java
@@ -851,8 +851,9 @@ public class RewriteTsFileTool {
       throws IOException, IoTDBConnectionException, StatementExecutionException {
     while (readerIterator.hasNext()) {
       Tablet tablet = new Tablet(device, schemaList, MAX_TABLET_LENGTH);
-      Pair<AlignedChunkReader, Long> chunkReaderAndChunkSize = readerIterator.nextReader();
-      AlignedChunkReader alignedChunkReader = chunkReaderAndChunkSize.left;
+      TsFileAlignedSeriesReaderIterator.NextAlignedChunkInfo readerInfo =
+          readerIterator.nextReader();
+      AlignedChunkReader alignedChunkReader = readerInfo.getReader();
       while (alignedChunkReader.hasNextSatisfiedPage()) {
         IBatchDataIterator batchDataIterator =
             alignedChunkReader.nextPageData().getBatchDataIterator();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
@@ -28,7 +28,7 @@ import org.apache.iotdb.db.engine.compaction.execute.performer.ISeqCompactionPer
 import org.apache.iotdb.db.engine.compaction.execute.performer.IUnseqCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionPerformerSubTask;
-import org.apache.iotdb.db.engine.compaction.execute.task.subtask.SubCompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.execute.utils.MultiTsFileDeviceIterator;
 import org.apache.iotdb.db.engine.compaction.execute.utils.writer.AbstractCompactionWriter;
@@ -75,9 +75,7 @@ public class FastCompactionPerformer
 
   public Map<TsFileResource, TsFileSequenceReader> readerCacheMap = new ConcurrentHashMap<>();
 
-  private CompactionTaskSummary summary;
-
-  private final SubCompactionTaskSummary subTaskSummary = new SubCompactionTaskSummary();
+  private FastCompactionTaskSummary subTaskSummary;
 
   private List<TsFileResource> targetFiles;
 
@@ -192,7 +190,7 @@ public class FastCompactionPerformer
       timeseriesMetadataOffsetMap.put(entry.getKey(), entry.getValue().right);
     }
 
-    SubCompactionTaskSummary taskSummary = new SubCompactionTaskSummary();
+    FastCompactionTaskSummary taskSummary = new FastCompactionTaskSummary();
     new FastCompactionPerformerSubTask(
             fastCrossCompactionWriter,
             timeseriesMetadataOffsetMap,
@@ -234,9 +232,9 @@ public class FastCompactionPerformer
 
     // construct sub tasks and start compacting measurements in parallel
     List<Future<Void>> futures = new ArrayList<>();
-    List<SubCompactionTaskSummary> taskSummaryList = new ArrayList<>();
+    List<FastCompactionTaskSummary> taskSummaryList = new ArrayList<>();
     for (int i = 0; i < subTaskNums; i++) {
-      SubCompactionTaskSummary taskSummary = new SubCompactionTaskSummary();
+      FastCompactionTaskSummary taskSummary = new FastCompactionTaskSummary();
       futures.add(
           CompactionTaskManager.getInstance()
               .submitSubTask(
@@ -272,7 +270,12 @@ public class FastCompactionPerformer
 
   @Override
   public void setSummary(CompactionTaskSummary summary) {
-    this.summary = summary;
+    if (!(summary instanceof FastCompactionTaskSummary)) {
+      throw new RuntimeException(
+          "CompactionTaskSummary for FastCompactionPerformer "
+              + "should be FastCompactionTaskSummary");
+    }
+    this.subTaskSummary = (FastCompactionTaskSummary) summary;
   }
 
   @Override
@@ -282,14 +285,14 @@ public class FastCompactionPerformer
   }
 
   private void checkThreadInterrupted() throws InterruptedException {
-    if (Thread.interrupted() || summary.isCancel()) {
+    if (Thread.interrupted() || subTaskSummary.isCancel()) {
       throw new InterruptedException(
           String.format(
               "[Compaction] compaction for target file %s abort", targetFiles.toString()));
     }
   }
 
-  public SubCompactionTaskSummary getSubTaskSummary() {
+  public FastCompactionTaskSummary getSubTaskSummary() {
     return subTaskSummary;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
@@ -134,7 +134,7 @@ public class ReadChunkCompactionPerformer implements ISeqCompactionPerformer {
     writer.startChunkGroup(device);
     AlignedSeriesCompactionExecutor compactionExecutor =
         new AlignedSeriesCompactionExecutor(
-            device, targetResource, readerAndChunkMetadataList, writer);
+            device, targetResource, readerAndChunkMetadataList, writer, summary);
     compactionExecutor.execute();
     writer.endChunkGroup();
   }
@@ -178,7 +178,8 @@ public class ReadChunkCompactionPerformer implements ISeqCompactionPerformer {
       LinkedList<Pair<TsFileSequenceReader, List<ChunkMetadata>>> readerAndChunkMetadataList =
           seriesIterator.getMetadataListForCurrentSeries();
       SingleSeriesCompactionExecutor compactionExecutorOfCurrentTimeSeries =
-          new SingleSeriesCompactionExecutor(p, readerAndChunkMetadataList, writer, targetResource);
+          new SingleSeriesCompactionExecutor(
+              p, readerAndChunkMetadataList, writer, targetResource, summary);
       compactionExecutorOfCurrentTimeSeries.execute();
     }
     writer.endChunkGroup();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
@@ -46,7 +46,7 @@ public abstract class AbstractCompactionTask {
   protected final TsFileManager tsFileManager;
   protected ICompactionPerformer performer;
   protected int hashCode = -1;
-  protected CompactionTaskSummary summary = new CompactionTaskSummary();
+  protected CompactionTaskSummary summary;
   protected long serialId;
 
   public AbstractCompactionTask(
@@ -148,4 +148,6 @@ public abstract class AbstractCompactionTask {
   public long getSerialId() {
     return serialId;
   }
+
+  protected abstract void createSummary();
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CompactionTaskSummary.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CompactionTaskSummary.java
@@ -18,11 +18,20 @@
  */
 package org.apache.iotdb.db.engine.compaction.execute.task;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 /** The summary of one {@link AbstractCompactionTask} execution */
 public class CompactionTaskSummary {
-  private long timeCost = 0L;
-  private volatile Status status = Status.NOT_STARTED;
-  private long startTime = -1L;
+  protected long timeCost = 0L;
+  protected volatile Status status = Status.NOT_STARTED;
+  protected long startTime = -1L;
+  protected int processChunkNum = 0;
+  protected int directlyFlushChunkNum = 0;
+  protected int deserializeChunkCount = 0;
+  protected int deserializePageCount = 0;
+  protected int mergedChunkNum = 0;
+  protected long processPointNum = 0;
 
   public CompactionTaskSummary() {}
 
@@ -65,11 +74,78 @@ public class CompactionTaskSummary {
     return timeCost;
   }
 
+  public void increaseProcessChunkNum(int increment) {
+    processChunkNum += increment;
+  }
+
+  public void increaseDirectlyFlushChunkNum(int increment) {
+    directlyFlushChunkNum += increment;
+  }
+
+  public void increaseDeserializedChunkNum(int increment) {
+    deserializeChunkCount += increment;
+  }
+
+  public void increaseProcessPointNum(long increment) {
+    processPointNum += increment;
+  }
+
+  public void increaseMergedChunkNum(int increment) {
+    this.mergedChunkNum += increment;
+  }
+
+  public void setDirectlyFlushChunkNum(int directlyFlushChunkNum) {
+    this.directlyFlushChunkNum = directlyFlushChunkNum;
+  }
+
+  public void setDeserializeChunkCount(int deserializeChunkCount) {
+    this.deserializeChunkCount = deserializeChunkCount;
+  }
+
+  public void setProcessPointNum(int processPointNum) {
+    this.processPointNum = processPointNum;
+  }
+
+  public int getProcessChunkNum() {
+    return processChunkNum;
+  }
+
+  public int getDirectlyFlushChunkNum() {
+    return directlyFlushChunkNum;
+  }
+
+  public int getDeserializeChunkCount() {
+    return deserializeChunkCount;
+  }
+
+  public int getMergedChunkNum() {
+    return mergedChunkNum;
+  }
+
+  public long getProcessPointNum() {
+    return processPointNum;
+  }
+
   enum Status {
     NOT_STARTED,
     STARTED,
     SUCCESS,
     FAILED,
     CANCELED
+  }
+
+  @Override
+  public String toString() {
+    String startTimeInStr = new SimpleDateFormat().format(new Date(startTime));
+    return String.format(
+        "Task start time: %s, total process chunk num: %d, "
+            + "directly flush chunk num: %d, merge chunk num: %d, deserialize chunk num: %d,"
+            + " total process point num: %d",
+        startTimeInStr,
+        processChunkNum,
+        directlyFlushChunkNum,
+        mergedChunkNum,
+        deserializeChunkCount,
+        processPointNum);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.compaction.execute.exception.CompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICrossCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.subtask.SubCompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.execute.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
@@ -34,6 +34,7 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.rescon.SystemInfo;
+import org.apache.iotdb.db.service.metrics.recorder.CompactionMetricsRecorder;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -86,6 +87,7 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
     this.performer = performer;
     this.hashCode = this.toString().hashCode();
     this.memoryCost = memoryCost;
+    createSummary();
   }
 
   @Override
@@ -190,19 +192,6 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
         if (logFile.exists()) {
           FileUtils.delete(logFile);
         }
-        if (performer instanceof FastCompactionPerformer) {
-          SubCompactionTaskSummary subTaskSummary =
-              ((FastCompactionPerformer) performer).getSubTaskSummary();
-          LOGGER.info(
-              "CHUNK_NONE_OVERLAP num is {}, CHUNK_NONE_OVERLAP_BUT_DESERIALIZE num is {}, CHUNK_OVERLAP_OR_MODIFIED num is {}, PAGE_NONE_OVERLAP num is {}, PAGE_NONE_OVERLAP_BUT_DESERIALIZE num is {}, PAGE_OVERLAP_OR_MODIFIED num is {}, PAGE_FAKE_OVERLAP num is {}.",
-              subTaskSummary.CHUNK_NONE_OVERLAP,
-              subTaskSummary.CHUNK_NONE_OVERLAP_BUT_DESERIALIZE,
-              subTaskSummary.CHUNK_OVERLAP_OR_MODIFIED,
-              subTaskSummary.PAGE_NONE_OVERLAP,
-              subTaskSummary.PAGE_NONE_OVERLAP_BUT_DESERIALIZE,
-              subTaskSummary.PAGE_OVERLAP_OR_MODIFIED,
-              subTaskSummary.PAGE_FAKE_OVERLAP);
-        }
 
         // update the metrics finally in case of any exception occurs
         for (TsFileResource targetResource : targetTsfileResourceList) {
@@ -217,13 +206,18 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
             .deleteFile(sequenceFileSize, true, selectedSequenceFiles.size());
         TsFileMetricManager.getInstance()
             .deleteFile(unsequenceFileSize, false, selectedUnsequenceFiles.size());
+
+        CompactionMetricsRecorder.updateSummary(summary);
+
         long costTime = (System.currentTimeMillis() - startTime) / 1000;
+
         LOGGER.info(
-            "{}-{} [Compaction] CrossSpaceCompaction task finishes successfully, time cost is {} s, compaction speed is {} MB/s",
+            "{}-{} [Compaction] CrossSpaceCompaction task finishes successfully, time cost is {} s, compaction speed is {} MB/s, {}",
             storageGroupName,
             dataRegionId,
             costTime,
-            (selectedSeqFileSize + selectedUnseqFileSize) / 1024 / 1024 / costTime);
+            (selectedSeqFileSize + selectedUnseqFileSize) / 1024 / 1024 / costTime,
+            summary);
       }
     } catch (Throwable throwable) {
       // catch throwable to handle OOM errors
@@ -378,5 +372,14 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
       throw e;
     }
     return true;
+  }
+
+  @Override
+  protected void createSummary() {
+    if (performer instanceof FastCompactionPerformer) {
+      this.summary = new FastCompactionTaskSummary();
+    } else {
+      this.summary = new CompactionTaskSummary();
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.compaction.execute.exception.CompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.subtask.SubCompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.execute.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
@@ -33,6 +33,7 @@ import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceList;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
+import org.apache.iotdb.db.service.metrics.recorder.CompactionMetricsRecorder;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.exception.write.TsFileNotCompleteException;
 
@@ -95,6 +96,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
     }
     this.hashCode = this.toString().hashCode();
     collectSelectedFilesInfo();
+    createSummary();
   }
 
   @Override
@@ -224,33 +226,9 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       CompactionUtils.deleteModificationForSourceFile(
           selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
 
-      if (performer instanceof FastCompactionPerformer) {
-        SubCompactionTaskSummary subTaskSummary =
-            ((FastCompactionPerformer) performer).getSubTaskSummary();
-        LOGGER.info(
-            "CHUNK_NONE_OVERLAP num is {}, CHUNK_NONE_OVERLAP_BUT_DESERIALIZE num is {}, CHUNK_OVERLAP_OR_MODIFIED num is {}, PAGE_NONE_OVERLAP num is {}, PAGE_NONE_OVERLAP_BUT_DESERIALIZE num is {}, PAGE_OVERLAP_OR_MODIFIED num is {}, PAGE_FAKE_OVERLAP num is {}.",
-            subTaskSummary.CHUNK_NONE_OVERLAP,
-            subTaskSummary.CHUNK_NONE_OVERLAP_BUT_DESERIALIZE,
-            subTaskSummary.CHUNK_OVERLAP_OR_MODIFIED,
-            subTaskSummary.PAGE_NONE_OVERLAP,
-            subTaskSummary.PAGE_NONE_OVERLAP_BUT_DESERIALIZE,
-            subTaskSummary.PAGE_OVERLAP_OR_MODIFIED,
-            subTaskSummary.PAGE_FAKE_OVERLAP);
-      }
-
       if (logFile.exists()) {
         FileUtils.delete(logFile);
       }
-
-      double costTime = (System.currentTimeMillis() - startTime) / 1000.0d;
-      LOGGER.info(
-          "{}-{} [Compaction] InnerSpaceCompaction task finishes successfully, target file is {},"
-              + "time cost is {} s, compaction speed is {} MB/s",
-          storageGroupName,
-          dataRegionId,
-          targetTsFileResource.getTsFile().getName(),
-          costTime,
-          selectedFileSize / 1024.0d / 1024.0d / costTime);
 
       // inner space compaction task has only one target file
       if (targetTsFileList.get(0) != null) {
@@ -263,6 +241,18 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       TsFileMetricManager.getInstance()
           .deleteFile(totalSizeOfDeletedFile, sequence, selectedTsFileResourceList.size());
 
+      CompactionMetricsRecorder.updateSummary(summary);
+
+      double costTime = (System.currentTimeMillis() - startTime) / 1000.0d;
+      LOGGER.info(
+          "{}-{} [Compaction] InnerSpaceCompaction task finishes successfully, target file is {},"
+              + "time cost is {} s, compaction speed is {} MB/s, {}",
+          storageGroupName,
+          dataRegionId,
+          targetTsFileResource.getTsFile().getName(),
+          costTime,
+          selectedFileSize / 1024.0d / 1024.0d / costTime,
+          summary);
     } catch (Throwable throwable) {
       // catch throwable to handle OOM errors
       if (!(throwable instanceof InterruptedException)) {
@@ -452,5 +442,14 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       throw e;
     }
     return true;
+  }
+
+  @Override
+  protected void createSummary() {
+    if (performer instanceof FastCompactionPerformer) {
+      this.summary = new FastCompactionTaskSummary();
+    } else {
+      this.summary = new CompactionTaskSummary();
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/subtask/FastCompactionPerformerSubTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/subtask/FastCompactionPerformerSubTask.java
@@ -37,7 +37,7 @@ import java.util.concurrent.Callable;
 
 public class FastCompactionPerformerSubTask implements Callable<Void> {
 
-  private SubCompactionTaskSummary summary;
+  private FastCompactionTaskSummary summary;
 
   private AbstractCompactionWriter compactionWriter;
 
@@ -73,7 +73,7 @@ public class FastCompactionPerformerSubTask implements Callable<Void> {
       List<TsFileResource> sortedSourceFiles,
       List<String> measurements,
       String deviceId,
-      SubCompactionTaskSummary summary,
+      FastCompactionTaskSummary summary,
       int subTaskId) {
     this.compactionWriter = compactionWriter;
     this.subTaskId = subTaskId;
@@ -96,7 +96,7 @@ public class FastCompactionPerformerSubTask implements Callable<Void> {
       List<TsFileResource> sortedSourceFiles,
       List<IMeasurementSchema> measurementSchemas,
       String deviceId,
-      SubCompactionTaskSummary summary) {
+      FastCompactionTaskSummary summary) {
     this.compactionWriter = compactionWriter;
     this.subTaskId = 0;
     this.timeseriesMetadataOffsetMap = timeseriesMetadataOffsetMap;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/subtask/FastCompactionTaskSummary.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/subtask/FastCompactionTaskSummary.java
@@ -18,7 +18,9 @@
  */
 package org.apache.iotdb.db.engine.compaction.execute.task.subtask;
 
-public class SubCompactionTaskSummary {
+import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+
+public class FastCompactionTaskSummary extends CompactionTaskSummary {
   public int CHUNK_NONE_OVERLAP;
   public int CHUNK_NONE_OVERLAP_BUT_DESERIALIZE;
   public int CHUNK_OVERLAP_OR_MODIFIED;
@@ -28,7 +30,7 @@ public class SubCompactionTaskSummary {
   public int PAGE_FAKE_OVERLAP;
   public int PAGE_NONE_OVERLAP_BUT_DESERIALIZE;
 
-  public void increase(SubCompactionTaskSummary summary) {
+  public void increase(FastCompactionTaskSummary summary) {
     this.CHUNK_NONE_OVERLAP += summary.CHUNK_NONE_OVERLAP;
     this.CHUNK_NONE_OVERLAP_BUT_DESERIALIZE += summary.CHUNK_NONE_OVERLAP_BUT_DESERIALIZE;
     this.CHUNK_OVERLAP_OR_MODIFIED += summary.CHUNK_OVERLAP_OR_MODIFIED;
@@ -36,5 +38,26 @@ public class SubCompactionTaskSummary {
     this.PAGE_OVERLAP_OR_MODIFIED += summary.PAGE_OVERLAP_OR_MODIFIED;
     this.PAGE_FAKE_OVERLAP += summary.PAGE_FAKE_OVERLAP;
     this.PAGE_NONE_OVERLAP_BUT_DESERIALIZE += summary.PAGE_NONE_OVERLAP_BUT_DESERIALIZE;
+    this.processChunkNum += summary.processChunkNum;
+    this.processPointNum += summary.processPointNum;
+    this.directlyFlushChunkNum += summary.directlyFlushChunkNum;
+    this.mergedChunkNum += summary.mergedChunkNum;
+    this.deserializeChunkCount += summary.deserializeChunkCount;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "CHUNK_NONE_OVERLAP num is %d, CHUNK_NONE_OVERLAP_BUT_DESERIALIZE num is %d,"
+            + " CHUNK_OVERLAP_OR_MODIFIED num is %d, PAGE_NONE_OVERLAP num is %d,"
+            + " PAGE_NONE_OVERLAP_BUT_DESERIALIZE num is %d, PAGE_OVERLAP_OR_MODIFIED num is %d,"
+            + " PAGE_FAKE_OVERLAP num is %d.",
+        CHUNK_NONE_OVERLAP,
+        CHUNK_NONE_OVERLAP_BUT_DESERIALIZE,
+        CHUNK_OVERLAP_OR_MODIFIED,
+        PAGE_NONE_OVERLAP,
+        PAGE_NONE_OVERLAP_BUT_DESERIALIZE,
+        PAGE_OVERLAP_OR_MODIFIED,
+        PAGE_FAKE_OVERLAP);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
@@ -20,7 +20,7 @@ package org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.engine.compaction.execute.task.subtask.SubCompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.ChunkMetadataElement;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.FileElement;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.PageElement;
@@ -66,7 +66,7 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
       String deviceId,
       int subTaskId,
       List<IMeasurementSchema> measurementSchemas,
-      SubCompactionTaskSummary summary) {
+      FastCompactionTaskSummary summary) {
     super(compactionWriter, readerCacheMap, modificationCacheMap, deviceId, subTaskId, summary);
     this.timeseriesMetadataOffsetMap = timeseriesMetadataOffsetMap;
     this.measurementSchemas = measurementSchemas;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/NonAlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/NonAlignedSeriesCompactionExecutor.java
@@ -20,7 +20,7 @@ package org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.engine.compaction.execute.task.subtask.SubCompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.ChunkMetadataElement;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.FileElement;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.PageElement;
@@ -64,7 +64,7 @@ public class NonAlignedSeriesCompactionExecutor extends SeriesCompactionExecutor
       List<TsFileResource> sortedSourceFiles,
       String deviceId,
       int subTaskId,
-      SubCompactionTaskSummary summary) {
+      FastCompactionTaskSummary summary) {
     super(compactionWriter, readerCacheMap, modificationCacheMap, deviceId, subTaskId, summary);
     this.sortResources = sortedSourceFiles;
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/SeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/SeriesCompactionExecutor.java
@@ -20,7 +20,7 @@ package org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.engine.compaction.execute.task.subtask.SubCompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.ChunkMetadataElement;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.FileElement;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.PageElement;
@@ -32,6 +32,7 @@ import org.apache.iotdb.db.exception.WriteProcessException;
 import org.apache.iotdb.tsfile.exception.write.PageException;
 import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.reader.chunk.AlignedChunkReader;
@@ -58,7 +59,7 @@ public abstract class SeriesCompactionExecutor {
         throws WriteProcessException, IOException, IllegalPathException;
   }
 
-  private final SubCompactionTaskSummary summary;
+  private final FastCompactionTaskSummary summary;
 
   // source files which are sorted by the start time of current device from old to new. Notice: If
   // the type of timeIndex is FileTimeIndex, it may contain resources in which the current device
@@ -93,7 +94,7 @@ public abstract class SeriesCompactionExecutor {
       Map<TsFileResource, List<Modification>> modificationCacheMap,
       String deviceId,
       int subTaskId,
-      SubCompactionTaskSummary summary) {
+      FastCompactionTaskSummary summary) {
     this.compactionWriter = compactionWriter;
     this.subTaskId = subTaskId;
     this.deviceId = deviceId;
@@ -154,6 +155,8 @@ public abstract class SeriesCompactionExecutor {
       throws IOException, PageException, WriteProcessException, IllegalPathException {
     for (ChunkMetadataElement overlappedChunkMetadata : overlappedChunkMetadataList) {
       readChunk(overlappedChunkMetadata);
+      updateSummary(overlappedChunkMetadata, ChunkStatus.READ_IN);
+      updateSummary(overlappedChunkMetadata, ChunkStatus.DESERIALIZE_CHUNK);
       deserializeChunkIntoQueue(overlappedChunkMetadata);
     }
     compactPages();
@@ -166,6 +169,7 @@ public abstract class SeriesCompactionExecutor {
   private void compactWithNonOverlapChunk(ChunkMetadataElement chunkMetadataElement)
       throws IOException, PageException, WriteProcessException, IllegalPathException {
     readChunk(chunkMetadataElement);
+    updateSummary(chunkMetadataElement, ChunkStatus.READ_IN);
     boolean success;
     if (chunkMetadataElement.chunkMetadata instanceof AlignedChunkMetadata) {
       success =
@@ -185,10 +189,12 @@ public abstract class SeriesCompactionExecutor {
     }
     if (success) {
       // flush chunk successfully, then remove this chunk
+      updateSummary(chunkMetadataElement, ChunkStatus.DIRECTORY_FLUSH);
       removeChunk(chunkMetadataQueue.peek());
     } else {
       // unsealed chunk is not large enough or chunk.endTime > file.endTime, then deserialize chunk
       summary.CHUNK_NONE_OVERLAP_BUT_DESERIALIZE += 1;
+      updateSummary(chunkMetadataElement, ChunkStatus.DESERIALIZE_CHUNK);
       deserializeChunkIntoQueue(chunkMetadataElement);
       compactPages();
     }
@@ -586,5 +592,60 @@ public abstract class SeriesCompactionExecutor {
       }
     }
     return pathModifications;
+  }
+
+  private void updateSummary(ChunkMetadataElement chunkMetadataElement, ChunkStatus status) {
+    switch (status) {
+      case READ_IN:
+        summary.increaseProcessChunkNum(
+            chunkMetadataElement.isAligned
+                ? ((AlignedChunkMetadata) chunkMetadataElement.chunkMetadata)
+                        .getValueChunkMetadataList()
+                        .size()
+                    + 1
+                : 1);
+        if (chunkMetadataElement.isAligned) {
+          for (IChunkMetadata valueChunkMetadata :
+              ((AlignedChunkMetadata) chunkMetadataElement.chunkMetadata)
+                  .getValueChunkMetadataList()) {
+            if (valueChunkMetadata == null) {
+              continue;
+            }
+            summary.increaseProcessPointNum(valueChunkMetadata.getStatistics().getCount());
+          }
+        } else {
+          summary.increaseProcessPointNum(
+              chunkMetadataElement.chunkMetadata.getStatistics().getCount());
+        }
+        break;
+      case DIRECTORY_FLUSH:
+        if (chunkMetadataElement.isAligned) {
+          summary.increaseDirectlyFlushChunkNum(
+              ((AlignedChunkMetadata) (chunkMetadataElement.chunkMetadata))
+                      .getValueChunkMetadataList()
+                      .size()
+                  + 1);
+        } else {
+          summary.increaseDirectlyFlushChunkNum(1);
+        }
+        break;
+      case DESERIALIZE_CHUNK:
+        if (chunkMetadataElement.isAligned) {
+          summary.increaseDeserializedChunkNum(
+              ((AlignedChunkMetadata) (chunkMetadataElement.chunkMetadata))
+                      .getValueChunkMetadataList()
+                      .size()
+                  + 1);
+        } else {
+          summary.increaseDeserializedChunkNum(1);
+        }
+        break;
+    }
+  }
+
+  enum ChunkStatus {
+    READ_IN,
+    DIRECTORY_FLUSH,
+    DESERIALIZE_CHUNK
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/ChunkMetadataElement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/ChunkMetadataElement.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element;
 
+import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 import org.apache.iotdb.tsfile.read.common.Chunk;
 
@@ -39,6 +40,7 @@ public class ChunkMetadataElement {
   public Chunk chunk;
 
   public List<Chunk> valueChunks;
+  public boolean isAligned;
 
   public ChunkMetadataElement(
       IChunkMetadata chunkMetadata, long priority, boolean isLastChunk, FileElement fileElement) {
@@ -47,6 +49,7 @@ public class ChunkMetadataElement {
     this.startTime = chunkMetadata.getStartTime();
     this.isLastChunk = isLastChunk;
     this.fileElement = fileElement;
+    this.isAligned = chunkMetadata instanceof AlignedChunkMetadata;
   }
 
   public void clearChunks() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.engine.compaction.execute.utils.executor.readchunk;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.cache.ChunkCache;
+import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.schedule.constant.CompactionType;
 import org.apache.iotdb.db.engine.compaction.schedule.constant.ProcessChunkType;
@@ -62,6 +63,7 @@ public class AlignedSeriesCompactionExecutor {
   private final AlignedChunkWriterImpl chunkWriter;
   private final List<IMeasurementSchema> schemaList;
   private long remainingPointInChunkWriter = 0L;
+  private final CompactionTaskSummary summary;
   private final RateLimiter rateLimiter =
       CompactionTaskManager.getInstance().getMergeWriteRateLimiter();
 
@@ -74,7 +76,8 @@ public class AlignedSeriesCompactionExecutor {
       String device,
       TsFileResource targetResource,
       LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>> readerAndChunkMetadataList,
-      TsFileIOWriter writer)
+      TsFileIOWriter writer,
+      CompactionTaskSummary summary)
       throws IOException {
     this.device = device;
     this.readerAndChunkMetadataList = readerAndChunkMetadataList;
@@ -82,6 +85,7 @@ public class AlignedSeriesCompactionExecutor {
     this.targetResource = targetResource;
     schemaList = collectSchemaFromAlignedChunkMetadataList(readerAndChunkMetadataList);
     chunkWriter = new AlignedChunkWriterImpl(schemaList);
+    this.summary = summary;
   }
 
   /**
@@ -137,9 +141,13 @@ public class AlignedSeriesCompactionExecutor {
       TsFileAlignedSeriesReaderIterator readerIterator =
           new TsFileAlignedSeriesReaderIterator(reader, alignedChunkMetadataList, schemaList);
       while (readerIterator.hasNext()) {
-        Pair<AlignedChunkReader, Long> chunkReaderAndChunkSize = readerIterator.nextReader();
-        CompactionMetricsRecorder.recordReadInfo(chunkReaderAndChunkSize.right);
-        compactOneAlignedChunk(chunkReaderAndChunkSize.left);
+        TsFileAlignedSeriesReaderIterator.NextAlignedChunkInfo nextAlignedChunkInfo =
+            readerIterator.nextReader();
+        summary.increaseProcessChunkNum(nextAlignedChunkInfo.getNotNullChunkNum());
+        summary.increaseProcessPointNum(nextAlignedChunkInfo.getTotalPointNum());
+        CompactionMetricsRecorder.recordReadInfo(nextAlignedChunkInfo.getTotalSize());
+        compactOneAlignedChunk(
+            nextAlignedChunkInfo.getReader(), nextAlignedChunkInfo.getNotNullChunkNum());
       }
     }
 
@@ -160,8 +168,10 @@ public class AlignedSeriesCompactionExecutor {
         .addCompactionTempFileSize(true, true, writer.getPos() - originTempFileSize);
   }
 
-  private void compactOneAlignedChunk(AlignedChunkReader chunkReader) throws IOException {
+  private void compactOneAlignedChunk(AlignedChunkReader chunkReader, int notNullChunkNum)
+      throws IOException {
     while (chunkReader.hasNextSatisfiedPage()) {
+      // including value chunk and time chunk, thus we should plus one
       IBatchDataIterator batchDataIterator = chunkReader.nextPageData().getBatchDataIterator();
       while (batchDataIterator.hasNext()) {
         TsPrimitiveType[] pointsData = (TsPrimitiveType[]) batchDataIterator.currentValue();

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/CompactionMetricsRecorder.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/CompactionMetricsRecorder.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.commons.service.metric.enums.Metric;
 import org.apache.iotdb.commons.service.metric.enums.Tag;
 import org.apache.iotdb.db.engine.compaction.execute.task.AbstractCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.task.CrossSpaceCompactionTask;
 import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.engine.compaction.schedule.constant.CompactionTaskStatus;
@@ -64,6 +65,44 @@ public class CompactionMetricsRecorder {
             byteNum,
             Metric.DATA_READ.toString(),
             MetricLevel.IMPORTANT,
+            Tag.NAME.toString(),
+            "compaction");
+  }
+
+  public static void updateSummary(CompactionTaskSummary summary) {
+    MetricService.getInstance()
+        .count(
+            summary.getProcessPointNum(),
+            "Compacted_Point_Num",
+            MetricLevel.IMPORTANT,
+            Tag.NAME.toString(),
+            "compaction");
+    MetricService.getInstance()
+        .count(
+            summary.getProcessChunkNum(),
+            "Compacted_Chunk_Num",
+            MetricLevel.IMPORTANT,
+            Tag.NAME.toString(),
+            "compaction");
+    MetricService.getInstance()
+        .count(
+            summary.getDirectlyFlushChunkNum(),
+            "Directly_Flush_Chunk_Num",
+            MetricLevel.NORMAL,
+            Tag.NAME.toString(),
+            "compaction");
+    MetricService.getInstance()
+        .count(
+            summary.getDeserializeChunkCount(),
+            "Deserialized_Chunk_Num",
+            MetricLevel.NORMAL,
+            Tag.NAME.toString(),
+            "compaction");
+    MetricService.getInstance()
+        .count(
+            summary.getMergedChunkNum(),
+            "Merged_Chunk_Num",
+            MetricLevel.NORMAL,
             Tag.NAME.toString(),
             "compaction");
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastCrossCompactionPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastCrossCompactionPerformerTest.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.execute.utils.reader.IDataBlockReader;
 import org.apache.iotdb.db.engine.compaction.execute.utils.reader.SeriesDataBlockReader;
@@ -143,7 +143,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -260,7 +260,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -458,7 +458,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -653,7 +653,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -838,7 +838,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -1016,7 +1016,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -1147,7 +1147,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
           CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
       ICompactionPerformer performer =
           new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
       Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -1224,7 +1224,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
           CompactionFileGeneratorUtils.getCrossCompactionTargetTsFileResources(seqResources);
       ICompactionPerformer performer =
           new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
       Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -1365,7 +1365,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -1496,7 +1496,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -1701,7 +1701,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -1941,7 +1941,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -2059,7 +2059,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -2188,7 +2188,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -2330,7 +2330,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -2451,7 +2451,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -2589,7 +2589,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -2749,7 +2749,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -2995,7 +2995,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -3266,7 +3266,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -3459,7 +3459,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -3779,7 +3779,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
@@ -3947,7 +3947,7 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     ICompactionPerformer performer =
         new FastCompactionPerformer(seqResources, unseqResources, targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithFastPerformerValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithFastPerformerValidationTest.java
@@ -24,9 +24,9 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.AbstractCompactionTest;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICrossCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.task.CrossSpaceCompactionTask;
 import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.selector.ICompactionSelector;
 import org.apache.iotdb.db.engine.compaction.selector.ICrossSpaceSelector;
@@ -2128,7 +2128,7 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
     FastCompactionPerformer performer = new FastCompactionPerformer(false);
     performer.setSourceFiles(sourceFiles);
     performer.setTargetFiles(targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
 
     CompactionUtils.moveTargetFile(targetResources, true, COMPACTION_TEST_SG + "-" + "0");
@@ -2234,7 +2234,7 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
             sourceFiles.getSeqFiles());
     performer.setSourceFiles(sourceFiles.getSeqFiles(), sourceFiles.getUnseqFiles());
     performer.setTargetFiles(targetResources);
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
 
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG + "-" + "0");

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/FastCompactionPerformerAlignedTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/FastCompactionPerformerAlignedTest.java
@@ -27,7 +27,7 @@ import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.TestUtilsForAlignedSeries;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionCheckerUtils;
@@ -145,7 +145,7 @@ public class FastCompactionPerformerAlignedTest {
             fullPaths, iMeasurementSchemas, resources, new ArrayList<>());
     performer.setSourceFiles(resources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
     CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
@@ -219,7 +219,7 @@ public class FastCompactionPerformerAlignedTest {
             fullPaths, iMeasurementSchemas, resources, new ArrayList<>());
     performer.setSourceFiles(resources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
     Map<PartialPath, List<TimeValuePair>> compactedData =
@@ -286,7 +286,7 @@ public class FastCompactionPerformerAlignedTest {
             fullPaths, iMeasurementSchemas, resources, new ArrayList<>());
     performer.setSourceFiles(resources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
     Map<PartialPath, List<TimeValuePair>> compactedData =
@@ -356,7 +356,7 @@ public class FastCompactionPerformerAlignedTest {
             fullPaths, iMeasurementSchemas, resources, new ArrayList<>());
     performer.setSourceFiles(resources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
     Map<PartialPath, List<TimeValuePair>> compactedData =
@@ -424,7 +424,7 @@ public class FastCompactionPerformerAlignedTest {
             fullPaths, iMeasurementSchemas, resources, new ArrayList<>());
     performer.setSourceFiles(resources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
     Map<PartialPath, List<TimeValuePair>> compactedData =
@@ -494,7 +494,7 @@ public class FastCompactionPerformerAlignedTest {
             fullPaths, iMeasurementSchemas, resources, new ArrayList<>());
     performer.setSourceFiles(resources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
     Map<PartialPath, List<TimeValuePair>> compactedData =
@@ -565,7 +565,7 @@ public class FastCompactionPerformerAlignedTest {
             fullPaths, iMeasurementSchemas, resources, new ArrayList<>());
     performer.setSourceFiles(resources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
     Map<PartialPath, List<TimeValuePair>> compactedData =
@@ -647,7 +647,7 @@ public class FastCompactionPerformerAlignedTest {
             fullPaths, iMeasurementSchemas, resources, new ArrayList<>());
     performer.setSourceFiles(resources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
     Map<PartialPath, List<TimeValuePair>> compactedData =

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/FastCompactionPerformerNoAlignedTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/FastCompactionPerformerNoAlignedTest.java
@@ -29,7 +29,7 @@ import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionCheckerUtils;
@@ -198,7 +198,7 @@ public class FastCompactionPerformerNoAlignedTest {
           TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
       Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
@@ -283,7 +283,7 @@ public class FastCompactionPerformerNoAlignedTest {
           TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
       Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
@@ -370,7 +370,7 @@ public class FastCompactionPerformerNoAlignedTest {
           TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
       Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
@@ -444,7 +444,7 @@ public class FastCompactionPerformerNoAlignedTest {
           TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
       Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
@@ -547,7 +547,7 @@ public class FastCompactionPerformerNoAlignedTest {
           TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
       Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
@@ -621,7 +621,7 @@ public class FastCompactionPerformerNoAlignedTest {
           TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
       Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
@@ -698,7 +698,7 @@ public class FastCompactionPerformerNoAlignedTest {
           TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
       Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
@@ -768,7 +768,7 @@ public class FastCompactionPerformerNoAlignedTest {
           TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
       Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
@@ -841,7 +841,7 @@ public class FastCompactionPerformerNoAlignedTest {
           TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(Collections.singletonList(targetResource), true, storageGroup);
       Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSeqCompactionWithFastPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSeqCompactionWithFastPerformerTest.java
@@ -27,8 +27,8 @@ import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionCheckerUtils;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionClearUtils;
@@ -244,7 +244,7 @@ public class InnerSeqCompactionWithFastPerformerTest {
               ICompactionPerformer performer = new FastCompactionPerformer(false);
               performer.setSourceFiles(sourceResources);
               performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-              performer.setSummary(new CompactionTaskSummary());
+              performer.setSummary(new FastCompactionTaskSummary());
               performer.perform();
               CompactionUtils.moveTargetFile(
                   Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);
@@ -477,7 +477,7 @@ public class InnerSeqCompactionWithFastPerformerTest {
             ICompactionPerformer performer = new FastCompactionPerformer(false);
             performer.setSourceFiles(toMergeResources);
             performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-            performer.setSummary(new CompactionTaskSummary());
+            performer.setSummary(new FastCompactionTaskSummary());
             performer.perform();
             CompactionUtils.moveTargetFile(
                 Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);
@@ -759,7 +759,7 @@ public class InnerSeqCompactionWithFastPerformerTest {
               ICompactionPerformer performer = new FastCompactionPerformer(false);
               performer.setSourceFiles(toMergeResources);
               performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-              performer.setSummary(new CompactionTaskSummary());
+              performer.setSummary(new FastCompactionTaskSummary());
               performer.perform();
               CompactionUtils.moveTargetFile(
                   Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSeqCompactionWithReadChunkPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSeqCompactionWithReadChunkPerformerTest.java
@@ -27,8 +27,8 @@ import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.ReadChunkCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionCheckerUtils;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionClearUtils;
@@ -242,7 +242,7 @@ public class InnerSeqCompactionWithReadChunkPerformerTest {
               }
               ICompactionPerformer performer =
                   new ReadChunkCompactionPerformer(sourceResources, targetTsFileResource);
-              performer.setSummary(new CompactionTaskSummary());
+              performer.setSummary(new FastCompactionTaskSummary());
               performer.perform();
               CompactionUtils.moveTargetFile(
                   Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);
@@ -470,7 +470,7 @@ public class InnerSeqCompactionWithReadChunkPerformerTest {
             }
             ICompactionPerformer performer =
                 new ReadChunkCompactionPerformer(toMergeResources, targetTsFileResource);
-            performer.setSummary(new CompactionTaskSummary());
+            performer.setSummary(new FastCompactionTaskSummary());
             performer.perform();
             CompactionUtils.moveTargetFile(
                 Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);
@@ -748,7 +748,7 @@ public class InnerSeqCompactionWithReadChunkPerformerTest {
               }
               ICompactionPerformer performer =
                   new ReadChunkCompactionPerformer(toMergeResources, targetTsFileResource);
-              performer.setSummary(new CompactionTaskSummary());
+              performer.setSummary(new FastCompactionTaskSummary());
               performer.perform();
               CompactionUtils.moveTargetFile(
                   Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionExceptionTest.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.db.engine.compaction.inner;
 import org.apache.iotdb.db.engine.compaction.execute.exception.CompactionExceptionHandler;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.execute.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
@@ -69,7 +69,7 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
         Collections.singletonList(targetResource), CompactionLogger.STR_TARGET_FILES);
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -121,7 +121,7 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
         Collections.singletonList(targetResource), CompactionLogger.STR_TARGET_FILES);
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -169,7 +169,7 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
         Collections.singletonList(targetResource), CompactionLogger.STR_TARGET_FILES);
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -228,7 +228,7 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
         Collections.singletonList(targetResource), CompactionLogger.STR_TARGET_FILES);
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -283,7 +283,7 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
         Collections.singletonList(targetResource), CompactionLogger.STR_TARGET_FILES);
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -361,7 +361,7 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
     }
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -423,7 +423,7 @@ public class InnerSpaceCompactionExceptionTest extends AbstractInnerSpaceCompact
     }
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerUnseqCompactionWithFastPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerUnseqCompactionWithFastPerformerTest.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionCheckerUtils;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionClearUtils;
@@ -383,7 +383,7 @@ public class InnerUnseqCompactionWithFastPerformerTest {
                       Collections.emptyList(),
                       toMergeResources,
                       Collections.singletonList(targetTsFileResource));
-              performer.setSummary(new CompactionTaskSummary());
+              performer.setSummary(new FastCompactionTaskSummary());
               performer.perform();
               CompactionUtils.moveTargetFile(
                   Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
@@ -28,7 +28,7 @@ import org.apache.iotdb.db.engine.cache.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.recover.CompactionRecoverTask;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.execute.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.compaction.inner.AbstractInnerSpaceCompactionTest;
@@ -150,7 +150,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     deleteFileIfExists(targetTsFileResource.getTsFile());
     performer.setSourceFiles(new ArrayList<>(seqResources.subList(0, 3)));
     performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     compactionLogger.close();
     CompactionUtils.moveTargetFile(
@@ -273,7 +273,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     deleteFileIfExists(targetTsFileResource.getTsFile());
     performer.setSourceFiles(new ArrayList<>(seqResources.subList(0, 3)));
     performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     compactionLogger.close();
     new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, true)
@@ -385,7 +385,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     deleteFileIfExists(targetTsFileResource.getTsFile());
     performer.setSourceFiles(new ArrayList<>(seqResources.subList(0, 3)));
     performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     // target file may not exist
     targetTsFileResource.remove();
@@ -489,7 +489,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     deleteFileIfExists(targetTsFileResource.getTsFile());
     performer.setSourceFiles(new ArrayList<>(seqResources.subList(0, 3)));
     performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);
@@ -565,7 +565,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     compactionLogger.logFiles(Collections.singletonList(targetResource), STR_TARGET_FILES);
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -637,7 +637,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     compactionLogger.logFiles(Collections.singletonList(targetResource), STR_TARGET_FILES);
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     // target file may not exist
     targetResource.remove();
@@ -711,7 +711,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     compactionLogger.logFiles(Collections.singletonList(targetResource), STR_TARGET_FILES);
     performer.setSourceFiles(seqResources);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -826,7 +826,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     deleteFileIfExists(targetTsFileResource.getTsFile());
     performer.setSourceFiles(new ArrayList<>(seqResources.subList(0, 3)));
     performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     compactionLogger.close();
     CompactionUtils.moveTargetFile(
@@ -917,7 +917,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     deleteFileIfExists(targetTsFileResource.getTsFile());
     performer.setSourceFiles(new ArrayList<>(seqResources.subList(0, 3)));
     performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetTsFileResource), true, COMPACTION_TEST_SG);
@@ -1011,7 +1011,7 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     deleteFileIfExists(targetTsFileResource.getTsFile());
     performer.setSourceFiles(new ArrayList<>(seqResources.subList(0, 3)));
     performer.setTargetFiles(Collections.singletonList(targetTsFileResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     compactionLogger.close();
     CompactionUtils.moveTargetFile(

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
@@ -28,7 +28,7 @@ import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.recover.CompactionRecoverTask;
-import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.execute.utils.log.CompactionLogger;
 import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
@@ -247,7 +247,7 @@ public class SizeTieredCompactionRecoverTest {
     compactionLogger.close();
     performer.setSourceFiles(sourceFiles);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -301,7 +301,7 @@ public class SizeTieredCompactionRecoverTest {
     compactionLogger.close();
     performer.setSourceFiles(sourceFiles);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -360,7 +360,7 @@ public class SizeTieredCompactionRecoverTest {
     logger.close();
     performer.setSourceFiles(sourceFiles);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -414,7 +414,7 @@ public class SizeTieredCompactionRecoverTest {
     compactionLogger.close();
     performer.setSourceFiles(sourceFiles);
     performer.setTargetFiles(Collections.singletonList(targetResource));
-    performer.setSummary(new CompactionTaskSummary());
+    performer.setSummary(new FastCompactionTaskSummary());
     performer.perform();
     CompactionUtils.moveTargetFile(
         Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -476,7 +476,7 @@ public class SizeTieredCompactionRecoverTest {
       compactionLogger.close();
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(
           Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -576,7 +576,7 @@ public class SizeTieredCompactionRecoverTest {
       compactionLogger.close();
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(
           Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -673,7 +673,7 @@ public class SizeTieredCompactionRecoverTest {
       compactionLogger.close();
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(
           Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);
@@ -773,7 +773,7 @@ public class SizeTieredCompactionRecoverTest {
       compactionLogger.close();
       performer.setSourceFiles(sourceFiles);
       performer.setTargetFiles(Collections.singletonList(targetResource));
-      performer.setSummary(new CompactionTaskSummary());
+      performer.setSummary(new FastCompactionTaskSummary());
       performer.perform();
       CompactionUtils.moveTargetFile(
           Collections.singletonList(targetResource), true, COMPACTION_TEST_SG);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileAlignedSeriesReaderIterator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileAlignedSeriesReaderIterator.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 import org.apache.iotdb.tsfile.read.common.Chunk;
 import org.apache.iotdb.tsfile.read.reader.chunk.AlignedChunkReader;
-import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 
 import java.io.IOException;
@@ -56,7 +55,7 @@ public class TsFileAlignedSeriesReaderIterator {
     return curIdx < alignedChunkMetadataList.size() - 1;
   }
 
-  public Pair<AlignedChunkReader, Long> nextReader() throws IOException {
+  public NextAlignedChunkInfo nextReader() throws IOException {
     AlignedChunkMetadata alignedChunkMetadata = alignedChunkMetadataList.get(++curIdx);
     IChunkMetadata timeChunkMetadata = alignedChunkMetadata.getTimeChunkMetadata();
     List<IChunkMetadata> valueChunkMetadataList = alignedChunkMetadata.getValueChunkMetadataList();
@@ -64,6 +63,8 @@ public class TsFileAlignedSeriesReaderIterator {
     Chunk timeChunk = reader.readMemChunk((ChunkMetadata) timeChunkMetadata);
     Chunk[] valueChunks = new Chunk[schemaList.size()];
     long totalSize = 0;
+    long totalPointNum = 0;
+    int notNullChunkNum = 0;
     for (IChunkMetadata valueChunkMetadata : valueChunkMetadataList) {
       if (valueChunkMetadata == null) {
         continue;
@@ -75,12 +76,45 @@ public class TsFileAlignedSeriesReaderIterator {
       }
       Chunk chunk = reader.readMemChunk((ChunkMetadata) valueChunkMetadata);
       valueChunks[schemaIdx++] = chunk;
+      notNullChunkNum++;
+      totalPointNum += ((ChunkMetadata) valueChunkMetadata).getNumOfPoints();
       totalSize += chunk.getHeader().getSerializedSize() + chunk.getHeader().getDataSize();
     }
 
     AlignedChunkReader chunkReader =
         new AlignedChunkReader(timeChunk, Arrays.asList(valueChunks), null);
 
-    return new Pair<>(chunkReader, totalSize);
+    return new NextAlignedChunkInfo(chunkReader, totalSize, notNullChunkNum, totalPointNum);
+  }
+
+  public class NextAlignedChunkInfo {
+    private AlignedChunkReader reader;
+    private long totalSize;
+    private int notNullChunkNum;
+    private long totalPointNum;
+
+    public NextAlignedChunkInfo(
+        AlignedChunkReader reader, long totalSize, int notNullChunkNum, long totalPointNum) {
+      this.reader = reader;
+      this.totalSize = totalSize;
+      this.notNullChunkNum = notNullChunkNum;
+      this.totalPointNum = totalPointNum;
+    }
+
+    public AlignedChunkReader getReader() {
+      return reader;
+    }
+
+    public long getTotalSize() {
+      return totalSize;
+    }
+
+    public long getTotalPointNum() {
+      return totalPointNum;
+    }
+
+    public int getNotNullChunkNum() {
+      return notNullChunkNum;
+    }
   }
 }


### PR DESCRIPTION
See [IOTDB-5140](https://issues.apache.org/jira/browse/IOTDB-5140).

This PR add serveral metrics for compaction execution, especially for the method that the chunk is processed. There are three types of chunk process method, which are directly-flush, merged, and deserialized into points. Monitoring the method the chunk is compacted can benifit the tuning of compaction.

<img width="1250" alt="3b39e1bbca488ba3add588ab65204c9" src="https://user-images.githubusercontent.com/37140360/212306545-578c639f-9858-41ad-afca-e58277840428.png">
