### PR TITLE
[To rel/1.0][IOTDB-5189][IOTDB-5529]Optimize the memory usage and execution of fast compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/NonAlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/NonAlignedSeriesCompactionExecutor.java
@@ -65,7 +65,14 @@ public class NonAlignedSeriesCompactionExecutor extends SeriesCompactionExecutor
       String deviceId,
       int subTaskId,
       FastCompactionTaskSummary summary) {
-    super(compactionWriter, readerCacheMap, modificationCacheMap, deviceId, subTaskId, summary);
+    super(
+        compactionWriter,
+        readerCacheMap,
+        modificationCacheMap,
+        deviceId,
+        false,
+        subTaskId,
+        summary);
     this.sortResources = sortedSourceFiles;
   }
 
@@ -93,14 +100,14 @@ public class NonAlignedSeriesCompactionExecutor extends SeriesCompactionExecutor
       List<FileElement> overlappedFiles = findOverlapFiles(fileList.get(0));
 
       // read chunk metadatas from files and put them into chunk metadata queue
-      deserializeFileIntoQueue(overlappedFiles);
+      deserializeFileIntoChunkMetadataQueue(overlappedFiles);
 
       compactChunks();
     }
   }
 
   /** Deserialize files into chunk metadatas and put them into the chunk metadata queue. */
