### PR TITLE
[To rel/1.1]Fix template type check on ClusterTemplateManager

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -68,6 +68,19 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
     // test create schema template repeatedly
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
+      // test datatype and encoding check
+      try {
+        statement.execute(
+            "CREATE SCHEMA TEMPLATE str1 (s1 TEXT encoding=GORILLA compressor=SNAPPY, s2 INT32)");
+        Assert.fail();
+      } catch (SQLException e) {
+        System.out.println(e.getMessage());
+        Assert.assertEquals(
+            TSStatusCode.CREATE_TEMPLATE_ERROR.getStatusCode()
+                + ": create template error -encoding GORILLA does not support TEXT",
+            e.getMessage());
+      }
+
       try {
         statement.execute(
             "CREATE SCHEMA TEMPLATE t1 (s1 INT64 encoding=RLE compressor=SNAPPY, s2 INT32)");

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/ClusterTemplateManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/ClusterTemplateManager.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.client.exception.ClientManagerException;
 import org.apache.iotdb.commons.consensus.ConfigRegionId;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.IoTDBException;
+import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.confignode.rpc.thrift.TCreateSchemaTemplateReq;
@@ -36,7 +37,10 @@ import org.apache.iotdb.db.client.ConfigNodeClient;
 import org.apache.iotdb.db.client.ConfigNodeClientManager;
 import org.apache.iotdb.db.client.ConfigNodeInfo;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.CreateSchemaTemplateStatement;
+import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.apache.thrift.TException;
@@ -87,6 +91,15 @@ public class ClusterTemplateManager implements ITemplateManager {
     TCreateSchemaTemplateReq req = constructTCreateSchemaTemplateReq(statement);
     try (ConfigNodeClient configNodeClient =
         CONFIG_NODE_CLIENT_MANAGER.borrowClient(ConfigNodeInfo.CONFIG_REGION_ID)) {
+      // Guardian statements for validity of datatype and encoding
+      List<List<TSDataType>> dataTypes = statement.getDataTypes();
+      List<List<TSEncoding>> encodings = statement.getEncodings();
+      for (int i = 0; i < dataTypes.size(); i++) {
+        for (int j = 0; j < dataTypes.get(i).size(); j++) {
+          SchemaUtils.checkDataTypeWithEncoding(dataTypes.get(i).get(j), encodings.get(i).get(j));
+        }
+      }
+
       // Send request to some API server
       TSStatus tsStatus = configNodeClient.createSchemaTemplate(req);
       // Get response or throw exception
@@ -97,6 +110,12 @@ public class ClusterTemplateManager implements ITemplateManager {
             tsStatus);
       }
       return tsStatus;
+    } catch (MetadataException e) {
+      throw new RuntimeException(
+          new IoTDBException(
+              "create template error -" + e.getMessage(),
+              e,
+              TSStatusCode.CREATE_TEMPLATE_ERROR.getStatusCode()));
     } catch (ClientManagerException | TException e) {
       throw new RuntimeException(
           new IoTDBException(


### PR DESCRIPTION
## Description

Previously, ClusterTemplateManager did not verify the compatibility between series type and its encoding, leading to incompatibility issues with erroneous creation request. 

A guardian statement has now been implemented to address this problem, and the related integration test case has been updated accordingly.