### PR TITLE
[To rel/1.0][IOTDB-5505] Bump Ratis version to latest 2.4.2-snapshotSnapshot

### DIFF
--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <ratis.version>2.4.1</ratis.version>
+        <ratis.version>2.4.2-ebba77d-SNAPSHOT</ratis.version>
         <consensus.test.skip>false</consensus.test.skip>
         <consensus.it.skip>${consensus.test.skip}</consensus.it.skip>
         <consensus.ut.skip>${consensus.test.skip}</consensus.ut.skip>


### PR DESCRIPTION
cherry-pick of https://github.com/apache/iotdb/pull/9027