### PR TITLE
Filter unsatisfied TimePartition while preparing resource list

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -176,7 +176,7 @@ public class ConfigNodeConfig {
   private String pipeTemporaryLibDir = pipeDir + File.separator + IoTDBConstant.TMP_FOLDER_NAME;
 
   /** Time partition interval in milliseconds */
-  private long timePartitionInterval = 604_800_000;
+  private long timePartitionInterval = 1_000;
 
   /** Procedure Evict ttl */
   private int procedureCompletedEvictTTL = 800;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
 import org.apache.iotdb.confignode.exception.physical.UnknownPhysicalPlanTypeException;
 import org.apache.iotdb.confignode.manager.ConfigManager;
+import org.apache.iotdb.confignode.manager.consensus.ConsensusManager;
 import org.apache.iotdb.confignode.persistence.executor.ConfigPlanExecutor;
 import org.apache.iotdb.confignode.writelog.io.SingleFileLogReader;
 import org.apache.iotdb.consensus.ConsensusFactory;
@@ -76,7 +77,7 @@ public class ConfigRegionStateMachine
   private int endIndex;
 
   private static final String CURRENT_FILE_DIR =
-      CONF.getConsensusDir() + File.separator + "simple" + File.separator + "current";
+      ConsensusManager.getConfigRegionDir() + File.separator + "current";
   private static final String PROGRESS_FILE_PATH =
       CURRENT_FILE_DIR + File.separator + "log_inprogress_";
   private static final String FILE_PATH = CURRENT_FILE_DIR + File.separator + "log_";

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -47,6 +47,7 @@ import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,10 +62,11 @@ public class ConsensusManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusManager.class);
   private static final ConfigNodeConfig CONF = ConfigNodeDescriptor.getInstance().getConf();
   private static final int SEED_CONFIG_NODE_ID = 0;
+  /** There is only one ConfigNodeGroup */
+  public static final ConsensusGroupId DEFAULT_CONSENSUS_GROUP_ID =
+      new ConfigRegionId(CONF.getConfigRegionId());;
 
   private final IManager configManager;
-
-  private ConsensusGroupId consensusGroupId;
   private IConsensus consensusImpl;
 
   public ConsensusManager(IManager configManager, ConfigRegionStateMachine stateMachine)
