### PR TITLE
[IOTDB-5725] Make internal report recording measurements asynchronous

### DIFF
--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/AbstractMetricService.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/AbstractMetricService.java
@@ -318,35 +318,35 @@ public abstract class AbstractMetricService {
   }
 
   /** Count with internal report. */
-  public void countWithInternalReport(
+  public void countWithInternalReportAsync(
       long delta, String metric, MetricLevel metricLevel, String... tags) {
     internalReporter.writeMetricToIoTDB(
         metricManager.count(delta, metric, metricLevel, tags), metric, tags);
   }
 
   /** Gauge value with internal report */
-  public void gaugeWithInternalReport(
+  public void gaugeWithInternalReportAsync(
       long value, String metric, MetricLevel metricLevel, String... tags) {
     internalReporter.writeMetricToIoTDB(
         metricManager.gauge(value, metric, metricLevel, tags), metric, tags);
   }
 
   /** Rate with internal report. */
-  public void rateWithInternalReport(
+  public void rateWithInternalReportAsync(
       long value, String metric, MetricLevel metricLevel, String... tags) {
     internalReporter.writeMetricToIoTDB(
         metricManager.rate(value, metric, metricLevel, tags), metric, tags);
   }
 
   /** Histogram with internal report. */
-  public void histogramWithInternalReport(
+  public void histogramWithInternalReportAsync(
       long value, String metric, MetricLevel metricLevel, String... tags) {
     internalReporter.writeMetricToIoTDB(
         metricManager.histogram(value, metric, metricLevel, tags), metric, tags);
   }
 
   /** Timer with internal report. */
-  public void timerWithInternalReport(
+  public void timerWithInternalReportAsync(
       long delta, TimeUnit timeUnit, String metric, MetricLevel metricLevel, String... tags) {
     internalReporter.writeMetricToIoTDB(
         metricManager.timer(delta, timeUnit, metric, metricLevel, tags), metric, tags);

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -286,7 +286,7 @@ public class MemTableFlushTask {
               lastIndex = storageGroup.length();
             }
             MetricService.getInstance()
-                .gaugeWithInternalReport(
+                .gaugeWithInternalReportAsync(
                     memTable.getTotalPointsNum(),
                     Metric.POINTS.toString(),
                     MetricLevel.CORE,


### PR DESCRIPTION
The flush time has been greatly reduced, and the system reject error has disappeared.
<img width="716" alt="image" src="https://user-images.githubusercontent.com/32640567/227425591-948b18a5-4a2e-4642-a602-0c1e56ffb213.png">
