### PR TITLE
[To rel/0.13][IOTDB-5726]Select the last sealed seq file for nonOverlap unseq files to compact in cross compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -191,8 +191,7 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
       if (seqSelectedNum != resource.getSeqFiles().size()) {
         selectOverlappedSeqFiles(unseqFile);
       }
-      if (!hasFoundSeqFiles(unseqFile)) {
-        tmpSelectedSeqFiles.clear();
+      if (tmpSelectedSeqFiles.isEmpty() && !tryToSelectLatestSealedSeqFile(unseqFile)) {
         break;
       }
       boolean isSeqFilesValid = checkIsSeqFilesValid();
@@ -239,13 +238,9 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
    * If the unseq file does not overlap with any seq files, then select the latest sealed seq file
    * for it to compact with. Notice: If the data is deleted and then start an inner space
    * compaction, it may cause unseqStartTime > seqEndTime or partial devices are in the unseq files
-   * but not in seq files, which will cause the unseq files to not overlap with any seq file
+   * but not in seq files, which will cause the unseq file not overlap with any seq files
    */
-  private boolean hasFoundSeqFiles(TsFileResource unseqFile) {
-    if (!tmpSelectedSeqFiles.isEmpty()) {
-      return true;
-    }
-    // the current unseq file does not overlap with any seq files
+  private boolean tryToSelectLatestSealedSeqFile(TsFileResource unseqFile) {
     logger.info("Unseq file {} does not overlap with seq files.", unseqFile);
     List<TsFileResource> seqResources = resource.getSeqFiles();
     for (int i = seqResources.size() - 1; i >= 0; i--) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionSelector.java
@@ -113,7 +113,7 @@ public class SizeTieredCompactionSelector extends AbstractInnerSpaceCompactionSe
    * @return return whether to continue the search to higher levels
    * @throws IOException
    */
-  private boolean selectLevelTask(
+  public boolean selectLevelTask(
       int level, PriorityQueue<Pair<List<TsFileResource>, Long>> taskPriorityQueue)
       throws IOException {
     boolean shouldContinueToSearch = true;
@@ -180,7 +180,7 @@ public class SizeTieredCompactionSelector extends AbstractInnerSpaceCompactionSe
     return CompactionTaskManager.getInstance().addTaskToWaitingQueue(compactionTask);
   }
 
-  private class SizeTieredCompactionTaskComparator
+  public static class SizeTieredCompactionTaskComparator
       implements Comparator<Pair<List<TsFileResource>, Long>> {
 
     @Override

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
@@ -26,16 +26,24 @@ import org.apache.iotdb.db.engine.compaction.cross.rewrite.manage.CrossSpaceComp
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.ICrossSpaceMergeFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.selector.RewriteCompactionFileSelector;
 import org.apache.iotdb.db.engine.compaction.cross.rewrite.task.RewriteCrossSpaceCompactionTask;
-import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
+import org.apache.iotdb.db.engine.compaction.inner.InnerSpaceCompactionTaskFactory;
+import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompactionSelector;
+import org.apache.iotdb.db.engine.compaction.inner.sizetiered.SizeTieredCompactionTask;
+import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.engine.storagegroup.TsFileNameGenerator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
+import org.apache.iotdb.db.metadata.path.MeasurementPath;
+import org.apache.iotdb.db.metadata.path.PartialPath;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.db.tools.validate.TsFileValidationTool;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.TimeValuePair;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -45,12 +53,16 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.iotdb.db.conf.IoTDBConstant.PATH_SEPARATOR;
+
 public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
-  TsFileManager tsFileManager =
-      new TsFileManager(COMPACTION_TEST_SG, "0", STORAGE_GROUP_DIR.getPath());
 
   private final String oldThreadName = Thread.currentThread().getName();
 
@@ -2101,5 +2113,229 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
     TsFileValidationTool.findUncorrectFiles(files);
     Assert.assertEquals(0, TsFileValidationTool.badFileNum);
     TsFileValidationTool.clearMap();
+  }
+
+  @Test
+  public void testNonAlignedUnseqFilesNotOverlapWithSeqFiles1() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(5, 10, 5, 1000, 0, 0, 100, 100, false, true);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, false, false);
+    createFiles(3, 10, 5, 1000, 7500, 7500, 100, 100, false, true);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + d + PATH_SEPARATOR + "s" + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new MeasurementPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
+                TSDataType.INT64));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    SizeTieredCompactionSelector sizeTieredCompactionSelector =
+        new SizeTieredCompactionSelector(
+            COMPACTION_TEST_SG, "0", 0, tsFileManager, true, new InnerSpaceCompactionTaskFactory());
+
+    PriorityQueue<Pair<List<TsFileResource>, Long>> taskPriorityQueue =
+        new PriorityQueue<>(new SizeTieredCompactionSelector.SizeTieredCompactionTaskComparator());
+    sizeTieredCompactionSelector.selectLevelTask(0, taskPriorityQueue);
+    ;
+    for (Pair<List<TsFileResource>, Long> taskResource : taskPriorityQueue) {
+      new SizeTieredCompactionTask(
+              COMPACTION_TEST_SG,
+              "0",
+              0,
+              tsFileManager,
+              taskResource.left,
+              true,
+              new AtomicInteger(0))
+          .call();
+    }
+
+    // select cross compaction
+    CrossSpaceCompactionResource crossSpaceCompactionResource =
+        new CrossSpaceCompactionResource(
+            tsFileManager.getTsFileList(true), tsFileManager.getTsFileList(false));
+    RewriteCompactionFileSelector crossSpaceCompactionSelector =
+        new RewriteCompactionFileSelector(crossSpaceCompactionResource, Long.MAX_VALUE);
+    List[] pairs = crossSpaceCompactionSelector.select();
+    Assert.assertEquals(2, pairs.length);
+    Assert.assertEquals(1, pairs[0].size());
+    Assert.assertEquals(2, pairs[1].size());
+
+    new RewriteCrossSpaceCompactionTask(
+            "0", COMPACTION_TEST_SG, 0, tsFileManager, pairs[0], pairs[1], new AtomicInteger(0), 0)
+        .call();
+
+    validateSeqFiles();
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  @Test
+  public void testNonAlignedUnseqFilesNotOverlapWithSeqFiles2() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(5, 10, 5, 1000, 0, 0, 100, 100, false, true);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, false, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + d + PATH_SEPARATOR + "s" + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new MeasurementPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
+                TSDataType.INT64));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    SizeTieredCompactionSelector sizeTieredCompactionSelector =
+        new SizeTieredCompactionSelector(
+            COMPACTION_TEST_SG, "0", 0, tsFileManager, true, new InnerSpaceCompactionTaskFactory());
+
+    PriorityQueue<Pair<List<TsFileResource>, Long>> taskPriorityQueue =
+        new PriorityQueue<>(new SizeTieredCompactionSelector.SizeTieredCompactionTaskComparator());
+    sizeTieredCompactionSelector.selectLevelTask(0, taskPriorityQueue);
+    ;
+    for (Pair<List<TsFileResource>, Long> taskResource : taskPriorityQueue) {
+      new SizeTieredCompactionTask(
+              COMPACTION_TEST_SG,
+              "0",
+              0,
+              tsFileManager,
+              taskResource.left,
+              true,
+              new AtomicInteger(0))
+          .call();
+    }
+
+    // select cross compaction
+    CrossSpaceCompactionResource crossSpaceCompactionResource =
+        new CrossSpaceCompactionResource(
+            tsFileManager.getTsFileList(true), tsFileManager.getTsFileList(false));
+    RewriteCompactionFileSelector crossSpaceCompactionSelector =
+        new RewriteCompactionFileSelector(crossSpaceCompactionResource, Long.MAX_VALUE);
+    List[] pairs = crossSpaceCompactionSelector.select();
+    Assert.assertEquals(2, pairs.length);
+    Assert.assertEquals(1, pairs[0].size());
+    Assert.assertEquals(2, pairs[1].size());
+
+    new RewriteCrossSpaceCompactionTask(
+            "0", COMPACTION_TEST_SG, 0, tsFileManager, pairs[0], pairs[1], new AtomicInteger(0), 0)
+        .call();
+
+    validateSeqFiles();
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  @Test
+  public void testNonAlignedUnseqFilesNotOverlapWithSeqFiles3() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(4, 10, 5, 1000, 0, 0, 100, 100, false, true);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, false, false);
+    createFiles(1, 10, 5, 1000, 7500, 7500, 100, 100, false, true);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + d + PATH_SEPARATOR + "s" + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new MeasurementPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
+                TSDataType.INT64));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    SizeTieredCompactionSelector sizeTieredCompactionSelector =
+        new SizeTieredCompactionSelector(
+            COMPACTION_TEST_SG, "0", 0, tsFileManager, true, new InnerSpaceCompactionTaskFactory());
+
+    PriorityQueue<Pair<List<TsFileResource>, Long>> taskPriorityQueue =
+        new PriorityQueue<>(new SizeTieredCompactionSelector.SizeTieredCompactionTaskComparator());
+    sizeTieredCompactionSelector.selectLevelTask(0, taskPriorityQueue);
+    ;
+    for (Pair<List<TsFileResource>, Long> taskResource : taskPriorityQueue) {
+      new SizeTieredCompactionTask(
+              COMPACTION_TEST_SG,
+              "0",
+              0,
+              tsFileManager,
+              taskResource.left,
+              true,
+              new AtomicInteger(0))
+          .call();
+    }
+
+    // select cross compaction
+    CrossSpaceCompactionResource crossSpaceCompactionResource =
+        new CrossSpaceCompactionResource(
+            tsFileManager.getTsFileList(true), tsFileManager.getTsFileList(false));
+    RewriteCompactionFileSelector crossSpaceCompactionSelector =
+        new RewriteCompactionFileSelector(crossSpaceCompactionResource, Long.MAX_VALUE);
+    List[] pairs = crossSpaceCompactionSelector.select();
+    Assert.assertEquals(2, pairs.length);
+    Assert.assertEquals(1, pairs[0].size());
+    Assert.assertEquals(2, pairs[1].size());
+
+    new RewriteCrossSpaceCompactionTask(
+            "0", COMPACTION_TEST_SG, 0, tsFileManager, pairs[0], pairs[1], new AtomicInteger(0), 0)
+        .call();
+
+    validateSeqFiles();
+    validateTargetDatas(sourceData, Collections.emptyList());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionValidationTest.java
@@ -2307,7 +2307,6 @@ public class CrossSpaceCompactionValidationTest extends AbstractCompactionTest {
     PriorityQueue<Pair<List<TsFileResource>, Long>> taskPriorityQueue =
         new PriorityQueue<>(new SizeTieredCompactionSelector.SizeTieredCompactionTaskComparator());
     sizeTieredCompactionSelector.selectLevelTask(0, taskPriorityQueue);
-    ;
     for (Pair<List<TsFileResource>, Long> taskResource : taskPriorityQueue) {
       new SizeTieredCompactionTask(
               COMPACTION_TEST_SG,


### PR DESCRIPTION
**Description**
Cross space compaction select one unseq file but none seq file, which causes cross compaction under this time partition can never be performed.

**Reason**
Unseq file does not overlap with any seq files under this time partition, including two cases: 1. The devices under the unseq files do not exist in the seq files. 2. The device of the unseq file exists in the seq file, but unseqDevice.startTime>seqDevice.endTime. This can happen if the data is deleted and an seq inner space compaction has been performed.

**Solution**
For nonOverlap unseq files, select the last sealed seq file, if it is valid (status is closed), then select it, otherwise stop the selection.