### PR TITLE
[IOTDB-5756] NPE when where predicate is NotEqualExpression and one of subExpression is not exist

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBNullOperandIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBNullOperandIT.java
@@ -254,6 +254,9 @@ public class IoTDBNullOperandIT {
 
     retArray = new String[] {};
     resultSetEqualTest("select s1, s3, s4 from root.** where notExist>0", expectedHeader, retArray);
+    resultSetEqualTest("select s1, s3, s4 from root.** where notExist=0", expectedHeader, retArray);
+    resultSetEqualTest(
+        "select s1, s3, s4 from root.** where notExist!=0", expectedHeader, retArray);
 
     resultSetEqualTest(
         "select s1, s3, s4 from root.** where diff(notExist)>0", expectedHeader, retArray);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/column/binary/CompareNonEqualColumnTransformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/column/binary/CompareNonEqualColumnTransformer.java
@@ -30,7 +30,7 @@ public class CompareNonEqualColumnTransformer extends CompareBinaryColumnTransfo
 
   @Override
   protected final void checkType() {
-    if (leftTransformer.getType().getTypeEnum().equals(rightTransformer.getType().getTypeEnum())) {
+    if (typeEquals(leftTransformer, rightTransformer)) {
       return;
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/column/binary/LogicBinaryColumnTransformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/transformation/dag/column/binary/LogicBinaryColumnTransformer.java
@@ -31,8 +31,8 @@ public abstract class LogicBinaryColumnTransformer extends BinaryColumnTransform
 
   @Override
   protected void checkType() {
-    if (!leftTransformer.getType().getTypeEnum().equals(TypeEnum.BOOLEAN)
-        || !rightTransformer.getType().getTypeEnum().equals(TypeEnum.BOOLEAN)) {
+    if (!leftTransformer.typeEquals(TypeEnum.BOOLEAN)
+        || !rightTransformer.typeEquals(TypeEnum.BOOLEAN)) {
       throw new UnsupportedOperationException("Unsupported Type");
     }
   }


### PR DESCRIPTION
Cause: method `checkType()` in `CompareNonEqualColumnTransformer` not use the safe TypeCompare method, so when a subExpression type is `null`, NPE occurs. 
Note: `LogicBinaryColumnTransformer` has same question. We don't add it case of it because there is another [bug](https://github.com/apache/iotdb/pull/9543) effects on this case.