### PR TITLE
[IOTDB-5613] Remove unnecessary serialization in IoTConsensus when replicaNum is 1 to improve write performance

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
@@ -54,6 +54,15 @@ public class IndexedConsensusRequest implements IConsensusRequest {
     this.syncIndex = syncIndex;
   }
 
+  public void buildSerializedRequests() {
+    this.requests.forEach(
+        r -> {
+          ByteBuffer buffer = r.serializeToByteBuffer();
+          this.serializedRequests.add(buffer);
+          this.serializedSize += buffer.capacity();
+        });
+  }
+
   @Override
   public ByteBuffer serializeToByteBuffer() {
     throw new UnsupportedOperationException();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
@@ -39,12 +39,6 @@ public class IndexedConsensusRequest implements IConsensusRequest {
     this.searchIndex = searchIndex;
     this.requests = requests;
     this.syncIndex = -1L;
-    this.requests.forEach(
-        r -> {
-          ByteBuffer buffer = r.serializeToByteBuffer();
-          this.serializedRequests.add(buffer);
-          this.serializedSize += buffer.capacity();
-        });
   }
 
   public IndexedConsensusRequest(

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
@@ -32,13 +32,14 @@ public class IndexedConsensusRequest implements IConsensusRequest {
 
   private final long syncIndex;
   private final List<IConsensusRequest> requests;
-  private final List<ByteBuffer> serializedRequests = new ArrayList<>();
+  private final List<ByteBuffer> serializedRequests;
   private long serializedSize = 0;
 
   public IndexedConsensusRequest(long searchIndex, List<IConsensusRequest> requests) {
     this.searchIndex = searchIndex;
     this.requests = requests;
     this.syncIndex = -1L;
+    this.serializedRequests = new ArrayList<>(requests.size());
   }
 
   public IndexedConsensusRequest(
@@ -46,6 +47,7 @@ public class IndexedConsensusRequest implements IConsensusRequest {
     this.searchIndex = searchIndex;
     this.requests = requests;
     this.syncIndex = syncIndex;
+    this.serializedRequests = new ArrayList<>(requests.size());
   }
 
   public void buildSerializedRequests() {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -199,8 +199,6 @@ public class IoTConsensusServerImpl {
         }
       }
       long writeToStateMachineStartTime = System.nanoTime();
-      IndexedConsensusRequest indexedConsensusRequest =
-          buildIndexedConsensusRequestForLocalRequest(request);
       // statistic the time of checking write block
       MetricService.getInstance()
           .getOrCreateHistogram(
@@ -213,6 +211,8 @@ public class IoTConsensusServerImpl {
               Tag.REGION.toString(),
               this.consensusGroupId)
           .update(writeToStateMachineStartTime - getStateMachineLockTime);
+      IndexedConsensusRequest indexedConsensusRequest =
+          buildIndexedConsensusRequestForLocalRequest(request);
       if (indexedConsensusRequest.getSearchIndex() % 1000 == 0) {
         logger.info(
             "DataRegion[{}]: index after build: safeIndex:{}, searchIndex: {}",
@@ -220,7 +220,6 @@ public class IoTConsensusServerImpl {
             getCurrentSafelyDeletedSearchIndex(),
             indexedConsensusRequest.getSearchIndex());
       }
-      // TODO wal and memtable
       IConsensusRequest planNode = stateMachine.deserializeRequest(indexedConsensusRequest);
       TSStatus result = stateMachine.write(planNode);
       long writeToStateMachineEndTime = System.nanoTime();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -156,6 +156,10 @@ public class LogDispatcher {
   }
 
   public void offer(IndexedConsensusRequest request) {
+    if (!threads.isEmpty()) {
+      // we don't need to serialize request when replicaNum is 1.
+      request.buildSerializedRequests();
+    }
     synchronized (this) {
       threads.forEach(
           thread -> {

--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/util/FakeConsensusReqReader.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/util/FakeConsensusReqReader.java
@@ -53,6 +53,7 @@ public class FakeConsensusReqReader implements ConsensusReqReader, DataSet {
   }
 
   private class FakeConsensusReqIterator implements ConsensusReqReader.ReqIterator {
+
     private long nextSearchIndex;
 
     public FakeConsensusReqIterator(long startIndex) {
@@ -70,7 +71,8 @@ public class FakeConsensusReqReader implements ConsensusReqReader, DataSet {
         for (IndexedConsensusRequest indexedConsensusRequest : requestSets.getRequestSet()) {
           if (indexedConsensusRequest.getSearchIndex() == nextSearchIndex) {
             nextSearchIndex++;
-            return indexedConsensusRequest;
+            return new IndexedConsensusRequest(
+                indexedConsensusRequest.getSearchIndex(), indexedConsensusRequest.getRequests());
           }
         }
         return null;

--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/util/TestStateMachine.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/util/TestStateMachine.java
@@ -117,11 +117,8 @@ public class TestStateMachine implements IStateMachine, IStateMachine.EventApi {
       ByteBuffer buffer = innerRequest.serializeToByteBuffer();
       transformedRequest.add(new TestEntry(buffer.getInt(), Peer.deserialize(buffer)));
     }
-    IndexedConsensusRequest request =
-        new IndexedConsensusRequest(indexedConsensusRequest.getSearchIndex(), transformedRequest);
-    request.buildSerializedRequests();
     requestSets.add(
-        request,
+        new IndexedConsensusRequest(indexedConsensusRequest.getSearchIndex(), transformedRequest),
         indexedConsensusRequest.getSearchIndex() != ConsensusReqReader.DEFAULT_SEARCH_INDEX);
   }
 

--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/util/TestStateMachine.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/util/TestStateMachine.java
@@ -117,8 +117,11 @@ public class TestStateMachine implements IStateMachine, IStateMachine.EventApi {
       ByteBuffer buffer = innerRequest.serializeToByteBuffer();
       transformedRequest.add(new TestEntry(buffer.getInt(), Peer.deserialize(buffer)));
     }
+    IndexedConsensusRequest request =
+        new IndexedConsensusRequest(indexedConsensusRequest.getSearchIndex(), transformedRequest);
+    request.buildSerializedRequests();
     requestSets.add(
-        new IndexedConsensusRequest(indexedConsensusRequest.getSearchIndex(), transformedRequest),
+        request,
         indexedConsensusRequest.getSearchIndex() != ConsensusReqReader.DEFAULT_SEARCH_INDEX);
   }
 


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/IOTDB-5613)

I tested with 1c1d on the machine and the throughput improved by 70%

Before:
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/32640567/222431249-beb89d50-3b2b-4b86-b4a1-7e8105f1d5a2.png">
After：
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/32640567/222431279-087b3fde-4c48-4218-9f23-3e6fa34dcc9d.png">
