### PR TITLE
Fix memory calculation is not accurate in SystemInfo

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -74,9 +74,9 @@ public class SystemInfo {
   public synchronized boolean reportStorageGroupStatus(
       DataRegionInfo dataRegionInfo, TsFileProcessor tsFileProcessor)
       throws WriteProcessRejectException {
-    long currentDataRegionInfo = dataRegionInfo.getMemCost();
+    long currentDataRegionMemCost = dataRegionInfo.getMemCost();
     long delta =
-        currentDataRegionInfo - reportedStorageGroupMemCostMap.getOrDefault(dataRegionInfo, 0L);
+        currentDataRegionMemCost - reportedStorageGroupMemCostMap.getOrDefault(dataRegionInfo, 0L);
     totalStorageGroupMemCost += delta;
     if (logger.isDebugEnabled()) {
       logger.debug(
@@ -84,8 +84,8 @@ public class SystemInfo {
           delta,
           totalStorageGroupMemCost);
     }
-    reportedStorageGroupMemCostMap.put(dataRegionInfo, currentDataRegionInfo);
-    dataRegionInfo.setLastReportedSize(currentDataRegionInfo);
+    reportedStorageGroupMemCostMap.put(dataRegionInfo, currentDataRegionMemCost);
+    dataRegionInfo.setLastReportedSize(currentDataRegionMemCost);
     if (totalStorageGroupMemCost < FLUSH_THERSHOLD) {
       return true;
     } else if (totalStorageGroupMemCost >= FLUSH_THERSHOLD
@@ -127,15 +127,15 @@ public class SystemInfo {
    * @param dataRegionInfo database
    */
   public synchronized void resetStorageGroupStatus(DataRegionInfo dataRegionInfo) {
-    long currentDataRegionInfo = dataRegionInfo.getMemCost();
+    long currentDataRegionMemCost = dataRegionInfo.getMemCost();
     long delta = 0;
     if (reportedStorageGroupMemCostMap.containsKey(dataRegionInfo)) {
-      delta = reportedStorageGroupMemCostMap.get(dataRegionInfo) - currentDataRegionInfo;
+      delta = reportedStorageGroupMemCostMap.get(dataRegionInfo) - currentDataRegionMemCost;
       this.totalStorageGroupMemCost -= delta;
-      dataRegionInfo.setLastReportedSize(currentDataRegionInfo);
+      dataRegionInfo.setLastReportedSize(currentDataRegionMemCost);
       // report after reset sg status, because slow write may not reach the report threshold
       dataRegionInfo.setNeedToReportToSystem(true);
-      reportedStorageGroupMemCostMap.put(dataRegionInfo, currentDataRegionInfo);
+      reportedStorageGroupMemCostMap.put(dataRegionInfo, currentDataRegionMemCost);
     }
 
     if (totalStorageGroupMemCost >= FLUSH_THERSHOLD

--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -74,9 +74,9 @@ public class SystemInfo {
   public synchronized boolean reportStorageGroupStatus(
       DataRegionInfo dataRegionInfo, TsFileProcessor tsFileProcessor)
       throws WriteProcessRejectException {
+    long currentDataRegionInfo = dataRegionInfo.getMemCost();
     long delta =
-        dataRegionInfo.getMemCost()
-            - reportedStorageGroupMemCostMap.getOrDefault(dataRegionInfo, 0L);
+        currentDataRegionInfo - reportedStorageGroupMemCostMap.getOrDefault(dataRegionInfo, 0L);
     totalStorageGroupMemCost += delta;
     if (logger.isDebugEnabled()) {
       logger.debug(
@@ -84,8 +84,8 @@ public class SystemInfo {
           delta,
           totalStorageGroupMemCost);
     }
-    reportedStorageGroupMemCostMap.put(dataRegionInfo, dataRegionInfo.getMemCost());
-    dataRegionInfo.setLastReportedSize(dataRegionInfo.getMemCost());
+    reportedStorageGroupMemCostMap.put(dataRegionInfo, currentDataRegionInfo);
+    dataRegionInfo.setLastReportedSize(currentDataRegionInfo);
     if (totalStorageGroupMemCost < FLUSH_THERSHOLD) {
       return true;
     } else if (totalStorageGroupMemCost >= FLUSH_THERSHOLD
@@ -127,15 +127,15 @@ public class SystemInfo {
    * @param dataRegionInfo database
    */
   public synchronized void resetStorageGroupStatus(DataRegionInfo dataRegionInfo) {
+    long currentDataRegionInfo = dataRegionInfo.getMemCost();
     long delta = 0;
-
     if (reportedStorageGroupMemCostMap.containsKey(dataRegionInfo)) {
-      delta = reportedStorageGroupMemCostMap.get(dataRegionInfo) - dataRegionInfo.getMemCost();
+      delta = reportedStorageGroupMemCostMap.get(dataRegionInfo) - currentDataRegionInfo;
       this.totalStorageGroupMemCost -= delta;
-      dataRegionInfo.setLastReportedSize(dataRegionInfo.getMemCost());
+      dataRegionInfo.setLastReportedSize(currentDataRegionInfo);
       // report after reset sg status, because slow write may not reach the report threshold
       dataRegionInfo.setNeedToReportToSystem(true);
-      reportedStorageGroupMemCostMap.put(dataRegionInfo, dataRegionInfo.getMemCost());
+      reportedStorageGroupMemCostMap.put(dataRegionInfo, currentDataRegionInfo);
     }
 
     if (totalStorageGroupMemCost >= FLUSH_THERSHOLD


### PR DESCRIPTION
## Description

The memory calculation method in SystemInfo is not accurate because `dataRegionInfo.getMemCost()` may changed by other thread. 

This PR is for fixing this issue.