### PR TITLE
[IOTDB-5545] Implement SchemaRegionLoader for SchemaEngine

### DIFF
--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -61,6 +61,7 @@ import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.rescon.MemSchemaRegionStatistics;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegionParams;
+import org.apache.iotdb.db.metadata.schemaregion.SchemaRegion;
 import org.apache.iotdb.db.metadata.schemaregion.SchemaRegionUtils;
 import org.apache.iotdb.db.metadata.schemaregion.rocksdb.mnode.RMNodeType;
 import org.apache.iotdb.db.metadata.schemaregion.rocksdb.mnode.RMNodeValueType;
@@ -119,6 +120,7 @@ import static org.apache.iotdb.db.metadata.schemaregion.rocksdb.RSchemaConstants
 import static org.apache.iotdb.db.metadata.schemaregion.rocksdb.RSchemaConstants.ROOT_STRING;
 import static org.apache.iotdb.db.metadata.schemaregion.rocksdb.RSchemaConstants.TABLE_NAME_TAGS;
 
+@SchemaRegion(mode = "Rocksdb_based")
 public class RSchemaRegion implements ISchemaRegion {
 
   private static final Logger logger = LoggerFactory.getLogger(RSchemaRegion.class);

--- a/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
+++ b/schema-engine-rocksdb/src/main/java/org/apache/iotdb/db/metadata/schemaregion/rocksdb/RSchemaRegion.java
@@ -60,6 +60,7 @@ import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.rescon.MemSchemaRegionStatistics;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
+import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegionParams;
 import org.apache.iotdb.db.metadata.schemaregion.SchemaRegionUtils;
 import org.apache.iotdb.db.metadata.schemaregion.rocksdb.mnode.RMNodeType;
 import org.apache.iotdb.db.metadata.schemaregion.rocksdb.mnode.RMNodeValueType;
@@ -150,11 +151,10 @@ public class RSchemaRegion implements ISchemaRegion {
     }
   }
 
