### PR TITLE
[To rel/0.13] Fix alias check when CreateAlignedTimeSeries

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -695,6 +695,11 @@ public class MManager {
     }
     int seriesCount = plan.getMeasurements().size();
 
+    List<String> aliasList = plan.getAliasList();
+    if (aliasList != null && !aliasList.isEmpty() && aliasList.size() != seriesCount) {
+      throw new MetadataException("The size of alias list must equals num of measurements.");
+    }
+
     if (seriesNumerMonitor != null && !seriesNumerMonitor.addTimeSeries(seriesCount)) {
       throw new SeriesNumberOverflowException();
     }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateAlignedTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/CreateAlignedTimeSeriesPlan.java
@@ -161,7 +161,7 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
     }
 
     // alias
-    if (aliasList != null) {
+    if (aliasList != null && !aliasList.isEmpty()) {
       stream.write(1);
       for (String alias : aliasList) {
         ReadWriteIOUtils.write(alias, stream);
@@ -194,7 +194,7 @@ public class CreateAlignedTimeSeriesPlan extends PhysicalPlan {
     }
 
     // alias
-    if (aliasList != null) {
+    if (aliasList != null && !aliasList.isEmpty()) {
       buffer.put((byte) 1);
       for (String alias : aliasList) {
         ReadWriteIOUtils.write(alias, buffer);

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSServiceImpl.java
@@ -1789,7 +1789,7 @@ public class TSServiceImpl implements TSIService.Iface {
               dataTypes,
               encodings,
               compressors,
-              req.measurementAlias);
+              null);
       TSStatus status = serviceProvider.checkAuthority(plan, session);
       return status != null ? status : executeNonQueryPlan(plan);
     } catch (IoTDBException e) {


### PR DESCRIPTION
## Description

Currently, IoTDB v0.13 doesn't support creating aligned timeseries with alias. Eliminate this field passed from client to server via SDK/API.