### PR TITLE
[To rel/1.1] [IOTDB-5487] Fix the problem that the timestamp is "null" when using jdbc

### DIFF
--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -272,6 +272,7 @@ public class IoTDBRpcDataSet {
   public boolean next() throws StatementExecutionException, IoTDBConnectionException {
     if (hasCachedBlock()) {
       constructOneRow();
+      lastReadWasNull = false;
       return true;
     }
     if (hasCachedByteBuffer()) {


### PR DESCRIPTION
see [[IOTDB-3936](https://issues.apache.org/jira/browse/IOTDB-3936)]Add an interface in IClientRPCService to directly return bytebuffer instead of TSQueryDataSet

This pr is modified to add lastReadWasNull = false; of the constructOneRow method to the constructOneTsBlock method, resulting in a call to the next() method that meets the first of the following criteria, The lastReadWasNull field was not reset to false.

![image](https://user-images.githubusercontent.com/79885238/223360989-3938c0a8-f4d3-42ff-8084-0033e6fdc878.png)
