### PR TITLE
[To rel/1.1] Compatible with the client parameters on DataNode

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -229,8 +229,7 @@ public class IoTDBDescriptor {
                     "dn_connection_timeout_ms", String.valueOf(conf.getConnectionTimeoutInMS()))
                 .trim()));
 
-    if (properties.getProperty("dn_core_client_count_for_each_node_in_client_manager", null)
-        != null) {
+    if (properties.getProperty("dn_core_connection_for_internal_service", null) != null) {
       conf.setCoreClientNumForEachNode(
           Integer.parseInt(
               properties.getProperty("dn_core_connection_for_internal_service").trim()));
@@ -245,15 +244,12 @@ public class IoTDBDescriptor {
                     String.valueOf(conf.getCoreClientNumForEachNode()))
                 .trim()));
 
-    if (properties.getProperty("dn_max_client_count_for_each_node_in_client_manager", null)
-        != null) {
+    if (properties.getProperty("dn_max_connection_for_internal_service", null) != null) {
       conf.setMaxClientNumForEachNode(
           Integer.parseInt(
-              properties
-                  .getProperty("dn_max_client_count_for_each_node_in_client_manager")
-                  .trim()));
+              properties.getProperty("dn_max_connection_for_internal_service").trim()));
       logger.warn(
-          "The parameter dn_max_client_count_for_each_node_in_client_manager is out of date. Please rename it to dn_max_client_count_for_each_node_in_client_manager.");
+          "The parameter dn_max_connection_for_internal_service is out of date. Please rename it to dn_max_client_count_for_each_node_in_client_manager.");
     }
     conf.setMaxClientNumForEachNode(
         Integer.parseInt(


### PR DESCRIPTION
**Updates:**

1. dn_core_connection_for_internal_service -> dn_core_client_count_for_each_node_in_client_manager
2. dn_max_connection_for_internal_service -> dn_max_client_count_for_each_node_in_client_manager

Fix bug of https://github.com/apache/iotdb/pull/9272