### PR TITLE
[To rel/1.0][IoTDB-5350] fix bug about show devices

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/EntityCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/EntityCollector.java
@@ -50,7 +50,7 @@ public abstract class EntityCollector<T> extends CollectorTraverser<T> {
       if (hasLimit) {
         curOffset += 1;
         if (curOffset < offset) {
-          return true;
+          return false;
         }
       }
       collectEntity(node.getAsEntityMNode());


### PR DESCRIPTION
fix a bug about show devices. 
[A bug about `show timeseries` while using offset](https://issues.apache.org/jira/browse/IOTDB-5350)

This bug only appears in version 1.0 or earlier version. In master branch, there is no such bug. 

Relevant unit tests have also been added.

