### PR TITLE
[IOTDB-5584] Fix wrong intialization in GROUP BY CONDITION

### DIFF
--- a/docs/UserGuide/Query-Data/Group-By.md
+++ b/docs/UserGuide/Query-Data/Group-By.md
@@ -726,7 +726,7 @@ Keep expression consists of a 'keep' string and a threshold of type `long` or a 
 Used to specify how to handle data rows that encounter null predict, skip the row when it's true and end current group when it's false.
 
 ### Precautions for Use
-1. keep condition is required in the query, but you can omit the 'keep' string and given a constant which defaults to 'keep=constant' condition.
+1. keep condition is required in the query, but you can omit the 'keep' string and given a `long` number which defaults to 'keep=long number' condition.
 2. IgnoreNull defaults to true.
 3. For a group in resultSet, the time column output the start time of the group by default. __endTime can be used in select clause to output the endTime of groups in resultSet.
 4. Each device is grouped separately when used with `ALIGN BY DEVICE`.

--- a/docs/zh/UserGuide/Query-Data/Group-By.md
+++ b/docs/zh/UserGuide/Query-Data/Group-By.md
@@ -709,7 +709,7 @@ keep表达式用来指定形成分组所需要连续满足`predict`条件的数�
 用于指定遇到predict为null的数据行时的处理方式，为true则跳过该行，为false则结束当前分组。
 
 ### 使用注意事项
-1. keep条件在查询中是必需的，但可以省略掉keep字符串给出一个常数，默认为`keep=该常数`的等于条件。
+1. keep条件在查询中是必需的，但可以省略掉keep字符串给出一个`long`类型常数，默认为`keep=该long型常数`的等于条件。
 2. `ignoreNull`默认为true。
 3. 对于一个分组，默认Time列输出分组的开始时间，查询时可以使用select `__endTime`的方式来使得结果输出分组的结束时间。
 4. 与`ALIGN BY DEVICE`搭配使用时会对每个device进行单独的分组操作。

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByConditionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByConditionIT.java
@@ -206,11 +206,11 @@ public class IoTDBGroupByConditionIT {
   @Test
   public void groupByConditionTest6() {
     String[][] res =
-            new String[][] {
-                    {"6", "2500000000", "2499999994", "13", "100.0"},
-            };
+        new String[][] {
+          {"6", "2500000000", "2499999994", "13", "100.0"},
+        };
     String sql =
-            "select __endTime,max_time(charging_status) - min_time(charging_status),count(vehicle_status),last_value(soc) from root.sg.beijing.car01 group by condition(soc>=24.0,KEEP<=20)";
+        "select __endTime,max_time(charging_status) - min_time(charging_status),count(vehicle_status),last_value(soc) from root.sg.beijing.car01 group by condition(soc>=24.0,KEEP<=20)";
     normalTestWithEndTime(res, sql);
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByConditionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByConditionIT.java
@@ -203,6 +203,17 @@ public class IoTDBGroupByConditionIT {
     normalTestWithEndTime(res, sql);
   }
 
+  @Test
+  public void groupByConditionTest6() {
+    String[][] res =
+            new String[][] {
+                    {"6", "2500000000", "2499999994", "13", "100.0"},
+            };
+    String sql =
+            "select __endTime,max_time(charging_status) - min_time(charging_status),count(vehicle_status),last_value(soc) from root.sg.beijing.car01 group by condition(soc>=24.0,KEEP<=20)";
+    normalTestWithEndTime(res, sql);
+  }
+
   private void normalTestWithEndTime(String[][] res, String sql) {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/window/SeriesWindowManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/window/SeriesWindowManager.java
@@ -49,6 +49,8 @@ public class SeriesWindowManager implements IWindowManager {
 
   public SeriesWindowManager(SeriesWindowParameter seriesWindowParameter) {
     this.seriesWindow = new SeriesWindow(seriesWindowParameter);
+    // In group by condition, the first data point cannot be guaranteed to be true in controlColumn,
+    // so there is going to be a skipPointsOutOfBounds() in the beginning.
     this.needSkip = true;
     this.keepEvaluator =
         AccumulatorFactory.initKeepEvaluator(seriesWindowParameter.getKeepExpression());

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/window/SeriesWindowManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/window/SeriesWindowManager.java
@@ -49,7 +49,7 @@ public class SeriesWindowManager implements IWindowManager {
 
   public SeriesWindowManager(SeriesWindowParameter seriesWindowParameter) {
     this.seriesWindow = new SeriesWindow(seriesWindowParameter);
-    this.needSkip = false;
+    this.needSkip = true;
     this.keepEvaluator =
         AccumulatorFactory.initKeepEvaluator(seriesWindowParameter.getKeepExpression());
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IOTDB-5584

When the controlColumn of first data point is false, conditon window wouldn't skip it because needSkip is intialized to false which leads to a redundant row in resultSet.

This PR fix the problem.