### PR TITLE
[IOTDB-5671] Fix inode cannot be released after deletion causing waste of disk space

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iotdb.db.engine.compaction.execute.utils.executor.readchunk;
 
+import com.google.common.util.concurrent.RateLimiter;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.TsFileMetricManager;
-import org.apache.iotdb.db.engine.cache.ChunkCache;
 import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.schedule.constant.CompactionType;
@@ -42,8 +42,6 @@ import org.apache.iotdb.tsfile.write.chunk.AlignedChunkWriterImpl;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
-
-import com.google.common.util.concurrent.RateLimiter;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -115,7 +113,7 @@ public class AlignedSeriesCompactionExecutor {
             continue;
           }
           measurementSet.add(chunkMetadata.getMeasurementUid());
-          Chunk chunk = ChunkCache.getInstance().get((ChunkMetadata) chunkMetadata);
+          Chunk chunk = reader.readMemChunk((ChunkMetadata) chunkMetadata);
           ChunkHeader header = chunk.getHeader();
           schemaSet.add(
               new MeasurementSchema(


### PR DESCRIPTION
See [IOTDB-5671](https://issues.apache.org/jira/browse/IOTDB-5671).

The reason is `AlignedSeriesCompactionExecutor` load chunk from chunk cache, but doesn't manage the reference count of file reader in `FileReaderManager`, thus the reader manager will not close the reader and release the fd after compaction is finished.