### PR TITLE
[To rel/0.13] [IOTDB-5662] Fix BufferedUnderflowException occurs in inner space compaction

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionUtilsNoAlignedTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerSpaceCompactionUtilsNoAlignedTest.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
 /**
@@ -454,6 +455,266 @@ public class InnerSpaceCompactionUtilsNoAlignedTest {
       }
       chunkPagePointsNumMerged.put(deletedPath, null);
       CompactionCheckerUtils.checkChunkAndPage(chunkPagePointsNumMerged, targetResource);
+      Map<PartialPath, List<TimeValuePair>> compactedData =
+          CompactionCheckerUtils.getDataByQuery(
+              paths, schemaList, Collections.singletonList(targetResource), new ArrayList<>());
+      CompactionCheckerUtils.validDataByValueList(originData, compactedData);
+    } finally {
+      IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(originTargetChunkSize);
+      IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(originTargetChunkPointNum);
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setChunkSizeLowerBoundInCompaction(originChunkSizeLowerBound);
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setChunkPointNumLowerBoundInCompaction(originChunkPointNumLowerBound);
+    }
+  }
+
+  @Test
+  public void testMergeChunkWithDifferentEncoding() throws Exception {
+    long testTargetChunkPointNum = 1000L;
+    long originTargetChunkSize = IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
+    long originTargetChunkPointNum =
+        IoTDBDescriptor.getInstance().getConfig().getTargetChunkPointNum();
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(10240);
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(testTargetChunkPointNum);
+    long originChunkSizeLowerBound =
+        IoTDBDescriptor.getInstance().getConfig().getChunkSizeLowerBoundInCompaction();
+    IoTDBDescriptor.getInstance().getConfig().setChunkSizeLowerBoundInCompaction(1);
+    long originChunkPointNumLowerBound =
+        IoTDBDescriptor.getInstance().getConfig().getChunkPointNumLowerBoundInCompaction();
+    IoTDBDescriptor.getInstance().getConfig().setChunkPointNumLowerBoundInCompaction(1);
+    try {
+      List<TsFileResource> sourceFiles = new ArrayList();
+      Set<String> fullPathSetWithDeleted = new HashSet<>(fullPathSet);
+      // we add a deleted timeseries to simulate timeseries is deleted before compaction.
+      String deletedPath = "root.compactionTest.device999.s999";
+      fullPathSetWithDeleted.add(deletedPath);
+      int fileNum = 6;
+      long pointStep = 300L;
+      for (int i = 0; i < fileNum; ++i) {
+        List<List<Long>> chunkPagePointsNum = new ArrayList<>();
+        List<Long> pagePointsNum = new ArrayList<>();
+        pagePointsNum.add((i + 1L) * pointStep);
+        chunkPagePointsNum.add(pagePointsNum);
+        TsFileResource resource =
+            new TsFileResource(new File(SEQ_DIRS, String.format("%d-%d-0-0.tsfile", i + 1, i + 1)));
+        sourceFiles.add(resource);
+        CompactionFileGeneratorUtils.writeTsFile(
+            fullPathSetWithDeleted,
+            chunkPagePointsNum,
+            i * 2000L,
+            resource,
+            i % 2 == 0 ? TSEncoding.PLAIN : TSEncoding.RLE,
+            CompressionType.SNAPPY);
+        Map<String, Pair<Long, Long>> deletionMap = new HashMap<>();
+        deletionMap.put(deletedPath, new Pair<>(i * 2000L, (i + 1) * 2000L));
+        CompactionFileGeneratorUtils.generateMods(deletionMap, resource, false);
+      }
+      Map<PartialPath, List<TimeValuePair>> originData =
+          CompactionCheckerUtils.getDataByQuery(paths, schemaList, sourceFiles, new ArrayList<>());
+      TsFileResource targetResource =
+          TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
+      InnerSpaceCompactionUtils.compact(targetResource, sourceFiles);
+      InnerSpaceCompactionUtils.moveTargetFile(targetResource, "");
+
+      Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
+      // outer list is a chunk, inner list is point num in each page
+      List<List<Long>> chunkPointsArray = new ArrayList<>();
+      List<Long> pointsArray = new ArrayList<>();
+      long curPointNum = 0L;
+      for (int i = 0; i < fileNum; ++i) {
+        curPointNum += (i + 1L) * pointStep;
+        pointsArray.add((i + 1L) * pointStep);
+        if (curPointNum > testTargetChunkPointNum) {
+          chunkPointsArray.add(pointsArray);
+          pointsArray = new ArrayList<>();
+          curPointNum = 0;
+        }
+      }
+      if (curPointNum > 0) {
+        chunkPointsArray.add(pointsArray);
+      }
+      for (String path : fullPathSetWithDeleted) {
+        chunkPagePointsNumMerged.put(path, chunkPointsArray);
+      }
+      chunkPagePointsNumMerged.put(deletedPath, null);
+      Map<PartialPath, List<TimeValuePair>> compactedData =
+          CompactionCheckerUtils.getDataByQuery(
+              paths, schemaList, Collections.singletonList(targetResource), new ArrayList<>());
+      CompactionCheckerUtils.validDataByValueList(originData, compactedData);
+    } finally {
+      IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(originTargetChunkSize);
+      IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(originTargetChunkPointNum);
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setChunkSizeLowerBoundInCompaction(originChunkSizeLowerBound);
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setChunkPointNumLowerBoundInCompaction(originChunkPointNumLowerBound);
+    }
+  }
+
+  @Test
+  public void testMergeChunkWithDifferentCompression() throws Exception {
+    long testTargetChunkPointNum = 1000L;
+    long originTargetChunkSize = IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
+    long originTargetChunkPointNum =
+        IoTDBDescriptor.getInstance().getConfig().getTargetChunkPointNum();
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(10240);
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(testTargetChunkPointNum);
+    long originChunkSizeLowerBound =
+        IoTDBDescriptor.getInstance().getConfig().getChunkSizeLowerBoundInCompaction();
+    IoTDBDescriptor.getInstance().getConfig().setChunkSizeLowerBoundInCompaction(1);
+    long originChunkPointNumLowerBound =
+        IoTDBDescriptor.getInstance().getConfig().getChunkPointNumLowerBoundInCompaction();
+    IoTDBDescriptor.getInstance().getConfig().setChunkPointNumLowerBoundInCompaction(1);
+    try {
+      List<TsFileResource> sourceFiles = new ArrayList();
+      Set<String> fullPathSetWithDeleted = new HashSet<>(fullPathSet);
+      // we add a deleted timeseries to simulate timeseries is deleted before compaction.
+      String deletedPath = "root.compactionTest.device999.s999";
+      fullPathSetWithDeleted.add(deletedPath);
+      int fileNum = 6;
+      long pointStep = 300L;
+      for (int i = 0; i < fileNum; ++i) {
+        List<List<Long>> chunkPagePointsNum = new ArrayList<>();
+        List<Long> pagePointsNum = new ArrayList<>();
+        pagePointsNum.add((i + 1L) * pointStep);
+        chunkPagePointsNum.add(pagePointsNum);
+        TsFileResource resource =
+            new TsFileResource(new File(SEQ_DIRS, String.format("%d-%d-0-0.tsfile", i + 1, i + 1)));
+        sourceFiles.add(resource);
+        CompactionFileGeneratorUtils.writeTsFile(
+            fullPathSetWithDeleted,
+            chunkPagePointsNum,
+            i * 2000L,
+            resource,
+            TSEncoding.PLAIN,
+            i % 2 == 0 ? CompressionType.SNAPPY : CompressionType.GZIP);
+        Map<String, Pair<Long, Long>> deletionMap = new HashMap<>();
+        deletionMap.put(deletedPath, new Pair<>(i * 2000L, (i + 1) * 2000L));
+        CompactionFileGeneratorUtils.generateMods(deletionMap, resource, false);
+      }
+      Map<PartialPath, List<TimeValuePair>> originData =
+          CompactionCheckerUtils.getDataByQuery(paths, schemaList, sourceFiles, new ArrayList<>());
+      TsFileResource targetResource =
+          TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
+      InnerSpaceCompactionUtils.compact(targetResource, sourceFiles);
+      InnerSpaceCompactionUtils.moveTargetFile(targetResource, "");
+
+      Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
+      // outer list is a chunk, inner list is point num in each page
+      List<List<Long>> chunkPointsArray = new ArrayList<>();
+      List<Long> pointsArray = new ArrayList<>();
+      long curPointNum = 0L;
+      for (int i = 0; i < fileNum; ++i) {
+        curPointNum += (i + 1L) * pointStep;
+        pointsArray.add((i + 1L) * pointStep);
+        if (curPointNum > testTargetChunkPointNum) {
+          chunkPointsArray.add(pointsArray);
+          pointsArray = new ArrayList<>();
+          curPointNum = 0;
+        }
+      }
+      if (curPointNum > 0) {
+        chunkPointsArray.add(pointsArray);
+      }
+      for (String path : fullPathSetWithDeleted) {
+        chunkPagePointsNumMerged.put(path, chunkPointsArray);
+      }
+      chunkPagePointsNumMerged.put(deletedPath, null);
+      Map<PartialPath, List<TimeValuePair>> compactedData =
+          CompactionCheckerUtils.getDataByQuery(
+              paths, schemaList, Collections.singletonList(targetResource), new ArrayList<>());
+      CompactionCheckerUtils.validDataByValueList(originData, compactedData);
+    } finally {
+      IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(originTargetChunkSize);
+      IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(originTargetChunkPointNum);
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setChunkSizeLowerBoundInCompaction(originChunkSizeLowerBound);
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setChunkPointNumLowerBoundInCompaction(originChunkPointNumLowerBound);
+    }
+  }
+
+  @Test
+  public void testMergeChunkWithDifferentCompressionAndEncoding() throws Exception {
+    long testTargetChunkPointNum = 1000L;
+    long originTargetChunkSize = IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
+    long originTargetChunkPointNum =
+        IoTDBDescriptor.getInstance().getConfig().getTargetChunkPointNum();
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(10240);
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(testTargetChunkPointNum);
+    long originChunkSizeLowerBound =
+        IoTDBDescriptor.getInstance().getConfig().getChunkSizeLowerBoundInCompaction();
+    IoTDBDescriptor.getInstance().getConfig().setChunkSizeLowerBoundInCompaction(1);
+    long originChunkPointNumLowerBound =
+        IoTDBDescriptor.getInstance().getConfig().getChunkPointNumLowerBoundInCompaction();
+    IoTDBDescriptor.getInstance().getConfig().setChunkPointNumLowerBoundInCompaction(1);
+    try {
+      List<TsFileResource> sourceFiles = new ArrayList();
+      Set<String> fullPathSetWithDeleted = new HashSet<>(fullPathSet);
+      // we add a deleted timeseries to simulate timeseries is deleted before compaction.
+      String deletedPath = "root.compactionTest.device999.s999";
+      fullPathSetWithDeleted.add(deletedPath);
+      int fileNum = 6;
+      long pointStep = 300L;
+      Random random = new Random();
+      for (int i = 0; i < fileNum; ++i) {
+        List<List<Long>> chunkPagePointsNum = new ArrayList<>();
+        List<Long> pagePointsNum = new ArrayList<>();
+        pagePointsNum.add((i + 1L) * pointStep);
+        chunkPagePointsNum.add(pagePointsNum);
+        TsFileResource resource =
+            new TsFileResource(new File(SEQ_DIRS, String.format("%d-%d-0-0.tsfile", i + 1, i + 1)));
+        sourceFiles.add(resource);
+        CompactionFileGeneratorUtils.writeTsFile(
+            fullPathSetWithDeleted,
+            chunkPagePointsNum,
+            i * 2000L,
+            resource,
+            random.nextInt() % 2 == 0
+                ? (random.nextInt() % 5 < 2 ? TSEncoding.RLE : TSEncoding.GORILLA)
+                : TSEncoding.PLAIN,
+            random.nextInt() % 3 == 0
+                ? (random.nextInt() % 5 < 2 ? CompressionType.SNAPPY : CompressionType.LZ4)
+                : CompressionType.GZIP);
+        Map<String, Pair<Long, Long>> deletionMap = new HashMap<>();
+        deletionMap.put(deletedPath, new Pair<>(i * 2000L, (i + 1) * 2000L));
+        CompactionFileGeneratorUtils.generateMods(deletionMap, resource, false);
+      }
+      Map<PartialPath, List<TimeValuePair>> originData =
+          CompactionCheckerUtils.getDataByQuery(paths, schemaList, sourceFiles, new ArrayList<>());
+      TsFileResource targetResource =
+          TsFileNameGenerator.getInnerCompactionTargetFileResource(sourceFiles, true);
+      InnerSpaceCompactionUtils.compact(targetResource, sourceFiles);
+      InnerSpaceCompactionUtils.moveTargetFile(targetResource, "");
+
+      Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
+      // outer list is a chunk, inner list is point num in each page
+      List<List<Long>> chunkPointsArray = new ArrayList<>();
+      List<Long> pointsArray = new ArrayList<>();
+      long curPointNum = 0L;
+      for (int i = 0; i < fileNum; ++i) {
+        curPointNum += (i + 1L) * pointStep;
+        pointsArray.add((i + 1L) * pointStep);
+        if (curPointNum > testTargetChunkPointNum) {
+          chunkPointsArray.add(pointsArray);
+          pointsArray = new ArrayList<>();
+          curPointNum = 0;
+        }
+      }
+      if (curPointNum > 0) {
+        chunkPointsArray.add(pointsArray);
+      }
+      for (String path : fullPathSetWithDeleted) {
+        chunkPagePointsNumMerged.put(path, chunkPointsArray);
+      }
+      chunkPagePointsNumMerged.put(deletedPath, null);
       Map<PartialPath, List<TimeValuePair>> compactedData =
           CompactionCheckerUtils.getDataByQuery(
               paths, schemaList, Collections.singletonList(targetResource), new ArrayList<>());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/recover/SizeTieredCompactionRecoverTest.java
@@ -121,6 +121,7 @@ public class SizeTieredCompactionRecoverTest {
   @Before
   public void setUp() throws Exception {
     IoTDB.metaManager.init();
+    IoTDB.activated = true;
     originDataDirs = config.getDataDirs();
     setDataDirs(testDataDirs);
     if (!new File(SEQ_FILE_DIR).exists()) {
@@ -134,6 +135,7 @@ public class SizeTieredCompactionRecoverTest {
 
   @After
   public void tearDown() throws Exception {
+    IoTDB.activated = false;
     new CompactionConfigRestorer().restoreCompactionConfig();
     setDataDirs(originDataDirs);
     IoTDB.metaManager.clear();


### PR DESCRIPTION
See [IOTDB-5662](https://issues.apache.org/jira/browse/IOTDB-5662).

The reason for this bug is that the encoding type of chunks that merged together is different with each other.