### PR TITLE
init subscription-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
         <module>isession</module>
         <module>mlnode</module>
         <module>pipe-api</module>
+        <module>subscription-api</module>
     </modules>
     <!-- Properties Management -->
     <properties>

--- a/subscription-api/pom.xml
+++ b/subscription-api/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>iotdb-parent</artifactId>
+        <groupId>org.apache.iotdb</groupId>
+        <version>1.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>subscription-api</artifactId>
+    <profiles>
+        <profile>
+            <id>get-jar-with-dependencies</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>${maven.assembly.version}</version>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <!-- this is used for inheritance merges -->
+                                <phase>package</phase>
+                                <!-- bind to the packaging phase -->
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>tsfile</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/common/ConsumerDataSet.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/common/ConsumerDataSet.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.common;
+
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.read.query.dataset.DataSetWithTimeGenerator;
+import org.apache.iotdb.tsfile.read.query.timegenerator.TimeGenerator;
+import org.apache.iotdb.tsfile.read.reader.series.FileSeriesReaderByTimestamp;
+
+import java.util.List;
+
+public class ConsumerDataSet extends DataSetWithTimeGenerator {
+  public ConsumerDataSet(
+      List<Path> paths,
+      List<Boolean> cached,
+      List<TSDataType> dataTypes,
+      TimeGenerator timeGenerator,
+      List<FileSeriesReaderByTimestamp> readers) {
+    super(paths, cached, dataTypes, timeGenerator, readers);
+  }
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/common/ReceiveErrorListener.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/common/ReceiveErrorListener.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.common;
+
+import org.apache.iotdb.subscription.api.exception.SubscriptionException;
+
+public interface ReceiveErrorListener {
+
+  void failed(SubscriptionException failure);
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/common/SubscriptionListener.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/common/SubscriptionListener.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.common;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+
+public interface SubscriptionListener {
+
+  void receiveMessages(List<ConsumerDataSet> consumerDataSets);
+
+  Executor getExecutor();
+
+  void stop();
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/config/SubscriptionConfiguration.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/config/SubscriptionConfiguration.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.config;
+
+import org.apache.iotdb.subscription.api.exception.SubscriptionException;
+import org.apache.iotdb.subscription.api.strategy.disorderHandling.DisorderHandlingStrategy;
+import org.apache.iotdb.subscription.api.strategy.topicsStrategy.TopicsStrategy;
+
+public class SubscriptionConfiguration {
+  private String host;
+  private int port;
+  private String username;
+  private String password;
+  private String group;
+  private DisorderHandlingStrategy disorderHandlingStrategy;
+  private TopicsStrategy topicsStrategy;
+
+  public SubscriptionConfiguration(String host, int port, String username, String password) {
+    this(host, port, username, password, null);
+  }
+
+  public SubscriptionConfiguration(
+      String host, int port, String username, String password, String group) {
+    this.host = host;
+    this.port = port;
+    this.username = username;
+    this.password = password;
+    this.group = group;
+  }
+
+  public SubscriptionConfiguration disorderHandlingStrategy(
+      DisorderHandlingStrategy disorderHandlingStrategy) {
+    this.disorderHandlingStrategy = disorderHandlingStrategy;
+    return this;
+  }
+
+  public SubscriptionConfiguration topicsStrategy(TopicsStrategy topicsStrategy) {
+    this.topicsStrategy = topicsStrategy;
+    return this;
+  }
+
+  public void check() throws SubscriptionException {
+    if (disorderHandlingStrategy == null) {
+      throw new SubscriptionException("WatermarkStrategy is not set!");
+    }
+    disorderHandlingStrategy.check();
+
+    if (topicsStrategy == null) {
+      throw new SubscriptionException("TopicsStrategy is not set!");
+    }
+    topicsStrategy.check();
+  }
+
+  public static class Builder {
+    private String host;
+    private int port;
+    private String username;
+    private String password;
+    // 消费者组
+    private String group;
+
+    public Builder host(String host) {
+      this.host = host;
+      return this;
+    }
+
+    public Builder port(int port) {
+      this.port = port;
+      return this;
+    }
+
+    public Builder username(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public Builder password(String password) {
+      this.password = password;
+      return this;
+    }
+
+    public Builder group(String group) {
+      this.group = group;
+      return this;
+    }
+
+    public SubscriptionConfiguration build() {
+      return new SubscriptionConfiguration(host, port, username, password, group);
+    }
+  }
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/consumer/Consumer.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/consumer/Consumer.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.consumer;
+
+import org.apache.iotdb.subscription.api.exception.SubscriptionException;
+
+import java.util.List;
+
+public interface Consumer extends AutoCloseable {
+
+  /**
+   * open Subscription
+   *
+   * @throws SubscriptionException
+   */
+  void openSubscription() throws SubscriptionException;
+
+  /**
+   * close Subscription
+   *
+   * @throws SubscriptionException
+   */
+  void closeSubscription() throws SubscriptionException;
+
+  /**
+   * show consumerGroup
+   *
+   * @return consumer group name
+   * @throws SubscriptionException
+   */
+  String consumerGroup() throws SubscriptionException;
+
+  /**
+   * list of all topics
+   *
+   * @return all topics
+   * @throws SubscriptionException
+   */
+  List<String> subscription() throws SubscriptionException;
+
+  /**
+   * Consumer isCloseable
+   *
+   * @return isCloseable
+   */
+  boolean isCloseable();
+
+  /**
+   * clear all message
+   *
+   * @throws SubscriptionException
+   */
+  void clear() throws SubscriptionException;
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/consumer/PullConsumer.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/consumer/PullConsumer.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.consumer;
+
+import org.apache.iotdb.subscription.api.common.ConsumerDataSet;
+import org.apache.iotdb.subscription.api.exception.SubscriptionException;
+
+import java.time.Duration;
+import java.util.List;
+
+public interface PullConsumer extends Consumer {
+  /**
+   * get next message for subscribe, like: consumer.poll(Duration.ofMillis(100))
+   *
+   * @param timeout
+   * @return next message
+   * @throws SubscriptionException
+   */
+  List<ConsumerDataSet> poll(Duration timeout) throws SubscriptionException;
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/consumer/PushConsumer.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/consumer/PushConsumer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.consumer;
+
+import org.apache.iotdb.subscription.api.common.ReceiveErrorListener;
+import org.apache.iotdb.subscription.api.common.SubscriptionListener;
+import org.apache.iotdb.subscription.api.exception.SubscriptionException;
+
+public interface PushConsumer extends Consumer {
+
+  /**
+   * set subscribe listener
+   *
+   * @param listener
+   * @return this
+   * @throws SubscriptionException
+   */
+  PushConsumer subscribe(SubscriptionListener listener) throws SubscriptionException;
+
+  /** resume current PushConsumer */
+  void resumeConsume();
+
+  /** pause current PushConsumer */
+  void pauseConsume();
+
+  /**
+   * show pushConsumer status
+   *
+   * @return
+   */
+  boolean isConsumePaused();
+
+  /**
+   * inject error listener
+   *
+   * @param listener
+   */
+  void errorListener(ReceiveErrorListener listener);
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/exception/SubscriptionException.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/exception/SubscriptionException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.exception;
+
+public class SubscriptionException extends RuntimeException {
+
+  public SubscriptionException(String message) {
+    super(message);
+  }
+
+  public SubscriptionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/exception/SubscriptionStrategyNotValidException.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/exception/SubscriptionStrategyNotValidException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.exception;
+
+public class SubscriptionStrategyNotValidException extends SubscriptionException {
+
+  public SubscriptionStrategyNotValidException(String message) {
+    super(message);
+  }
+
+  public SubscriptionStrategyNotValidException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/factory/SubscriptionFactory.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/factory/SubscriptionFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.factory;
+
+import org.apache.iotdb.subscription.api.config.SubscriptionConfiguration;
+import org.apache.iotdb.subscription.api.consumer.PullConsumer;
+import org.apache.iotdb.subscription.api.consumer.PushConsumer;
+import org.apache.iotdb.subscription.api.exception.SubscriptionException;
+
+public interface SubscriptionFactory {
+  /**
+   * create new PushConsumer with SubscriptionConfiguration
+   *
+   * @param subscriptionConfiguration
+   * @return
+   * @throws SubscriptionException
+   */
+  PushConsumer createPushConsumer(SubscriptionConfiguration subscriptionConfiguration)
+      throws SubscriptionException;
+
+  /**
+   * create new PullConsumer with SubscriptionConfiguration
+   *
+   * @param subscriptionConfiguration
+   * @return
+   * @throws SubscriptionException
+   */
+  PullConsumer createPullConsumer(SubscriptionConfiguration subscriptionConfiguration)
+      throws SubscriptionException;
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/SubscriptionStrategy.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/SubscriptionStrategy.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.strategy;
+
+import org.apache.iotdb.subscription.api.exception.SubscriptionStrategyNotValidException;
+
+public interface SubscriptionStrategy {
+
+  /** @throws SubscriptionStrategyNotValidException if invalid strategy is set */
+  void check() throws SubscriptionStrategyNotValidException;
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/disorderHandling/DisorderHandlingStrategy.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/disorderHandling/DisorderHandlingStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.strategy.disorderHandling;
+
+import org.apache.iotdb.subscription.api.strategy.SubscriptionStrategy;
+
+public interface DisorderHandlingStrategy extends SubscriptionStrategy {}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/disorderHandling/IntolerableStrategy.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/disorderHandling/IntolerableStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.strategy.disorderHandling;
+
+import org.apache.iotdb.subscription.api.exception.SubscriptionStrategyNotValidException;
+
+public class IntolerableStrategy implements DisorderHandlingStrategy {
+  private final int watermark = 0;
+
+  public int getWatermark() {
+    return watermark;
+  }
+
+  @Override
+  public void check() throws SubscriptionStrategyNotValidException {}
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/disorderHandling/WatermarkStrategy.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/disorderHandling/WatermarkStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.strategy.disorderHandling;
+
+import org.apache.iotdb.subscription.api.exception.SubscriptionStrategyNotValidException;
+
+public class WatermarkStrategy implements DisorderHandlingStrategy {
+  private final int watermark;
+
+  public WatermarkStrategy(int watermark) {
+    this.watermark = watermark;
+  }
+
+  public int getWatermark() {
+    return watermark;
+  }
+
+  @Override
+  public void check() throws SubscriptionStrategyNotValidException {
+    if (watermark == 0) {
+      throw new SubscriptionStrategyNotValidException("watermark is not set!");
+    }
+    if (watermark < 0) {
+      throw new SubscriptionStrategyNotValidException("watermark is set to error value!");
+    }
+  }
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/topicsStrategy/MutipileConnectionStrategy.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/topicsStrategy/MutipileConnectionStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.strategy.topicsStrategy;
+
+import org.apache.iotdb.subscription.api.exception.SubscriptionStrategyNotValidException;
+import org.apache.iotdb.tsfile.read.common.parser.PathNodesGenerator;
+
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+
+import java.util.List;
+
+public class MutipileConnectionStrategy implements TopicsStrategy {
+  private final List<String> topics;
+
+  public MutipileConnectionStrategy(List<String> topics) {
+    this.topics = topics;
+  }
+
+  @Override
+  public void check() throws SubscriptionStrategyNotValidException {
+    if (topics == null || topics.isEmpty()) {
+      throw new SubscriptionStrategyNotValidException("topics is not set!");
+    }
+    topics.forEach(
+        topic -> {
+          try {
+            PathNodesGenerator.checkPath(topic);
+          } catch (ParseCancellationException ex) {
+            throw new SubscriptionStrategyNotValidException(
+                String.format("%s is not a legal path, topic is set to error value", topic), ex);
+          }
+        });
+  }
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/topicsStrategy/SingleTopicStrategy.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/topicsStrategy/SingleTopicStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.strategy.topicsStrategy;
+
+import org.apache.iotdb.subscription.api.exception.SubscriptionStrategyNotValidException;
+import org.apache.iotdb.tsfile.read.common.parser.PathNodesGenerator;
+
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.apache.commons.lang3.StringUtils;
+
+public class SingleTopicStrategy implements TopicsStrategy {
+  private final String topic;
+
+  public SingleTopicStrategy(String topic) {
+    this.topic = topic;
+  }
+
+  public String getTopic() {
+    return topic;
+  }
+
+  @Override
+  public void check() throws SubscriptionStrategyNotValidException {
+    if (StringUtils.isAllBlank(topic)) {
+      throw new SubscriptionStrategyNotValidException("topic is not set!");
+    }
+    try {
+      PathNodesGenerator.checkPath(topic);
+    } catch (ParseCancellationException ex) {
+      throw new SubscriptionStrategyNotValidException(
+          String.format("%s is not a legal path, topic is set to error value", topic), ex);
+    }
+  }
+}

--- a/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/topicsStrategy/TopicsStrategy.java
+++ b/subscription-api/src/main/java/org/apache/iotdb/subscription/api/strategy/topicsStrategy/TopicsStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.subscription.api.strategy.topicsStrategy;
+
+import org.apache.iotdb.subscription.api.strategy.SubscriptionStrategy;
+
+public interface TopicsStrategy extends SubscriptionStrategy {}


### PR DESCRIPTION
- [IOTDB-5577] Metric dashboard for Schema Module (#9135)
- [IOTDB-5533] Add IoTDB Internal Reporter params back and Modify the config of root.__system (#9119)
- feat(WebSite) :DocSearch Filter By Version (#9134)
- [IOTDB-4005] Allow the following child pipeline to run in advance
- [IOTDB-5559] Implement metric exporters for RatisConsensus (#9099)
- Remove 0.8-0.12 docs & fix the bad urls on the master branch (#9091)
- Add a paper to the Publication_zh doc (#9067)
- [IOTDB-5454] Support shuffle function of DataExchangeModule
- [IOTDB-5147]Optimize compaction schedule when priority is BALANCE (#9103)
- Update nifi doc (#9051)
- Fix some broken links in README (#9066)
- [IOTDB-5578] Keep CacheMemoryManager monitor alive when exception (#9133)
- [IOTDB-5524] Update metric docs for schema module (#9136)
- Modify Group-By UserGuide
- [IOTDB-5542] ConfigNode counter dashboard (#9129)
- [IOTDB-5581] Missing reset of aggregators in RawDataAggregationOperator
- [IOTDB-5575] Pipe SDK: PipeProcessor & PipeConnector (#9131)
- [IOTDB-4898] Push offset and limit down to ScanOperator if possible
- [IOTDB-5582] Add region type in ratis metric prefix (#9140)
- [IOTDB-5538] Deprecate configuration parameter `max_deduplicated_path_num`
- [IOTDB-5585] Change InternalReporterType from IoTDB to Memory to reduce performance degradation
- Use req.getName() as templateName in ClientRpcServiceImpl (#9142)
- [IOTDB-5584] Fix wrong intialization in GROUP BY CONDITION
- [IOTDB-5462] Optimize the memory estimation of ExchangeOperator in the pipelin
- fix exception caused by pre deleted db (#9151)
- [IOTDB-5081] Implement model management on ConfigNode (#9090)
- [IOTDB-5458] Add Session Idle Time Metrics and Upgrade Thrift related Metrics (#9124)
- [IOTDB-5587] Add dataRegionId into Memtable and update flush point metrics (#9148)
- Bump http-cache-semantics from 4.1.0 to 4.1.1 in /grafana-plugin (#8980)
- Bump decode-uri-component from 0.2.0 to 0.2.2 in /grafana-plugin (#8292)
- [IOTDB-5587] Update the cluster info and node info of metrics (#9147)
- [IOTDB-5590] convert __endTime to UTC in cli
- [IOTDB-5555] Enable modify external RPC EndPoint of DataNode (#9155)
- [IOTDB-5592] Fix unexpected error when use full path in having/where (#9157)
- [IOTDB-5593] Improve efficiency of DistributionPlanner by recording map instead of recursive search
- [IOTDB-5545] Implement SchemaRegionLoader for SchemaEngine (#9156)
- [IOTDB-5595] Fix memory leak for TsFileProcessorInfoMetrics in TsFileProcessorInfo (#9162)
- Add TsFileResource back to TsFileResourceManager when all time index are file level (#9164)
- [IOTDB-5147]Optimize compaction schedule when priority is BALANCE (#9163)
- [IOTDB-5516] Fix delete schema region bug during drop database (#9170)
- [IOTDB-5596] Rename ConfigNodeRegion to ConfigRegion (#9168)
- Bump jackson.version from 2.13.4 to 2.13.5 (#9177)
- [IOTDB-5599] Bug: One query is divided too much tasks to be allowed by system
- Update the version of master branch & deploy 1.1 website (#9178)
- Update website deploy command (#9181)
- [IOTDB-5594] Update timeout after completing logical plan and distribution plan
- feat(site): image move to site (#9182)
- Update Apache-IoTDB-ConfigNode-Dashboard.json (#9190)
- [IOTDB-5604]Fix NPE when execute Agg + align by device query without assigned DataRegion
-  Use ConfigurableTByteBuffer instead of TByteBuffer in ThriftCommonsSerDeUtils
- [IOTDB-5601] [Refactor] Remove AsyncConfigNodeHeartbeatServiceClient and AsyncDataNodeHeartbeatServiceClient as there core logic are duplicated (#9180)
- feat(site): update to website 2.0 (#9196)
- [fix(people): fix Community display] (#9198)
- IOTDB-5610 Don't pipeline cosumeAllNode and consumeOneByOneNode with only one child (#9197)
- Add write metrics and dashboard (#9167)
- fix(site):fix home url error (#9202)
- Remove jackson-mapper-asl to fix security alert (#9199)
- Fix timeout in Schema UT (#9195)
- feat(site):home break-word (#9203)
- Remove redundant logic in reconstructExpressions() (#9200)
- Update query user guide (#9205)
- [IOTDB-5563] Extract and decouple the logic of window segmentation in Aggregator (#9141)
- [IOTDB-5613] Remove unnecessary serialization in IoTConsensus when replicaNum is 1 to improve write performance (#9204)
- [IOTDB-5517] Add metrics for disk io (#9209)
- [IOTDB-5598] Pipe Plugins Management: from SQL to CN (#9175)
- [IOTDB-5580] Add limitation of time and tsBlock size to MergeSortOperator   (#9193)
- [IOTDB-5586] Reduce the scope of lock in MemoryPool
- [IOTDB-5621] Eliminate the deprecated code in the template (#9219)
- [IOTDB-5624] Optimize the organization of Apache IoTDB ConfigNode Dashboard (#9221)
- [IOTDB-5620] Fix flush stuck when there is a lot of time partitions in each DataRegion (#9218)
- [IOTDB-5631] Add aggregate  method time_duration for query
- [IOTDB-5616] Fix some code smells (#9217)
- [IOTDB-5487] Fix the problem that the timestamp is "null" when using jdbc (#8998)
- Remove 0.75 report (#9224)
- Update Aggregation.md (#9227)
- Fix memory calculation is not accurate in SystemInfo (#9237)
- Change log level of array pool to debug (#9208)
- [IOTDB-5619] Fix NPE in processing GroupByTagNode (#9235)
- Add Tsfile-settle-tool docs and modify the default port of the tool (#9233)
- Set some runtime fields in FIConetxt to null when the FI is done
- remove stale docs (#9249)
- [IOTDB-5240] Fix ConfigMTree snapshot deserialization while using template (#9247)
- [IOTDB-5649] Refactor `ExpressionAnalyzer` using visitor pattern (#9236)
- fix(home): fix home url error (#9252)
- [IOTDB-5644] Fix unexpected result when there are no select expressions after analyzed in query (#9242)
- [IOTDB-5646] Support insert bytes directly by Python API (#9222)
- [IOTDB-5630] Make Function cast a built-in function
- [IOTDB-4497][Doc] Improve NodeStatus definition (#9256)
- fix(home): fix home url error

## Description


### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
