### PR TITLE
Fix MemoryPool free NPE

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
@@ -138,7 +138,7 @@ public class SinkChannel implements ISinkChannel {
             localFragmentInstanceId.queryId,
             localFragmentInstanceId.fragmentId,
             localFragmentInstanceId.instanceId);
-    this.bufferRetainedSizeInBytes = DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
+    this.bufferRetainedSizeInBytes = 0;
     this.currentTsBlockSize = DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
     localMemoryManager
         .getQueryPool()
@@ -385,6 +385,7 @@ public class SinkChannel implements ISinkChannel {
             // the handle is created, so we use DEFAULT here. It is ok to use DEFAULT here because
             // at first this SinkChannel has not reserved memory.
             .left;
+    this.bufferRetainedSizeInBytes = DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
   }
 
   @Override


### PR DESCRIPTION
We should only assign value to `bufferRetainedSizeInBytes` in `SinkChannel` after it's opened, otherwise we may encounter NPE while this sinkChannel is aborted before it's opened.
<img width="1902" alt="image" src="https://user-images.githubusercontent.com/16079446/231350485-ebd78447-76f2-43ba-b642-b1baa9c68893.png">
