### PR TITLE
[To rel/1.1][IOTDB-5726]Select the last sealed seq file for nonOverlap unseq files to compact in cross compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
@@ -156,7 +156,9 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
           split.seqFiles.stream().map(c -> c.resource).collect(Collectors.toList());
 
       if (!split.hasOverlap) {
-        TsFileResource latestSealedSeqFile = getLatestSealedSeqFile(candidate.getSeqFileCandidates());
+        LOGGER.info("Unseq file {} does not overlap with any seq files.", unseqFile);
+        TsFileResource latestSealedSeqFile =
+            getLatestSealedSeqFile(candidate.getSeqFileCandidates());
         if (latestSealedSeqFile == null) {
           break;
         }
@@ -180,7 +182,8 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
     return taskResource;
   }
 
-  private TsFileResource getLatestSealedSeqFile(List<TsFileResourceCandidate> seqResourceCandidateList) {
+  private TsFileResource getLatestSealedSeqFile(
+      List<TsFileResourceCandidate> seqResourceCandidateList) {
     for (int i = seqResourceCandidateList.size() - 1; i >= 0; i--) {
       TsFileResourceCandidate seqResourceCandidate = seqResourceCandidateList.get(i);
       if (seqResourceCandidate.resource.isClosed()) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/utils/CrossSpaceCompactionCandidate.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/utils/CrossSpaceCompactionCandidate.java
@@ -183,7 +183,9 @@ public class CrossSpaceCompactionCandidate {
     public boolean hasOverlap;
 
     public CrossCompactionTaskResourceSplit(
-        TsFileResourceCandidate unseqFile, List<TsFileResourceCandidate> seqFiles, boolean hasOverlap) {
+        TsFileResourceCandidate unseqFile,
+        List<TsFileResourceCandidate> seqFiles,
+        boolean hasOverlap) {
       this.unseqFile = unseqFile;
       this.seqFiles = seqFiles;
       this.hasOverlap = hasOverlap;

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/utils/CrossSpaceCompactionCandidate.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/utils/CrossSpaceCompactionCandidate.java
@@ -40,6 +40,7 @@ public class CrossSpaceCompactionCandidate {
   private List<TsFileResourceCandidate> unseqFiles;
 
   private int nextUnseqFileIndex;
+  public boolean nextUnseqFileOverlap;
   private CrossCompactionTaskResourceSplit nextSplit;
   private long ttlLowerBound = Long.MIN_VALUE;
 
@@ -65,6 +66,7 @@ public class CrossSpaceCompactionCandidate {
     if (nextUnseqFileIndex >= unseqFiles.size()) {
       return false;
     }
+    nextUnseqFileOverlap = false;
     return prepareNextSplit();
   }
 
@@ -110,6 +112,7 @@ public class CrossSpaceCompactionCandidate {
             ret.add(seqFile);
             seqFile.markAsSelected();
           }
+          nextUnseqFileOverlap = true;
           // if this condition is satisfied, all subsequent seq files is unnecessary to check
           break;
         } else if (unseqDeviceInfo.startTime <= seqDeviceInfo.endTime) {
@@ -117,6 +120,7 @@ public class CrossSpaceCompactionCandidate {
             ret.add(seqFile);
             seqFile.markAsSelected();
           }
+          nextUnseqFileOverlap = true;
         }
       }
     }
@@ -158,6 +162,10 @@ public class CrossSpaceCompactionCandidate {
     return seqFiles.stream()
         .map(tsFileResourceCandidate -> tsFileResourceCandidate.resource)
         .collect(Collectors.toList());
+  }
+
+  public List<TsFileResourceCandidate> getSeqFileCandidates() {
+    return seqFiles;
   }
 
   public List<TsFileResourceCandidate> getUnseqFileCandidates() {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithReadPointPerformerValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithReadPointPerformerValidationTest.java
@@ -19,7 +19,11 @@
 
 package org.apache.iotdb.db.engine.compaction.cross;
 
+import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.path.AlignedPath;
+import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.AbstractCompactionTest;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICrossCompactionPerformer;
@@ -27,13 +31,14 @@ import org.apache.iotdb.db.engine.compaction.execute.performer.impl.ReadChunkCom
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.ReadPointCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.execute.task.CrossSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.engine.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.engine.compaction.selector.ICrossSpaceSelector;
 import org.apache.iotdb.db.engine.compaction.selector.impl.RewriteCrossSpaceCompactionSelector;
+import org.apache.iotdb.db.engine.compaction.selector.impl.SizeTieredCompactionSelector;
 import org.apache.iotdb.db.engine.compaction.selector.utils.CrossCompactionTaskResource;
 import org.apache.iotdb.db.engine.compaction.selector.utils.CrossSpaceCompactionCandidate;
 import org.apache.iotdb.db.engine.compaction.utils.CompactionFileGeneratorUtils;
-import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 import org.apache.iotdb.db.exception.MergeException;
@@ -41,7 +46,12 @@ import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.db.tools.validate.TsFileValidationTool;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.TimeValuePair;
+import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -51,13 +61,18 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.iotdb.commons.conf.IoTDBConstant.PATH_SEPARATOR;
+import static org.apache.iotdb.tsfile.utils.TsFileGeneratorUtils.alignDeviceOffset;
 
 public class CrossSpaceCompactionWithReadPointPerformerValidationTest
     extends AbstractCompactionTest {
-  TsFileManager tsFileManager =
-      new TsFileManager(COMPACTION_TEST_SG, "0", STORAGE_GROUP_DIR.getPath());
+  //  TsFileManager tsFileManager =
+  //      new TsFileManager(COMPACTION_TEST_SG, "0", STORAGE_GROUP_DIR.getPath());
 
   private final String oldThreadName = Thread.currentThread().getName();
 
@@ -2146,5 +2161,697 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
         selector.selectCrossSpaceTask(seqResources, unseqResources);
 
     Assert.assertEquals(0, selected.size());
+  }
+
+  @Test
+  public void testNonAlignedUnseqFilesNotOverlapWithSeqFiles1() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(5, 10, 5, 1000, 0, 0, 100, 100, false, true);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, false, false);
+    createFiles(3, 10, 5, 1000, 7500, 7500, 100, 100, false, true);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + d + PATH_SEPARATOR + "s" + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new MeasurementPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
+                TSDataType.INT64));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    List<List<TsFileResource>> taskResources =
+        new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
+            .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
+    for (List<TsFileResource> taskResource : taskResources) {
+      new InnerSpaceCompactionTask(
+              0,
+              tsFileManager,
+              taskResource,
+              true,
+              new ReadPointCompactionPerformer(),
+              new AtomicInteger(0),
+              0L)
+          .start();
+    }
+
+    // select cross compaction
+    ICrossSpaceSelector crossSpaceCompactionSelector =
+        IoTDBDescriptor.getInstance()
+            .getConfig()
+            .getCrossCompactionSelector()
+            .createInstance(COMPACTION_TEST_SG, "0", 0, tsFileManager);
+    CrossCompactionTaskResource sourceFiles =
+        crossSpaceCompactionSelector
+            .selectCrossSpaceTask(
+                tsFileManager.getOrCreateSequenceListByTimePartition(0),
+                tsFileManager.getOrCreateUnsequenceListByTimePartition(0))
+            .get(0);
+    Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
+    Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            sourceFiles.getSeqFiles(),
+            sourceFiles.getUnseqFiles(),
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            sourceFiles.getTotalMemoryCost(),
+            0)
+        .start();
+
+    validateSeqFiles(true);
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  @Test
+  public void testNonAlignedUnseqFilesNotOverlapWithSeqFiles2() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(5, 10, 5, 1000, 0, 0, 100, 100, false, true);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, false, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + d + PATH_SEPARATOR + "s" + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new MeasurementPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
+                TSDataType.INT64));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    List<List<TsFileResource>> taskResources =
+        new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
+            .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
+    for (List<TsFileResource> taskResource : taskResources) {
+      new InnerSpaceCompactionTask(
+              0,
+              tsFileManager,
+              taskResource,
+              true,
+              new ReadPointCompactionPerformer(),
+              new AtomicInteger(0),
+              0L)
+          .start();
+    }
+
+    // select cross compaction
+    ICrossSpaceSelector crossSpaceCompactionSelector =
+        IoTDBDescriptor.getInstance()
+            .getConfig()
+            .getCrossCompactionSelector()
+            .createInstance(COMPACTION_TEST_SG, "0", 0, tsFileManager);
+    CrossCompactionTaskResource sourceFiles =
+        crossSpaceCompactionSelector
+            .selectCrossSpaceTask(
+                tsFileManager.getOrCreateSequenceListByTimePartition(0),
+                tsFileManager.getOrCreateUnsequenceListByTimePartition(0))
+            .get(0);
+    Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
+    Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            sourceFiles.getSeqFiles(),
+            sourceFiles.getUnseqFiles(),
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            sourceFiles.getTotalMemoryCost(),
+            0)
+        .start();
+
+    validateSeqFiles(true);
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  @Test
+  public void testNonAlignedUnseqFilesNotOverlapWithSeqFiles3() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(4, 10, 5, 1000, 0, 0, 100, 100, false, true);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, false, false);
+    createFiles(1, 10, 5, 1000, 7500, 7500, 100, 100, false, true);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + d + PATH_SEPARATOR + "s" + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new MeasurementPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
+                TSDataType.INT64));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    List<List<TsFileResource>> taskResources =
+        new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
+            .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
+    for (List<TsFileResource> taskResource : taskResources) {
+      new InnerSpaceCompactionTask(
+              0,
+              tsFileManager,
+              taskResource,
+              true,
+              new ReadPointCompactionPerformer(),
+              new AtomicInteger(0),
+              0L)
+          .start();
+    }
+
+    // select cross compaction
+    ICrossSpaceSelector crossSpaceCompactionSelector =
+        IoTDBDescriptor.getInstance()
+            .getConfig()
+            .getCrossCompactionSelector()
+            .createInstance(COMPACTION_TEST_SG, "0", 0, tsFileManager);
+    CrossCompactionTaskResource sourceFiles =
+        crossSpaceCompactionSelector
+            .selectCrossSpaceTask(
+                tsFileManager.getOrCreateSequenceListByTimePartition(0),
+                tsFileManager.getOrCreateUnsequenceListByTimePartition(0))
+            .get(0);
+    Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
+    Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            sourceFiles.getSeqFiles(),
+            sourceFiles.getUnseqFiles(),
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            sourceFiles.getTotalMemoryCost(),
+            0)
+        .start();
+
+    validateSeqFiles(true);
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  @Test
+  public void testNonAlignedUnseqFilesNotOverlapWithSeqFiles4() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(5, 10, 5, 1000, 0, 0, 100, 100, false, true);
+    createFiles(1, 9, 10, 500, 100, 100, 0, 100, false, false);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, false, false);
+    createFiles(3, 10, 5, 1000, 7500, 7500, 100, 100, false, true);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + d + PATH_SEPARATOR + "s" + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new MeasurementPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i + PATH_SEPARATOR + "s" + j,
+                TSDataType.INT64));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    List<List<TsFileResource>> taskResources =
+        new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
+            .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
+    for (List<TsFileResource> taskResource : taskResources) {
+      new InnerSpaceCompactionTask(
+              0,
+              tsFileManager,
+              taskResource,
+              true,
+              new ReadPointCompactionPerformer(),
+              new AtomicInteger(0),
+              0L)
+          .start();
+    }
+
+    // select cross compaction
+    ICrossSpaceSelector crossSpaceCompactionSelector =
+        IoTDBDescriptor.getInstance()
+            .getConfig()
+            .getCrossCompactionSelector()
+            .createInstance(COMPACTION_TEST_SG, "0", 0, tsFileManager);
+    CrossCompactionTaskResource sourceFiles =
+        crossSpaceCompactionSelector
+            .selectCrossSpaceTask(
+                tsFileManager.getOrCreateSequenceListByTimePartition(0),
+                tsFileManager.getOrCreateUnsequenceListByTimePartition(0))
+            .get(0);
+    Assert.assertEquals(2, sourceFiles.getSeqFiles().size());
+    Assert.assertEquals(3, sourceFiles.getUnseqFiles().size());
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            sourceFiles.getSeqFiles(),
+            sourceFiles.getUnseqFiles(),
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            sourceFiles.getTotalMemoryCost(),
+            0)
+        .start();
+
+    validateSeqFiles(true);
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  @Test
+  public void testAlignedUnseqFilesNotOverlapWithSeqFiles1() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(5, 10, 5, 1000, 0, 0, 100, 100, true, true);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, true, false);
+    createFiles(3, 10, 5, 1000, 7500, 7500, 100, 100, true, true);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG
+                + PATH_SEPARATOR
+                + "d"
+                + (alignDeviceOffset + d)
+                + PATH_SEPARATOR
+                + "s"
+                + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new AlignedPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
+                Collections.singletonList("s" + j),
+                Collections.singletonList(new MeasurementSchema("s" + j, TSDataType.INT64))));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    List<List<TsFileResource>> taskResources =
+        new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
+            .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
+    for (List<TsFileResource> taskResource : taskResources) {
+      new InnerSpaceCompactionTask(
+              0,
+              tsFileManager,
+              taskResource,
+              true,
+              new ReadPointCompactionPerformer(),
+              new AtomicInteger(0),
+              0L)
+          .start();
+    }
+
+    // select cross compaction
+    ICrossSpaceSelector crossSpaceCompactionSelector =
+        IoTDBDescriptor.getInstance()
+            .getConfig()
+            .getCrossCompactionSelector()
+            .createInstance(COMPACTION_TEST_SG, "0", 0, tsFileManager);
+    CrossCompactionTaskResource sourceFiles =
+        crossSpaceCompactionSelector
+            .selectCrossSpaceTask(
+                tsFileManager.getOrCreateSequenceListByTimePartition(0),
+                tsFileManager.getOrCreateUnsequenceListByTimePartition(0))
+            .get(0);
+    Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
+    Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            sourceFiles.getSeqFiles(),
+            sourceFiles.getUnseqFiles(),
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            sourceFiles.getTotalMemoryCost(),
+            0)
+        .start();
+
+    validateSeqFiles(true);
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  @Test
+  public void testAlignedUnseqFilesNotOverlapWithSeqFiles2() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(5, 10, 5, 1000, 0, 0, 100, 100, true, true);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, true, false);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG
+                + PATH_SEPARATOR
+                + "d"
+                + (alignDeviceOffset + d)
+                + PATH_SEPARATOR
+                + "s"
+                + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new AlignedPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
+                Collections.singletonList("s" + j),
+                Collections.singletonList(new MeasurementSchema("s" + j, TSDataType.INT64))));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    List<List<TsFileResource>> taskResources =
+        new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
+            .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
+    for (List<TsFileResource> taskResource : taskResources) {
+      new InnerSpaceCompactionTask(
+              0,
+              tsFileManager,
+              taskResource,
+              true,
+              new ReadPointCompactionPerformer(),
+              new AtomicInteger(0),
+              0L)
+          .start();
+    }
+
+    // select cross compaction
+    ICrossSpaceSelector crossSpaceCompactionSelector =
+        IoTDBDescriptor.getInstance()
+            .getConfig()
+            .getCrossCompactionSelector()
+            .createInstance(COMPACTION_TEST_SG, "0", 0, tsFileManager);
+    CrossCompactionTaskResource sourceFiles =
+        crossSpaceCompactionSelector
+            .selectCrossSpaceTask(
+                tsFileManager.getOrCreateSequenceListByTimePartition(0),
+                tsFileManager.getOrCreateUnsequenceListByTimePartition(0))
+            .get(0);
+    Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
+    Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            sourceFiles.getSeqFiles(),
+            sourceFiles.getUnseqFiles(),
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            sourceFiles.getTotalMemoryCost(),
+            0)
+        .start();
+
+    validateSeqFiles(true);
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  @Test
+  public void testAlignedUnseqFilesNotOverlapWithSeqFiles3() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(4, 10, 5, 1000, 0, 0, 100, 100, true, true);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, true, false);
+    createFiles(1, 10, 5, 1000, 7500, 7500, 100, 100, true, true);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG
+                + PATH_SEPARATOR
+                + "d"
+                + (alignDeviceOffset + d)
+                + PATH_SEPARATOR
+                + "s"
+                + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new AlignedPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
+                Collections.singletonList("s" + j),
+                Collections.singletonList(new MeasurementSchema("s" + j, TSDataType.INT64))));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    List<List<TsFileResource>> taskResources =
+        new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
+            .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
+    for (List<TsFileResource> taskResource : taskResources) {
+      new InnerSpaceCompactionTask(
+              0,
+              tsFileManager,
+              taskResource,
+              true,
+              new ReadPointCompactionPerformer(),
+              new AtomicInteger(0),
+              0L)
+          .start();
+    }
+
+    // select cross compaction
+    ICrossSpaceSelector crossSpaceCompactionSelector =
+        IoTDBDescriptor.getInstance()
+            .getConfig()
+            .getCrossCompactionSelector()
+            .createInstance(COMPACTION_TEST_SG, "0", 0, tsFileManager);
+    CrossCompactionTaskResource sourceFiles =
+        crossSpaceCompactionSelector
+            .selectCrossSpaceTask(
+                tsFileManager.getOrCreateSequenceListByTimePartition(0),
+                tsFileManager.getOrCreateUnsequenceListByTimePartition(0))
+            .get(0);
+    Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
+    Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            sourceFiles.getSeqFiles(),
+            sourceFiles.getUnseqFiles(),
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            sourceFiles.getTotalMemoryCost(),
+            0)
+        .start();
+
+    validateSeqFiles(true);
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  @Test
+  public void testAlignedUnseqFilesNotOverlapWithSeqFiles4() throws Exception {
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(2);
+    createFiles(5, 10, 5, 1000, 0, 0, 100, 100, true, true);
+    createFiles(1, 9, 10, 500, 100, 100, 0, 100, true, false);
+    createFiles(2, 5, 10, 500, 6000, 6000, 0, 100, true, false);
+    createFiles(3, 10, 5, 1000, 7500, 7500, 100, 100, true, true);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    // delete d0 ~ d5 in seq files
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (int d = 0; d < 5; d++) {
+      for (int m = 0; m < 5; m++) {
+        deleteMap.put(
+            COMPACTION_TEST_SG
+                + PATH_SEPARATOR
+                + "d"
+                + (alignDeviceOffset + d)
+                + PATH_SEPARATOR
+                + "s"
+                + m,
+            new Pair<>(Long.MIN_VALUE, Long.MAX_VALUE));
+      }
+    }
+    for (TsFileResource resource : seqResources) {
+      CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
+    }
+
+    List<PartialPath> timeseriesPaths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        timeseriesPaths.add(
+            new AlignedPath(
+                COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + i,
+                Collections.singletonList("s" + j),
+                Collections.singletonList(new MeasurementSchema("s" + j, TSDataType.INT64))));
+      }
+    }
+    Map<PartialPath, List<TimeValuePair>> sourceData =
+        readSourceFiles(timeseriesPaths, Collections.emptyList());
+
+    // inner seq space compact
+    List<List<TsFileResource>> taskResources =
+        new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
+            .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
+    for (List<TsFileResource> taskResource : taskResources) {
+      new InnerSpaceCompactionTask(
+              0,
+              tsFileManager,
+              taskResource,
+              true,
+              new ReadChunkCompactionPerformer(),
+              new AtomicInteger(0),
+              0L)
+          .start();
+    }
+
+    // select cross compaction
+    ICrossSpaceSelector crossSpaceCompactionSelector =
+        IoTDBDescriptor.getInstance()
+            .getConfig()
+            .getCrossCompactionSelector()
+            .createInstance(COMPACTION_TEST_SG, "0", 0, tsFileManager);
+    CrossCompactionTaskResource sourceFiles =
+        crossSpaceCompactionSelector
+            .selectCrossSpaceTask(
+                tsFileManager.getOrCreateSequenceListByTimePartition(0),
+                tsFileManager.getOrCreateUnsequenceListByTimePartition(0))
+            .get(0);
+    Assert.assertEquals(2, sourceFiles.getSeqFiles().size());
+    Assert.assertEquals(3, sourceFiles.getUnseqFiles().size());
+
+    new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            sourceFiles.getSeqFiles(),
+            sourceFiles.getUnseqFiles(),
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            sourceFiles.getTotalMemoryCost(),
+            0)
+        .start();
+
+    validateSeqFiles(true);
+    validateTargetDatas(sourceData, Collections.emptyList());
+  }
+
+  public void generateModsFile(
+      List<PartialPath> seriesPaths, TsFileResource resource, long startValue, long endValue)
+      throws IllegalPathException, IOException {
+    Map<String, Pair<Long, Long>> deleteMap = new HashMap<>();
+    for (PartialPath path : seriesPaths) {
+      String fullPath =
+          (path instanceof AlignedPath)
+              ? path.getFullPath()
+                  + TsFileConstant.PATH_SEPARATOR
+                  + ((AlignedPath) path).getMeasurementList().get(0)
+              : path.getFullPath();
+      deleteMap.put(fullPath, new Pair<>(startValue, endValue));
+    }
+    CompactionFileGeneratorUtils.generateMods(deleteMap, resource, false);
   }
 }


### PR DESCRIPTION
**Description**
Cross space compaction select one unseq file but none seq file, which causes cross compaction under this time partition can never be performed.

**Reason**
Unseq file does not overlap with any seq files under this time partition, including two cases: 1. The devices under the unseq files do not exist in the seq files. 2. The device of the unseq file exists in the seq file, but unseqDevice.startTime>seqDevice.endTime. This can happen if the data is deleted and an seq inner space compaction has been performed.

**Solution**
For nonOverlap unseq files, select the last sealed seq file, if it is valid (status is closed), then select it, otherwise stop the selection.