### PR TITLE
[IOTDB-5585] Change InternalReporterType from IoTDB to Memory to reduce performance degradation

### DIFF
--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
@@ -55,7 +55,7 @@ public class MetricConfig {
   private final IoTDBReporterConfig iotdbReporterConfig = new IoTDBReporterConfig();
 
   /** The type of internal reporter. */
-  private InternalReporterType internalReporterType = InternalReporterType.IOTDB;
+  private InternalReporterType internalReporterType = InternalReporterType.MEMORY;
 
   /** The address of iotdb instance that is monitored. */
   private String rpcAddress = "0.0.0.0";

--- a/metrics/interface/src/test/java/org/apache/iotdb/metrics/config/MetricConfigTest.java
+++ b/metrics/interface/src/test/java/org/apache/iotdb/metrics/config/MetricConfigTest.java
@@ -85,7 +85,7 @@ public class MetricConfigTest {
     properties.setProperty("dn_metric_iotdb_reporter_max_connection_number", "1");
     properties.setProperty("dn_metric_iotdb_reporter_location", "metric");
     properties.setProperty("dn_metric_iotdb_reporter_push_period", "5");
-    properties.setProperty("dn_metric_internal_reporter_type", "MEMORY");
+    properties.setProperty("dn_metric_internal_reporter_type", "IOTDB");
 
     MetricConfigDescriptor.getInstance().loadProps(properties);
 
@@ -105,6 +105,6 @@ public class MetricConfigTest {
     assertEquals(1, (int) reporterConfig.getMaxConnectionNumber());
     assertEquals("metric", reporterConfig.getLocation());
     assertEquals(5, (int) reporterConfig.getPushPeriodInSecond());
-    assertEquals(InternalReporterType.MEMORY, metricConfig.getInternalReportType());
+    assertEquals(InternalReporterType.IOTDB, metricConfig.getInternalReportType());
   }
 }

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -273,4 +273,4 @@ dn_target_config_node_list=127.0.0.1:10710
 # The type of internal reporter in metric module
 # Options: [MEMORY, IOTDB]
 # Datatype: String
-# dn_metric_internal_reporter_type=IOTDB
+# dn_metric_internal_reporter_type=MEMORY


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/IOTDB-5585)