### PR TITLE
[IOTDB-5112] Fixed IoTConsensus synchronization stuck under low load or during restart

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -895,6 +895,7 @@ public class IoTConsensusServerImpl {
                     request.getStartSyncIndex(),
                     nextSyncIndex);
                 requestCache.remove(request);
+                nextSyncIndex = Long.max(nextSyncIndex, request.getEndSyncIndex() + 1);
                 break;
               }
             }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -92,9 +92,8 @@ public class IoTConsensusServerImpl {
   private static final String CONFIGURATION_FILE_NAME = "configuration.dat";
   private static final String CONFIGURATION_TMP_FILE_NAME = "configuration.dat.tmp";
   public static final String SNAPSHOT_DIR_NAME = "snapshot";
-
+  private static final Pattern SNAPSHOT_INDEX_PATTEN = Pattern.compile(".*[^\\d](?=(\\d+))");
   private final Logger logger = LoggerFactory.getLogger(IoTConsensusServerImpl.class);
-
   private final Peer thisNode;
   private final IStateMachine stateMachine;
   private final ConcurrentHashMap<String, SyncLogCacheQueue> cacheQueueMap;
@@ -108,7 +107,6 @@ public class IoTConsensusServerImpl {
   private final ConsensusReqReader reader;
   private volatile boolean active;
   private String newSnapshotDirName;
-  private static final Pattern snapshotIndexPatten = Pattern.compile(".*[^\\d](?=(\\d+))");
   private final IClientManager<TEndPoint, SyncIoTConsensusServiceClient> syncClientManager;
   private final IoTConsensusServerMetrics metrics;
 
@@ -381,9 +379,9 @@ public class IoTConsensusServerImpl {
     }
     for (File file : versionFiles) {
       snapShotIndex =
-          Long.max(
+          Math.max(
               snapShotIndex,
-              Long.parseLong(snapshotIndexPatten.matcher(file.getName()).replaceAll("")));
+              Long.parseLong(SNAPSHOT_INDEX_PATTEN.matcher(file.getName()).replaceAll("")));
     }
     return snapShotIndex;
   }
@@ -895,7 +893,7 @@ public class IoTConsensusServerImpl {
                     request.getStartSyncIndex(),
                     nextSyncIndex);
                 requestCache.remove(request);
-                nextSyncIndex = Long.max(nextSyncIndex, request.getEndSyncIndex() + 1);
+                nextSyncIndex = Math.max(nextSyncIndex, request.getEndSyncIndex() + 1);
                 break;
               }
             }


### PR DESCRIPTION
## Description


### The log synchronization logic of the receiving end of IoTConsensus is judged by nextSyncIndex, which may cause a 10-second delay when the iotdb is initially started and under low load.

Solution: Set the nextSyncIndex when timeout.


Please see details in [IOTDB-5112](https://issues.apache.org/jira/browse/IOTDB-5112) and [feishu cloud doc](https://apache-iotdb.feishu.cn/docx/TekkdtRvTo181UxI2x0c42iTnsN).