### PR TITLE
[Doc] Add example of 'kill query' in doc

### DIFF
--- a/docs/UserGuide/Maintenance-Tools/Maintenance-Command.md
+++ b/docs/UserGuide/Maintenance-Tools/Maintenance-Command.md
@@ -101,9 +101,14 @@ In addition to waiting for the query to time out passively, IoTDB also supports 
 KILL QUERY <queryId>
 ```
 
-You can kill the specified query by specifying `queryId`.
+You can kill the specified query by specifying `queryId`. `queryId` is a string, so you need to put quotes around it.
 
 To get the executing `queryId`，you can use the [show queries](#show-queries) command, which will show the list of all executing queries.
+
+##### Example
+```sql
+kill query '20221205_114444_00003_5'
+```
 
 #### Kill all queries
 

--- a/docs/zh/UserGuide/Maintenance-Tools/Maintenance-Command.md
+++ b/docs/zh/UserGuide/Maintenance-Tools/Maintenance-Command.md
@@ -99,9 +99,14 @@ session.executeQueryStatement(String sql, long timeout)
 KILL QUERY <queryId>
 ```
 
-通过指定 `queryId` 可以中止指定的查询。
+通过指定 `queryId` 可以中止指定的查询，`queryId`是一个字符串，所以使用时需要添加引号。
 
 为了获取正在执行的查询 id，用户可以使用 [show queries](#show-queries) 命令，该命令将显示所有正在执行的查询列表。
+
+##### 示例
+```sql
+kill query '20221205_114444_00003_5'
+```
 
 #### 终止所有查询
 


### PR DESCRIPTION
Add example of 'kill query', because user may not think `queryId ` as a string.