### PR TITLE
[IOTDB-5729] Fix RatisConsensus ResponseMessage conversion error

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.consensus.common.request.ByteBufferConsensusRequest;
 import org.apache.iotdb.consensus.common.request.IConsensusRequest;
 import org.apache.iotdb.consensus.ratis.metrics.RatisMetricsManager;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.proto.RaftProtos.RaftConfigurationProto;
@@ -163,7 +164,10 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
         Thread.currentThread().interrupt();
       } catch (Throwable rte) {
         logger.error("application statemachine throws a runtime exception: ", rte);
-        ret = Message.valueOf("internal error. statemachine throws a runtime exception: " + rte);
+        ret =
+            new ResponseMessage(
+                new TSStatus(TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode())
+                    .setMessage("internal error. statemachine throws a runtime exception: " + rte));
         if (applicationStateMachine.isReadOnly()) {
           waitUntilSystemNotReadOnly();
           shouldRetry = true;


### PR DESCRIPTION
An error occurred during a recent run:
```shell
org.apache.iotdb.rpc.StatementExecutionException: 305: 
class org.apache.ratis.protocol.Message$1 cannot be cast to class org.apache.iotdb.consensus.ratis.ResponseMessage 
(org.apache.ratis.protocol.Message$1 and org.apache.iotdb.consensus.ratis.ResponseMessage are in unnamed module of loader 'app')
```

The error is originated from a incorrect return value in `applicationStateMachineProxy.write`, see the details in PR.