### PR TITLE
[IOTDB-5707] Support Activate Template for Session API

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSchemaTemplateIT.java
@@ -224,4 +224,65 @@ public class IoTDBSessionSchemaTemplateIT {
 
     return sessionTemplate;
   }
+
+  @Test
+  public void testBatchActivateTemplate()
+      throws StatementExecutionException, IoTDBConnectionException, IOException {
+    session.createDatabase("root.db");
+
+    Template temp1 = getTemplate("template1");
+    Template temp2 = getTemplate("template2");
+
+    assertEquals("[]", session.showAllTemplates().toString());
+
+    session.createSchemaTemplate(temp1);
+    session.createSchemaTemplate(temp2);
+
+    assertEquals(
+        new HashSet<>(Arrays.asList("template1", "template2")),
+        new HashSet<>(session.showAllTemplates()));
+
+    session.setSchemaTemplate("template1", "root.db.v1");
+    session.setSchemaTemplate("template1", "root.db.v2");
+    session.setSchemaTemplate("template1", "root.db.v3");
+
+    assertEquals(
+        new HashSet<>(Collections.emptyList()),
+        new HashSet<>(session.showPathsTemplateUsingOn("template1")));
+
+    session.setSchemaTemplate("template2", "root.db.v4");
+    session.setSchemaTemplate("template2", "root.db.v5");
+    session.setSchemaTemplate("template2", "root.db.v6");
+
+    assertEquals(
+        new HashSet<>(Arrays.asList("root.db.v4", "root.db.v5", "root.db.v6")),
+        new HashSet<>(session.showPathsTemplateSetOn("template2")));
+
+    session.createTimeseriesOfSchemaTemplate(Collections.singletonList("root.db.v1.GPS"));
+
+    assertEquals(
+        new HashSet<>(Collections.singletonList("root.db.v1.GPS")),
+        new HashSet<>(session.showPathsTemplateUsingOn("template1")));
+
+    session.createTimeseriesOfSchemaTemplate(Collections.singletonList("root.db.v5.GPS"));
+
+    assertEquals(
+        new HashSet<>(Collections.singletonList("root.db.v1.GPS")),
+        new HashSet<>(session.showPathsTemplateUsingOn("template1")));
+
+    assertEquals(
+        new HashSet<>(Collections.singletonList("root.db.v5.GPS")),
+        new HashSet<>(session.showPathsTemplateUsingOn("template2")));
+
+    session.createTimeseriesOfSchemaTemplate(
+        Arrays.asList("root.db.v2.GPS", "root.db.v3.GPS", "root.db.v4.GPS", "root.db.v6.GPS"));
+
+    assertEquals(
+        new HashSet<>(Arrays.asList("root.db.v1.GPS", "root.db.v2.GPS", "root.db.v3.GPS")),
+        new HashSet<>(session.showPathsTemplateUsingOn("template1")));
+
+    assertEquals(
+        new HashSet<>(Arrays.asList("root.db.v4.GPS", "root.db.v5.GPS", "root.db.v6.GPS")),
+        new HashSet<>(session.showPathsTemplateUsingOn("template2")));
+  }
 }

