### PR TITLE
[To rel/1.1] [IOTDB-5671] Fix inode cannot be released after deletion causing waste of disk space

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
@@ -20,7 +20,6 @@ package org.apache.iotdb.db.engine.compaction.execute.utils.executor.readchunk;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.TsFileMetricManager;
-import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.schedule.constant.CompactionType;
@@ -115,7 +114,7 @@ public class AlignedSeriesCompactionExecutor {
             continue;
           }
           measurementSet.add(chunkMetadata.getMeasurementUid());
-          Chunk chunk = ChunkCache.getInstance().get((ChunkMetadata) chunkMetadata);
+          Chunk chunk = reader.readMemChunk((ChunkMetadata) chunkMetadata);
           ChunkHeader header = chunk.getHeader();
           schemaSet.add(
               new MeasurementSchema(


### PR DESCRIPTION
See [IOTDB-5671](https://issues.apache.org/jira/browse/IOTDB-5671).

The reason is `AlignedSeriesCompactionExecutor` load chunk from chunk cache, but doesn't manage the reference count of file reader in `FileReaderManager`, thus the reader manager will not close the reader and release the fd after compaction is finished.