### PR TITLE
[IOTDB-5730] Fix use a hard link when loading a SchemaFile snapshot

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -477,7 +477,7 @@ public class SchemaFile implements ISchemaFile {
             getDirPath(sgName, schemaRegionId), MetadataConstant.SCHEMA_LOG_FILE_NAME);
     Files.deleteIfExists(schemaFile.toPath());
     Files.deleteIfExists(schemaLogFile.toPath());
-    Files.createLink(schemaFile.toPath(), snapshot.toPath());
+    Files.copy(snapshot.toPath(), schemaFile.toPath());
     return new SchemaFile(
         sgName,
         schemaRegionId,


### PR DESCRIPTION
## Description

Using a hard link when loading a SchemaFile snapshot on the current system can lead to corruption of snaptshot. Files.copy should be used instead.