### PR TITLE
[To rel/0.13][IOTDB-5776]Update memory estimation of cross space compaction

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -453,6 +453,11 @@ timestamp_precision=ms
 # BALANCE: alternate two compaction types
 # compaction_priority=BALANCE
 
+# Whether to enable compaction memory control. If true and estimated memory size of
+# one compaction task exceeds the threshold, system will block it.
+# Datatype: boolean
+# enable_compaction_mem_control=true
+
 # size proportion for chunk metadata maintains in memory when compacting
 # Datatype: double
 # chunk_metadata_memory_size_proportion=0.1

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -454,7 +454,7 @@ timestamp_precision=ms
 # compaction_priority=BALANCE
 
 # Whether to enable compaction memory control. If true and estimated memory size of
-# one compaction task exceeds the threshold, system will block it.
+# one compaction task exceeds the threshold, system will block it. It only works for cross space compaction currently.
 # Datatype: boolean
 # enable_compaction_mem_control=true
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -404,6 +404,12 @@ public class IoTDBConfig {
    */
   private CompactionPriority compactionPriority = CompactionPriority.BALANCE;
 
+  /**
+   * Enable compaction memory control or not. If true and estimated memory size of one compaction
+   * task exceeds the threshold, system will block the compaction.
+   */
+  private boolean enableCompactionMemControl = true;
+
   private double chunkMetadataMemorySizeProportion = 0.1;
 
   /** The target tsfile size in compaction, 1 GB by default */
@@ -2821,6 +2827,14 @@ public class IoTDBConfig {
 
   public void setCustomizedProperties(Properties customizedProperties) {
     this.customizedProperties = customizedProperties;
+  }
+
+  public boolean isEnableCompactionMemControl() {
+    return enableCompactionMemControl;
+  }
+
+  public void setEnableCompactionMemControl(boolean enableCompactionMemControl) {
+    this.enableCompactionMemControl = enableCompactionMemControl;
   }
 
   public double getChunkMetadataMemorySizeProportion() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -406,7 +406,8 @@ public class IoTDBConfig {
 
   /**
    * Enable compaction memory control or not. If true and estimated memory size of one compaction
-   * task exceeds the threshold, system will block the compaction.
+   * task exceeds the threshold, system will block the compaction. It only works for cross space
+   * compaction currently.
    */
   private boolean enableCompactionMemControl = true;
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -344,7 +344,11 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "max_waiting_time_when_insert_blocked",
                 Integer.toString(conf.getMaxWaitingTimeWhenInsertBlocked()))));
