### PR TITLE
[To rel/1.1] [IOTDB-5676] Improve ConfigurationException description and analyzing of cluster parameters

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -60,27 +60,40 @@ public class ConfigNodeStartupCheck {
       throw new ConfigurationException(
           IoTDBConstant.CN_TARGET_CONFIG_NODE_LIST,
           CONF.getTargetConfigNode().getIp() + ":" + CONF.getTargetConfigNode().getPort(),
-          CONF.getInternalAddress() + ":" + CONF.getInternalPort());
+          CONF.getInternalAddress() + ":" + CONF.getInternalPort(),
+          "the config_node_consensus_protocol_class is set to" + ConsensusFactory.SIMPLE_CONSENSUS);
     }
 
-    // When the data region consensus protocol is set to SIMPLE_CONSENSUS,
-    // the data replication factor must be 1
-    if (CONF.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.SIMPLE_CONSENSUS)
-        && CONF.getDataReplicationFactor() != 1) {
-      throw new ConfigurationException(
-          "data_replication_factor",
-          String.valueOf(CONF.getDataReplicationFactor()),
-          String.valueOf(1));
+    // The replication factor should be positive
+    if (CONF.getSchemaReplicationFactor() <= 0) {
+      throw new ConfigurationException("The schema_replication_factor should be positive");
+    }
+    if (CONF.getDataReplicationFactor() <= 0) {
+      throw new ConfigurationException("The data_replication_factor should be positive");
     }
 
-    // When the schema region consensus protocol is set to SIMPLE_CONSENSUS,
-    // the schema replication factor must be 1
-    if (CONF.getSchemaRegionConsensusProtocolClass().equals(ConsensusFactory.SIMPLE_CONSENSUS)
-        && CONF.getSchemaReplicationFactor() != 1) {
+    // When the schema_replication_factor is greater than 1
+    // the schema_region_consensus_protocol can't be set to SIMPLE_CONSENSUS
+    if (CONF.getSchemaReplicationFactor() > 1
+        && ConsensusFactory.SIMPLE_CONSENSUS.equals(CONF.getSchemaRegionConsensusProtocolClass())) {
       throw new ConfigurationException(
-          "schema_replication_factor",
-          String.valueOf(CONF.getSchemaReplicationFactor()),
-          String.valueOf(1));
+          "schema_region_consensus_protocol_class",
+          CONF.getSchemaRegionConsensusProtocolClass(),
+          ConsensusFactory.RATIS_CONSENSUS,
+          ConsensusFactory.SIMPLE_CONSENSUS
+              + "available only when schema_replication_factor is set to 1");
+    }
+
+    // When the data_replication_factor is greater than 1
+    // the data_region_consensus_protocol can't be set to SIMPLE_CONSENSUS
+    if (CONF.getDataReplicationFactor() > 1
+        && ConsensusFactory.SIMPLE_CONSENSUS.equals(CONF.getDataRegionConsensusProtocolClass())) {
+      throw new ConfigurationException(
+          "data_region_consensus_protocol_class",
+          CONF.getDataRegionConsensusProtocolClass(),
+          ConsensusFactory.IOT_CONSENSUS + "or" + ConsensusFactory.RATIS_CONSENSUS,
+          ConsensusFactory.SIMPLE_CONSENSUS
+              + "available only when data_replication_factor is set to 1");
     }
 
     // When the schema region consensus protocol is set to IoTConsensus,
@@ -90,21 +103,28 @@ public class ConfigNodeStartupCheck {
           "schema_region_consensus_protocol_class",
           String.valueOf(CONF.getSchemaRegionConsensusProtocolClass()),
           String.format(
-              "%s or %s", ConsensusFactory.SIMPLE_CONSENSUS, ConsensusFactory.RATIS_CONSENSUS));
+              "%s or %s", ConsensusFactory.SIMPLE_CONSENSUS, ConsensusFactory.RATIS_CONSENSUS),
+          "the SchemaRegion doesn't support org.apache.iotdb.consensus.iot.IoTConsensus");
     }
 
     // The leader distribution policy is limited
     if (!ILeaderBalancer.GREEDY_POLICY.equals(CONF.getLeaderDistributionPolicy())
         && !ILeaderBalancer.MIN_COST_FLOW_POLICY.equals(CONF.getLeaderDistributionPolicy())) {
       throw new ConfigurationException(
-          "leader_distribution_policy", CONF.getRoutePriorityPolicy(), "GREEDY or MIN_COST_FLOW");
+          "leader_distribution_policy",
+          CONF.getRoutePriorityPolicy(),
+          "GREEDY or MIN_COST_FLOW",
+          "an unrecognized leader_distribution_policy is set");
     }
 
     // The route priority policy is limited
     if (!CONF.getRoutePriorityPolicy().equals(IPriorityBalancer.LEADER_POLICY)
         && !CONF.getRoutePriorityPolicy().equals(IPriorityBalancer.GREEDY_POLICY)) {
       throw new ConfigurationException(
-          "route_priority_policy", CONF.getRoutePriorityPolicy(), "LEADER or GREEDY");
+          "route_priority_policy",
+          CONF.getRoutePriorityPolicy(),
+          "LEADER or GREEDY",
+          "an unrecognized route_priority_policy is set");
     }
 
     // The ip of target ConfigNode couldn't be 0.0.0.0
