### PR TITLE
[IOTDB-5368] add port check for confignode and datanode

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -45,16 +45,17 @@ public class ConfigNodeStartupCheck extends StartupChecks {
 
   private static final ConfigNodeConfig CONF = ConfigNodeDescriptor.getInstance().getConf();
 
+  private static final int CONFIGNODE_PORTS = 2;
+
   public ConfigNodeStartupCheck(String nodeRole) {
     super(nodeRole);
   }
 
   private void portCheck() throws StartupException {
     Set<Integer> portSet = new HashSet<>();
-    int configNodePort = 2;
     portSet.add(CONF.getConsensusPort());
     portSet.add(CONF.getInternalPort());
-    if (portSet.size() != configNodePort) {
+    if (portSet.size() != CONFIGNODE_PORTS) {
       throw new StartupException("ports used in configNode have repeat.");
     } else {
       LOGGER.info("configNode port check successful.");

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -54,13 +54,13 @@ public class ConfigNodeStartupCheck extends StartupChecks {
     int configNodePort = 2;
     portSet.add(CONF.getConsensusPort());
     portSet.add(CONF.getInternalPort());
-    if(portSet.size()!=configNodePort){
+    if (portSet.size() != configNodePort) {
       throw new StartupException("ports used in configNode have repeat.");
-    }
-    else{
+    } else {
       LOGGER.info("configNode port check successful.");
     }
   }
+
   public void startUpCheck() throws StartupException, IOException, ConfigurationException {
     envCheck();
     portCheck();
@@ -72,69 +72,67 @@ public class ConfigNodeStartupCheck extends StartupChecks {
     }
   }
 
-  /**
-   * Check whether the global configuration of the cluster is correct
-   */
+  /** Check whether the global configuration of the cluster is correct */
   private void checkGlobalConfig() throws ConfigurationException {
     // When the ConfigNode consensus protocol is set to SIMPLE_CONSENSUS,
     // the target_config_node_list needs to point to itself
     if (CONF.getConfigNodeConsensusProtocolClass().equals(ConsensusFactory.SIMPLE_CONSENSUS)
-            && (!CONF.getInternalAddress().equals(CONF.getTargetConfigNode().getIp())
+        && (!CONF.getInternalAddress().equals(CONF.getTargetConfigNode().getIp())
             || CONF.getInternalPort() != CONF.getTargetConfigNode().getPort())) {
       throw new ConfigurationException(
-              IoTDBConstant.CN_TARGET_CONFIG_NODE_LIST,
-              CONF.getTargetConfigNode().getIp() + ":" + CONF.getTargetConfigNode().getPort(),
-              CONF.getInternalAddress() + ":" + CONF.getInternalPort());
+          IoTDBConstant.CN_TARGET_CONFIG_NODE_LIST,
+          CONF.getTargetConfigNode().getIp() + ":" + CONF.getTargetConfigNode().getPort(),
+          CONF.getInternalAddress() + ":" + CONF.getInternalPort());
     }
 
     // When the data region consensus protocol is set to SIMPLE_CONSENSUS,
     // the data replication factor must be 1
     if (CONF.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.SIMPLE_CONSENSUS)
-            && CONF.getDataReplicationFactor() != 1) {
+        && CONF.getDataReplicationFactor() != 1) {
       throw new ConfigurationException(
-              "data_replication_factor",
-              String.valueOf(CONF.getDataReplicationFactor()),
-              String.valueOf(1));
+          "data_replication_factor",
+          String.valueOf(CONF.getDataReplicationFactor()),
+          String.valueOf(1));
     }
 
     // When the schema region consensus protocol is set to SIMPLE_CONSENSUS,
     // the schema replication factor must be 1
     if (CONF.getSchemaRegionConsensusProtocolClass().equals(ConsensusFactory.SIMPLE_CONSENSUS)
-            && CONF.getSchemaReplicationFactor() != 1) {
+        && CONF.getSchemaReplicationFactor() != 1) {
       throw new ConfigurationException(
-              "schema_replication_factor",
-              String.valueOf(CONF.getSchemaReplicationFactor()),
-              String.valueOf(1));
+          "schema_replication_factor",
+          String.valueOf(CONF.getSchemaReplicationFactor()),
+          String.valueOf(1));
     }
 
     // When the schema region consensus protocol is set to IoTConsensus,
     // we should report an error
     if (CONF.getSchemaRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)) {
       throw new ConfigurationException(
-              "schema_region_consensus_protocol_class",
-              String.valueOf(CONF.getSchemaRegionConsensusProtocolClass()),
-              String.format(
-                      "%s or %s", ConsensusFactory.SIMPLE_CONSENSUS, ConsensusFactory.RATIS_CONSENSUS));
+          "schema_region_consensus_protocol_class",
+          String.valueOf(CONF.getSchemaRegionConsensusProtocolClass()),
+          String.format(
+              "%s or %s", ConsensusFactory.SIMPLE_CONSENSUS, ConsensusFactory.RATIS_CONSENSUS));
     }
 
     // The leader distribution policy is limited
     if (!ILeaderBalancer.GREEDY_POLICY.equals(CONF.getLeaderDistributionPolicy())
-            && !ILeaderBalancer.MIN_COST_FLOW_POLICY.equals(CONF.getLeaderDistributionPolicy())) {
+        && !ILeaderBalancer.MIN_COST_FLOW_POLICY.equals(CONF.getLeaderDistributionPolicy())) {
       throw new ConfigurationException(
-              "leader_distribution_policy", CONF.getRoutePriorityPolicy(), "GREEDY or MIN_COST_FLOW");
+          "leader_distribution_policy", CONF.getRoutePriorityPolicy(), "GREEDY or MIN_COST_FLOW");
     }
 
     // The route priority policy is limited
     if (!CONF.getRoutePriorityPolicy().equals(IPriorityBalancer.LEADER_POLICY)
-            && !CONF.getRoutePriorityPolicy().equals(IPriorityBalancer.GREEDY_POLICY)) {
+        && !CONF.getRoutePriorityPolicy().equals(IPriorityBalancer.GREEDY_POLICY)) {
       throw new ConfigurationException(
-              "route_priority_policy", CONF.getRoutePriorityPolicy(), "LEADER or GREEDY");
+          "route_priority_policy", CONF.getRoutePriorityPolicy(), "LEADER or GREEDY");
     }
 
     // The ip of target ConfigNode couldn't be 0.0.0.0
     if (CONF.getTargetConfigNode().getIp().equals("0.0.0.0")) {
       throw new ConfigurationException(
-              "The ip address of any target_config_node_list couldn't be 0.0.0.0");
+          "The ip address of any target_config_node_list couldn't be 0.0.0.0");
     }
 
     // The least RegionGroupNum should be positive
