### PR TITLE
[To rel/1.1]Fix WrappedSegment extension with big name on edge case

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SegmentedPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SegmentedPage.java
@@ -84,10 +84,16 @@ public class SegmentedPage extends SchemaPage implements ISegmentedPage {
     ISegment<ByteBuffer, IMNode> tarSeg = getSegment(segIdx);
 
     if (tarSeg.insertRecord(key, buffer) < 0) {
-      // relocate inside page, if not enough space for new size segment, throw exception
+      // relocate inside page, if not enough space for new size segment, throw SchemaPageOverflow
+      // exception
+      // increment of segment includes: buffer, key, length of the key(4 bytes), offset of the
+      // buffer(2 bytes)
       tarSeg =
           relocateSegment(
-              tarSeg, segIdx, SchemaFile.reEstimateSegSize(tarSeg.size() + buffer.capacity()));
+              tarSeg,
+              segIdx,
+              SchemaFile.reEstimateSegSize(
+                  tarSeg.size() + buffer.capacity() + key.getBytes().length + 4 + 2));
     } else {
       return 0L;
     }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
@@ -518,7 +518,7 @@ public class SchemaFileTest {
         fillChildren(
             sgNode,
             300,
-            "device中文abcdefahiklmnoparstuwwxyz1ABCDEFGHUKLMNOPORSTUVWXYZ",
+            "deviceabcdabcdefahiklmnoparstuwwxyz1ABCDEFGHUKLMNOPORSTUVWXYZ",
             this::supplyEntity);
     ISchemaFile sf = SchemaFile.initSchemaFile("root.sg", TEST_SCHEMA_REGION_ID);
 
@@ -530,7 +530,7 @@ public class SchemaFileTest {
       fillChildren(
           d1,
           2,
-          "sensor2中文abcdefahiklmnoparstuwwxyz1ABCDEFGHUKLMNOPORSTUVWXYZPORSTUVWXYZ",
+          "sensor2abcdabcdefahiklmnoparstuwwxyz1ABCDEFGHUKLMNOPORSTUVWXYZPORSTUVWXYZ",
           this::supplyMeasurementWithoutAlias);
 
       sf.writeMNode(d1);

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
@@ -504,6 +504,55 @@ public class SchemaFileTest {
     sf.close();
   }
 
+  /**
+   * This test case is designed to examine a scenario in which, every time a SegmentedPage inserts a
+   * record, the process of checking whether there is enough space in the segment takes into account
+   * not only the size of the record's buffer, but also the size of the key and related pointers.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testEstimateSegSizeWithBigName() throws Exception {
+    IMNode sgNode = new StorageGroupMNode(null, "mma", 111111111L);
+    IMNode d1 =
+        fillChildren(
+            sgNode,
+            300,
+            "device中文abcdefahiklmnoparstuwwxyz1ABCDEFGHUKLMNOPORSTUVWXYZ",
+            this::supplyEntity);
+    ISchemaFile sf = SchemaFile.initSchemaFile("root.sg", TEST_SCHEMA_REGION_ID);
+
+    try {
+      fillChildren(d1, 19, "ss1", this::supplyMeasurement);
+
+      sf.writeMNode(sgNode);
+
+      fillChildren(
+          d1,
+          2,
+          "sensor2中文abcdefahiklmnoparstuwwxyz1ABCDEFGHUKLMNOPORSTUVWXYZPORSTUVWXYZ",
+          this::supplyMeasurementWithoutAlias);
+
+      sf.writeMNode(d1);
+
+      moveAllToBuffer(d1);
+      moveAllToBuffer(sgNode);
+
+      fillChildren(d1, 20, "ss", this::supplyMeasurement);
+      sf.writeMNode(d1);
+
+      Iterator<IMNode> verifyChildren = sf.getChildren(d1);
+      int cnt = 0;
+      while (verifyChildren.hasNext()) {
+        cnt++;
+        verifyChildren.next();
+      }
+      Assert.assertEquals(41, cnt);
+    } finally {
+      sf.close();
+    }
+  }
+
   @Test
   public void testEstimateSegSize() throws Exception {
     // to test whether estimation of segment size works on edge cases
@@ -920,6 +969,10 @@ public class SchemaFileTest {
 
   private IMNode supplyMeasurement(IMNode par, String name) {
     return getMeasurementNode(par, name, name + "_als");
+  }
+
+  private IMNode supplyMeasurementWithoutAlias(IMNode par, String name) {
+    return getMeasurementNode(par, name, null);
   }
 
   private IMNode supplyInternal(IMNode par, String name) {


### PR DESCRIPTION
## Description

In determining the size of the pre-allocated segment for an EntityNode, an accurate calculation is performed by examining the children of the EntityNode if it has fewer than 20 children. Alternatively, the size is estimated using a hard-coded step list based on the cardinality of the EntityNode's children. 

During the flushing process of the EntityNode, the segment size is assessed prior to the insertion of each child, and the segment is re-allocated or extended according to the anticipated size. If the segment is unable to accommodate the inserted child even after an extension, an exception will be raised, indicating that the record is too large or the extension has failed.

This issue arises in an edge case where the EntityNode has fewer than 20 children, each with a large size (approximately 1000 bytes in total) when calculated for pre-allocation. However, before the EntityNode is flushed, a new child with a large name and a small buffer, which includes aliases and other schema data but measures under 20 bytes, for instance, is inserted. The segment size assessment may be misled, resulting in a minor increment for the segment extension, e.g., from 1000 bytes to 1022 bytes, leading to an overflow since the segment cannot accommodate the large name.

This hotfix takes into account the length of the name, bytes of the name, and the record buffer offset when assessing the expected size of the WrappedSegment. This issue will not occur with AliasIndexPage or InternalPage, as their lengths will never be assessed multiple times due to their fixed length. The root cause of the original issue, as well as potential performance improvements, can be attributed to the design of the WrappedSegment increment, which is determined by a hard-coded step list as aforementioned.