### PR TITLE
[To rel/0.13][IOTDB-5809]The search configuration file path specification is inconsistent

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/rest/IoTDBRestServiceDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/rest/IoTDBRestServiceDescriptor.java
@@ -119,8 +119,6 @@ public class IoTDBRestServiceDescriptor {
                 + File.separatorChar
                 + "conf"
                 + File.separatorChar
-                + "rest"
-                + File.separatorChar
                 + IoTDBRestServiceConfig.CONFIG_NAME;
       } else {
         // If this too wasn't provided, try to find a default config in the root of the classpath.


### PR DESCRIPTION
When configuring IOTDB_HOME, find ${IOTDB_HOME}/conf/iotdb-rest.properties