### PR TITLE
[IOTDB-5560] Increase default consensusLogAppenderBufferSize from 4M to 16M to reduce the probability of large request write failures

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -202,10 +202,10 @@ public class ConfigNodeConfig {
   private String readConsistencyLevel = "strong";
 
   /** RatisConsensus protocol, Max size for a single log append request from leader */
-  private long dataRegionRatisConsensusLogAppenderBufferSize = 4 * 1024 * 1024L;
+  private long dataRegionRatisConsensusLogAppenderBufferSize = 16 * 1024 * 1024L;
 
-  private long configNodeRatisConsensusLogAppenderBufferSize = 4 * 1024 * 1024L;
-  private long schemaRegionRatisConsensusLogAppenderBufferSize = 4 * 1024 * 1024L;
+  private long configNodeRatisConsensusLogAppenderBufferSize = 16 * 1024 * 1024L;
+  private long schemaRegionRatisConsensusLogAppenderBufferSize = 16 * 1024 * 1024L;
 
   /**
    * RatisConsensus protocol, trigger a snapshot when ratis_snapshot_trigger_threshold logs are

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -915,10 +915,10 @@ cluster_name=defaultCluster
 ### RatisConsensus Configuration
 ####################
 
-# max payload size for a single log-sync-RPC from leader to follower
-# config_node_ratis_log_appender_buffer_size_max=4194304
-# schema_region_ratis_log_appender_buffer_size_max=4194304
-# data_region_ratis_log_appender_buffer_size_max=4194304
+# max payload size for a single log-sync-RPC from leader to follower(in byte, by default 16MB)
+# config_node_ratis_log_appender_buffer_size_max=16777216
+# schema_region_ratis_log_appender_buffer_size_max=16777216
+# data_region_ratis_log_appender_buffer_size_max=16777216
 
 # trigger a snapshot when snapshot_trigger_threshold logs are written
 # config_node_ratis_snapshot_trigger_threshold=400000

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -987,8 +987,8 @@ public class IoTDBConfig {
   /** Maximum wait time of write cache in IoTConsensus. Unit: ms */
   private long cacheWindowTimeInMs = 10 * 1000L;
 
-  private long dataRatisConsensusLogAppenderBufferSizeMax = 4 * 1024 * 1024L;
-  private long schemaRatisConsensusLogAppenderBufferSizeMax = 4 * 1024 * 1024L;
+  private long dataRatisConsensusLogAppenderBufferSizeMax = 16 * 1024 * 1024L;
+  private long schemaRatisConsensusLogAppenderBufferSizeMax = 16 * 1024 * 1024L;
 
   private long dataRatisConsensusSnapshotTriggerThreshold = 400000L;
   private long schemaRatisConsensusSnapshotTriggerThreshold = 400000L;


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/IOTDB-5560)