@@ -113,7 +133,7 @@ public class ConfigNodeStartupCheck {
           "The ip address of any target_config_node_list couldn't be 0.0.0.0");
     }
 
-    // The least RegionGroupNum should be positive
+    // The default RegionGroupNum should be positive
     if (CONF.getDefaultSchemaRegionGroupNumPerDatabase() <= 0) {
       throw new ConfigurationException("The default_schema_region_group_num should be positive");
     }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
@@ -73,7 +73,11 @@ public class SystemPropertiesUtils {
     // Startup configuration
     String clusterName = systemProperties.getProperty(CLUSTER_NAME, null);
     if (clusterName != null && !clusterName.equals(conf.getClusterName())) {
-      throw new ConfigurationException(CLUSTER_NAME, conf.getClusterName(), clusterName);
+      throw new ConfigurationException(
+          CLUSTER_NAME,
+          conf.getClusterName(),
+          clusterName,
+          "cluster_name can't be modified after first startup");
     }
 
     String internalAddress = systemProperties.getProperty("cn_internal_address", null);
@@ -81,7 +85,10 @@ public class SystemPropertiesUtils {
       needReWrite = true;
     } else if (!internalAddress.equals(conf.getInternalAddress())) {
       throw new ConfigurationException(
-          "cn_internal_address", conf.getInternalAddress(), internalAddress);
+          "cn_internal_address",
+          conf.getInternalAddress(),
+          internalAddress,
+          "cn_internal_address can't be modified after first startup");
     }
 
     if (systemProperties.getProperty("cn_internal_port", null) == null) {
@@ -92,7 +99,8 @@ public class SystemPropertiesUtils {
         throw new ConfigurationException(
             "cn_internal_port",
             String.valueOf(conf.getInternalPort()),
-            String.valueOf(internalPort));
+            String.valueOf(internalPort),
+            "cn_internal_port can't be modified after first startup");
       }
     }
 
@@ -104,7 +112,8 @@ public class SystemPropertiesUtils {
         throw new ConfigurationException(
             "cn_consensus_port",
             String.valueOf(conf.getConsensusPort()),
-            String.valueOf(consensusPort));
+            String.valueOf(consensusPort),
+            "cn_consensus_port can't be modified after first startup");
       }
     }
 
@@ -118,7 +127,8 @@ public class SystemPropertiesUtils {
       throw new ConfigurationException(
           "config_node_consensus_protocol_class",
           conf.getConfigNodeConsensusProtocolClass(),
-          configNodeConsensusProtocolClass);
+          configNodeConsensusProtocolClass,
+          "config_node_consensus_protocol_class can't be modified after first startup");
     }
 
     String dataRegionConsensusProtocolClass =
