### PR TITLE
[To rel/1.1][IOTDB-5685] Fix error msg of failing to create a timeseries on an existing path when ReadOnly state

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.mpp.execution.executor;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.consensus.DataRegionId;
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
@@ -146,6 +147,16 @@ public class RegionWriteExecutor {
     @Override
     public RegionExecutionResult visitPlan(PlanNode node, WritePlanNodeExecutionContext context) {
       RegionExecutionResult response = new RegionExecutionResult();
+
+      if (CommonDescriptor.getInstance().getConfig().isReadOnly()) {
+        response.setAccepted(false);
+        response.setMessage("Fail to do non-query operations because system is read-only.");
+        response.setStatus(
+            RpcUtils.getStatus(
+                TSStatusCode.SYSTEM_READ_ONLY,
+                "Fail to do non-query operations because system is read-only."));
+        return response;
+      }
 
       ConsensusWriteResponse writeResponse =
           executePlanNodeInConsensusLayer(context.getRegionId(), node);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
@@ -161,7 +161,9 @@ public class RegionWriteExecutor {
             writeResponse.getException());
         response.setAccepted(false);
         response.setMessage(writeResponse.getException().toString());
-        response.setStatus(RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR));
+        response.setStatus(
+            RpcUtils.getStatus(
+                TSStatusCode.EXECUTE_STATEMENT_ERROR, writeResponse.getErrorMessage()));
       }
       return response;
     }


### PR DESCRIPTION
## Description

The error msg thrown from consensus layer was not correctly returned to client. Fix it.

```
IoTDB> set system to readonly
Msg: The statement is executed successfully.
IoTDB> create timeseries root.db2.device2.s3 int32
Msg: 600: Fail to do non-query operations because system is read-only.
```
