### PR TITLE
[ Metrics ] The repair leader distribution panel

### DIFF
--- a/docs/UserGuide/Monitor-Alert/Apache-IoTDB-ConfigNode-Dashboard.json
+++ b/docs/UserGuide/Monitor-Alert/Apache-IoTDB-ConfigNode-Dashboard.json
@@ -487,7 +487,7 @@
           "interval": "",
           "legendFormat": "Total Region",
           "range": true,
-          "refId": "C"
+          "refId": "A"
         },
         {
           "datasource": {
@@ -501,7 +501,7 @@
           "interval": "",
           "legendFormat": "{{type}}",
           "range": true,
-          "refId": "D"
+          "refId": "B"
         }
       ],
       "title": "Region Number",
@@ -560,7 +560,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "max(cluster_node_leader_count{}) by (name) ",
+          "expr": "cluster_node_leader_count{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Total leaders on {{name}} ",
           "range": true,
@@ -1190,11 +1190,11 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60",
+          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60 / max(sys_cpu_cores{instance=\"$instance\",name=\"system\"})",
           "hide": false,
           "legendFormat": "Process CPU Time",
           "range": true,
-          "refId": "B"
+          "refId": "A"
         }
       ],
       "title": "CPU Time Per Minute",

--- a/docs/UserGuide/Monitor-Alert/Apache-IoTDB-ConfigNode-Dashboard.json
+++ b/docs/UserGuide/Monitor-Alert/Apache-IoTDB-ConfigNode-Dashboard.json
@@ -1190,7 +1190,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60)",
+          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60",
           "hide": false,
           "legendFormat": "Process CPU Time",
           "range": true,

--- a/docs/UserGuide/Monitor-Alert/Apache-IoTDB-ConfigNode-Dashboard.json
+++ b/docs/UserGuide/Monitor-Alert/Apache-IoTDB-ConfigNode-Dashboard.json
@@ -1190,7 +1190,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60 / max(sys_cpu_cores{instance=\"$instance\",name=\"system\"})",
+          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60)",
           "hide": false,
           "legendFormat": "Process CPU Time",
           "range": true,

--- a/docs/UserGuide/Monitor-Alert/Apache-IoTDB-DataNode-Dashboard.json
+++ b/docs/UserGuide/Monitor-Alert/Apache-IoTDB-DataNode-Dashboard.json
@@ -3246,7 +3246,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60",
+          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60 / max(sys_cpu_cores{instance=\"$instance\",name=\"system\"})",
           "interval": "",
           "legendFormat": "System CPU Load",
           "range": true,

--- a/docs/UserGuide/Monitor-Alert/Apache-IoTDB-DataNode-Dashboard.json
+++ b/docs/UserGuide/Monitor-Alert/Apache-IoTDB-DataNode-Dashboard.json
@@ -469,7 +469,7 @@
           "refId": "B"
         }
       ],
-      "title": "The Time Consumed Of Operation (50%)",
+      "title": "The Time Consumed of Operation (50%)",
       "type": "timeseries"
     },
     {
@@ -1492,7 +1492,7 @@
           "exemplar": true,
           "expr": "sum(rate(data_read_total{instance=~\"$instance\"}[1m]))*60 / sum(rate(data_written_total{instance=~\"$instance\"}[1m]))*60",
           "interval": "",
-          "legendFormat": "Write",
+          "legendFormat": "R/W Ratio",
           "range": true,
           "refId": "A"
         }

--- a/docs/UserGuide/Monitor-Alert/Apache-IoTDB-DataNode-Dashboard.json
+++ b/docs/UserGuide/Monitor-Alert/Apache-IoTDB-DataNode-Dashboard.json
@@ -3246,7 +3246,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60 / max(sys_cpu_cores{instance=\"$instance\",name=\"system\"})",
+          "expr": "sum(rate(process_cpu_time{instance=\"$instance\",name=\"process\"}[1m]))*60",
           "interval": "",
           "legendFormat": "System CPU Load",
           "range": true,


### PR DESCRIPTION
## The repair process takes up CPU time Panel and leader distribution panel


### Leadership Distribution
The reason why nodes are not limited before is that the leader distribution can be observed on the non-leader confignode. However, when there are multiple iotdb clusters in prom, the panel will display the leader distribution of all clusters, causing the cluster display to be unclear. Therefore, it is better to add instance in the attribute to limit.

Before : 
![图片](https://user-images.githubusercontent.com/71131924/217752586-c295e5da-2de6-4184-beea-c214c89f1cfe.png)

After:
![图片](https://user-images.githubusercontent.com/71131924/217752677-4dfe9006-709d-4f1f-b2ec-a87997e712a6.png)


### Other small problems

![图片](https://user-images.githubusercontent.com/71131924/217706102-34f67346-c564-4c87-8c4f-2e72c3e0f5dc.png)
![图片](https://user-images.githubusercontent.com/71131924/217706156-8aa5f273-f7d7-4e3f-95b3-e4c0dcd64375.png)
