### PR TITLE
[ISSUE-9611] Reduce the size of UDF-Library jar

### DIFF
--- a/library-udf/Readme.md
+++ b/library-udf/Readme.md
@@ -1,0 +1,7 @@
+# README
+
+In order to package a jar with all dependencies, please use the following command:
+
+```sh
+mvn clean package -DskipTests -P get-jar-with-dependencies
+```

--- a/library-udf/Readme.md
+++ b/library-udf/Readme.md
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 # README
 
 In order to package a jar with all dependencies, please use the following command:

--- a/library-udf/pom.xml
+++ b/library-udf/pom.xml
@@ -52,6 +52,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+        </dependency>
         <!-- FFT, IFFT, LowPass, HighPass -->
         <dependency>
             <groupId>com.github.wendykierp</groupId>
@@ -71,7 +75,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
-            <artifactId>node-commons</artifactId>
+            <artifactId>udf-api</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/library-udf/pom.xml
+++ b/library-udf/pom.xml
@@ -44,17 +44,6 @@
             <version>${eclipse-collections.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.iotdb</groupId>
-            <artifactId>tsfile</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iotdb</groupId>
-            <artifactId>iotdb-session</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>3.5</version>
@@ -62,32 +51,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.reload4j</groupId>
-            <artifactId>reload4j</artifactId>
-        </dependency>
-        <!-- TimeStampRepair -->
-        <dependency>
-            <groupId>gov.nist.math</groupId>
-            <artifactId>jama</artifactId>
-            <version>1.0.3</version>
-        </dependency>
-        <!-- LOF -->
-        <dependency>
-            <groupId>com.github.chen0040</groupId>
-            <artifactId>java-local-outlier-factor</artifactId>
-            <version>1.0.4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- FFT, IFFT, LowPass, HighPass -->
         <dependency>
@@ -104,16 +67,6 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>23.0.0</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iotdb</groupId>
-            <artifactId>iotdb-server</artifactId>
-            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFKSigma.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFKSigma.java
@@ -19,11 +19,9 @@
 
 package org.apache.iotdb.library.anomaly;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.util.CircularQueue;
 import org.apache.iotdb.library.util.LongCircularQueue;
 import org.apache.iotdb.library.util.Util;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.UDTF;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.collector.PointCollector;
@@ -43,7 +41,7 @@ public class UDTFKSigma implements UDTF {
   private int windowSize = 0;
   private CircularQueue<Object> v;
   private LongCircularQueue t;
-  private TSDataType dataType;
+  private Type dataType;
 
   @Override
   public void validate(UDFParameterValidator validator) throws Exception {
@@ -67,7 +65,7 @@ public class UDTFKSigma implements UDTF {
         .setAccessStrategy(new RowByRowAccessStrategy())
         .setOutputDataType(udfParameters.getDataType(0));
     this.multipleK = udfParameters.getDoubleOrDefault("k", 3);
-    this.dataType = UDFDataTypeTransformer.transformToTsDataType(udfParameters.getDataType(0));
+    this.dataType = udfParameters.getDataType(0);
     this.windowSize = udfParameters.getIntOrDefault("window", 10000);
     this.v = new CircularQueue<>(windowSize);
     this.t = new LongCircularQueue(windowSize);

--- a/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFRange.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFRange.java
@@ -19,9 +19,7 @@
 
 package org.apache.iotdb.library.anomaly;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.util.Util;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.UDTF;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.collector.PointCollector;
@@ -33,7 +31,7 @@ import org.apache.iotdb.udf.api.type.Type;
 
 /** This function is used to detect range anomaly of time series. */
 public class UDTFRange implements UDTF {
-  private TSDataType dataType;
+  private Type dataType;
   private double upperBound;
   private double lowerBound;
 
@@ -52,7 +50,7 @@ public class UDTFRange implements UDTF {
         .setOutputDataType(parameters.getDataType(0));
     this.lowerBound = parameters.getDouble("lower_bound");
     this.upperBound = parameters.getDouble("upper_bound");
-    this.dataType = UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0));
+    this.dataType = parameters.getDataType(0);
   }
 
   @Override

--- a/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFTwoSidedFilter.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFTwoSidedFilter.java
@@ -19,9 +19,7 @@
 
 package org.apache.iotdb.library.anomaly;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.anomaly.util.WindowDetect;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.UDTF;
 import org.apache.iotdb.udf.api.access.RowWindow;
 import org.apache.iotdb.udf.api.collector.PointCollector;
@@ -54,7 +52,6 @@ public class UDTFTwoSidedFilter implements UDTF {
         .setOutputDataType(parameters.getDataType(0));
     this.len = parameters.getDoubleOrDefault("len", 5);
     this.threshold = parameters.getDoubleOrDefault("threshold", 0.4);
-    TSDataType dataType = UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0));
   }
 
   @Override

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFMad.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFMad.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.library.dprofile;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.dprofile.util.ExactOrderStatistics;
 import org.apache.iotdb.library.dprofile.util.MADSketch;
 import org.apache.iotdb.library.util.Util;
@@ -57,9 +56,7 @@ public class UDAFMad implements UDTF {
     double error = parameters.getDoubleOrDefault("error", 0);
     exact = (error == 0);
     if (exact) {
-      statistics =
-          new ExactOrderStatistics(
-              UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0)));
+      statistics = new ExactOrderStatistics(parameters.getDataType(0));
     } else {
       sketch = new MADSketch(error);
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFMedian.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFMedian.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.library.dprofile;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.dprofile.util.ExactOrderStatistics;
 import org.apache.iotdb.library.dprofile.util.GKArray;
 import org.apache.iotdb.library.util.Util;
@@ -57,9 +56,7 @@ public class UDAFMedian implements UDTF {
     double error = parameters.getDoubleOrDefault("error", 0);
     exact = (error == 0);
     if (exact) {
-      statistics =
-          new ExactOrderStatistics(
-              UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0)));
+      statistics = new ExactOrderStatistics(parameters.getDataType(0));
     } else {
       sketch = new GKArray(error);
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFPercentile.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFPercentile.java
@@ -19,11 +19,9 @@
 
 package org.apache.iotdb.library.dprofile;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.dprofile.util.ExactOrderStatistics;
 import org.apache.iotdb.library.dprofile.util.GKArray;
 import org.apache.iotdb.library.util.Util;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.UDTF;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.collector.PointCollector;
@@ -45,7 +43,7 @@ public class UDAFPercentile implements UDTF {
   private GKArray sketch;
   private boolean exact;
   private double rank;
-  private TSDataType dataType;
+  private Type dataType;
 
   @Override
   public void validate(UDFParameterValidator validator) throws Exception {
@@ -68,14 +66,12 @@ public class UDAFPercentile implements UDTF {
     configurations
         .setAccessStrategy(new RowByRowAccessStrategy())
         .setOutputDataType(parameters.getDataType(0));
-    dataType = UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0));
+    dataType = parameters.getDataType(0);
     double error = parameters.getDoubleOrDefault("error", 0);
     rank = parameters.getDoubleOrDefault("rank", 0.5);
     exact = (error == 0);
     if (exact) {
-      statistics =
-          new ExactOrderStatistics(
-              UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0)));
+      statistics = new ExactOrderStatistics(parameters.getDataType(0));
     } else {
       sketch = new GKArray(error);
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFQuantile.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFQuantile.java
@@ -19,9 +19,7 @@
 
 package org.apache.iotdb.library.dprofile;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.util.Util;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.UDTF;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.collector.PointCollector;
@@ -35,7 +33,7 @@ import org.apache.iotdb.udf.api.type.Type;
 public class UDAFQuantile implements UDTF {
   private org.apache.iotdb.library.dprofile.util.HeapLongKLLSketch sketch;
   private double rank;
-  private TSDataType dataType;
+  private Type dataType;
 
   @Override
   public void validate(UDFParameterValidator validator) throws Exception {
@@ -58,7 +56,7 @@ public class UDAFQuantile implements UDTF {
     configurations
         .setAccessStrategy(new RowByRowAccessStrategy())
         .setOutputDataType(parameters.getDataType(0));
-    dataType = UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0));
+    dataType = parameters.getDataType(0);
     int K = parameters.getIntOrDefault("K", 800);
     rank = parameters.getDoubleOrDefault("rank", 0.5);
 

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFSpread.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFSpread.java
@@ -19,9 +19,7 @@
 
 package org.apache.iotdb.library.dprofile;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.util.NoNumberException;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.UDTF;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.collector.PointCollector;
@@ -41,7 +39,7 @@ public class UDAFSpread implements UDTF {
   long longMin = Long.MAX_VALUE, longMax = Long.MIN_VALUE;
   float floatMin = Float.MAX_VALUE, floatMax = -Float.MAX_VALUE;
   double doubleMin = Double.MAX_VALUE, doubleMax = -Double.MAX_VALUE;
-  TSDataType dataType;
+  Type dataType;
 
   @Override
   public void validate(UDFParameterValidator validator) throws Exception {
@@ -53,10 +51,8 @@ public class UDAFSpread implements UDTF {
   @Override
   public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations)
       throws Exception {
-    dataType = UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0));
-    configurations
-        .setAccessStrategy(new RowByRowAccessStrategy())
-        .setOutputDataType(UDFDataTypeTransformer.transformToUDFDataType(dataType));
+    dataType = parameters.getDataType(0);
+    configurations.setAccessStrategy(new RowByRowAccessStrategy()).setOutputDataType(dataType);
   }
 
   @Override

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFDistinct.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFDistinct.java
@@ -19,8 +19,6 @@
 
 package org.apache.iotdb.library.dprofile;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.UDTF;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.collector.PointCollector;
@@ -52,7 +50,7 @@ public class UDTFDistinct implements UDTF {
   private DoubleHashSet doubleSet;
   private BooleanHashSet booleanSet;
   private HashSet<String> stringSet;
-  private TSDataType dataType;
+  private Type dataType;
 
   @Override
   public void validate(UDFParameterValidator validator) throws Exception {
@@ -68,7 +66,7 @@ public class UDTFDistinct implements UDTF {
     configurations
         .setAccessStrategy(new RowByRowAccessStrategy())
         .setOutputDataType(parameters.getDataType(0));
-    dataType = UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0));
+    dataType = parameters.getDataType(0);
     switch (dataType) {
       case INT32:
         intSet = new IntHashSet();

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFMvAvg.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFMvAvg.java
@@ -19,10 +19,8 @@
 
 package org.apache.iotdb.library.dprofile;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.util.DoubleCircularQueue;
 import org.apache.iotdb.library.util.Util;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.UDTF;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.collector.PointCollector;
@@ -35,7 +33,7 @@ import org.apache.iotdb.udf.api.type.Type;
 /** This function calculates moving average of given window length of input series. */
 public class UDTFMvAvg implements UDTF {
   int windowSize;
-  TSDataType dataType;
+  Type dataType;
   DoubleCircularQueue v;
 
   @Override
@@ -53,7 +51,7 @@ public class UDTFMvAvg implements UDTF {
   public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations)
       throws Exception {
     configurations.setAccessStrategy(new RowByRowAccessStrategy()).setOutputDataType(Type.DOUBLE);
-    dataType = UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0));
+    dataType = parameters.getDataType(0);
     windowSize = parameters.getIntOrDefault("window", 10);
     v = new DoubleCircularQueue(windowSize);
   }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFSample.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFSample.java
@@ -19,10 +19,8 @@
 
 package org.apache.iotdb.library.dprofile;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.library.util.NoNumberException;
 import org.apache.iotdb.library.util.Util;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.UDTF;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.access.RowIterator;
@@ -33,6 +31,7 @@ import org.apache.iotdb.udf.api.customizer.parameter.UDFParameterValidator;
 import org.apache.iotdb.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.udf.api.customizer.strategy.RowByRowAccessStrategy;
 import org.apache.iotdb.udf.api.customizer.strategy.SlidingSizeWindowAccessStrategy;
+import org.apache.iotdb.udf.api.type.Type;
 
 import com.github.ggalmazor.ltdownsampling.LTThreeBuckets;
 import com.github.ggalmazor.ltdownsampling.Point;
@@ -59,7 +58,7 @@ public class UDTFSample implements UDTF {
   private Pair<Long, Object>[] samples; // sampled data
   private int num = 0; // number of points already sampled
   private Random random;
-  private TSDataType dataType;
+  private Type dataType;
 
   @Override
   public void validate(UDFParameterValidator validator) throws Exception {
@@ -82,7 +81,7 @@ public class UDTFSample implements UDTF {
   public void beforeStart(UDFParameters parameters, UDTFConfigurations configurations)
       throws Exception {
     this.k = parameters.getIntOrDefault("k", 1);
-    this.dataType = UDFDataTypeTransformer.transformToTsDataType(parameters.getDataType(0));
+    this.dataType = parameters.getDataType(0);
     String method = parameters.getStringOrDefault("method", "reservoir");
     if ("triangle".equalsIgnoreCase(method)) this.method = Method.TRIANGLE;
     else if ("isometric".equalsIgnoreCase(method)) this.method = Method.ISOMETRIC;

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/ExactOrderStatistics.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/ExactOrderStatistics.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iotdb.library.dprofile.util;
 
-import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.exception.UDFInputSeriesDataTypeNotValidException;
 import org.apache.iotdb.udf.api.type.Type;
@@ -35,13 +33,13 @@ import java.util.NoSuchElementException;
 /** Util for computing median, MAD, percentile */
 public class ExactOrderStatistics {
 
-  private final TSDataType dataType;
+  private final Type dataType;
   private FloatArrayList floatArrayList;
   private DoubleArrayList doubleArrayList;
   private IntArrayList intArrayList;
   private LongArrayList longArrayList;
 
-  public ExactOrderStatistics(TSDataType type) throws UDFInputSeriesDataTypeNotValidException {
+  public ExactOrderStatistics(Type type) throws UDFInputSeriesDataTypeNotValidException {
     this.dataType = type;
     switch (dataType) {
       case INT32:
@@ -59,12 +57,7 @@ public class ExactOrderStatistics {
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
-            0,
-            UDFDataTypeTransformer.transformToUDFDataType(dataType),
-            Type.INT32,
-            Type.INT64,
-            Type.FLOAT,
-            Type.DOUBLE);
+            0, dataType, Type.INT32, Type.INT64, Type.FLOAT, Type.DOUBLE);
     }
   }
 
@@ -91,12 +84,7 @@ public class ExactOrderStatistics {
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
-            0,
-            UDFDataTypeTransformer.transformToUDFDataType(dataType),
-            Type.INT32,
-            Type.INT64,
-            Type.FLOAT,
-            Type.DOUBLE);
+            0, dataType, Type.INT32, Type.INT64, Type.FLOAT, Type.DOUBLE);
     }
   }
 
@@ -113,12 +101,7 @@ public class ExactOrderStatistics {
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
-            0,
-            UDFDataTypeTransformer.transformToUDFDataType(dataType),
-            Type.INT32,
-            Type.INT64,
-            Type.FLOAT,
-            Type.DOUBLE);
+            0, dataType, Type.INT32, Type.INT64, Type.FLOAT, Type.DOUBLE);
     }
   }
 
@@ -135,12 +118,7 @@ public class ExactOrderStatistics {
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
-            0,
-            UDFDataTypeTransformer.transformToUDFDataType(dataType),
-            Type.INT32,
-            Type.INT64,
-            Type.FLOAT,
-            Type.DOUBLE);
+            0, dataType, Type.INT32, Type.INT64, Type.FLOAT, Type.DOUBLE);
     }
   }
 