@@ -162,9 +160,9 @@ public class ConfigNodeStartupCheck extends StartupChecks {
         LOGGER.info("Make dirs: {}", dir);
       } else {
         throw new IOException(
-                String.format(
-                        "Start ConfigNode failed, because couldn't make system dirs: %s.",
-                        dir.getAbsolutePath()));
+            String.format(
+                "Start ConfigNode failed, because couldn't make system dirs: %s.",
+                dir.getAbsolutePath()));
       }
     }
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.confignode.conf;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.ConfigurationException;
 import org.apache.iotdb.commons.exception.StartupException;
+import org.apache.iotdb.commons.service.StartupChecks;
 import org.apache.iotdb.confignode.manager.load.balancer.router.leader.ILeaderBalancer;
 import org.apache.iotdb.confignode.manager.load.balancer.router.priority.IPriorityBalancer;
 import org.apache.iotdb.consensus.ConsensusFactory;
@@ -31,18 +32,39 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * ConfigNodeStartupCheck checks the parameters in iotdb-confignode.properties and
  * confignode-system.properties when start and restart
  */
-public class ConfigNodeStartupCheck {
+public class ConfigNodeStartupCheck extends StartupChecks {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigNodeStartupCheck.class);
 
   private static final ConfigNodeConfig CONF = ConfigNodeDescriptor.getInstance().getConf();
 
+  public ConfigNodeStartupCheck(String nodeRole) {
+    super(nodeRole);
+  }
+
+  private void portCheck() throws StartupException {
+    Set<Integer> portSet = new HashSet<>();
+    int configNodePort = 2;
+    portSet.add(CONF.getConsensusPort());
+    portSet.add(CONF.getInternalPort());
+    if(portSet.size()!=configNodePort){
+      throw new StartupException("ports used in configNode have repeat.");
+    }
+    else{
+      LOGGER.info("configNode port check successful.");
+    }
+  }
   public void startUpCheck() throws StartupException, IOException, ConfigurationException {
+    envCheck();
+    portCheck();
+    verify();
     checkGlobalConfig();
     createDirsIfNecessary();
     if (SystemPropertiesUtils.isRestarted()) {
@@ -50,67 +72,69 @@ public class ConfigNodeStartupCheck {
     }
   }
 
-  /** Check whether the global configuration of the cluster is correct */
+  /**
+   * Check whether the global configuration of the cluster is correct
+   */
   private void checkGlobalConfig() throws ConfigurationException {
     // When the ConfigNode consensus protocol is set to SIMPLE_CONSENSUS,
     // the target_config_node_list needs to point to itself
     if (CONF.getConfigNodeConsensusProtocolClass().equals(ConsensusFactory.SIMPLE_CONSENSUS)
-        && (!CONF.getInternalAddress().equals(CONF.getTargetConfigNode().getIp())
+            && (!CONF.getInternalAddress().equals(CONF.getTargetConfigNode().getIp())
             || CONF.getInternalPort() != CONF.getTargetConfigNode().getPort())) {
       throw new ConfigurationException(
-          IoTDBConstant.CN_TARGET_CONFIG_NODE_LIST,
-          CONF.getTargetConfigNode().getIp() + ":" + CONF.getTargetConfigNode().getPort(),
-          CONF.getInternalAddress() + ":" + CONF.getInternalPort());
+              IoTDBConstant.CN_TARGET_CONFIG_NODE_LIST,
+              CONF.getTargetConfigNode().getIp() + ":" + CONF.getTargetConfigNode().getPort(),
+              CONF.getInternalAddress() + ":" + CONF.getInternalPort());
     }
 
     // When the data region consensus protocol is set to SIMPLE_CONSENSUS,
     // the data replication factor must be 1
     if (CONF.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.SIMPLE_CONSENSUS)
-        && CONF.getDataReplicationFactor() != 1) {
+            && CONF.getDataReplicationFactor() != 1) {
       throw new ConfigurationException(
-          "data_replication_factor",
-          String.valueOf(CONF.getDataReplicationFactor()),
-          String.valueOf(1));
+              "data_replication_factor",
+              String.valueOf(CONF.getDataReplicationFactor()),
+              String.valueOf(1));
     }
 
     // When the schema region consensus protocol is set to SIMPLE_CONSENSUS,
     // the schema replication factor must be 1
     if (CONF.getSchemaRegionConsensusProtocolClass().equals(ConsensusFactory.SIMPLE_CONSENSUS)
-        && CONF.getSchemaReplicationFactor() != 1) {
+            && CONF.getSchemaReplicationFactor() != 1) {
       throw new ConfigurationException(
-          "schema_replication_factor",
-          String.valueOf(CONF.getSchemaReplicationFactor()),
-          String.valueOf(1));
+              "schema_replication_factor",
+              String.valueOf(CONF.getSchemaReplicationFactor()),
+              String.valueOf(1));
     }
 
     // When the schema region consensus protocol is set to IoTConsensus,
     // we should report an error
     if (CONF.getSchemaRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)) {
       throw new ConfigurationException(
-          "schema_region_consensus_protocol_class",
-          String.valueOf(CONF.getSchemaRegionConsensusProtocolClass()),
-          String.format(
-              "%s or %s", ConsensusFactory.SIMPLE_CONSENSUS, ConsensusFactory.RATIS_CONSENSUS));
+              "schema_region_consensus_protocol_class",
+              String.valueOf(CONF.getSchemaRegionConsensusProtocolClass()),
+              String.format(
+                      "%s or %s", ConsensusFactory.SIMPLE_CONSENSUS, ConsensusFactory.RATIS_CONSENSUS));
     }
 
     // The leader distribution policy is limited
     if (!ILeaderBalancer.GREEDY_POLICY.equals(CONF.getLeaderDistributionPolicy())
-        && !ILeaderBalancer.MIN_COST_FLOW_POLICY.equals(CONF.getLeaderDistributionPolicy())) {
+            && !ILeaderBalancer.MIN_COST_FLOW_POLICY.equals(CONF.getLeaderDistributionPolicy())) {
       throw new ConfigurationException(
-          "leader_distribution_policy", CONF.getRoutePriorityPolicy(), "GREEDY or MIN_COST_FLOW");
+              "leader_distribution_policy", CONF.getRoutePriorityPolicy(), "GREEDY or MIN_COST_FLOW");
     }
 
     // The route priority policy is limited
     if (!CONF.getRoutePriorityPolicy().equals(IPriorityBalancer.LEADER_POLICY)
-        && !CONF.getRoutePriorityPolicy().equals(IPriorityBalancer.GREEDY_POLICY)) {
+            && !CONF.getRoutePriorityPolicy().equals(IPriorityBalancer.GREEDY_POLICY)) {
       throw new ConfigurationException(
-          "route_priority_policy", CONF.getRoutePriorityPolicy(), "LEADER or GREEDY");
+              "route_priority_policy", CONF.getRoutePriorityPolicy(), "LEADER or GREEDY");
     }
 
     // The ip of target ConfigNode couldn't be 0.0.0.0
     if (CONF.getTargetConfigNode().getIp().equals("0.0.0.0")) {
       throw new ConfigurationException(
-          "The ip address of any target_config_node_list couldn't be 0.0.0.0");
+              "The ip address of any target_config_node_list couldn't be 0.0.0.0");
     }
 
     // The least RegionGroupNum should be positive
