### PR TITLE
[IOTDB-5593] Improve efficiency of DistributionPlanner by recording map instead of recursive search

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
@@ -60,7 +60,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -506,8 +505,7 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
       String localPlanNodeId,
       // TODO: replace with callbacks to decouple MPPDataExchangeManager from
       // FragmentInstanceContext
-      FragmentInstanceContext instanceContext,
-      int index) {
+      FragmentInstanceContext instanceContext) {
 
     LOGGER.debug(
         "Create sink handle to plan node {} of {} for {}",
@@ -525,8 +523,7 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
         executorService,
         tsBlockSerdeFactory.get(),
         new SinkListenerImpl(instanceContext, instanceContext::failed),
-        mppDataExchangeServiceClientManager,
-        index);
+        mppDataExchangeServiceClientManager);
   }
 
   @Override
@@ -544,8 +541,6 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
           "ShuffleSinkHandle for " + localFragmentInstanceId + " exists.");
     }
 
-    AtomicInteger index = new AtomicInteger(0);
-
     List<ISinkChannel> downStreamChannelList =
         downStreamChannelLocationList.stream()
             .map(
@@ -554,8 +549,7 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
                         localFragmentInstanceId,
                         localPlanNodeId,
                         downStreamChannelLocation,
-                        instanceContext,
-                        index.getAndIncrement()))
+                        instanceContext))
             .collect(Collectors.toList());
 
     ShuffleSinkHandle shuffleSinkHandle =
@@ -574,8 +568,7 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
       TFragmentInstanceId localFragmentInstanceId,
       String localPlanNodeId,
       DownStreamChannelLocation downStreamChannelLocation,
