### PR TITLE
[IOTDB-5723] Pipe: Consensus Index

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/index/ComparableConsensusRequest.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/index/ComparableConsensusRequest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common.index;
+
+public interface ComparableConsensusRequest {
+  ConsensusIndex getConsensusIndex();
+
+  void setConsensusIndex(ConsensusIndex consensusIndex);
+}

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/index/ComparableConsensusRequest.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/index/ComparableConsensusRequest.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.consensus.common.index;
 
+/** */
 public interface ComparableConsensusRequest {
   ConsensusIndex getConsensusIndex();
 

--- a/consensus/src/main/java/org/apache/iotdb/consensus/common/index/ConsensusIndex.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/common/index/ConsensusIndex.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.common.index;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+public interface ConsensusIndex {
+
+  void serialize(ByteBuffer byteBuffer);
+
+  void serialize(OutputStream stream) throws IOException;
+
+  static ConsensusIndex deserializeFrom(ByteBuffer byteBuffer) {
+    return null;
+  }
+
+  static ConsensusIndex deserializeFrom(InputStream byteBuffer) {
+    return null;
+  }
+
+  CompareResult compareTo(ConsensusIndex consensusIndex);
+
+  enum CompareResult {
+    INCOMPARABLE,
+    SMALLER,
+    GREATER,
+    EQUAL
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -287,6 +287,7 @@ public class TsFileProcessor {
       tsFileResource.updateEndTime(
           insertRowNode.getDeviceID().toStringID(), insertRowNode.getTime());
     }
+    tsFileResource.updateConsensusIndex(insertRowNode.getConsensusIndex());
     PERFORMANCE_OVERVIEW_METRICS.recordScheduleMemTableCost(System.nanoTime() - startTime);
   }
 
@@ -392,6 +393,7 @@ public class TsFileProcessor {
       tsFileResource.updateEndTime(
           insertTabletNode.getDeviceID().toStringID(), insertTabletNode.getTimes()[end - 1]);
     }
+    tsFileResource.updateConsensusIndex(insertTabletNode.getConsensusIndex());
     PERFORMANCE_OVERVIEW_METRICS.recordScheduleMemTableCost(System.nanoTime() - startTime);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertMultiTabletsNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertMultiTabletsNode.java
@@ -223,6 +223,7 @@ public class InsertMultiTabletsNode extends InsertNode implements BatchInsertNod
     InsertMultiTabletsNode insertMultiTabletsNode = new InsertMultiTabletsNode(planNodeId);
     insertMultiTabletsNode.setInsertTabletNodeList(insertTabletNodeList);
     insertMultiTabletsNode.setParentInsertTabletNodeIndexList(parentIndex);
+    insertMultiTabletsNode.deserializeInsertNodeAttributes(byteBuffer);
     return insertMultiTabletsNode;
   }
 
@@ -238,6 +239,8 @@ public class InsertMultiTabletsNode extends InsertNode implements BatchInsertNod
     for (Integer index : parentInsertTabletNodeIndexList) {
       ReadWriteIOUtils.write(index, byteBuffer);
     }
+
+    super.serializeAttributes(byteBuffer);
   }
 
   @Override
@@ -252,6 +255,8 @@ public class InsertMultiTabletsNode extends InsertNode implements BatchInsertNod
     for (Integer index : parentInsertTabletNodeIndexList) {
       ReadWriteIOUtils.write(index, stream);
     }
