### PR TITLE
[IOTDB-5491] Add IoTConsumus memory control metric items

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManager.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManager.java
@@ -64,16 +64,22 @@ public class IoTConsensusMemoryManager {
           }
         });
     if (result.get()) {
-      if (fromQueue) queueMemorySizeInByte.addAndGet(size);
-      else syncMemorySizeInByte.addAndGet(size);
+      if (fromQueue) {
+        queueMemorySizeInByte.addAndGet(size);
+      } else {
+        syncMemorySizeInByte.addAndGet(size);
+      }
     }
     return result.get();
   }
 
   public void free(long size, boolean fromQueue) {
     long currentUsedMemory = memorySizeInByte.addAndGet(-size);
-    if (fromQueue) queueMemorySizeInByte.addAndGet(-size);
-    else syncMemorySizeInByte.addAndGet(-size);
+    if (fromQueue) {
+      queueMemorySizeInByte.addAndGet(-size);
+    } else {
+      syncMemorySizeInByte.addAndGet(-size);
+    }
     logger.debug(
         "{} free {} bytes, total memory size: {} bytes.",
         Thread.currentThread().getName(),

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManager.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManager.java
@@ -30,6 +30,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class IoTConsensusMemoryManager {
   private static final Logger logger = LoggerFactory.getLogger(IoTConsensusMemoryManager.class);
   private final AtomicLong memorySizeInByte = new AtomicLong(0);
+  private final AtomicLong queueMemorySizeInByte = new AtomicLong(0);
+  private final AtomicLong syncMemorySizeInByte = new AtomicLong(0);
   private Long maxMemorySizeInByte = Runtime.getRuntime().maxMemory() / 10;
   private Long maxMemorySizeForQueueInByte = Runtime.getRuntime().maxMemory() / 100 * 6;
 
@@ -61,11 +63,17 @@ public class IoTConsensusMemoryManager {
             return memorySize + size;
           }
         });
+    if (result.get()) {
+      if (fromQueue) queueMemorySizeInByte.addAndGet(size);
+      else syncMemorySizeInByte.addAndGet(size);
+    }
     return result.get();
   }
 
-  public void free(long size) {
+  public void free(long size, boolean fromQueue) {
     long currentUsedMemory = memorySizeInByte.addAndGet(-size);
+    if (fromQueue) queueMemorySizeInByte.addAndGet(-size);
+    else syncMemorySizeInByte.addAndGet(-size);
     logger.debug(
         "{} free {} bytes, total memory size: {} bytes.",
         Thread.currentThread().getName(),
@@ -80,6 +88,14 @@ public class IoTConsensusMemoryManager {
 
   long getMemorySizeInByte() {
     return memorySizeInByte.get();
+  }
+
+  long getQueueMemorySizeInByte() {
+    return queueMemorySizeInByte.get();
+  }
+
+  long getSyncMemorySizeInByte() {
+    return syncMemorySizeInByte.get();
   }
 
   private static final IoTConsensusMemoryManager INSTANCE = new IoTConsensusMemoryManager();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManagerMetrics.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManagerMetrics.java
@@ -42,11 +42,29 @@ public class IoTConsensusMemoryManagerMetrics implements IMetricSet {
         IoTConsensusMemoryManager::getMemorySizeInByte,
         Tag.NAME.toString(),
         "IoTConsensus");
+    metricService.createAutoGauge(
+        Metric.MEM.toString(),
+        MetricLevel.IMPORTANT,
+        iotConsensusMemoryManager,
+        IoTConsensusMemoryManager::getQueueMemorySizeInByte,
+        Tag.NAME.toString(),
+        "IoTConsensus_Queue");
+    metricService.createAutoGauge(
+        Metric.MEM.toString(),
+        MetricLevel.IMPORTANT,
+        iotConsensusMemoryManager,
+        IoTConsensusMemoryManager::getSyncMemorySizeInByte,
+        Tag.NAME.toString(),
+        "IoTConsensus_Sync");
   }
 
   @Override
   public void unbindFrom(AbstractMetricService metricService) {
     metricService.remove(
         MetricType.AUTO_GAUGE, Metric.MEM.toString(), Tag.NAME.toString(), "IoTConsensus");
+    metricService.remove(
+        MetricType.AUTO_GAUGE, Metric.MEM.toString(), Tag.NAME.toString(), "IoTConsensus_Queue");
+    metricService.remove(
+        MetricType.AUTO_GAUGE, Metric.MEM.toString(), Tag.NAME.toString(), "IoTConsensus_Sync");
   }
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManagerMetrics.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IoTConsensusMemoryManagerMetrics.java
@@ -48,14 +48,14 @@ public class IoTConsensusMemoryManagerMetrics implements IMetricSet {
         iotConsensusMemoryManager,
         IoTConsensusMemoryManager::getQueueMemorySizeInByte,
         Tag.NAME.toString(),
-        "IoTConsensus_Queue");
+        "IoTConsensusQueue");
     metricService.createAutoGauge(
         Metric.MEM.toString(),
         MetricLevel.IMPORTANT,
         iotConsensusMemoryManager,
         IoTConsensusMemoryManager::getSyncMemorySizeInByte,
         Tag.NAME.toString(),
-        "IoTConsensus_Sync");
+        "IoTConsensusSync");
   }
 
   @Override
