### PR TITLE
[IOTDB-5774] Fix the syntax that path nodes start or end with a wildcard to fuzzy match is not supported

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -1001,7 +1001,8 @@ intoPath
 
 nodeName
     : wildcard
-    | wildcard? nodeNameSlice wildcard?
+    | wildcard nodeNameSlice wildcard?
+    | nodeNameSlice wildcard
     | nodeNameWithoutWildcard
     ;
 

--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -1001,12 +1001,17 @@ intoPath
 
 nodeName
     : wildcard
-    | wildcard? identifier wildcard?
-    | identifier
+    | wildcard? nodeNameSlice wildcard?
+    | nodeNameWithoutWildcard
     ;
 
 nodeNameWithoutWildcard
     : identifier
+    ;
+
+nodeNameSlice
+    : identifier
+    | INTEGER_LITERAL
     ;
 
 nodeNameInIntoPath

--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/PathParser.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/PathParser.g4
@@ -42,8 +42,17 @@ suffixPath
 
 nodeName
     : wildcard
-    | wildcard? identifier wildcard?
-    | identifier
+    | wildcard? nodeNameSlice wildcard?
+    | nodeNameWithoutWildcard
+    ;
+
+nodeNameWithoutWildcard
+    : identifier
+    ;
+
+nodeNameSlice
+    : identifier
+    | INTEGER_LITERAL
     ;
 
 wildcard

--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/PathParser.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/PathParser.g4
@@ -42,7 +42,8 @@ suffixPath
 
 nodeName
     : wildcard
-    | wildcard? nodeNameSlice wildcard?
+    | wildcard nodeNameSlice wildcard?
+    | nodeNameSlice wildcard
     | nodeNameWithoutWildcard
     ;
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSyntaxConventionIdentifierIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSyntaxConventionIdentifierIT.java
@@ -1063,4 +1063,44 @@ public class IoTDBSyntaxConventionIdentifierIT {
       fail();
     }
   }
+
+  @Test
+  public void testNodeNameWithWildcard() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("CREATE TIMESERIES root.sg.device_123.s1 INT32");
+
+      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.device_123")) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertFalse(resultSet.next());
+      }
+      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.device_*")) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertFalse(resultSet.next());
+      }
+      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*_123")) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertFalse(resultSet.next());
+      }
+      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*123")) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertFalse(resultSet.next());
+      }
+      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*_12*")) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertFalse(resultSet.next());
+      }
+      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*12*")) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertFalse(resultSet.next());
+      }
+      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*e*")) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertFalse(resultSet.next());
+      }
+    } catch (SQLException e) {
+      e.printStackTrace();
+      fail();
+    }
+  }
 }


### PR DESCRIPTION
see IOTDB-5774.

**Before:**
<img width="704" alt="c3693f30ac36d38c3163319aaeee07a" src="https://user-images.githubusercontent.com/36565497/231503276-8d399d6b-ba0b-47cf-bec0-d82535199274.png">


**After:**
<img width="212" alt="c3ceef30115615296fe5e8a0b8b7f45" src="https://user-images.githubusercontent.com/36565497/231505938-97301ae0-24c0-4731-be44-171b08071d2d.png">

