### PR TITLE
[IOTDB-5757] Fix Not Supported Exception when use like 's3 || false' in where even Type of s3 is Boolean

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBFilterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBFilterIT.java
@@ -147,6 +147,11 @@ public class IoTDBFilterIT {
         "select s1, s2 from root.vehicle.testTimeSeries " + "Where s1 || s2",
         expectedHeader,
         retArray);
+
+    resultSetEqualTest(
+        "select s1, s2 from root.vehicle.testTimeSeries " + "Where s1 || false",
+        expectedHeader,
+        retArray);
   }
 
   @Test

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ExpressionAnalyzer.java
@@ -540,7 +540,9 @@ public class ExpressionAnalyzer {
             false);
       }
       return new Pair<>(null, true);
-    } else if (predicate.getExpressionType().equals(ExpressionType.TIMESERIES)) {
+    } else if (predicate.getExpressionType().equals(ExpressionType.TIMESERIES)
+        || predicate.getExpressionType().equals(ExpressionType.CONSTANT)
+        || predicate.getExpressionType().equals(ExpressionType.NULL)) {
       return new Pair<>(null, true);
     } else {
       throw new IllegalArgumentException(


### PR DESCRIPTION
cause: `extractGlobalTimeFilter` forget the case of `constant`