### PR TITLE
Fix NPE when using template and executing select into

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeTemplateSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeTemplateSchemaCache.java
@@ -96,13 +96,16 @@ public class DataNodeTemplateSchemaCache {
     ClusterSchemaTree schemaTree = new ClusterSchemaTree();
     if (deviceCacheEntry != null) {
       Template template = templateManager.getTemplate(deviceCacheEntry.getTemplateId());
-      schemaTree.appendSingleMeasurement(
-          fullPath,
-          (MeasurementSchema) template.getSchema(fullPath.getMeasurement()),
-          null,
-          null,
-          template.isDirectAligned());
-      schemaTree.setDatabases(Collections.singleton(deviceCacheEntry.getDatabase()));
+      IMeasurementSchema measurementSchema = template.getSchema(fullPath.getMeasurement());
+      if (measurementSchema != null) {
+        schemaTree.appendSingleMeasurement(
+            fullPath,
+            (MeasurementSchema) measurementSchema,
+            null,
+            null,
+            template.isDirectAligned());
+        schemaTree.setDatabases(Collections.singleton(deviceCacheEntry.getDatabase()));
+      }
     }
     return schemaTree;
   }


### PR DESCRIPTION
## Description


### Problem Description

NPE occurs when executing the following instructions.
``` sql
create schema template t1(s1 int32, s2 int32)

create database root.db

set schema template to root.db

insert into root.db.d1(time, s1, s2) values(1, 1, 1)

select s1, s2 into root.::(t1, t2) from root.db.d1

```

### Cause and Solution

When fetch schema from DataNodeTemplateSchemaCache, there's no measurement existence check before taking the measurement from template, and this causes the NPE. 

Add existence check to fix it.
