### PR TITLE
[IOTDB-5526] Fix NPE while construct timeseries black list in SchemaRegion

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -112,7 +112,9 @@ public abstract class Traverser<R> extends AbstractTreeVisitor<IMNode, R> {
     if (parent.isAboveDatabase()) {
       child = parent.getChild(childName);
     } else {
-      if (parent.getSchemaTemplateId() != NON_TEMPLATE // the device is using template
+      if (templateMap != null
+          && !templateMap.isEmpty() // this task will cover some timeseries represented by template
+          && parent.getSchemaTemplateId() != NON_TEMPLATE // the device is using template
           && !(skipPreDeletedSchema
               && parent
                   .getAsEntityMNode()

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
@@ -243,4 +243,62 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
       Assert.assertEquals(expectedTimeseries.get(i), result.get(i).getFullPath());
     }
   }
+
+  @Test
+  public void testDeleteSchemaWithTemplate() throws Exception {
+    ISchemaRegion schemaRegion = getSchemaRegion("root.db", 0);
+    int templateId = 1;
+    Template template =
+        new Template(
+            "t1",
+            Arrays.asList(Collections.singletonList("s1"), Collections.singletonList("s2")),
+            Arrays.asList(
+                Collections.singletonList(TSDataType.DOUBLE),
+                Collections.singletonList(TSDataType.INT32)),
+            Arrays.asList(
+                Collections.singletonList(TSEncoding.RLE),
+                Collections.singletonList(TSEncoding.RLE)),
+            Arrays.asList(
+                Collections.singletonList(CompressionType.SNAPPY),
+                Collections.singletonList(CompressionType.SNAPPY)));
+    template.setId(templateId);
+    schemaRegion.activateSchemaTemplate(
+        SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
+            new PartialPath("root.db.d1"), 3, templateId),
+        template);
+
+    schemaRegion.createTimeseries(
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.db.d1.s3"),
+            TSDataType.BOOLEAN,
+            TSEncoding.PLAIN,
+            CompressionType.SNAPPY,
+            null,
+            null,
+            null,
+            null),
+        -1);
+
+    Assert.assertEquals(
+        0, SchemaRegionTestUtil.deleteTimeSeries(schemaRegion, new PartialPath("root.db.d1.s1")));
+    Assert.assertEquals(
+        1, SchemaRegionTestUtil.deleteTimeSeries(schemaRegion, new PartialPath("root.db.d1.s3")));
+
+    Assert.assertEquals(
+        1,
+        schemaRegion
+            .fetchSchema(
+                new PartialPath("root.db.d1.s1"),
+                Collections.singletonMap(templateId, template),
+                false)
+            .size());
+    Assert.assertEquals(
+        0,
+        schemaRegion
+            .fetchSchema(
+                new PartialPath("root.db.d1.s3"),
+                Collections.singletonMap(templateId, template),
+                false)
+            .size());
+  }
 }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.metadata.schemaRegion;
 
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.write.SchemaRegionWritePlanFactory;
 import org.apache.iotdb.db.metadata.plan.schemaregion.read.IShowDevicesPlan;
@@ -297,5 +298,15 @@ public class SchemaRegionTestUtil {
       throw new RuntimeException(e);
     }
     return result;
+  }
+
+  public static long deleteTimeSeries(ISchemaRegion schemaRegion, PartialPath pathPattern)
+      throws MetadataException {
+    PathPatternTree patternTree = new PathPatternTree();
+    patternTree.appendPathPattern(pathPattern);
+    patternTree.constructTree();
+    long num = schemaRegion.constructSchemaBlackList(patternTree);
+    schemaRegion.deleteTimeseriesInBlackList(patternTree);
+    return num;
   }
 }


### PR DESCRIPTION
## Description

When constructing timeseries black list in SchemaRegion, there won't be any schema template provided, which brings npe when trying to get child node from template. Add judgement before getting child node will fix this.
