### PR TITLE
[To rel/1.1] Adapt insert data by 0.13 client

### DIFF
--- a/docs/UserGuide/Reference/Common-Config-Manual.md
+++ b/docs/UserGuide/Reference/Common-Config-Manual.md
@@ -781,6 +781,15 @@ Different configuration parameters take effect in the following three ways:
 |Default| 5000                                                                    |
 |Effective| After restarting system                                                 |
 
+* 0.13\_data\_insert\_adapt
+
+|Name| 0.13\_data\_insert\_adapt                                             |
+|:---:|:----------------------------------------------------------------------|
+|Description| if using v0.13 client to insert data, set this configuration to true. |
+|Type| Boolean                                                               |
+|Default| false                                                                 |
+|Effective| After restarting system                                               |
+
 * upgrade\_thread\_count
 
 |   Name    | upgrade\_thread\_count                                                                            |

--- a/docs/zh/UserGuide/Reference/Common-Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/Common-Config-Manual.md
@@ -829,6 +829,15 @@ IoTDB ConfigNode 和 DataNode 的公共配置参数位于 `conf` 目录下。
 |    默认值    | 5000                            |
 | 改后生效方式 | 重启服务生效                          |
 
+* 0.13\_data\_insert\_adapt
+
+|     名字     | 0.13\_data\_insert\_adapt         |
+| :----------: |:----------------------------------|
+|     描述     | 如果 0.13 版本客户端进行写入，需要将此配置项设置为 true |
+|     类型     | Boolean                           |
+|    默认值    | false                             |
+| 改后生效方式 | 重启服务生效                            |
+
 * upgrade\_thread\_count
 
 |     名字     | upgrade\_thread\_count          |

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -515,7 +515,7 @@ cluster_name=defaultCluster
 # recovery_log_interval_in_ms=5000
 
 # If using v0.13 client to insert data, please set this configuration to true.
-# Notice: if using v1.0 client or setting Client Version to V_0_13 manually, enable this config may reduce the insert performance.
+# Notice: if using v0.13/v1.0 client or setting Client Version to V_0_13 manually, enable this config will disable insert redirection.
 # Datatype: boolean
 # 0.13_data_insert_adapt=false
 

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -514,6 +514,11 @@ cluster_name=defaultCluster
 # Datatype: int
 # recovery_log_interval_in_ms=5000
 
+# If using v0.13 client to insert data, please set this configuration to true.
+# Notice: if using v1.0 client or setting Client Version to V_0_13 manually, enable this config may reduce the insert performance.
+# Datatype: boolean
+# 0.13_data_insert_adapt=false
+
 # When there exists old version(v2) TsFile, how many thread will be set up to perform upgrade tasks, 1 by default.
 # Set to 1 when less than or equal to 0.
 # Datatype: int

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -752,6 +752,8 @@ public class IoTDBConfig {
   // if enable partial insert, one measurement failure will not impact other measurements
   private boolean enablePartialInsert = true;
 
+  private boolean enable13DataInsertAdapt = false;
+
   /**
    * Used to estimate the memory usage of text fields in a UDF query. It is recommended to set this
    * value to be slightly larger than the average length of all text records.
@@ -1836,6 +1838,14 @@ public class IoTDBConfig {
 
   public void setEnablePartialInsert(boolean enablePartialInsert) {
     this.enablePartialInsert = enablePartialInsert;
+  }
+
+  public boolean isEnable13DataInsertAdapt() {
+    return enable13DataInsertAdapt;
+  }
+
+  public void setEnable13DataInsertAdapt(boolean enable13DataInsertAdapt) {
+    this.enable13DataInsertAdapt = enable13DataInsertAdapt;
   }
 
   public int getCompactionThreadCount() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -671,6 +671,11 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "enable_partial_insert", String.valueOf(conf.isEnablePartialInsert()))));
 
+    conf.setEnable13DataInsertAdapt(
+        Boolean.parseBoolean(
+            properties.getProperty(
+                "0.13_data_insert_adapt", String.valueOf(conf.isEnable13DataInsertAdapt()))));
+
     int rpcSelectorThreadNum =
         Integer.parseInt(
             properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/SessionInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/SessionInfo.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.mpp.common;
 
+import org.apache.iotdb.commons.conf.IoTDBConstant.ClientVersion;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataOutputStream;
@@ -29,10 +30,19 @@ public class SessionInfo {
   private final String userName;
   private final String zoneId;
 
+  private ClientVersion version = ClientVersion.V_1_0;
+
   public SessionInfo(long sessionId, String userName, String zoneId) {
     this.sessionId = sessionId;
     this.userName = userName;
     this.zoneId = zoneId;
+  }
+
+  public SessionInfo(long sessionId, String userName, String zoneId, ClientVersion version) {
+    this.sessionId = sessionId;
+    this.userName = userName;
+    this.zoneId = zoneId;
+    this.version = version;
   }
 
   public long getSessionId() {
@@ -45,6 +55,10 @@ public class SessionInfo {
 
   public String getZoneId() {
     return zoneId;
+  }
+
+  public ClientVersion getVersion() {
+    return version;
   }
 
   public static SessionInfo deserializeFrom(ByteBuffer buffer) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.async.AsyncDataNodeInternalServiceClient;
 import org.apache.iotdb.commons.client.sync.SyncDataNodeInternalServiceClient;
+import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.service.metric.enums.PerformanceOverviewMetrics;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -618,8 +619,12 @@ public class QueryExecution implements IQueryExecution {
     }
 
     // collect redirect info to client for writing
+    // if 0.13_data_insert_adapt is true and ClientVersion is NOT V_1_0, stop returning redirect
+    // info to client
     if (analysis.getStatement() instanceof InsertBaseStatement
-        && !analysis.isFinishQueryAfterAnalyze()) {
+        && !analysis.isFinishQueryAfterAnalyze()
+        && (!config.isEnable13DataInsertAdapt()
+            || IoTDBConstant.ClientVersion.V_1_0.equals(context.getSession().getVersion()))) {
       InsertBaseStatement insertStatement = (InsertBaseStatement) analysis.getStatement();
       List<TEndPoint> redirectNodeList =
           insertStatement.collectRedirectInfo(analysis.getDataPartitionInfo());

--- a/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/SessionManager.java
@@ -351,7 +351,11 @@ public class SessionManager implements SessionManagerMBean {
   }
 
   public SessionInfo getSessionInfo(IClientSession session) {
-    return new SessionInfo(session.getId(), session.getUsername(), session.getZoneId().getId());
+    return new SessionInfo(
+        session.getId(),
+        session.getUsername(),
+        session.getZoneId().getId(),
+        session.getClientVersion());
   }
 
   @Override


### PR DESCRIPTION
## Description

Since v1.0 uses redirection status code 400, which is different with v0.13. We need a strategy to adapt insert data by 0.13 client to v1.0. 

This PR adds a configuration `0.13_data_insert_adapt`. The default value is false. When set `0.13_data_insert_adapt=true`, and the Client Version was set `V_0_13`, the insert redirection info will not return to client side.

Notice: if using v1.0 client or setting Client Version to V_0_13 manually, enable this config will disable insert redirection.
