### PR TITLE
Fix unexcepted error message when use raw query with Group By Tag

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBTagAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBTagAggregationIT.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.it.aggregation;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -40,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.apache.iotdb.db.it.utils.TestUtils.assertTestFail;
 import static org.junit.Assert.fail;
 
 @RunWith(IoTDBTestRunner.class)
@@ -579,5 +581,13 @@ public class IoTDBTagAggregationIT {
       e.printStackTrace();
       fail(e.getMessage());
     }
+  }
+
+  @Test
+  public void testWithRawInSelect() {
+    assertTestFail(
+        "SELECT s1 FROM root.case2.** GROUP BY TAGS(k1)",
+        TSStatusCode.SEMANTIC_ERROR.getStatusCode()
+            + ": Common queries and aggregated queries are not allowed to appear at the same time");
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
@@ -439,7 +439,7 @@ public class QueryStatement extends Statement {
         }
       }
     } else {
-      if (isGroupBy() || isGroupByLevel()) {
+      if (isGroupBy() || isGroupByLevel() || isGroupByTag()) {
         throw new SemanticException(
             "Common queries and aggregated queries are not allowed to appear at the same time");
       }


### PR DESCRIPTION
cause: forget to add SemanticCheck
origin jira: https://jira.infra.timecho.com:8443/browse/TIMECHODB-74

content of jira:
Msg: 305: [INTERNAL_SERVER_ERROR(305)] Exception occurred: "select s_19 from root.test.g_0.** where time=1535587210000 group by tags(workshop,city)". executeStatement failed. org.apache.iotdb.db.mpp.plan.expression.leaf.TimeSeriesOperand cannot be cast to org.apache.iotdb.db.mpp.plan.expression.multi.FunctionExpression

测试流程：

启动1C3D ,1副本 IoT协议
benchmark运行附件配置
给序列s_19 add tags
cli 执行查询

./sbin/start-cli.sh -h 172.20.70.2  -e "select s_19 from root.test.g_0.** where time=1535587210000 group by tags(workshop,city);"
Msg: 305: [INTERNAL_SERVER_ERROR(305)] Exception occurred: "select s_19 from root.test.g_0.** where time=1535587210000 group by tags(workshop,city)". executeStatement failed. org.apache.iotdb.db.mpp.plan.expression.leaf.TimeSeriesOperand cannot be cast to org.apache.iotdb.db.mpp.plan.expression.multi.FunctionExpression

datanode的warn log：

2023-04-04 13:47:45,982 [pool-31-IoTDB-ClientRPC-Processor-33] WARN  o.a.i.d.u.ErrorHandlingUtils:61 - Status code: INTERNAL_SERVER_ERROR(305), operation: "select s_19 from root.test.g_0.** where time=1535587210000 group by tags(workshop,city)". executeStatement failed
java.lang.ClassCastException: org.apache.iotdb.db.mpp.plan.expression.leaf.TimeSeriesOperand cannot be cast to org.apache.iotdb.db.mpp.plan.expression.multi.FunctionExpression
        at org.apache.iotdb.db.mpp.plan.analyze.AnalyzeVisitor.analyzeGroupByTag(AnalyzeVisitor.java:816)
        at org.apache.iotdb.db.mpp.plan.analyze.AnalyzeVisitor.visitQuery(AnalyzeVisitor.java:317)
        at org.apache.iotdb.db.mpp.plan.analyze.AnalyzeVisitor.visitQuery(AnalyzeVisitor.java:192)
        at org.apache.iotdb.db.mpp.plan.statement.crud.QueryStatement.accept(QueryStatement.java:595)
        at org.apache.iotdb.db.mpp.plan.statement.StatementVisitor.process(StatementVisitor.java:117)
        at org.apache.iotdb.db.mpp.plan.analyze.Analyzer.analyze(Analyzer.java:48)
        at org.apache.iotdb.db.mpp.plan.execution.QueryExecution.analyze(QueryExecution.java:285)
        at org.apache.iotdb.db.mpp.plan.execution.QueryExecution.<init>(QueryExecution.java:157)
        at org.apache.iotdb.db.mpp.plan.Coordinator.createQueryExecution(Coordinator.java:114)
        at org.apache.iotdb.db.mpp.plan.Coordinator.execute(Coordinator.java:148)
        at org.apache.iotdb.db.service.thrift.impl.ClientRPCServiceImpl.executeStatementInternal(ClientRPCServiceImpl.java:223)
        at org.apache.iotdb.db.service.thrift.impl.ClientRPCServiceImpl.executeStatementV2(ClientRPCServiceImpl.java:484)
        at org.apache.iotdb.service.rpc.thrift.IClientRPCService$Processor$executeStatementV2.getResult(IClientRPCService.java:3861)
        at org.apache.iotdb.service.rpc.thrift.IClientRPCService$Processor$executeStatementV2.getResult(IClientRPCService.java:3841)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.iotdb.db.service.thrift.ProcessorWithMetrics.process(ProcessorWithMetrics.java:64)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)