### PR TITLE
[IOTDB-5659] Fix dead lock condition in shutdown hook

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -116,6 +116,8 @@ public class CommonConfig {
   /** Status of current system. */
   private volatile NodeStatus status = NodeStatus.Running;
 
+  private volatile boolean isStopping = false;
+
   private volatile String statusReason = null;
 
   /** Disk Monitor */
@@ -359,5 +361,13 @@ public class CommonConfig {
 
   public void setTargetMLNodeEndPoint(TEndPoint targetMLNodeEndPoint) {
     this.targetMLNodeEndPoint = targetMLNodeEndPoint;
+  }
+
+  public boolean isStopping() {
+    return isStopping;
+  }
+
+  public void setStopping(boolean stopping) {
+    isStopping = stopping;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -83,7 +83,8 @@ public class DataRegionStateMachine extends BaseStateMachine {
 
   @Override
   public boolean isReadOnly() {
-    return CommonDescriptor.getInstance().getConfig().isReadOnly();
+    return CommonDescriptor.getInstance().getConfig().isReadOnly()
+        && !CommonDescriptor.getInstance().getConfig().isStopping();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -54,6 +54,7 @@ public class IoTDBShutdownHook extends Thread {
     }
 
     // reject write operations to make sure all tsfiles will be sealed
+    CommonDescriptor.getInstance().getConfig().setStopping(true);
     CommonDescriptor.getInstance().getConfig().setNodeStatus(NodeStatus.ReadOnly);
     // wait all wal are flushed
     WALManager.getInstance().waitAllWALFlushed();


### PR DESCRIPTION
Current stop hook produces dead lock situations that prevent the process to terminate.

Ratis waits applyIndex to advance to commitIndex. However, it cannot be done when node is ReadOnly.