### PR TITLE
[IOTDB-5720] Fix release processor fail to release memory due to writer-preferred starvation

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -205,7 +205,7 @@ public class CacheMemoryManager {
                     store ->
                         CompletableFuture.runAsync(
                             () -> {
-                              store.getLock().threadReadLock();
+                              store.getLock().threadReadLock(true);
                               try {
                                 executeMemoryRelease(store);
                               } finally {


### PR DESCRIPTION
## Description

We've implemented StampedWriterPreferredLock to enable memory release when a flush task is waiting for write lock. However, the priority is not set when release task try taking a read lock. Fix it.