### PR TITLE
[IOTDB-5691] The first level-0 tsfile too large to trigger "Unsequence InnerSpaceComapction" and "CrossSpaceCompaction"

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
@@ -182,11 +182,12 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
       throws IOException {
     TsFileNameGenerator.TsFileName unseqFileName =
         TsFileNameGenerator.getTsFileName(unseqFile.getTsFile().getName());
-    // we add a hard limit for cross compaction that selected unseqFile should be compacted in inner
+    // we add a hard limit for cross compaction that selected unseqFile should reach a certain size
+    // or be compacted in inner
     // space at least once. This is used to make to improve the priority of inner compaction and
     // avoid too much cross compaction with small files.
-    if (unseqFileName.getInnerCompactionCnt() < config.getMinCrossCompactionUnseqFileLevel()
-        && unseqFile.getTsFileSize() < config.getTargetCompactionFileSize()) {
+    if (unseqFile.getTsFileSize() < config.getTargetCompactionFileSize()
+        && unseqFileName.getInnerCompactionCnt() < config.getMinCrossCompactionUnseqFileLevel()) {
       return false;
     }
     // currently, we must allow at least one unseqFile be selected to handle the situation that

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
@@ -185,7 +185,8 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
     // we add a hard limit for cross compaction that selected unseqFile should be compacted in inner
     // space at least once. This is used to make to improve the priority of inner compaction and
     // avoid too much cross compaction with small files.
-    if (unseqFileName.getInnerCompactionCnt() < config.getMinCrossCompactionUnseqFileLevel()) {
+    if (unseqFileName.getInnerCompactionCnt() < config.getMinCrossCompactionUnseqFileLevel()
+        && unseqFile.getTsFileSize() < config.getTargetCompactionFileSize()) {
       return false;
     }
     // currently, we must allow at least one unseqFile be selected to handle the situation that

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -1025,4 +1025,15 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
       // fail();
     }
   }
+
+  @Test
+  public void testFirstUnseqFileIsLarge() {
+    IoTDBDescriptor.getInstance().getConfig().setMinCrossCompactionUnseqFileLevel(1);
+    IoTDBDescriptor.getInstance().getConfig().setTargetCompactionFileSize(1024);
+    RewriteCrossSpaceCompactionSelector selector =
+        new RewriteCrossSpaceCompactionSelector("", "", 0, null);
+    List<CrossCompactionTaskResource> selected =
+        selector.selectCrossSpaceTask(seqResources, unseqResources);
+    Assert.assertEquals(1, selected.size());
+  }
 }


### PR DESCRIPTION
The first unseq file is 0 level and it is too large to trigger unseq inner space compaction and cross space compaction. 