### PR TITLE
[To rel/1.1] Bump ratis dependency version to 2.5.0

### DIFF
--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <ratis.version>2.4.2-ebba77d-SNAPSHOT</ratis.version>
+        <ratis.version>2.5.0</ratis.version>
         <consensus.test.skip>false</consensus.test.skip>
         <consensus.it.skip>${consensus.test.skip}</consensus.it.skip>
         <consensus.ut.skip>${consensus.test.skip}</consensus.ut.skip>


### PR DESCRIPTION
cherry-pick of https://github.com/apache/iotdb/pull/9587