### PR TITLE
[IOTDB-5695] Ensures backward compatibility between 1.0 and 1.1 for ConfigNode when using SimpleConsensus

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
 import org.apache.iotdb.confignode.exception.physical.UnknownPhysicalPlanTypeException;
 import org.apache.iotdb.confignode.manager.ConfigManager;
+import org.apache.iotdb.confignode.manager.consensus.ConsensusManager;
 import org.apache.iotdb.confignode.persistence.executor.ConfigPlanExecutor;
 import org.apache.iotdb.confignode.writelog.io.SingleFileLogReader;
 import org.apache.iotdb.consensus.ConsensusFactory;
@@ -76,7 +77,7 @@ public class ConfigRegionStateMachine
   private int endIndex;
 
   private static final String CURRENT_FILE_DIR =
-      CONF.getConsensusDir() + File.separator + "simple" + File.separator + "current";
+      ConsensusManager.getConfigRegionDir() + File.separator + "current";
   private static final String PROGRESS_FILE_PATH =
       CURRENT_FILE_DIR + File.separator + "log_inprogress_";
   private static final String FILE_PATH = CURRENT_FILE_DIR + File.separator + "log_";

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -47,6 +47,7 @@ import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,10 +62,11 @@ public class ConsensusManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusManager.class);
   private static final ConfigNodeConfig CONF = ConfigNodeDescriptor.getInstance().getConf();
   private static final int SEED_CONFIG_NODE_ID = 0;
+  /** There is only one ConfigNodeGroup */
+  public static final ConsensusGroupId DEFAULT_CONSENSUS_GROUP_ID =
+      new ConfigRegionId(CONF.getConfigRegionId());;
 
   private final IManager configManager;
-
-  private ConsensusGroupId consensusGroupId;
   private IConsensus consensusImpl;
 
   public ConsensusManager(IManager configManager, ConfigRegionStateMachine stateMachine)
@@ -79,10 +81,9 @@ public class ConsensusManager {
 
   /** ConsensusLayer local implementation. */
   private void setConsensusLayer(ConfigRegionStateMachine stateMachine) throws IOException {
-    // There is only one ConfigNodeGroup
-    consensusGroupId = new ConfigRegionId(CONF.getConfigRegionId());
 
     if (SIMPLE_CONSENSUS.equals(CONF.getConfigNodeConsensusProtocolClass())) {
+      upgrade();
       consensusImpl =
           ConsensusFactory.getConsensusImpl(
                   SIMPLE_CONSENSUS,
@@ -214,6 +215,25 @@ public class ConsensusManager {
   }
 
   /**
+   * In version 1.1, we fixed a 1.0 SimpleConsensus bug that incorrectly set the consensus
+   * directory. For backward compatibility, we added this function, which we may remove in version
+   * 2.x
+   */
+  private void upgrade() {
+    File consensusDir = new File(CONF.getConsensusDir());
+    if (consensusDir.exists()) {
+      File oldWalDir = new File(consensusDir, "simple");
+      if (oldWalDir.exists()) {
+        if (!oldWalDir.renameTo(new File(getConfigRegionDir()))) {
+          LOGGER.warn(
+              "upgrade ConfigNode consensus wal dir for SimpleConsensus from version/1.0 to version/1.1 failed, "
+                  + "you maybe need to rename the simple dir to 0_0 manually.");
+        }
+      }
+    }
+  }
+
+  /**
    * Create peer in new node to build consensus group.
    *
    * @param configNodeLocations All registered ConfigNodes
@@ -225,11 +245,11 @@ public class ConsensusManager {
     for (TConfigNodeLocation configNodeLocation : configNodeLocations) {
       peerList.add(
           new Peer(
-              consensusGroupId,
+              DEFAULT_CONSENSUS_GROUP_ID,
               configNodeLocation.getConfigNodeId(),
               configNodeLocation.getConsensusEndPoint()));
     }
-    consensusImpl.createPeer(consensusGroupId, peerList);
+    consensusImpl.createPeer(DEFAULT_CONSENSUS_GROUP_ID, peerList);
   }
 
   /**
@@ -242,9 +262,9 @@ public class ConsensusManager {
     boolean result =
         consensusImpl
             .addPeer(
-                consensusGroupId,
+                DEFAULT_CONSENSUS_GROUP_ID,
                 new Peer(
-                    consensusGroupId,
+                    DEFAULT_CONSENSUS_GROUP_ID,
                     configNodeLocation.getConfigNodeId(),
                     configNodeLocation.getConsensusEndPoint()))
             .isSuccess();
@@ -264,9 +284,9 @@ public class ConsensusManager {
   public boolean removeConfigNodePeer(TConfigNodeLocation configNodeLocation) {
     return consensusImpl
         .removePeer(
-            consensusGroupId,
+            DEFAULT_CONSENSUS_GROUP_ID,
             new Peer(
-                consensusGroupId,
+                DEFAULT_CONSENSUS_GROUP_ID,
                 configNodeLocation.getConfigNodeId(),
                 configNodeLocation.getConsensusEndPoint()))
         .isSuccess();
@@ -274,22 +294,22 @@ public class ConsensusManager {
 
   /** Transmit PhysicalPlan to confignode.consensus.statemachine */
   public ConsensusWriteResponse write(ConfigPhysicalPlan plan) {
-    return consensusImpl.write(consensusGroupId, plan);
+    return consensusImpl.write(DEFAULT_CONSENSUS_GROUP_ID, plan);
   }
 
   /** Transmit PhysicalPlan to confignode.consensus.statemachine */
   public ConsensusReadResponse read(ConfigPhysicalPlan plan) {
-    return consensusImpl.read(consensusGroupId, plan);
+    return consensusImpl.read(DEFAULT_CONSENSUS_GROUP_ID, plan);
   }
 
   public boolean isLeader() {
-    return consensusImpl.isLeader(consensusGroupId);
+    return consensusImpl.isLeader(DEFAULT_CONSENSUS_GROUP_ID);
   }
 
   /** @return ConfigNode-leader's location if leader exists, null otherwise. */
   public TConfigNodeLocation getLeader() {
     for (int retry = 0; retry < 50; retry++) {
-      Peer leaderPeer = consensusImpl.getLeader(consensusGroupId);
+      Peer leaderPeer = consensusImpl.getLeader(DEFAULT_CONSENSUS_GROUP_ID);
       if (leaderPeer != null) {
         List<TConfigNodeLocation> registeredConfigNodes =
             getNodeManager().getRegisteredConfigNodes();
@@ -338,7 +358,15 @@ public class ConsensusManager {
   }
 
   public ConsensusGroupId getConsensusGroupId() {
-    return consensusGroupId;
+    return DEFAULT_CONSENSUS_GROUP_ID;
+  }
+
+  public static String getConfigRegionDir() {
+    return CONF.getConsensusDir()
+        + File.separator
+        + ConsensusManager.DEFAULT_CONSENSUS_GROUP_ID.getType().getValue()
+        + "_"
+        + ConsensusManager.DEFAULT_CONSENSUS_GROUP_ID.getId();
   }
 
   public IConsensus getConsensusImpl() {


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/IOTDB-5695)