### PR TITLE
[To rel/1.1][IOTDB-5798] Fix concurrent problem when sinkChannel acknowledgeTsBlock() and close()

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/sink/SinkChannel.java
@@ -327,20 +327,21 @@ public class SinkChannel implements ISinkChannel {
         iterator.remove();
         LOGGER.debug("[ACKTsBlock] {}.", entry.getKey());
       }
+
+      // there may exist duplicate ack message in network caused by caller retrying, if so duplicate
+      // ack message's freedBytes may be zero
+      if (freedBytes > 0) {
+        localMemoryManager
+            .getQueryPool()
+            .free(
+                localFragmentInstanceId.getQueryId(),
+                fullFragmentInstanceId,
+                localPlanNodeId,
+                freedBytes);
+      }
     }
     if (isFinished()) {
       sinkListener.onFinish(this);
-    }
-    // there may exist duplicate ack message in network caused by caller retrying, if so duplicate
-    // ack message's freedBytes may be zero
-    if (freedBytes > 0) {
-      localMemoryManager
-          .getQueryPool()
-          .free(
-              localFragmentInstanceId.getQueryId(),
-              fullFragmentInstanceId,
-              localPlanNodeId,
-              freedBytes);
     }
   }
 


### PR DESCRIPTION
When sinkChannel invokes acknowledgeTsBlock(), bufferRetainedSizeInBytes is reduced first, but free() is not executed within Lock. If close() is called at this time, it will check bufferRetainedSizeInBytes 0 and pass. Then the finished method of fragmentInstance will be invoked, and it will check the memory reserved in memoryPool. But free() is not finished, so it will cause the memory leak exception.