### PR TITLE
chore: remove unused methods

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -61,7 +61,7 @@ public class SnapshotStorage implements StateMachineStorage {
   @Override
   public void init(RaftStorage raftStorage) throws IOException {
     this.stateMachineDir =
-        Optional.ofNullable(getSnapshotDir())
+        Optional.ofNullable(applicationStateMachine.getSnapshotRoot())
             .orElse(raftStorage.getStorageDir().getStateMachineDir());
 
     if (!stateMachineDir.exists()) {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -191,16 +191,4 @@ public class SnapshotStorage implements StateMachineStorage {
   String getSnapshotTmpId(String snapshotMetadata) {
     return TMP_PREFIX + snapshotMetadata;
   }
-
-  @Override
-  public File getSnapshotDir() {
-    return applicationStateMachine.getSnapshotRoot();
-  }
-
-  @Override
-  public File getTmpDir() {
-    return getSnapshotDir() == null
-        ? null
-        : new File(getSnapshotDir().getParentFile(), TMP_PREFIX + groupId.toString());
-  }
 }


### PR DESCRIPTION
Also, these methods don't override any one from superclasses and generate warnings.