### PR TITLE
[To rel/1.1] Resolve quadratic complexity issue when flushing numerous Internal/Entity nodes in SchemaFile

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFileConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SchemaFileConfig.java
@@ -68,7 +68,7 @@ public class SchemaFileConfig {
 
   // region Segment Configuration
 
-  public static final int SEG_HEADER_SIZE = 25; // in bytes
+  public static final int SEG_HEADER_SIZE = 25; // (bytes) minimum segment size de facto
   public static final short SEG_OFF_DIG =
       2; // length of short, which is the type of segment offset and index
   public static final short SEG_MAX_SIZ = (short) (PAGE_LENGTH - PAGE_HEADER_SIZE - SEG_OFF_DIG);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SegmentedPage.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/SegmentedPage.java
@@ -38,6 +38,7 @@ public class SegmentedPage extends SchemaPage implements ISegmentedPage {
 
   // segment address array inside a page, map segmentIndex -> segmentOffset
   // if only one full-page segment inside, it still stores the offset
+  // TODO offset bits of segment never removed since it is 'sequential-indexed'
   private final transient List<Short> segOffsetLst;
 
   // maintains leaf segment instance inside this page, lazily instantiated

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/pagemgr/PageManager.java
@@ -43,6 +43,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -435,11 +436,13 @@ public abstract class PageManager implements IPageManager {
     }
     logWriter.commit();
     dirtyPages.clear();
+    Arrays.stream(tieredDirtyPageIndex).forEach(LinkedList::clear);
   }
 
   @Override
   public void clear() throws IOException, MetadataException {
     dirtyPages.clear();
+    Arrays.stream(tieredDirtyPageIndex).forEach(LinkedList::clear);
     pageInstCache.clear();
     lastPageIndex.set(0);
     logWriter = logWriter.renew();

--- a/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
@@ -233,10 +233,10 @@ public class SchemaFileTest {
   }
 
   @Test
-  public void testFaltTree() throws MetadataException, IOException {
+  public void testFlatTree() throws MetadataException, IOException {
     ISchemaFile sf = SchemaFile.initSchemaFile("root.test.vRoot1", TEST_SCHEMA_REGION_ID);
 
-    Iterator<IMNode> ite = getTreeBFT(getFlatTree(50000, "aa"));
+    Iterator<IMNode> ite = getTreeBFT(getFlatTree(6000, "aa"));
     while (ite.hasNext()) {
       IMNode cur = ite.next();
       if (!cur.isMeasurement()) {
@@ -274,8 +274,8 @@ public class SchemaFileTest {
   }
 
   @Test
-  public void test200KMeasurement() throws MetadataException, IOException {
-    int i = 200000, j = 20;
+  public void test2KMeasurement() throws MetadataException, IOException {
+    int i = 2000, j = 20;
     IMNode sgNode = new StorageGroupMNode(null, "sgRoot", 11111111L);
     ISchemaFile sf = SchemaFile.initSchemaFile(sgNode.getName(), TEST_SCHEMA_REGION_ID);
 
@@ -298,8 +298,8 @@ public class SchemaFileTest {
     sf.writeMNode(dev);
 
     Assert.assertEquals(
-        "ma_199406", sf.getChildNode(dev, "m_199406").getAsMeasurementMNode().getAlias());
-    Assert.assertEquals("m_1995", sf.getChildNode(dev, "ma_1995").getName());
+        "ma_1994", sf.getChildNode(dev, "m_1994").getAsMeasurementMNode().getAlias());
+    Assert.assertEquals("m_19", sf.getChildNode(dev, "ma_19").getName());
 
     sf.delete(dev);
     Assert.assertNull(sf.getChildNode(sgNode, "dev_2"));
@@ -309,7 +309,7 @@ public class SchemaFileTest {
   @Test
   public void testMassiveSegment() throws MetadataException, IOException {
     IMNode sgNode = new StorageGroupMNode(null, "sgRoot", 11111111L);
-    fillChildren(sgNode, 100000, "MEN", this::supplyEntity);
+    fillChildren(sgNode, 500, "MEN", this::supplyEntity);
     ISchemaFile sf = SchemaFile.initSchemaFile(sgNode.getName(), TEST_SCHEMA_REGION_ID);
 
     // verify operation with massive segment under quadratic complexity
@@ -320,7 +320,7 @@ public class SchemaFileTest {
     }
 
     IMNode sgNode2 = new StorageGroupMNode(null, "sgRoot2", 11111111L);
-    fillChildren(sgNode2, 1000000, "MEN", this::supplyEntity);
+    fillChildren(sgNode2, 5000, "MEN", this::supplyEntity);
     ISchemaFile sf2 = SchemaFile.initSchemaFile(sgNode2.getName(), TEST_SCHEMA_REGION_ID);
     try {
       sf2.writeMNode(sgNode2);
@@ -335,7 +335,7 @@ public class SchemaFileTest {
       cnt++;
       ite.next();
     }
-    Assert.assertEquals(cnt, 100000);
+    Assert.assertEquals(cnt, 500);
     sf.close();
 
     cnt = 0;
@@ -345,13 +345,13 @@ public class SchemaFileTest {
       cnt++;
       ite.next();
     }
-    Assert.assertEquals(cnt, 1000000);
+    Assert.assertEquals(cnt, 5000);
     sf.close();
   }
 
   @Test
-  public void test10KDevices() throws MetadataException, IOException {
-    int i = 1000;
+  public void testDevices() throws MetadataException, IOException {
+    int i = 100;
     IMNode sgNode = new StorageGroupMNode(null, "sgRoot", 11111111L);
 
     // write with empty entitiy
@@ -374,7 +374,7 @@ public class SchemaFileTest {
       }
 
       // update to entity
-      i = 1000;
+      i = 100;
       while (i >= 0) {
         long addr = getSegAddrInContainer(sgNode.getChild("dev_" + i));
         IMNode aDevice = new EntityMNode(sgNode, "dev_" + i);
@@ -426,18 +426,19 @@ public class SchemaFileTest {
     }
 
     Set<String> resName = new HashSet<>();
-    // more measurement
+    // fill resName set with more measurement
     for (IMNode etn : sgNode.getChildren().values()) {
-      int j = 1000;
+      int j = 50;
       while (j >= 0) {
         addMeasurementChild(etn, String.format("mtc2_%d_%d", i, j));
-        if (resName.size() < 101) {
+        if (Math.random() > 0.5) {
           resName.add(String.format("mtc2_%d_%d", i, j));
         }
         j--;
       }
     }
 
+    // fill arbitraryNode list
     orderedTree = getTreeBFT(sgNode);
     sf = SchemaFile.loadSchemaFile(sgNode.getName(), TEST_SCHEMA_REGION_ID);
     List<IMNode> arbitraryNode = new ArrayList<>();
@@ -446,7 +447,7 @@ public class SchemaFileTest {
         node = orderedTree.next();
         if (!node.isMeasurement() && !node.isStorageGroup()) {
           sf.writeMNode(node);
-          if (arbitraryNode.size() < 50) {
+          if (Math.random() > 0.5) {
             arbitraryNode.add(node);
           }
         }
@@ -460,14 +461,17 @@ public class SchemaFileTest {
 
     sf = SchemaFile.loadSchemaFile("sgRoot", TEST_SCHEMA_REGION_ID);
 
+    // verify alias of random measurement
     for (String key : resName) {
-      IMNode resNode = sf.getChildNode(arbitraryNode.get(arbitraryNode.size() - 3), key);
+      IMNode resNode =
+          sf.getChildNode(arbitraryNode.get((int) (arbitraryNode.size() * Math.random())), key);
       Assert.assertTrue(
           resNode.getAsMeasurementMNode().getAlias().equals(resNode.getName() + "alias"));
     }
 
-    Iterator<IMNode> res = sf.getChildren(arbitraryNode.get(arbitraryNode.size() - 1));
-    int i2 = 0;
+    // verify children subset of random entity node
+    Iterator<IMNode> res =
+        sf.getChildren(arbitraryNode.get((int) (arbitraryNode.size() * Math.random())));
     while (res.hasNext()) {
       resName.remove(res.next().getName());
     }
@@ -636,11 +640,11 @@ public class SchemaFileTest {
   }
 
   @Test
-  public void test200KAlias() throws Exception {
+  public void test2KAlias() throws Exception {
     ISchemaFile sf = SchemaFile.initSchemaFile("root.sg", TEST_SCHEMA_REGION_ID);
     IMNode sgNode = new StorageGroupMNode(null, "mma", 111111111L);
     // 5 devices, each for 200k measurements
-    int factor20K = 20000;
+    int factor2K = 2000;
     List<IMNode> devs = new ArrayList<>();
     List<List> senList = new ArrayList<>();
     Map<String, String> aliasAns = new HashMap<>();
@@ -653,7 +657,7 @@ public class SchemaFileTest {
 
       for (IMNode dev : devs) {
         List<IMNode> sens = new ArrayList<>();
-        for (int i = 0; i < factor20K; i++) {
+        for (int i = 0; i < factor2K; i++) {
           sens.add(getMeasurementNode(dev, "s_" + i, null));
           dev.addChild(sens.get(i));
 
@@ -705,7 +709,7 @@ public class SchemaFileTest {
         cnt++;
         children.next();
       }
-      Assert.assertEquals(factor20K, cnt);
+      Assert.assertEquals(factor2K, cnt);
 
     } finally {
       sf.close();


### PR DESCRIPTION
## Description
During a flush of `SchemaFile` for numerous Entity/Internal Nodes, a surge in dirty pages occurs due to the pre-allocation mechanism. Retrieval for a suitable `SegmentedPage` may require a full iteration if each of these pages has too little space spare to accommodate another segment. The quadratic time overhead may appear to be stucked while handling a massive number of child nodes, e.g., 10 million child nodes.

## Solution
An array of LinkedLists has been introduced to index dirty pages into a tiered structure based on their spare size, considering the minimum segment and other step sizes. When a `SegmentedPage` is marked as dirty, it will be integrated into one of the LinkedLists if its spare size is larger than the minimum segment.

## Further Improvement
Although the size of `pageInstCache` is constrained by the config file, and the complexity of retrieval from it will not surge like the dirty pages do, there is a performance pitfall if the application frequently writes small amounts of data after reading almost full pages. This will lead to an optimizable full iteration over the `pageInstCache`. This issue requires a refactor of the cache mechanism or a complete spare page index and should be addressed in future versions.