### PR TITLE
[To rel/0.13] Fix execution succeed with incorrect password by python api

### DIFF
--- a/client-py/iotdb/Session.py
+++ b/client-py/iotdb/Session.py
@@ -165,7 +165,7 @@ class Session(object):
 
         try:
             open_resp = self.__client.openSession(open_req)
-
+            Session.verify_success(open_resp.status)
             if self.protocol_version != open_resp.serverProtocolVersion:
                 logger.exception(
                     "Protocol differ, Client version is {}, but Server version is {}".format(


### PR DESCRIPTION
## Description

To reproduce, insert data like

```
insert into root.test.d_01(time,s_01) values(16,1);
```

Then execute the following python code

```python
from iotdb.Session import Session

session = Session.init_from_node_urls(
    node_urls=["127.0.0.1:6667"],
    user="root",
    password="roo",
    fetch_size=1024,
    zone_id="UTC+8",
)
session.open(False)

dataset = session.execute_last_data_query(["root.test.d_01.s_01"], 16)
print(dataset.has_next())
print(dataset.get_column_names())
print(dataset.next())

session.close()
```