### PR TITLE
[To rel/1.1][IOTDB-5732] Add Device Schema Statistics

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/CachedMTreeStore.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/CachedMTreeStore.java
@@ -327,8 +327,8 @@ public class CachedMTreeStore implements IMTreeStore {
   @Override
   public IEntityMNode setToEntity(IMNode node) {
     IEntityMNode result = MNodeUtils.setToEntity(node);
-    regionStatistics.addDevice();
     if (result != node) {
+      regionStatistics.addDevice();
       memManager.updatePinnedSize(IMNodeSizeEstimator.getEntityNodeBaseSize());
     }
     updateMNode(result);
@@ -338,8 +338,8 @@ public class CachedMTreeStore implements IMTreeStore {
   @Override
   public IMNode setToInternal(IEntityMNode entityMNode) {
     IMNode result = MNodeUtils.setToInternal(entityMNode);
-    regionStatistics.deleteDevice();
     if (result != entityMNode) {
+      regionStatistics.deleteDevice();
       memManager.updatePinnedSize(-IMNodeSizeEstimator.getEntityNodeBaseSize());
     }
     updateMNode(result);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/CachedMTreeStore.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/CachedMTreeStore.java
@@ -57,15 +57,10 @@ public class CachedMTreeStore implements IMTreeStore {
   private static final Logger logger = LoggerFactory.getLogger(CachedMTreeStore.class);
 
   private final MemManager memManager;
-
   private final ICacheManager cacheManager;
-
   private ISchemaFile file;
-
   private IMNode root;
-
   private final Runnable flushCallback;
-
   private final CachedSchemaRegionStatistics regionStatistics;
 
   private final StampedWriterPreferredLock lock = new StampedWriterPreferredLock();
@@ -332,6 +327,7 @@ public class CachedMTreeStore implements IMTreeStore {
   @Override
   public IEntityMNode setToEntity(IMNode node) {
     IEntityMNode result = MNodeUtils.setToEntity(node);
+    regionStatistics.addDevice();
     if (result != node) {
       memManager.updatePinnedSize(IMNodeSizeEstimator.getEntityNodeBaseSize());
     }
@@ -342,6 +338,7 @@ public class CachedMTreeStore implements IMTreeStore {
   @Override
   public IMNode setToInternal(IEntityMNode entityMNode) {
     IMNode result = MNodeUtils.setToInternal(entityMNode);
+    regionStatistics.deleteDevice();
     if (result != entityMNode) {
       memManager.updatePinnedSize(-IMNodeSizeEstimator.getEntityNodeBaseSize());
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/MemMTreeStore.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/MemMTreeStore.java
@@ -156,8 +156,8 @@ public class MemMTreeStore implements IMTreeStore {
   @Override
   public IEntityMNode setToEntity(IMNode node) {
     IEntityMNode result = MNodeUtils.setToEntity(node);
-    regionStatistics.addDevice();
     if (result != node) {
+      regionStatistics.addDevice();
       requestMemory(IMNodeSizeEstimator.getEntityNodeBaseSize());
     }
 
@@ -170,8 +170,8 @@ public class MemMTreeStore implements IMTreeStore {
   @Override
   public IMNode setToInternal(IEntityMNode entityMNode) {
     IMNode result = MNodeUtils.setToInternal(entityMNode);
-    regionStatistics.deleteDevice();
     if (result != entityMNode) {
+      regionStatistics.deleteDevice();
       releaseMemory(IMNodeSizeEstimator.getEntityNodeBaseSize());
     }
     if (result.isStorageGroup()) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/MemMTreeStore.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/MemMTreeStore.java
@@ -156,6 +156,7 @@ public class MemMTreeStore implements IMTreeStore {
   @Override
   public IEntityMNode setToEntity(IMNode node) {
     IEntityMNode result = MNodeUtils.setToEntity(node);
+    regionStatistics.addDevice();
     if (result != node) {
       requestMemory(IMNodeSizeEstimator.getEntityNodeBaseSize());
     }
@@ -169,6 +170,7 @@ public class MemMTreeStore implements IMTreeStore {
   @Override
   public IMNode setToInternal(IEntityMNode entityMNode) {
     IMNode result = MNodeUtils.setToInternal(entityMNode);
+    regionStatistics.deleteDevice();
     if (result != entityMNode) {
       releaseMemory(IMNodeSizeEstimator.getEntityNodeBaseSize());
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFile.java
@@ -468,7 +468,7 @@ public class SchemaFile implements ISchemaFile {
             getDirPath(sgName, schemaRegionId), MetadataConstant.SCHEMA_LOG_FILE_NAME);
     Files.deleteIfExists(schemaFile.toPath());
     Files.deleteIfExists(schemaLogFile.toPath());
-    Files.createLink(schemaFile.toPath(), snapshot.toPath());
+    Files.copy(snapshot.toPath(), schemaFile.toPath());
     return new SchemaFile(
         sgName,
         schemaRegionId,

--- a/server/src/main/java/org/apache/iotdb/db/metadata/rescon/ISchemaRegionStatistics.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/rescon/ISchemaRegionStatistics.java
@@ -28,6 +28,8 @@ public interface ISchemaRegionStatistics {
 
   long getSeriesNumber();
 
+  long getDevicesNumber();
+
   int getTemplateActivatedNumber();
 
   long getTemplateSeriesNumber();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/rescon/MemSchemaRegionStatistics.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/rescon/MemSchemaRegionStatistics.java
@@ -31,6 +31,7 @@ public class MemSchemaRegionStatistics implements ISchemaRegionStatistics {
   private final int schemaRegionId;
   private final AtomicLong memoryUsage = new AtomicLong(0);
   private final AtomicLong seriesNumber = new AtomicLong(0);
+  private final AtomicLong devicesNumber = new AtomicLong(0);
   private final Map<Integer, Integer> templateUsage = new ConcurrentHashMap<>();
 
   private long mLogLength = 0;
@@ -68,6 +69,19 @@ public class MemSchemaRegionStatistics implements ISchemaRegionStatistics {
   public void deleteTimeseries(long deletedNum) {
     seriesNumber.addAndGet(-deletedNum);
     schemaEngineStatistics.deleteTimeseries(deletedNum);
+  }
+
+  @Override
+  public long getDevicesNumber() {
+    return devicesNumber.get();
+  }
+
+  public void addDevice() {
+    devicesNumber.incrementAndGet();
+  }
+
+  public void deleteDevice() {
+    devicesNumber.decrementAndGet();
   }
 
   @Override
@@ -130,6 +144,7 @@ public class MemSchemaRegionStatistics implements ISchemaRegionStatistics {
     schemaEngineStatistics.deleteTimeseries(seriesNumber.get());
     memoryUsage.getAndSet(0);
     seriesNumber.getAndSet(0);
+    devicesNumber.getAndSet(0);
     templateUsage.forEach(
         (templateId, cnt) -> schemaEngineStatistics.deactivateTemplate(templateId, cnt));
     templateUsage.clear();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -129,10 +129,10 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   private boolean isRecovering = true;
   private volatile boolean initialized = false;
 
-  private String storageGroupDirPath;
-  private String schemaRegionDirPath;
-  private String storageGroupFullPath;
-  private SchemaRegionId schemaRegionId;
+  private final String storageGroupDirPath;
+  private final String schemaRegionDirPath;
+  private final String storageGroupFullPath;
+  private final SchemaRegionId schemaRegionId;
 
   // the log file writer
   private boolean usingMLog = true;
@@ -144,7 +144,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   private TagManager tagManager;
 
   // seriesNumberMonitor may be null
-  private final ISeriesNumerMonitor seriesNumerMonitor;
+  private final ISeriesNumerMonitor seriesNumberMonitor;
 
   // region Interfaces and Implementation of initialization、snapshot、recover and clear
   public SchemaRegionMemoryImpl(ISchemaRegionParams schemaRegionParams) throws MetadataException {
@@ -167,7 +167,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       }
     }
 
-    this.seriesNumerMonitor = schemaRegionParams.getSeriesNumberMonitor();
+    this.seriesNumberMonitor = schemaRegionParams.getSeriesNumberMonitor();
     this.regionStatistics =
         new MemSchemaRegionStatistics(
             schemaRegionId.getId(), schemaRegionParams.getSchemaEngineStatistics());
@@ -389,8 +389,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   public synchronized void deleteSchemaRegion() throws MetadataException {
     // collect all the LeafMNode in this schema region
     long seriesCount = regionStatistics.getSeriesNumber();
-    if (seriesNumerMonitor != null) {
-      seriesNumerMonitor.deleteTimeSeries((int) seriesCount);
+    if (seriesNumberMonitor != null) {
+      seriesNumberMonitor.deleteTimeSeries((int) seriesCount);
     }
 
     // clear all the components and release all the file handlers
@@ -477,6 +477,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
                 }
               },
               deviceMNode -> {
+                regionStatistics.addDevice();
                 if (deviceMNode.getSchemaTemplateIdWithState() >= 0) {
                   regionStatistics.activateTemplate(deviceMNode.getSchemaTemplateId());
                 }
@@ -530,7 +531,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       throw new SeriesOverflowException();
     }
 
-    if (seriesNumerMonitor != null && !seriesNumerMonitor.addTimeSeries(1)) {
+    if (seriesNumberMonitor != null && !seriesNumberMonitor.addTimeSeries(1)) {
       throw new SeriesNumberOverflowException();
     }
 
@@ -553,8 +554,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
                 plan.getProps(),
                 plan.getAlias());
       } catch (Throwable t) {
-        if (seriesNumerMonitor != null) {
-          seriesNumerMonitor.deleteTimeSeries(1);
+        if (seriesNumberMonitor != null) {
+          seriesNumberMonitor.deleteTimeSeries(1);
         }
         throw t;
       }
@@ -610,7 +611,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       throw new SeriesOverflowException();
     }
 
-    if (seriesNumerMonitor != null && !seriesNumerMonitor.addTimeSeries(seriesCount)) {
+    if (seriesNumberMonitor != null && !seriesNumberMonitor.addTimeSeries(seriesCount)) {
       throw new SeriesNumberOverflowException();
     }
 
@@ -639,8 +640,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
                 plan.getCompressors(),
                 plan.getAliasList());
       } catch (Throwable t) {
-        if (seriesNumerMonitor != null) {
-          seriesNumerMonitor.deleteTimeSeries(seriesCount);
+        if (seriesNumberMonitor != null) {
+          seriesNumberMonitor.deleteTimeSeries(seriesCount);
         }
         throw t;
       }
@@ -782,8 +783,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
     removeFromTagInvertedIndex(measurementMNode);
 
     regionStatistics.deleteTimeseries(1L);
-    if (seriesNumerMonitor != null) {
-      seriesNumerMonitor.deleteTimeSeries(1);
+    if (seriesNumberMonitor != null) {
+      seriesNumberMonitor.deleteTimeSeries(1);
     }
   }
 
@@ -799,8 +800,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
     removeFromTagInvertedIndex(measurementMNode);
 
     regionStatistics.deleteTimeseries(1L);
-    if (seriesNumerMonitor != null) {
-      seriesNumerMonitor.deleteTimeSeries(1);
+    if (seriesNumberMonitor != null) {
+      seriesNumberMonitor.deleteTimeSeries(1);
     }
   }
   // endregion

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGTest.java
@@ -99,6 +99,9 @@ public abstract class MTreeBelowSGTest {
                 node -> {
                   // do nothing
                 },
+                node -> {
+                  // do nothing
+                },
                 0,
                 new CachedSchemaRegionStatistics(0, new CachedSchemaEngineStatistics()));
       } else {

--- a/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
@@ -200,6 +200,36 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
   }
 
   @Test
+  public void testDeviceNumStatistics() throws Exception {
+    ISchemaRegion schemaRegion1 = getSchemaRegion("root.sg1", 0);
+    ISchemaRegion schemaRegion2 = getSchemaRegion("root.sg2", 1);
+    ISchemaEngineStatistics engineStatistics =
+        SchemaEngine.getInstance().getSchemaEngineStatistics();
+
+    SchemaRegionTestUtil.createSimpleTimeseriesByList(
+        schemaRegion1, Arrays.asList("root.sg1.d0", "root.sg1.d1.s1", "root.sg1.d1.s2.t1"));
+    SchemaRegionTestUtil.createSimpleTimeseriesByList(
+        schemaRegion2, Arrays.asList("root.sg2.d1.s3", "root.sg2.d2.s1", "root.sg2.d2.s2"));
+    SchemaRegionTestUtil.createSimpleTimeseriesByList(
+        schemaRegion2, Collections.singletonList("root.sg2.s1"));
+    // check series number
+    Assert.assertEquals(3, schemaRegion1.getSchemaRegionStatistics().getDevicesNumber());
+    Assert.assertEquals(3, schemaRegion2.getSchemaRegionStatistics().getDevicesNumber());
+
+    PathPatternTree patternTree = new PathPatternTree();
+    patternTree.appendPathPattern(new PartialPath("root.**.s1"));
+    patternTree.constructTree();
+    Assert.assertTrue(schemaRegion1.constructSchemaBlackList(patternTree) >= 1);
+    Assert.assertTrue(schemaRegion2.constructSchemaBlackList(patternTree) >= 1);
+    schemaRegion1.deleteTimeseriesInBlackList(patternTree);
+    schemaRegion2.deleteTimeseriesInBlackList(patternTree);
+
+    // check series number
+    Assert.assertEquals(2, schemaRegion1.getSchemaRegionStatistics().getDevicesNumber());
+    Assert.assertEquals(2, schemaRegion2.getSchemaRegionStatistics().getDevicesNumber());
+  }
+
+  @Test
   public void testSchemaFileNodeStatistics() throws Exception {
     if (testParams.getSchemaEngineMode().equals("Schema_File")) {
       ISchemaRegion schemaRegion1 = getSchemaRegion("root.sg1", 0);


### PR DESCRIPTION
## Description

In order to better implement cluster quota management and enrich the metadata monitoring dashboard, it is necessary to add device-related statistical values when SchemaRegion creates and deletes device nodes.