-  void deserializeFileIntoQueue(List<FileElement> fileElements)
+  void deserializeFileIntoChunkMetadataQueue(List<FileElement> fileElements)
       throws IOException, IllegalPathException {
     for (FileElement fileElement : fileElements) {
       TsFileResource resource = fileElement.resource;
@@ -144,7 +151,8 @@ public class NonAlignedSeriesCompactionExecutor extends SeriesCompactionExecutor
   }
 
   /** Deserialize chunk into pages without uncompressing and put them into the page queue. */
-  void deserializeChunkIntoQueue(ChunkMetadataElement chunkMetadataElement) throws IOException {
+  void deserializeChunkIntoPageQueue(ChunkMetadataElement chunkMetadataElement) throws IOException {
+    updateSummary(chunkMetadataElement, ChunkStatus.DESERIALIZE_CHUNK);
     Chunk chunk = chunkMetadataElement.chunk;
     ChunkReader chunkReader = new ChunkReader(chunk);
     ByteBuffer chunkDataBuffer = chunk.getData();
@@ -174,6 +182,7 @@ public class NonAlignedSeriesCompactionExecutor extends SeriesCompactionExecutor
 
   @Override
   void readChunk(ChunkMetadataElement chunkMetadataElement) throws IOException {
+    updateSummary(chunkMetadataElement, ChunkStatus.READ_IN);
     chunkMetadataElement.chunk =
         readerCacheMap
             .get(chunkMetadataElement.fileElement.resource)

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/SeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/SeriesCompactionExecutor.java
@@ -33,14 +33,13 @@ import org.apache.iotdb.tsfile.exception.write.PageException;
 import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
-import org.apache.iotdb.tsfile.read.reader.chunk.AlignedChunkReader;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +77,7 @@ public abstract class SeriesCompactionExecutor {
 
   private final Map<TsFileResource, List<Modification>> modificationCacheMap;
 
-  private final PointPriorityReader pointPriorityReader = new PointPriorityReader(this::removePage);
+  private final PointPriorityReader pointPriorityReader;
 
   protected String deviceId;
 
@@ -87,12 +86,18 @@ public abstract class SeriesCompactionExecutor {
   // writer. During the process of compacting overlapped page, there may be new overlapped pages
   // added into this list.
   private final List<PageElement> candidateOverlappedPages = new ArrayList<>();
+  private long nextChunkStartTime = Long.MAX_VALUE;
+
+  private long nextPageStartTime = Long.MAX_VALUE;
+
+  protected boolean isAligned;
 
   protected SeriesCompactionExecutor(
       AbstractCompactionWriter compactionWriter,
       Map<TsFileResource, TsFileSequenceReader> readerCacheMap,
       Map<TsFileResource, List<Modification>> modificationCacheMap,
       String deviceId,
+      boolean isAligned,
       int subTaskId,
       FastCompactionTaskSummary summary) {
     this.compactionWriter = compactionWriter;
@@ -101,6 +106,8 @@ public abstract class SeriesCompactionExecutor {
     this.readerCacheMap = readerCacheMap;
     this.modificationCacheMap = modificationCacheMap;
     this.summary = summary;
+    pointPriorityReader = new PointPriorityReader(this::checkShouldRemoveFile, isAligned);
+    this.isAligned = isAligned;
 
     chunkMetadataQueue =
         new PriorityQueue<>(
@@ -127,16 +134,17 @@ public abstract class SeriesCompactionExecutor {
   protected void compactChunks()
       throws IOException, PageException, WriteProcessException, IllegalPathException {
     while (!chunkMetadataQueue.isEmpty()) {
-      ChunkMetadataElement firstChunkMetadataElement = chunkMetadataQueue.peek();
-      List<ChunkMetadataElement> overlappedChunkMetadataList =
-          findOverlapChunkMetadatas(firstChunkMetadataElement);
-      boolean isChunkOverlap = overlappedChunkMetadataList.size() > 1;
+      ChunkMetadataElement firstChunkMetadataElement = chunkMetadataQueue.poll();
+      nextChunkStartTime =
+          chunkMetadataQueue.isEmpty() ? Long.MAX_VALUE : chunkMetadataQueue.peek().startTime;
+      boolean isChunkOverlap =
+          firstChunkMetadataElement.chunkMetadata.getEndTime() >= nextChunkStartTime;
       boolean isModified = firstChunkMetadataElement.chunkMetadata.isModified();
 
       if (isChunkOverlap || isModified) {
         // has overlap or modified chunk, then deserialize it
-        summary.CHUNK_OVERLAP_OR_MODIFIED += overlappedChunkMetadataList.size();
-        compactWithOverlapChunks(overlappedChunkMetadataList);
+        summary.CHUNK_OVERLAP_OR_MODIFIED++;
+        compactWithOverlapChunks(firstChunkMetadataElement);
       } else {
         // has none overlap or modified chunk, flush it to file writer directly
         summary.CHUNK_NONE_OVERLAP += 1;
@@ -151,14 +159,11 @@ public abstract class SeriesCompactionExecutor {
    * chunk 2, while chunk 2 overlap with chunk 3, chunk 3 overlap with chunk 4,and so on, there are
    * 10 chunks in total. This method will merge all 10 chunks.
    */
-  private void compactWithOverlapChunks(List<ChunkMetadataElement> overlappedChunkMetadataList)
+  private void compactWithOverlapChunks(ChunkMetadataElement overlappedChunkMetadata)
       throws IOException, PageException, WriteProcessException, IllegalPathException {
-    for (ChunkMetadataElement overlappedChunkMetadata : overlappedChunkMetadataList) {
-      readChunk(overlappedChunkMetadata);
-      updateSummary(overlappedChunkMetadata, ChunkStatus.READ_IN);
-      updateSummary(overlappedChunkMetadata, ChunkStatus.DESERIALIZE_CHUNK);
-      deserializeChunkIntoQueue(overlappedChunkMetadata);
-    }
+    readChunk(overlappedChunkMetadata);
+    deserializeChunkIntoPageQueue(overlappedChunkMetadata);
+
     compactPages();
   }
 
@@ -169,9 +174,8 @@ public abstract class SeriesCompactionExecutor {
   private void compactWithNonOverlapChunk(ChunkMetadataElement chunkMetadataElement)
       throws IOException, PageException, WriteProcessException, IllegalPathException {
     readChunk(chunkMetadataElement);
-    updateSummary(chunkMetadataElement, ChunkStatus.READ_IN);
     boolean success;
-    if (chunkMetadataElement.chunkMetadata instanceof AlignedChunkMetadata) {
+    if (isAligned) {
       success =
           compactionWriter.flushAlignedChunk(
               chunkMetadataElement.chunk,
@@ -190,46 +194,45 @@ public abstract class SeriesCompactionExecutor {
     if (success) {
       // flush chunk successfully, then remove this chunk
       updateSummary(chunkMetadataElement, ChunkStatus.DIRECTORY_FLUSH);
-      removeChunk(chunkMetadataQueue.peek());
+      checkShouldRemoveFile(chunkMetadataElement);
     } else {
       // unsealed chunk is not large enough or chunk.endTime > file.endTime, then deserialize chunk
       summary.CHUNK_NONE_OVERLAP_BUT_DESERIALIZE += 1;
-      updateSummary(chunkMetadataElement, ChunkStatus.DESERIALIZE_CHUNK);
-      deserializeChunkIntoQueue(chunkMetadataElement);
+      deserializeChunkIntoPageQueue(chunkMetadataElement);
       compactPages();
     }
   }
 
-  abstract void deserializeChunkIntoQueue(ChunkMetadataElement chunkMetadataElement)
+  abstract void deserializeChunkIntoPageQueue(ChunkMetadataElement chunkMetadataElement)
       throws IOException;
 
   abstract void readChunk(ChunkMetadataElement chunkMetadataElement) throws IOException;
 
   /** Deserialize files into chunk metadatas and put them into the chunk metadata queue. */
-  abstract void deserializeFileIntoQueue(List<FileElement> fileElements)
+  abstract void deserializeFileIntoChunkMetadataQueue(List<FileElement> fileElements)
       throws IOException, IllegalPathException;
 
   /** Compact pages in page queue. */
   private void compactPages()
       throws IOException, PageException, WriteProcessException, IllegalPathException {
     while (!pageQueue.isEmpty()) {
-      PageElement firstPageElement = pageQueue.peek();
+      PageElement firstPageElement = getPageFromPageQueue(pageQueue.peek().startTime);
       ModifiedStatus modifiedStatus = isPageModified(firstPageElement);
 
       if (modifiedStatus == ModifiedStatus.ALL_DELETED) {
         // all data on this page has been deleted, remove it
-        removePage(firstPageElement);
+        checkShouldRemoveFile(firstPageElement);
         continue;
       }
 
-      List<PageElement> overlapPages = findOverlapPages(firstPageElement);
-      boolean isPageOverlap = overlapPages.size() > 1;
+      boolean isPageOverlap =
+          firstPageElement.pageHeader.getEndTime() >= nextPageStartTime
+              || firstPageElement.pageHeader.getEndTime() >= nextChunkStartTime;
 
       if (isPageOverlap || modifiedStatus == ModifiedStatus.PARTIAL_DELETED) {
         // has overlap or modified pages, then deserialize it
         summary.PAGE_OVERLAP_OR_MODIFIED += 1;
-        pointPriorityReader.addNewPage(overlapPages.remove(0));
-        addOverlappedPagesIntoList(overlapPages);
+        pointPriorityReader.addNewPage(firstPageElement);
         compactWithOverlapPages();
       } else {
         // has none overlap or modified pages, flush it to chunk writer directly
@@ -242,7 +245,7 @@ public abstract class SeriesCompactionExecutor {
   private void compactWithNonOverlapPage(PageElement pageElement)
       throws PageException, IOException, WriteProcessException, IllegalPathException {
     boolean success;
-    if (pageElement.iChunkReader instanceof AlignedChunkReader) {
+    if (isAligned) {
       success =
           compactionWriter.flushAlignedPage(
               pageElement.pageData,
@@ -257,17 +260,21 @@ public abstract class SeriesCompactionExecutor {
     }
     if (success) {
       // flush the page successfully, then remove this page
-      removePage(pageElement);
+      checkShouldRemoveFile(pageElement);
     } else {
       // unsealed page is not large enough or page.endTime > file.endTime, then deserialze it
       summary.PAGE_NONE_OVERLAP_BUT_DESERIALIZE += 1;
       pointPriorityReader.addNewPage(pageElement);
 
       // write data points of the current page into chunk writer
-      while (pointPriorityReader.hasNext()
-          && pointPriorityReader.currentPoint().getTimestamp()
-              <= pageElement.pageHeader.getEndTime()) {
-        compactionWriter.write(pointPriorityReader.currentPoint(), subTaskId);
+      TimeValuePair point;
+      while (pointPriorityReader.hasNext()) {
+        point = pointPriorityReader.currentPoint();
+        if (point.getTimestamp() > pageElement.pageHeader.getEndTime()) {
+          // finish writing this page
+          break;
+        }
+        compactionWriter.write(point, subTaskId);
         pointPriorityReader.next();
       }
     }
@@ -288,19 +295,25 @@ public abstract class SeriesCompactionExecutor {
    */
   private void compactWithOverlapPages()
       throws IOException, PageException, WriteProcessException, IllegalPathException {
-    checkAndCompactOverlapPages();
-
-    // write remaining data points, of which point.time >= the last overlapped page.startTime
     while (pointPriorityReader.hasNext()) {
-      // write data point to chunk writer
+      TimeValuePair currentPoint = pointPriorityReader.currentPoint();
+      long currentTime = currentPoint.getTimestamp();
 
-      compactionWriter.write(pointPriorityReader.currentPoint(), subTaskId);
-      pointPriorityReader.next();
-      if (candidateOverlappedPages.size() > 0) {
-        // finish compacting the first page or there are new chunks being deserialized and find
-        // the new overlapped pages, then start compacting them
-        checkAndCompactOverlapPages();
+      while (currentTime >= nextChunkStartTime || currentTime >= nextPageStartTime) {
+        // current point overlaps with next chunk or next page, then deserialize next chunk if
+        // necessary and get next page
+        PageElement nextPageElement = getPageFromPageQueue(currentTime);
+        // check whether next page is fake overlap or not
+        checkAndCompactOverlapPage(nextPageElement, currentPoint);
+
+        // get new current point
+        currentPoint = pointPriorityReader.currentPoint();
+        currentTime = currentPoint.getTimestamp();
       }
+
+      // write data point into chunk writer
+      compactionWriter.write(currentPoint, subTaskId);
+      pointPriorityReader.next();
     }
   }
 
@@ -309,108 +322,29 @@ public abstract class SeriesCompactionExecutor {
    * another page, then this page is fake overlap, which can be flushed to chunk writer directly.
    * Otherwise, deserialize this page into point priority reader.
    */
-  private void checkAndCompactOverlapPages()
-      throws IllegalPathException, IOException, WriteProcessException, PageException {
-    // write point.time < the last overlapped page.startTime
-    while (candidateOverlappedPages.size() > 0) {
-      PageElement nextPageElement = candidateOverlappedPages.get(0);
+  private void checkAndCompactOverlapPage(PageElement nextPageElement, TimeValuePair currentPoint)
+      throws IOException, IllegalPathException, PageException, WriteProcessException {
+    ModifiedStatus nextPageModifiedStatus = isPageModified(nextPageElement);
 
-      int oldSize = candidateOverlappedPages.size();
-      // write currentPage.point.time < nextPage.startTime to chunk writer
-      while (pointPriorityReader.hasNext()
-          && pointPriorityReader.currentPoint().getTimestamp() < nextPageElement.startTime) {
-        // write data point to chunk writer
-        compactionWriter.write(pointPriorityReader.currentPoint(), subTaskId);
-        pointPriorityReader.next();
-        if (candidateOverlappedPages.size() > oldSize) {
-          // during the process of writing overlapped points, if the first page is compacted
-          // completely or a new chunk is deserialized, there may be new pages overlapped with the
-          // first page in page queue which are added into the list. If so, the next overlapped
-          // page in the list may be changed, so we should re-get next overlap page here.
-          oldSize = candidateOverlappedPages.size();
-          nextPageElement = candidateOverlappedPages.get(0);
-        }
-      }
-
-      ModifiedStatus nextPageModifiedStatus = isPageModified(nextPageElement);
-
-      if (nextPageModifiedStatus == ModifiedStatus.ALL_DELETED) {
-        // all data on next page has been deleted, remove it
-        removePage(nextPageElement);
+    if (nextPageModifiedStatus == ModifiedStatus.ALL_DELETED) {
+      // all data on next page has been deleted, remove it
+      checkShouldRemoveFile(nextPageElement);
+    } else {
+      // check is next page fake overlap (locates in the gap) or not
+      boolean isNextPageOverlap =
+          currentPoint.getTimestamp() <= nextPageElement.pageHeader.getEndTime()
+              || nextPageElement.pageHeader.getEndTime() >= nextPageStartTime
+              || nextPageElement.pageHeader.getEndTime() >= nextChunkStartTime;
+      if (isNextPageOverlap || nextPageModifiedStatus == ModifiedStatus.PARTIAL_DELETED) {
+        // next page is overlapped or modified, then deserialize it
+        summary.PAGE_OVERLAP_OR_MODIFIED++;
+        pointPriorityReader.addNewPage(nextPageElement);
       } else {
-        boolean isNextPageOverlap =
-            (pointPriorityReader.hasNext()
-                    && pointPriorityReader.currentPoint().getTimestamp()
-                        <= nextPageElement.pageHeader.getEndTime())
-                || isPageOverlap(nextPageElement);
-
-        if (isNextPageOverlap || nextPageModifiedStatus == ModifiedStatus.PARTIAL_DELETED) {
-          // has overlap or modified pages, then deserialize it
-          pointPriorityReader.addNewPage(nextPageElement);
-        } else {
-          // has none overlap or modified pages, flush it to chunk writer directly
-          summary.PAGE_FAKE_OVERLAP += 1;
-          compactWithNonOverlapPage(nextPageElement);
-        }
-      }
-      candidateOverlappedPages.remove(0);
-    }
-  }
-
-  /**
-   * Add the new overlapped pages into the global list and sort it according to the startTime of the
-   * page from small to large, so that each page can be compacted in order. If the page has been
-   * deleted completely, we remove it.
-   */
-  private void addOverlappedPagesIntoList(List<PageElement> newOverlappedPages) {
-    summary.PAGE_OVERLAP_OR_MODIFIED += newOverlappedPages.size();
-    int oldSize = candidateOverlappedPages.size();
-    candidateOverlappedPages.addAll(newOverlappedPages);
-    if (oldSize != 0 && candidateOverlappedPages.size() > oldSize) {
-      // if there is no pages in the overlappedPages, then we don't need to sort it after adding the
-      // new overlapped pages, because newOverlappedPages is already sorted. When there is pages in
-      // list before and there is new pages added into list, then we need to sort it again.
-      // we should ensure that the list is ordered according to the startTime of the page from small
-      // to large, so that each page can be compacted in order
-      candidateOverlappedPages.sort(Comparator.comparingLong(o -> o.startTime));
-    }
-  }
-
-  /**
-   * Find overlaped pages which have not been selected. Notice: We must ensure that the returned
-   * list is ordered according to the startTime of the page from small to large, so that each page
-   * can be compacted in order.
-   */
-  private List<PageElement> findOverlapPages(PageElement page) {
-    List<PageElement> elements = new ArrayList<>();
-    long endTime = page.pageHeader.getEndTime();
-    for (PageElement element : pageQueue) {
-      if (element.startTime <= endTime && !element.isSelected) {
-        elements.add(element);
-        element.isSelected = true;
+        // has none overlap or modified pages, flush it to chunk writer directly
+        summary.PAGE_FAKE_OVERLAP += 1;
+        compactWithNonOverlapPage(nextPageElement);
       }
     }
-    elements.sort(Comparator.comparingLong(o -> o.startTime));
-    return elements;
-  }
-
-  /**
-   * Find overlapped chunks which have not been selected. Notice: We must ensure that the returned
-   * list is ordered according to the startTime of the chunk from small to large, so that each chunk
-   * can be compacted in order.
-   */
-  private List<ChunkMetadataElement> findOverlapChunkMetadatas(
-      ChunkMetadataElement chunkMetadataElement) {
-    List<ChunkMetadataElement> elements = new ArrayList<>();
-    long endTime = chunkMetadataElement.chunkMetadata.getEndTime();
-    for (ChunkMetadataElement element : chunkMetadataQueue) {
-      if (element.chunkMetadata.getStartTime() <= endTime && !element.isSelected) {
-        elements.add(element);
-        element.isSelected = true;
-      }
-    }
-    elements.sort(Comparator.comparingLong(o -> o.startTime));
-    return elements;
   }
 
   /**
@@ -432,22 +366,6 @@ public abstract class SeriesCompactionExecutor {
       }
     }
     return overlappedFiles;
-  }
-
-  /** Check is the page overlap with other pages later then the specific page in queue or not. */
-  private boolean isPageOverlap(PageElement pageElement) {
-    long endTime = pageElement.pageHeader.getEndTime();
-    long startTime = pageElement.startTime;
-    for (PageElement element : pageQueue) {
-      if (element.equals(pageElement)) {
-        continue;
-      }
-      // only check pages later than the specific page
-      if (element.startTime >= startTime && element.startTime <= endTime) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**
@@ -479,97 +397,64 @@ public abstract class SeriesCompactionExecutor {
   }
 
   /**
-   * Remove the page from page queue. If the page to be removed is the last page of chunk, it means
-   * this chunk has been compacted completely, we should remove this chunk. When removing chunks,
-   * there may be new overlapped chunks being deserialized and their pages are put into pageQueue.
-   * Therefore, when the removed page is the first page or when new chunks are deserialized and
-   * their pages are put into the queue, it is necessary to re-find new pages that overlap with the
-   * first page in the current queue, and put them put into list.
+   * Check whether current page is overlap with next chunk which has not been read into memory yet
+   * before getting one page. If it is, then read next chunk into memory and deserialize it into
+   * pages.
    */
-  private void removePage(PageElement pageElement) throws IOException, IllegalPathException {
-    boolean isFirstPage = pageQueue.peek().equals(pageElement);
-    boolean hasNewOverlappedChunks = false;
-    pageQueue.remove(pageElement);
-    if (pageElement.isLastPage) {
-      // finish compacting the chunk, remove it from queue
-      hasNewOverlappedChunks = removeChunk(pageElement.chunkMetadataElement);
+  private PageElement getPageFromPageQueue(long curTime) throws IOException {
+    if (curTime >= nextChunkStartTime) {
+      // overlap with next chunk, then read it into memory and deserialize it into page queue
+      summary.CHUNK_OVERLAP_OR_MODIFIED++;
+      ChunkMetadataElement chunkMetadataElement = chunkMetadataQueue.poll();
+      nextChunkStartTime =
+          chunkMetadataQueue.isEmpty() ? Long.MAX_VALUE : chunkMetadataQueue.peek().startTime;
+      readChunk(chunkMetadataElement);
+      deserializeChunkIntoPageQueue(chunkMetadataElement);
     }
+    PageElement page = pageQueue.poll();
+    nextPageStartTime = pageQueue.isEmpty() ? Long.MAX_VALUE : pageQueue.peek().startTime;
+    return page;
+  }
 
-    if ((isFirstPage || hasNewOverlappedChunks)
-        && (pointPriorityReader.hasNext() || candidateOverlappedPages.size() > 0)
-        && pageQueue.size() != 0) {
-      // During the procession of compacting overlapped pages, when deserializing new chunks into
-      // page queue or first page is removed from page queue, we should find new overlapped pages
-      // and put them into list.
-      // If (candidateOverlappedPages.size() > 0 || pointPriorityReader.hasNext()) is true, it
-      // indicates that it is still in the process of compacting overlapped pages.
-      // pointPriorityReader.hasNext() indicates that the new first page in page queue has not been
-      // finished compacting yet,  so there may be other pages overlap with it.
-      // Due to modifications of this page, the new first page in page queue may not been
-      // deserialized into pointPriorityReader yet, but it is still in the candidateOverlappedPages
-      // list, so there may be other pages overlap with it.
-      addOverlappedPagesIntoList(findOverlapPages(pageQueue.peek()));
+  /**
+   * Check should remove file or not. If it is the last page in the chunk and the last chunk in the
+   * file, then it means the file has been finished compacting and needs to be removed.
+   */
+  private void checkShouldRemoveFile(PageElement pageElement)
+      throws IOException, IllegalPathException {
+    if (pageElement.isLastPage && pageElement.chunkMetadataElement.isLastChunk) {
+      // finish compacting the file, remove it from list
+      removeFile(pageElement.chunkMetadataElement.fileElement);
     }
   }
 
   /**
-   * Remove chunk metadata from chunk metadata queue. If the chunk metadata to be removed is the
-   * last chunk of file, it means this file has been compacted completely, we should remove this
-   * file. When removing file, there may be new overlapped files being deserialized and their chunk
-   * metadatas are put into chunk metadata queue. Therefore, when the removed chunk is the first
-   * chunk or when new files are deserialized and their chunk metadatas are put into the queue, it
-   * is necessary to re-find new chunk metadatas that overlap with the first chunk metadata in the
-   * current queue, deserialize them into pages and put them into page queue.
-   *
-   * @return has new overlapped chunks or not
+   * Check if it is the last chunk in the file. If it is, it means the file has been finished
+   * compacting and needs to be removed.
    */
-  private boolean removeChunk(ChunkMetadataElement chunkMetadataElement)
+  private void checkShouldRemoveFile(ChunkMetadataElement chunkMetadataElement)
       throws IOException, IllegalPathException {
-    boolean hasNewOverlappedChunks = false;
-    boolean isFirstChunk = chunkMetadataQueue.peek().equals(chunkMetadataElement);
-    boolean hasNewOverlappedFiles = false;
-    chunkMetadataQueue.remove(chunkMetadataElement);
     if (chunkMetadataElement.isLastChunk) {
       // finish compacting the file, remove it from list
-      hasNewOverlappedFiles = removeFile(chunkMetadataElement.fileElement);
+      removeFile(chunkMetadataElement.fileElement);
     }
-
-    if ((isFirstChunk || hasNewOverlappedFiles)
-        && pageQueue.size() != 0
-        && chunkMetadataQueue.size() != 0) {
-      // pageQueue.size > 0 indicates that the new first chunk in chunk metadata queue has not been
-      // finished compacting yet, so there may be other chunks overlap with it.
-      // when deserializing new files into chunk metadata queue or first chunk is removed from chunk
-      // metadata queue, we should find new overlapped chunks and deserialize them into page queue
-      for (ChunkMetadataElement newOverlappedChunkMetadata :
-          findOverlapChunkMetadatas(chunkMetadataQueue.peek())) {
-        summary.CHUNK_OVERLAP_OR_MODIFIED++;
-        readChunk(newOverlappedChunkMetadata);
-        deserializeChunkIntoQueue(newOverlappedChunkMetadata);
-        hasNewOverlappedChunks = true;
-      }
-    }
-    return hasNewOverlappedChunks;
   }
 
   /**
    * Remove file from sorted list. If the file to be removed is the first file, we should re-find
    * new overlapped files with the first file in the current file list, deserialize them into chunk
    * metadatas and put them into chunk metadata queue.
-   *
-   * @return has new overlapped files or not
    */
-  protected boolean removeFile(FileElement fileElement) throws IllegalPathException, IOException {
-    boolean hasNewOverlappedFiles = false;
+  protected void removeFile(FileElement fileElement) throws IllegalPathException, IOException {
     boolean isFirstFile = fileList.get(0).equals(fileElement);
     fileList.remove(fileElement);
     if (isFirstFile && !fileList.isEmpty()) {
       // find new overlapped files and deserialize them into chunk metadata queue
       List<FileElement> newOverlappedFiles = findOverlapFiles(fileList.get(0));
-      deserializeFileIntoQueue(newOverlappedFiles);
-      hasNewOverlappedFiles = newOverlappedFiles.size() > 0;
+      deserializeFileIntoChunkMetadataQueue(newOverlappedFiles);
+      nextChunkStartTime =
+          chunkMetadataQueue.isEmpty() ? Long.MAX_VALUE : chunkMetadataQueue.peek().startTime;
     }
-    return hasNewOverlappedFiles;
   }
 
   /**
@@ -594,17 +479,17 @@ public abstract class SeriesCompactionExecutor {
     return pathModifications;
   }
 
-  private void updateSummary(ChunkMetadataElement chunkMetadataElement, ChunkStatus status) {
+  protected void updateSummary(ChunkMetadataElement chunkMetadataElement, ChunkStatus status) {
     switch (status) {
       case READ_IN:
         summary.increaseProcessChunkNum(
-            chunkMetadataElement.isAligned
+            isAligned
                 ? ((AlignedChunkMetadata) chunkMetadataElement.chunkMetadata)
                         .getValueChunkMetadataList()
                         .size()
                     + 1
                 : 1);
-        if (chunkMetadataElement.isAligned) {
+        if (isAligned) {
           for (IChunkMetadata valueChunkMetadata :
               ((AlignedChunkMetadata) chunkMetadataElement.chunkMetadata)
                   .getValueChunkMetadataList()) {
@@ -619,7 +504,7 @@ public abstract class SeriesCompactionExecutor {
         }
         break;
       case DIRECTORY_FLUSH:
-        if (chunkMetadataElement.isAligned) {
+        if (isAligned) {
           summary.increaseDirectlyFlushChunkNum(
               ((AlignedChunkMetadata) (chunkMetadataElement.chunkMetadata))
                       .getValueChunkMetadataList()
@@ -630,7 +515,7 @@ public abstract class SeriesCompactionExecutor {
         }
         break;
       case DESERIALIZE_CHUNK:
-        if (chunkMetadataElement.isAligned) {
+        if (isAligned) {
           summary.increaseDeserializedChunkNum(
               ((AlignedChunkMetadata) (chunkMetadataElement.chunkMetadata))
                       .getValueChunkMetadataList()

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/ChunkMetadataElement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/ChunkMetadataElement.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element;
 
-import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 import org.apache.iotdb.tsfile.read.common.Chunk;
 
@@ -29,8 +28,6 @@ public class ChunkMetadataElement {
 
   public long priority;
 
-  public boolean isSelected = false;
-
   public long startTime;
 
   public boolean isLastChunk;
@@ -40,7 +37,6 @@ public class ChunkMetadataElement {
   public Chunk chunk;
 
   public List<Chunk> valueChunks;
-  public boolean isAligned;
 
   public ChunkMetadataElement(
       IChunkMetadata chunkMetadata, long priority, boolean isLastChunk, FileElement fileElement) {
@@ -49,7 +45,6 @@ public class ChunkMetadataElement {
     this.startTime = chunkMetadata.getStartTime();
     this.isLastChunk = isLastChunk;
     this.fileElement = fileElement;
-    this.isAligned = chunkMetadata instanceof AlignedChunkMetadata;
   }
 
   public void clearChunks() {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PointElement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PointElement.java
@@ -32,6 +32,7 @@ public class PointElement {
   public PageElement pageElement;
 
   public PointElement(PageElement pageElement) throws IOException {
+    pageElement.deserializePage();
     this.pageElement = pageElement;
     if (pageElement.iChunkReader instanceof ChunkReader) {
       this.pointReader = pageElement.batchData.getTsBlockSingleColumnIterator();
@@ -43,8 +44,13 @@ public class PointElement {
     this.priority = pageElement.priority;
   }
 
-  public void setPoint(TimeValuePair timeValuePair) {
-    this.timeValuePair = timeValuePair;
-    this.timestamp = timeValuePair.getTimestamp();
+  public boolean hasNext() throws IOException {
+    return pointReader.hasNextTimeValuePair();
+  }
+
+  public TimeValuePair next() throws IOException {
+    timeValuePair = pointReader.nextTimeValuePair();
+    timestamp = timeValuePair.getTimestamp();
+    return timeValuePair;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/reader/PointPriorityReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/reader/PointPriorityReader.java
@@ -23,9 +23,7 @@ import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.SeriesC
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.PageElement;
 import org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element.PointElement;
 import org.apache.iotdb.db.exception.WriteProcessException;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
-import org.apache.iotdb.tsfile.read.reader.IPointReader;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
 import java.io.IOException;
@@ -46,13 +44,13 @@ public class PointPriorityReader {
 
   private TimeValuePair currentPoint;
 
-  private boolean shouldReadPointFromQueue = true;
-
   private long nextPointInOtherPage = Long.MAX_VALUE;
 
   private PointElement currentPointElement;
 
-  public PointPriorityReader(SeriesCompactionExecutor.RemovePage removePage) {
+  private final boolean isAligned;
+
+  public PointPriorityReader(SeriesCompactionExecutor.RemovePage removePage, boolean isAligned) {
     this.removePage = removePage;
     pointQueue =
         new PriorityQueue<>(
@@ -60,21 +58,20 @@ public class PointPriorityReader {
               int timeCompare = Long.compare(o1.timestamp, o2.timestamp);
               return timeCompare != 0 ? timeCompare : Long.compare(o2.priority, o1.priority);
             });
+    this.isAligned = isAligned;
   }
 
   public TimeValuePair currentPoint() {
-    if (shouldReadPointFromQueue && currentPointElement == null) {
+    if (currentPointElement == null) {
       // if the current point is overlapped with other pages, then get the highest priority point
       // from queue
       currentPoint = pointQueue.peek().timeValuePair;
       lastTime = currentPoint.getTimestamp();
 
       // fill aligned null value with the same timestamp
-      if (currentPoint.getValue().getDataType().equals(TSDataType.VECTOR)) {
+      if (isAligned) {
         fillAlignedNullValue();
       }
-
-      shouldReadPointFromQueue = false;
     }
     return currentPoint;
   }
@@ -124,13 +121,12 @@ public class PointPriorityReader {
 
   public void next() throws IllegalPathException, IOException, WriteProcessException {
     if (currentPointElement != null) {
-      IPointReader pointReader = currentPointElement.pointReader;
-      if (pointReader.hasNextTimeValuePair()) {
+
+      if (currentPointElement.hasNext()) {
         // get the point directly if it is not overlapped with other points
-        currentPoint = pointReader.nextTimeValuePair();
+        currentPoint = currentPointElement.next();
         if (currentPoint.getTimestamp() >= nextPointInOtherPage) {
           // if the point is overlapped with other points, then add it into priority queue
-          currentPointElement.setPoint(currentPoint);
           pointQueue.add(currentPointElement);
           currentPointElement = null;
         }
@@ -142,32 +138,25 @@ public class PointPriorityReader {
       }
     } else {
       // remove data points with the same timestamp as the last point
-      while (!pointQueue.isEmpty()) {
-        if (pointQueue.peek().timestamp > lastTime) {
-          // the smallest time of all pages is later than the last time, then break the loop
-          break;
-        } else {
-          // find the data points in other pages that has the same timestamp
-          PointElement pointElement = pointQueue.poll();
-          IPointReader pointReader = pointElement.pointReader;
-          if (pointReader.hasNextTimeValuePair()) {
-            pointElement.setPoint(pointReader.nextTimeValuePair());
-            nextPointInOtherPage =
-                pointQueue.size() > 0 ? pointQueue.peek().timestamp : Long.MAX_VALUE;
-            if (pointElement.timestamp < nextPointInOtherPage) {
-              currentPointElement = pointElement;
-              currentPoint = currentPointElement.timeValuePair;
-            } else {
-              pointQueue.add(pointElement);
-            }
+      while (!pointQueue.isEmpty() && pointQueue.peek().timestamp == lastTime) {
+        // find the data points in other pages that has the same timestamp
+        PointElement pointElement = pointQueue.poll();
+        if (pointElement.hasNext()) {
+          pointElement.next();
+          nextPointInOtherPage =
+              pointQueue.size() > 0 ? pointQueue.peek().timestamp : Long.MAX_VALUE;
+          if (pointElement.timestamp < nextPointInOtherPage) {
+            currentPointElement = pointElement;
+            currentPoint = currentPointElement.timeValuePair;
           } else {
-            // end page
-            removePage.call(pointElement.pageElement);
+            pointQueue.add(pointElement);
           }
+        } else {
+          // end page
+          removePage.call(pointElement.pageElement);
         }
       }
     }
-    shouldReadPointFromQueue = true;
   }
 
   public boolean hasNext() {
@@ -179,13 +168,10 @@ public class PointPriorityReader {
     if (currentPointElement != null) {
       nextPointInOtherPage = Math.min(nextPointInOtherPage, pageElement.startTime);
       if (currentPoint.getTimestamp() >= nextPointInOtherPage) {
-        currentPointElement.setPoint(currentPoint);
         pointQueue.add(currentPointElement);
         currentPointElement = null;
       }
     }
-    pageElement.deserializePage();
     pointQueue.add(new PointElement(pageElement));
-    shouldReadPointFromQueue = true;
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastAlignedCrossCompactionTest.java
@@ -6812,6 +6812,404 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
+  @Test
+  public void test22() throws IOException, IllegalPathException {
+    List<PartialPath> timeserisPathList = new ArrayList<>();
+    List<TSDataType> tsDataTypes = new ArrayList<>();
+    // seq file 1
+    int deviceNum = 10;
+    int measurementNum = 10;
+    TsFileResource resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+
+        // write first chunk
+        List<TimeRange> pages = createPages(0, 1000, 100);
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, true);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        // write second chunk
+        pages = createPages(1100, 1200, 30);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        // write third chunk
+        pages = createPages(1300, 1400, 80);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 0);
+        resource.updateEndTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 1400);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // unseq file 1
+    deviceNum = 15;
+    measurementNum = 5;
+    resource = createEmptyFileAndResource(false);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+
+        // write first chunk
+        List<TimeRange> pages = createPages(50, 250, 100);
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, true);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write second chunk
+        pages = createPages(300, 500, 60);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write third chunk
+        pages = createPages(550, 650, 60);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write forth chunk
+        pages = createPages(950, 1450, 45);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 50);
+        resource.updateEndTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 1450);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    unseqResources.add(resource);
+
+    // unseq file 2
+    deviceNum = 12;
+    measurementNum = 12;
+    resource = createEmptyFileAndResource(false);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+
+        // write first chunk
+        List<TimeRange> pages = createPages(700, 800, 50);
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, true);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write second chunk
+        pages = createPages(850, 1350, 90);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write third chunk
+        pages = createPages(1500, 1600, 30);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 700);
+        resource.updateEndTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 1600);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    unseqResources.add(resource);
+
+    Map<PartialPath, List<TimeValuePair>> sourceDatas =
+        readSourceFiles(timeserisPathList, tsDataTypes);
+
+    // start compacting
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+    CrossSpaceCompactionTask task =
+        new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            unseqResources,
+            new FastCompactionPerformer(true),
+            new AtomicInteger(0),
+            0,
+            0);
+    task.start();
+
+    validateSeqFiles(true);
+
+    validateTargetDatas(sourceDatas, tsDataTypes);
+  }
+
+  @Test
+  public void test23() throws MetadataException, IOException {
+    IoTDBDescriptor.getInstance().getConfig().setChunkPointNumLowerBoundInCompaction(1000);
+    List<PartialPath> timeserisPathList = new ArrayList<>();
+    List<TSDataType> tsDataTypes = new ArrayList<>();
+    // seq file 1
+    int deviceNum = 10;
+    int measurementNum = 10;
+    TsFileResource resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+
+        List<TimeRange> pages = new ArrayList<>();
+        pages.add(new TimeRange(0, 300L));
+        pages.add(new TimeRange(500L, 600L));
+
+        for (IChunkWriter iChunkWriter : createChunkWriter(timeseriesPath, dataTypes, true)) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 0);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 600);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // seq file 2
+    deviceNum = 12;
+    measurementNum = 5;
+    resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+
+        // write first chunk
+        List<TimeRange> timeRanges = new ArrayList<>();
+        timeRanges.add(new TimeRange(900L, 1200L));
+        timeRanges.add(new TimeRange(1350, 1700));
+        timeRanges.add(new TimeRange(1750, 2000));
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, true);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk(
+              (AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, true);
+        }
+
+        // write second chunk
+        timeRanges.clear();
+        timeRanges.add(new TimeRange(2220, 2300));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk(
+              (AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, true);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 900);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2300);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // unseq file 1
+    deviceNum = 12;
+    measurementNum = 15;
+    resource = createEmptyFileAndResource(false);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+
+        // write first chunk
+        List<TimeRange> timeRanges = new ArrayList<>();
+        timeRanges.add(new TimeRange(500, 950));
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, true);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk(
+              (AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        // write second chunk
+        timeRanges.clear();
+        timeRanges.add(new TimeRange(1000, 1320));
+        timeRanges.add(new TimeRange(1400, 1850));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk(
+              (AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        // write third chunk
+        timeRanges.clear();
+        timeRanges.add(new TimeRange(2000, 2200));
+        timeRanges.add(new TimeRange(2220, 2300));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk(
+              (AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 500);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2300);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    unseqResources.add(resource);
+
+    // unseq file 2
+    deviceNum = 20;
+    measurementNum = 20;
+    resource = createEmptyFileAndResource(false);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+
+        // write first chunk
+        List<TimeRange> timeRanges = new ArrayList<>();
+        timeRanges.add(new TimeRange(500, 800));
+        timeRanges.add(new TimeRange(850, 950));
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, true);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk(
+              (AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        // write second chunk
+        timeRanges.clear();
+        timeRanges.add(new TimeRange(1000, 1300));
+        timeRanges.add(new TimeRange(1400, 1850));
+        timeRanges.add(new TimeRange(2220, 2300));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk(
+              (AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 500);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2300);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    unseqResources.add(resource);
+
+    Map<PartialPath, List<TimeValuePair>> sourceDatas =
+        readSourceFiles(timeserisPathList, tsDataTypes);
+
+    // start compacting
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+    CrossSpaceCompactionTask task =
+        new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            unseqResources,
+            new FastCompactionPerformer(true),
+            new AtomicInteger(0),
+            0,
+            0);
+    task.start();
+
+    validateSeqFiles(true);
+
+    validateTargetDatas(sourceDatas, tsDataTypes);
+  }
+
   private List<TimeRange> createPages(long startTime, long endTime, int pagePointNum) {
     List<TimeRange> pages = new ArrayList<>();
     for (long i = startTime; i <= endTime; i += pagePointNum) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastNonAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastNonAlignedCrossCompactionTest.java
@@ -6778,6 +6778,397 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
+  @Test
+  public void test22() throws IOException, IllegalPathException {
+    List<PartialPath> timeserisPathList = new ArrayList<>();
+    List<TSDataType> tsDataTypes = new ArrayList<>();
+    // seq file 1
+    int deviceNum = 10;
+    int measurementNum = 10;
+    TsFileResource resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
+
+        // write first chunk
+        List<TimeRange> pages = createPages(0, 1000, 100);
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        // write second chunk
+        pages = createPages(1100, 1200, 30);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        // write third chunk
+        pages = createPages(1300, 1400, 80);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 0);
+        resource.updateEndTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 1400);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // unseq file 1
+    deviceNum = 15;
+    measurementNum = 5;
+    resource = createEmptyFileAndResource(false);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
+
+        // write first chunk
+        List<TimeRange> pages = createPages(50, 250, 100);
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write second chunk
+        pages = createPages(300, 500, 60);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write third chunk
+        pages = createPages(550, 650, 60);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write forth chunk
+        pages = createPages(950, 1450, 45);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 50);
+        resource.updateEndTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 1450);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    unseqResources.add(resource);
+
+    // unseq file 2
+    deviceNum = 12;
+    measurementNum = 12;
+    resource = createEmptyFileAndResource(false);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
+
+        // write first chunk
+        List<TimeRange> pages = createPages(700, 800, 50);
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write second chunk
+        pages = createPages(850, 1350, 90);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        // write third chunk
+        pages = createPages(1500, 1600, 30);
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 700);
+        resource.updateEndTime(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex, 1600);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    unseqResources.add(resource);
+
+    Map<PartialPath, List<TimeValuePair>> sourceDatas =
+        readSourceFiles(timeserisPathList, tsDataTypes);
+
+    // start compacting
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+    CrossSpaceCompactionTask task =
+        new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            unseqResources,
+            new FastCompactionPerformer(true),
+            new AtomicInteger(0),
+            0,
+            0);
+    task.start();
+
+    validateSeqFiles(true);
+
+    validateTargetDatas(sourceDatas, tsDataTypes);
+  }
+
+  @Test
+  public void test23() throws MetadataException, IOException {
+    IoTDBDescriptor.getInstance().getConfig().setChunkPointNumLowerBoundInCompaction(1000);
+    List<PartialPath> timeserisPathList = new ArrayList<>();
+    List<TSDataType> tsDataTypes = new ArrayList<>();
+    // seq file 1
+    int deviceNum = 10;
+    int measurementNum = 10;
+    TsFileResource resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
+
+        List<TimeRange> pages = new ArrayList<>();
+        pages.add(new TimeRange(0, 300L));
+        pages.add(new TimeRange(500L, 600L));
+
+        for (IChunkWriter iChunkWriter : createChunkWriter(timeseriesPath, dataTypes, false)) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 0);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 600);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // seq file 2
+    deviceNum = 12;
+    measurementNum = 5;
+    resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
+
+        // write first chunk
+        List<TimeRange> timeRanges = new ArrayList<>();
+        timeRanges.add(new TimeRange(900L, 1200L));
+        timeRanges.add(new TimeRange(1350, 1700));
+        timeRanges.add(new TimeRange(1750, 2000));
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, true);
+        }
+
+        // write second chunk
+        timeRanges.clear();
+        timeRanges.add(new TimeRange(2220, 2300));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, true);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 900);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2300);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // unseq file 1
+    deviceNum = 12;
+    measurementNum = 15;
+    resource = createEmptyFileAndResource(false);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
+
+        // write first chunk
+        List<TimeRange> timeRanges = new ArrayList<>();
+        timeRanges.add(new TimeRange(500, 950));
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        // write second chunk
+        timeRanges.clear();
+        timeRanges.add(new TimeRange(1000, 1320));
+        timeRanges.add(new TimeRange(1400, 1850));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        // write third chunk
+        timeRanges.clear();
+        timeRanges.add(new TimeRange(2000, 2200));
+        timeRanges.add(new TimeRange(2220, 2300));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 500);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2300);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    unseqResources.add(resource);
+
+    // unseq file 2
+    deviceNum = 20;
+    measurementNum = 20;
+    resource = createEmptyFileAndResource(false);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
+
+        // write first chunk
+        List<TimeRange> timeRanges = new ArrayList<>();
+        timeRanges.add(new TimeRange(500, 800));
+        timeRanges.add(new TimeRange(850, 950));
+
+        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        // write second chunk
+        timeRanges.clear();
+        timeRanges.add(new TimeRange(1000, 1300));
+        timeRanges.add(new TimeRange(1400, 1850));
+        timeRanges.add(new TimeRange(2220, 2300));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 500);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2300);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    unseqResources.add(resource);
+
+    Map<PartialPath, List<TimeValuePair>> sourceDatas =
+        readSourceFiles(timeserisPathList, tsDataTypes);
+
+    // start compacting
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+    CrossSpaceCompactionTask task =
+        new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            unseqResources,
+            new FastCompactionPerformer(true),
+            new AtomicInteger(0),
+            0,
+            0);
+    task.start();
+
+    validateSeqFiles(true);
+
+    validateTargetDatas(sourceDatas, tsDataTypes);
+  }
+
   /**
    * Create pages from startTime to endTime and each page has pagePointNum points except the last
    * page.


### PR DESCRIPTION
In the past, all the chunks that overlap with the current chunk were read into the memory at one time, but now only the chunks that need to be used are read into the memory.
For example: in the figure below, first read 1 into the memory, and then read 2 3 4 in sequence. At most two chunks can be stored in the memory at the same time instead of 4 chunks.
<img width="464" alt="image" src="https://user-images.githubusercontent.com/45144903/218389667-6a8a5fa8-9e9a-469d-ad94-43c85b5e5bb2.png">