### PR TITLE
[IOTDB-5499] Eliminate useless log during auto creating schema

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/visitor/SchemaExecutionVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/visitor/SchemaExecutionVisitor.java
@@ -213,12 +213,12 @@ public class SchemaExecutionVisitor extends PlanVisitor<TSStatus, ISchemaRegion>
         schemaRegion.createTimeseries(
             transformToCreateTimeSeriesPlan(devicePath, measurementGroup, i), -1);
       } catch (MeasurementAlreadyExistException e) {
-        logger.info("There's no need to internal create timeseries. {}", e.getMessage());
+        // There's no need to internal create timeseries.
         alreadyExistingTimeseries.add(
             RpcUtils.getStatus(
                 e.getErrorCode(), MeasurementPath.transformDataToString(e.getMeasurementPath())));
       } catch (MetadataException e) {
-        logger.error("{}: MetaData error: ", IoTDBConstant.GLOBAL_DB_NAME, e);
+        logger.warn("{}: MetaData error: ", e.getMessage(), e);
         failingStatus.add(RpcUtils.getStatus(e.getErrorCode(), e.getMessage()));
       }
     }
@@ -252,7 +252,7 @@ public class SchemaExecutionVisitor extends PlanVisitor<TSStatus, ISchemaRegion>
         shouldRetry = false;
       } catch (MeasurementAlreadyExistException e) {
         // the existence check will be executed before truly creation
-        logger.info("There's no need to internal create timeseries. {}", e.getMessage());
+        // There's no need to internal create timeseries.
         MeasurementPath measurementPath = e.getMeasurementPath();
         alreadyExistingTimeseries.add(
             RpcUtils.getStatus(
@@ -270,7 +270,7 @@ public class SchemaExecutionVisitor extends PlanVisitor<TSStatus, ISchemaRegion>
         }
 
       } catch (MetadataException e) {
-        logger.error("{}: MetaData error: ", IoTDBConstant.GLOBAL_DB_NAME, e);
+        logger.warn("{}: MetaData error: ", e.getMessage(), e);
         failingStatus.add(RpcUtils.getStatus(e.getErrorCode(), e.getMessage()));
         shouldRetry = false;
       }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
@@ -432,9 +432,7 @@ public class RegionWriteExecutor {
             metadataException = failingMeasurement.getValue();
             if (metadataException.getErrorCode()
                 == TSStatusCode.TIMESERIES_ALREADY_EXIST.getStatusCode()) {
-              LOGGER.info(
-                  "There's no need to internal create timeseries. {}",
-                  failingMeasurement.getValue().getMessage());
+              // There's no need to internal create timeseries.
               alreadyExistingStatus.add(
                   RpcUtils.getStatus(
                       metadataException.getErrorCode(),
@@ -442,7 +440,7 @@ public class RegionWriteExecutor {
                           ((MeasurementAlreadyExistException) metadataException)
                               .getMeasurementPath())));
             } else {
-              LOGGER.error("Metadata error: ", metadataException);
+              LOGGER.warn("Metadata error: ", metadataException);
               failingStatus.add(
                   RpcUtils.getStatus(
                       metadataException.getErrorCode(), metadataException.getMessage()));
@@ -484,15 +482,16 @@ public class RegionWriteExecutor {
             }
           }
 
+          RegionExecutionResult result = new RegionExecutionResult();
           TSStatus status;
           if (failingStatus.isEmpty()) {
             status = RpcUtils.getStatus(alreadyExistingStatus);
+            result.setAccepted(true);
           } else {
             status = RpcUtils.getStatus(failingStatus);
+            result.setAccepted(false);
           }
 
-          RegionExecutionResult result = new RegionExecutionResult();
-          result.setAccepted(false);
           result.setMessage(status.getMessage());
           result.setStatus(status);
           return result;
@@ -532,9 +531,7 @@ public class RegionWriteExecutor {
               metadataException = failingMeasurement.getValue();
               if (metadataException.getErrorCode()
                   == TSStatusCode.TIMESERIES_ALREADY_EXIST.getStatusCode()) {
-                LOGGER.info(
-                    "There's no need to internal create timeseries. {}",
-                    failingMeasurement.getValue().getMessage());
+                // There's no need to internal create timeseries.
                 alreadyExistingStatus.add(
                     RpcUtils.getStatus(
                         metadataException.getErrorCode(),
@@ -542,7 +539,7 @@ public class RegionWriteExecutor {
                             ((MeasurementAlreadyExistException) metadataException)
                                 .getMeasurementPath())));
               } else {
-                LOGGER.error("Metadata error: ", metadataException);
+                LOGGER.warn("Metadata error: ", metadataException);
                 failingStatus.add(
                     RpcUtils.getStatus(
                         metadataException.getErrorCode(), metadataException.getMessage()));
@@ -585,15 +582,16 @@ public class RegionWriteExecutor {
             }
           }
 
+          RegionExecutionResult result = new RegionExecutionResult();
           TSStatus status;
           if (failingStatus.isEmpty()) {
             status = RpcUtils.getStatus(alreadyExistingStatus);
+            result.setAccepted(true);
           } else {
             status = RpcUtils.getStatus(failingStatus);
+            result.setAccepted(false);
           }
 
-          RegionExecutionResult result = new RegionExecutionResult();
-          result.setAccepted(false);
           result.setMessage(status.getMessage());
           result.setStatus(status);
           return result;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -209,6 +209,12 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
             } else {
               throw new FragmentInstanceDispatchException(sendPlanNodeResp.getStatus());
             }
+          } else {
+            // some expected and accepted status except SUCCESS_STATUS need to be returned
+            TSStatus status = sendPlanNodeResp.getStatus();
+            if (status != null && status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+              throw new FragmentInstanceDispatchException(status);
+            }
           }
           break;
         default:
@@ -273,6 +279,12 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
                 RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, writeResult.getMessage()));
           } else {
             throw new FragmentInstanceDispatchException(writeResult.getStatus());
+          }
+        } else {
+          // some expected and accepted status except SUCCESS_STATUS need to be returned
+          TSStatus status = writeResult.getStatus();
+          if (status != null && status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+            throw new FragmentInstanceDispatchException(status);
           }
         }
         break;


### PR DESCRIPTION
## Description


### Motivation

see [IOTDB-5499](https://issues.apache.org/jira/browse/IOTDB-5499)

### Modification

Eliminate useless log in SchemaExecutionVisitor, RegionWriteExecutor and FragmentInstanceDispatcherImpl.
