### PR TITLE
[To rel/1.1][IOTDB-5684] Standardize log folder of ConfigNode's Simple consensus protocol

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -90,7 +90,7 @@ public class ConsensusManager {
                   ConsensusConfig.newBuilder()
                       .setThisNode(
                           new TEndPoint(CONF.getInternalAddress(), CONF.getConsensusPort()))
-                      .setStorageDir("target" + java.io.File.separator + "simple")
+                      .setStorageDir(CONF.getConsensusDir())
                       .setConsensusGroupType(TConsensusGroupType.ConfigRegion)
                       .build(),
                   gid -> stateMachine)


### PR DESCRIPTION
Now the Simple consensus protocol of ConfigNode willl use the same folder as Ratis consensus protocol