### PR TITLE
[To rel/1.1] Fix Performance Overview Dashboard localScheduler record inaccurately 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -182,22 +182,24 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
 
     List<TSStatus> dataNodeFailureList = new ArrayList<>();
 
-    // sync dispatch to local
-    long localScheduleStartTime = System.nanoTime();
-    for (FragmentInstance localInstance : localInstances) {
-      try (SetThreadName threadName = new SetThreadName(localInstance.getId().getFullId())) {
-        dispatchOneInstance(localInstance);
-      } catch (FragmentInstanceDispatchException e) {
-        dataNodeFailureList.add(e.getFailureStatus());
-      } catch (Throwable t) {
-        logger.warn("[DispatchFailed]", t);
-        dataNodeFailureList.add(
-            RpcUtils.getStatus(
-                TSStatusCode.INTERNAL_SERVER_ERROR, "Unexpected errors: " + t.getMessage()));
+    if (!localInstances.isEmpty()) {
+      // sync dispatch to local
+      long localScheduleStartTime = System.nanoTime();
+      for (FragmentInstance localInstance : localInstances) {
+        try (SetThreadName threadName = new SetThreadName(localInstance.getId().getFullId())) {
+          dispatchOneInstance(localInstance);
+        } catch (FragmentInstanceDispatchException e) {
+          dataNodeFailureList.add(e.getFailureStatus());
+        } catch (Throwable t) {
+          logger.warn("[DispatchFailed]", t);
+          dataNodeFailureList.add(
+              RpcUtils.getStatus(
+                  TSStatusCode.INTERNAL_SERVER_ERROR, "Unexpected errors: " + t.getMessage()));
+        }
       }
+      PERFORMANCE_OVERVIEW_METRICS.recordScheduleLocalCost(
+          System.nanoTime() - localScheduleStartTime);
     }
-    PERFORMANCE_OVERVIEW_METRICS.recordScheduleLocalCost(
-        System.nanoTime() - localScheduleStartTime);
     // wait until remote dispatch done
     try {
       asyncPlanNodeSender.waitUntilCompleted();


### PR DESCRIPTION
The elapsed time of the Local Scheduler may be recorded repeatedly on the Performance Overview panel. That is, a timer is recorded even when no instance is executed locally. As a result, the elapsed time may be inaccurate.