### PR TITLE
Fix potential Npe of ShuffleSinkHandle

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
@@ -151,7 +151,8 @@ public class SinkChannel implements ISinkChannel {
   public synchronized ListenableFuture<?> isFull() {
     checkState();
     // blocked could be null if this channel is closed before it is opened by ShuffleSinkHandle
-    if (blocked == null) {
+    // return immediateVoidFuture() to avoid NPE
+    if (closed) {
       return immediateVoidFuture();
     }
     return nonCancellationPropagating(blocked);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
 
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
 import static org.apache.iotdb.db.mpp.common.FragmentInstanceId.createFullId;
 import static org.apache.iotdb.db.mpp.metric.DataExchangeCostMetricSet.SEND_NEW_DATA_BLOCK_EVENT_TASK_CALLER;
@@ -149,6 +150,10 @@ public class SinkChannel implements ISinkChannel {
   @Override
   public synchronized ListenableFuture<?> isFull() {
     checkState();
+    // blocked could be null if this channel is closed before it is opened by ShuffleSinkHandle
+    if (blocked == null) {
+      return immediateVoidFuture();
+    }
     return nonCancellationPropagating(blocked);
   }
 


### PR DESCRIPTION
isFull() of SinkChannel returns its blocked while this blocked could be null if the SinkChannel is closed before it is opened. We need to check whether the blocked is null.
