### PR TITLE
Fix potential NPE in SinkChannel

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/ShuffleSinkHandle.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/ShuffleSinkHandle.java
@@ -166,7 +166,7 @@ public class ShuffleSinkHandle implements ISinkHandle {
 
   @Override
   public synchronized void abort() {
-    if (aborted) {
+    if (aborted || closed) {
       return;
     }
     LOGGER.debug("[StartAbortShuffleSinkHandle]");
@@ -192,7 +192,7 @@ public class ShuffleSinkHandle implements ISinkHandle {
 
   @Override
   public synchronized void close() {
-    if (closed) {
+    if (closed || aborted) {
       return;
     }
     LOGGER.debug("[StartCloseShuffleSinkHandle]");


### PR DESCRIPTION
After lazy opening SinChannel, `blcoked` future in `SinkChannel` may be null while being aborted or closed because this FI may not be runned while the root FI may encounter error and decide to abort other FIs.

<img width="1902" alt="image" src="https://user-images.githubusercontent.com/16079446/231189074-2895e9c8-01ea-4769-b1a0-b54301837573.png">
