### PR TITLE
[IOTDB-5505] Bump Ratis version to latest 2.4.2-snapshot

### DIFF
--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <ratis.version>2.4.2-55abd1d-SNAPSHOT</ratis.version>
+        <ratis.version>2.4.2-55abd1d2-SNAPSHOT</ratis.version>
         <consensus.test.skip>false</consensus.test.skip>
         <consensus.it.skip>${consensus.test.skip}</consensus.it.skip>
         <consensus.ut.skip>${consensus.test.skip}</consensus.ut.skip>

--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <ratis.version>2.4.1</ratis.version>
+        <ratis.version>2.4.2-55abd1d-SNAPSHOT</ratis.version>
         <consensus.test.skip>false</consensus.test.skip>
         <consensus.it.skip>${consensus.test.skip}</consensus.it.skip>
         <consensus.ut.skip>${consensus.test.skip}</consensus.ut.skip>

--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <ratis.version>2.4.2-55abd1d2-SNAPSHOT</ratis.version>
+        <ratis.version>2.4.2-ebba77d-SNAPSHOT</ratis.version>
         <consensus.test.skip>false</consensus.test.skip>
         <consensus.it.skip>${consensus.test.skip}</consensus.it.skip>
         <consensus.ut.skip>${consensus.test.skip}</consensus.ut.skip>


### PR DESCRIPTION
1. Release a ratis snapshot version including latest required patches
2. Open this PR to verify CI

The Ratis snapshot version is build upon the following commit: https://github.com/apache/ratis/commit/ebba77d8057e64492dfb318b170706f4a765462d
The Ratis snapshot branch is snapshot-branch2, see https://github.com/apache/ratis/commits/snapshot-branch2