### PR TITLE
[To rel/1.1][IOTDB-5639][compaction]Fix file not found exception in cross space compaction selector

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/utils/CrossSpaceCompactionCandidate.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/utils/CrossSpaceCompactionCandidate.java
@@ -82,6 +82,10 @@ public class CrossSpaceCompactionCandidate {
     // of
     // target seq file
     for (DeviceInfo unseqDeviceInfo : unseqFile.getDevices()) {
+      if (!unseqFile.isDeviceTimeIndex) {
+        // unseq file resource has been deleted due to TTL and cannot upgrade to DEVICE_TIME_INDEX
+        return false;
+      }
       for (TsFileResourceCandidate seqFile : seqFiles) {
         if (!seqFile.containsDevice(unseqDeviceInfo.deviceId)) {
           continue;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/utils/CrossSpaceCompactionCandidate.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/utils/CrossSpaceCompactionCandidate.java
@@ -77,24 +77,26 @@ public class CrossSpaceCompactionCandidate {
     List<TsFileResourceCandidate> ret = new ArrayList<>();
 
     // The startTime and endTime of each device are different in one TsFile. So we need to do the
-    // check
-    // one by one. And we cannot skip any device in the unseq file because it may lead to omission
-    // of
-    // target seq file
+    // check one by one. And we cannot skip any device in the unseq file because it may lead to
+    // omission of target seq file
+    if (!unseqFile.hasDetailedDeviceInfo()) {
+      // It means unseq file resource has been deleted due to TTL and cannot upgrade to
+      // DEVICE_TIME_INDEX
+      return false;
+    }
     for (DeviceInfo unseqDeviceInfo : unseqFile.getDevices()) {
-      if (!unseqFile.isDeviceTimeIndex) {
-        // unseq file resource has been deleted due to TTL and cannot upgrade to DEVICE_TIME_INDEX
-        return false;
-      }
       for (TsFileResourceCandidate seqFile : seqFiles) {
+        // If the seqFile may need to be selected but its invalid, the selection should be
+        // terminated.
+        if ((!seqFile.isValidCandidate || !seqFile.hasDetailedDeviceInfo())
+            && seqFile.mayHasOverlapWithUnseqFile(unseqDeviceInfo)) {
+          return false;
+        }
         if (!seqFile.containsDevice(unseqDeviceInfo.deviceId)) {
           continue;
         }
         DeviceInfo seqDeviceInfo = seqFile.getDeviceInfoById(unseqDeviceInfo.deviceId);
-        // If the seqFile should be selected but its invalid, the selection should be terminated.
-        if (!seqFile.isValidCandidate && unseqDeviceInfo.startTime <= seqDeviceInfo.endTime) {
-          return false;
-        }
+
         // If the unsealed file is unclosed, the file should not be selected only when its startTime
         // is larger than endTime of unseqFile. Or, the selection should be terminated.
         if (seqFile.unsealed() && unseqDeviceInfo.endTime >= seqDeviceInfo.startTime) {
@@ -185,7 +187,7 @@ public class CrossSpaceCompactionCandidate {
     public boolean isValidCandidate;
     private Map<String, DeviceInfo> deviceInfoMap;
 
-    private boolean isDeviceTimeIndex = true;
+    private boolean hasDetailedDeviceInfo;
 
     protected TsFileResourceCandidate(TsFileResource tsFileResource) {
       this.resource = tsFileResource;
@@ -213,10 +215,7 @@ public class CrossSpaceCompactionCandidate {
       deviceInfoMap = new LinkedHashMap<>();
       if (resource.getTimeIndexType() == ITimeIndex.FILE_TIME_INDEX_TYPE) {
         if (!resource.resourceFileExists()) {
-          // resource file does not exist, cannot upgrade to DEVICE_TIME_INDEX
-          isDeviceTimeIndex = false;
-          deviceInfoMap.put(
-              "", new DeviceInfo("", resource.getFileStartTime(), resource.getFileEndTime()));
+          hasDetailedDeviceInfo = false;
           return;
         }
         DeviceTimeIndex timeIndex = resource.buildDeviceTimeIndex();
@@ -234,6 +233,7 @@ public class CrossSpaceCompactionCandidate {
                   deviceId, resource.getStartTime(deviceId), resource.getEndTime(deviceId)));
         }
       }
+      hasDetailedDeviceInfo = true;
     }
 
     protected void markAsSelected() {
@@ -247,12 +247,27 @@ public class CrossSpaceCompactionCandidate {
 
     protected DeviceInfo getDeviceInfoById(String deviceId) throws IOException {
       prepareDeviceInfos();
-      return isDeviceTimeIndex ? deviceInfoMap.get(deviceId) : deviceInfoMap.get("");
+      return deviceInfoMap.get(deviceId);
     }
 
     protected boolean containsDevice(String deviceId) throws IOException {
       prepareDeviceInfos();
-      return isDeviceTimeIndex ? deviceInfoMap.containsKey(deviceId) : true;
+      return deviceInfoMap.containsKey(deviceId);
+    }
+
+    protected boolean hasDetailedDeviceInfo() throws IOException {
+      prepareDeviceInfos();
+      return hasDetailedDeviceInfo;
+    }
+
+    protected boolean mayHasOverlapWithUnseqFile(DeviceInfo unseqFileDeviceInfo)
+        throws IOException {
+      prepareDeviceInfos();
+      long endTime =
+          containsDevice(unseqFileDeviceInfo.deviceId)
+              ? getDeviceInfoById(unseqFileDeviceInfo.deviceId).endTime
+              : resource.getFileEndTime();
+      return unseqFileDeviceInfo.startTime <= endTime;
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/MergeTest.java
@@ -176,6 +176,7 @@ abstract class MergeTest {
       }
     }
     fileWriter.close();
+    tsFileResource.serialize();
   }
 
   void mkdirs(File file) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -1039,6 +1039,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
                 Thread.sleep(1000);
                 List<CrossCompactionTaskResource> selected =
                     selector.selectCrossSpaceTask(seqResources, unseqResources);
+                Assert.assertEquals(1, selected.get(0).getSeqFiles().size());
+                Assert.assertEquals(1, selected.get(0).getUnseqFiles().size());
               } catch (Exception e) {
                 logger.error("Exception occurs", e);
                 fail.set(true);
@@ -1047,8 +1049,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     Thread thread2 =
         new Thread(
             () -> {
-              seqResources.get(0).degradeTimeIndex();
-              if (!seqResources.get(0).remove()) {
+              seqResources.get(1).degradeTimeIndex();
+              if (!seqResources.get(1).remove()) {
                 fail.set(true);
               }
             });


### PR DESCRIPTION
When selecting files in cross space compaction, we need to upgrade the fileTimeindex by reading its resource file. If the resource file has been deleted by other thread, it will report "file not found" exception. To solve this problem, we check file is existed or not before reading it.