### PR TITLE
[IOTDB-5786] Fix potential deadlock in DriverScheduler

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
@@ -299,13 +299,9 @@ public class DriverScheduler implements IDriverScheduler, IService {
       for (Set<DriverTask> fragmentRelatedTasks : queryRelatedTasks.values()) {
         if (fragmentRelatedTasks != null) {
           for (DriverTask task : fragmentRelatedTasks) {
-            task.lock();
-            try {
-              task.setAbortCause(DriverTaskAbortedException.BY_QUERY_CASCADING_ABORTED);
-              clearDriverTask(task);
-            } finally {
-              task.unlock();
-            }
+
+            task.setAbortCause(DriverTaskAbortedException.BY_QUERY_CASCADING_ABORTED);
+            clearDriverTask(task);
           }
         }
       }
@@ -324,13 +320,8 @@ public class DriverScheduler implements IDriverScheduler, IService {
             if (task == null) {
               return;
             }
-            task.lock();
-            try {
-              task.setAbortCause(DriverTaskAbortedException.BY_FRAGMENT_ABORT_CALLED);
-              clearDriverTask(task);
-            } finally {
-              task.unlock();
-            }
+            task.setAbortCause(DriverTaskAbortedException.BY_FRAGMENT_ABORT_CALLED);
+            clearDriverTask(task);
           }
         }
       }
@@ -340,26 +331,31 @@ public class DriverScheduler implements IDriverScheduler, IService {
   private void clearDriverTask(DriverTask task) {
     try (SetThreadName driverTaskName =
         new SetThreadName(task.getDriver().getDriverTaskId().getFullId())) {
-      DriverTaskStatus status = task.getStatus();
-      switch (status) {
-          // If it has been aborted, return directly
-        case ABORTED:
-          return;
-        case READY:
-          task.setStatus(DriverTaskStatus.ABORTED);
-          readyQueue.remove(task.getDriverTaskId());
-          break;
-        case BLOCKED:
-          task.setStatus(DriverTaskStatus.ABORTED);
-          blockedTasks.remove(task);
-          readyQueue.decreaseReservedSize();
-          break;
-        case RUNNING:
-          task.setStatus(DriverTaskStatus.ABORTED);
-          readyQueue.decreaseReservedSize();
-          break;
-        case FINISHED:
-          break;
+      try {
+        task.lock();
+        DriverTaskStatus status = task.getStatus();
+        switch (status) {
+            // If it has been aborted, return directly
+          case ABORTED:
+            return;
+          case READY:
+            task.setStatus(DriverTaskStatus.ABORTED);
+            readyQueue.remove(task.getDriverTaskId());
+            break;
+          case BLOCKED:
+            task.setStatus(DriverTaskStatus.ABORTED);
+            blockedTasks.remove(task);
+            readyQueue.decreaseReservedSize();
+            break;
+          case RUNNING:
+            task.setStatus(DriverTaskStatus.ABORTED);
+            readyQueue.decreaseReservedSize();
+            break;
+          case FINISHED:
+            break;
+        }
+      } finally {
+        task.unlock();
       }
 
       timeoutQueue.remove(task.getDriverTaskId());
@@ -378,26 +374,31 @@ public class DriverScheduler implements IDriverScheduler, IService {
           queryMap.remove(task.getDriverTaskId().getQueryId());
         }
       }
-      if (task.getAbortCause() != null) {
-        try {
-          task.getDriver()
-              .failed(
-                  new DriverTaskAbortedException(
-                      task.getDriver().getDriverTaskId().getFullId(), task.getAbortCause()));
-        } catch (Exception e) {
-          logger.error("Clear DriverTask failed", e);
+      try {
+        task.lock();
+        if (task.getAbortCause() != null) {
+          try {
+            task.getDriver()
+                .failed(
+                    new DriverTaskAbortedException(
+                        task.getDriver().getDriverTaskId().getFullId(), task.getAbortCause()));
+          } catch (Exception e) {
+            logger.error("Clear DriverTask failed", e);
+          }
         }
-      }
-      if (task.getStatus() == DriverTaskStatus.ABORTED) {
-        try {
-          blockManager.forceDeregisterFragmentInstance(
-              new TFragmentInstanceId(
-                  task.getDriverTaskId().getQueryId().getId(),
-                  task.getDriverTaskId().getFragmentId().getId(),
-                  task.getDriverTaskId().getFragmentInstanceId().getInstanceId()));
-        } catch (Exception e) {
-          logger.error("Clear DriverTask failed", e);
+        if (task.getStatus() == DriverTaskStatus.ABORTED) {
+          try {
+            blockManager.forceDeregisterFragmentInstance(
+                new TFragmentInstanceId(
+                    task.getDriverTaskId().getQueryId().getId(),
+                    task.getDriverTaskId().getFragmentId().getId(),
+                    task.getDriverTaskId().getFragmentInstanceId().getInstanceId()));
+          } catch (Exception e) {
+            logger.error("Clear DriverTask failed", e);
+          }
         }
+      } finally {
+        task.unlock();
       }
     }
   }
@@ -534,6 +535,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
       } finally {
         task.unlock();
       }
+      // wrap this clearDriverTask to avoid that status is changed to Aborted during clearDriverTask
       task.lock();
       try {
         clearDriverTask(task);
@@ -556,10 +558,10 @@ public class DriverScheduler implements IDriverScheduler, IService {
           logger.warn(
               "The task {} is aborted. All other tasks in the same query will be cancelled",
               task.getDriverTaskId());
-          clearDriverTask(task);
         } finally {
           task.unlock();
         }
+        clearDriverTask(task);
         QueryId queryId = task.getDriverTaskId().getQueryId();
         Map<FragmentInstanceId, Set<DriverTask>> queryRelatedTasks = queryMap.remove(queryId);
         if (queryRelatedTasks != null) {
@@ -570,13 +572,8 @@ public class DriverScheduler implements IDriverScheduler, IService {
                   if (task.equals(otherTask)) {
                     continue;
                   }
-                  otherTask.lock();
-                  try {
-                    otherTask.setAbortCause(DriverTaskAbortedException.BY_QUERY_CASCADING_ABORTED);
-                    clearDriverTask(otherTask);
-                  } finally {
-                    otherTask.unlock();
-                  }
+                  otherTask.setAbortCause(DriverTaskAbortedException.BY_QUERY_CASCADING_ABORTED);
+                  clearDriverTask(otherTask);
                 }
               }
             }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
@@ -299,7 +299,6 @@ public class DriverScheduler implements IDriverScheduler, IService {
       for (Set<DriverTask> fragmentRelatedTasks : queryRelatedTasks.values()) {
         if (fragmentRelatedTasks != null) {
           for (DriverTask task : fragmentRelatedTasks) {
-
             task.setAbortCause(DriverTaskAbortedException.BY_QUERY_CASCADING_ABORTED);
             clearDriverTask(task);
           }


### PR DESCRIPTION
This pr aims to fix potential deadlock in DriverScheduler caused by concurrently calling abortFramentInstance and toAborted.
See https://apache-iotdb.feishu.cn/docx/KFsvdMwL4orqkCxrdARc37W8nxf for more details.