### PR TITLE
Fixed resource stop failure after remote scheduling retry

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -255,6 +255,8 @@ public class QueryExecution implements IQueryExecution {
     context.prepareForRetry();
     // re-analyze the query
     this.analysis = analyze(rawStatement, context, partitionFetcher, schemaFetcher);
+    // re-stop
+    this.stopped = new AtomicBoolean(false);
     // re-start the QueryExecution
     this.start();
     return getStatus();


### PR DESCRIPTION
When multiple datanodes are started, a request from a client may be distributed to different datanodes. For example, if A client sends A request to datanode A,A may forward the request to dataNode B. If an exception occurs during the execution of the request,A tries again. When the retry occurs,A fails to stop resources.