### PR TITLE
[IOTDB-5469] create template with backquote characters successfully but get schema info failed

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -1528,6 +1528,8 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
         return getNotLoggedInStatus();
       }
 
+      req.setName(PathUtils.checkAndReturnSingleMeasurement(req.getName()));
+
       // Step 1: transfer from TSCreateSchemaTemplateReq to Statement
       CreateSchemaTemplateStatement statement = StatementGenerator.createStatement(req);
 
@@ -1687,6 +1689,8 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       if (!SESSION_MANAGER.checkLogin(SESSION_MANAGER.getCurrSession())) {
         return getNotLoggedInStatus();
       }
+
+      req.setTemplateName(PathUtils.checkAndReturnSingleMeasurement(req.getTemplateName()));
 
       // Step 1: transfer from TSCreateSchemaTemplateReq to Statement
       SetSchemaTemplateStatement statement = StatementGenerator.createStatement(req);


### PR DESCRIPTION
SchemaTemplate related interfaces were added after the change of syntax conventions. Now we update the related interfaces.