### PR TITLE
Fix Group By Tag with empty grouped timeseries

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBTagAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBTagAggregationIT.java
@@ -40,6 +40,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.apache.iotdb.db.it.utils.TestUtils.resultSetEqualTest;
+import static org.apache.iotdb.itbase.constant.TestConstant.count;
 import static org.junit.Assert.fail;
 
 @RunWith(IoTDBTestRunner.class)
@@ -85,6 +87,10 @@ public class IoTDBTagAggregationIT {
         "insert into root.case2.d2(time, s1) values(10, 7.7);",
         "insert into root.case2.d1(time, s2) values(10, 6.6);",
         "insert into root.case2.d3(time, s1) values(10, 9.9);",
+        "create timeseries root.test.g_0.tab1.s_0 with datatype=int32;",
+        "create timeseries root.test.g_0.tab1.s_1 with datatype=int32;",
+        "insert into root.test.g_0.tab1(time,s_0,s_1) values (1,1,1);",
+        "alter timeseries root.test.g_0.tab1.s_0 add tags city=beijing;"
       };
 
   protected static final double DELTA = 0.001D;
@@ -579,5 +585,12 @@ public class IoTDBTagAggregationIT {
       e.printStackTrace();
       fail(e.getMessage());
     }
+
+    String[] expectedHeader = new String[] {"city", count("s_0"), count("s_1")};
+    String[] retArray = new String[] {"beijing,1,null,", "NULL,null,1,"};
+    resultSetEqualTest(
+        "select count(s_0) ,count(s_1) from root.test.g_0.tab1 group by tags(city)",
+        expectedHeader,
+        retArray);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
@@ -104,7 +104,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -737,24 +736,25 @@ public class LogicalPlanBuilder {
           tagValuesToGroupedTimeseriesOperands.get(tagValues);
       List<CrossSeriesAggregationDescriptor> aggregationDescriptors = new ArrayList<>();
 
-      Iterator<Expression> iter = groupedTimeseriesOperands.keySet().iterator();
+      // Bind an AggregationDescriptor for each GroupByTagOutputExpression
       for (Expression groupByTagOutputExpression : groupByTagOutputExpressions) {
-        if (!iter.hasNext()) {
-          aggregationDescriptors.add(null);
-          continue;
+        boolean added = false;
+        for (Expression expression : groupedTimeseriesOperands.keySet()) {
+          if (expression.equals(groupByTagOutputExpression)) {
+            String functionName = ((FunctionExpression) expression).getFunctionName();
+            CrossSeriesAggregationDescriptor aggregationDescriptor =
+                new CrossSeriesAggregationDescriptor(
+                    functionName,
+                    curStep,
+                    groupedTimeseriesOperands.get(expression),
+                    ((FunctionExpression) expression).getFunctionAttributes(),
+                    expression.getExpressions().get(0));
+            aggregationDescriptors.add(aggregationDescriptor);
+            added = true;
+            break;
+          }
         }
-        Expression next = iter.next();
-        if (next.equals(groupByTagOutputExpression)) {
-          String functionName = ((FunctionExpression) next).getFunctionName();
-          CrossSeriesAggregationDescriptor aggregationDescriptor =
-              new CrossSeriesAggregationDescriptor(
-                  functionName,
-                  curStep,
-                  groupedTimeseriesOperands.get(next),
-                  ((FunctionExpression) next).getFunctionAttributes(),
-                  next.getExpressions().get(0));
-          aggregationDescriptors.add(aggregationDescriptor);
-        } else {
+        if (!added) {
           aggregationDescriptors.add(null);
         }
       }


### PR DESCRIPTION
cause: incorrect logicPlan process
origin jira: https://jira.infra.timecho.com:8443/browse/TIMECHODB-73
content of jira: 
版本
master Enterprise version 1.2.0-SNAPSHOT (Build: 71b6bbf)

复现步骤
方法一： 

create timeseries root.test.g_0.tab1.s_0 with datatype=int32;
 create timeseries root.test.g_0.tab1.s_1 with datatype=int32;
 
 insert into root.test.g_0.tab1(time,s_0,s_1) values (1,1,1);
 alter timeseries root.test.g_0.tab1.s_0 add tags city=beijing;
 select count(s_0) ,count(s_1) from root.test.g_0.tab1 group by tags(city);

方法二：

启动1C3D ,1副本 IoT协议
benchmark运行附件配置
给序列s_19 add tags
cli 执行查询
./sbin/start-cli.sh -h 172.20.70.2  -e "select sum(s_19),sum(s_20) from root.test.g_0.** group by tags(city);"
Msg: 301: 2



2023-04-04 13:13:48,613 [Query-Worker-Thread-7$20230404_051348_41492_1.1.0.0] WARN  o.a.i.d.m.e.s.AbstractDriverThread:79 - [ExecuteFailed]
java.lang.RuntimeException: java.lang.ArrayIndexOutOfBoundsException: 2
        at org.apache.iotdb.db.mpp.execution.driver.Driver.processInternal(Driver.java:231)
        at org.apache.iotdb.db.mpp.execution.driver.Driver.lambda$processFor$1(Driver.java:144)
        at org.apache.iotdb.db.mpp.execution.driver.Driver.tryWithLock(Driver.java:308)
        at org.apache.iotdb.db.mpp.execution.driver.Driver.processFor(Driver.java:125)
        at org.apache.iotdb.db.mpp.execution.schedule.DriverTaskThread.execute(DriverTaskThread.java:69)
        at org.apache.iotdb.db.mpp.execution.schedule.AbstractDriverThread.run(AbstractDriverThread.java:73)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 2
        at org.apache.iotdb.db.mpp.execution.operator.process.TagAggregationOperator.processOneRow(TagAggregationOperator.java:131)
        at org.apache.iotdb.db.mpp.execution.operator.process.TagAggregationOperator.next(TagAggregationOperator.java:91)
        at org.apache.iotdb.db.mpp.execution.operator.sink.IdentitySinkOperator.next(IdentitySinkOperator.java:99)
        at org.apache.iotdb.db.mpp.execution.operator.Operator.nextWithTimer(Operator.java:46)
        at org.apache.iotdb.db.mpp.execution.driver.Driver.processInternal(Driver.java:221)
        ... 5 common frames omitted
2023-04-04 13:13:48,613 [Query-Worker-Thread-7$20230404_051348_41492_1.1.0.0] WARN  o.a.i.d.m.e.s.DriverScheduler$Scheduler:509 - The task 20230404_051348_41492_1.1.0.0 is aborted. All other tasks in the same query will be cancelled
2023-04-04 13:13:48,616 [pool-31-IoTDB-ClientRPC-Processor-33] WARN  o.a.i.d.u.ErrorHandlingUtils:89 - Status code: 301, Query Statement: "select sum(s_19),sum(s_20) from root.test.g_0.** group by tags(city)". executeStatement failed
org.apache.iotdb.commons.exception.IoTDBException: java.lang.ArrayIndexOutOfBoundsException: 2
        at org.apache.iotdb.db.mpp.plan.execution.QueryExecution.dealWithException(QueryExecution.java:479)
        at org.apache.iotdb.db.mpp.plan.execution.QueryExecution.getResult(QueryExecution.java:462)
        at org.apache.iotdb.db.mpp.plan.execution.QueryExecution.getByteBufferBatchResult(QueryExecution.java:497)
        at org.apache.iotdb.db.utils.QueryDataSetUtils.convertQueryResultByFetchSize(QueryDataSetUtils.java:254)
        at org.apache.iotdb.db.service.thrift.impl.ClientRPCServiceImpl.lambda$static$0(ClientRPCServiceImpl.java:171)
        at org.apache.iotdb.db.service.thrift.impl.ClientRPCServiceImpl.executeStatementInternal(ClientRPCServiceImpl.java:243)
        at org.apache.iotdb.db.service.thrift.impl.ClientRPCServiceImpl.executeStatementV2(ClientRPCServiceImpl.java:484)
        at org.apache.iotdb.service.rpc.thrift.IClientRPCService$Processor$executeStatementV2.getResult(IClientRPCService.java:3861)
        at org.apache.iotdb.service.rpc.thrift.IClientRPCService$Processor$executeStatementV2.getResult(IClientRPCService.java:3841)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.iotdb.db.service.thrift.ProcessorWithMetrics.process(ProcessorWithMetrics.java:64)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 2
        at org.apache.iotdb.db.mpp.execution.operator.process.TagAggregationOperator.processOneRow(TagAggregationOperator.java:131)
        at org.apache.iotdb.db.mpp.execution.operator.process.TagAggregationOperator.next(TagAggregationOperator.java:91)
        at org.apache.iotdb.db.mpp.execution.operator.sink.IdentitySinkOperator.next(IdentitySinkOperator.java:99)
        at org.apache.iotdb.db.mpp.execution.operator.Operator.nextWithTimer(Operator.java:46)
        at org.apache.iotdb.db.mpp.execution.driver.Driver.processInternal(Driver.java:221)
        at org.apache.iotdb.db.mpp.execution.driver.Driver.lambda$processFor$1(Driver.java:144)
        at org.apache.iotdb.db.mpp.execution.driver.Driver.tryWithLock(Driver.java:308)
        at org.apache.iotdb.db.mpp.execution.driver.Driver.processFor(Driver.java:125)
        at org.apache.iotdb.db.mpp.execution.schedule.DriverTaskThread.execute(DriverTaskThread.java:69)
        at org.apache.iotdb.db.mpp.execution.schedule.AbstractDriverThread.run(AbstractDriverThread.java:73)

 