### PR TITLE
Implement all fragment instance of one query in one dataNode sharing dop 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceContext.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.mpp.execution.fragment;
 
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.engine.storagegroup.IDataRegionForQuery;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
@@ -27,6 +28,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.idtable.IDTable;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.SessionInfo;
+import org.apache.iotdb.db.mpp.plan.planner.plan.FragmentInstance;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
@@ -75,6 +77,8 @@ public class FragmentInstanceContext extends QueryContext {
   // session info
   private SessionInfo sessionInfo;
 
+  private int degreeOfParallelism = 1;
+
   //    private final GcMonitor gcMonitor;
   //    private final AtomicLong startNanos = new AtomicLong();
   //    private final AtomicLong startFullGcCount = new AtomicLong(-1);
@@ -84,9 +88,12 @@ public class FragmentInstanceContext extends QueryContext {
   //    private final AtomicLong endFullGcTimeNanos = new AtomicLong(-1);
 
   public static FragmentInstanceContext createFragmentInstanceContext(
-      FragmentInstanceId id, FragmentInstanceStateMachine stateMachine, SessionInfo sessionInfo) {
+      FragmentInstanceId id,
+      FragmentInstanceStateMachine stateMachine,
+      FragmentInstance fragmentInstance) {
     FragmentInstanceContext instanceContext =
-        new FragmentInstanceContext(id, stateMachine, sessionInfo);
+        new FragmentInstanceContext(id, stateMachine, fragmentInstance.getSessionInfo());
+    instanceContext.setDegreeOfParallelism(calculateDegreeOfParallelism(fragmentInstance));
     instanceContext.initialize();
     instanceContext.start();
     return instanceContext;
@@ -95,11 +102,16 @@ public class FragmentInstanceContext extends QueryContext {
   public static FragmentInstanceContext createFragmentInstanceContext(
       FragmentInstanceId id,
       FragmentInstanceStateMachine stateMachine,
-      SessionInfo sessionInfo,
       IDataRegionForQuery dataRegion,
-      Filter timeFilter) {
+      FragmentInstance fragmentInstance) {
     FragmentInstanceContext instanceContext =
-        new FragmentInstanceContext(id, stateMachine, sessionInfo, dataRegion, timeFilter);
+        new FragmentInstanceContext(
+            id,
+            stateMachine,
+            fragmentInstance.getSessionInfo(),
+            dataRegion,
+            fragmentInstance.getTimeFilter());
+    instanceContext.setDegreeOfParallelism(calculateDegreeOfParallelism(fragmentInstance));
     instanceContext.initialize();
     instanceContext.start();
     return instanceContext;
@@ -367,5 +379,25 @@ public class FragmentInstanceContext extends QueryContext {
     timeFilter = null;
     sourcePaths = null;
     sharedQueryDataSource = null;
+  }
+
+  private static int calculateDegreeOfParallelism(FragmentInstance fragmentInstance) {
+    int systemDop = IoTDBDescriptor.getInstance().getConfig().getDegreeOfParallelism();
+    int instanceNumInDataNode = fragmentInstance.getInstanceNumInDataNode();
+    if (instanceNumInDataNode >= systemDop) {
+      return 1;
+    } else if (fragmentInstance.isRoot()) {
+      return systemDop / instanceNumInDataNode + systemDop % instanceNumInDataNode;
+    } else {
+      return systemDop / instanceNumInDataNode;
+    }
+  }
+
+  public void setDegreeOfParallelism(int degreeOfParallelism) {
+    this.degreeOfParallelism = degreeOfParallelism;
+  }
+
+  public int getDegreeOfParallelism() {
+    return degreeOfParallelism;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceManager.java
@@ -123,11 +123,7 @@ public class FragmentInstanceManager {
                         instanceId,
                         fragmentInstanceId ->
                             createFragmentInstanceContext(
-                                fragmentInstanceId,
-                                stateMachine,
-                                instance.getSessionInfo(),
-                                dataRegion,
-                                instance.getTimeFilter()));
+                                fragmentInstanceId, stateMachine, dataRegion, instance));
 
                 try {
                   List<PipelineDriverFactory> driverFactories =
@@ -190,7 +186,7 @@ public class FragmentInstanceManager {
                       instanceId,
                       fragmentInstanceId ->
                           createFragmentInstanceContext(
-                              fragmentInstanceId, stateMachine, instance.getSessionInfo()));
+                              fragmentInstanceId, stateMachine, instance));
 
               try {
                 List<PipelineDriverFactory> driverFactories =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LocalExecutionPlanContext.java
@@ -89,6 +89,7 @@ public class LocalExecutionPlanContext {
     this.nextPipelineId = new AtomicInteger(0);
     this.driverContext = new DataDriverContext(instanceContext, getNextPipelineId());
     this.pipelineDriverFactories = new ArrayList<>();
+    this.degreeOfParallelism = instanceContext.getDegreeOfParallelism();
   }
 
   // For creating subContext, differ from parent context mainly in driver context
@@ -119,6 +120,7 @@ public class LocalExecutionPlanContext {
     this.dataRegionTTL = Long.MAX_VALUE;
     this.driverContext =
         new SchemaDriverContext(instanceContext, schemaRegion, getNextPipelineId());
+    this.degreeOfParallelism = instanceContext.getDegreeOfParallelism();
     this.pipelineDriverFactories = new ArrayList<>();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/FragmentInstance.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/FragmentInstance.java
@@ -68,6 +68,8 @@ public class FragmentInstance implements IConsensusRequest {
 
   private final SessionInfo sessionInfo;
 
+  private int instanceNumInDataNode;
+
   // We can add some more params for a specific FragmentInstance
   // So that we can make different FragmentInstance owns different data range.
 
@@ -124,6 +126,14 @@ public class FragmentInstance implements IConsensusRequest {
 
   public TRegionReplicaSet getRegionReplicaSet() {
     return executorType.getRegionReplicaSet();
+  }
+
+  public void setInstanceNumInDataNode(int instanceNumInDataNode) {
+    this.instanceNumInDataNode = instanceNumInDataNode;
+  }
+
+  public int getInstanceNumInDataNode() {
+    return instanceNumInDataNode;
   }
 
   public PlanFragment getFragment() {
@@ -183,6 +193,7 @@ public class FragmentInstance implements IConsensusRequest {
     boolean hasHostDataNode = ReadWriteIOUtils.readBool(buffer);
     fragmentInstance.hostDataNode =
         hasHostDataNode ? ThriftCommonsSerDeUtils.deserializeTDataNodeLocation(buffer) : null;
+    fragmentInstance.setInstanceNumInDataNode(ReadWriteIOUtils.readInt(buffer));
     return fragmentInstance;
   }
 
@@ -205,6 +216,7 @@ public class FragmentInstance implements IConsensusRequest {
       if (hostDataNode != null) {
         ThriftCommonsSerDeUtils.serializeTDataNodeLocation(hostDataNode, outputStream);
       }
+      ReadWriteIOUtils.write(instanceNumInDataNode, outputStream);
       return ByteBuffer.wrap(publicBAOS.getBuf(), 0, publicBAOS.size());
     } catch (IOException e) {
       logger.error("Unexpected error occurs when serializing this FragmentInstance.", e);


### PR DESCRIPTION
Before, every fragment instance can enjoy the dop of system even though they belong to the same query. However, if we have 5 data regions and 5 fragment instances are allocated to one dataNode, they will use 5 * dop which is not our expectation. There, I Implement all fragment instance of one query in one dataNode sharing dop.