### PR TITLE
[To rel/1.0] [IOTDB-5487] Fix the problem that the timestamp is "null" when using jdbc

### DIFF
--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -272,6 +272,7 @@ public class IoTDBRpcDataSet {
   public boolean next() throws StatementExecutionException, IoTDBConnectionException {
     if (hasCachedBlock()) {
       constructOneRow();
+      lastReadWasNull = false;
       return true;
     }
     if (hasCachedByteBuffer()) {


### PR DESCRIPTION
see [[IOTDB-3936](https://issues.apache.org/jira/browse/IOTDB-3936)]Add an interface in IClientRPCService to directly return bytebuffer instead of TSQueryDataSet

This pr is modified to add lastReadWasNull = false; of the constructOneRow method to the constructOneTsBlock method, resulting in a call to the next() method that meets the first of the following criteria, The lastReadWasNull field was not reset to false.

![image](https://user-images.githubusercontent.com/79885238/223317026-e9513067-aa89-43e7-89bd-235d58fe1293.png)
