### PR TITLE
Fix device alignment check during data insertion

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
@@ -160,7 +160,7 @@ public class DataNodeSchemaCache {
 
   public List<Integer> compute(ISchemaComputation schemaComputation) {
     List<Integer> indexOfMissingMeasurements = new ArrayList<>();
-    final AtomicBoolean isFirstMeasurement = new AtomicBoolean();
+    final AtomicBoolean isFirstMeasurement = new AtomicBoolean(true);
     dualKeyCache.compute(
         new IDualKeyCacheComputation<PartialPath, String, SchemaCacheEntry>() {
           @Override


### PR DESCRIPTION
## Description

When compute measurement in schema cache, the isFirst variable is not initialized as true, which results in the missing of compute device.
