### PR TITLE
[IOTDB-5604]Fix NPE when execute Agg + align by device query without assigned DataRegion

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteServerEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteServerEnv.java
@@ -63,8 +63,8 @@ public class RemoteServerEnv implements BaseEnv {
   public void initClusterEnvironment() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      // statement.execute("CREATE DATABASE root.init;");
-      // statement.execute("DELETE DATABASE root;");
+      statement.execute("CREATE DATABASE root.init;");
+      statement.execute("DELETE DATABASE root;");
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteServerEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteServerEnv.java
@@ -63,8 +63,8 @@ public class RemoteServerEnv implements BaseEnv {
   public void initClusterEnvironment() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.init;");
-      statement.execute("DELETE DATABASE root;");
+      // statement.execute("CREATE DATABASE root.init;");
+      // statement.execute("DELETE DATABASE root;");
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBAggregationIT.java
@@ -46,7 +46,9 @@ import static org.apache.iotdb.db.constant.TestConstant.maxValue;
 import static org.apache.iotdb.db.constant.TestConstant.minTime;
 import static org.apache.iotdb.db.constant.TestConstant.minValue;
 import static org.apache.iotdb.db.constant.TestConstant.sum;
+import static org.apache.iotdb.db.it.utils.TestUtils.resultSetEqualTest;
 import static org.apache.iotdb.db.it.utils.TestUtils.resultSetEqualWithDescOrderTest;
+import static org.apache.iotdb.itbase.constant.TestConstant.DEVICE;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
 
@@ -971,5 +973,12 @@ public class IoTDBAggregationIT {
     String[] retArray = new String[] {"0,null,"};
     resultSetEqualWithDescOrderTest(
         "select count(s1), sum(s1) from root.test.noDataRegion", expectedHeader, retArray);
+
+    expectedHeader = new String[] {DEVICE, count("s1"), sum("s1")};
+    retArray = new String[] {"root.test.noDataRegion,0,null,"};
+    resultSetEqualTest(
+        "select count(s1), sum(s1) from root.test.noDataRegion align by device",
+        expectedHeader,
+        retArray);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/NodeGroupContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/NodeGroupContext.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class NodeGroupContext {
   protected final MPPQueryContext queryContext;
@@ -52,20 +51,19 @@ public class NodeGroupContext {
   private TRegionReplicaSet getMostlyUsedDataRegion(PlanNode root) {
     Map<TRegionReplicaSet, Long> regionCount = new HashMap<>();
     countRegionOfSourceNodes(root, regionCount);
-    return Collections.max(
-            regionCount.entrySet().stream()
-                .filter(e -> e.getKey() != DataPartition.NOT_ASSIGNED)
-                .collect(Collectors.toList()),
-            Map.Entry.comparingByValue())
-        .getKey();
+    if (regionCount.isEmpty()) {
+      return DataPartition.NOT_ASSIGNED;
+    }
+    return Collections.max(regionCount.entrySet(), Map.Entry.comparingByValue()).getKey();
   }
 
   private void countRegionOfSourceNodes(PlanNode root, Map<TRegionReplicaSet, Long> result) {
     root.getChildren().forEach(child -> countRegionOfSourceNodes(child, result));
     if (root instanceof SourceNode) {
-      result.compute(
-          ((SourceNode) root).getRegionReplicaSet(),
-          (region, count) -> (count == null) ? 1 : count + 1);
+      TRegionReplicaSet regionReplicaSet = ((SourceNode) root).getRegionReplicaSet();
+      if (regionReplicaSet != DataPartition.NOT_ASSIGNED) {
+        result.compute(regionReplicaSet, (region, count) -> (count == null) ? 1 : count + 1);
+      }
     }
   }
 


### PR DESCRIPTION
cause: If all data regions are not assigned, the Collection is empty.

<img width="743" alt="image" src="https://user-images.githubusercontent.com/60659567/222076313-d21dd012-3432-44c9-9380-4e5457c9fd6a.png">