### PR TITLE
[To rel/1.1][IOTDB-5613] Remove unnecessary serialization in IoTConsensus when replicaNum is 1 to improve write performance

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
@@ -32,19 +32,14 @@ public class IndexedConsensusRequest implements IConsensusRequest {
 
   private final long syncIndex;
   private final List<IConsensusRequest> requests;
-  private final List<ByteBuffer> serializedRequests = new ArrayList<>();
+  private final List<ByteBuffer> serializedRequests;
   private long serializedSize = 0;
 
   public IndexedConsensusRequest(long searchIndex, List<IConsensusRequest> requests) {
     this.searchIndex = searchIndex;
     this.requests = requests;
     this.syncIndex = -1L;
-    this.requests.forEach(
-        r -> {
-          ByteBuffer buffer = r.serializeToByteBuffer();
-          this.serializedRequests.add(buffer);
-          this.serializedSize += buffer.capacity();
-        });
+    this.serializedRequests = new ArrayList<>(requests.size());
   }
 
   public IndexedConsensusRequest(
@@ -52,6 +47,16 @@ public class IndexedConsensusRequest implements IConsensusRequest {
     this.searchIndex = searchIndex;
     this.requests = requests;
     this.syncIndex = syncIndex;
+    this.serializedRequests = new ArrayList<>(requests.size());
+  }
+
+  public void buildSerializedRequests() {
+    this.requests.forEach(
+        r -> {
+          ByteBuffer buffer = r.serializeToByteBuffer();
+          this.serializedRequests.add(buffer);
+          this.serializedSize += buffer.capacity();
+        });
   }
 
   @Override

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -199,8 +199,6 @@ public class IoTConsensusServerImpl {
         }
       }
       long writeToStateMachineStartTime = System.nanoTime();
-      IndexedConsensusRequest indexedConsensusRequest =
-          buildIndexedConsensusRequestForLocalRequest(request);
       // statistic the time of checking write block
       MetricService.getInstance()
           .getOrCreateHistogram(
@@ -213,6 +211,8 @@ public class IoTConsensusServerImpl {
               Tag.REGION.toString(),
               this.consensusGroupId)
           .update(writeToStateMachineStartTime - getStateMachineLockTime);
+      IndexedConsensusRequest indexedConsensusRequest =
+          buildIndexedConsensusRequestForLocalRequest(request);
       if (indexedConsensusRequest.getSearchIndex() % 1000 == 0) {
         logger.info(
             "DataRegion[{}]: index after build: safeIndex:{}, searchIndex: {}",
@@ -220,7 +220,6 @@ public class IoTConsensusServerImpl {
             getCurrentSafelyDeletedSearchIndex(),
             indexedConsensusRequest.getSearchIndex());
       }
-      // TODO wal and memtable
       IConsensusRequest planNode = stateMachine.deserializeRequest(indexedConsensusRequest);
       TSStatus result = stateMachine.write(planNode);
       long writeToStateMachineEndTime = System.nanoTime();

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -156,22 +156,26 @@ public class LogDispatcher {
   }
 
   public void offer(IndexedConsensusRequest request) {
-    synchronized (this) {
-      threads.forEach(
-          thread -> {
-            logger.debug(
-                "{}->{}: Push a log to the queue, where the queue length is {}",
-                impl.getThisNode().getGroupId(),
-                thread.getPeer().getEndpoint().getIp(),
-                thread.getPendingEntriesSize());
-            if (!thread.offer(request)) {
+    // we don't need to serialize and offer request when replicaNum is 1.
+    if (!threads.isEmpty()) {
+      request.buildSerializedRequests();
+      synchronized (this) {
+        threads.forEach(
+            thread -> {
               logger.debug(
-                  "{}: Log queue of {} is full, ignore the log to this node, searchIndex: {}",
+                  "{}->{}: Push a log to the queue, where the queue length is {}",
                   impl.getThisNode().getGroupId(),
-                  thread.getPeer(),
-                  request.getSearchIndex());
-            }
-          });
+                  thread.getPeer().getEndpoint().getIp(),
+                  thread.getPendingEntriesSize());
+              if (!thread.offer(request)) {
+                logger.debug(
+                    "{}: Log queue of {} is full, ignore the log to this node, searchIndex: {}",
+                    impl.getThisNode().getGroupId(),
+                    thread.getPeer(),
+                    request.getSearchIndex());
+              }
+            });
+      }
     }
   }
 
@@ -510,6 +514,7 @@ public class LogDispatcher {
           }
         }
         targetIndex = data.getSearchIndex() + 1;
+        data.buildSerializedRequests();
         // construct request from wal
         logBatches.addTLogEntry(
             new TLogEntry(data.getSerializedRequests(), data.getSearchIndex(), true));

--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/util/FakeConsensusReqReader.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/util/FakeConsensusReqReader.java
@@ -53,6 +53,7 @@ public class FakeConsensusReqReader implements ConsensusReqReader, DataSet {
   }
 
   private class FakeConsensusReqIterator implements ConsensusReqReader.ReqIterator {
+
     private long nextSearchIndex;
 
     public FakeConsensusReqIterator(long startIndex) {
@@ -70,7 +71,8 @@ public class FakeConsensusReqReader implements ConsensusReqReader, DataSet {
         for (IndexedConsensusRequest indexedConsensusRequest : requestSets.getRequestSet()) {
           if (indexedConsensusRequest.getSearchIndex() == nextSearchIndex) {
             nextSearchIndex++;
-            return indexedConsensusRequest;
+            return new IndexedConsensusRequest(
+                indexedConsensusRequest.getSearchIndex(), indexedConsensusRequest.getRequests());
           }
         }
         return null;


### PR DESCRIPTION
cherry-pick [pull/9204](https://github.com/apache/iotdb/pull/9204)