### PR TITLE
[IOTDB-5553] Fix NPE while using count_if (contains keep expression) with group by level

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBCountIfIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBCountIfIT.java
@@ -217,6 +217,12 @@ public class IoTDBCountIfIT {
         expectedHeader,
         retArray);
 
+    expectedHeader = new String[] {"Count_if(root.db.*.s1 = 0 & root.db.*.s2 = 0, keep >= 3)"};
+    resultSetEqualTest(
+        "select Count_if(s1=0 & s2=0, keep>=3) from root.db.* group by level = 1",
+        expectedHeader,
+        retArray);
+
     expectedHeader =
         new String[] {
           "Count_if(root.*.d1.s1 = 0 & root.*.d1.s2 = 0, 3)",
@@ -227,6 +233,18 @@ public class IoTDBCountIfIT {
     retArray = new String[] {"2,0,1,1,"};
     resultSetEqualTest(
         "select Count_if(s1=0 & s2=0, 3) from root.db.* group by level = 2",
+        expectedHeader,
+        retArray);
+
+    expectedHeader =
+        new String[] {
+          "Count_if(root.*.d1.s1 = 0 & root.*.d1.s2 = 0, keep >= 3)",
+          "Count_if(root.*.d1.s1 = 0 & root.*.d2.s2 = 0, keep >= 3)",
+          "Count_if(root.*.d2.s1 = 0 & root.*.d1.s2 = 0, keep >= 3)",
+          "Count_if(root.*.d2.s1 = 0 & root.*.d2.s2 = 0, keep >= 3)"
+        };
+    resultSetEqualTest(
+        "select Count_if(s1=0 & s2=0, keep>=3) from root.db.* group by level = 2",
         expectedHeader,
         retArray);
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
@@ -629,6 +629,17 @@ public class ExpressionAnalyzer {
       for (Expression childExpression : expression.getExpressions()) {
         childrenExpressions.add(
             replaceRawPathWithGroupedPath(childExpression, rawPathToGroupedPathMap));
+
+        // We just process first input Expression of AggregationFunction.
+        // If AggregationFunction need more than one input series,
+        // we need to reconsider the process of it
+        if (expression.isBuiltInAggregationFunctionExpression()) {
+          List<Expression> children = expression.getExpressions();
+          for (int i = 1; i < children.size(); i++) {
+            childrenExpressions.add(children.get(i));
+          }
+          break;
+        }
       }
       return reconstructFunctionExpression((FunctionExpression) expression, childrenExpressions);
     } else if (expression instanceof TimeSeriesOperand) {


### PR DESCRIPTION
Bug cause: Forget to ignore the Keep Expression when process `group by level`.
Fix: Add judgement in the process, this is a temporary method to fix this bug, we will use a more elegant way to replace it when multi input series Function are introduced.