@@ -130,7 +140,8 @@ public class SystemPropertiesUtils {
       throw new ConfigurationException(
           "data_region_consensus_protocol_class",
           conf.getDataRegionConsensusProtocolClass(),
-          dataRegionConsensusProtocolClass);
+          dataRegionConsensusProtocolClass,
+          "data_region_consensus_protocol_class can't be modified after first startup");
     }
 
     String schemaRegionConsensusProtocolClass =
@@ -142,7 +153,8 @@ public class SystemPropertiesUtils {
       throw new ConfigurationException(
           "schema_region_consensus_protocol_class",
           conf.getSchemaRegionConsensusProtocolClass(),
-          schemaRegionConsensusProtocolClass);
+          schemaRegionConsensusProtocolClass,
+          "schema_region_consensus_protocol_class can't be modified after first startup");
     }
 
     // PartitionSlot configuration
@@ -155,7 +167,8 @@ public class SystemPropertiesUtils {
         throw new ConfigurationException(
             "series_partition_slot_num",
             String.valueOf(conf.getSeriesSlotNum()),
-            String.valueOf(seriesPartitionSlotNum));
+            String.valueOf(seriesPartitionSlotNum),
+            "series_partition_slot_num can't be modified after first startup");
       }
     }
 
@@ -168,7 +181,8 @@ public class SystemPropertiesUtils {
       throw new ConfigurationException(
           "series_partition_executor_class",
           conf.getSeriesPartitionExecutorClass(),
-          seriesPartitionSlotExecutorClass);
+          seriesPartitionSlotExecutorClass,
+          "series_partition_executor_class can't be modified after first startup");
     }
 
     if (needReWrite) {

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -32,7 +32,7 @@ cluster_name=defaultCluster
 # This parameter is unmodifiable after ConfigNode starts for the first time.
 # These consensus protocols are currently supported:
 # 1. org.apache.iotdb.consensus.ratis.RatisConsensus
-# 2. org.apache.iotdb.consensus.simple.SimpleConsensus
+# 2. org.apache.iotdb.consensus.simple.SimpleConsensus   (Only 1 ConfigNode can be deployed)
 # Datatype: string
 # config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 
@@ -45,7 +45,7 @@ cluster_name=defaultCluster
 # This parameter is unmodifiable after ConfigNode starts for the first time.
 # These consensus protocols are currently supported:
 # 1. org.apache.iotdb.consensus.ratis.RatisConsensus
-# 2. org.apache.iotdb.consensus.simple.SimpleConsensus
+# 2. org.apache.iotdb.consensus.simple.SimpleConsensus   (The schema_replication_factor can only be set to 1)
 # Datatype: string
 # schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 
@@ -57,7 +57,7 @@ cluster_name=defaultCluster
 # DataRegion consensus protocol type.
 # This parameter is unmodifiable after ConfigNode starts for the first time.
 # These consensus protocols are currently supported:
-# 1. org.apache.iotdb.consensus.simple.SimpleConsensus
+# 1. org.apache.iotdb.consensus.simple.SimpleConsensus   (The data_replication_factor can only be set to 1)
 # 2. org.apache.iotdb.consensus.iot.IoTConsensus
 # 3. org.apache.iotdb.consensus.ratis.RatisConsensus
 # Datatype: string

--- a/node-commons/src/main/java/org/apache/iotdb/commons/exception/ConfigurationException.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/exception/ConfigurationException.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.commons.exception;
 
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 public class ConfigurationException extends IoTDBException {
@@ -26,37 +27,35 @@ public class ConfigurationException extends IoTDBException {
   private String correctValue;
 
   /**
+   * Notice: The error reason should always be set for ease of use.
+   *
    * @param parameter The error parameter
    * @param badValue The bad value
    * @param correctValue The correct value (if it could be listed)
+   * @param reason The reason why lead to the exception
    */
-  public ConfigurationException(String parameter, String badValue, String correctValue) {
+  public ConfigurationException(
+      String parameter, String badValue, String correctValue, String reason) {
     super(
         String.format(
-            "Parameter %s can not be %s, please set to: %s", parameter, badValue, correctValue),
+            "Parameter %s can not be %s, please set to: %s. Because %s",
+            parameter, badValue, correctValue, reason),
         TSStatusCode.CONFIGURATION_ERROR.getStatusCode());
     this.parameter = parameter;
     this.correctValue = correctValue;
   }
 
-  /**
-   * @param parameter The error parameter
-   * @param badValue The bad value
-   */
-  public ConfigurationException(String parameter, String badValue) {
-    super(
-        String.format("Parameter %s can not be %s", parameter, badValue),
-        TSStatusCode.CONFIGURATION_ERROR.getStatusCode());
+  /** Notice: The error reason should always be set for ease of use. */
+  public ConfigurationException(String reason) {
+    super(reason, TSStatusCode.CONFIGURATION_ERROR.getStatusCode());
   }
 
-  public ConfigurationException(String errorStr) {
-    super(errorStr, TSStatusCode.CONFIGURATION_ERROR.getStatusCode());
-  }
-
+  @TestOnly
   public String getParameter() {
     return parameter;
   }
 
+  @TestOnly
   public String getCorrectValue() {
     return correctValue;
   }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1798,6 +1798,7 @@ public class IoTDBDescriptor {
     String configNodeUrls = properties.getProperty(IoTDBConstant.DN_TARGET_CONFIG_NODE_LIST);
     if (configNodeUrls != null) {
       try {
+        configNodeUrls = configNodeUrls.trim();
         conf.setTargetConfigNodeList(NodeUrlUtils.parseTEndPointUrls(configNodeUrls));
       } catch (BadNodeUrlException e) {
         logger.error(
@@ -1806,29 +1807,39 @@ public class IoTDBDescriptor {
     }
 
     conf.setInternalAddress(
-        properties.getProperty(IoTDBConstant.DN_INTERNAL_ADDRESS, conf.getInternalAddress()));
+        properties
+            .getProperty(IoTDBConstant.DN_INTERNAL_ADDRESS, conf.getInternalAddress())
+            .trim());
 
     conf.setInternalPort(
         Integer.parseInt(
-            properties.getProperty(
-                IoTDBConstant.DN_INTERNAL_PORT, Integer.toString(conf.getInternalPort()))));
+            properties
+                .getProperty(
+                    IoTDBConstant.DN_INTERNAL_PORT, Integer.toString(conf.getInternalPort()))
+                .trim()));
 
     conf.setDataRegionConsensusPort(
         Integer.parseInt(
-            properties.getProperty(
-                "dn_data_region_consensus_port",
-                Integer.toString(conf.getDataRegionConsensusPort()))));
+            properties
+                .getProperty(
+                    "dn_data_region_consensus_port",
+                    Integer.toString(conf.getDataRegionConsensusPort()))
+                .trim()));
 
     conf.setSchemaRegionConsensusPort(
         Integer.parseInt(
-            properties.getProperty(
-                "dn_schema_region_consensus_port",
-                Integer.toString(conf.getSchemaRegionConsensusPort()))));
+            properties
+                .getProperty(
+                    "dn_schema_region_consensus_port",
+                    Integer.toString(conf.getSchemaRegionConsensusPort()))
+                .trim()));
     conf.setJoinClusterRetryIntervalMs(
         Long.parseLong(
-            properties.getProperty(
-                "dn_join_cluster_retry_interval_ms",
-                Long.toString(conf.getJoinClusterRetryIntervalMs()))));
+            properties
+                .getProperty(
+                    "dn_join_cluster_retry_interval_ms",
+                    Long.toString(conf.getJoinClusterRetryIntervalMs()))
+                .trim()));
   }
 
   public void loadShuffleProps(Properties properties) {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -449,7 +449,10 @@ public class IoTDBStartCheck {
 
   private void throwException(String parameter, Object badValue) throws ConfigurationException {
     throw new ConfigurationException(
-        parameter, String.valueOf(badValue), properties.getProperty(parameter));
+        parameter,
+        String.valueOf(badValue),
+        properties.getProperty(parameter),
+        parameter + "can't be modified after first startup");
   }
 
   // reload properties from system.properties


### PR DESCRIPTION
Improvement:

1. The ConfigurationException must point out reason before thrown
2. Add .trim() for cluster parameters' analyzing