### PR TITLE
[IOTDB-5667] Fix compaction scheduler strategy issue

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionTaskManager.java
@@ -221,8 +221,7 @@ public class CompactionTaskManager implements IService {
       throws InterruptedException {
     if (init
         && !candidateCompactionTaskQueue.contains(compactionTask)
-        && !isTaskRunning(compactionTask)
-        && candidateCompactionTaskQueue.size() < config.getCandidateCompactionTaskQueueSize()) {
+        && !isTaskRunning(compactionTask)) {
       compactionTask.setSourceFilesToCompactionCandidate();
       candidateCompactionTaskQueue.put(compactionTask);
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
@@ -208,10 +208,7 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
 
   private boolean canSubmitCrossTask(
       List<TsFileResource> sequenceFileList, List<TsFileResource> unsequenceFileList) {
-    return CompactionTaskManager.getInstance().getCompactionCandidateTaskCount()
-            < config.getCandidateCompactionTaskQueueSize()
-        && !sequenceFileList.isEmpty()
-        && !unsequenceFileList.isEmpty();
+    return !sequenceFileList.isEmpty() && !unsequenceFileList.isEmpty();
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/SizeTieredCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/SizeTieredCompactionSelector.java
@@ -107,9 +107,7 @@ public class SizeTieredCompactionSelector
       if (currentName.getInnerCompactionCnt() != level) {
         // meet files of another level
         if (selectedFileList.size() > 1) {
-          if (!addOneTaskToQueue(taskPriorityQueue, selectedFileList, selectedFileSize)) {
-            return false;
-          }
+          taskPriorityQueue.add(new Pair<>(new ArrayList<>(selectedFileList), selectedFileSize));
           shouldContinueToSearch = false;
         }
         selectedFileList = new ArrayList<>();
@@ -134,9 +132,7 @@ public class SizeTieredCompactionSelector
           || selectedFileList.size() >= config.getMaxInnerCompactionCandidateFileNum()) {
         // submit the task
         if (selectedFileList.size() > 1) {
-          if (!addOneTaskToQueue(taskPriorityQueue, selectedFileList, selectedFileSize)) {
-            return false;
-          }
+          taskPriorityQueue.add(new Pair<>(new ArrayList<>(selectedFileList), selectedFileSize));
           shouldContinueToSearch = false;
         }
         selectedFileList = new ArrayList<>();
@@ -147,23 +143,10 @@ public class SizeTieredCompactionSelector
     // if next time partition exists
     // submit a merge task even it does not meet the requirement for file num or file size
     if (hasNextTimePartition && selectedFileList.size() > 1) {
-      addOneTaskToQueue(taskPriorityQueue, selectedFileList, selectedFileSize);
+      taskPriorityQueue.add(new Pair<>(new ArrayList<>(selectedFileList), selectedFileSize));
       shouldContinueToSearch = false;
     }
     return shouldContinueToSearch;
-  }
-
-  private boolean addOneTaskToQueue(
-      PriorityQueue<Pair<List<TsFileResource>, Long>> taskPriorityQueue,
-      List<TsFileResource> selectedFileList,
-      long selectedFileSize) {
-    if (CompactionTaskManager.getInstance().getCompactionCandidateTaskCount()
-            + taskPriorityQueue.size()
-        < config.getCandidateCompactionTaskQueueSize()) {
-      taskPriorityQueue.add(new Pair<>(new ArrayList<>(selectedFileList), selectedFileSize));
-      return true;
-    }
-    return false;
   }
 
   /**
@@ -223,9 +206,11 @@ public class SizeTieredCompactionSelector
         TsFileNameGenerator.TsFileName fileNameOfO2 =
             TsFileNameGenerator.getTsFileName(resourceOfO2.getTsFile().getName());
         if (fileNameOfO1.getInnerCompactionCnt() != fileNameOfO2.getInnerCompactionCnt()) {
+          // the higher the inner compaction count, the higher the priority is
           return fileNameOfO2.getInnerCompactionCnt() - fileNameOfO1.getInnerCompactionCnt();
         }
-        return (int) (fileNameOfO1.getVersion() - fileNameOfO2.getVersion());
+        // the larger the version number, the higher the priority is
+        return (int) (fileNameOfO2.getVersion() - fileNameOfO1.getVersion());
       } catch (IOException e) {
         return 0;
       }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionSchedulerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/InnerCompactionSchedulerTest.java
@@ -94,7 +94,7 @@ public class InnerCompactionSchedulerTest extends AbstractCompactionTest {
     TsFileManager tsFileManager = new TsFileManager("testSG", "0", "tmp");
     tsFileManager.addAll(seqResources, true);
 
-    CompactionScheduler.tryToSubmitInnerSpaceCompactionTask(tsFileManager, 0L);
+    CompactionScheduler.tryToSubmitInnerSpaceCompactionTask(tsFileManager, 0L, true);
     try {
       Thread.sleep(5000);
     } catch (Exception e) {
@@ -115,7 +115,7 @@ public class InnerCompactionSchedulerTest extends AbstractCompactionTest {
     seqResources.get(0).setStatus(TsFileResourceStatus.COMPACTING);
     TsFileManager tsFileManager = new TsFileManager("testSG", "0", "tmp");
     tsFileManager.addAll(seqResources, true);
-    CompactionScheduler.tryToSubmitInnerSpaceCompactionTask(tsFileManager, 0L);
+    CompactionScheduler.tryToSubmitInnerSpaceCompactionTask(tsFileManager, 0L, true);
 
     long waitingTime = 0;
     while (CompactionTaskManager.getInstance().getExecutingTaskCount() != 0) {
@@ -144,7 +144,7 @@ public class InnerCompactionSchedulerTest extends AbstractCompactionTest {
     seqResources.get(3).setStatus(TsFileResourceStatus.UNCLOSED);
     TsFileManager tsFileManager = new TsFileManager("testSG", "0", "tmp");
     tsFileManager.addAll(seqResources, true);
-    CompactionScheduler.tryToSubmitInnerSpaceCompactionTask(tsFileManager, 0L);
+    CompactionScheduler.tryToSubmitInnerSpaceCompactionTask(tsFileManager, 0L, true);
     long waitingTime = 0;
     while (CompactionTaskManager.getInstance().getExecutingTaskCount() != 0) {
       try {


### PR DESCRIPTION
When the queue is full, tasks are allowed to be submitted and the task with the lowest priority is polled out.