### PR TITLE
[IOTDB-5512] Fixed same flushIndex situation

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexController.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/IndexController.java
@@ -110,6 +110,9 @@ public class IndexController {
 
   private void persist() {
     long flushIndex = currentIndex;
+    if (flushIndex == lastFlushedIndex) {
+      return;
+    }
     File oldFile = new File(storageDir, prefix + lastFlushedIndex);
     File newFile = new File(storageDir, prefix + flushIndex);
     try {


### PR DESCRIPTION
## Description


### Fixed same flushIndex situation which will cause a move file exception.

Please see details in https://github.com/apache/iotdb/pull/9074
