### PR TITLE
distinguish whether an exception has occurred when releasing the QueryExecution resource

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/fragment/FragmentInstanceManager.java
@@ -243,14 +243,18 @@ public class FragmentInstanceManager {
   }
 
   /** Cancels a FragmentInstance. */
-  public FragmentInstanceInfo cancelTask(FragmentInstanceId instanceId) {
+  public FragmentInstanceInfo cancelTask(FragmentInstanceId instanceId, boolean hasThrowable) {
     logger.debug("[CancelFI]");
     requireNonNull(instanceId, "taskId is null");
 
     FragmentInstanceContext context = instanceContext.remove(instanceId);
     if (context != null) {
       instanceExecution.remove(instanceId);
-      context.cancel();
+      if (hasThrowable) {
+        context.cancel();
+      } else {
+        context.finished();
+      }
       return context.getInstanceInfo();
     }
     return null;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/Coordinator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/Coordinator.java
@@ -208,12 +208,12 @@ public class Coordinator {
     return queryIdGenerator.createNextQueryId();
   }
 
-  public void cleanupQueryExecution(Long queryId) {
+  public void cleanupQueryExecution(Long queryId, Throwable t) {
     IQueryExecution queryExecution = getQueryExecution(queryId);
     if (queryExecution != null) {
       try (SetThreadName threadName = new SetThreadName(queryExecution.getQueryId())) {
         LOGGER.debug("[CleanUpQuery]]");
-        queryExecution.stopAndCleanup();
+        queryExecution.stopAndCleanup(t);
         queryExecutionMap.remove(queryId);
         if (queryExecution.isQuery()) {
           long costTime = queryExecution.getTotalExecutionTime();
@@ -226,6 +226,10 @@ public class Coordinator {
         }
       }
     }
+  }
+
+  public void cleanupQueryExecution(Long queryId) {
+    cleanupQueryExecution(queryId, null);
   }
 
   public IClientManager<TEndPoint, SyncDataNodeInternalServiceClient>

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetchExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetchExecutor.java
@@ -152,6 +152,7 @@ class ClusterSchemaFetchExecutor {
 
   private ClusterSchemaTree executeSchemaFetchQuery(SchemaFetchStatement schemaFetchStatement) {
     long queryId = queryIdProvider.get();
+    Throwable t = null;
     try {
       ExecutionResult executionResult = statementExecutor.apply(queryId, schemaFetchStatement);
       if (executionResult.status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
@@ -170,6 +171,7 @@ class ClusterSchemaFetchExecutor {
           try {
             tsBlock = coordinator.getQueryExecution(queryId).getBatchResult();
           } catch (IoTDBException e) {
+            t = e;
             throw new RuntimeException("Fetch Schema failed. ", e);
           }
           if (!tsBlock.isPresent() || tsBlock.get().isEmpty()) {
@@ -184,7 +186,7 @@ class ClusterSchemaFetchExecutor {
         return result;
       }
     } finally {
-      coordinator.cleanupQueryExecution(queryId);
+      coordinator.cleanupQueryExecution(queryId, t);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetchExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetchExecutor.java
@@ -185,6 +185,9 @@ class ClusterSchemaFetchExecutor {
         result.setDatabases(databaseSet);
         return result;
       }
+    } catch (Throwable throwable) {
+      t = throwable;
+      throw throwable;
     } finally {
       coordinator.cleanupQueryExecution(queryId, t);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/IQueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/IQueryExecution.java
@@ -35,6 +35,8 @@ public interface IQueryExecution {
 
   void stopAndCleanup();
 
+  void stopAndCleanup(Throwable t);
+
   void cancel();
 
   ExecutionResult getStatus();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/IQueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/IQueryExecution.java
@@ -31,7 +31,7 @@ public interface IQueryExecution {
 
   void start();
 
-  void stop();
+  void stop(Throwable t);
 
   void stopAndCleanup();
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -390,7 +390,7 @@ public class QueryExecution implements IQueryExecution {
     // If the QueryExecution's state is abnormal, we should also abort the resultHandle without
     // waiting it to be finished.
     if (resultHandle != null) {
-      resultHandle.abort();
+      resultHandle.close();
     }
   }
 
@@ -410,7 +410,11 @@ public class QueryExecution implements IQueryExecution {
     // If the QueryExecution's state is abnormal, we should also abort the resultHandle without
     // waiting it to be finished.
     if (resultHandle != null) {
-      resultHandle.abort(t);
+      if (t != null) {
+        resultHandle.abort(t);
+      } else {
+        resultHandle.close();
+      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -256,8 +256,6 @@ public class QueryExecution implements IQueryExecution {
     context.prepareForRetry();
     // re-analyze the query
     this.analysis = analyze(rawStatement, context, partitionFetcher, schemaFetcher);
-    // re-stop
-    this.stopped = new AtomicBoolean(false);
     // re-start the QueryExecution
     this.start();
     return getStatus();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ConfigExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ConfigExecution.java
@@ -151,6 +151,9 @@ public class ConfigExecution implements IQueryExecution {
   public void stopAndCleanup() {}
 
   @Override
+  public void stopAndCleanup(Throwable t) {}
+
+  @Override
   public void cancel() {
     throw new UnsupportedOperationException(getClass().getName());
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ConfigExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/ConfigExecution.java
@@ -145,7 +145,7 @@ public class ConfigExecution implements IQueryExecution {
   }
 
   @Override
-  public void stop() {}
+  public void stop(Throwable t) {}
 
   @Override
   public void stopAndCleanup() {}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
@@ -154,7 +154,7 @@ public class ClusterScheduler implements IScheduler {
   }
 
   @Override
-  public void stop() {
+  public void stop(Throwable t) {
     // TODO: It seems that it is unnecessary to check whether they are null or not. Is it a best
     // practice ?
     dispatcher.abort();
@@ -163,7 +163,7 @@ public class ClusterScheduler implements IScheduler {
     }
     // TODO: (xingtanzjr) handle the exception when the termination cannot succeed
     if (queryTerminator != null) {
-      queryTerminator.terminate();
+      queryTerminator.terminate(t);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/IQueryTerminator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/IQueryTerminator.java
@@ -22,5 +22,5 @@ package org.apache.iotdb.db.mpp.plan.scheduler;
 import java.util.concurrent.Future;
 
 public interface IQueryTerminator {
-  Future<Boolean> terminate();
+  Future<Boolean> terminate(Throwable t);
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/IScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/IScheduler.java
@@ -28,7 +28,7 @@ public interface IScheduler {
 
   void start();
 
-  void stop();
+  void stop(Throwable t);
 
   Duration getTotalCpuTime();
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileScheduler.java
@@ -287,7 +287,7 @@ public class LoadTsFileScheduler implements IScheduler {
   }
 
   @Override
-  public void stop() {}
+  public void stop(Throwable t) {}
 
   @Override
   public Duration getTotalCpuTime() {

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -260,6 +260,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       t = e;
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(e, "\"" + statement + "\". " + OperationType.EXECUTE_STATEMENT));
+    } catch (Error error) {
+      t = error;
+      throw error;
     } finally {
       COORDINATOR.recordExecutionTime(queryId, System.currentTimeMillis() - startTime);
       if (finished) {
@@ -342,6 +345,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       t = e;
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(e, "\"" + req + "\". " + OperationType.EXECUTE_RAW_DATA_QUERY));
+    } catch (Error error) {
+      t = error;
+      throw error;
     } finally {
       COORDINATOR.recordExecutionTime(queryId, System.currentTimeMillis() - startTime);
       if (finished) {
@@ -421,6 +427,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       t = e;
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(e, "\"" + req + "\". " + OperationType.EXECUTE_LAST_DATA_QUERY));
+    } catch (Error error) {
+      t = error;
+      throw error;
     } finally {
       COORDINATOR.recordExecutionTime(queryId, System.currentTimeMillis() - startTime);
       if (finished) {
@@ -497,6 +506,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       t = e;
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(e, "\"" + req + "\". " + OperationType.EXECUTE_LAST_DATA_QUERY));
+    } catch (Error error) {
+      t = error;
+      throw error;
     } finally {
       COORDINATOR.recordExecutionTime(queryId, System.currentTimeMillis() - startTime);
       if (finished) {
@@ -581,6 +593,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       finished = true;
       t = e;
       return RpcUtils.getTSFetchResultsResp(onQueryException(e, OperationType.FETCH_RESULTS));
+    } catch (Error error) {
+      t = error;
+      throw error;
     } finally {
       COORDINATOR.recordExecutionTime(req.queryId, System.currentTimeMillis() - startTime);
       if (finished) {
@@ -1102,6 +1117,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       finished = true;
       t = e;
       return RpcUtils.getTSFetchResultsResp(onQueryException(e, OperationType.FETCH_RESULTS));
+    } catch (Error error) {
+      t = error;
+      throw error;
     } finally {
       COORDINATOR.recordExecutionTime(req.queryId, System.currentTimeMillis() - startTime);
       if (finished) {

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/ClientRPCServiceImpl.java
@@ -199,6 +199,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
 
     long startTime = System.currentTimeMillis();
     StatementType statementType = null;
+    Throwable t = null;
     try {
       Statement s = StatementGenerator.createStatement(statement, clientSession.getZoneId());
 
@@ -256,6 +257,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
     } catch (Exception e) {
       finished = true;
+      t = e;
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(e, "\"" + statement + "\". " + OperationType.EXECUTE_STATEMENT));
     } finally {
@@ -268,7 +270,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
               statementType,
               executionTime > 0 ? executionTime : System.currentTimeMillis() - startTime);
         }
-        COORDINATOR.cleanupQueryExecution(queryId);
+        COORDINATOR.cleanupQueryExecution(queryId, t);
       }
       SESSION_MANAGER.updateIdleTime();
       if (quota != null) {
@@ -287,6 +289,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       return RpcUtils.getTSExecuteStatementResp(getNotLoggedInStatus());
     }
     long startTime = System.currentTimeMillis();
+    Throwable t = null;
     try {
       Statement s = StatementGenerator.createStatement(req, clientSession.getZoneId());
 
@@ -336,6 +339,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
     } catch (Exception e) {
       finished = true;
+      t = e;
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(e, "\"" + req + "\". " + OperationType.EXECUTE_RAW_DATA_QUERY));
     } finally {
@@ -345,7 +349,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
             OperationType.EXECUTE_RAW_DATA_QUERY,
             StatementType.QUERY,
             COORDINATOR.getTotalExecutionTime(queryId));
-        COORDINATOR.cleanupQueryExecution(queryId);
+        COORDINATOR.cleanupQueryExecution(queryId, t);
       }
       SESSION_MANAGER.updateIdleTime();
       if (quota != null) {
@@ -364,6 +368,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       return RpcUtils.getTSExecuteStatementResp(getNotLoggedInStatus());
     }
     long startTime = System.currentTimeMillis();
+    Throwable t = null;
     try {
       Statement s = StatementGenerator.createStatement(req, clientSession.getZoneId());
       // permission check
@@ -413,6 +418,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
 
     } catch (Exception e) {
       finished = true;
+      t = e;
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(e, "\"" + req + "\". " + OperationType.EXECUTE_LAST_DATA_QUERY));
     } finally {
@@ -422,7 +428,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
             OperationType.EXECUTE_LAST_DATA_QUERY,
             StatementType.QUERY,
             COORDINATOR.getTotalExecutionTime(queryId));
-        COORDINATOR.cleanupQueryExecution(queryId);
+        COORDINATOR.cleanupQueryExecution(queryId, t);
       }
       SESSION_MANAGER.updateIdleTime();
       if (quota != null) {
@@ -441,6 +447,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       return RpcUtils.getTSExecuteStatementResp(getNotLoggedInStatus());
     }
     long startTime = System.currentTimeMillis();
+    Throwable t = null;
     try {
       Statement s = StatementGenerator.createStatement(req, clientSession.getZoneId());
       // permission check
@@ -487,6 +494,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
 
     } catch (Exception e) {
       finished = true;
+      t = e;
       return RpcUtils.getTSExecuteStatementResp(
           onQueryException(e, "\"" + req + "\". " + OperationType.EXECUTE_LAST_DATA_QUERY));
     } finally {
@@ -496,7 +504,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
             OperationType.EXECUTE_LAST_DATA_QUERY,
             StatementType.QUERY,
             COORDINATOR.getTotalExecutionTime(queryId));
-        COORDINATOR.cleanupQueryExecution(queryId);
+        COORDINATOR.cleanupQueryExecution(queryId, t);
       }
       SESSION_MANAGER.updateIdleTime();
       if (quota != null) {
@@ -540,6 +548,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
     long startTime = System.currentTimeMillis();
     boolean finished = false;
     StatementType statementType = null;
+    Throwable t = null;
     try {
       IClientSession clientSession = SESSION_MANAGER.getCurrSessionAndUpdateIdleTime();
       if (!SESSION_MANAGER.checkLogin(clientSession)) {
@@ -570,6 +579,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
     } catch (Exception e) {
       finished = true;
+      t = e;
       return RpcUtils.getTSFetchResultsResp(onQueryException(e, OperationType.FETCH_RESULTS));
     } finally {
       COORDINATOR.recordExecutionTime(req.queryId, System.currentTimeMillis() - startTime);
@@ -580,7 +590,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
               statementType,
               COORDINATOR.getTotalExecutionTime(req.queryId));
         }
-        COORDINATOR.cleanupQueryExecution(req.queryId);
+        COORDINATOR.cleanupQueryExecution(req.queryId, t);
       }
       SESSION_MANAGER.updateIdleTime();
     }
@@ -1059,6 +1069,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
     boolean finished = false;
     long startTime = System.currentTimeMillis();
     StatementType statementType = null;
+    Throwable t = null;
     try {
       IClientSession clientSession = SESSION_MANAGER.getCurrSessionAndUpdateIdleTime();
       if (!SESSION_MANAGER.checkLogin(clientSession)) {
@@ -1089,6 +1100,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       }
     } catch (Exception e) {
       finished = true;
+      t = e;
       return RpcUtils.getTSFetchResultsResp(onQueryException(e, OperationType.FETCH_RESULTS));
     } finally {
       COORDINATOR.recordExecutionTime(req.queryId, System.currentTimeMillis() - startTime);
@@ -1099,7 +1111,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
               statementType,
               COORDINATOR.getTotalExecutionTime(req.queryId));
         }
-        COORDINATOR.cleanupQueryExecution(req.queryId);
+        COORDINATOR.cleanupQueryExecution(req.queryId, t);
       }
       SESSION_MANAGER.updateIdleTime();
     }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -330,7 +330,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
               .map(FragmentInstanceId::fromThrift)
               .collect(Collectors.toList());
       for (FragmentInstanceId taskId : taskIds) {
-        FragmentInstanceManager.getInstance().cancelTask(taskId);
+        FragmentInstanceManager.getInstance().cancelTask(taskId, req.hasThrowable);
       }
       return new TCancelResp(true);
     }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/MLNodeRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/MLNodeRPCServiceImpl.java
@@ -134,6 +134,9 @@ public class MLNodeRPCServiceImpl implements IMLNodeRPCServiceWithHandler {
       t = e;
       resp.setStatus(onQueryException(e, OperationType.EXECUTE_STATEMENT));
       return resp;
+    } catch (Error error) {
+      t = error;
+      throw error;
     } finally {
       if (finished) {
         COORDINATOR.cleanupQueryExecution(resp.queryId, t);
@@ -169,6 +172,9 @@ public class MLNodeRPCServiceImpl implements IMLNodeRPCServiceWithHandler {
       t = e;
       resp.setStatus(onQueryException(e, OperationType.FETCH_RESULTS));
       return resp;
+    } catch (Error error) {
+      t = error;
+      throw error;
     } finally {
       if (finished) {
         COORDINATOR.cleanupQueryExecution(req.queryId, t);

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/MLNodeRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/MLNodeRPCServiceImpl.java
@@ -88,7 +88,7 @@ public class MLNodeRPCServiceImpl implements IMLNodeRPCServiceWithHandler {
   public TFetchTimeseriesResp fetchTimeseries(TFetchTimeseriesReq req) throws TException {
     boolean finished = false;
     TFetchTimeseriesResp resp = new TFetchTimeseriesResp();
-
+    Throwable t = null;
     try {
       QueryStatement s =
           (QueryStatement) StatementGenerator.createStatement(req, session.getZoneId());
@@ -131,11 +131,12 @@ public class MLNodeRPCServiceImpl implements IMLNodeRPCServiceWithHandler {
       }
     } catch (Exception e) {
       finished = true;
+      t = e;
       resp.setStatus(onQueryException(e, OperationType.EXECUTE_STATEMENT));
       return resp;
     } finally {
       if (finished) {
-        COORDINATOR.cleanupQueryExecution(resp.queryId);
+        COORDINATOR.cleanupQueryExecution(resp.queryId, t);
       }
     }
   }
@@ -144,6 +145,7 @@ public class MLNodeRPCServiceImpl implements IMLNodeRPCServiceWithHandler {
   public TFetchMoreDataResp fetchMoreData(TFetchMoreDataReq req) throws TException {
     TFetchMoreDataResp resp = new TFetchMoreDataResp();
     boolean finished = false;
+    Throwable t = null;
     try {
       IQueryExecution queryExecution = COORDINATOR.getQueryExecution(req.queryId);
       resp.setStatus(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
@@ -164,11 +166,12 @@ public class MLNodeRPCServiceImpl implements IMLNodeRPCServiceWithHandler {
       }
     } catch (Exception e) {
       finished = true;
+      t = e;
       resp.setStatus(onQueryException(e, OperationType.FETCH_RESULTS));
       return resp;
     } finally {
       if (finished) {
-        COORDINATOR.cleanupQueryExecution(req.queryId);
+        COORDINATOR.cleanupQueryExecution(req.queryId, t);
       }
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/ConfigExecutionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/ConfigExecutionTest.java
@@ -153,7 +153,7 @@ public class ConfigExecutionTest {
     } catch (InterruptedException e) {
       ExecutionResult result = execution.getStatus();
       assertEquals(TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), result.status.code);
-      execution.stop();
+      execution.stop(e);
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/MergeSortOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/MergeSortOperatorTest.java
@@ -1656,7 +1656,7 @@ public class MergeSortOperatorTest {
     public void start() {}
 
     @Override
-    public void stop() {}
+    public void stop(Throwable t) {}
 
     @Override
     public void stopAndCleanup() {}

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/MergeSortOperatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/operator/MergeSortOperatorTest.java
@@ -1662,6 +1662,9 @@ public class MergeSortOperatorTest {
     public void stopAndCleanup() {}
 
     @Override
+    public void stopAndCleanup(Throwable t) {}
+
+    @Override
     public void cancel() {}
 
     @Override

--- a/thrift/src/main/thrift/datanode.thrift
+++ b/thrift/src/main/thrift/datanode.thrift
@@ -144,6 +144,7 @@ struct TFragmentInstanceInfoResp {
 struct TCancelQueryReq {
   1: required string queryId
   2: required list<TFragmentInstanceId> fragmentInstanceIds
+  3: required bool hasThrowable
 }
 
 struct TCancelPlanFragmentReq {


### PR DESCRIPTION
The current situation where the resultHandle.abort() method is eventually executed when a client request completes, regardless of whether an exception occurred, is not accurate. The right way to release resources is to say,
1. To end a normal operation, run resultHandle.close();
2. To terminate the exception, run resultHandle.abort().