### PR TITLE
Improve ineffective check in ColumnEncoderFactory

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnEncoderFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnEncoderFactory.java
@@ -35,9 +35,10 @@ public class ColumnEncoderFactory {
   }
 
   public static ColumnEncoder get(ColumnEncoding columnEncoding) {
-    if (!encodingToEncoder.containsKey(columnEncoding)) {
+    ColumnEncoder res = encodingToEncoder.get(columnEncoding);
+    if (res == null) {
       throw new IllegalArgumentException("Unsupported column encoding: " + columnEncoding);
     }
-    return encodingToEncoder.get(columnEncoding);
+    return res;
   }
 }


### PR DESCRIPTION
We can directly use get result of map to judge whether the map contains the key.