@@ -79,10 +81,9 @@ public class ConsensusManager {
 
   /** ConsensusLayer local implementation. */
   private void setConsensusLayer(ConfigRegionStateMachine stateMachine) throws IOException {
-    // There is only one ConfigNodeGroup
-    consensusGroupId = new ConfigRegionId(CONF.getConfigRegionId());
 
     if (SIMPLE_CONSENSUS.equals(CONF.getConfigNodeConsensusProtocolClass())) {
+      upgrade();
       consensusImpl =
           ConsensusFactory.getConsensusImpl(
                   SIMPLE_CONSENSUS,
@@ -214,6 +215,25 @@ public class ConsensusManager {
   }
 
   /**
+   * In version 1.1, we fixed a 1.0 SimpleConsensus bug that incorrectly set the consensus
+   * directory. For backward compatibility, we added this function, which we may remove in version
+   * 2.x
+   */
+  private void upgrade() {
+    File consensusDir = new File(CONF.getConsensusDir());
+    if (consensusDir.exists()) {
+      File oldWalDir = new File(consensusDir, "simple");
+      if (oldWalDir.exists()) {
+        if (!oldWalDir.renameTo(new File(getConfigRegionDir()))) {
+          LOGGER.warn(
+              "upgrade ConfigNode consensus wal dir for SimpleConsensus from version/1.0 to version/1.1 failed, "
+                  + "you maybe need to rename the simple dir to 0_0 manually.");
+        }
+      }
+    }
+  }
+
+  /**
    * Create peer in new node to build consensus group.
    *
    * @param configNodeLocations All registered ConfigNodes
@@ -225,11 +245,11 @@ public class ConsensusManager {
     for (TConfigNodeLocation configNodeLocation : configNodeLocations) {
       peerList.add(
           new Peer(
-              consensusGroupId,
+              DEFAULT_CONSENSUS_GROUP_ID,
               configNodeLocation.getConfigNodeId(),
               configNodeLocation.getConsensusEndPoint()));
     }
-    consensusImpl.createPeer(consensusGroupId, peerList);
+    consensusImpl.createPeer(DEFAULT_CONSENSUS_GROUP_ID, peerList);
   }
 
   /**
@@ -242,9 +262,9 @@ public class ConsensusManager {
     boolean result =
         consensusImpl
             .addPeer(
-                consensusGroupId,
+                DEFAULT_CONSENSUS_GROUP_ID,
                 new Peer(
-                    consensusGroupId,
+                    DEFAULT_CONSENSUS_GROUP_ID,
                     configNodeLocation.getConfigNodeId(),
                     configNodeLocation.getConsensusEndPoint()))
             .isSuccess();
@@ -264,9 +284,9 @@ public class ConsensusManager {
   public boolean removeConfigNodePeer(TConfigNodeLocation configNodeLocation) {
     return consensusImpl
         .removePeer(
-            consensusGroupId,
+            DEFAULT_CONSENSUS_GROUP_ID,
             new Peer(
-                consensusGroupId,
+                DEFAULT_CONSENSUS_GROUP_ID,
                 configNodeLocation.getConfigNodeId(),
                 configNodeLocation.getConsensusEndPoint()))
         .isSuccess();
@@ -274,22 +294,22 @@ public class ConsensusManager {
 
   /** Transmit PhysicalPlan to confignode.consensus.statemachine */
   public ConsensusWriteResponse write(ConfigPhysicalPlan plan) {
-    return consensusImpl.write(consensusGroupId, plan);
+    return consensusImpl.write(DEFAULT_CONSENSUS_GROUP_ID, plan);
   }
 
   /** Transmit PhysicalPlan to confignode.consensus.statemachine */
   public ConsensusReadResponse read(ConfigPhysicalPlan plan) {
-    return consensusImpl.read(consensusGroupId, plan);
+    return consensusImpl.read(DEFAULT_CONSENSUS_GROUP_ID, plan);
   }
 
   public boolean isLeader() {
-    return consensusImpl.isLeader(consensusGroupId);
+    return consensusImpl.isLeader(DEFAULT_CONSENSUS_GROUP_ID);
   }
 
   /** @return ConfigNode-leader's location if leader exists, null otherwise. */
   public TConfigNodeLocation getLeader() {
     for (int retry = 0; retry < 50; retry++) {
-      Peer leaderPeer = consensusImpl.getLeader(consensusGroupId);
+      Peer leaderPeer = consensusImpl.getLeader(DEFAULT_CONSENSUS_GROUP_ID);
       if (leaderPeer != null) {
         List<TConfigNodeLocation> registeredConfigNodes =
             getNodeManager().getRegisteredConfigNodes();
@@ -338,7 +358,15 @@ public class ConsensusManager {
   }
 
   public ConsensusGroupId getConsensusGroupId() {
-    return consensusGroupId;
+    return DEFAULT_CONSENSUS_GROUP_ID;
+  }
+
+  public static String getConfigRegionDir() {
+    return CONF.getConsensusDir()
+        + File.separator
+        + ConsensusManager.DEFAULT_CONSENSUS_GROUP_ID.getType().getValue()
+        + "_"
+        + ConsensusManager.DEFAULT_CONSENSUS_GROUP_ID.getId();
   }
 
   public IConsensus getConsensusImpl() {

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteServerEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteServerEnv.java
@@ -64,7 +64,7 @@ public class RemoteServerEnv implements BaseEnv {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
       statement.execute("CREATE DATABASE root.init;");
-      statement.execute("DELETE DATABASE root;");
+      statement.execute("DELETE DATABASE root.init;");
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -732,7 +732,7 @@ public class IoTDBConfig {
   private int primitiveArraySize = 64;
 
   /** Time partition interval in milliseconds */
-  private long timePartitionInterval = 604_800_000;
+  private long timePartitionInterval = 1_000;
 
   /**
    * Level of TimeIndex, which records the start time and end time of TsFileResource. Currently,

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1700,7 +1700,8 @@ public class DataRegion implements IDataRegionForQuery {
       List<PartialPath> pathList, String singleDeviceId, QueryContext context, Filter timeFilter)
       throws QueryProcessException {
     try {
-      List<Long> timePartitions = lastFlushTimeMap.getAllSatisfiedTimePartitions(singleDeviceId);
+      List<Long> timePartitions =
+          lastFlushTimeMap.getAllSatisfiedTimePartitions(singleDeviceId, timeFilter);
       List<TsFileResource> seqResources =
           getFileResourceListForQuery(
               tsFileManager.getTsFileList(timePartitions, true),

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -878,7 +878,7 @@ public class DataRegion implements IDataRegionForQuery {
     for (TsFileResource tsFileResource : resourceList) {
       recoverSealedTsFiles(tsFileResource, context, isSeq);
     }
-    if (isLatestPartition && isSeq) {
+    if (isSeq) {
       lastFlushTimeMap.checkAndCreateFlushedTimePartition(partitionId);
       for (TsFileResource tsFileResource : resourceList) {
         updateLastFlushTime(tsFileResource, true);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1700,9 +1700,10 @@ public class DataRegion implements IDataRegionForQuery {
       List<PartialPath> pathList, String singleDeviceId, QueryContext context, Filter timeFilter)
       throws QueryProcessException {
     try {
+      List<Long> timePartitions = lastFlushTimeMap.getAllSatisfiedTimePartitions(singleDeviceId);
       List<TsFileResource> seqResources =
           getFileResourceListForQuery(
-              tsFileManager.getTsFileList(true),
+              tsFileManager.getTsFileList(timePartitions, true),
               upgradeSeqFileList,
               pathList,
               singleDeviceId,
@@ -1711,7 +1712,7 @@ public class DataRegion implements IDataRegionForQuery {
               true);
       List<TsFileResource> unseqResources =
           getFileResourceListForQuery(
-              tsFileManager.getTsFileList(false),
+              tsFileManager.getTsFileList(timePartitions, false),
               upgradeUnseqFileList,
               pathList,
               singleDeviceId,

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
@@ -259,7 +259,7 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
                 long[] startAndEndTime =
                     TimePartitionUtils.getStartAndEndTimeForTimePartition(stringLongMap);
                 return (timeFilter == null
-                    || timeFilter.satisfy(startAndEndTime[0], startAndEndTime[1]));
+                    || timeFilter.satisfyStartEndTime(startAndEndTime[0], startAndEndTime[1]));
               })
           .collect(Collectors.toList());
     } else {
@@ -269,7 +269,7 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
                 long[] startAndEndTime =
                     TimePartitionUtils.getStartAndEndTimeForTimePartition(entry.getKey());
                 return (timeFilter == null
-                        || timeFilter.satisfy(startAndEndTime[0], startAndEndTime[1]))
+                        || timeFilter.satisfyStartEndTime(startAndEndTime[0], startAndEndTime[1]))
                     && entry.getValue().containsKey(deviceId);
               })
           .map(Map.Entry::getKey)

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
@@ -22,9 +22,11 @@ package org.apache.iotdb.db.engine.storagegroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class HashLastFlushTimeMap implements ILastFlushTimeMap {
 
@@ -244,5 +246,15 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
       return memCostForEachPartition.get(partitionId);
     }
     return 0;
+  }
+
+  @Override
+  public List<Long> getAllSatisfiedTimePartitions(String deviceId) {
+    return deviceId == null
+        ? new ArrayList<>(newlyFlushedPartitionLatestFlushedTimeForEachDevice.keySet())
+        : newlyFlushedPartitionLatestFlushedTimeForEachDevice.entrySet().stream()
+            .filter(entry -> entry.getValue().containsKey(deviceId))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
@@ -271,6 +271,7 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
                 return (timeFilter == null
                     || timeFilter.satisfyStartEndTime(startAndEndTime[0], startAndEndTime[1]));
               })
+          .sorted()
           .collect(Collectors.toList());
     } else {
       return partitionLatestFlushedTimeForEachDevice.entrySet().stream()
@@ -289,13 +290,17 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
                   logger.info("time filter is null");
                 }
 
-                logger.info("all devices: {}", entry.getValue().keySet());
+                logger.info(
+                    "all devices: {}, result: {}",
+                    entry.getValue().keySet(),
+                    entry.getValue().containsKey(deviceId));
 
                 return (timeFilter == null
                         || timeFilter.satisfyStartEndTime(startAndEndTime[0], startAndEndTime[1]))
                     && entry.getValue().containsKey(deviceId);
               })
           .map(Map.Entry::getKey)
+          .sorted()
           .collect(Collectors.toList());
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
@@ -253,7 +253,7 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
   @Override
   public List<Long> getAllSatisfiedTimePartitions(String deviceId, Filter timeFilter) {
     if (deviceId == null) {
-      return newlyFlushedPartitionLatestFlushedTimeForEachDevice.keySet().stream()
+      return partitionLatestFlushedTimeForEachDevice.keySet().stream()
           .filter(
               stringLongMap -> {
                 long[] startAndEndTime =
@@ -263,7 +263,7 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
               })
           .collect(Collectors.toList());
     } else {
-      return newlyFlushedPartitionLatestFlushedTimeForEachDevice.entrySet().stream()
+      return partitionLatestFlushedTimeForEachDevice.entrySet().stream()
           .filter(
               entry -> {
                 long[] startAndEndTime =

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/HashLastFlushTimeMap.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -258,6 +259,15 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
               stringLongMap -> {
                 long[] startAndEndTime =
                     TimePartitionUtils.getStartAndEndTimeForTimePartition(stringLongMap);
+                logger.info("start end time: {}", Arrays.toString(startAndEndTime));
+                if (timeFilter != null) {
+                  logger.info(
+                      "time filter: {}, result: {}",
+                      timeFilter,
+                      timeFilter.satisfyStartEndTime(startAndEndTime[0], startAndEndTime[1]));
+                } else {
+                  logger.info("time filter is null");
+                }
                 return (timeFilter == null
                     || timeFilter.satisfyStartEndTime(startAndEndTime[0], startAndEndTime[1]));
               })
@@ -268,6 +278,19 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
               entry -> {
                 long[] startAndEndTime =
                     TimePartitionUtils.getStartAndEndTimeForTimePartition(entry.getKey());
+                logger.info(
+                    "start end time: {}, deviceId: {}", Arrays.toString(startAndEndTime), deviceId);
+                if (timeFilter != null) {
+                  logger.info(
+                      "time filter: {}, result: {}",
+                      timeFilter,
+                      timeFilter.satisfyStartEndTime(startAndEndTime[0], startAndEndTime[1]));
+                } else {
+                  logger.info("time filter is null");
+                }
+
+                logger.info("all devices: {}", entry.getValue().keySet());
+
                 return (timeFilter == null
                         || timeFilter.satisfyStartEndTime(startAndEndTime[0], startAndEndTime[1]))
                     && entry.getValue().containsKey(deviceId);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/IDTableLastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/IDTableLastFlushTimeMap.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.engine.storagegroup;
 import org.apache.iotdb.db.metadata.idtable.IDTable;
 import org.apache.iotdb.db.metadata.idtable.entry.DeviceEntry;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -183,5 +184,10 @@ public class IDTableLastFlushTimeMap implements ILastFlushTimeMap {
       return memCostForEachPartition.get(partitionId);
     }
     return 0;
+  }
+
+  @Override
+  public List<Long> getAllSatisfiedTimePartitions(String deviceId) {
+    return new ArrayList<>(partitionSet);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/IDTableLastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/IDTableLastFlushTimeMap.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.engine.storagegroup;
 
 import org.apache.iotdb.db.metadata.idtable.IDTable;
 import org.apache.iotdb.db.metadata.idtable.entry.DeviceEntry;
+import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -187,7 +188,7 @@ public class IDTableLastFlushTimeMap implements ILastFlushTimeMap {
   }
 
   @Override
-  public List<Long> getAllSatisfiedTimePartitions(String deviceId) {
+  public List<Long> getAllSatisfiedTimePartitions(String deviceId, Filter timeFilter) {
     return new ArrayList<>(partitionSet);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/ILastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/ILastFlushTimeMap.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.db.engine.storagegroup;
 
+import org.apache.iotdb.tsfile.read.filter.basic.Filter;
+
 import java.util.List;
 import java.util.Map;
 
@@ -72,5 +74,5 @@ public interface ILastFlushTimeMap {
 
   long getMemSize(long partitionId);
 
-  List<Long> getAllSatisfiedTimePartitions(String deviceId);
+  List<Long> getAllSatisfiedTimePartitions(String deviceId, Filter timeFilter);
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/ILastFlushTimeMap.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/ILastFlushTimeMap.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.engine.storagegroup;
 
+import java.util.List;
 import java.util.Map;
 
 /** This interface manages last time and flush time for sequence and unsequence determination */
@@ -70,4 +71,6 @@ public interface ILastFlushTimeMap {
   void removePartition(long partitionId);
 
   long getMemSize(long partitionId);
+
+  List<Long> getAllSatisfiedTimePartitions(String deviceId);
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
@@ -85,6 +85,22 @@ public class TsFileManager {
     }
   }
 
+  public List<TsFileResource> getTsFileList(List<Long> timePartitions, boolean sequence) {
+    // the iteration of ConcurrentSkipListMap is not concurrent secure
+    // so we must add read lock here
+    readLock();
+    try {
+      List<TsFileResource> allResources = new ArrayList<>();
+      Map<Long, TsFileResourceList> chosenMap = sequence ? sequenceFiles : unsequenceFiles;
+      for (Long timePartition : timePartitions) {
+        allResources.addAll(chosenMap.get(timePartition).getArrayList());
+      }
+      return allResources;
+    } finally {
+      readUnlock();
+    }
+  }
+
   public TsFileResourceList getOrCreateSequenceListByTimePartition(long timePartition) {
     writeLock("getOrCreateSequenceListByTimePartition");
     try {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
@@ -93,7 +93,10 @@ public class TsFileManager {
       List<TsFileResource> allResources = new ArrayList<>();
       Map<Long, TsFileResourceList> chosenMap = sequence ? sequenceFiles : unsequenceFiles;
       for (Long timePartition : timePartitions) {
-        allResources.addAll(chosenMap.get(timePartition).getArrayList());
+        TsFileResourceList tsFileResourceList = chosenMap.get(timePartition);
+        if (tsFileResourceList != null) {
+          allResources.addAll(tsFileResourceList.getArrayList());
+        }
       }
       return allResources;
     } finally {

--- a/server/src/main/java/org/apache/iotdb/db/utils/TimePartitionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TimePartitionUtils.java
@@ -38,6 +38,17 @@ public class TimePartitionUtils {
     return timePartitionInterval;
   }
 
+  /**
+   * get start and end time(included) for one time partition
+   *
+   * @param timePartition time partition id
+   * @return long[2] {startTime, endTime(included)}
+   */
+  public static long[] getStartAndEndTimeForTimePartition(long timePartition) {
+    long startTime = timePartition * timePartitionInterval;
+    return new long[] {startTime, startTime + timePartitionInterval - 1};
+  }
+
   @TestOnly
   public static void setTimePartitionInterval(long timePartitionInterval) {
     TimePartitionUtils.timePartitionInterval = timePartitionInterval;


### PR DESCRIPTION
One dataregion may contain many time partition, previously, we need to scan all time partition's tsfiles even if the time partition in that dataregion doesn't contains the device's data.