### PR TITLE
[IOTDB-5204 ] Add last task rather than first task to timeoutQueue

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
@@ -216,6 +216,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
     for (DriverTask task : submittedTasks) {
       registerTaskToQueryMap(queryId, task);
     }
+    timeoutQueue.push(submittedTasks.get(submittedTasks.size() - 1));
     for (DriverTask task : submittedTasks) {
       submitTaskToReadyQueue(task);
     }
@@ -225,12 +226,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
     // If query has not been registered by other fragment instances,
     // add the first task as timeout checking task to timeoutQueue.
     queryMap
-        .computeIfAbsent(
-            queryId,
-            v -> {
-              timeoutQueue.push(driverTask);
-              return new ConcurrentHashMap<>();
-            })
+        .computeIfAbsent(queryId, k -> new ConcurrentHashMap<>())
         .computeIfAbsent(
             driverTask.getDriverTaskId().getFragmentInstanceId(),
             v -> Collections.synchronizedSet(new HashSet<>()))

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/schedule/DriverSchedulerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/schedule/DriverSchedulerTest.java
@@ -77,8 +77,8 @@ public class DriverSchedulerTest {
     Assert.assertEquals(2, manager.getQueryMap().get(queryId).size());
     Assert.assertEquals(1, manager.getTimeoutQueue().size());
     Assert.assertEquals(2, manager.getReadyQueue().size());
-    Assert.assertNotNull(manager.getTimeoutQueue().get(driverTaskId1));
-    Assert.assertNull(manager.getTimeoutQueue().get(driverTaskId2));
+    Assert.assertNull(manager.getTimeoutQueue().get(driverTaskId1));
+    Assert.assertNotNull(manager.getTimeoutQueue().get(driverTaskId2));
     DriverTask task1 =
         (DriverTask) manager.getQueryMap().get(queryId).get(instanceId1).toArray()[0];
     DriverTask task2 =
@@ -99,9 +99,9 @@ public class DriverSchedulerTest {
     Assert.assertEquals(1, manager.getQueryMap().size());
     Assert.assertTrue(manager.getQueryMap().containsKey(queryId));
     Assert.assertEquals(3, manager.getQueryMap().get(queryId).size());
-    Assert.assertEquals(1, manager.getTimeoutQueue().size());
+    Assert.assertEquals(2, manager.getTimeoutQueue().size());
     Assert.assertEquals(3, manager.getReadyQueue().size());
-    Assert.assertNull(manager.getTimeoutQueue().get(driverTaskId3));
+    Assert.assertNotNull(manager.getTimeoutQueue().get(driverTaskId3));
     DriverTask task3 =
         (DriverTask) manager.getQueryMap().get(queryId).get(instanceId3).toArray()[0];
     Assert.assertEquals(task3.getDriverTaskId(), driverTaskId3);
@@ -120,7 +120,7 @@ public class DriverSchedulerTest {
     Assert.assertEquals(2, manager.getQueryMap().size());
     Assert.assertTrue(manager.getQueryMap().containsKey(queryId2));
     Assert.assertEquals(1, manager.getQueryMap().get(queryId2).size());
-    Assert.assertEquals(2, manager.getTimeoutQueue().size());
+    Assert.assertEquals(3, manager.getTimeoutQueue().size());
     Assert.assertEquals(4, manager.getReadyQueue().size());
     DriverTask task4 = manager.getTimeoutQueue().get(driverTaskId4);
     Assert.assertNotNull(task4);
@@ -136,7 +136,7 @@ public class DriverSchedulerTest {
     Assert.assertTrue(manager.getBlockedTasks().isEmpty());
     Assert.assertEquals(2, manager.getQueryMap().size());
     Assert.assertTrue(manager.getQueryMap().containsKey(queryId));
-    Assert.assertEquals(1, manager.getTimeoutQueue().size());
+    Assert.assertEquals(3, manager.getTimeoutQueue().size());
     Assert.assertEquals(3, manager.getReadyQueue().size());
     Assert.assertEquals(DriverTaskStatus.ABORTED, task1.getStatus());
     Assert.assertEquals(DriverTaskStatus.READY, task2.getStatus());


### PR DESCRIPTION
The first task is only a part of FI, so it may finish early. So we should add last task which is the root task of FI to the timeoutQueue.