### PR TITLE
[IOTDB-5715] Improve the performance of query order by time desc

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/RowBasedTimeJoinOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/RowBasedTimeJoinOperator.java
@@ -33,6 +33,8 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.read.common.block.column.TimeColumnBuilder;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +43,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.successfulAsList;
 
 public class RowBasedTimeJoinOperator extends AbstractConsumeAllOperator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RowBasedTimeJoinOperator.class);
 
   /** start index for each input TsBlocks and size of it is equal to inputTsBlocks */
   private final int[] inputIndex;
@@ -177,7 +181,7 @@ public class RowBasedTimeJoinOperator extends AbstractConsumeAllOperator {
         }
       }
       tsBlockBuilder.declarePosition();
-    } while (currentTime < currentEndTime && !timeSelector.isEmpty());
+    } while (comparator.canContinue(currentTime, currentEndTime) && !timeSelector.isEmpty());
 
     resultTsBlock = tsBlockBuilder.build();
     return checkTsBlockSizeAndGetResult();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/RowBasedTimeJoinOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/RowBasedTimeJoinOperator.java
@@ -33,8 +33,6 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.read.common.block.column.TimeColumnBuilder;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,8 +41,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.successfulAsList;
 
 public class RowBasedTimeJoinOperator extends AbstractConsumeAllOperator {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(RowBasedTimeJoinOperator.class);
 
   /** start index for each input TsBlocks and size of it is equal to inputTsBlocks */
   private final int[] inputIndex;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/merge/AscTimeComparator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/merge/AscTimeComparator.java
@@ -30,4 +30,9 @@ public class AscTimeComparator implements TimeComparator {
   public long getCurrentEndTime(long time1, long time2) {
     return Math.min(time1, time2);
   }
+
+  @Override
+  public boolean canContinue(long time, long endTime) {
+    return time < endTime;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/merge/DescTimeComparator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/merge/DescTimeComparator.java
@@ -30,4 +30,9 @@ public class DescTimeComparator implements TimeComparator {
   public long getCurrentEndTime(long time1, long time2) {
     return Math.max(time1, time2);
   }
+
+  @Override
+  public boolean canContinue(long time, long endTime) {
+    return time > endTime;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/merge/TimeComparator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/process/join/merge/TimeComparator.java
@@ -25,4 +25,7 @@ public interface TimeComparator {
 
   /** @return min(time1, time2) if order by time asc, max(time1, time2) if order by desc */
   long getCurrentEndTime(long time1, long time2);
+
+  /** @return time < endTime if order by time asc, time > endTime if order by desc */
+  boolean canContinue(long time, long endTime);
 }


### PR DESCRIPTION
more about the issue can be seen in https://issues.apache.org/jira/browse/IOTDB-5715.
The reason it that we directly use `currentTime < currentEndTime` to break the loop, however we should use `currentTime > currentEndTime` in order by time desc.

Now the query speed pf `order by time desc` is the same as `order by time asc`.
<img width="1882" alt="image" src="https://user-images.githubusercontent.com/16079446/226903931-7720a956-0ea4-4937-b3ee-a406e4c86068.png">
<img width="1867" alt="image" src="https://user-images.githubusercontent.com/16079446/226903982-4de342f1-41b2-46c9-a018-48c9ced8ade7.png">
