### PR TITLE
Set some runtime fields in FIConetxt to null when the FI is done

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/driver/DataDriver.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/driver/DataDriver.java
@@ -71,6 +71,12 @@ public class DataDriver extends Driver {
           ((DataDriverContext) driverContext).getSourceOperators();
       if (sourceOperators != null && !sourceOperators.isEmpty()) {
         QueryDataSource dataSource = initQueryDataSource();
+        if (dataSource == null) {
+          // if this driver is being initialized, meanwhile the whole FI was aborted or cancelled
+          // for some reasons, we may get null QueryDataSource here.
+          // And it's safe for us to throw this exception here in such case.
+          throw new IllegalStateException("QueryDataSource should never be null!");
+        }
         sourceOperators.forEach(
             sourceOperator -> {
               // construct QueryDataSource for source operator

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceContext.java
@@ -55,7 +55,7 @@ public class FragmentInstanceContext extends QueryContext {
 
   private IDataRegionForQuery dataRegion;
   private Filter timeFilter;
-  List<PartialPath> sourcePaths;
+  private List<PartialPath> sourcePaths;
   // Shared by all scan operators in this fragment instance to avoid memory problem
   private QueryDataSource sharedQueryDataSource;
   /** closed tsfile used in this fragment instance */
@@ -354,7 +354,7 @@ public class FragmentInstanceContext extends QueryContext {
    * All file paths used by this fragment instance must be cleared and thus the usage reference must
    * be decreased.
    */
-  protected void releaseResource() {
+  protected synchronized void releaseResource() {
     for (TsFileResource tsFile : closedFilePaths) {
       FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, true);
     }
@@ -363,5 +363,9 @@ public class FragmentInstanceContext extends QueryContext {
       FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, false);
     }
     unClosedFilePaths = null;
+    dataRegion = null;
+    timeFilter = null;
+    sourcePaths = null;
+    sharedQueryDataSource = null;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceExecution.java
@@ -99,6 +99,10 @@ public class FragmentInstanceExecution {
         context.getFailureInfoList());
   }
 
+  public long getStartTime() {
+    return context.getStartTime();
+  }
+
   public FragmentInstanceStateMachine getStateMachine() {
     return stateMachine;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceManager.java
@@ -92,12 +92,12 @@ public class FragmentInstanceManager {
     this.infoCacheTime = new Duration(5, TimeUnit.MINUTES);
 
     ScheduledExecutorUtil.safelyScheduleWithFixedDelay(
-        instanceManagementExecutor, this::removeOldInstances, 200, 200, TimeUnit.MILLISECONDS);
+        instanceManagementExecutor, this::removeOldInstances, 2000, 2000, TimeUnit.MILLISECONDS);
     ScheduledExecutorUtil.safelyScheduleWithFixedDelay(
         instanceManagementExecutor,
         this::cancelTimeoutFlushingInstances,
-        200,
-        200,
+        2000,
+        2000,
         TimeUnit.MILLISECONDS);
 
     this.intoOperationExecutor =
@@ -297,14 +297,13 @@ public class FragmentInstanceManager {
 
   private void cancelTimeoutFlushingInstances() {
     long now = System.currentTimeMillis();
-    instanceContext.entrySet().stream()
-        .filter(
-            entry -> {
-              FragmentInstanceContext context = entry.getValue();
-              return context.getStateMachine().getState() == FragmentInstanceState.FLUSHING
-                  && (now - context.getStartTime()) > QUERY_TIMEOUT_MS;
-            })
-        .forEach(entry -> entry.getValue().failed(new TimeoutException()));
+    instanceExecution.forEach(
+        (key, execution) -> {
+          if (execution.getStateMachine().getState() == FragmentInstanceState.FLUSHING
+              && (now - execution.getStartTime()) > QUERY_TIMEOUT_MS) {
+            execution.getStateMachine().failed(new TimeoutException());
+          }
+        });
   }
 
   public ExecutorService getIntoOperationExecutor() {


### PR DESCRIPTION
We will keep FIContext in memory for 5 mins, so we only keep necessary infos in FIContext for memory cost.