### PR TITLE
Remove jackson-mapper-asl to fix security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,6 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <log4j.version>1.2.24</log4j.version>
         <lz4-java.version>1.8.0</lz4-java.version>
-        <jackson-mapper-asl.version>1.9.13</jackson-mapper-asl.version>
         <jaxb-runtime.version>3.0.2</jaxb-runtime.version>
         <mockito-core.version>2.23.4</mockito-core.version>
         <objenesis.version>3.2</objenesis.version>
@@ -428,11 +427,6 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${jackson-core-asl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <version>${jackson-mapper-asl.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>


### PR DESCRIPTION
## Description

This PR is trying to fix the following security alerts.

https://github.com/apache/iotdb/security/dependabot/205  https://github.com/apache/iotdb/security/dependabot/6 

jackson-mapper-asl is useless in IoTDB, just remove it.