### PR TITLE
Double-check protect memory-control boundary to avoid concurrent bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -205,7 +205,7 @@ public class CacheMemoryManager {
                     store ->
                         CompletableFuture.runAsync(
                             () -> {
-                              store.getLock().threadReadLock(true);
+                              store.getLock().threadReadLock();
                               try {
                                 executeMemoryRelease(store);
                               } finally {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/cache/CacheMemoryManager.java
@@ -205,7 +205,7 @@ public class CacheMemoryManager {
                     store ->
                         CompletableFuture.runAsync(
                             () -> {
-                              store.getLock().threadReadLock();
+                              store.getLock().threadReadLock(true);
                               try {
                                 executeMemoryRelease(store);
                               } finally {


### PR DESCRIPTION
cherry-pick from #9602 
## Description


Currently, the variable allowToCreateNewSeries is not maintained in a thread-safe manner. Use synchronized and double-check to protect it and ensure accuracy.