### PR TITLE
[IOTDB-5442] SchemaFile update StorageGroupNode asynchronously

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheManager.java
@@ -176,7 +176,10 @@ public abstract class CacheManager implements ICacheManager {
         // the status change affects the subTre collect in nodeBuffer
         cacheEntry.setVolatile(true);
       }
-      getBelongedContainer(node).updateMNode(node.getName());
+      if (!node.isStorageGroup()) {
+        // if node is StorageGroup, getBelongedContainer is null
+        getBelongedContainer(node).updateMNode(node.getName());
+      }
       // MNode update operation like node replace may reset the mapping between cacheEntry and node,
       // thus it should be updated
       updateCacheStatusAfterUpdate(cacheEntry, node);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/ICacheManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/ICacheManager.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.metadata.mtree.store.disk.cache;
 import org.apache.iotdb.db.exception.metadata.cache.MNodeNotCachedException;
 import org.apache.iotdb.db.exception.metadata.cache.MNodeNotPinnedException;
 import org.apache.iotdb.db.metadata.mnode.IMNode;
+import org.apache.iotdb.db.metadata.mnode.IStorageGroupMNode;
 
 import java.util.List;
 
@@ -37,6 +38,8 @@ public interface ICacheManager {
   void updateCacheStatusAfterUpdate(IMNode node);
 
   void updateCacheStatusAfterPersist(IMNode node);
+
+  IStorageGroupMNode collectUpdatedStorageGroupMNodes();
 
   List<IMNode> collectVolatileMNodes();
 


### PR DESCRIPTION
## Description

Synchronous updates require a mutex lock and asynchronous updates require a shared lock. 

In order to ensure that no mutex locks are applied during the update process, the update of the StorageGroupNode needs to be changed to asynchronous.