@@ -157,12 +135,7 @@ public class ExactOrderStatistics {
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
-            0,
-            UDFDataTypeTransformer.transformToUDFDataType(dataType),
-            Type.INT32,
-            Type.INT64,
-            Type.FLOAT,
-            Type.DOUBLE);
+            0, dataType, Type.INT32, Type.INT64, Type.FLOAT, Type.DOUBLE);
     }
   }
 

--- a/library-udf/src/main/java/org/apache/iotdb/library/util/Util.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/util/Util.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iotdb.library.util;
 
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.udf.api.access.Row;
 import org.apache.iotdb.udf.api.collector.PointCollector;
+import org.apache.iotdb.udf.api.type.Type;
 
 import org.apache.commons.math3.stat.descriptive.rank.Median;
 import org.eclipse.collections.api.tuple.primitive.LongIntPair;
@@ -115,8 +115,7 @@ public class Util {
    * @param t timestamp
    * @param o value in Object type
    */
-  public static void putValue(PointCollector pc, TSDataType type, long t, Object o)
-      throws Exception {
+  public static void putValue(PointCollector pc, Type type, long t, Object o) throws Exception {
     switch (type) {
       case INT32:
         pc.putInt(t, (Integer) o);


### PR DESCRIPTION
The size of UDF-Library jar is about **94MB**, which is extremely and surprisingly large. Since too many useless dependencies are included in the jar package, such a large package is inconvenient for users. With the following optimizations, the size is reduced to only **19MB**.

+ Remove unused dependencies, e.g., **iotdb-session**, **jama**, **java-local-outlier-factor**, **gson**, **iotdb-server**.
+ Replace the remaining *org.apache.iotdb.tsfile.file.metadata.enums.TSDataType* to *org.apache.iotdb.udf.api.type.Type*. Meanwhile, *org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer* is also removed. Thus, dependency **tsfile** is removed and **node-commons** is changed to much smaller **udf-api**.