### PR TITLE
[IOTDB-5471] Add isDone() check in WrappedThreadPoolExecutor#afterExecute

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/WrappedThreadPoolExecutor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/threadpool/WrappedThreadPoolExecutor.java
@@ -92,7 +92,10 @@ public class WrappedThreadPoolExecutor extends ThreadPoolExecutor
     super.afterExecute(r, t);
     if (t == null && r instanceof Future<?>) {
       try {
-        ((Future<?>) r).get();
+        Future<?> future = (Future<?>) r;
+        if (future.isDone()) {
+          future.get();
+        }
       } catch (CancellationException ce) {
         t = ce;
       } catch (ExecutionException ee) {


### PR DESCRIPTION
## Description

I want to use the thread pool created by the IoTDBThreadPoolFactory in CompleteFuture. However, I have found that this can cause problems with threads not being released.

Here is the example code.

```java

import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;

import java.util.concurrent.CompletableFuture;
import java.util.concurrent.ExecutorService;

public class Tests {

  public static void main(String[] args) {
    ExecutorService flushTaskExecutor1 = IoTDBThreadPoolFactory.newFixedThreadPool(2, "1");
    CompletableFuture<Void>[] completableFutures = new CompletableFuture[5];
    for (int j = 0; j < 5; j++) {
      completableFutures[j] =
          CompletableFuture.supplyAsync(
              () -> {
                System.out.println("run");
                return null;
              },
              flushTaskExecutor1);
    }
    CompletableFuture.allOf(completableFutures).join();
    System.out.println("done");
    flushTaskExecutor1.shutdown();
  }
}
```
 
Only two “run” are printed, whereas the expectation is that 5 “run” should be printed. if I change the thread creation code to 
`ExecutorService flushTaskExecutor1 = Executors.newFixedThreadPool(2); `, it works as expected.

Using the thread dump, I found that the thread was blocking at `WrappedThreadPoolExecutor#afterExecute` after execution. This was due to a problem with the implementation of `CompleteFuture#AsyncRun`. One solution I found in https://stackoverflow.com/questions/2248131/handling-exceptions-from-java-executorservice-tasks is to add the `isDone()` check before invoking get().  The `isDone()` check is necessary in certain cases to avoid blocking. There are some similar problems, you can see [bugs.openjdk.org/browse/JDK-8071638](https://bugs.openjdk.org/browse/JDK-8071638) and [bugs.openjdk.org/browse/JDK-7146994](https://bugs.openjdk.org/browse/JDK-7146994) for details.