### PR TITLE
[To rel/1.1] Accelerate count all schema via schema statistic

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -266,7 +266,6 @@ public class CacheMemoryManager {
         .join();
     if (engineMetric != null) {
       engineMetric.recordFlush(System.currentTimeMillis() - startTime);
-      logger.info("Schema flush takes {}ms", System.currentTimeMillis() - startTime);
     }
     synchronized (blockObject) {
       hasFlushTask = false;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -70,7 +70,7 @@ public class CacheMemoryManager {
 
   private IReleaseFlushStrategy releaseFlushStrategy;
 
-  private static final int MAX_WAITING_TIME_WHEN_RELEASING = 10_000;
+  private static final int MAX_WAITING_TIME_WHEN_RELEASING = 1_000;
   private final Object blockObject = new Object();
 
   /**
@@ -266,6 +266,7 @@ public class CacheMemoryManager {
         .join();
     if (engineMetric != null) {
       engineMetric.recordFlush(System.currentTimeMillis() - startTime);
+      logger.info("Schema flush takes {}ms", System.currentTimeMillis() - startTime);
     }
     synchronized (blockObject) {
       hasFlushTask = false;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -70,7 +70,7 @@ public class CacheMemoryManager {
 
   private IReleaseFlushStrategy releaseFlushStrategy;
 
-  private static final int MAX_WAITING_TIME_WHEN_RELEASING = 10_000;
+  private static final int MAX_WAITING_TIME_WHEN_RELEASING = 3_000;
   private final Object blockObject = new Object();
 
   /**
@@ -266,6 +266,7 @@ public class CacheMemoryManager {
         .join();
     if (engineMetric != null) {
       engineMetric.recordFlush(System.currentTimeMillis() - startTime);
+      logger.info("Schema flush takes {}ms", System.currentTimeMillis() - startTime);
     }
     synchronized (blockObject) {
       hasFlushTask = false;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -70,7 +70,7 @@ public class CacheMemoryManager {
 
   private IReleaseFlushStrategy releaseFlushStrategy;
 
-  private static final int MAX_WAITING_TIME_WHEN_RELEASING = 1_000;
+  private static final int MAX_WAITING_TIME_WHEN_RELEASING = 10_000;
   private final Object blockObject = new Object();
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/rescon/MemSchemaEngineStatistics.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/rescon/MemSchemaEngineStatistics.java
@@ -72,9 +72,11 @@ public class MemSchemaEngineStatistics implements ISchemaEngineStatistics {
     memoryUsage.addAndGet(size);
     if (memoryUsage.get() >= memoryCapacity) {
       synchronized (allowToCreateNewSeriesLock) {
-        if (allowToCreateNewSeries && memoryUsage.get() >= memoryCapacity) {
+        if (memoryUsage.get() >= memoryCapacity) {
           logger.warn("Current series memory {} is too large...", memoryUsage);
-          allowToCreateNewSeries = false;
+          if (allowToCreateNewSeries) {
+            allowToCreateNewSeries = false;
+          }
         }
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/rescon/MemSchemaEngineStatistics.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/rescon/MemSchemaEngineStatistics.java
@@ -72,11 +72,9 @@ public class MemSchemaEngineStatistics implements ISchemaEngineStatistics {
     memoryUsage.addAndGet(size);
     if (memoryUsage.get() >= memoryCapacity) {
       synchronized (allowToCreateNewSeriesLock) {
-        if (memoryUsage.get() >= memoryCapacity) {
+        if (allowToCreateNewSeries && memoryUsage.get() >= memoryCapacity) {
           logger.warn("Current series memory {} is too large...", memoryUsage);
-          if (allowToCreateNewSeries) {
-            allowToCreateNewSeries = false;
-          }
+          allowToCreateNewSeries = false;
         }
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -582,11 +582,13 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void createTimeseries(ICreateTimeSeriesPlan plan, long offset) throws MetadataException {
     if (!regionStatistics.isAllowToCreateNewSeries()) {
-      CacheMemoryManager.getInstance().waitIfReleasing();
-      if (!regionStatistics.isAllowToCreateNewSeries()) {
-        logger.warn("Series overflow when creating: [{}]", plan.getPath().getFullPath());
-        throw new SeriesOverflowException();
+      while (!regionStatistics.isAllowToCreateNewSeries()) {
+        CacheMemoryManager.getInstance().waitIfReleasing();
       }
+      //      if (!regionStatistics.isAllowToCreateNewSeries()) {
+      //        logger.warn("Series overflow when creating: [{}]", plan.getPath().getFullPath());
+      //        throw new SeriesOverflowException();
+      //      }
     }
 
     schemaQuotaManager.checkMeasurementLevel(1);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -582,13 +582,11 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void createTimeseries(ICreateTimeSeriesPlan plan, long offset) throws MetadataException {
     if (!regionStatistics.isAllowToCreateNewSeries()) {
-      while (!regionStatistics.isAllowToCreateNewSeries()) {
-        CacheMemoryManager.getInstance().waitIfReleasing();
+      CacheMemoryManager.getInstance().waitIfReleasing();
+      if (!regionStatistics.isAllowToCreateNewSeries()) {
+        logger.warn("Series overflow when creating: [{}]", plan.getPath().getFullPath());
+        throw new SeriesOverflowException();
       }
-      //      if (!regionStatistics.isAllowToCreateNewSeries()) {
-      //        logger.warn("Series overflow when creating: [{}]", plan.getPath().getFullPath());
-      //        throw new SeriesOverflowException();
-      //      }
     }
 
     schemaQuotaManager.checkMeasurementLevel(1);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionSchemaFileImpl.java
@@ -581,12 +581,8 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   @Override
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void createTimeseries(ICreateTimeSeriesPlan plan, long offset) throws MetadataException {
-    if (!regionStatistics.isAllowToCreateNewSeries()) {
+    while (!regionStatistics.isAllowToCreateNewSeries()) {
       CacheMemoryManager.getInstance().waitIfReleasing();
-      if (!regionStatistics.isAllowToCreateNewSeries()) {
-        logger.warn("Series overflow when creating: [{}]", plan.getPath().getFullPath());
-        throw new SeriesOverflowException();
-      }
     }
 
     schemaQuotaManager.checkMeasurementLevel(1);
@@ -693,11 +689,8 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   @Override
   public void createAlignedTimeSeries(ICreateAlignedTimeSeriesPlan plan) throws MetadataException {
     int seriesCount = plan.getMeasurements().size();
-    if (!regionStatistics.isAllowToCreateNewSeries()) {
+    while (!regionStatistics.isAllowToCreateNewSeries()) {
       CacheMemoryManager.getInstance().waitIfReleasing();
-      if (!regionStatistics.isAllowToCreateNewSeries()) {
-        throw new SeriesOverflowException();
-      }
     }
     schemaQuotaManager.checkMeasurementLevel(seriesCount);
 
@@ -1181,7 +1174,9 @@ public class SchemaRegionSchemaFileImpl implements ISchemaRegion {
   @Override
   public void activateSchemaTemplate(IActivateTemplateInClusterPlan plan, Template template)
       throws MetadataException {
-
+    while (!regionStatistics.isAllowToCreateNewSeries()) {
+      CacheMemoryManager.getInstance().waitIfReleasing();
+    }
     try {
       IMNode deviceNode = getDeviceNodeWithAutoCreate(plan.getActivatePath());
       try {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperator.java
@@ -76,15 +76,19 @@ public class SchemaCountOperator<T extends ISchemaInfo> implements SourceOperato
     isFinished = true;
     TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(OUTPUT_DATA_TYPES);
     long count = 0;
-    if (schemaReader == null) {
-      schemaReader = createSchemaReader();
-    }
-    while (schemaReader.hasNext()) {
-      schemaReader.next();
-      count++;
-    }
-    if (!schemaReader.isSuccess()) {
-      throw new RuntimeException(schemaReader.getFailure());
+    if (schemaSource.hasSchemaStatistic()) {
+      count = schemaSource.getSchemaStatistic(getSchemaRegion());
+    } else {
+      if (schemaReader == null) {
+        schemaReader = createSchemaReader();
+      }
+      while (schemaReader.hasNext()) {
+        schemaReader.next();
+        count++;
+      }
+      if (!schemaReader.isSuccess()) {
+        throw new RuntimeException(schemaReader.getFailure());
+      }
     }
 
     tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperator.java
@@ -76,8 +76,9 @@ public class SchemaCountOperator<T extends ISchemaInfo> implements SourceOperato
     isFinished = true;
     TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(OUTPUT_DATA_TYPES);
     long count = 0;
-    if (schemaSource.hasSchemaStatistic()) {
-      count = schemaSource.getSchemaStatistic(getSchemaRegion());
+    ISchemaRegion schemaRegion = getSchemaRegion();
+    if (schemaSource.hasSchemaStatistic(schemaRegion)) {
+      count = schemaSource.getSchemaStatistic(schemaRegion);
     } else {
       if (schemaReader == null) {
         schemaReader = createSchemaReader();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/DeviceSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/DeviceSchemaSource.java
@@ -88,7 +88,7 @@ public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
   }
 
   @Override
-  public boolean hasSchemaStatistic() {
+  public boolean hasSchemaStatistic(ISchemaRegion schemaRegion) {
     return pathPattern.equals(ALL_MATCH_PATTERN);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/DeviceSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/DeviceSchemaSource.java
@@ -32,6 +32,8 @@ import org.apache.iotdb.tsfile.utils.Binary;
 
 import java.util.List;
 
+import static org.apache.iotdb.db.metadata.MetadataConstant.ALL_MATCH_PATTERN;
+
 public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
 
   private final PartialPath pathPattern;
@@ -83,5 +85,15 @@ public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
       builder.getColumnBuilder(1).writeBinary(new Binary(String.valueOf(device.isAligned())));
     }
     builder.declarePosition();
+  }
+
+  @Override
+  public boolean hasSchemaStatistic() {
+    return pathPattern.equals(ALL_MATCH_PATTERN);
+  }
+
+  @Override
+  public long getSchemaStatistic(ISchemaRegion schemaRegion) {
+    return schemaRegion.getSchemaRegionStatistics().getDevicesNumber();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/ISchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/ISchemaSource.java
@@ -48,7 +48,7 @@ public interface ISchemaSource<T extends ISchemaInfo> {
    */
   void transformToTsBlockColumns(T schemaInfo, TsBlockBuilder tsBlockBuilder, String database);
 
-  boolean hasSchemaStatistic();
+  boolean hasSchemaStatistic(ISchemaRegion schemaRegion);
 
   long getSchemaStatistic(ISchemaRegion schemaRegion);
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/ISchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/ISchemaSource.java
@@ -47,4 +47,8 @@ public interface ISchemaSource<T extends ISchemaInfo> {
    * @param database the belonged databased of given SchemaInfo
    */
   void transformToTsBlockColumns(T schemaInfo, TsBlockBuilder tsBlockBuilder, String database);
+
+  boolean hasSchemaStatistic();
+
+  long getSchemaStatistic(ISchemaRegion schemaRegion);
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/NodeSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/NodeSchemaSource.java
@@ -78,4 +78,14 @@ public class NodeSchemaSource implements ISchemaSource<INodeSchemaInfo> {
         .writeBinary(new Binary(String.valueOf(nodeSchemaInfo.getNodeType().getNodeType())));
     tsBlockBuilder.declarePosition();
   }
+
+  @Override
+  public boolean hasSchemaStatistic() {
+    return false;
+  }
+
+  @Override
+  public long getSchemaStatistic(ISchemaRegion schemaRegion) {
+    return 0;
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/NodeSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/NodeSchemaSource.java
@@ -80,7 +80,7 @@ public class NodeSchemaSource implements ISchemaSource<INodeSchemaInfo> {
   }
 
   @Override
-  public boolean hasSchemaStatistic() {
+  public boolean hasSchemaStatistic(ISchemaRegion schemaRegion) {
     return false;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
@@ -62,7 +62,7 @@ public class PathsUsingTemplateSource implements ISchemaSource<IDeviceSchemaInfo
   }
 
   @Override
-  public boolean hasSchemaStatistic() {
+  public boolean hasSchemaStatistic(ISchemaRegion schemaRegion) {
     return false;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
@@ -61,6 +61,16 @@ public class PathsUsingTemplateSource implements ISchemaSource<IDeviceSchemaInfo
     builder.declarePosition();
   }
 
+  @Override
+  public boolean hasSchemaStatistic() {
+    return false;
+  }
+
+  @Override
+  public long getSchemaStatistic(ISchemaRegion schemaRegion) {
+    return schemaRegion.getSchemaRegionStatistics().getTemplateActivatedNumber();
+  }
+
   private class DevicesUsingTemplateReader implements ISchemaReader<IDeviceSchemaInfo> {
 
     final Iterator<PartialPath> pathPatternIterator;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
@@ -111,6 +111,7 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
   @Override
   public boolean hasSchemaStatistic(ISchemaRegion schemaRegion) {
     return pathPattern.equals(ALL_MATCH_PATTERN)
+        && key == null
         && schemaRegion.getSchemaRegionStatistics().getTemplateActivatedNumber() == 0;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.iotdb.db.metadata.MetadataConstant.ALL_MATCH_PATTERN;
+
 public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaInfo> {
 
   private final PartialPath pathPattern;
@@ -104,6 +106,16 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
     builder.writeNullableText(8, deadbandInfo.left);
     builder.writeNullableText(9, deadbandInfo.right);
     builder.declarePosition();
+  }
+
+  @Override
+  public boolean hasSchemaStatistic() {
+    return pathPattern.equals(ALL_MATCH_PATTERN);
+  }
+
+  @Override
+  public long getSchemaStatistic(ISchemaRegion schemaRegion) {
+    return schemaRegion.getSchemaRegionStatistics().getSeriesNumber();
   }
 
   private String mapToString(Map<String, String> map) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
@@ -109,8 +109,9 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
   }
 
   @Override
-  public boolean hasSchemaStatistic() {
-    return pathPattern.equals(ALL_MATCH_PATTERN);
+  public boolean hasSchemaStatistic(ISchemaRegion schemaRegion) {
+    return pathPattern.equals(ALL_MATCH_PATTERN)
+        && schemaRegion.getSchemaRegionStatistics().getTemplateActivatedNumber() == 0;
   }
 
   @Override


### PR DESCRIPTION
## Description

When registering timeseries, we usually want to check current registered timeseries num via ```count timeseries```. 

Since there's a statistic value recording the total timeseries num, we can directly return such statistic value without traversing the MTree.
