### PR TITLE
[IOTDB-5788] Built-in pipe plug-in management mechanism

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -51,6 +51,8 @@ ddlStatement
     | createFunction | dropFunction | showFunctions
     // Trigger
     | createTrigger | dropTrigger | showTriggers | startTrigger | stopTrigger
+    // Pipe Plugin
+    | createPipePlugin | dropPipePlugin | showPipePlugins
     // CQ
     | createContinuousQuery | dropContinuousQuery | showContinuousQueries
     // Cluster
@@ -484,7 +486,6 @@ dropPipePlugin
 showPipePlugins
     : SHOW PIPEPLUGINS
     ;
-
 
 // ML Model =========================================================================================
 // ---- Create Model

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/PipePluginCoordinator.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/PipePluginCoordinator.java
@@ -69,7 +69,7 @@ public class PipePluginCoordinator {
     final String jarName = req.getJarName();
     final String jarMD5 = req.getJarMD5();
     final PipePluginMeta pipePluginMeta =
-        new PipePluginMeta(pluginName, className, jarName, jarMD5);
+        new PipePluginMeta(pluginName, className, false, jarName, jarMD5);
 
     return configManager.getProcedureManager().createPipePlugin(pipePluginMeta, req.getJarFile());
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/plugin/DropPipePluginProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/plugin/DropPipePluginProcedure.java
@@ -110,7 +110,7 @@ public class DropPipePluginProcedure extends AbstractNodeProcedure<DropPipePlugi
     try {
       pipePluginCoordinator.getPipePluginInfo().validateBeforeDroppingPipePlugin(pluginName);
     } catch (PipeManagementException e) {
-      // if the pipe plugin is not exist, we should end the procedure
+      // if the pipe plugin is a built-in plugin, we should not drop it
       LOGGER.warn(e.getMessage());
       setFailure(new ProcedureException(e.getMessage()));
       pipePluginCoordinator.unlock();
@@ -180,14 +180,14 @@ public class DropPipePluginProcedure extends AbstractNodeProcedure<DropPipePlugi
     LOGGER.info("DropPipePluginProcedure: rollbackFromDropOnDataNodes({})", pluginName);
 
     // do nothing but wait for rolling back to the previous state: LOCK
-    // TODO: we should drop the pipe plugin on data nodes
+    // TODO: we should drop the pipe plugin on data nodes properly with RuntimeAgent's help
   }
 
   private void rollbackFromDropOnConfigNodes(ConfigNodeProcedureEnv env) {
     LOGGER.info("DropPipePluginProcedure: rollbackFromDropOnConfigNodes({})", pluginName);
 
     // do nothing but wait for rolling back to the previous state: DROP_ON_DATA_NODES
-    // TODO: we should drop the pipe plugin on config nodes
+    // TODO: we should drop the pipe plugin on config nodes properly with RuntimeCoordinator's help
   }
 
   @Override

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -897,7 +897,6 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
   }
 
   @Override
-  @Deprecated
   public TGetAllPipeInfoResp getAllPipeInfo() {
     return configManager.getAllPipeInfo();
   }

