### PR TITLE
Fix Context release source NPE

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceContext.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceContext.java
@@ -355,14 +355,21 @@ public class FragmentInstanceContext extends QueryContext {
    * be decreased.
    */
   protected synchronized void releaseResource() {
-    for (TsFileResource tsFile : closedFilePaths) {
-      FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, true);
+    // For schema related query FI, closedFilePaths and unClosedFilePaths will be null
+    if (closedFilePaths != null) {
+      for (TsFileResource tsFile : closedFilePaths) {
+        FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, true);
+      }
+      closedFilePaths = null;
     }
-    closedFilePaths = null;
-    for (TsFileResource tsFile : unClosedFilePaths) {
-      FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, false);
+
+    if (unClosedFilePaths != null) {
+      for (TsFileResource tsFile : unClosedFilePaths) {
+        FileReaderManager.getInstance().decreaseFileReaderReference(tsFile, false);
+      }
+      unClosedFilePaths = null;
     }
-    unClosedFilePaths = null;
+
     dataRegion = null;
     timeFilter = null;
     sourcePaths = null;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceExecution.java
@@ -145,6 +145,11 @@ public class FragmentInstanceExecution {
             if (newState.isFailed()) {
               scheduler.abortFragmentInstance(instanceId);
             }
+          } catch (Throwable t) {
+            try (SetThreadName threadName = new SetThreadName(instanceId.getFullId())) {
+              LOGGER.error(
+                  "Errors happened while trying to finish FI, resource may already leak!", t);
+            }
           }
         });
   }


### PR DESCRIPTION
For schema related query FI, `closedFilePaths` and `unClosedFilePaths` in FragmentInstanceContext are null, so while calling `context.releaseResource()` in statemachine callback, it will throw NPE and the remaining codes won't be executed like `deRegisterFragmentInstanceFromMemoryPool` and so on which will cause resource leaky.

And in this pr, I also add the error log while there is exception throwed in the release process.