### PR TITLE
[IOTDB-5578] Keep CacheMemoryManager monitor alive when exception

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -118,8 +118,6 @@ public class CacheMemoryManager {
                 }
               } catch (Throwable throwable) {
                 logger.error("Something wrong happened during MTree release.", throwable);
-                throwable.printStackTrace();
-                throw throwable;
               }
             }
           } catch (InterruptedException e) {
@@ -138,8 +136,6 @@ public class CacheMemoryManager {
                 }
               } catch (Throwable throwable) {
                 logger.error("Something wrong happened during MTree flush.", throwable);
-                throwable.printStackTrace();
-                throw throwable;
               }
             }
           } catch (InterruptedException e) {


### PR DESCRIPTION
## Description

flushTaskMonitor and releaseTaskMonitor should keep alive until CacheMemoryManager#clear() is invoked expecitly. So they should not throw exception in catch clause.