### PR TITLE
Change the log level of array pool to DEBUG

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/PrimitiveArrayManager.java
@@ -182,8 +182,8 @@ public class PrimitiveArrayManager {
       int newLimit = (int) (limitBase * ratios[i]);
       LIMITS[i] = newLimit;
 
-      if (LOGGER.isInfoEnabled() && oldLimit != newLimit) {
-        LOGGER.info(
+      if (LOGGER.isDebugEnabled() && oldLimit != newLimit) {
+        LOGGER.debug(
             "limit of {} array deque size updated: {} -> {}",
             TSDataType.deserialize((byte) i).name(),
             oldLimit,
@@ -197,10 +197,12 @@ public class PrimitiveArrayManager {
     for (int limit : LIMITS) {
       limitUpdateThreshold += limit;
     }
-    LOGGER.info(
-        "limitUpdateThreshold of PrimitiveArrayManager updated: {} -> {}",
-        oldLimitUpdateThreshold,
-        limitUpdateThreshold);
+    if (LOGGER.isDebugEnabled() && oldLimitUpdateThreshold != limitUpdateThreshold) {
+      LOGGER.debug(
+          "limitUpdateThreshold of PrimitiveArrayManager updated: {} -> {}",
+          oldLimitUpdateThreshold,
+          limitUpdateThreshold);
+    }
 
     for (AtomicLong allocationRequestCount : ALLOCATION_REQUEST_COUNTS) {
       allocationRequestCount.set(0);


### PR DESCRIPTION
## Description

If we set `buffered_arrays_memory_proportion` to 0, there will be a lot of unnecessary info logs. 
![1161677812510_ pic](https://user-images.githubusercontent.com/25913899/222627632-d27a8f2c-ea66-49a0-842a-8594ac571da9.jpg)

This PR changes the log level of array pool to DEBUG.