### PR TITLE
[IOTDB-5395] Update file metrics when loading tsfile

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -2326,6 +2326,9 @@ public class DataRegion implements IDataRegionForQuery {
           newFilePartitionId,
           insertPos,
           deleteOriginFile);
+      TsFileMetricManager.getInstance()
+          .addFile(
+              newTsFileResource.getTsFile().length(), tsFileType == LoadTsFileType.LOAD_SEQUENCE);
 
       resetLastCacheWhenLoadingTsFile(); // update last cache
       updateLastFlushTime(newTsFileResource); // update last flush time


### PR DESCRIPTION
See [IOTDB-5395](https://issues.apache.org/jira/browse/IOTDB-5395).

This issue is fixed by updating file metrics when loading tsfile.

![958ba0d1579d2f600a54a2b6e906954](https://user-images.githubusercontent.com/37140360/215700414-c8c7cf05-16c0-4f56-8a3b-39b60d1840cc.png)
