### PR TITLE
[IOTDB-5509] Add level control for cross compaction selecting

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
@@ -191,13 +191,15 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
       throws IOException {
     TsFileNameGenerator.TsFileName unseqFileName =
         TsFileNameGenerator.getTsFileName(unseqFile.getTsFile().getName());
-    // for the level-0 unseqFile, it is not allowed to be selected as the candidate of cross
-    // compaction task
+    // we add a hard limit for cross compaction that selected unseqFile should be compacted in inner
+    // space at least once. This is used to make to improve the priority of inner compaction and
+    // avoid too much cross compaction with small files.
     if (unseqFileName.getInnerCompactionCnt() < 1) {
       return false;
     }
     // currently, we must allow at least one unseqFile be selected to handle the situation that
     // an unseqFile has huge time range but few data points.
+    // IMPORTANT: this logic is opposite to previous level control
     if (taskResource.getUnseqFiles().isEmpty()) {
       return true;
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.engine.compaction.selector.utils.CrossSpaceCompaction
 import org.apache.iotdb.db.engine.compaction.selector.utils.CrossSpaceCompactionCandidate.CrossCompactionTaskResourceSplit;
 import org.apache.iotdb.db.engine.compaction.selector.utils.CrossSpaceCompactionCandidate.TsFileResourceCandidate;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
+import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.MergeException;
 import org.apache.iotdb.db.rescon.SystemInfo;
@@ -186,7 +187,15 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
       CrossCompactionTaskResource taskResource,
       TsFileResource unseqFile,
       List<TsFileResource> seqFiles,
-      long memoryCost) {
+      long memoryCost)
+      throws IOException {
+    TsFileNameGenerator.TsFileName unseqFileName =
+        TsFileNameGenerator.getTsFileName(unseqFile.getTsFile().getName());
+    // for the level-0 unseqFile, it is not allowed to be selected as the candidate of cross
+    // compaction task
+    if (unseqFileName.getInnerCompactionCnt() < 1) {
+      return false;
+    }
     // currently, we must allow at least one unseqFile be selected to handle the situation that
     // an unseqFile has huge time range but few data points.
     if (taskResource.getUnseqFiles().isEmpty()) {


### PR DESCRIPTION
## Description
In this change, we add a limitation for cross compaction selector to increase the compaction efficiency. That is, only the unseqFile whose level larger that 0 can be selected as the candidate of cross compaction.

So, the small unseq file will be compacted inner before doing cross space compaction