### PR TITLE
[IOTDB-5441] Fix NPE while fetch schema that is not in template used by related device

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -487,6 +487,26 @@ public class IoTDBSchemaTemplateIT {
   }
 
   @Test
+  public void testInsertDataWithMeasurementsBeyondTemplate() throws Exception {
+    // set schema template
+    statement.execute("SET SCHEMA TEMPLATE t1 TO root.sg1.d1");
+    // insert data and auto activate schema template
+    statement.execute("INSERT INTO root.sg1.d1(time,s1,s2) VALUES (1,1,1)");
+    // insert twice to make sure the timeseries in template has been cached
+    statement.execute("INSERT INTO root.sg1.d1(time,s1,s2) VALUES (2,1,1)");
+
+    // insert data with extra measurement s3 which should be checked by schema fetch and auto
+    // created
+    statement.execute("INSERT INTO root.sg1.d1(time,s1,s2,s3) VALUES (2,1,1,1)");
+
+    try (ResultSet resultSet = statement.executeQuery("count timeseries")) {
+      Assert.assertTrue(resultSet.next());
+      long resultRecord = resultSet.getLong(1);
+      Assert.assertEquals(3, resultRecord);
+    }
+  }
+
+  @Test
   public void testUnsetTemplate() throws SQLException {
     // set schema template
     statement.execute("SET SCHEMA TEMPLATE t1 TO root.sg1.d1");

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -29,6 +29,9 @@ import org.apache.iotdb.db.metadata.mtree.store.IMTreeStore;
 import org.apache.iotdb.db.metadata.mtree.store.ReentrantReadOnlyCachedMTreeStore;
 import org.apache.iotdb.db.metadata.template.Template;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Iterator;
 import java.util.Map;
 
@@ -46,6 +49,8 @@ import static org.apache.iotdb.db.metadata.MetadataConstant.NON_TEMPLATE;
  * </ol>
  */
 public abstract class Traverser<R> extends AbstractTreeVisitor<IMNode, R> {
+
+  private static final Logger logger = LoggerFactory.getLogger(Traverser.class);
 
   protected IMTreeStore store;
 
@@ -96,7 +101,7 @@ public abstract class Traverser<R> extends AbstractTreeVisitor<IMNode, R> {
     }
     if (!isSuccess()) {
       Throwable e = getFailure();
-      e.printStackTrace();
+      logger.warn(e.getMessage(), e);
       throw new MetadataException(e.getMessage(), e);
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -112,9 +112,7 @@ public abstract class Traverser<R> extends AbstractTreeVisitor<IMNode, R> {
     if (parent.isAboveDatabase()) {
       child = parent.getChild(childName);
     } else {
-      child = store.getChild(parent, childName);
-      if (child == null
-          && parent.getSchemaTemplateId() != NON_TEMPLATE // the device is using template
+      if (parent.getSchemaTemplateId() != NON_TEMPLATE // the device is using template
           && !(skipPreDeletedSchema
               && parent
                   .getAsEntityMNode()
@@ -126,6 +124,9 @@ public abstract class Traverser<R> extends AbstractTreeVisitor<IMNode, R> {
           child = templateMap.get(parent.getSchemaTemplateId()).getDirectNode(childName);
         }
       }
+    }
+    if (child == null) {
+      child = store.getChild(parent, childName);
     }
     return child;
   }


### PR DESCRIPTION
## Description


### Cause

While fetching a normal timeseries under a device using template, since there's no template provided for traverser, which is brought by the mpp  or schema fetcher analyzing stage result, current implementation still tries to check the template and result in npe.

### Solution

Skip the template check while there's no template provided for traverser.