-  public RSchemaRegion(
-      PartialPath storageGroup, SchemaRegionId schemaRegionId, RSchemaConfLoader rSchemaConfLoader)
-      throws MetadataException {
-    this.schemaRegionId = schemaRegionId;
-    storageGroupFullPath = storageGroup.getFullPath();
+  public RSchemaRegion(ISchemaRegionParams schemaRegionParams) throws MetadataException {
+    RSchemaConfLoader rSchemaConfLoader = new RSchemaConfLoader();
+    this.schemaRegionId = schemaRegionParams.getSchemaRegionId();
+    storageGroupFullPath = schemaRegionParams.getDatabase().getFullPath();
     init();
     try {
       readWriteHandler = new RSchemaReadWriteHandler(schemaRegionDirPath, rSchemaConfLoader);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MetadataConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MetadataConstant.java
@@ -73,6 +73,8 @@ public class MetadataConstant {
   public static final String SCHEMA_REGION_METRIC_NAME = "schema_region";
   public static final String SCHEMA_ENGINE_METRIC_NAME = "schema_file";
 
+  public static final String DEFAULT_SCHEMA_ENGINE_MODE = "Memory";
+
   public static String getMNodeTypeName(byte type) {
     switch (type) {
       case INTERNAL_MNODE_TYPE:

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegionParams.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/ISchemaRegionParams.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.metadata.schemaregion;
+
+import org.apache.iotdb.commons.consensus.SchemaRegionId;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.metadata.rescon.ISchemaEngineStatistics;
+import org.apache.iotdb.external.api.ISeriesNumerMonitor;
+
+public interface ISchemaRegionParams {
+
+  PartialPath getDatabase();
+
+  SchemaRegionId getSchemaRegionId();
+
+  ISchemaEngineStatistics getSchemaEngineStatistics();
+
+  ISeriesNumerMonitor getSeriesNumberMonitor();
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegion.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.metadata.schemaregion;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface SchemaRegion {
+  String mode();
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionLoader.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.metadata.schemaregion;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.db.metadata.MetadataConstant;
+
+import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+class SchemaRegionLoader {
+  private static final String ROCKSDB_BASED = "Rocksdb_based";
+
+  private static final Logger logger = LoggerFactory.getLogger(SchemaEngine.class);
+
+  private static final String PACKAGE_NAME = "org.apache.iotdb.db.metadata";
+
+  private final Map<String, Constructor<ISchemaRegion>> constructorMap = new ConcurrentHashMap<>();
+
+  private String currentMode;
+
+  private Constructor<ISchemaRegion> currentConstructor;
+
+  @SuppressWarnings("unchecked")
+  SchemaRegionLoader() {
+    Reflections reflections =
+        new Reflections(
+            new ConfigurationBuilder()
+                .forPackages(PACKAGE_NAME)
+                .filterInputsBy(new FilterBuilder().includePackage(PACKAGE_NAME)));
+
+    Set<Class<?>> annotatedSchemaRegionSet = reflections.getTypesAnnotatedWith(SchemaRegion.class);
+
+    for (Class<?> annotatedSchemaRegion : annotatedSchemaRegionSet) {
+      if (!annotatedSchemaRegion.isInstance(ISchemaRegion.class)) {
+        logger.warn(
+            String.format(
+                "Class %s is not a subclass of ISchemaRegion.", annotatedSchemaRegion.getName()));
+      }
+      SchemaRegion annotationInfo = annotatedSchemaRegion.getAnnotation(SchemaRegion.class);
+      constructorMap.compute(
+          annotationInfo.mode(),
+          (k, v) -> {
+            if (v == null) {
+              try {
+                return (Constructor<ISchemaRegion>)
+                    annotatedSchemaRegion.getConstructor(ISchemaRegionParams.class);
+              } catch (NoSuchMethodException e) {
+                logger.error(e.getMessage(), e);
+                return null;
+              }
+            }
+            logger.warn(
+                "Duplicated SchemaRegion implementation, {} and {}, with same mode name [{}]",
+                v.getClass().getName(),
+                annotatedSchemaRegion.getName(),
+                k);
+            return v;
+          });
+    }
+  }
+
+  void init(String schemaEngineMode) {
+    if (schemaEngineMode.equals(ROCKSDB_BASED)) {
+      currentMode = ROCKSDB_BASED;
+      return;
+    }
+    Constructor<ISchemaRegion> constructor = constructorMap.get(schemaEngineMode);
+    if (constructor == null) {
+      logger.warn(
+          "There's no SchemaRegion implementation with target mode {}. Use default mode {}",
+          schemaEngineMode,
+          MetadataConstant.DEFAULT_SCHEMA_ENGINE_MODE);
+      currentMode = MetadataConstant.DEFAULT_SCHEMA_ENGINE_MODE;
+      currentConstructor = constructorMap.get(currentMode);
+    } else {
+      currentMode = schemaEngineMode;
+      currentConstructor = constructor;
+    }
+  }
+
+  ISchemaRegion createSchemaRegion(ISchemaRegionParams schemaRegionParams)
+      throws MetadataException {
+    if (currentMode.equals(ROCKSDB_BASED)) {
+      return new RSchemaRegionLoader().loadRSchemaRegion(schemaRegionParams);
+    }
+    try {
+      return currentConstructor.newInstance(schemaRegionParams);
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      logger.warn(e.getMessage(), e);
+      throw new MetadataException(e);
+    }
+  }
+
+  void clear() {
+    currentMode = null;
+    currentConstructor = null;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionLoader.java
@@ -35,8 +35,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 class SchemaRegionLoader {
-  private static final String ROCKSDB_BASED = "Rocksdb_based";
-
   private static final Logger logger = LoggerFactory.getLogger(SchemaEngine.class);
 
   private static final String PACKAGE_NAME = "org.apache.iotdb.db.metadata";
@@ -95,10 +93,6 @@ class SchemaRegionLoader {
   }
 
   void init(String schemaEngineMode) {
-    if (schemaEngineMode.equals(ROCKSDB_BASED)) {
-      currentMode = ROCKSDB_BASED;
-      return;
-    }
     Constructor<ISchemaRegion> constructor = constructorMap.get(schemaEngineMode);
     if (constructor == null) {
       logger.warn(
@@ -115,9 +109,6 @@ class SchemaRegionLoader {
 
   ISchemaRegion createSchemaRegion(ISchemaRegionParams schemaRegionParams)
       throws MetadataException {
-    if (currentMode.equals(ROCKSDB_BASED)) {
-      return new RSchemaRegionLoader().loadRSchemaRegion(schemaRegionParams);
-    }
     try {
       return currentConstructor.newInstance(schemaRegionParams);
     } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionLoader.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionLoader.java
@@ -58,10 +58,18 @@ class SchemaRegionLoader {
     Set<Class<?>> annotatedSchemaRegionSet = reflections.getTypesAnnotatedWith(SchemaRegion.class);
 
     for (Class<?> annotatedSchemaRegion : annotatedSchemaRegionSet) {
-      if (!annotatedSchemaRegion.isInstance(ISchemaRegion.class)) {
+      boolean isSchemaRegion = false;
+      for (Class<?> interfaces : annotatedSchemaRegion.getInterfaces()) {
+        if (interfaces == ISchemaRegion.class) {
+          isSchemaRegion = true;
+          break;
+        }
+      }
+      if (!isSchemaRegion) {
         logger.warn(
             String.format(
                 "Class %s is not a subclass of ISchemaRegion.", annotatedSchemaRegion.getName()));
+        continue;
       }
       SchemaRegion annotationInfo = annotatedSchemaRegion.getAnnotation(SchemaRegion.class);
       constructorMap.compute(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -68,7 +68,6 @@ import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
-import org.apache.iotdb.db.metadata.rescon.ISchemaEngineStatistics;
 import org.apache.iotdb.db.metadata.rescon.MemSchemaRegionStatistics;
 import org.apache.iotdb.db.metadata.tag.TagManager;
 import org.apache.iotdb.db.metadata.template.Template;
@@ -120,6 +119,7 @@ import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARA
  * </ol>
  */
 @SuppressWarnings("java:S1135") // ignore todos
+@SchemaRegion(mode = MetadataConstant.DEFAULT_SCHEMA_ENGINE_MODE)
 public class SchemaRegionMemoryImpl implements ISchemaRegion {
 
   private static final Logger logger = LoggerFactory.getLogger(SchemaRegionMemoryImpl.class);
@@ -147,15 +147,10 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   private final ISeriesNumerMonitor seriesNumerMonitor;
 
   // region Interfaces and Implementation of initialization、snapshot、recover and clear
-  public SchemaRegionMemoryImpl(
-      PartialPath storageGroup,
-      SchemaRegionId schemaRegionId,
-      ISchemaEngineStatistics engineStatistics,
-      ISeriesNumerMonitor seriesNumerMonitor)
-      throws MetadataException {
+  public SchemaRegionMemoryImpl(ISchemaRegionParams schemaRegionParams) throws MetadataException {
 
-    storageGroupFullPath = storageGroup.getFullPath();
-    this.schemaRegionId = schemaRegionId;
+    storageGroupFullPath = schemaRegionParams.getDatabase().getFullPath();
+    this.schemaRegionId = schemaRegionParams.getSchemaRegionId();
 
     storageGroupDirPath = config.getSchemaDir() + File.separator + storageGroupFullPath;
     schemaRegionDirPath = storageGroupDirPath + File.separator + schemaRegionId.getId();
@@ -172,8 +167,10 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       }
     }
 
-    this.seriesNumerMonitor = seriesNumerMonitor;
-    this.regionStatistics = new MemSchemaRegionStatistics(schemaRegionId.getId(), engineStatistics);
+    this.seriesNumerMonitor = schemaRegionParams.getSeriesNumberMonitor();
+    this.regionStatistics =
+        new MemSchemaRegionStatistics(
+            schemaRegionId.getId(), schemaRegionParams.getSchemaEngineStatistics());
     init();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionParams.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionParams.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.metadata.schemaregion;
+
+import org.apache.iotdb.commons.consensus.SchemaRegionId;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.metadata.rescon.ISchemaEngineStatistics;
+import org.apache.iotdb.external.api.ISeriesNumerMonitor;
+
+public class SchemaRegionParams implements ISchemaRegionParams {
+
+  private final PartialPath database;
+
+  private final SchemaRegionId schemaRegionId;
+
+  private final ISchemaEngineStatistics schemaEngineStatistics;
+
+  private final ISeriesNumerMonitor seriesNumberMonitor;
+
+  public SchemaRegionParams(
+      PartialPath database,
+      SchemaRegionId schemaRegionId,
+      ISchemaEngineStatistics schemaEngineStatistics,
+      ISeriesNumerMonitor seriesNumberMonitor) {
+    this.database = database;
+    this.schemaRegionId = schemaRegionId;
+    this.schemaEngineStatistics = schemaEngineStatistics;
+    this.seriesNumberMonitor = seriesNumberMonitor;
+  }
+
+  @Override
+  public PartialPath getDatabase() {
+    return database;
+  }
+
+  @Override
+  public SchemaRegionId getSchemaRegionId() {
+    return schemaRegionId;
+  }
+
+  @Override
+  public ISchemaEngineStatistics getSchemaEngineStatistics() {
+    return schemaEngineStatistics;
+  }
+
+  @Override
+  public ISeriesNumerMonitor getSeriesNumberMonitor() {
+    return seriesNumberMonitor;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -70,7 +70,6 @@ import org.apache.iotdb.db.metadata.query.info.INodeSchemaInfo;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.rescon.CachedSchemaRegionStatistics;
-import org.apache.iotdb.db.metadata.rescon.ISchemaEngineStatistics;
 import org.apache.iotdb.db.metadata.rescon.MemSchemaRegionStatistics;
 import org.apache.iotdb.db.metadata.tag.TagManager;
 import org.apache.iotdb.db.metadata.template.Template;
@@ -122,6 +121,7 @@ import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARA
  * </ol>
  */
 @SuppressWarnings("java:S1135") // ignore todos
+@SchemaRegion(mode = "Schema_File")
 public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
 
   private static final Logger logger = LoggerFactory.getLogger(SchemaRegionSchemaFileImpl.class);
@@ -152,22 +152,19 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   private final ISeriesNumerMonitor seriesNumerMonitor;
 
   // region Interfaces and Implementation of initialization、snapshot、recover and clear
-  public SchemaRegionSchemaFileImpl(
-      PartialPath storageGroup,
-      SchemaRegionId schemaRegionId,
-      ISchemaEngineStatistics engineStatistics,
-      ISeriesNumerMonitor seriesNumerMonitor)
+  public SchemaRegionSchemaFileImpl(ISchemaRegionParams schemaRegionParams)
       throws MetadataException {
 
-    storageGroupFullPath = storageGroup.getFullPath();
-    this.schemaRegionId = schemaRegionId;
+    storageGroupFullPath = schemaRegionParams.getDatabase().getFullPath();
+    this.schemaRegionId = schemaRegionParams.getSchemaRegionId();
 
     storageGroupDirPath = config.getSchemaDir() + File.separator + storageGroupFullPath;
     schemaRegionDirPath = storageGroupDirPath + File.separator + schemaRegionId.getId();
 
-    this.seriesNumerMonitor = seriesNumerMonitor;
+    this.seriesNumerMonitor = schemaRegionParams.getSeriesNumberMonitor();
     this.regionStatistics =
-        new CachedSchemaRegionStatistics(schemaRegionId.getId(), engineStatistics);
+        new CachedSchemaRegionStatistics(
+            schemaRegionId.getId(), schemaRegionParams.getSchemaEngineStatistics());
     init();
   }
 


### PR DESCRIPTION
## Description

We use java reflections and annotation to implement SchemaRegionLoader, which brings better extension-ability for SchemaEngine.
