### PR TITLE
[To rel/1.1] Fix SchemaEngine memory control concurrent bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -203,7 +203,7 @@ public class CacheMemoryManager {
                     store ->
                         CompletableFuture.runAsync(
                             () -> {
-                              store.getLock().threadReadLock();
+                              store.getLock().threadReadLock(true);
                               try {
                                 executeMemoryRelease(store);
                               } finally {


### PR DESCRIPTION
## Description


### Release-Task Lock Priority

We've implemented ```StampedWriterPreferredLock``` to enable memory release when a flush task is waiting for write lock. However, the priority is not set when release task try taking a read lock. Fix it.

### Memory-Control Boundary

Currently, the variable ```allowToCreateNewSeries``` is not maintained in a thread-safe manner. Use synchronized and double-check to protect it and ensure accuracy.

