### PR TITLE
[To rel/1.0] [IOTDB-5504] Fix illegal argument exception occurs when scheduling compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -112,6 +112,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2172,7 +2173,7 @@ public class DataRegion implements IDataRegionForQuery {
     try {
       List<Long> timePartitions = new ArrayList<>(tsFileManager.getTimePartitions());
       // sort the time partition from largest to smallest
-      timePartitions.sort((o1, o2) -> (int) (o2 - o1));
+      timePartitions.sort(Comparator.reverseOrder());
       for (long timePartition : timePartitions) {
         CompactionScheduler.scheduleCompaction(tsFileManager, timePartition);
       }


### PR DESCRIPTION
See [IOTDB-5504](https://issues.apache.org/jira/browse/IOTDB-5504).

The reason for this bug is that integer overflow occurs when casting long to integer in `executeCompaction`.