+
+    super.serializeAttributes(stream);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowNode.java
@@ -277,12 +277,14 @@ public class InsertRowNode extends InsertNode implements WALEntryValue, ISchemaV
   protected void serializeAttributes(ByteBuffer byteBuffer) {
     PlanNodeType.INSERT_ROW.serialize(byteBuffer);
     subSerialize(byteBuffer);
+    super.serializeAttributes(byteBuffer);
   }
 
   @Override
   protected void serializeAttributes(DataOutputStream stream) throws IOException {
     PlanNodeType.INSERT_ROW.serialize(stream);
     subSerialize(stream);
+    super.serializeAttributes(stream);
   }
 
   void subSerialize(ByteBuffer buffer) {
@@ -444,6 +446,7 @@ public class InsertRowNode extends InsertNode implements WALEntryValue, ISchemaV
     InsertRowNode insertNode = new InsertRowNode(new PlanNodeId(""));
     insertNode.subDeserialize(byteBuffer);
     insertNode.setPlanNodeId(PlanNodeId.deserialize(byteBuffer));
+    insertNode.deserializeInsertNodeAttributes(byteBuffer);
     return insertNode;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsNode.java
@@ -195,6 +195,7 @@ public class InsertRowsNode extends InsertNode implements BatchInsertNode {
     InsertRowsNode insertRowsNode = new InsertRowsNode(planNodeId);
     insertRowsNode.setInsertRowNodeList(insertRowNodeList);
     insertRowsNode.setInsertRowNodeIndexList(insertRowNodeIndex);
+    insertRowsNode.deserializeInsertNodeAttributes(byteBuffer);
     return insertRowsNode;
   }
 
@@ -210,6 +211,8 @@ public class InsertRowsNode extends InsertNode implements BatchInsertNode {
     for (Integer index : insertRowNodeIndexList) {
       ReadWriteIOUtils.write(index, byteBuffer);
     }
+
+    super.serializeAttributes(byteBuffer);
   }
 
   @Override
@@ -224,6 +227,8 @@ public class InsertRowsNode extends InsertNode implements BatchInsertNode {
     for (Integer index : insertRowNodeIndexList) {
       ReadWriteIOUtils.write(index, stream);
     }
+
+    super.serializeAttributes(stream);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -234,6 +234,7 @@ public class InsertRowsOfOneDeviceNode extends InsertNode implements BatchInsert
     insertRowsOfOneDeviceNode.setInsertRowNodeList(insertRowNodeList);
     insertRowsOfOneDeviceNode.setInsertRowNodeIndexList(insertRowNodeIndex);
     insertRowsOfOneDeviceNode.setDevicePath(devicePath);
+    insertRowsOfOneDeviceNode.deserializeInsertNodeAttributes(byteBuffer);
     return insertRowsOfOneDeviceNode;
   }
 
@@ -251,6 +252,8 @@ public class InsertRowsOfOneDeviceNode extends InsertNode implements BatchInsert
     for (Integer index : insertRowNodeIndexList) {
       ReadWriteIOUtils.write(index, byteBuffer);
     }
+
+    super.serializeAttributes(byteBuffer);
   }
 
   @Override
@@ -267,6 +270,8 @@ public class InsertRowsOfOneDeviceNode extends InsertNode implements BatchInsert
     for (Integer index : insertRowNodeIndexList) {
       ReadWriteIOUtils.write(index, stream);
     }