--- a/isession/src/main/java/org/apache/iotdb/isession/ISession.java
+++ b/isession/src/main/java/org/apache/iotdb/isession/ISession.java
@@ -478,6 +478,9 @@ public interface ISession extends AutoCloseable {
   void dropSchemaTemplate(String templateName)
       throws IoTDBConnectionException, StatementExecutionException;
 
+  void createTimeseriesOfSchemaTemplate(List<String> devicePathList)
+      throws IoTDBConnectionException, StatementExecutionException;
+
   boolean isEnableQueryRedirection();
 
   void setEnableQueryRedirection(boolean enableQueryRedirection);

--- a/isession/src/main/java/org/apache/iotdb/isession/pool/ISessionPool.java
+++ b/isession/src/main/java/org/apache/iotdb/isession/pool/ISessionPool.java
@@ -394,6 +394,9 @@ public interface ISessionPool {
   void dropSchemaTemplate(String templateName)
       throws StatementExecutionException, IoTDBConnectionException;
 
+  void createTimeseriesOfSchemaTemplate(List<String> devicePathList)
+      throws StatementExecutionException, IoTDBConnectionException;
+
   SessionDataSetWrapper executeQueryStatement(String sql)
       throws IoTDBConnectionException, StatementExecutionException;
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/executor/RegionWriteExecutor.java
@@ -45,6 +45,7 @@ import org.apache.iotdb.db.mpp.plan.analyze.schema.SchemaValidator;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanVisitor;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.ActivateTemplateNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.BatchActivateTemplateNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateAlignedTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateMultiTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateTimeSeriesNode;
@@ -615,6 +616,36 @@ public class RegionWriteExecutor {
           return result;
         }
         return super.visitActivateTemplate(node, context);
+      } finally {
+        context.getRegionWriteValidationRWLock().readLock().unlock();
+      }
+    }
+
+    @Override
+    public RegionExecutionResult visitBatchActivateTemplate(
+        BatchActivateTemplateNode node, WritePlanNodeExecutionContext context) {
+      // activate template operation shall be blocked by unset template check
+      context.getRegionWriteValidationRWLock().readLock().lock();
+      try {
+        for (PartialPath devicePath : node.getTemplateActivationMap().keySet()) {
+          Pair<Template, PartialPath> templateSetInfo =
+              ClusterTemplateManager.getInstance().checkTemplateSetInfo(devicePath);
+          if (templateSetInfo == null) {
+            // The activation has already been validated during analyzing.
+            // That means the template is being unset during the activation plan transport.
+            RegionExecutionResult result = new RegionExecutionResult();
+            result.setAccepted(false);
+            String message =
+                String.format(
+                    "Template is being unsetting from path %s. Please try activating later.",
+                    node.getPathSetTemplate(devicePath));
+            result.setMessage(message);
+            result.setStatus(RpcUtils.getStatus(TSStatusCode.METADATA_ERROR, message));
+            return result;
+          }
+        }
+
+        return super.visitBatchActivateTemplate(node, context);
       } finally {
         context.getRegionWriteValidationRWLock().readLock().unlock();
       }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analysis.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analysis.java
@@ -199,6 +199,9 @@ public class Analysis {
   // template and paths set template
   private Pair<Template, List<PartialPath>> templateSetInfo;
 
+  // devicePath -> <template, paths set template>
+  private Map<PartialPath, Pair<Template, PartialPath>> deviceTemplateSetInfoMap;
+
   // potential template used in timeseries query or fetch
   private Map<Integer, Template> relatedTemplateInfo;
 
@@ -492,6 +495,15 @@ public class Analysis {
 
   public void setTemplateSetInfo(Pair<Template, List<PartialPath>> templateSetInfo) {
     this.templateSetInfo = templateSetInfo;
+  }
+
+  public Map<PartialPath, Pair<Template, PartialPath>> getDeviceTemplateSetInfoMap() {
+    return deviceTemplateSetInfoMap;
+  }
+
+  public void setDeviceTemplateSetInfoMap(
+      Map<PartialPath, Pair<Template, PartialPath>> deviceTemplateSetInfoMap) {
+    this.deviceTemplateSetInfoMap = deviceTemplateSetInfoMap;
   }
 
   public Map<Integer, Template> getRelatedTemplateInfo() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -122,6 +122,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowDevicesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowTTLStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ActivateTemplateStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.template.BatchActivateTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.CreateSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.SetSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowNodesInSchemaTemplateStatement;
@@ -2749,6 +2750,38 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     PathPatternTree patternTree = new PathPatternTree();
     patternTree.appendPathPattern(activatePath.concatNode(ONE_LEVEL_PATH_WILDCARD));
+    SchemaPartition partition = partitionFetcher.getOrCreateSchemaPartition(patternTree);
+
+    analysis.setSchemaPartitionInfo(partition);
+
+    return analysis;
+  }
+
+  @Override
+  public Analysis visitBatchActivateTemplate(
+      BatchActivateTemplateStatement batchActivateTemplateStatement, MPPQueryContext context) {
+    context.setQueryType(QueryType.WRITE);
+    Analysis analysis = new Analysis();
+    analysis.setStatement(batchActivateTemplateStatement);
+
+    Map<PartialPath, Pair<Template, PartialPath>> deviceTemplateSetInfoMap =
+        new HashMap<>(batchActivateTemplateStatement.getPaths().size());
+    for (PartialPath devicePath : batchActivateTemplateStatement.getDevicePathList()) {
+      Pair<Template, PartialPath> templateSetInfo = schemaFetcher.checkTemplateSetInfo(devicePath);
+      if (templateSetInfo == null) {
+        throw new StatementAnalyzeException(
+            new MetadataException(
+                String.format(
+                    "Path [%s] has not been set any template.", devicePath.getFullPath())));
+      }
+      deviceTemplateSetInfoMap.put(devicePath, templateSetInfo);
+    }
+    analysis.setDeviceTemplateSetInfoMap(deviceTemplateSetInfoMap);
+
+    PathPatternTree patternTree = new PathPatternTree();
+    for (PartialPath devicePath : batchActivateTemplateStatement.getDevicePathList()) {
+      patternTree.appendPathPattern(devicePath.concatNode(ONE_LEVEL_PATH_WILDCARD));
+    }
     SchemaPartition partition = partitionFetcher.getOrCreateSchemaPartition(patternTree);
 
     analysis.setSchemaPartitionInfo(partition);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/StatementGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/StatementGenerator.java
@@ -54,6 +54,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.CreateTimeSeriesStatement
 import org.apache.iotdb.db.mpp.plan.statement.metadata.DatabaseSchemaStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.DeleteDatabaseStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.DeleteTimeSeriesStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.template.BatchActivateTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.CreateSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.DropSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.SetSchemaTemplateStatement;
@@ -695,6 +696,18 @@ public class StatementGenerator {
   public static DropSchemaTemplateStatement createStatement(TSDropSchemaTemplateReq req) {
     final long startTime = System.nanoTime();
     DropSchemaTemplateStatement statement = new DropSchemaTemplateStatement(req.getTemplateName());
+    PerformanceOverviewMetricsManager.recordParseCost(System.nanoTime() - startTime);
+    return statement;
+  }
+
+  public static BatchActivateTemplateStatement createBatchActivateTemplateStatement(
+      List<String> devicePathStringList) throws IllegalPathException {
+    final long startTime = System.nanoTime();
+    List<PartialPath> devicePathList = new ArrayList<>(devicePathStringList.size());
+    for (String pathString : devicePathStringList) {
+      devicePathList.add(new PartialPath(pathString));
+    }
+    BatchActivateTemplateStatement statement = new BatchActivateTemplateStatement(devicePathList);
     PerformanceOverviewMetricsManager.recordParseCost(System.nanoTime() - startTime);
     return statement;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanVisitor.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.load.LoadTsFileNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.ActivateTemplateNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.AlterTimeSeriesNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.BatchActivateTemplateNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateAlignedTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateMultiTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateTimeSeriesNode;
@@ -73,6 +74,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowChildPathsStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowDevicesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowTimeSeriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ActivateTemplateStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.template.BatchActivateTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowPathsUsingTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.ShowQueriesStatement;
 import org.apache.iotdb.tsfile.utils.Pair;
@@ -740,6 +742,20 @@ public class LogicalPlanVisitor extends StatementVisitor<PlanNode, MPPQueryConte
         activateTemplateStatement.getPath(),
         analysis.getTemplateSetInfo().right.get(0).getNodeLength() - 1,
         analysis.getTemplateSetInfo().left.getId());
+  }
+
+  @Override
+  public PlanNode visitBatchActivateTemplate(
+      BatchActivateTemplateStatement batchActivateTemplateStatement, MPPQueryContext context) {
+    Map<PartialPath, Pair<Integer, Integer>> templateActivationMap = new HashMap<>();
+    for (Map.Entry<PartialPath, Pair<Template, PartialPath>> entry :
+        analysis.getDeviceTemplateSetInfoMap().entrySet()) {
+      templateActivationMap.put(
+          entry.getKey(),
+          new Pair<>(entry.getValue().left.getId(), entry.getValue().right.getNodeLength() - 1));
+    }
+    return new BatchActivateTemplateNode(
+        context.getQueryId().genPlanNodeId(), templateActivationMap);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanNodeType.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanNodeType.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.TimeSeriesCo
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.TimeSeriesSchemaScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.ActivateTemplateNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.AlterTimeSeriesNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.BatchActivateTemplateNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.ConstructSchemaBlackListNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateAlignedTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateMultiTimeSeriesNode;
@@ -165,7 +166,8 @@ public enum PlanNodeType {
   INTERNAL_BATCH_ACTIVATE_TEMPLATE((short) 68),
   INTERNAL_CREATE_MULTI_TIMESERIES((short) 69),
   IDENTITY_SINK((short) 70),
-  SHUFFLE_SINK((short) 71);
+  SHUFFLE_SINK((short) 71),
+  BATCH_ACTIVATE_TEMPLATE((short) 72);
 
   public static final int BYTES = Short.BYTES;
 
@@ -356,6 +358,8 @@ public enum PlanNodeType {
         return IdentitySinkNode.deserialize(buffer);
       case 71:
         return ShuffleSinkNode.deserialize(buffer);
+      case 72:
+        return BatchActivateTemplateNode.deserialize(buffer);
       default:
         throw new IllegalArgumentException("Invalid node type: " + nodeType);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanVisitor.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.TimeSeriesCo
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.TimeSeriesSchemaScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.ActivateTemplateNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.AlterTimeSeriesNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.BatchActivateTemplateNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.ConstructSchemaBlackListNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateAlignedTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateMultiTimeSeriesNode;
@@ -322,6 +323,10 @@ public abstract class PlanVisitor<R, C> {
   }
 
   public R visitActivateTemplate(ActivateTemplateNode node, C context) {
+    return visitPlan(node, context);
+  }
+
+  public R visitBatchActivateTemplate(BatchActivateTemplateNode node, C context) {
     return visitPlan(node, context);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/write/ActivateTemplateNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/write/ActivateTemplateNode.java
@@ -45,7 +45,7 @@ public class ActivateTemplateNode extends WritePlanNode implements IActivateTemp
   private int templateSetLevel;
   private int templateId;
 
-  private boolean isAligned;
+  private transient boolean isAligned;
 
   private TRegionReplicaSet regionReplicaSet;
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/write/BatchActivateTemplateNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/write/BatchActivateTemplateNode.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write;
+
+import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathDeserializeUtil;
+import org.apache.iotdb.db.mpp.plan.analyze.Analysis;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeType;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanVisitor;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.WritePlanNode;
+import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BatchActivateTemplateNode extends WritePlanNode {
+
+  // devicePath -> <templateId, templateSetLevel>
+  private final Map<PartialPath, Pair<Integer, Integer>> templateActivationMap;
+
+  private TRegionReplicaSet regionReplicaSet;
+
+  public BatchActivateTemplateNode(
+      PlanNodeId id, Map<PartialPath, Pair<Integer, Integer>> templateActivationMap) {
+    super(id);
+    this.templateActivationMap = templateActivationMap;
+  }
+
+  private BatchActivateTemplateNode(
+      PlanNodeId id,
+      Map<PartialPath, Pair<Integer, Integer>> templateActivationMap,
+      TRegionReplicaSet regionReplicaSet) {
+    super(id);
+    this.templateActivationMap = templateActivationMap;
+    this.regionReplicaSet = regionReplicaSet;
+  }
+
+  public Map<PartialPath, Pair<Integer, Integer>> getTemplateActivationMap() {
+    return templateActivationMap;
+  }
+
+  public PartialPath getPathSetTemplate(PartialPath devicePath) {
+    return new PartialPath(
+        Arrays.copyOf(devicePath.getNodes(), templateActivationMap.get(devicePath).right + 1));
+  }
+
+  @Override
+  public TRegionReplicaSet getRegionReplicaSet() {
+    return regionReplicaSet;
+  }
+
+  @Override
+  public List<PlanNode> getChildren() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public void addChild(PlanNode child) {}
+
+  @Override
+  public PlanNode clone() {
+    return new BatchActivateTemplateNode(getPlanNodeId(), templateActivationMap, regionReplicaSet);
+  }
+
+  @Override
+  public int allowedChildCount() {
+    return 0;
+  }
+
+  @Override
+  public List<String> getOutputColumnNames() {
+    return null;
+  }
+
+  @Override
+  protected void serializeAttributes(ByteBuffer byteBuffer) {
+    PlanNodeType.BATCH_ACTIVATE_TEMPLATE.serialize(byteBuffer);
+
+    int size = templateActivationMap.size();
+    ReadWriteIOUtils.write(size, byteBuffer);
+    for (Map.Entry<PartialPath, Pair<Integer, Integer>> entry : templateActivationMap.entrySet()) {
+      entry.getKey().serialize(byteBuffer);
+      ReadWriteIOUtils.write(entry.getValue().left, byteBuffer);
+      ReadWriteIOUtils.write(entry.getValue().right, byteBuffer);
+    }
+  }
+
+  @Override
+  protected void serializeAttributes(DataOutputStream stream) throws IOException {
+    PlanNodeType.BATCH_ACTIVATE_TEMPLATE.serialize(stream);
+
+    int size = templateActivationMap.size();
+    ReadWriteIOUtils.write(size, stream);
+    for (Map.Entry<PartialPath, Pair<Integer, Integer>> entry : templateActivationMap.entrySet()) {
+      entry.getKey().serialize(stream);
+      ReadWriteIOUtils.write(entry.getValue().left, stream);
+      ReadWriteIOUtils.write(entry.getValue().right, stream);
+    }
+  }
+
+  public static InternalBatchActivateTemplateNode deserialize(ByteBuffer byteBuffer) {
+    int size = ReadWriteIOUtils.readInt(byteBuffer);
+    Map<PartialPath, Pair<Integer, Integer>> templateActivationMap = new HashMap<>(size);
+    for (int i = 0; i < size; i++) {
+      templateActivationMap.put(
+          (PartialPath) PathDeserializeUtil.deserialize(byteBuffer),
+          new Pair<>(ReadWriteIOUtils.readInt(byteBuffer), ReadWriteIOUtils.readInt(byteBuffer)));
+    }
+
+    PlanNodeId planNodeId = PlanNodeId.deserialize(byteBuffer);
+    return new InternalBatchActivateTemplateNode(planNodeId, templateActivationMap);
+  }
+
+  @Override
+  public List<WritePlanNode> splitByPartition(Analysis analysis) {
+    // gather devices to same target region
+    Map<TRegionReplicaSet, Map<PartialPath, Pair<Integer, Integer>>> splitMap = new HashMap<>();
+    for (Map.Entry<PartialPath, Pair<Integer, Integer>> entry : templateActivationMap.entrySet()) {
+      TRegionReplicaSet regionReplicaSet =
+          analysis.getSchemaPartitionInfo().getSchemaRegionReplicaSet(entry.getKey().getFullPath());
+      splitMap
+          .computeIfAbsent(regionReplicaSet, k -> new HashMap<>())
+          .put(entry.getKey(), entry.getValue());
+    }
+
+    List<WritePlanNode> result = new ArrayList<>();
+    for (Map.Entry<TRegionReplicaSet, Map<PartialPath, Pair<Integer, Integer>>> entry :
+        splitMap.entrySet()) {
+      result.add(new BatchActivateTemplateNode(getPlanNodeId(), entry.getValue(), entry.getKey()));
+    }
+
+    return result;
+  }
+
+  @Override
+  public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
+    return visitor.visitBatchActivateTemplate(this, context);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/StatementType.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/StatementType.java
@@ -159,4 +159,6 @@ public enum StatementType {
   SHOW_PIPEPLUGINS,
 
   SHOW_PIPES,
+
+  BATCH_ACTIVATE_TEMPLATE,
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/StatementVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/StatementVisitor.java
@@ -74,6 +74,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowTriggersStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowVariablesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.UnSetTTLStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ActivateTemplateStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.template.BatchActivateTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.CreateSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.DeactivateTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.DropSchemaTemplateStatement;
@@ -396,6 +397,11 @@ public abstract class StatementVisitor<R, C> {
 
   public R visitActivateTemplate(ActivateTemplateStatement activateTemplateStatement, C context) {
     return visitStatement(activateTemplateStatement, context);
+  }
+
+  public R visitBatchActivateTemplate(
+      BatchActivateTemplateStatement batchActivateTemplateStatement, C context) {
+    return visitStatement(batchActivateTemplateStatement, context);
   }
 
   public R visitShowPathsUsingTemplate(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/template/BatchActivateTemplateStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/template/BatchActivateTemplateStatement.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.plan.statement.metadata.template;
+
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.mpp.plan.statement.Statement;
+import org.apache.iotdb.db.mpp.plan.statement.StatementType;
+import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
+
+import java.util.List;
+
+public class BatchActivateTemplateStatement extends Statement {
+
+  private final List<PartialPath> devicePathList;
+
+  public BatchActivateTemplateStatement(List<PartialPath> devicePathList) {
+    super();
+    this.devicePathList = devicePathList;
+    statementType = StatementType.BATCH_ACTIVATE_TEMPLATE;
+  }
+
+  @Override
+  public List<? extends PartialPath> getPaths() {
+    return devicePathList;
+  }
+
+  public List<PartialPath> getDevicePathList() {
+    return devicePathList;
+  }
+
+  @Override
+  public <R, C> R accept(StatementVisitor<R, C> visitor, C context) {
+    return super.accept(visitor, context);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/template/BatchActivateTemplateStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/template/BatchActivateTemplateStatement.java
@@ -47,6 +47,6 @@ public class BatchActivateTemplateStatement extends Statement {
 
   @Override
   public <R, C> R accept(StatementVisitor<R, C> visitor, C context) {
-    return super.accept(visitor, context);
+    return visitor.visitBatchActivateTemplate(this, context);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/template/DropSchemaTemplateStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/template/DropSchemaTemplateStatement.java
@@ -19,13 +19,17 @@
 
 package org.apache.iotdb.db.mpp.plan.statement.metadata.template;
 
+import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.mpp.plan.analyze.QueryType;
 import org.apache.iotdb.db.mpp.plan.statement.IConfigStatement;
+import org.apache.iotdb.db.mpp.plan.statement.Statement;
 import org.apache.iotdb.db.mpp.plan.statement.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
-import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowStatement;
 
-public class DropSchemaTemplateStatement extends ShowStatement implements IConfigStatement {
+import java.util.Collections;
+import java.util.List;
+
+public class DropSchemaTemplateStatement extends Statement implements IConfigStatement {
 
   private String templateName;
 
@@ -51,5 +55,10 @@ public class DropSchemaTemplateStatement extends ShowStatement implements IConfi
   @Override
   public QueryType getQueryType() {
     return QueryType.WRITE;
+  }
+
+  @Override
+  public List<? extends PartialPath> getPaths() {
+    return Collections.emptyList();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -72,6 +72,7 @@ import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.ServerProperties;
+import org.apache.iotdb.service.rpc.thrift.TCreateTimeseriesOfSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSAggregationQueryReq;
 import org.apache.iotdb.service.rpc.thrift.TSAppendSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSBackupConfigurationResp;
@@ -1869,7 +1870,8 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
   }
 
   @Override
-  public TSStatus createTimeseriesOfSchemaTemplate(List<String> devicePathList) throws TException {
+  public TSStatus createTimeseriesOfSchemaTemplate(TCreateTimeseriesOfSchemaTemplateReq req)
+      throws TException {
     try {
       IClientSession clientSession = SESSION_MANAGER.getCurrSessionAndUpdateIdleTime();
       if (!SESSION_MANAGER.checkLogin(clientSession)) {
@@ -1878,11 +1880,11 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
 
       // Step 1: transfer to Statement
       BatchActivateTemplateStatement statement =
-          StatementGenerator.createBatchActivateTemplateStatement(devicePathList);
+          StatementGenerator.createBatchActivateTemplateStatement(req.getDevicePathList());
 
       if (enableAuditLog) {
         AuditLogger.log(
-            String.format("batch activate schema template %s", devicePathList), statement);
+            String.format("batch activate schema template %s", req.getDevicePathList()), statement);
       }
 
       // permission check

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.NoValidValueException;
 import org.apache.iotdb.rpc.RedirectException;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.service.rpc.thrift.TCreateTimeseriesOfSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSAppendSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSBackupConfigurationResp;
 import org.apache.iotdb.service.rpc.thrift.TSConnectionInfoResp;
@@ -3337,6 +3338,19 @@ public class Session implements ISession {
     TSDropSchemaTemplateReq request = new TSDropSchemaTemplateReq();
     request.setTemplateName(templateName);
     return request;
+  }
+
+  /**
+   * Create timeseries represented by schema template under given device paths.
+   *
+   * @param devicePathList the target device paths used for timeseries creation
+   */
+  @Override
+  public void createTimeseriesOfSchemaTemplate(List<String> devicePathList)
+      throws IoTDBConnectionException, StatementExecutionException {
+    TCreateTimeseriesOfSchemaTemplateReq request = new TCreateTimeseriesOfSchemaTemplateReq();
+    request.setDevicePathList(devicePathList);
+    defaultSessionConnection.createTimeseriesOfSchemaTemplate(request);
   }
 
   /**

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
+import org.apache.iotdb.service.rpc.thrift.TCreateTimeseriesOfSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSAggregationQueryReq;
 import org.apache.iotdb.service.rpc.thrift.TSAppendSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSBackupConfigurationResp;
@@ -1053,6 +1054,25 @@ public class SessionConnection {
         }
       } else {
         throw new IoTDBConnectionException(logForReconnectionFailure());
+      }
+    }
+  }
+
+  protected void createTimeseriesOfSchemaTemplate(TCreateTimeseriesOfSchemaTemplateReq request)
+      throws IoTDBConnectionException, StatementExecutionException {
+    request.setSessionId(sessionId);
+    try {
+      RpcUtils.verifySuccess(client.createTimeseriesOfSchemaTemplate(request));
+    } catch (TException e) {
+      if (reconnect()) {
+        try {
+          request.setSessionId(sessionId);
+          RpcUtils.verifySuccess(client.createTimeseriesOfSchemaTemplate(request));
+        } catch (TException tException) {
+          throw new IoTDBConnectionException(tException);
+        }
+      } else {
+        throw new IoTDBConnectionException(MSG_RECONNECTION_FAIL);
       }
     }
   }

--- a/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -2401,6 +2401,26 @@ public class SessionPool implements ISessionPool {
     }
   }
 
+  public void createTimeseriesOfSchemaTemplate(List<String> devicePathList)
+      throws StatementExecutionException, IoTDBConnectionException {
+    for (int i = 0; i < RETRY; i++) {
+      ISession session = getSession();
+      try {
+        session.createTimeseriesOfSchemaTemplate(devicePathList);
+        putBack(session);
+        return;
+      } catch (IoTDBConnectionException e) {
+        // TException means the connection is broken, remove it and get a new one.
+        logger.warn(
+            String.format("createTimeseriesOfSchemaTemplate [%s] failed", devicePathList), e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
+      } catch (StatementExecutionException | RuntimeException e) {
+        putBack(session);
+        throw e;
+      }
+    }
+  }
+
   /**
    * execure query sql users must call closeResultSet(SessionDataSetWrapper) if they do not use the
    * SessionDataSet any more. users do not need to call sessionDataSet.closeOpeationHandler() any

--- a/thrift/src/main/thrift/client.thrift
+++ b/thrift/src/main/thrift/client.thrift
@@ -578,6 +578,8 @@ service IClientRPCService {
 
   common.TSStatus dropSchemaTemplate(1:TSDropSchemaTemplateReq req);
 
+  common.TSStatus createTimeseriesOfSchemaTemplate(list<string> devicePathList);
+
   common.TSStatus handshake(TSyncIdentityInfo info);
 
   common.TSStatus sendPipeData(1:binary buff);

--- a/thrift/src/main/thrift/client.thrift
+++ b/thrift/src/main/thrift/client.thrift
@@ -429,6 +429,11 @@ struct TSDropSchemaTemplateReq {
   2: required string templateName
 }
 
+struct TCreateTimeseriesOfSchemaTemplateReq{
+  1: required i64 sessionId
+  2: required list<string> devicePathList
+}
+
 // The sender and receiver need to check some info to confirm validity
 struct TSyncIdentityInfo{
   // Sender needs to tell receiver its identity.
@@ -578,7 +583,7 @@ service IClientRPCService {
 
   common.TSStatus dropSchemaTemplate(1:TSDropSchemaTemplateReq req);
 
-  common.TSStatus createTimeseriesOfSchemaTemplate(list<string> devicePathList);
+  common.TSStatus createTimeseriesOfSchemaTemplate(1:TCreateTimeseriesOfSchemaTemplateReq req);
 
   common.TSStatus handshake(TSyncIdentityInfo info);
 


### PR DESCRIPTION
## Description


### Motivation

When using session API, there should be an interface to provide service like ```create timeseries of schema template ```.

### Modification

Add interface ```createTimeseriesOfSchemaTemplate``` to Session API, which support batch activating template on different device path.
