### PR TITLE
[IOTDB-5764] Fix that cannot specify alias successfully when the FROM clause contains multiple path suffixes

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ConcatPathRewriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/ConcatPathRewriter.java
@@ -20,7 +20,6 @@ package org.apache.iotdb.db.mpp.plan.analyze;
 
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
-import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.exception.sql.StatementAnalyzeException;
 import org.apache.iotdb.db.mpp.plan.expression.Expression;
 import org.apache.iotdb.db.mpp.plan.statement.Statement;
@@ -105,16 +104,9 @@ public class ConcatPathRewriter {
     // resultColumns after concat
     List<ResultColumn> resultColumns = new ArrayList<>();
     for (ResultColumn resultColumn : selectComponent.getResultColumns()) {
-      boolean needAliasCheck = resultColumn.hasAlias() && !isGroupByLevel;
       List<Expression> resultExpressions =
           ExpressionAnalyzer.concatExpressionWithSuffixPaths(
               resultColumn.getExpression(), prefixPaths, patternTree);
-      if (needAliasCheck && resultExpressions.size() > 1) {
-        throw new SemanticException(
-            String.format(
-                "alias '%s' can only be matched with one time series", resultColumn.getAlias()));
-      }
-
       for (Expression resultExpression : resultExpressions) {
         resultColumns.add(
             new ResultColumn(

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeTest.java
@@ -758,6 +758,42 @@ public class AnalyzeTest {
     }
   }
 
+  @Test
+  public void testAlias1() {
+    Analysis analysis = analyzeSQL("select s1 as a, s2 as b from root.sg.d2.a, root.sg.d2.b");
+    assert analysis != null;
+    Assert.assertEquals(
+        analysis.getRespDatasetHeader(),
+        new DatasetHeader(
+            Arrays.asList(
+                new ColumnHeader("root.sg.d2.a.s1", TSDataType.INT32, "a"),
+                new ColumnHeader("root.sg.d2.a.s2", TSDataType.DOUBLE, "b")),
+            false));
+  }
+
+  @Test
+  public void testAlias2() {
+    assertTestFail(
+        "select s1 as a from root.sg.*", "alias 'a' can only be matched with one time series");
+    assertTestFail(
+        "select s1 as a from root.sg.d1, root.sg.d2",
+        "alias 'a' can only be matched with one time series");
+  }
+
+  private void assertTestFail(String sql, String errMsg) {
+    try {
+      Statement statement =
+          StatementGenerator.createStatement(sql, ZonedDateTime.now().getOffset());
+      MPPQueryContext context = new MPPQueryContext(new QueryId("test_query"));
+      Analyzer analyzer =
+          new Analyzer(context, new FakePartitionFetcherImpl(), new FakeSchemaFetcherImpl());
+      analyzer.analyze(statement);
+      fail("No exception!");
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage(), e.getMessage().contains(errMsg));
+    }
+  }
+
   private Analysis analyzeSQL(String sql) {
     try {
       Statement statement =


### PR DESCRIPTION
**Before:**
<img width="638" alt="c15bf4b1c2162b15b685a722d2c62f9" src="https://user-images.githubusercontent.com/36565497/230778781-8d38414a-7c08-4441-a4be-2d504eb6704c.png">


**After:**
<img width="644" alt="26fac192b5d44e7110b11507abf84e3" src="https://user-images.githubusercontent.com/36565497/230778717-c721be72-2b36-4483-a0ef-af1c2bb377b4.png">
