### PR TITLE
[IOTDB-5758] add check in ClientRpcServiceImpl

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSyntaxConventionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSyntaxConventionIT.java
@@ -132,6 +132,27 @@ public class IoTDBSessionSyntaxConventionIT {
   }
 
   @Test
+  public void insertWithIllegalDeviceTest() {
+    try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
+      String deviceId = "root.sg1.d#1";
+      List<String> measurements = new ArrayList<>();
+      List<String> values = new ArrayList<>();
+      measurements.add("a");
+      values.add("b");
+      try {
+        session.insertRecord(deviceId, 1L, measurements, values);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      SessionDataSet dataSet = session.executeQueryStatement("show timeseries root");
+      assertFalse(dataSet.hasNext());
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
   public void inserRecordWithIllegalMeasurementTest() {
     try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
       String deviceId = "root.sg1.d1";

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/parser/PathVisitor.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/parser/PathVisitor.java
@@ -70,7 +70,15 @@ public class PathVisitor extends PathParserBaseVisitor<String[]> {
       }
       return unWrapped;
     }
+    checkNodeName(nodeName);
     return nodeName;
+  }
+
+  private void checkNodeName(String src) {
+    if (!TsFileConstant.IDENTIFIER_PATTERN.matcher(src).matches()) {
+      throw new IllegalArgumentException(
+          String.format("%s is illegal, unquoted node name can only consist of digits.", src));
+    }
   }
 
   /** Return true if the str is a real number. Examples: 1.0; +1.0; -1.0; 0011; 011e3; +23e-3 */


### PR DESCRIPTION
We missed the check of nodeName in Session interfaces when node name contains some special characters like "#".