@@ -138,23 +162,10 @@ public class ConfigNodeStartupCheck {
         LOGGER.info("Make dirs: {}", dir);
       } else {
         throw new IOException(
-            String.format(
-                "Start ConfigNode failed, because couldn't make system dirs: %s.",
-                dir.getAbsolutePath()));
+                String.format(
+                        "Start ConfigNode failed, because couldn't make system dirs: %s.",
+                        dir.getAbsolutePath()));
       }
     }
-  }
-
-  private static class ConfigNodeConfCheckHolder {
-
-    private static final ConfigNodeStartupCheck INSTANCE = new ConfigNodeStartupCheck();
-
-    private ConfigNodeConfCheckHolder() {
-      // Empty constructor
-    }
-  }
-
-  public static ConfigNodeStartupCheck getInstance() {
-    return ConfigNodeConfCheckHolder.INSTANCE;
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -51,7 +51,8 @@ public class ConfigNodeStartupCheck extends StartupChecks {
     super(nodeRole);
   }
 
-  private void portCheck() throws StartupException {
+  @Override
+  protected void portCheck() throws StartupException {
     Set<Integer> portSet = new HashSet<>();
     portSet.add(CONF.getConsensusPort());
     portSet.add(CONF.getInternalPort());
@@ -62,6 +63,7 @@ public class ConfigNodeStartupCheck extends StartupChecks {
     }
   }
 
+  @Override
   public void startUpCheck() throws StartupException, IOException, ConfigurationException {
     envCheck();
     portCheck();

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNodeCommandLine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNodeCommandLine.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.ServerCommandLine;
 import org.apache.iotdb.commons.exception.BadNodeUrlException;
 import org.apache.iotdb.commons.exception.ConfigurationException;
 import org.apache.iotdb.commons.exception.StartupException;
+import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.confignode.conf.ConfigNodeRemoveCheck;
 import org.apache.iotdb.confignode.conf.ConfigNodeStartupCheck;
 
@@ -67,11 +68,9 @@ public class ConfigNodeCommandLine extends ServerCommandLine {
     LOGGER.info("Running mode {}", mode);
     if (MODE_START.equals(mode)) {
       try {
-        // Startup environment check
-        //        StartupChecks checks = new StartupChecks(IoTDBConstant.CN_ROLE).withDefaultTest();
-        //        checks.verify();
         // Do ConfigNode startup checks
-        ConfigNodeStartupCheck.getInstance().startUpCheck();
+        ConfigNodeStartupCheck checks = new ConfigNodeStartupCheck(IoTDBConstant.CN_ROLE);
+        checks.startUpCheck();
       } catch (StartupException | ConfigurationException | IOException e) {
         LOGGER.error("Meet error when doing start checking", e);
         return -1;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNodeCommandLine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNodeCommandLine.java
@@ -20,11 +20,9 @@ package org.apache.iotdb.confignode.service;
 
 import org.apache.iotdb.common.rpc.thrift.TConfigNodeLocation;
 import org.apache.iotdb.commons.ServerCommandLine;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.BadNodeUrlException;
 import org.apache.iotdb.commons.exception.ConfigurationException;
 import org.apache.iotdb.commons.exception.StartupException;
-import org.apache.iotdb.commons.service.StartupChecks;
 import org.apache.iotdb.confignode.conf.ConfigNodeRemoveCheck;
 import org.apache.iotdb.confignode.conf.ConfigNodeStartupCheck;
 
@@ -70,8 +68,8 @@ public class ConfigNodeCommandLine extends ServerCommandLine {
     if (MODE_START.equals(mode)) {
       try {
         // Startup environment check
-        StartupChecks checks = new StartupChecks(IoTDBConstant.CN_ROLE).withDefaultTest();
-        checks.verify();
+        //        StartupChecks checks = new StartupChecks(IoTDBConstant.CN_ROLE).withDefaultTest();
+        //        checks.verify();
         // Do ConfigNode startup checks
         ConfigNodeStartupCheck.getInstance().startUpCheck();
       } catch (StartupException | ConfigurationException | IOException e) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNodeCommandLine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNodeCommandLine.java
@@ -20,10 +20,10 @@ package org.apache.iotdb.confignode.service;
 
 import org.apache.iotdb.common.rpc.thrift.TConfigNodeLocation;
 import org.apache.iotdb.commons.ServerCommandLine;
+import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.BadNodeUrlException;
 import org.apache.iotdb.commons.exception.ConfigurationException;
 import org.apache.iotdb.commons.exception.StartupException;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.confignode.conf.ConfigNodeRemoveCheck;
 import org.apache.iotdb.confignode.conf.ConfigNodeStartupCheck;
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/cluster/IoTDBClusterNodeErrorStartUpIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/cluster/IoTDBClusterNodeErrorStartUpIT.java
@@ -25,8 +25,6 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.client.exception.ClientManagerException;
 import org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient;
 import org.apache.iotdb.commons.cluster.NodeStatus;
-import org.apache.iotdb.commons.exception.ConfigurationException;
-import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.confignode.it.utils.ConfigNodeTestUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TConfigNodeRegisterResp;
@@ -304,8 +302,7 @@ public class IoTDBClusterNodeErrorStartUpIT {
 
   @Test
   public void testIllegalNodeStartUp()
-      throws StartupException, ConfigurationException, IOException, ClientManagerException,
-          InterruptedException, TException {
+      throws IOException, ClientManagerException, InterruptedException, TException {
     ConfigNodeWrapper portConflictConfigNodeWrapper =
         EnvFactory.getEnv().generateRandomConfigNodeWrapper();
     DataNodeWrapper portConflictDataNodeWrapper =
@@ -325,9 +322,9 @@ public class IoTDBClusterNodeErrorStartUpIT {
       int afterStartConfigNodes;
       for (int i = 0; i < START_RETRY_NUM; ++i) {
         showClusterResp = client.showCluster();
-        Thread.sleep(1000);
         afterStartConfigNodes = showClusterResp.getConfigNodeListSize();
         Assert.assertEquals(beforeStartConfigNodes, afterStartConfigNodes);
+        Thread.sleep(1000);
       }
 
       // set datanode port repeat
@@ -341,9 +338,9 @@ public class IoTDBClusterNodeErrorStartUpIT {
       int afterStartDataNodes;
       for (int i = 0; i < START_RETRY_NUM; ++i) {
         showClusterResp = client.showCluster();
-        Thread.sleep(1000);
         afterStartDataNodes = showClusterResp.getDataNodeListSize();
         Assert.assertEquals(beforeStartDataNodes, afterStartDataNodes);
+        Thread.sleep(1000);
       }
     }
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
@@ -55,7 +55,7 @@ public abstract class StartupChecks {
     Boolean jmxLocal = Boolean.valueOf(System.getProperty(IoTDBConstant.IOTDB_JMX_LOCAL));
     String jmxPort = System.getProperty(IoTDBConstant.IOTDB_JMX_PORT);
 
-    if (Boolean.TRUE.equals(jmxLocal)) {
+    if (jmxLocal) {
       logger.info("Start JMX locally.");
       return;
     }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
@@ -31,7 +31,9 @@ import java.util.List;
 public abstract class StartupChecks {
 
   private static final Logger logger = LoggerFactory.getLogger(StartupChecks.class);
-  public static final StartupCheck checkJDK =
+
+  private final String nodeRole ;
+  private static final StartupCheck checkJDK =
       () -> {
         int version = JVMCommonUtils.getJdkVersion();
         if (version < IoTDBConstant.MIN_SUPPORTED_JDK_VERSION) {
@@ -46,8 +48,7 @@ public abstract class StartupChecks {
   protected final List<StartupCheck> preChecks = new ArrayList<>();
 
   protected StartupChecks(String nodeRole) {
-    preChecks.add(() -> checkJMXPort(nodeRole));
-    preChecks.add(checkJDK);
+    this.nodeRole=nodeRole;
   }
 
   private void checkJMXPort(String nodeRole) {
@@ -75,6 +76,14 @@ public abstract class StartupChecks {
     }
   }
 
+  protected void envCheck(){
+    preChecks.add(() -> checkJMXPort(nodeRole));
+    preChecks.add(checkJDK);
+  }
   /** execute every pretest. */
-  public abstract void verify() throws StartupException;
+  protected void verify() throws StartupException {
+    for (StartupCheck check : preChecks) {
+      check.execute();
+    }
+  }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
@@ -32,7 +32,7 @@ public abstract class StartupChecks {
 
   private static final Logger logger = LoggerFactory.getLogger(StartupChecks.class);
 
-  private final String nodeRole ;
+  private final String nodeRole;
   private static final StartupCheck checkJDK =
       () -> {
         int version = JVMCommonUtils.getJdkVersion();
@@ -48,7 +48,7 @@ public abstract class StartupChecks {
   protected final List<StartupCheck> preChecks = new ArrayList<>();
 
   protected StartupChecks(String nodeRole) {
-    this.nodeRole=nodeRole;
+    this.nodeRole = nodeRole;
   }
 
   private void checkJMXPort(String nodeRole) {
@@ -76,7 +76,7 @@ public abstract class StartupChecks {
     }
   }
 
-  protected void envCheck(){
+  protected void envCheck() {
     preChecks.add(() -> checkJMXPort(nodeRole));
     preChecks.add(checkJDK);
   }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
@@ -52,7 +52,7 @@ public abstract class StartupChecks {
   }
 
   private void checkJMXPort(String nodeRole) {
-    Boolean jmxLocal = Boolean.valueOf(System.getProperty(IoTDBConstant.IOTDB_JMX_LOCAL));
+    boolean jmxLocal = Boolean.parseBoolean(System.getProperty(IoTDBConstant.IOTDB_JMX_LOCAL));
     String jmxPort = System.getProperty(IoTDBConstant.IOTDB_JMX_PORT);
 
     if (jmxLocal) {
@@ -86,4 +86,8 @@ public abstract class StartupChecks {
       check.execute();
     }
   }
+
+  protected abstract void portCheck() throws StartupException;
+
+  protected abstract void startUpCheck() throws Exception;
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
@@ -1,7 +1,6 @@
 package org.apache.iotdb.db.conf;
 
 import org.apache.iotdb.commons.exception.StartupException;
-import org.apache.iotdb.commons.service.StartupCheck;
 import org.apache.iotdb.commons.service.StartupChecks;
 
 import org.slf4j.Logger;
@@ -15,9 +14,9 @@ public class DataNodeStartCheck extends StartupChecks {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeStartCheck.class);
   private final IoTDBConfig config;
 
-  public DataNodeStartCheck(String nodeRole,IoTDBConfig config) {
+  public DataNodeStartCheck(String nodeRole, IoTDBConfig config) {
     super(nodeRole);
-    this.config=config;
+    this.config = config;
   }
 
   private void checkDataNodePortUnique() throws StartupException {
@@ -31,7 +30,7 @@ public class DataNodeStartCheck extends StartupChecks {
     portSet.add(config.getSchemaRegionConsensusPort());
     if (portSet.size() != dataNodePort)
       throw new StartupException("ports used in datanode have repeat.");
-    else{
+    else {
       LOGGER.info("DataNode port check successful.");
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
@@ -53,10 +53,12 @@ public class DataNodeStartCheck extends StartupChecks {
     }
   }
 
+  @Override
   protected void portCheck() {
     preChecks.add(this::checkDataNodePortUnique);
   }
 
+  @Override
   public void startUpCheck() throws StartupException {
     envCheck();
     portCheck();

--- a/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
@@ -1,0 +1,45 @@
+package org.apache.iotdb.db.conf;
+
+import org.apache.iotdb.commons.exception.StartupException;
+import org.apache.iotdb.commons.service.StartupCheck;
+import org.apache.iotdb.commons.service.StartupChecks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** DataNodeStartCheck checks the parameters in iotdb-datanode.properties when start and restart */
+public class DataNodeStartCheck extends StartupChecks {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeStartCheck.class);
+
+  public DataNodeStartCheck(String nodeRole) {
+    super(nodeRole);
+  }
+
+  @Override
+  public void verify() throws StartupException {
+    for (StartupCheck check : preChecks) {
+      check.execute();
+    }
+  }
+
+  private void checkDataNodePortUnique(IoTDBConfig config) throws StartupException {
+    Set<Integer> portSet = new HashSet<>();
+    int dataNodePort = 6;
+    portSet.add(config.getInternalPort());
+    portSet.add(config.getMqttPort());
+    portSet.add(config.getRpcPort());
+    portSet.add(config.getMppDataExchangePort());
+    portSet.add(config.getDataRegionConsensusPort());
+    portSet.add(config.getSchemaRegionConsensusPort());
+    if (portSet.size() == dataNodePort)
+      throw new StartupException("ports used in datanode have repeat");
+  }
+
+  public DataNodeStartCheck withPortCheck(IoTDBConfig config) {
+    preChecks.add(() -> checkDataNodePortUnique(config));
+    return this;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
@@ -31,6 +31,7 @@ import java.util.Set;
 public class DataNodeStartCheck extends StartupChecks {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeStartCheck.class);
   private final IoTDBConfig config;
+  private static final int DATANODE_PORTS = 6;
 
   public DataNodeStartCheck(String nodeRole, IoTDBConfig config) {
     super(nodeRole);
@@ -39,14 +40,13 @@ public class DataNodeStartCheck extends StartupChecks {
 
   private void checkDataNodePortUnique() throws StartupException {
     Set<Integer> portSet = new HashSet<>();
-    int dataNodePort = 6;
     portSet.add(config.getInternalPort());
     portSet.add(config.getMqttPort());
     portSet.add(config.getRpcPort());
     portSet.add(config.getMppDataExchangePort());
     portSet.add(config.getDataRegionConsensusPort());
     portSet.add(config.getSchemaRegionConsensusPort());
-    if (portSet.size() != dataNodePort)
+    if (portSet.size() != DATANODE_PORTS)
       throw new StartupException("ports used in datanode have repeat.");
     else {
       LOGGER.info("DataNode port check successful.");

--- a/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartCheck.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.iotdb.db.conf;
 
 import org.apache.iotdb.commons.exception.StartupException;

--- a/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartupCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/DataNodeStartupCheck.java
@@ -27,13 +27,15 @@ import org.slf4j.LoggerFactory;
 import java.util.HashSet;
 import java.util.Set;
 
-/** DataNodeStartCheck checks the parameters in iotdb-datanode.properties when start and restart */
-public class DataNodeStartCheck extends StartupChecks {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeStartCheck.class);
+/**
+ * DataNodeStartupCheck checks the parameters in iotdb-datanode.properties when start and restart
+ */
+public class DataNodeStartupCheck extends StartupChecks {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeStartupCheck.class);
   private final IoTDBConfig config;
   private static final int DATANODE_PORTS = 6;
 
-  public DataNodeStartCheck(String nodeRole, IoTDBConfig config) {
+  public DataNodeStartupCheck(String nodeRole, IoTDBConfig config) {
     super(nodeRole);
     this.config = config;
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -212,7 +212,7 @@ public class DataNode implements DataNodeMBean {
     thisNode.setPort(config.getInternalPort());
 
     // Startup checks
-    DataNodeStartCheck checks = new DataNodeStartCheck(IoTDBConstant.DN_ROLE,config);
+    DataNodeStartCheck checks = new DataNodeStartCheck(IoTDBConstant.DN_ROLE, config);
     checks.startUpCheck();
     return isFirstStart;
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -33,7 +33,6 @@ import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.commons.file.SystemFileFactory;
 import org.apache.iotdb.commons.service.JMXService;
 import org.apache.iotdb.commons.service.RegisterManager;
-import org.apache.iotdb.commons.service.StartupChecks;
 import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.commons.trigger.TriggerInformation;
 import org.apache.iotdb.commons.trigger.exception.TriggerManagementException;
@@ -54,6 +53,7 @@ import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.db.client.ConfigNodeClient;
 import org.apache.iotdb.db.client.ConfigNodeClientManager;
 import org.apache.iotdb.db.client.ConfigNodeInfo;
+import org.apache.iotdb.db.conf.DataNodeStartCheck;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.IoTDBStartCheck;
@@ -141,7 +141,7 @@ public class DataNode implements DataNodeMBean {
   }
 
   public static void main(String[] args) {
-    logger.info("IoTDB-DataNode environment variables: {}",IoTDBConfig.getEnvironmentVariables());
+    logger.info("IoTDB-DataNode environment variables: {}", IoTDBConfig.getEnvironmentVariables());
     new DataNodeServerCommandLine().doMain(args);
   }
 
@@ -212,7 +212,7 @@ public class DataNode implements DataNodeMBean {
     thisNode.setPort(config.getInternalPort());
 
     // Startup checks
-    StartupChecks checks = new StartupChecks(IoTDBConstant.DN_ROLE).withDefaultTest();
+    DataNodeStartCheck checks = new DataNodeStartCheck(IoTDBConstant.DN_ROLE);
     checks.withPortCheck(config);
     checks.verify();
     return isFirstStart;

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -141,7 +141,7 @@ public class DataNode implements DataNodeMBean {
   }
 
   public static void main(String[] args) {
-    logger.info("IoTDB-DataNode environment variables: " + IoTDBConfig.getEnvironmentVariables());
+    logger.info("IoTDB-DataNode environment variables: {}",IoTDBConfig.getEnvironmentVariables());
     new DataNodeServerCommandLine().doMain(args);
   }
 
@@ -213,8 +213,8 @@ public class DataNode implements DataNodeMBean {
 
     // Startup checks
     StartupChecks checks = new StartupChecks(IoTDBConstant.DN_ROLE).withDefaultTest();
+    checks.withPortCheck(config);
     checks.verify();
-
     return isFirstStart;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -128,7 +128,8 @@ public class DataNode implements DataNodeMBean {
   private final TriggerInformationUpdater triggerInformationUpdater =
       new TriggerInformationUpdater();
 
-  private static final String REGISTER_INTERRUPTION = "Unexpected interruption when waiting to register to the cluster";
+  private static final String REGISTER_INTERRUPTION =
+      "Unexpected interruption when waiting to register to the cluster";
 
   private DataNode() {
     // we do not init anything here, so that we can re-initialize the instance in IT.
@@ -177,10 +178,10 @@ public class DataNode implements DataNodeMBean {
       // Serialize mutable system properties
       IoTDBStartCheck.getInstance().serializeMutableSystemPropertiesIfNecessary();
 
-      logger.info("IoTDB configuration: {}" ,config.getConfigMessage());
+      logger.info("IoTDB configuration: {}", config.getConfigMessage());
       logger.info("Congratulation, IoTDB DataNode is set up successfully. Now, enjoy yourself!");
 
-    } catch (StartupException |  IOException e) {
+    } catch (StartupException | IOException e) {
       logger.error("Fail to start server", e);
       if (isFirstStart) {
         // Delete the system.properties file when first start failed.
@@ -457,7 +458,7 @@ public class DataNode implements DataNodeMBean {
     try {
       processPid();
       setUp();
-    } catch ( StartupException e) {
+    } catch (StartupException e) {
       logger.error("Meet error while starting up.", e);
       throw new StartupException("Error in activating IoTDB DataNode.");
     }

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -53,7 +53,7 @@ import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.db.client.ConfigNodeClient;
 import org.apache.iotdb.db.client.ConfigNodeClientManager;
 import org.apache.iotdb.db.client.ConfigNodeInfo;
-import org.apache.iotdb.db.conf.DataNodeStartCheck;
+import org.apache.iotdb.db.conf.DataNodeStartupCheck;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.IoTDBStartCheck;
@@ -212,7 +212,7 @@ public class DataNode implements DataNodeMBean {
     thisNode.setPort(config.getInternalPort());
 
     // Startup checks
-    DataNodeStartCheck checks = new DataNodeStartCheck(IoTDBConstant.DN_ROLE, config);
+    DataNodeStartupCheck checks = new DataNodeStartupCheck(IoTDBConstant.DN_ROLE, config);
     checks.startUpCheck();
     return isFirstStart;
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -212,9 +212,8 @@ public class DataNode implements DataNodeMBean {
     thisNode.setPort(config.getInternalPort());
 
     // Startup checks
-    DataNodeStartCheck checks = new DataNodeStartCheck(IoTDBConstant.DN_ROLE);
-    checks.withPortCheck(config);
-    checks.verify();
+    DataNodeStartCheck checks = new DataNodeStartCheck(IoTDBConstant.DN_ROLE,config);
+    checks.startUpCheck();
     return isFirstStart;
   }
 


### PR DESCRIPTION
add port check for confignode and datanode to avoid launching node which has same ports
see more information in [IOTDB-5368](https://issues.apache.org/jira/browse/IOTDB-5368)