### PR TITLE
Accelerate Count TimeSeries

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -43,6 +43,7 @@ import org.apache.iotdb.db.metadata.mnode.InternalMNode;
 import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
 import org.apache.iotdb.db.metadata.mnode.iterator.IMNodeIterator;
 import org.apache.iotdb.db.metadata.mtree.store.CachedMTreeStore;
+import org.apache.iotdb.db.metadata.mtree.traverser.Traverser;
 import org.apache.iotdb.db.metadata.mtree.traverser.TraverserWithLimitOffsetWrapper;
 import org.apache.iotdb.db.metadata.mtree.traverser.collector.EntityCollector;
 import org.apache.iotdb.db.metadata.mtree.traverser.collector.MNodeCollector;
@@ -56,7 +57,6 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowNodesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowDevicesResult;
 import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowNodesResult;
-import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
 import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
@@ -1020,20 +1020,63 @@ public class MTreeBelowSGCachedImpl implements IMTreeBelowSG {
           protected ITimeSeriesSchemaInfo collectMeasurement(IMeasurementMNode node) {
             Pair<Map<String, String>, Map<String, String>> tagAndAttribute =
                 tagAndAttributeProvider.apply(node.getOffset());
-            return new ShowTimeSeriesResult(
-                getPartialPathFromRootToNode(node).getFullPath(),
-                node.getAlias(),
-                (MeasurementSchema) node.getSchema(),
-                tagAndAttribute.left,
-                tagAndAttribute.right,
-                getParentOfNextMatchedNode().getAsEntityMNode().isAligned());
+            return new ITimeSeriesSchemaInfo() {
+
+              private Pair<Map<String, String>, Map<String, String>> tagAndAttribute = null;
+
+              @Override
+              public String getAlias() {
+                return node.getAlias();
+              }
+
+              @Override
+              public MeasurementSchema getSchema() {
+                return (MeasurementSchema) node.getSchema();
+              }
+
+              @Override
+              public Map<String, String> getTags() {
+                if (tagAndAttribute == null) {
+                  tagAndAttribute = tagAndAttributeProvider.apply(node.getOffset());
+                }
+                return tagAndAttribute.left;
+              }
+
+              @Override
+              public Map<String, String> getAttributes() {
+                if (tagAndAttribute == null) {
+                  tagAndAttribute = tagAndAttributeProvider.apply(node.getOffset());
+                }
+                return tagAndAttribute.right;
+              }
+
+              @Override
+              public boolean isUnderAlignedDevice() {
+                return getParentOfNextMatchedNode().getAsEntityMNode().isAligned();
+              }
+
+              @Override
+              public String getFullPath() {
+                return getPartialPathFromRootToNode(node).getFullPath();
+              }
+
+              @Override
+              public PartialPath getPartialPath() {
+                return getPartialPathFromRootToNode(node);
+              }
+            };
           }
         };
 
     collector.setTemplateMap(showTimeSeriesPlan.getRelatedTemplate());
-    TraverserWithLimitOffsetWrapper<ITimeSeriesSchemaInfo> traverser =
-        new TraverserWithLimitOffsetWrapper<>(
-            collector, showTimeSeriesPlan.getLimit(), showTimeSeriesPlan.getOffset());
+    Traverser<ITimeSeriesSchemaInfo> traverser;
+    if (showTimeSeriesPlan.getLimit() > 0 || showTimeSeriesPlan.getOffset() > 0) {
+      traverser =
+          new TraverserWithLimitOffsetWrapper<>(
+              collector, showTimeSeriesPlan.getLimit(), showTimeSeriesPlan.getOffset());
+    } else {
+      traverser = collector;
+    }
     return new ISchemaReader<ITimeSeriesSchemaInfo>() {
       @Override
       public boolean isSuccess() {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -258,6 +258,10 @@ public interface ISchemaRegion {
   ISchemaReader<IDeviceSchemaInfo> getDeviceReader(IShowDevicesPlan showDevicesPlan)
       throws MetadataException;
 
+  /**
+   * The iterated result shall be consumed before calling reader.haxNext() or read.next(). Its
+   * implementation is based on the reader's process context.
+   */
   ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(IShowTimeSeriesPlan showTimeSeriesPlan)
       throws MetadataException;
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegion.java
@@ -259,7 +259,7 @@ public interface ISchemaRegion {
       throws MetadataException;
 
   /**
-   * The iterated result shall be consumed before calling reader.haxNext() or read.next(). Its
+   * The iterated result shall be consumed before calling reader.hasNext() or reader.next(). Its
    * implementation is based on the reader's process context.
    */
   ISchemaReader<ITimeSeriesSchemaInfo> getTimeSeriesReader(IShowTimeSeriesPlan showTimeSeriesPlan)

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionRead
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWritePlanFactory;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowTimeSeriesPlan;
+import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
 import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
@@ -266,9 +267,18 @@ public class SchemaRegionTestUtil {
   public static List<ITimeSeriesSchemaInfo> showTimeseries(
       ISchemaRegion schemaRegion, IShowTimeSeriesPlan plan) {
     List<ITimeSeriesSchemaInfo> result = new ArrayList<>();
+    ITimeSeriesSchemaInfo timeSeriesSchemaInfo;
     try (ISchemaReader<ITimeSeriesSchemaInfo> reader = schemaRegion.getTimeSeriesReader(plan)) {
       while (reader.hasNext()) {
-        result.add(reader.next());
+        timeSeriesSchemaInfo = reader.next();
+        result.add(
+            new ShowTimeSeriesResult(
+                timeSeriesSchemaInfo.getFullPath(),
+                timeSeriesSchemaInfo.getAlias(),
+                timeSeriesSchemaInfo.getSchema(),
+                timeSeriesSchemaInfo.getTags(),
+                timeSeriesSchemaInfo.getAttributes(),
+                timeSeriesSchemaInfo.isUnderAlignedDevice()));
       }
     } catch (Exception e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
## Description

Currently, the time series reader is implemented based on ```ShowTimeSeriesResult```, which is used as temporary schema result carrier and costs construction time. The construction time of ```ShowTimeSeriesResult``` can be saved via a light implementation generating fewest extra temporary objects.

Count timeseries operation benefits from the modification most. Its time consumption decreased to 1/4~1/3.
