### PR TITLE
[IOTDB-5240] Fix ConfigMTree snapshot deserialization while using template

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/ConfigMTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/ConfigMTreeTest.java
@@ -261,6 +261,7 @@ public class ConfigMTreeTest {
       storageGroupMNode.setDataReplicationFactor(i);
       storageGroupMNode.setSchemaReplicationFactor(i);
       storageGroupMNode.setTimePartitionInterval(i);
+      root.getNodeWithAutoCreate(pathList[i].concatNode("a")).setSchemaTemplateId(i);
     }
 
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -277,6 +278,8 @@ public class ConfigMTreeTest {
       Assert.assertEquals(i, storageGroupSchema.getSchemaReplicationFactor());
       Assert.assertEquals(i, storageGroupSchema.getDataReplicationFactor());
       Assert.assertEquals(i, storageGroupSchema.getTimePartitionInterval());
+      Assert.assertEquals(
+          i, newTree.getNodeWithAutoCreate(pathList[i].concatNode("a")).getSchemaTemplateId());
     }
 
     Assert.assertEquals(


### PR DESCRIPTION
## Description

The origin implementation of ConfigMTree#deserialization doesn't consider the node beneath database node. Fix it.