### PR TITLE
Fix python IT fail caused by the database root.__system

### DIFF
--- a/client-py/iotdb/sqlalchemy/tests/test_dialect.py
+++ b/client-py/iotdb/sqlalchemy/tests/test_dialect.py
@@ -66,7 +66,7 @@ def test_dialect():
         insp = inspect(eng)
         # test get_schema_names
         schema_names = insp.get_schema_names()
-        if not operator.eq(schema_names, ["root.cursor_s1", "root.cursor"]):
+        if not operator.contains(schema_names, ["root.cursor_s1", "root.cursor"]):
             test_fail()
             print_message("test get_schema_names failed!")
         # test get_table_names

--- a/client-py/iotdb/sqlalchemy/tests/test_dialect.py
+++ b/client-py/iotdb/sqlalchemy/tests/test_dialect.py
@@ -66,7 +66,7 @@ def test_dialect():
         insp = inspect(eng)
         # test get_schema_names
         schema_names = insp.get_schema_names()
-        if not operator.contains(schema_names, ["root.cursor_s1", "root.cursor"]):
+        if not operator.gt(schema_names, ["root.cursor_s1", "root.cursor"]):
             test_fail()
             print_message("test get_schema_names failed!")
         # test get_table_names

--- a/client-py/tests/test_dataframe.py
+++ b/client-py/tests/test_dataframe.py
@@ -33,7 +33,7 @@ def test_simple_query():
         session.insert_str_record("root.device0", 123, "pressure", "15.0")
 
         # Read
-        session_data_set = session.execute_query_statement("SELECT ** FROM root.device0.**")
+        session_data_set = session.execute_query_statement("SELECT ** FROM root.device0.*")
         df = session_data_set.todf()
 
         session.close()
@@ -53,7 +53,7 @@ def test_non_time_query():
         session.insert_str_record("root.device0", 123, "pressure", "15.0")
 
         # Read
-        session_data_set = session.execute_query_statement("SHOW TIMESERIES root.device0.**")
+        session_data_set = session.execute_query_statement("SHOW TIMESERIES root.device0.*")
         df = session_data_set.todf()
 
         session.close()

--- a/client-py/tests/test_dataframe.py
+++ b/client-py/tests/test_dataframe.py
@@ -33,7 +33,7 @@ def test_simple_query():
         session.insert_str_record("root.device0", 123, "pressure", "15.0")
 
         # Read
-        session_data_set = session.execute_query_statement("SELECT ** FROM root")
+        session_data_set = session.execute_query_statement("SELECT ** FROM root.device0.**")
         df = session_data_set.todf()
 
         session.close()
@@ -53,7 +53,7 @@ def test_non_time_query():
         session.insert_str_record("root.device0", 123, "pressure", "15.0")
 
         # Read
-        session_data_set = session.execute_query_statement("SHOW TIMESERIES")
+        session_data_set = session.execute_query_statement("SHOW TIMESERIES root.device0.**")
         df = session_data_set.todf()
 
         session.close()

--- a/client-py/tests/test_dataframe.py
+++ b/client-py/tests/test_dataframe.py
@@ -33,7 +33,7 @@ def test_simple_query():
         session.insert_str_record("root.device0", 123, "pressure", "15.0")
 
         # Read
-        session_data_set = session.execute_query_statement("SELECT ** FROM root.device0.*")
+        session_data_set = session.execute_query_statement("SELECT * FROM root.device0")
         df = session_data_set.todf()
 
         session.close()

--- a/client-py/tests/test_todf.py
+++ b/client-py/tests/test_todf.py
@@ -93,7 +93,7 @@ def test_simple_query():
 
         df_input.insert(0, "Time", timestamps)
 
-        session_data_set = session.execute_query_statement("SELECT ** FROM root")
+        session_data_set = session.execute_query_statement("SELECT ** FROM root.wt1")
         df_output = session_data_set.todf()
         df_output = df_output[df_input.columns.tolist()]
 
@@ -173,7 +173,7 @@ def test_with_null_query():
 
         df_input.insert(0, "Time", timestamps)
 
-        session_data_set = session.execute_query_statement("SELECT ** FROM root")
+        session_data_set = session.execute_query_statement("SELECT ** FROM root.wt1")
         df_output = session_data_set.todf()
         df_output = df_output[df_input.columns.tolist()]
 
@@ -210,7 +210,7 @@ def test_multi_fetch():
 
         df_input.insert(0, "Time", timestamps)
 
-        session_data_set = session.execute_query_statement("SELECT ** FROM root")
+        session_data_set = session.execute_query_statement("SELECT ** FROM root.wt1")
         session_data_set.set_fetch_size(100)
         df_output = session_data_set.todf()
         df_output = df_output[df_input.columns.tolist()]


### PR DESCRIPTION
## Description

Since #9085 introduced a hidden database `root.__system`, some test cases which using `show database`, `select ** from root` or `show timeseries` need to be modified.