+
+    super.serializeAttributes(stream);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertTabletNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertTabletNode.java
@@ -411,12 +411,14 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue, ISche
   protected void serializeAttributes(ByteBuffer byteBuffer) {
     PlanNodeType.INSERT_TABLET.serialize(byteBuffer);
     subSerialize(byteBuffer);
+    super.serializeAttributes(byteBuffer);
   }
 
   @Override
   protected void serializeAttributes(DataOutputStream stream) throws IOException {
     PlanNodeType.INSERT_TABLET.serialize(stream);
     subSerialize(stream);
+    super.serializeAttributes(stream);
   }
 
   void subSerialize(ByteBuffer buffer) {
@@ -666,6 +668,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue, ISche
     InsertTabletNode insertNode = new InsertTabletNode(new PlanNodeId(""));
     insertNode.subDeserialize(byteBuffer);
     insertNode.setPlanNodeId(PlanNodeId.deserialize(byteBuffer));
+    insertNode.deserializeInsertNodeAttributes(byteBuffer);
     return insertNode;
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileResourceConsensusIndexTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileResourceConsensusIndexTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.engine.storagegroup;
+
+import org.apache.iotdb.consensus.common.index.ConsensusIndex;
+import org.apache.iotdb.db.constant.TestConstant;
+import org.apache.iotdb.db.engine.storagegroup.timeindex.DeviceTimeIndex;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+public class TsFileResourceConsensusIndexTest {
+  private final File file =
+      new File(
+          TsFileNameGenerator.generateNewTsFilePath(TestConstant.BASE_OUTPUT_PATH, 1, 1, 1, 1));
+  private final TsFileResource tsFileResource = new TsFileResource(file);
+  private final Map<String, Integer> deviceToIndex = new HashMap<>();
+  private final long[] startTimes = new long[DEVICE_NUM];
+  private final long[] endTimes = new long[DEVICE_NUM];
+  private static final int DEVICE_NUM = 100;
+
+  private final List<ConsensusIndex> indexList = new ArrayList<>();
+  private static final int INDEX_NUM = 1000;
+
+  @Before
+  public void setUp() {
+    IntStream.range(0, DEVICE_NUM).forEach(i -> deviceToIndex.put("root.sg.d" + i, i));
+    DeviceTimeIndex deviceTimeIndex = new DeviceTimeIndex(deviceToIndex, startTimes, endTimes);
+    IntStream.range(0, DEVICE_NUM)
+        .forEach(
+            i -> {
+              deviceTimeIndex.updateStartTime("root.sg.d" + i, i);
+              deviceTimeIndex.updateEndTime("root.sg.d" + i, i + 1);
+            });
+    tsFileResource.setTimeIndex(deviceTimeIndex);
+    tsFileResource.setStatus(TsFileResourceStatus.CLOSED);
+
+    IntStream.range(0, INDEX_NUM).forEach(i -> indexList.add(new MockConsensusIndex(i)));
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // clean fake file
+    if (file.exists()) {
+      FileUtils.delete(file);
+    }
+    File resourceFile = new File(file.getName() + TsFileResource.RESOURCE_SUFFIX);
+    if (resourceFile.exists()) {
+      FileUtils.delete(resourceFile);
+    }
+  }
+
+  @Test
+  public void testConsensusIndexRecorder() {
+    Assert.assertFalse(tsFileResource.containConsensusIndexRange(new MockConsensusIndex(0)));
+
+    indexList.forEach(tsFileResource::updateConsensusIndex);
+
+    Assert.assertTrue(tsFileResource.containConsensusIndexRange(new MockConsensusIndex(-1)));
+    Assert.assertTrue(tsFileResource.containConsensusIndexRange(new MockConsensusIndex(0)));
+    Assert.assertTrue(tsFileResource.containConsensusIndexRange(new MockConsensusIndex(1)));
+    Assert.assertTrue(
+        tsFileResource.containConsensusIndexRange(new MockConsensusIndex(INDEX_NUM - 1)));
+
+    Assert.assertFalse(
+        tsFileResource.containConsensusIndexRange(new MockConsensusIndex(INDEX_NUM)));
+    Assert.assertFalse(
+        tsFileResource.containConsensusIndexRange(new MockConsensusIndex(Integer.MAX_VALUE)));
+
+    Assert.assertFalse(
+        tsFileResource.containConsensusIndexRange(new MockConsensusIndex(1, INDEX_NUM - 1)));
+    Assert.assertFalse(tsFileResource.containConsensusIndexRange(null));
+  }
+
+  @Test
+  public void testConsensusIndexRecorderSerialize() {
+    // TODO: wait for implements of ConsensusIndex.deserializeFrom
+  }
+
+  public static class MockConsensusIndex implements ConsensusIndex {
+    private final int type;
+    private final int val;
+
+    public MockConsensusIndex(int val) {
+      this(0, val);
+    }
+
+    public MockConsensusIndex(int type, int val) {
+      this.type = type;
+      this.val = val;
+    }
+
+    @Override
+    public void serialize(ByteBuffer byteBuffer) {
+      ReadWriteIOUtils.write(val, byteBuffer);
+    }
+
+    @Override
+    public void serialize(OutputStream stream) throws IOException {
+      ReadWriteIOUtils.write(val, stream);
+    }
+
+    @Override
+    public CompareResult compareTo(ConsensusIndex consensusIndex) {
+      if (!(consensusIndex instanceof MockConsensusIndex)) {
+        return CompareResult.INCOMPARABLE;
+      }
+      if (((MockConsensusIndex) consensusIndex).type != type) {
+        return CompareResult.INCOMPARABLE;
+      }
+      if (val < ((MockConsensusIndex) consensusIndex).val) {
+        return CompareResult.SMALLER;
+      } else if (val == ((MockConsensusIndex) consensusIndex).val) {
+        return CompareResult.EQUAL;
+      }
+      return CompareResult.GREATER;
+    }
+  }
+}


### PR DESCRIPTION
Create interface, used for pipe's fault tolerance.
- ConsensusIndex
- ComparableConsensusRequest

Manage ConsensusIndex Life:
InsertNode(add ConsensusIndex, add it to serialize result
-> TsFileProcessor(add in write process so it can be caught by TsFileResource)
-> TsFileResource(add Recorder for ConsensusIndex, implement compare and serialize)