### PR TITLE
[IOTDB-5496] Rename VerticallyConcatOperator as HorizontallyConcatOperator

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/HorizontallyConcatOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/HorizontallyConcatOperator.java
@@ -38,7 +38,14 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.successfulAsList;
 
-public class VerticallyConcatOperator implements ProcessOperator {
+/**
+ * This operator is used to horizontally concatenate TsBlocks with the same timestamp column.
+ *
+ * <p>For example, TsBlock A is: [1, 1.0; 2, 2.0], TsBlock B is: [1, true; 2, false]
+ *
+ * <p>HorizontallyConcat(A,B) is: [1, 1.0, true; 2, 2.0, false]
+ */
+public class HorizontallyConcatOperator implements ProcessOperator {
 
   private final OperatorContext operatorContext;
 
@@ -58,7 +65,7 @@ public class VerticallyConcatOperator implements ProcessOperator {
 
   private boolean finished;
 
-  public VerticallyConcatOperator(
+  public HorizontallyConcatOperator(
       OperatorContext operatorContext, List<Operator> children, List<TSDataType> dataTypes) {
     checkArgument(
         children != null && !children.isEmpty(),

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
@@ -80,9 +80,9 @@ import org.apache.iotdb.db.mpp.execution.operator.process.fill.previous.DoublePr
 import org.apache.iotdb.db.mpp.execution.operator.process.fill.previous.FloatPreviousFill;
 import org.apache.iotdb.db.mpp.execution.operator.process.fill.previous.IntPreviousFill;
 import org.apache.iotdb.db.mpp.execution.operator.process.fill.previous.LongPreviousFill;
+import org.apache.iotdb.db.mpp.execution.operator.process.join.HorizontallyConcatOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.join.RowBasedTimeJoinOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.join.TimeJoinOperator;
-import org.apache.iotdb.db.mpp.execution.operator.process.join.VerticallyConcatOperator;
 import org.apache.iotdb.db.mpp.execution.operator.process.join.merge.AscTimeComparator;
 import org.apache.iotdb.db.mpp.execution.operator.process.join.merge.ColumnMerger;
 import org.apache.iotdb.db.mpp.execution.operator.process.join.merge.DescTimeComparator;
@@ -155,6 +155,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.FillNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.FilterNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByLevelNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByTagNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.HorizontallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.IntoNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.LimitNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MergeSortNode;
@@ -165,7 +166,6 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggre
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SortNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TimeJoinNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TransformNode;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.VerticallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryCollectNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryNode;
@@ -1690,8 +1690,8 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
   }
 
   @Override
-  public Operator visitVerticallyConcat(
-      VerticallyConcatNode node, LocalExecutionPlanContext context) {
+  public Operator visitHorizontallyConcat(
+      HorizontallyConcatNode node, LocalExecutionPlanContext context) {
     List<Operator> children = dealWithConsumeAllChildrenPipelineBreaker(node, context);
     OperatorContext operatorContext =
         context
@@ -1699,11 +1699,11 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
             .addOperatorContext(
                 context.getNextOperatorId(),
                 node.getPlanNodeId(),
-                VerticallyConcatOperator.class.getSimpleName());
+                HorizontallyConcatOperator.class.getSimpleName());
     List<TSDataType> outputColumnTypes = getOutputColumnTypes(node, context.getTypeProvider());
 
     context.getTimeSliceAllocator().recordExecutionWeight(operatorContext, 1);
-    return new VerticallyConcatOperator(operatorContext, children, outputColumnTypes);
+    return new HorizontallyConcatOperator(operatorContext, children, outputColumnTypes);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/ExchangeNodeAdder.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/ExchangeNodeAdder.java
@@ -39,13 +39,13 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.ExchangeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.FilterNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByLevelNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByTagNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.HorizontallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MergeSortNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MultiChildProcessNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SingleDeviceViewNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggregationNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TimeJoinNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TransformNode;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.VerticallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryCollectNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryNode;
@@ -346,7 +346,7 @@ public class ExchangeNodeAdder extends PlanVisitor<PlanNode, NodeGroupContext> {
   }
 
   @Override
-  public PlanNode visitVerticallyConcat(VerticallyConcatNode node, NodeGroupContext context) {
+  public PlanNode visitHorizontallyConcat(HorizontallyConcatNode node, NodeGroupContext context) {
     return processMultiChildNode(node, context);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
@@ -39,12 +39,12 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.AggregationNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.DeviceViewNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByLevelNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByTagNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.HorizontallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MergeSortNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MultiChildProcessNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SingleDeviceViewNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggregationNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TimeJoinNode;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.VerticallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryCollectNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryNode;
@@ -718,7 +718,7 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
               root, context, sources, eachSeriesOneRegion, regionCountPerSeries);
 
       if (eachSeriesOneRegion[0]) {
-        newRoot = new VerticallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
+        newRoot = new HorizontallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
       } else {
         List<AggregationDescriptor> rootAggDescriptorList = new ArrayList<>();
         for (PlanNode child : root.getChildren()) {
@@ -780,8 +780,8 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
               sourceNodes.forEach(newRoot::addChild);
               addParent[0] = true;
             } else {
-              VerticallyConcatNode parentOfGroup =
-                  new VerticallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
+              HorizontallyConcatNode parentOfGroup =
+                  new HorizontallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
               sourceNodes.forEach(parentOfGroup::addChild);
               newRoot.addChild(parentOfGroup);
             }
@@ -869,8 +869,8 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
           if (sourceNodes.size() == 1) {
             parentOfGroup.addChild(sourceNodes.get(0));
           } else {
-            VerticallyConcatNode verticallyConcatNode =
-                new VerticallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
+            HorizontallyConcatNode verticallyConcatNode =
+                new HorizontallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
             sourceNodes.forEach(verticallyConcatNode::addChild);
             parentOfGroup.addChild(verticallyConcatNode);
           }
@@ -1009,8 +1009,8 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
           if (sourceNodes.size() == 1) {
             parentOfGroup.addChild(sourceNodes.get(0));
           } else {
-            VerticallyConcatNode verticallyConcatNode =
-                new VerticallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
+            HorizontallyConcatNode verticallyConcatNode =
+                new HorizontallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
             sourceNodes.forEach(verticallyConcatNode::addChild);
             parentOfGroup.addChild(verticallyConcatNode);
           }
@@ -1034,10 +1034,10 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
               sourceNodes.forEach(newRoot::addChild);
               addParent[0] = true;
             } else {
-              VerticallyConcatNode verticallyConcatNode =
-                  new VerticallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
-              sourceNodes.forEach(verticallyConcatNode::addChild);
-              newRoot.addChild(verticallyConcatNode);
+              HorizontallyConcatNode horizontallyConcatNode =
+                  new HorizontallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());
+              sourceNodes.forEach(horizontallyConcatNode::addChild);
+              newRoot.addChild(horizontallyConcatNode);
             }
           }
         });

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanGraphPrinter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanGraphPrinter.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.FillNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.FilterNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByLevelNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByTagNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.HorizontallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.IntoNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.LimitNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MergeSortNode;
@@ -41,7 +42,6 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggre
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SortNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TimeJoinNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TransformNode;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.VerticallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryCollectNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryNode;
@@ -414,7 +414,7 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
   }
 
   @Override
-  public List<String> visitVerticallyConcat(VerticallyConcatNode node, GraphContext context) {
+  public List<String> visitHorizontallyConcat(HorizontallyConcatNode node, GraphContext context) {
     List<String> boxValue = new ArrayList<>();
     boxValue.add(String.format("VerticallyConcat-%s", node.getPlanNodeId().getId()));
     return render(node, boxValue, context);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanNodeType.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanNodeType.java
@@ -58,6 +58,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.FillNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.FilterNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByLevelNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByTagNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.HorizontallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.IntoNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.LimitNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MergeSortNode;
@@ -68,7 +69,6 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggre
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SortNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TimeJoinNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TransformNode;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.VerticallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryCollectNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryNode;
@@ -340,7 +340,7 @@ public enum PlanNodeType {
       case 63:
         return DeviceViewIntoNode.deserialize(buffer);
       case 64:
-        return VerticallyConcatNode.deserialize(buffer);
+        return HorizontallyConcatNode.deserialize(buffer);
       case 65:
         return SingleDeviceViewNode.deserialize(buffer);
       case 66:

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanVisitor.java
@@ -56,6 +56,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.FillNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.FilterNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByLevelNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByTagNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.HorizontallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.IntoNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.LimitNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MergeSortNode;
@@ -66,7 +67,6 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggre
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SortNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TimeJoinNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TransformNode;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.VerticallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryCollectNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.last.LastQueryNode;
@@ -341,7 +341,7 @@ public abstract class PlanVisitor<R, C> {
     return visitPlan(node, context);
   }
 
-  public R visitVerticallyConcat(VerticallyConcatNode node, C context) {
+  public R visitHorizontallyConcat(HorizontallyConcatNode node, C context) {
     return visitPlan(node, context);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/process/HorizontallyConcatNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/process/HorizontallyConcatNode.java
@@ -36,15 +36,15 @@ import java.util.stream.Collectors;
  * same time column or no time column at all, and we can merge the value column directly without
  * compare.
  */
-public class VerticallyConcatNode extends MultiChildProcessNode {
+public class HorizontallyConcatNode extends MultiChildProcessNode {
 
-  public VerticallyConcatNode(PlanNodeId id) {
+  public HorizontallyConcatNode(PlanNodeId id) {
     super(id, new ArrayList<>());
   }
 
   @Override
   public PlanNode clone() {
-    return new VerticallyConcatNode(getPlanNodeId());
+    return new HorizontallyConcatNode(getPlanNodeId());
   }
 
   @Override
@@ -58,7 +58,7 @@ public class VerticallyConcatNode extends MultiChildProcessNode {
 
   @Override
   public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
-    return visitor.visitVerticallyConcat(this, context);
+    return visitor.visitHorizontallyConcat(this, context);
   }
 
   @Override
@@ -71,9 +71,9 @@ public class VerticallyConcatNode extends MultiChildProcessNode {
     PlanNodeType.VERTICALLY_CONCAT.serialize(stream);
   }
 
-  public static VerticallyConcatNode deserialize(ByteBuffer byteBuffer) {
+  public static HorizontallyConcatNode deserialize(ByteBuffer byteBuffer) {
     PlanNodeId planNodeId = PlanNodeId.deserialize(byteBuffer);
-    return new VerticallyConcatNode(planNodeId);
+    return new HorizontallyConcatNode(planNodeId);
   }
 
   @Override
@@ -92,7 +92,7 @@ public class VerticallyConcatNode extends MultiChildProcessNode {
     if (!super.equals(o)) {
       return false;
     }
-    VerticallyConcatNode that = (VerticallyConcatNode) o;
+    HorizontallyConcatNode that = (HorizontallyConcatNode) o;
     return children.equals(that.children);
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/HorizontallyConcatOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/HorizontallyConcatOperatorTest.java
@@ -33,7 +33,7 @@ import org.apache.iotdb.db.mpp.common.QueryId;
 import org.apache.iotdb.db.mpp.execution.driver.DriverContext;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceStateMachine;
-import org.apache.iotdb.db.mpp.execution.operator.process.join.VerticallyConcatOperator;
+import org.apache.iotdb.db.mpp.execution.operator.process.join.HorizontallyConcatOperator;
 import org.apache.iotdb.db.mpp.execution.operator.source.SeriesAggregationScanOperator;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.AggregationStep;
@@ -64,9 +64,9 @@ import static org.apache.iotdb.tsfile.read.common.block.TsBlockBuilderStatus.DEF
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class VerticallyConcatOperatorTest {
-  private static final String VERTICALLY_CONCAT_OPERATOR_TEST_SG =
-      "root.VerticallyConcatOperatorTest";
+public class HorizontallyConcatOperatorTest {
+  private static final String HORIZONTALLY_CONCAT_OPERATOR_TEST_SG =
+      "root.HorizontallyConcatOperatorTest";
   private final List<String> deviceIds = new ArrayList<>();
   private final List<MeasurementSchema> measurementSchemas = new ArrayList<>();
 
@@ -80,7 +80,7 @@ public class VerticallyConcatOperatorTest {
         deviceIds,
         seqResources,
         unSeqResources,
-        VERTICALLY_CONCAT_OPERATOR_TEST_SG);
+        HORIZONTALLY_CONCAT_OPERATOR_TEST_SG);
   }
 
   @After
@@ -112,11 +112,11 @@ public class VerticallyConcatOperatorTest {
       driverContext.addOperatorContext(
           2, planNodeId2, SeriesAggregationScanOperator.class.getSimpleName());
       driverContext.addOperatorContext(
-          3, new PlanNodeId("3"), VerticallyConcatOperator.class.getSimpleName());
+          3, new PlanNodeId("3"), HorizontallyConcatOperator.class.getSimpleName());
 
       MeasurementPath measurementPath1 =
           new MeasurementPath(
-              VERTICALLY_CONCAT_OPERATOR_TEST_SG + ".device0.sensor0", TSDataType.INT32);
+              HORIZONTALLY_CONCAT_OPERATOR_TEST_SG + ".device0.sensor0", TSDataType.INT32);
       List<TAggregationType> aggregationTypes =
           Arrays.asList(TAggregationType.COUNT, TAggregationType.SUM, TAggregationType.FIRST_VALUE);
       GroupByTimeParameter groupByTimeParameter = new GroupByTimeParameter(0, 10, 1, 1, true);
@@ -143,7 +143,7 @@ public class VerticallyConcatOperatorTest {
 
       MeasurementPath measurementPath2 =
           new MeasurementPath(
-              VERTICALLY_CONCAT_OPERATOR_TEST_SG + ".device0.sensor1", TSDataType.INT32);
+              HORIZONTALLY_CONCAT_OPERATOR_TEST_SG + ".device0.sensor1", TSDataType.INT32);
       SeriesAggregationScanOperator seriesAggregationScanOperator2 =
           new SeriesAggregationScanOperator(
               planNodeId2,
@@ -162,8 +162,8 @@ public class VerticallyConcatOperatorTest {
           .getOperatorContext()
           .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
-      VerticallyConcatOperator verticallyConcatOperator =
-          new VerticallyConcatOperator(
+      HorizontallyConcatOperator horizontallyConcatOperator =
+          new HorizontallyConcatOperator(
               driverContext.getOperatorContexts().get(2),
               Arrays.asList(seriesAggregationScanOperator1, seriesAggregationScanOperator2),
               Arrays.asList(
@@ -175,8 +175,8 @@ public class VerticallyConcatOperatorTest {
                   TSDataType.INT32));
 
       int count = 0;
-      while (verticallyConcatOperator.hasNext()) {
-        TsBlock tsBlock = verticallyConcatOperator.next();
+      while (horizontallyConcatOperator.hasNext()) {
+        TsBlock tsBlock = horizontallyConcatOperator.next();
         assertEquals(6, tsBlock.getValueColumnCount());
         for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
           assertEquals(count, tsBlock.getTimeByIndex(i));

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/AggregationDistributionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/AggregationDistributionTest.java
@@ -38,10 +38,10 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.AggregationNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.DeviceViewNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.GroupByLevelNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.HorizontallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.MergeSortNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.SlidingWindowAggregationNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.TimeJoinNode;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.VerticallyConcatNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.SeriesAggregationScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.SeriesAggregationSourceNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.AggregationDescriptor;
@@ -734,7 +734,7 @@ public class AggregationDistributionTest {
     PlanNode f2Root =
         plan.getInstances().get(1).getFragment().getPlanNodeTree().getChildren().get(0);
     assertTrue(f1Root instanceof DeviceViewNode);
-    assertTrue(f2Root instanceof VerticallyConcatNode);
+    assertTrue(f2Root instanceof HorizontallyConcatNode);
     assertTrue(f1Root.getChildren().get(0) instanceof AggregationNode);
     assertEquals(3, f1Root.getChildren().get(0).getChildren().size());
   }
@@ -758,9 +758,9 @@ public class AggregationDistributionTest {
     PlanNode f3Root =
         plan.getInstances().get(2).getFragment().getPlanNodeTree().getChildren().get(0);
     assertTrue(f1Root instanceof MergeSortNode);
-    assertTrue(f2Root instanceof VerticallyConcatNode);
+    assertTrue(f2Root instanceof HorizontallyConcatNode);
     assertTrue(f3Root instanceof DeviceViewNode);
-    assertTrue(f3Root.getChildren().get(0) instanceof VerticallyConcatNode);
+    assertTrue(f3Root.getChildren().get(0) instanceof HorizontallyConcatNode);
     assertTrue(f1Root.getChildren().get(0) instanceof DeviceViewNode);
     assertTrue(f1Root.getChildren().get(0).getChildren().get(0) instanceof AggregationNode);
     assertEquals(3, f1Root.getChildren().get(0).getChildren().get(0).getChildren().size());
@@ -783,7 +783,7 @@ public class AggregationDistributionTest {
     PlanNode f2Root =
         plan.getInstances().get(1).getFragment().getPlanNodeTree().getChildren().get(0);
     assertTrue(f1Root instanceof DeviceViewNode);
-    assertTrue(f2Root instanceof VerticallyConcatNode);
+    assertTrue(f2Root instanceof HorizontallyConcatNode);
     assertEquals(2, f1Root.getChildren().size());
   }
 
@@ -878,7 +878,7 @@ public class AggregationDistributionTest {
         fragmentInstance ->
             assertTrue(
                 fragmentInstance.getFragment().getPlanNodeTree().getChildren().get(0)
-                    instanceof VerticallyConcatNode));
+                    instanceof HorizontallyConcatNode));
 
     Map<String, AggregationStep> expectedStep = new HashMap<>();
     expectedStep.put("root.sg.d22.s1", AggregationStep.SINGLE);


### PR DESCRIPTION
VerticallyConcatOperator is used to horizontally concatenate TsBlocks with the same timestamp column. For example,
TsBlock A is:
| Time | ColumnA |
|    1    |     1.0    |
TsBlock B is:
| Time | ColumnB |
|    1    |       2.0    |
After the VerticallyConcatOperator, the result will be:
| Time | ColumnA | ColumnB |
|    1    |       1.0    |     2.0      |

Literally, I think it's a horizontal concatenation. So I suggest rename it as HorizontallyConcatOperator.