### PR TITLE
[IOTDB-5704] Change default parameters for wal part

### DIFF
--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -663,22 +663,22 @@ cluster_name=defaultCluster
 # A duration greater than 0 batches multiple wal fsync calls into one. This is useful when disks are slow or WAL write contention exists.
 # Notice: this value affects write performance significantly, values in the range of 0ms-10ms are recommended.
 # Datatype: long
-# fsync_wal_delay_in_ms=3
+# fsync_wal_delay_in_ms=1000
 
 # Buffer size of each wal node
 # If it's a value smaller than 0, use the default value 16 * 1024 * 1024 bytes (16MB).
 # Datatype: int
-# wal_buffer_size_in_byte=16777216
+# wal_buffer_size_in_byte=33554432
 
 # Blocking queue capacity of each wal buffer, restricts maximum number of WALEdits cached in the blocking queue.
 # Datatype: int
-# wal_buffer_queue_capacity=50
+# wal_buffer_queue_capacity=500
 
 # Size threshold of each wal file
 # When a wal file's size exceeds this, the wal file will be closed and a new wal file will be created.
 # If it's a value smaller than 0, use the default value 10 * 1024 * 1024 (10MB).
 # Datatype: long
-# wal_file_size_threshold_in_byte=10485760
+# wal_file_size_threshold_in_byte=31457280
 
 # Minimum ratio of effective information in wal files
 # This value should be between 0.0 and 1.0

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -661,12 +661,12 @@ cluster_name=defaultCluster
 
 # Duration a wal flush operation will wait before calling fsync
 # A duration greater than 0 batches multiple wal fsync calls into one. This is useful when disks are slow or WAL write contention exists.
-# Notice: this value affects write performance significantly, values in the range of 0ms-10ms are recommended.
+# Notice: this value affects write performance significantly, values in the range of 0ms-2000ms are recommended.
 # Datatype: long
 # fsync_wal_delay_in_ms=1000
 
 # Buffer size of each wal node
-# If it's a value smaller than 0, use the default value 16 * 1024 * 1024 bytes (16MB).
+# If it's a value smaller than 0, use the default value 32 * 1024 * 1024 bytes (16MB).
 # Datatype: int
 # wal_buffer_size_in_byte=33554432
 
@@ -676,7 +676,7 @@ cluster_name=defaultCluster
 
 # Size threshold of each wal file
 # When a wal file's size exceeds this, the wal file will be closed and a new wal file will be created.
-# If it's a value smaller than 0, use the default value 10 * 1024 * 1024 (10MB).
+# If it's a value smaller than 0, use the default value 30 * 1024 * 1024 (10MB).
 # Datatype: long
 # wal_file_size_threshold_in_byte=31457280
 

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -666,7 +666,7 @@ cluster_name=defaultCluster
 # fsync_wal_delay_in_ms=1000
 
 # Buffer size of each wal node
-# If it's a value smaller than 0, use the default value 32 * 1024 * 1024 bytes (16MB).
+# If it's a value smaller than 0, use the default value 32 * 1024 * 1024 bytes (32MB).
 # Datatype: int
 # wal_buffer_size_in_byte=33554432
 
@@ -676,7 +676,7 @@ cluster_name=defaultCluster
 
 # Size threshold of each wal file
 # When a wal file's size exceeds this, the wal file will be closed and a new wal file will be created.
-# If it's a value smaller than 0, use the default value 30 * 1024 * 1024 (10MB).
+# If it's a value smaller than 0, use the default value 30 * 1024 * 1024 (30MB).
 # Datatype: long
 # wal_file_size_threshold_in_byte=31457280
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -183,19 +183,19 @@ public class IoTDBConfig {
   private int maxWalNodesNum = 0;
 
   /** Duration a wal flush operation will wait before calling fsync. Unit: millisecond */
-  private volatile long fsyncWalDelayInMs = 3;
+  private volatile long fsyncWalDelayInMs = 1000;
 
   /** Buffer size of each wal node. Unit: byte */
-  private int walBufferSize = 16 * 1024 * 1024;
+  private int walBufferSize = 32 * 1024 * 1024;
 
   /** Buffer entry size of each wal buffer. Unit: byte */
   private int walBufferEntrySize = 16 * 1024;
 
   /** Blocking queue capacity of each wal buffer */
-  private int walBufferQueueCapacity = 50;
+  private int walBufferQueueCapacity = 500;
 
   /** Size threshold of each wal file. Unit: byte */
-  private volatile long walFileSizeThresholdInByte = 10 * 1024 * 1024L;
+  private volatile long walFileSizeThresholdInByte = 30 * 1024 * 1024L;
 
   /** Size threshold of each checkpoint file. Unit: byte */
   private volatile long checkpointFileSizeThresholdInByte = 3 * 1024 * 1024L;


### PR DESCRIPTION
## Description
Change default parameter values for wal part. See the changes below
```
sync_wal_delay_in_ms=1500
wal_buffer_size_in_byte=33554432
wal_file_size_threshold_in_byte=31457280
wal_buffer_queue_capacity=500
```