--- a/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
@@ -1098,7 +1098,7 @@ public class ConfigPhysicalPlanSerDeTest {
   public void CreatePipePluginPlanTest() throws IOException {
     CreatePipePluginPlan createPipePluginPlan =
         new CreatePipePluginPlan(
-            new PipePluginMeta("testPlugin", "org.apache.iotdb.testJar", "testJar", "???"),
+            new PipePluginMeta("testPlugin", "org.apache.iotdb.TestJar", false, "test.jar", "???"),
             new Binary("123"));
     CreatePipePluginPlan createPipePluginPlan1 =
         (CreatePipePluginPlan)

--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PipeInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PipeInfoTest.java
@@ -84,7 +84,7 @@ public class PipeInfoTest {
 
     CreatePipePluginPlan createPipePluginPlan =
         new CreatePipePluginPlan(
-            new PipePluginMeta("testPlugin", "org.apache.iotdb.testJar", "testJar", "???"),
+            new PipePluginMeta("testPlugin", "org.apache.iotdb.testJar", false, "testJar", "???"),
             new Binary("123"));
     pipeInfo.getPipePluginInfo().createPipePlugin(createPipePluginPlan);
 

--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PipeInfoTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PipeInfoTest.java
@@ -84,7 +84,7 @@ public class PipeInfoTest {
 
     CreatePipePluginPlan createPipePluginPlan =
         new CreatePipePluginPlan(
-            new PipePluginMeta("testPlugin", "org.apache.iotdb.testJar", false, "testJar", "???"),
+            new PipePluginMeta("testPlugin", "org.apache.iotdb.TestJar", false, "test.jar", "???"),
             new Binary("123"));
     pipeInfo.getPipePluginInfo().createPipePlugin(createPipePluginPlan);
 

--- a/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/plugin/CreatePipePluginProcedureTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/plugin/CreatePipePluginProcedureTest.java
@@ -39,7 +39,7 @@ public class CreatePipePluginProcedureTest {
     DataOutputStream outputStream = new DataOutputStream(byteArrayOutputStream);
 
     PipePluginMeta pipePluginMeta =
-        new PipePluginMeta("test", "test.class", "test.jar", "testMD5test");
+        new PipePluginMeta("test", "test.class", false, "test.jar", "testMD5test");
     CreatePipePluginProcedure proc =
         new CreatePipePluginProcedure(pipePluginMeta, new byte[] {1, 2, 3});
 

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/AbstractNodeWrapper.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/AbstractNodeWrapper.java
@@ -127,6 +127,7 @@ public abstract class AbstractNodeWrapper implements BaseNodeWrapper {
     // these properties can't be mutated.
     immutableCommonProperties.setProperty("udf_lib_dir", MppBaseConfig.NULL_VALUE);
     immutableCommonProperties.setProperty("trigger_lib_dir", MppBaseConfig.NULL_VALUE);
+    immutableCommonProperties.setProperty("pipe_lib_dir", MppBaseConfig.NULL_VALUE);
     immutableCommonProperties.setProperty("mqtt_host", MppBaseConfig.NULL_VALUE);
     immutableCommonProperties.setProperty("mqtt_port", MppBaseConfig.NULL_VALUE);
     immutableCommonProperties.setProperty("rest_service_port", MppBaseConfig.NULL_VALUE);

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/BuiltinPipePlugin.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/BuiltinPipePlugin.java
@@ -17,5 +17,39 @@
  * under the License.
  */
 
-package org.apache.iotdb.commons.pipe.plugin.builtin;public enum BuiltinPipePlugin {
+package org.apache.iotdb.commons.pipe.plugin.builtin;
+
+import org.apache.iotdb.commons.pipe.plugin.builtin.connector.DoNothingConnector;
+import org.apache.iotdb.commons.pipe.plugin.builtin.processor.DoNothingProcessor;
+
+public enum BuiltinPipePlugin {
+
+  // processors
+  DO_NOTHING_PROCESSOR("do_nothing_processor", DoNothingProcessor.class),
+
+  // connectors
+  DO_NOTHING_CONNECTOR("do_nothing_connector", DoNothingConnector.class),
+  ;
+
+  private final String pipePluginName;
+  private final Class<?> pipePluginClass;
+  private final String className;
+
+  BuiltinPipePlugin(String functionName, Class<?> pipePluginClass) {
+    this.pipePluginName = functionName;
+    this.pipePluginClass = pipePluginClass;
+    this.className = pipePluginClass.getName();
+  }
+
+  public String getPipePluginName() {
+    return pipePluginName;
+  }
+
+  public Class<?> getPipePluginClass() {
+    return pipePluginClass;
+  }
+
+  public String getClassName() {
+    return className;
+  }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/BuiltinPipePlugin.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/BuiltinPipePlugin.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.pipe.plugin.builtin;public enum BuiltinPipePlugin {
+}

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/connector/DoNothingConnector.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/connector/DoNothingConnector.java
@@ -17,5 +17,56 @@
  * under the License.
  */
 
-package org.apache.iotdb.commons.pipe.plugin.builtin.connector;public class DoNothingConnector {
+package org.apache.iotdb.commons.pipe.plugin.builtin.connector;
+
+import org.apache.iotdb.pipe.api.PipeConnector;
+import org.apache.iotdb.pipe.api.customizer.PipeParameterValidator;
+import org.apache.iotdb.pipe.api.customizer.PipeParameters;
+import org.apache.iotdb.pipe.api.customizer.connector.PipeConnectorRuntimeConfiguration;
+import org.apache.iotdb.pipe.api.event.deletion.DeletionEvent;
+import org.apache.iotdb.pipe.api.event.insertion.TabletInsertionEvent;
+import org.apache.iotdb.pipe.api.event.insertion.TsFileInsertionEvent;
+
+public class DoNothingConnector implements PipeConnector {
+
+  @Override
+  public void validate(PipeParameterValidator validator) {
+    // do nothing
+  }
+
+  @Override
+  public void customize(
+      PipeParameters parameters, PipeConnectorRuntimeConfiguration configuration) {
+    // do nothing
+  }
+
+  @Override
+  public void handshake() {
+    // do nothing
+  }
+
+  @Override
+  public void heartbeat() {
+    // do nothing
+  }
+
+  @Override
+  public void transfer(TabletInsertionEvent tabletInsertionEvent) {
+    // do nothing
+  }
+
+  @Override
+  public void transfer(TsFileInsertionEvent tsFileInsertionEvent) {
+    // do nothing
+  }
+
+  @Override
+  public void transfer(DeletionEvent deletionEvent) {
+    // do nothing
+  }
+
+  @Override
+  public void close() {
+    // do nothing
+  }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/connector/DoNothingConnector.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/connector/DoNothingConnector.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.pipe.plugin.builtin.connector;public class DoNothingConnector {
+}

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/processor/DoNothingProcessor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/processor/DoNothingProcessor.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.pipe.plugin.builtin.processor;public class DoNothingProcessor {
+}

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/processor/DoNothingProcessor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/processor/DoNothingProcessor.java
@@ -17,5 +17,52 @@
  * under the License.
  */
 
-package org.apache.iotdb.commons.pipe.plugin.builtin.processor;public class DoNothingProcessor {
+package org.apache.iotdb.commons.pipe.plugin.builtin.processor;
+
+import org.apache.iotdb.pipe.api.PipeProcessor;
+import org.apache.iotdb.pipe.api.collector.EventCollector;
+import org.apache.iotdb.pipe.api.customizer.PipeParameterValidator;
+import org.apache.iotdb.pipe.api.customizer.PipeParameters;
+import org.apache.iotdb.pipe.api.customizer.processor.PipeProcessorRuntimeConfiguration;
+import org.apache.iotdb.pipe.api.event.deletion.DeletionEvent;
+import org.apache.iotdb.pipe.api.event.insertion.TabletInsertionEvent;
+import org.apache.iotdb.pipe.api.event.insertion.TsFileInsertionEvent;
+
+import java.io.IOException;
+
+public class DoNothingProcessor implements PipeProcessor {
+
+  @Override
+  public void validate(PipeParameterValidator validator) {
+    // do nothing
+  }
+
+  @Override
+  public void customize(
+      PipeParameters parameters, PipeProcessorRuntimeConfiguration configuration) {
+    // do nothing
+  }
+
+  @Override
+  public void process(TabletInsertionEvent tabletInsertionEvent, EventCollector eventCollector)
+      throws IOException {
+    eventCollector.collectTabletInsertionEvent(tabletInsertionEvent);
+  }
+
+  @Override
+  public void process(TsFileInsertionEvent tsFileInsertionEvent, EventCollector eventCollector)
+      throws IOException {
+    eventCollector.collectTsFileInsertionEvent(tsFileInsertionEvent);
+  }
+
+  @Override
+  public void process(DeletionEvent deletionEvent, EventCollector eventCollector)
+      throws IOException {
+    eventCollector.collectDeletionEvent(deletionEvent);
+  }
+
+  @Override
+  public void close() {
+    // do nothing
+  }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/DataNodePipePluginMetaKeeper.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/DataNodePipePluginMetaKeeper.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.commons.pipe.plugin.meta;
 
+import org.apache.iotdb.commons.pipe.plugin.builtin.BuiltinPipePlugin;
 import org.apache.iotdb.commons.pipe.plugin.service.PipePluginClassLoader;
 
 import java.util.Map;
@@ -26,28 +27,39 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class DataNodePipePluginMetaKeeper extends PipePluginMetaKeeper {
 
-  private final Map<String, Class<?>> pipeNameToPipeClassMap;
+  private final Map<String, Class<?>> pipePluginNameToClassMap;
 
   public DataNodePipePluginMetaKeeper() {
-    super();
-    pipeNameToPipeClassMap = new ConcurrentHashMap<>();
+    pipePluginNameToClassMap = new ConcurrentHashMap<>();
+
+    loadBuiltInPlugins();
+  }
+
+  @Override
+  protected void loadBuiltInPlugins() {
+    super.loadBuiltInPlugins();
+
+    for (final BuiltinPipePlugin builtinPipePlugin : BuiltinPipePlugin.values()) {
+      addPluginAndClass(
+          builtinPipePlugin.getPipePluginName(), builtinPipePlugin.getPipePluginClass());
+    }
   }
 
   public void addPluginAndClass(String pluginName, Class<?> clazz) {
-    pipeNameToPipeClassMap.put(pluginName.toUpperCase(), clazz);
+    pipePluginNameToClassMap.put(pluginName.toUpperCase(), clazz);
   }
 
   public Class<?> getPluginClass(String pluginName) {
-    return pipeNameToPipeClassMap.get(pluginName.toUpperCase());
+    return pipePluginNameToClassMap.get(pluginName.toUpperCase());
   }
 
   public void removePluginClass(String pluginName) {
-    pipeNameToPipeClassMap.remove(pluginName.toUpperCase());
+    pipePluginNameToClassMap.remove(pluginName.toUpperCase());
   }
 
   public void updatePluginClass(PipePluginMeta pipePluginMeta, PipePluginClassLoader classLoader)
       throws ClassNotFoundException {
-    Class<?> functionClass = Class.forName(pipePluginMeta.getClassName(), true, classLoader);
-    pipeNameToPipeClassMap.put(pipePluginMeta.getPluginName().toUpperCase(), functionClass);
+    final Class<?> functionClass = Class.forName(pipePluginMeta.getClassName(), true, classLoader);
+    pipePluginNameToClassMap.put(pipePluginMeta.getPluginName().toUpperCase(), functionClass);
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMeta.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMeta.java
@@ -45,8 +45,13 @@ public class PipePluginMeta {
     this.className = Objects.requireNonNull(className);
 
     this.isBuiltin = isBuiltin;
-    this.jarName = Objects.requireNonNull(jarName);
-    this.jarMD5 = Objects.requireNonNull(jarMD5);
+    if (isBuiltin) {
+      this.jarName = jarName;
+      this.jarMD5 = jarMD5;
+    } else {
+      this.jarName = Objects.requireNonNull(jarName);
+      this.jarMD5 = Objects.requireNonNull(jarMD5);
+    }
   }
 
   public PipePluginMeta(String pluginName, String className) {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMeta.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMeta.java
@@ -39,11 +39,12 @@ public class PipePluginMeta {
   private final String jarName;
   private final String jarMD5;
 
-  public PipePluginMeta(String pluginName, String className, String jarName, String jarMD5) {
+  public PipePluginMeta(
+      String pluginName, String className, boolean isBuiltin, String jarName, String jarMD5) {
     this.pluginName = Objects.requireNonNull(pluginName).toUpperCase();
     this.className = Objects.requireNonNull(className);
 
-    isBuiltin = false;
+    this.isBuiltin = isBuiltin;
     this.jarName = Objects.requireNonNull(jarName);
     this.jarMD5 = Objects.requireNonNull(jarMD5);
   }
@@ -84,13 +85,10 @@ public class PipePluginMeta {
     return ByteBuffer.wrap(byteArrayOutputStream.getBuf(), 0, byteArrayOutputStream.size());
   }
 
-  /**
-   * All built-in plugins' information is kept in Java class {@code BuiltinPipePlugin }. So we never
-   * serialize the built-in plugins, then we don't need to serialize the isBuiltin field.
-   */
   public void serialize(DataOutputStream outputStream) throws IOException {
     ReadWriteIOUtils.write(pluginName, outputStream);
     ReadWriteIOUtils.write(className, outputStream);
+    ReadWriteIOUtils.write(isBuiltin, outputStream);
     ReadWriteIOUtils.write(jarName, outputStream);
     ReadWriteIOUtils.write(jarMD5, outputStream);
   }
@@ -98,9 +96,10 @@ public class PipePluginMeta {
   public static PipePluginMeta deserialize(ByteBuffer byteBuffer) {
     final String pluginName = ReadWriteIOUtils.readString(byteBuffer);
     final String className = ReadWriteIOUtils.readString(byteBuffer);
+    final boolean isBuiltin = ReadWriteIOUtils.readBool(byteBuffer);
     final String jarName = ReadWriteIOUtils.readString(byteBuffer);
     final String jarMD5 = ReadWriteIOUtils.readString(byteBuffer);
-    return new PipePluginMeta(pluginName, className, jarName, jarMD5);
+    return new PipePluginMeta(pluginName, className, isBuiltin, jarName, jarMD5);
   }
 
   public static PipePluginMeta deserialize(InputStream inputStream) throws IOException {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaKeeper.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaKeeper.java
@@ -19,40 +19,78 @@
 
 package org.apache.iotdb.commons.pipe.plugin.meta;
 
+import org.apache.iotdb.commons.pipe.plugin.builtin.BuiltinPipePlugin;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class PipePluginMetaKeeper {
 
-  protected final Map<String, PipePluginMeta> pipeNameToPipeMetaMap;
+  protected final Map<String, PipePluginMeta> pipePluginNameToMetaMap = new ConcurrentHashMap<>();
 
-  public PipePluginMetaKeeper() {
-    pipeNameToPipeMetaMap = new ConcurrentHashMap<>();
+  protected void loadBuiltInPlugins() {
+    for (final BuiltinPipePlugin builtinPipePlugin : BuiltinPipePlugin.values()) {
+      addPipePluginMeta(
+          builtinPipePlugin.getPipePluginName(),
+          new PipePluginMeta(
+              builtinPipePlugin.getPipePluginName(), builtinPipePlugin.getClassName()));
+    }
   }
 
   public void addPipePluginMeta(String pluginName, PipePluginMeta pipePluginMeta) {
-    pipeNameToPipeMetaMap.put(pluginName.toUpperCase(), pipePluginMeta);
+    pipePluginNameToMetaMap.put(pluginName.toUpperCase(), pipePluginMeta);
   }
 
   public void removePipePluginMeta(String pluginName) {
-    pipeNameToPipeMetaMap.remove(pluginName.toUpperCase());
+    pipePluginNameToMetaMap.remove(pluginName.toUpperCase());
   }
 
   public PipePluginMeta getPipePluginMeta(String pluginName) {
-    return pipeNameToPipeMetaMap.get(pluginName.toUpperCase());
+    return pipePluginNameToMetaMap.get(pluginName.toUpperCase());
   }
 
   public PipePluginMeta[] getAllPipePluginMeta() {
-    return pipeNameToPipeMetaMap.values().toArray(new PipePluginMeta[0]);
+    return pipePluginNameToMetaMap.values().toArray(new PipePluginMeta[0]);
   }
 
   public boolean containsPipePlugin(String pluginName) {
-    return pipeNameToPipeMetaMap.containsKey(pluginName.toUpperCase());
+    return pipePluginNameToMetaMap.containsKey(pluginName.toUpperCase());
   }
 
-  public void clear() {
-    pipeNameToPipeMetaMap.clear();
+  protected void processTakeSnapshot(OutputStream outputStream) throws IOException {
+    ReadWriteIOUtils.write(
+        (int)
+            pipePluginNameToMetaMap.values().stream()
+                .filter(pipePluginMeta -> !pipePluginMeta.isBuiltin())
+                .count(),
+        outputStream);
+
+    for (PipePluginMeta pipePluginMeta : pipePluginNameToMetaMap.values()) {
+      if (pipePluginMeta.isBuiltin()) {
+        continue;
+      }
+      ReadWriteIOUtils.write(pipePluginMeta.serialize(), outputStream);
+    }
+  }
+
+  protected void processLoadSnapshot(InputStream inputStream) throws IOException {
+    pipePluginNameToMetaMap.forEach(
+        (pluginName, pluginMeta) -> {
+          if (!pluginMeta.isBuiltin()) {
+            pipePluginNameToMetaMap.remove(pluginName);
+          }
+        });
+
+    final int pipePluginMetaSize = ReadWriteIOUtils.readInt(inputStream);
+    for (int i = 0; i < pipePluginMetaSize; i++) {
+      final PipePluginMeta pipePluginMeta = PipePluginMeta.deserialize(inputStream);
+      addPipePluginMeta(pipePluginMeta.getPluginName().toUpperCase(), pipePluginMeta);
+    }
   }
 
   @Override
@@ -64,11 +102,11 @@ public abstract class PipePluginMetaKeeper {
       return false;
     }
     PipePluginMetaKeeper that = (PipePluginMetaKeeper) o;
-    return pipeNameToPipeMetaMap.equals(that.pipeNameToPipeMetaMap);
+    return pipePluginNameToMetaMap.equals(that.pipePluginNameToMetaMap);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pipeNameToPipeMetaMap);
+    return Objects.hash(pipePluginNameToMetaMap);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
@@ -98,6 +98,7 @@ public class ColumnHeaderConstant {
 
   // column names for show pipe plugins statement
   public static final String PLUGIN_NAME = "PluginName";
+  public static final String PLUGIN_TYPE = "PluginType";
   public static final String PLUGIN_JAR = "PluginJar";
 
   // show cluster status
@@ -354,6 +355,7 @@ public class ColumnHeaderConstant {
   public static final List<ColumnHeader> showPipePluginsColumnHeaders =
       ImmutableList.of(
           new ColumnHeader(PLUGIN_NAME, TSDataType.TEXT),
+          new ColumnHeader(PLUGIN_TYPE, TSDataType.TEXT),
           new ColumnHeader(CLASS_NAME, TSDataType.TEXT),
           new ColumnHeader(PLUGIN_JAR, TSDataType.TEXT));
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -172,6 +172,7 @@ import org.apache.iotdb.db.mpp.plan.statement.sys.sync.CreatePipeSinkStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.sync.DropPipeSinkStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.sync.ShowPipeSinkStatement;
 import org.apache.iotdb.db.trigger.service.TriggerClassLoader;
+import org.apache.iotdb.pipe.api.PipePlugin;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -759,7 +760,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
       try (PipePluginClassLoader classLoader = new PipePluginClassLoader(libRoot)) {
         // ensure that jar file contains the class and the class is a pipe plugin
         Class<?> clazz = Class.forName(createPipePluginStatement.getClassName(), true, classLoader);
-        clazz.getDeclaredConstructor().newInstance();
+        PipePlugin ignored = (PipePlugin) clazz.getDeclaredConstructor().newInstance();
       } catch (ClassNotFoundException
           | NoSuchMethodException
           | InstantiationException

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowPipePluginsTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowPipePluginsTask.java
@@ -42,6 +42,9 @@ import java.util.stream.Collectors;
 
 public class ShowPipePluginsTask implements IConfigTask {
 
+  private static final Binary PIPE_PLUGIN_TYPE_BUILTIN = Binary.valueOf("Builtin");
+  private static final Binary PIPE_PLUGIN_TYPE_EXTERNAL = Binary.valueOf("External");
+
   @Override
   public ListenableFuture<ConfigTaskResult> execute(IConfigTaskExecutor configTaskExecutor)
       throws InterruptedException {
@@ -66,8 +69,12 @@ public class ShowPipePluginsTask implements IConfigTask {
     for (final PipePluginMeta pipePluginMeta : pipePluginMetaList) {
       builder.getTimeColumnBuilder().writeLong(0L);
       builder.getColumnBuilder(0).writeBinary(Binary.valueOf(pipePluginMeta.getPluginName()));
-      builder.getColumnBuilder(1).writeBinary(Binary.valueOf(pipePluginMeta.getClassName()));
-      builder.getColumnBuilder(2).writeBinary(Binary.valueOf(pipePluginMeta.getJarName()));
+      builder
+          .getColumnBuilder(1)
+          .writeBinary(
+              pipePluginMeta.isBuiltin() ? PIPE_PLUGIN_TYPE_BUILTIN : PIPE_PLUGIN_TYPE_EXTERNAL);
+      builder.getColumnBuilder(2).writeBinary(Binary.valueOf(pipePluginMeta.getClassName()));
+      builder.getColumnBuilder(3).writeBinary(Binary.valueOf(pipePluginMeta.getJarName()));
       builder.declarePosition();
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowPipePluginsTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/metadata/ShowPipePluginsTask.java
@@ -45,6 +45,8 @@ public class ShowPipePluginsTask implements IConfigTask {
   private static final Binary PIPE_PLUGIN_TYPE_BUILTIN = Binary.valueOf("Builtin");
   private static final Binary PIPE_PLUGIN_TYPE_EXTERNAL = Binary.valueOf("External");
 
+  private static final Binary PIPE_JAR_NAME_EMPTY_FIELD = Binary.valueOf("");
+
   @Override
   public ListenableFuture<ConfigTaskResult> execute(IConfigTaskExecutor configTaskExecutor)
       throws InterruptedException {
@@ -74,7 +76,12 @@ public class ShowPipePluginsTask implements IConfigTask {
           .writeBinary(
               pipePluginMeta.isBuiltin() ? PIPE_PLUGIN_TYPE_BUILTIN : PIPE_PLUGIN_TYPE_EXTERNAL);
       builder.getColumnBuilder(2).writeBinary(Binary.valueOf(pipePluginMeta.getClassName()));
-      builder.getColumnBuilder(3).writeBinary(Binary.valueOf(pipePluginMeta.getJarName()));
+      builder
+          .getColumnBuilder(3)
+          .writeBinary(
+              pipePluginMeta.getJarName() == null
+                  ? PIPE_JAR_NAME_EMPTY_FIELD
+                  : Binary.valueOf(pipePluginMeta.getJarName()));
       builder.declarePosition();
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/pipe/agent/PipeAgent.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/agent/PipeAgent.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.pipe.agent;
 
-import org.apache.iotdb.commons.pipe.plugin.meta.DataNodePipePluginMetaKeeper;
 import org.apache.iotdb.db.pipe.agent.plugin.PipePluginAgent;
 import org.apache.iotdb.db.pipe.agent.runtime.PipeRuntimeAgent;
 import org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent;
@@ -33,9 +32,7 @@ public class PipeAgent {
 
   /** Private constructor to prevent users from creating a new instance. */
   private PipeAgent() {
-    final DataNodePipePluginMetaKeeper pipePluginMetaKeeper = new DataNodePipePluginMetaKeeper();
-
-    pipePluginAgent = PipePluginAgent.setupAndGetInstance(pipePluginMetaKeeper);
+    pipePluginAgent = PipePluginAgent.setupAndGetInstance();
     pipeTaskAgent = PipeTaskAgent.setupAndGetInstance();
     pipeRuntimeAgent = PipeRuntimeAgent.setupAndGetInstance();
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -861,6 +861,9 @@ public class DataNode implements DataNodeMBean {
     // create instances of pipe plugins and do registration
     try {
       for (PipePluginMeta meta : resourcesInformationHolder.getPipePluginMetaList()) {
+        if (meta.isBuiltin()) {
+          continue;
+        }
         PipeAgent.plugin().doRegister(meta);
       }
     } catch (Exception e) {
@@ -881,6 +884,9 @@ public class DataNode implements DataNodeMBean {
   private List<PipePluginMeta> getJarListForPipePlugin() {
     List<PipePluginMeta> res = new ArrayList<>();
     for (PipePluginMeta pipePluginMeta : resourcesInformationHolder.getPipePluginMetaList()) {
+      if (pipePluginMeta.isBuiltin()) {
+        continue;
+      }
       // If jar does not exist, add current pipePluginMeta to list
       if (!PipePluginExecutableManager.getInstance()
           .hasFileUnderInstallDir(pipePluginMeta.getJarName())) {


### PR DESCRIPTION
The following things are done in this PR:

1. support built-in pipe plugins. do_nothing_processor & do_nothing_connector are added as built-in plugins.
2. allow to create / drop the same function multiple times without errors at PipePluginAgent / PipePluginInfo to adapt the retry policy of the Procedure mechanism.
3. allow to drop a function that is not registered on leader config node so that user can have a chance to change the inconsistant registration state over different config / data nodes.
4. fix ci build error: https://ci-builds.apache.org/job/IoTDB/job/IoTDB-pip-new/job/master/173/console

---

1. 支持内置 Pipe 插件，为内置插件适配了增、删、启动流程
2. 幂等操作支持：允许在 PipePluginAgent / PipePluginInfo 层面对同一个插件进行多次增、删（不对已经注册的插件进行检查，允许 procedure 的多次执行）
3. 创建：仅仅在 coordinator 层面检查是否合规。删除：coordinator 不对是否创建过进行检查，允许用户多次 drop pipe plugin 来消除不一致状态（即使该插件已经在 leader confignode 上被 drop）
4. 修复 ci build error: https://ci-builds.apache.org/job/IoTDB/job/IoTDB-pip-new/job/master/173/console