### PR TITLE
[IOTDB-5487] Fix the problem that the timestamp is "null" when using jdbc

### DIFF
--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -271,6 +271,7 @@ public class IoTDBRpcDataSet {
 
   public boolean next() throws StatementExecutionException, IoTDBConnectionException {
     if (hasCachedBlock()) {
+      lastReadWasNull = false;
       constructOneRow();
       return true;
     }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -271,6 +271,7 @@ public class IoTDBRpcDataSet {
 
   public boolean next() throws StatementExecutionException, IoTDBConnectionException {
     if (hasCachedBlock()) {
+      lastReadWasNull=false;
       constructOneRow();
       return true;
     }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -271,7 +271,6 @@ public class IoTDBRpcDataSet {
 
   public boolean next() throws StatementExecutionException, IoTDBConnectionException {
     if (hasCachedBlock()) {
-      lastReadWasNull=false;
       constructOneRow();
       return true;
     }


### PR DESCRIPTION
see [IOTDB-3936]Add an interface in IClientRPCService to directly return bytebuffer instead of TSQueryDataSet

This pr is modified to add `lastReadWasNull = false;` of the `constructOneRow` method to the `constructOneTsBlock` method, resulting in a call to the next() method that meets the first of the following criteria, The `lastReadWasNull` field was not reset to false.

![image](https://user-images.githubusercontent.com/79885238/217172759-89a66184-1766-4aa9-b6d2-f1cf9932bb10.png)