-      FragmentInstanceContext instanceContext,
-      int index) {
+      FragmentInstanceContext instanceContext) {
     if (isSameNode(downStreamChannelLocation.getRemoteEndpoint())) {
       return createLocalSinkChannel(
           localFragmentInstanceId,
@@ -590,8 +583,7 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
           downStreamChannelLocation.getRemoteFragmentInstanceId(),
           downStreamChannelLocation.getRemotePlanNodeId(),
           localPlanNodeId,
-          instanceContext,
-          index);
+          instanceContext);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
@@ -119,41 +119,6 @@ public class SinkChannel implements ISinkChannel {
       TsBlockSerde serde,
       SinkListener sinkListener,
       IClientManager<TEndPoint, SyncDataNodeMPPDataExchangeServiceClient>
-          mppDataExchangeServiceClientManager,
-      int index) {
-    this.remoteEndpoint = Validate.notNull(remoteEndpoint);
-    this.remoteFragmentInstanceId = Validate.notNull(remoteFragmentInstanceId);
-    this.remotePlanNodeId = Validate.notNull(remotePlanNodeId);
-    this.localPlanNodeId = Validate.notNull(localPlanNodeId);
-    this.localFragmentInstanceId = Validate.notNull(localFragmentInstanceId);
-    this.fullFragmentInstanceId =
-        FragmentInstanceId.createFragmentInstanceIdFromTFragmentInstanceId(localFragmentInstanceId);
-    this.localMemoryManager = Validate.notNull(localMemoryManager);
-    this.executorService = Validate.notNull(executorService);
-    this.serde = Validate.notNull(serde);
-    this.sinkListener = Validate.notNull(sinkListener);
-    this.mppDataExchangeServiceClientManager = mppDataExchangeServiceClientManager;
-    this.retryIntervalInMs = DEFAULT_RETRY_INTERVAL_IN_MS;
-    this.threadName =
-        createFullId(
-            localFragmentInstanceId.queryId,
-            localFragmentInstanceId.fragmentId,
-            localFragmentInstanceId.instanceId + "-" + index);
-    this.bufferRetainedSizeInBytes = DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
-    this.currentTsBlockSize = DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
-  }
-
-  public SinkChannel(
-      TEndPoint remoteEndpoint,
-      TFragmentInstanceId remoteFragmentInstanceId,
-      String remotePlanNodeId,
-      String localPlanNodeId,
-      TFragmentInstanceId localFragmentInstanceId,
-      LocalMemoryManager localMemoryManager,
-      ExecutorService executorService,
-      TsBlockSerde serde,
-      SinkListener sinkListener,
-      IClientManager<TEndPoint, SyncDataNodeMPPDataExchangeServiceClient>
           mppDataExchangeServiceClientManager) {
     this.remoteEndpoint = Validate.notNull(remoteEndpoint);
     this.remoteFragmentInstanceId = Validate.notNull(remoteFragmentInstanceId);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/source/SourceHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/source/SourceHandle.java
@@ -470,7 +470,12 @@ public class SourceHandle implements ISourceHandle {
     @Override
     public void run() {
       try (SetThreadName sourceHandleName = new SetThreadName(threadName)) {
-        LOGGER.debug("[StartPullTsBlocksFromRemote] [{}, {}) ", startSequenceId, endSequenceId);
+        LOGGER.debug(
+            "[StartPullTsBlocksFromRemote] {}-{} [{}, {}) ",
+            remoteFragmentInstanceId,
+            indexOfUpstreamSinkHandle,
+            startSequenceId,
+            endSequenceId);
         TGetDataBlockRequest req =
             new TGetDataBlockRequest(
                 remoteFragmentInstanceId,

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/DistributionPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/DistributionPlanner.java
@@ -44,8 +44,6 @@ import org.apache.iotdb.db.mpp.plan.statement.component.SortKey;
 import org.apache.iotdb.db.mpp.plan.statement.crud.QueryStatement;
 
 import org.apache.commons.lang3.Validate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,9 +53,6 @@ import java.util.Map;
 import java.util.Set;
 
 public class DistributionPlanner {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(DistributionPlanner.class);
-
   private Analysis analysis;
   private MPPQueryContext context;
   private LogicalQueryPlan logicalPlan;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/NodeGroupContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/NodeGroupContext.java
@@ -24,13 +24,10 @@ import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.db.mpp.common.MPPQueryContext;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.ExchangeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.SourceNode;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -39,14 +36,14 @@ public class NodeGroupContext {
   private final Map<PlanNodeId, NodeDistribution> nodeDistributionMap;
   private final boolean isAlignByDevice;
   private final TRegionReplicaSet mostlyUsedDataRegion;
-  protected final List<ExchangeNode> exchangeNodes;
+  protected boolean hasExchangeNode;
 
   public NodeGroupContext(MPPQueryContext queryContext, boolean isAlignByDevice, PlanNode root) {
     this.queryContext = queryContext;
     this.nodeDistributionMap = new HashMap<>();
     this.isAlignByDevice = isAlignByDevice;
     this.mostlyUsedDataRegion = isAlignByDevice ? getMostlyUsedDataRegion(root) : null;
-    this.exchangeNodes = new ArrayList<>();
+    this.hasExchangeNode = false;
   }
 
   private TRegionReplicaSet getMostlyUsedDataRegion(PlanNode root) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SimpleFragmentParallelPlanner.java
@@ -34,12 +34,12 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.PlanFragment;
 import org.apache.iotdb.db.mpp.plan.planner.plan.SubPlan;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeUtil;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.process.ExchangeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.sink.MultiChildrenSinkNode;
 import org.apache.iotdb.db.mpp.plan.statement.crud.QueryStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.ShowQueriesStatement;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +64,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
   // Record all the FragmentInstances belonged to same PlanFragment
   Map<PlanFragmentId, FragmentInstance> instanceMap;
   // Record which PlanFragment the PlanNode belongs
-  Map<PlanNodeId, PlanFragmentId> planNodeMap;
+  Map<PlanNodeId, Pair<PlanFragmentId, PlanNode>> planNodeMap;
   List<FragmentInstance> fragmentInstanceList;
 
   public SimpleFragmentParallelPlanner(
@@ -93,13 +93,10 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
   }
 
   private void produceFragmentInstance(PlanFragment fragment) {
-    // If one PlanFragment will produce several FragmentInstance, the instanceIdx will be increased
-    // one by one
-    PlanNode rootCopy = PlanNodeUtil.deepCopy(fragment.getPlanNodeTree());
     Filter timeFilter = analysis.getGlobalTimeFilter();
     FragmentInstance fragmentInstance =
         new FragmentInstance(
-            new PlanFragment(fragment.getId(), rootCopy),
+            fragment,
             fragment.getId().genFragmentInstanceId(),
             timeFilter,
             queryContext.getQueryType(),
@@ -217,8 +214,7 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
                       downStreamInstance.getId().toThrift());
 
                   // Set upstream info for corresponding ExchangeNode in downstream FragmentInstance
-                  PlanNode downStreamExchangeNode =
-                      downStreamInstance.getFragment().getPlanNodeById(downStreamNodeId);
+                  PlanNode downStreamExchangeNode = planNodeMap.get(downStreamNodeId).right;
                   ((ExchangeNode) downStreamExchangeNode)
                       .setUpstream(
                           instance.getHostDataNode().getMPPDataExchangeEndPoint(),
@@ -230,11 +226,11 @@ public class SimpleFragmentParallelPlanner implements IFragmentParallelPlaner {
   }
 
   private FragmentInstance findDownStreamInstance(PlanNodeId exchangeNodeId) {
-    return instanceMap.get(planNodeMap.get(exchangeNodeId));
+    return instanceMap.get(planNodeMap.get(exchangeNodeId).left);
   }
 
   private void recordPlanNodeRelation(PlanNode root, PlanFragmentId planFragmentId) {
-    planNodeMap.put(root.getPlanNodeId(), planFragmentId);
+    planNodeMap.put(root.getPlanNodeId(), new Pair<>(planFragmentId, root));
     for (PlanNode child : root.getChildren()) {
       recordPlanNodeRelation(child, planFragmentId);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/PlanFragment.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/PlanFragment.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.db.mpp.plan.analyze.TypeProvider;
 import org.apache.iotdb.db.mpp.plan.planner.SubPlanTypeExtractor;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.IPartitionRelatedNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
-import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeType;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.source.VirtualSourceNode;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
@@ -128,23 +127,6 @@ public class PlanFragment {
       TDataNodeLocation result = getNodeLocation(child);
       if (result != null) {
         return result;
-      }
-    }
-    return null;
-  }
-
-  public PlanNode getPlanNodeById(PlanNodeId nodeId) {
-    return getPlanNodeById(planNodeTree, nodeId);
-  }
-
-  private PlanNode getPlanNodeById(PlanNode root, PlanNodeId nodeId) {
-    if (root.getPlanNodeId().equals(nodeId)) {
-      return root;
-    }
-    for (PlanNode child : root.getChildren()) {
-      PlanNode node = getPlanNodeById(child, nodeId);
-      if (node != null) {
-        return node;
       }
     }
     return null;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/sink/MultiChildrenSinkNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/sink/MultiChildrenSinkNode.java
@@ -114,4 +114,8 @@ public abstract class MultiChildrenSinkNode extends SinkNode {
   public void addDownStreamChannelLocation(DownStreamChannelLocation downStreamChannelLocation) {
     downStreamChannelLocationList.add(downStreamChannelLocation);
   }
+
+  public int getCurrentLastIndex() {
+    return children.size() - 1;
+  }
 }


### PR DESCRIPTION
Before this pr, calculateNodeTopologyBetweenInstance() in SimpleFragmentParallelPlanner uses recursive search to locate a ExchangeNode, which is very time-consuming when PlanNodeTree is quite large. We record a map in this pr to avoid this cost. Also, we fix the issue of wrong upstreamIndex of ExchangeNode in this pr, the ITs will be added later.