### PR TITLE
[ISSUE-9508] Fix the bug of UDF Median and Percentile

### DIFF
--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/GKArray.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/GKArray.java
@@ -18,17 +18,16 @@
  */
 package org.apache.iotdb.library.dprofile.util;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 
 /** Util for UDAFPercentile */
 public class GKArray {
 
   private final double rankAccuracy;
-  private MutableList<Tuple> entries;
+  private ArrayList<Tuple> entries;
   private final double[] incoming;
   private int incomingIndex;
   private long compressedCount;
@@ -36,7 +35,7 @@ public class GKArray {
 
   public GKArray(double rankAccuracy) {
     this.rankAccuracy = rankAccuracy;
-    this.entries = Lists.mutable.empty();
+    this.entries = new ArrayList<>();
     this.incoming = new double[(int) (1 / rankAccuracy) + 1];
     this.incomingIndex = 0;
     this.minValue = Double.MAX_VALUE;
@@ -87,10 +86,10 @@ public class GKArray {
   }
 
   private void compress() {
-    compress(Lists.mutable.empty());
+    compress(new ArrayList<>());
   }
 
-  private void compress(MutableList<Tuple> additionalEntries) {
+  private void compress(List<Tuple> additionalEntries) {
 
     for (int i = 0; i < incomingIndex; i++) {
       additionalEntries.add(new Tuple(incoming[i], 1, 0));
@@ -103,8 +102,8 @@ public class GKArray {
     }
 
     final long removalThreshold = 2 * (long) (rankAccuracy * (compressedCount - 1));
-    final MutableList<Tuple> mergedEntries =
-        Lists.mutable.ofInitialCapacity(entries.size() + additionalEntries.size() / 3);
+    final ArrayList<Tuple> mergedEntries =
+        new ArrayList<>(entries.size() + additionalEntries.size() / 3);
 
     int i = 0, j = 0;
     while (i < additionalEntries.size() || j < entries.size()) {


### PR DESCRIPTION
The bug is caused by the service load failure of MutableListFactoryImpl, which is used by MutableList. Thus, MutableList is replaced by ArrayList to solve the problem.