### PR TITLE
[To rel/1.1][IOTDB-5720] Fix release processor fail to release memory due to writer-preferred starvation

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -35,9 +35,9 @@ import org.apache.iotdb.db.utils.concurrent.FiniteSemaphore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -49,7 +49,7 @@ public class CacheMemoryManager {
 
   private static final Logger logger = LoggerFactory.getLogger(CacheMemoryManager.class);
 
-  private final List<CachedMTreeStore> storeList = new ArrayList<>();
+  private final List<CachedMTreeStore> storeList = new CopyOnWriteArrayList<>();
 
   private CachedSchemaEngineStatistics engineStatistics;
   private SchemaEngineCachedMetric engineMetric;
@@ -80,11 +80,9 @@ public class CacheMemoryManager {
    * @return LRUCacheManager
    */
   public ICacheManager createLRUCacheManager(CachedMTreeStore store, MemManager memManager) {
-    synchronized (storeList) {
-      ICacheManager cacheManager = new LRUCacheManager(memManager);
-      storeList.add(store);
-      return cacheManager;
-    }
+    ICacheManager cacheManager = new LRUCacheManager(memManager);
+    storeList.add(store);
+    return cacheManager;
   }
 
   public void init(ISchemaEngineStatistics engineStatistics) {
@@ -198,34 +196,32 @@ public class CacheMemoryManager {
    * added or updated, fire flush task.
    */
   private void tryExecuteMemoryRelease() {
-    synchronized (storeList) {
-      long startTime = System.currentTimeMillis();
-      CompletableFuture.allOf(
-              storeList.stream()
-                  .map(
-                      store ->
-                          CompletableFuture.runAsync(
-                              () -> {
-                                store.getLock().threadReadLock();
-                                try {
-                                  executeMemoryRelease(store);
-                                } finally {
-                                  store.getLock().threadReadUnlock();
-                                }
-                              },
-                              releaseTaskProcessor))
-                  .toArray(CompletableFuture[]::new))
-          .join();
-      if (engineMetric != null) {
-        engineMetric.recordRelease(System.currentTimeMillis() - startTime);
-      }
-      synchronized (blockObject) {
-        hasReleaseTask = false;
-        if (isExceedFlushThreshold()) {
-          registerFlushTask();
-        } else {
-          blockObject.notifyAll();
-        }
+    long startTime = System.currentTimeMillis();
+    CompletableFuture.allOf(
+            storeList.stream()
+                .map(
+                    store ->
+                        CompletableFuture.runAsync(
+                            () -> {
+                              store.getLock().threadReadLock();
+                              try {
+                                executeMemoryRelease(store);
+                              } finally {
+                                store.getLock().threadReadUnlock();
+                              }
+                            },
+                            releaseTaskProcessor))
+                .toArray(CompletableFuture[]::new))
+        .join();
+    if (engineMetric != null) {
+      engineMetric.recordRelease(System.currentTimeMillis() - startTime);
+    }
+    synchronized (blockObject) {
+      hasReleaseTask = false;
+      if (isExceedFlushThreshold()) {
+        registerFlushTask();
+      } else {
+        blockObject.notifyAll();
       }
     }
   }
@@ -250,32 +246,30 @@ public class CacheMemoryManager {
 
   /** Sync all volatile nodes to schemaFile and execute memory release after flush. */
   private void tryFlushVolatileNodes() {
-    synchronized (storeList) {
-      long startTime = System.currentTimeMillis();
-      CompletableFuture.allOf(
-              storeList.stream()
-                  .map(
-                      store ->
-                          CompletableFuture.runAsync(
-                              () -> {
-                                store.getLock().writeLock();
-                                try {
-                                  store.flushVolatileNodes();
-                                  executeMemoryRelease(store);
-                                } finally {
-                                  store.getLock().unlockWrite();
-                                }
-                              },
-                              flushTaskProcessor))
-                  .toArray(CompletableFuture[]::new))
-          .join();
-      if (engineMetric != null) {
-        engineMetric.recordFlush(System.currentTimeMillis() - startTime);
-      }
-      synchronized (blockObject) {
-        hasFlushTask = false;
-        blockObject.notifyAll();
-      }
+    long startTime = System.currentTimeMillis();
+    CompletableFuture.allOf(
+            storeList.stream()
+                .map(
+                    store ->
+                        CompletableFuture.runAsync(
+                            () -> {
+                              store.getLock().writeLock();
+                              try {
+                                store.flushVolatileNodes();
+                                executeMemoryRelease(store);
+                              } finally {
+                                store.getLock().unlockWrite();
+                              }
+                            },
+                            flushTaskProcessor))
+                .toArray(CompletableFuture[]::new))
+        .join();
+    if (engineMetric != null) {
+      engineMetric.recordFlush(System.currentTimeMillis() - startTime);
+    }
+    synchronized (blockObject) {
+      hasFlushTask = false;
+      blockObject.notifyAll();
     }
   }
 


### PR DESCRIPTION
## Description


The current stampedLock uses a writer-preferred rule, which may lead to extreme cases where a waiting write lock request blocks the subsequent release thread from acquiring the read lock, resulting in memory not being released. To solve this problem, a high priority read lock request interface needs to be introduced.


https://apache-iotdb.feishu.cn/docx/WwdAd6SYLofsAHxEJeRcDuWBnPh

 
<img width="529" alt="image" src="https://user-images.githubusercontent.com/43774645/227133543-6acbd563-8452-42d0-9c4c-be88b72d9267.png">
