### PR TITLE
Simplify collect redirect Info logic

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analysis.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analysis.java
@@ -272,7 +272,7 @@ public class Analysis {
     this.redirectNodeList = redirectNodeList;
   }
 
-  public void addEndPointInRedirectNodeList(TEndPoint endPoint) {
+  public void addEndPointToRedirectNodeList(TEndPoint endPoint) {
     if (redirectNodeList == null) {
       redirectNodeList = new ArrayList<>();
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analysis.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/Analysis.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.mpp.plan.analyze;
 
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSchemaNode;
 import org.apache.iotdb.commons.partition.DataPartition;
@@ -44,6 +45,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.utils.Pair;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +71,8 @@ public class Analysis {
   private SchemaPartition schemaPartition;
 
   private ISchemaTree schemaTree;
+
+  private List<TEndPoint> redirectNodeList;
 
   // map from output column name (for every node) to its datatype
   private final Map<NodeRef<Expression>, TSDataType> expressionTypes = new LinkedHashMap<>();
@@ -258,6 +262,21 @@ public class Analysis {
 
   public void setSchemaTree(ISchemaTree schemaTree) {
     this.schemaTree = schemaTree;
+  }
+
+  public List<TEndPoint> getRedirectNodeList() {
+    return redirectNodeList;
+  }
+
+  public void setRedirectNodeList(List<TEndPoint> redirectNodeList) {
+    this.redirectNodeList = redirectNodeList;
+  }
+
+  public void addEndPointInRedirectNodeList(TEndPoint endPoint) {
+    if (redirectNodeList == null) {
+      redirectNodeList = new ArrayList<>();
+    }
+    redirectNodeList.add(endPoint);
   }
 
   public Filter getGlobalTimeFilter() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -1924,7 +1924,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     DataPartitionQueryParam dataPartitionQueryParam = new DataPartitionQueryParam();
     dataPartitionQueryParam.setDevicePath(insertRowStatement.getDevicePath().getFullPath());
-    dataPartitionQueryParam.setTimePartitionSlotList(insertRowStatement.getTimePartitionSlots());
+    dataPartitionQueryParam.setTimePartitionSlotList(
+        Collections.singletonList(insertRowStatement.getTimePartitionSlot()));
 
     return getAnalysisForWriting(
         insertRowStatement, Collections.singletonList(dataPartitionQueryParam));
@@ -1940,7 +1941,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Set<TTimePartitionSlot> timePartitionSlotSet =
           dataPartitionQueryParamMap.computeIfAbsent(
               insertRowStatement.getDevicePath().getFullPath(), k -> new HashSet<>());
-      timePartitionSlotSet.addAll(insertRowStatement.getTimePartitionSlots());
+      timePartitionSlotSet.add(insertRowStatement.getTimePartitionSlot());
     }
 
     List<DataPartitionQueryParam> dataPartitionQueryParams = new ArrayList<>();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -632,8 +632,7 @@ public class QueryExecution implements IQueryExecution {
         && (!config.isEnable13DataInsertAdapt()
             || IoTDBConstant.ClientVersion.V_1_0.equals(context.getSession().getVersion()))) {
       InsertBaseStatement insertStatement = (InsertBaseStatement) analysis.getStatement();
-      List<TEndPoint> redirectNodeList =
-          insertStatement.collectRedirectInfo(analysis.getDataPartitionInfo());
+      List<TEndPoint> redirectNodeList = analysis.getRedirectNodeList();
       if (insertStatement instanceof InsertRowsStatement
           || insertStatement instanceof InsertMultiTabletsStatement) {
         // multiple devices

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowNode.java
@@ -105,6 +105,10 @@ public class InsertRowNode extends InsertNode implements WALEntryValue, ISchemaV
         analysis
             .getDataPartitionInfo()
             .getDataRegionReplicaSetForWriting(devicePath.getFullPath(), timePartitionSlot);
+    // collect redirectInfo
+    analysis.setRedirectNodeList(
+        Collections.singletonList(
+            dataRegionReplicaSet.getDataNodeLocations().get(0).getClientRpcEndPoint()));
     return Collections.singletonList(this);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -40,6 +40,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -170,6 +171,12 @@ public class InsertRowsOfOneDeviceNode extends InsertNode implements BatchInsert
 
       tmpMap.add(insertRowNode);
       tmpIndexMap.add(insertRowNodeIndexList.get(i));
+
+      if (i == insertRowNodeList.size() - 1) {
+        analysis.setRedirectNodeList(
+            Collections.singletonList(
+                dataRegionReplicaSet.getDataNodeLocations().get(0).getClientRpcEndPoint()));
+      }
     }
 
     for (Map.Entry<TRegionReplicaSet, List<InsertRowNode>> entry : splitMap.entrySet()) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertTabletNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertTabletNode.java
@@ -239,7 +239,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue, ISche
             .getDataRegionReplicaSetForWriting(devicePath.getFullPath(), timePartitionSlots);
 
     // collect redirectInfo
-    analysis.addEndPointInRedirectNodeList(
+    analysis.addEndPointToRedirectNodeList(
         dataRegionReplicaSets
             .get(dataRegionReplicaSets.size() - 1)
             .getDataNodeLocations()

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertTabletNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertTabletNode.java
@@ -238,6 +238,14 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue, ISche
             .getDataPartitionInfo()
             .getDataRegionReplicaSetForWriting(devicePath.getFullPath(), timePartitionSlots);
 
+    // collect redirectInfo
+    analysis.addEndPointInRedirectNodeList(
+        dataRegionReplicaSets
+            .get(dataRegionReplicaSets.size() - 1)
+            .getDataNodeLocations()
+            .get(0)
+            .getClientRpcEndPoint());
+
     Map<TRegionReplicaSet, List<Integer>> splitMap = new HashMap<>();
     for (int i = 0; i < dataRegionReplicaSets.size(); i++) {
       List<Integer> sub_ranges =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertBaseStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertBaseStatement.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iotdb.db.mpp.plan.statement.crud;
 
-import org.apache.iotdb.common.rpc.thrift.TEndPoint;
-import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.mpp.plan.statement.Statement;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -80,6 +78,4 @@ public abstract class InsertBaseStatement extends Statement {
   public List<PartialPath> getPaths() {
     return Collections.emptyList();
   }
-
-  public abstract List<TEndPoint> collectRedirectInfo(DataPartition dataPartition);
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertMultiTabletsStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertMultiTabletsStatement.java
@@ -19,13 +19,9 @@
 
 package org.apache.iotdb.db.mpp.plan.statement.crud;
 
-import org.apache.iotdb.common.rpc.thrift.TEndPoint;
-import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
-import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.mpp.plan.statement.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
-import org.apache.iotdb.db.utils.TimePartitionUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
 import java.util.ArrayList;
@@ -96,20 +92,6 @@ public class InsertMultiTabletsStatement extends InsertBaseStatement {
     List<PartialPath> result = new ArrayList<>();
     for (InsertTabletStatement insertTabletStatement : insertTabletStatementList) {
       result.addAll(insertTabletStatement.getPaths());
-    }
-    return result;
-  }
-
-  @Override
-  public List<TEndPoint> collectRedirectInfo(DataPartition dataPartition) {
-    List<TEndPoint> result = new ArrayList<>();
-    for (InsertTabletStatement insertTabletStatement : insertTabletStatementList) {
-      TRegionReplicaSet regionReplicaSet =
-          dataPartition.getDataRegionReplicaSetForWriting(
-              insertTabletStatement.devicePath.getFullPath(),
-              TimePartitionUtils.getTimePartition(
-                  insertTabletStatement.getTimes()[insertTabletStatement.getTimes().length - 1]));
-      result.add(regionReplicaSet.getDataNodeLocations().get(0).getClientRpcEndPoint());
     }
     return result;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowStatement.java
@@ -126,8 +126,8 @@ public class InsertRowStatement extends InsertBaseStatement {
     }
   }
 
-  public List<TTimePartitionSlot> getTimePartitionSlots() {
-    return Collections.singletonList(TimePartitionUtils.getTimePartition(time));
+  public TTimePartitionSlot getTimePartitionSlot() {
+    return TimePartitionUtils.getTimePartition(time);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowStatement.java
@@ -19,10 +19,7 @@
 
 package org.apache.iotdb.db.mpp.plan.statement.crud;
 
-import org.apache.iotdb.common.rpc.thrift.TEndPoint;
-import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
-import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.mpp.plan.statement.StatementType;
@@ -33,7 +30,6 @@ import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class InsertRowStatement extends InsertBaseStatement {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowStatement.java
@@ -131,15 +131,6 @@ public class InsertRowStatement extends InsertBaseStatement {
   }
 
   @Override
-  public List<TEndPoint> collectRedirectInfo(DataPartition dataPartition) {
-    TRegionReplicaSet regionReplicaSet =
-        dataPartition.getDataRegionReplicaSetForWriting(
-            devicePath.getFullPath(), TimePartitionUtils.getTimePartition(time));
-    return Collections.singletonList(
-        regionReplicaSet.getDataNodeLocations().get(0).getClientRpcEndPoint());
-  }
-
-  @Override
   public <R, C> R accept(StatementVisitor<R, C> visitor, C context) {
     return visitor.visitInsertRow(this, context);
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsOfOneDeviceStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsOfOneDeviceStatement.java
@@ -19,9 +19,7 @@
 
 package org.apache.iotdb.db.mpp.plan.statement.crud;
 
-import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
-import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.mpp.plan.statement.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
@@ -80,13 +78,6 @@ public class InsertRowsOfOneDeviceStatement extends InsertBaseStatement {
       timePartitionSlotSet.add(TimePartitionUtils.getTimePartition(insertRowStatement.getTime()));
     }
     return new ArrayList<>(timePartitionSlotSet);
-  }
-
-  @Override
-  public List<TEndPoint> collectRedirectInfo(DataPartition dataPartition) {
-    return insertRowStatementList
-        .get(insertRowStatementList.size() - 1)
-        .collectRedirectInfo(dataPartition);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsStatement.java
@@ -19,13 +19,9 @@
 
 package org.apache.iotdb.db.mpp.plan.statement.crud;
 
-import org.apache.iotdb.common.rpc.thrift.TEndPoint;
-import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
-import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.mpp.plan.statement.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
-import org.apache.iotdb.db.utils.TimePartitionUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
 import java.util.ArrayList;
@@ -96,19 +92,6 @@ public class InsertRowsStatement extends InsertBaseStatement {
     List<PartialPath> result = new ArrayList<>();
     for (InsertRowStatement insertRowStatement : insertRowStatementList) {
       result.addAll(insertRowStatement.getPaths());
-    }
-    return result;
-  }
-
-  @Override
-  public List<TEndPoint> collectRedirectInfo(DataPartition dataPartition) {
-    List<TEndPoint> result = new ArrayList<>();
-    for (InsertRowStatement insertRowStatement : insertRowStatementList) {
-      TRegionReplicaSet regionReplicaSet =
-          dataPartition.getDataRegionReplicaSetForWriting(
-              insertRowStatement.devicePath.getFullPath(),
-              TimePartitionUtils.getTimePartition(insertRowStatement.getTime()));
-      result.add(regionReplicaSet.getDataNodeLocations().get(0).getClientRpcEndPoint());
     }
     return result;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertTabletStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertTabletStatement.java
@@ -18,10 +18,7 @@
  */
 package org.apache.iotdb.db.mpp.plan.statement.crud;
 
-import org.apache.iotdb.common.rpc.thrift.TEndPoint;
-import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
-import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.mpp.plan.statement.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
@@ -29,7 +26,6 @@ import org.apache.iotdb.db.utils.TimePartitionUtils;
 import org.apache.iotdb.tsfile.utils.BitMap;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class InsertTabletStatement extends InsertBaseStatement {
@@ -105,15 +101,6 @@ public class InsertTabletStatement extends InsertBaseStatement {
     }
     result.add(timePartitionSlot);
     return result;
-  }
-
-  @Override
-  public List<TEndPoint> collectRedirectInfo(DataPartition dataPartition) {
-    TRegionReplicaSet regionReplicaSet =
-        dataPartition.getDataRegionReplicaSetForWriting(
-            devicePath.getFullPath(), TimePartitionUtils.getTimePartition(times[times.length - 1]));
-    return Collections.singletonList(
-        regionReplicaSet.getDataNodeLocations().get(0).getClientRpcEndPoint());
   }
 
   @Override

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/node/write/WritePlanNodeSplitTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/node/write/WritePlanNodeSplitTest.java
@@ -21,6 +21,8 @@ package org.apache.iotdb.db.mpp.plan.plan.node.write;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
+import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
@@ -88,6 +90,15 @@ public class WritePlanNodeSplitTest {
     dataPartitionMap = new HashMap<>();
     Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>
         seriesPartitionSlotMap = new HashMap<>();
+    List<TDataNodeLocation> locationList = new ArrayList<>();
+    locationList.add(
+        new TDataNodeLocation(
+            0,
+            new TEndPoint("127.0.0.1", 6667),
+            new TEndPoint("127.0.0.1", 10730),
+            new TEndPoint("127.0.0.1", 10740),
+            new TEndPoint("127.0.0.1", 10760),
+            new TEndPoint("127.0.0.1", 10750)));
     // sg1 has 5 data regions
     for (int i = 0; i < seriesSlotPartitionNum; i++) {
       Map<TTimePartitionSlot, List<TRegionReplicaSet>> timePartitionSlotMap = new HashMap<>();
@@ -99,7 +110,7 @@ public class WritePlanNodeSplitTest {
                 new TRegionReplicaSet(
                     new TConsensusGroupId(
                         TConsensusGroupType.DataRegion, getRegionIdByTime(startTime)),
-                    null)));
+                    locationList)));
       }
 
       seriesPartitionSlotMap.put(new TSeriesPartitionSlot(i), timePartitionSlotMap);
@@ -116,7 +127,7 @@ public class WritePlanNodeSplitTest {
             new TTimePartitionSlot(t * TimePartitionUtils.timePartitionInterval),
             Collections.singletonList(
                 new TRegionReplicaSet(
-                    new TConsensusGroupId(TConsensusGroupType.DataRegion, 99), null)));
+                    new TConsensusGroupId(TConsensusGroupType.DataRegion, 99), locationList)));
       }
 
       seriesPartitionSlotMap.put(new TSeriesPartitionSlot(i), timePartitionSlotMap);


### PR DESCRIPTION
# Description

The previous logic of collect redirect information will calculate the ReplicaSet when set redirectInfo to TsStatus. However, the calculation is already done when get data partition before insert. The logic can be simplified by set RedirectInfo to Analysis and get it when construct TsStatus. 

Before this optimization
![image](https://user-images.githubusercontent.com/25913899/233904700-9916d7e4-c830-4ffe-86e6-9fc89acd6a87.png)

After then

![image](https://user-images.githubusercontent.com/25913899/233905059-5c0cd7f0-068b-4ad0-9e91-5f705d2ca0eb.png)