@@ -63,8 +63,8 @@ public class IoTConsensusMemoryManagerMetrics implements IMetricSet {
     metricService.remove(
         MetricType.AUTO_GAUGE, Metric.MEM.toString(), Tag.NAME.toString(), "IoTConsensus");
     metricService.remove(
-        MetricType.AUTO_GAUGE, Metric.MEM.toString(), Tag.NAME.toString(), "IoTConsensus_Queue");
+        MetricType.AUTO_GAUGE, Metric.MEM.toString(), Tag.NAME.toString(), "IoTConsensusQueue");
     metricService.remove(
-        MetricType.AUTO_GAUGE, Metric.MEM.toString(), Tag.NAME.toString(), "IoTConsensus_Sync");
+        MetricType.AUTO_GAUGE, Metric.MEM.toString(), Tag.NAME.toString(), "IoTConsensusSync");
   }
 }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -244,19 +244,19 @@ public class LogDispatcher {
         success = pendingEntries.offer(indexedConsensusRequest);
       } catch (Throwable t) {
         // If exception occurs during request offer, the reserved memory should be released
-        iotConsensusMemoryManager.free(indexedConsensusRequest.getSerializedSize());
+        iotConsensusMemoryManager.free(indexedConsensusRequest.getSerializedSize(), true);
         throw t;
       }
       if (!success) {
         // If offer failed, the reserved memory should be released
-        iotConsensusMemoryManager.free(indexedConsensusRequest.getSerializedSize());
+        iotConsensusMemoryManager.free(indexedConsensusRequest.getSerializedSize(), true);
       }
       return success;
     }
 
     /** try to remove a request from queue with memory control. */
     private void releaseReservedMemory(IndexedConsensusRequest indexedConsensusRequest) {
-      iotConsensusMemoryManager.free(indexedConsensusRequest.getSerializedSize());
+      iotConsensusMemoryManager.free(indexedConsensusRequest.getSerializedSize(), true);
     }
 
     public void stop() {
@@ -266,12 +266,12 @@ public class LogDispatcher {
         requestSize += indexedConsensusRequest.getSerializedSize();
       }
       pendingEntries.clear();
-      iotConsensusMemoryManager.free(requestSize);
+      iotConsensusMemoryManager.free(requestSize, true);
       requestSize = 0;
       for (IndexedConsensusRequest indexedConsensusRequest : bufferedEntries) {
         requestSize += indexedConsensusRequest.getSerializedSize();
       }
-      iotConsensusMemoryManager.free(requestSize);
+      iotConsensusMemoryManager.free(requestSize, true);
       syncStatus.free();
       MetricService.getInstance().removeMetricSet(metrics);
     }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatus.java
@@ -64,7 +64,7 @@ public class SyncStatus {
         while (current.isSynced()) {
           controller.updateAndGet(current.getEndIndex());
           iterator.remove();
-          iotConsensusMemoryManager.free(current.getSerializedSize());
+          iotConsensusMemoryManager.free(current.getSerializedSize(), false);
           if (iterator.hasNext()) {
             current = iterator.next();
           } else {
@@ -83,7 +83,7 @@ public class SyncStatus {
       size += pendingBatch.getSerializedSize();
     }
     pendingBatches.clear();
-    iotConsensusMemoryManager.free(size);
+    iotConsensusMemoryManager.free(size, false);
   }
 
   /** Gets the first index that is not currently synchronized. */

--- a/docs/UserGuide/Monitor-Alert/Metric-Tool.md
+++ b/docs/UserGuide/Monitor-Alert/Metric-Tool.md
@@ -216,6 +216,8 @@ carefully evaluated. The current Core-level metrics are as follows:
 | mem    | name="database_{{name}}"             | AutoGauge | The memory usage of DataRegion in DataNode, Unit: byte             |
 | mem    | name="chunkMetaData_{{name}}"        | AutoGauge | The memory usage of chunkMetaData when writting TsFile, Unit: byte |
 | mem    | name="IoTConsensus"                  | AutoGauge | The memory usage of IoTConsensus, Unit: byte                       |
+| mem    | name="IoTConsensusQueue"             | AutoGauge | The memory usage of IoTConsensus Queue, Unit: byte                 |
+| mem    | name="IoTConsensusSync"              | AutoGauge | The memory usage of IoTConsensus SyncStatus, Unit: byte            |
 | mem    | name="schema_region_total_usage"     | AutoGauge | The memory usage of all SchemaRegion, Unit: byte                   |
 | mem    | name="schema_region_total_remaining" | AutoGauge | The memory remaining for all SchemaRegion, Unit: byte              |
 

--- a/docs/zh/UserGuide/Monitor-Alert/Metric-Tool.md
+++ b/docs/zh/UserGuide/Monitor-Alert/Metric-Tool.md
@@ -196,6 +196,8 @@ Core 级别的监控指标在系统运行中默认开启，每一个 Core 级别
 | mem    | name="database_{{name}}"             | AutoGauge | DataNode内对应DataRegion的内存占用，单位为byte   |
 | mem    | name="chunkMetaData_{{name}}"        | AutoGauge | 写入TsFile时的ChunkMetaData的内存占用，单位为byte |
 | mem    | name="IoTConsensus"                  | AutoGauge | IoT共识协议的内存占用，单位为byte                 |
+| mem    | name="IoTConsensusQueue"             | AutoGauge | IoT共识协议用于队列的内存占用，单位为byte             |
+| mem    | name="IoTConsensusSync"              | AutoGauge | IoT共识协议用于同步的内存占用，单位为byte             |
 | mem    | name="schema_region_total_usage"     | AutoGauge | 所有SchemaRegion的总内存占用，单位为byte         |
 | mem    | name="schema_region_total_remaining" | AutoGauge | 所有SchemaRegion的总内存剩余，单位为byte         |
 


### PR DESCRIPTION
## Description


#### Add queue memory and synchronization memory items to distinguish memory occupation

Please see details in [IOTDB-5491](https://issues.apache.org/jira/browse/IOTDB-5491).