### PR TITLE
[IOTDB-5455]Fix case sensitive when use Diff in where & NPE when series in where/having is not exist

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/builtinfunction/scalar/IoTDBDiffFunctionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/builtinfunction/scalar/IoTDBDiffFunctionIT.java
@@ -343,4 +343,18 @@ public class IoTDBDiffFunctionIT {
         expectedHeader,
         retArray);
   }
+
+  @Test
+  public void testCaseInSensitive() {
+    String[] expectedHeader = new String[] {TIMESTAMP_STR, "root.db.d1.s1", "root.db.d1.s2"};
+    String[] retArray = new String[] {"2,2,null,", "4,4,null,", "5,5,5.0,"};
+    resultSetEqualTest(
+        "select s1, s2 from root.db.d1 where Diff(s1) between 1 and 2", expectedHeader, retArray);
+
+    retArray = new String[] {};
+    resultSetEqualTest(
+        "select s1, s2 from root.db.d1 where Diff(notExist) between 1 and 2",
+        expectedHeader,
+        retArray);
+  }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBNullOperandIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBNullOperandIT.java
@@ -236,4 +236,44 @@ public class IoTDBNullOperandIT {
         expectedHeader,
         retArray);
   }
+
+  @Test
+  public void testSeriesNotExist() {
+    // series in select not exist
+    String[] expectedHeader =
+        new String[] {
+          TIMESTAMP_STR, "root.test.sg1.s1", "root.test.sg1.s3", "root.test.sg1.s4",
+        };
+    String[] retArray =
+        new String[] {
+          "1,1,true,false,", "2,2,true,null,", "3,3,null,false,",
+        };
+    resultSetEqualTest("select s1, s3, s4, notExist from root.**", expectedHeader, retArray);
+
+    // series in where not exist
+
+    retArray = new String[] {};
+    resultSetEqualTest("select s1, s3, s4 from root.** where notExist>0", expectedHeader, retArray);
+
+    resultSetEqualTest(
+        "select s1, s3, s4 from root.** where diff(notExist)>0", expectedHeader, retArray);
+
+    retArray =
+        new String[] {
+          "1,1,true,false,", "2,2,true,null,", "3,3,null,false,",
+        };
+    resultSetEqualTest(
+        "select s1, s3, s4 from root.** where diff(notExist) is null", expectedHeader, retArray);
+
+    // series in having not exist
+    expectedHeader =
+        new String[] {
+          TIMESTAMP_STR, "count(root.test.sg1.s1)", "count(root.test.sg1.s2)",
+        };
+    retArray = new String[] {};
+    resultSetEqualTest(
+        "select count(s1), count(s2) from root.** group by ([1,4),1ms) having count(notExist)>0",
+        expectedHeader,
+        retArray);
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/TypeProvider.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/TypeProvider.java
@@ -46,7 +46,10 @@ public class TypeProvider {
   }
 
   public void setType(String symbol, TSDataType dataType) {
-    this.typeMap.put(symbol, dataType);
+    // DataType of NullOperand is null, we needn't put it into TypeProvider
+    if (dataType != null) {
+      this.typeMap.put(symbol, dataType);
+    }
   }
 
   public boolean containsTypeInfoOf(String path) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/component/WhereCondition.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/component/WhereCondition.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.mpp.plan.statement.component;
 
+import org.apache.iotdb.db.mpp.plan.analyze.ExpressionAnalyzer;
 import org.apache.iotdb.db.mpp.plan.expression.Expression;
 import org.apache.iotdb.db.mpp.plan.statement.StatementNode;
 
@@ -29,8 +30,9 @@ public class WhereCondition extends StatementNode {
 
   public WhereCondition() {}
 
+  // cast functionName to lowercase in where predicate
   public WhereCondition(Expression predicate) {
-    this.predicate = predicate;
+    this.predicate = ExpressionAnalyzer.removeAliasFromExpression(predicate);
   }
 
   public Expression getPredicate() {
@@ -38,7 +40,7 @@ public class WhereCondition extends StatementNode {
   }
 
   public void setPredicate(Expression predicate) {
-    this.predicate = predicate;
+    this.predicate = ExpressionAnalyzer.removeAliasFromExpression(predicate);
   }
 
   public String toSQLString() {

--- a/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
@@ -173,6 +173,10 @@ public class TypeInferenceUtils {
   }
 
   private static void verifyIsScalarFunctionDataTypeMatched(String funcName, TSDataType dataType) {
+    // input is NullOperand, needn't check
+    if (dataType == null) {
+      return;
+    }
     switch (funcName.toLowerCase()) {
       case SqlConstant.DIFF:
         if (dataType.isNumeric()) {

--- a/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
@@ -140,6 +140,10 @@ public class TypeInferenceUtils {
 
   private static boolean verifyIsAggregationDataTypeMatched(
       String aggrFuncName, TSDataType dataType) {
+    // input is NullOperand, needn't check
+    if (dataType == null) {
+      return true;
+    }
     switch (aggrFuncName.toLowerCase()) {
       case SqlConstant.AVG:
       case SqlConstant.SUM:


### PR DESCRIPTION
 cause of bug1: we forget to  cast functionName to lowercase in where predicate 
 cause of bug2: forget corner case when check type in FunctionExpression----input expression is `NullOperand` 

fix result:
<img width="809" alt="image" src="https://user-images.githubusercontent.com/60659567/215998830-2f08e76b-5186-475c-a0b8-3a26456bdea8.png">
