### PR TITLE
[IOTDB-5510] Block and wait to create timeseries when releasing memory

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -523,7 +523,7 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
     if (!memoryStatistics.isAllowToCreateNewSeries()) {
       CacheMemoryManager.getInstance().waitIfReleasing();
       if (!memoryStatistics.isAllowToCreateNewSeries()) {
-        logger.error("Series overflow when creating: [{}]", plan.getPath().getFullPath());
+        logger.warn("Series overflow when creating: [{}]", plan.getPath().getFullPath());
         throw new SeriesOverflowException();
       }
     }


### PR DESCRIPTION
## Description

The current strategy when creating a time series is to simply throw a SeriesOverflowException if memory resources are running low. However, there may be background tasks on the system that are releasing memory at this time and memory resources may become available immediately.

This PR provides a mechanism to wait for a limited time when memory is low and a releasingTask is running.