### PR TITLE
Open schema cache statistics

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
@@ -59,6 +59,7 @@ public class DataNodeSchemaCache {
             .weigher(
                 (PartialPath key, SchemaCacheEntry value) ->
                     PartialPath.estimateSize(key) + SchemaCacheEntry.estimateSize(value))
+            .recordStats()
             .build();
     MetricService.getInstance().addMetricSet(new DataNodeSchemaCacheMetrics(this));
   }


### PR DESCRIPTION
## Description

We need to open ```recordStas``` when build caffiene, otherwise the cache hit rate won't be updated.