-
+    conf.setEnableCompactionMemControl(
+        Boolean.parseBoolean(
+            properties.getProperty(
+                "enable_compaction_mem_control",
+                Boolean.toString(conf.isEnableCompactionMemControl()))));
     conf.setChunkMetadataMemorySizeProportion(
         Double.parseDouble(
             properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/AbstractCompactionEstimator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/AbstractCompactionEstimator.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iotdb.db.engine.compaction.cross.rewrite.selector;
 
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 
@@ -33,6 +35,8 @@ import java.util.Map;
 public abstract class AbstractCompactionEstimator implements AutoCloseable {
 
   protected Map<TsFileResource, TsFileSequenceReader> fileReaderCache = new HashMap<>();
+
+  protected IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
   /**
    * Estimate the memory cost of compacting the unseq file and its corresponding overlapped seq

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/AbstractCompactionEstimator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/AbstractCompactionEstimator.java
@@ -38,6 +38,8 @@ public abstract class AbstractCompactionEstimator implements AutoCloseable {
 
   protected IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
+  protected int compressionRatio = 5;
+
   /**
    * Estimate the memory cost of compacting the unseq file and its corresponding overlapped seq
    * files in cross space compaction task.

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCompactionFileSelector.java
@@ -148,14 +148,14 @@ public class RewriteCompactionFileSelector implements ICrossSpaceMergeFileSelect
     }
     if (logger.isInfoEnabled()) {
       logger.info(
-          "Selected merge candidates, {} seqFiles, {} unseqFiles, total memory cost {}, total file size is {}, total seq file size is {}, total unseq file size is {}, "
+          "Selected merge candidates, {} seqFiles, {} unseqFiles, total memory cost {} MB, total file size is {} MB, total seq file size is {} MB, total unseq file size is {} MB, "
               + "time consumption {}ms",
           selectedSeqFiles.size(),
           selectedUnseqFiles.size(),
-          totalCost,
-          totalUnseqFileSize + totalSeqFileSize,
-          totalSeqFileSize,
-          totalUnseqFileSize,
+          (float) totalCost / 1024 / 1024,
+          (float) (totalUnseqFileSize + totalSeqFileSize) / 1024 / 1024,
+          (float) totalSeqFileSize / 1024 / 1024,
+          (float) totalUnseqFileSize / 1024 / 1024,
           System.currentTimeMillis() - startTime);
     }
     return new List[] {selectedSeqFiles, selectedUnseqFiles};

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCrossCompactionEstimator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/selector/RewriteCrossCompactionEstimator.java
@@ -39,6 +39,9 @@ public class RewriteCrossCompactionEstimator extends AbstractCrossSpaceEstimator
   // task
   private long maxCostOfReadingSeqFile;
 
+  // the max cost of writing target file
+  private long maxCostOfWritingTargetFile;
+
   private int maxConcurrentSeriesNum = 1;
 
   // the number of timeseries being compacted at the same time
@@ -47,6 +50,7 @@ public class RewriteCrossCompactionEstimator extends AbstractCrossSpaceEstimator
 
   public RewriteCrossCompactionEstimator() {
     this.maxCostOfReadingSeqFile = 0;
+    this.maxCostOfWritingTargetFile = 0;
   }
 
   @Override
@@ -140,8 +144,15 @@ public class RewriteCrossCompactionEstimator extends AbstractCrossSpaceEstimator
     }
     // add unseq file metadata size
     cost += getFileReader(unseqResource).getFileMetadataSize();
-    // add concurrent series chunk size
-    cost += maxConcurrentSeriesNum * config.getTargetChunkSize();
+
+    // concurrent series chunk size
+    long writingTargetCost = maxConcurrentSeriesNum * config.getTargetChunkSize();
+    if (writingTargetCost > maxCostOfWritingTargetFile) {
+      cost -= maxCostOfWritingTargetFile;
+      cost += writingTargetCost;
+      maxCostOfWritingTargetFile = writingTargetCost;
+    }
+
     return cost;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -278,6 +278,9 @@ public class SystemInfo {
   }
 
   public void addCompactionMemoryCost(long memoryCost) throws InterruptedException {
+    if (!config.isEnableCompactionMemControl()) {
+      return;
+    }
     long originSize = this.compactionMemoryCost.get();
     while (originSize + memoryCost > memorySizeForCompaction
         || !compactionMemoryCost.compareAndSet(originSize, originSize + memoryCost)) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/RewriteCompactionFileSelectorTest.java
@@ -101,8 +101,8 @@ public class RewriteCompactionFileSelectorTest extends MergeTest {
     List[] result = mergeFileSelector.select();
     List<TsFileResource> seqSelected = result[0];
     List<TsFileResource> unseqSelected = result[1];
-    assertEquals(seqResources.subList(0, 3), seqSelected);
-    assertEquals(unseqResources.subList(0, 3), unseqSelected);
+    assertEquals(seqResources.subList(0, 1), seqSelected);
+    assertEquals(unseqResources.subList(0, 1), unseqSelected);
     resource.clear();
   }
 


### PR DESCRIPTION
1. Update memory estimation of cross space compaction and make it more accurate.
2. Increase the compaction memory control parameter, allowing users to customize the closing or opening of the compaction memory control.
