### PR TITLE
[IoTDB-5721] Streaming query DataPartition and Schema while loading TsFile

### DIFF
--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -87,7 +87,7 @@ cluster_name=defaultCluster
 # The limit of the TTimePartitionSlot allowed to be transmitted between DataNode and ConfigNode
 # Mainly used to balance communication efficiency when loading very large TsFile
 # Datatype: Integer
-# time_partition_slot_transmit_limit=65536
+# time_partition_slot_transmit_limit=1000
 
 
 # The policy of extension SchemaRegionGroup for each Database.

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -84,6 +84,11 @@ cluster_name=defaultCluster
 # Datatype: String
 # series_partition_executor_class=org.apache.iotdb.commons.partition.executor.hash.BKDRHashExecutor
 
+# The limit of the TTimePartitionSlot allowed to be transmitted between DataNode and ConfigNode
+# Mainly used to balance communication efficiency when loading very large TsFile
+# Datatype: Integer
+# time_partition_slot_transmit_limit=65536
+
 
 # The policy of extension SchemaRegionGroup for each Database.
 # These policies are currently supported:

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -120,6 +120,8 @@ public class CommonConfig {
 
   private volatile String statusReason = null;
 
+  private int TTimePartitionSlotTransmitLimit = 65536;
+
   /** Disk Monitor */
   private double diskSpaceWarningThreshold = 0.05;
 
@@ -361,6 +363,14 @@ public class CommonConfig {
 
   public void setTargetMLNodeEndPoint(TEndPoint targetMLNodeEndPoint) {
     this.targetMLNodeEndPoint = targetMLNodeEndPoint;
+  }
+
+  public int getTTimePartitionSlotTransmitLimit() {
+    return TTimePartitionSlotTransmitLimit;
+  }
+
+  public void setTTimePartitionSlotTransmitLimit(int TTimePartitionSlotTransmitLimit) {
+    this.TTimePartitionSlotTransmitLimit = TTimePartitionSlotTransmitLimit;
   }
 
   public boolean isStopping() {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -120,7 +120,7 @@ public class CommonConfig {
 
   private volatile String statusReason = null;
 
-  private int TTimePartitionSlotTransmitLimit = 65536;
+  private int TTimePartitionSlotTransmitLimit = 1000;
 
   /** Disk Monitor */
   private double diskSpaceWarningThreshold = 0.05;

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -188,6 +188,14 @@ public class CommonDescriptor {
                     String.valueOf(config.getDiskSpaceWarningThreshold()))
                 .trim()));
 
+    config.setTTimePartitionSlotTransmitLimit(
+        Integer.parseInt(
+            properties
+                .getProperty(
+                    "time_partition_slot_transmit_limit",
+                    String.valueOf(config.getTTimePartitionSlotTransmitLimit()))
+                .trim()));
+
     String endPointUrl =
         properties.getProperty(
             "target_ml_node_endpoint",

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -159,6 +159,8 @@ public class IoTDBConfig {
   /** The proportion of write memory for loading TsFile */
   private double loadTsFileProportion = 0.125;
 
+  private final int maxLoadingDeviceNumber = 10000;
+
   /**
    * If memory cost of data region increased more than proportion of {@linkplain
    * IoTDBConfig#getAllocateMemoryForStorageEngine()}*{@linkplain
@@ -3322,6 +3324,10 @@ public class IoTDBConfig {
 
   public double getLoadTsFileProportion() {
     return loadTsFileProportion;
+  }
+
+  public int getMaxLoadingDeviceNumber() {
+    return maxLoadingDeviceNumber;
   }
 
   public static String getEnvironmentVariables() {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -1994,8 +1994,6 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   public Analysis visitLoadFile(LoadTsFileStatement loadTsFileStatement, MPPQueryContext context) {
     context.setQueryType(QueryType.WRITE);
 
-    Map<String, Long> device2MinTime = new HashMap<>();
-    Map<String, Long> device2MaxTime = new HashMap<>();
     Map<String, Map<MeasurementSchema, File>> device2Schemas = new HashMap<>();
     Map<String, Pair<Boolean, File>> device2IsAligned = new HashMap<>();
 
@@ -2010,13 +2008,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       }
       try {
         TsFileResource resource =
-            analyzeTsFile(
-                loadTsFileStatement,
-                tsFile,
-                device2MinTime,
-                device2MaxTime,
-                device2Schemas,
-                device2IsAligned);
+            analyzeTsFile(loadTsFileStatement, tsFile, device2Schemas, device2IsAligned);
         loadTsFileStatement.addTsFileResource(resource);
       } catch (IllegalArgumentException e) {
         logger.warn(
@@ -2056,25 +2048,10 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
               loadTsFileStatement));
     }
 
-    // construct partition info
-    List<DataPartitionQueryParam> params = new ArrayList<>();
-    for (Map.Entry<String, Long> entry : device2MinTime.entrySet()) {
-      List<TTimePartitionSlot> timePartitionSlots = new ArrayList<>();
-      String device = entry.getKey();
-      long endTime = device2MaxTime.get(device);
-      long interval = TimePartitionUtils.timePartitionInterval;
-      long time = (entry.getValue() / interval) * interval;
-      for (; time <= endTime; time += interval) {
-        timePartitionSlots.add(TimePartitionUtils.getTimePartition(time));
-      }
-
-      DataPartitionQueryParam dataPartitionQueryParam = new DataPartitionQueryParam();
-      dataPartitionQueryParam.setDevicePath(device);
-      dataPartitionQueryParam.setTimePartitionSlotList(timePartitionSlots);
-      params.add(dataPartitionQueryParam);
-    }
-
-    return getAnalysisForWriting(loadTsFileStatement, params);
+    // load function will query data partition in scheduler
+    Analysis analysis = new Analysis();
+    analysis.setStatement(loadTsFileStatement);
+    return analysis;
   }
 
   /** get analysis according to statement and params */
@@ -2097,8 +2074,6 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   private TsFileResource analyzeTsFile(
       LoadTsFileStatement statement,
       File tsFile,
-      Map<String, Long> device2MinTime,
-      Map<String, Long> device2MaxTime,
       Map<String, Map<MeasurementSchema, File>> device2Schemas,
       Map<String, Pair<Boolean, File>> device2IsAligned)
       throws IOException, VerifyMetadataException {
@@ -2152,19 +2127,6 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
         resource.updatePlanIndexes(reader.getMaxPlanIndex());
       } else {
         resource.deserialize();
-      }
-
-      // construct device time range
-      for (String device : resource.getDevices()) {
-        device2MinTime.put(
-            device,
-            Math.min(
-                device2MinTime.getOrDefault(device, Long.MAX_VALUE),
-                resource.getStartTime(device)));
-        device2MaxTime.put(
-            device,
-            Math.max(
-                device2MaxTime.getOrDefault(device, Long.MIN_VALUE), resource.getEndTime(device)));
       }
 
       resource.setStatus(TsFileResourceStatus.CLOSED);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/QueryExecution.java
@@ -297,7 +297,11 @@ public class QueryExecution implements IQueryExecution {
     if (rawStatement instanceof LoadTsFileStatement) {
       this.scheduler =
           new LoadTsFileScheduler(
-              distributedPlan, context, stateMachine, syncInternalServiceClientManager);
+              distributedPlan,
+              context,
+              stateMachine,
+              syncInternalServiceClientManager,
+              partitionFetcher);
       this.scheduler.start();
       return;
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/load/LoadTsFileNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/load/LoadTsFileNode.java
@@ -90,21 +90,7 @@ public class LoadTsFileNode extends WritePlanNode {
     List<WritePlanNode> res = new ArrayList<>();
     LoadTsFileStatement statement = (LoadTsFileStatement) analysis.getStatement();
     for (TsFileResource resource : resources) {
-      try {
-        LoadSingleTsFileNode singleTsFileNode =
-            new LoadSingleTsFileNode(
-                getPlanNodeId(),
-                resource,
-                statement.isDeleteAfterLoad(),
-                analysis.getDataPartitionInfo());
-        singleTsFileNode.checkIfNeedDecodeTsFile();
-        res.add(singleTsFileNode);
-      } catch (Exception e) {
-        logger.error(
-            String.format(
-                "Check whether TsFile %s need decode or not error", resource.getTsFile().getPath()),
-            e);
-      }
+      res.add(new LoadSingleTsFileNode(getPlanNodeId(), resource, statement.isDeleteAfterLoad()));
     }
     return res;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileDispatcherImpl.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.mpp.plan.scheduler.load;
 
-import io.airlift.concurrent.SetThreadName;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
@@ -46,6 +45,8 @@ import org.apache.iotdb.mpp.rpc.thrift.TLoadResp;
 import org.apache.iotdb.mpp.rpc.thrift.TTsFilePieceReq;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
+
+import io.airlift.concurrent.SetThreadName;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileDispatcherImpl.java
@@ -165,7 +165,7 @@ public class LoadTsFileDispatcherImpl implements IFragInstanceDispatcher {
       if (!RpcUtils.SUCCESS_STATUS.equals(resultStatus)) {
         throw new FragmentInstanceDispatchException(resultStatus);
       }
-    } else if (planNode instanceof LoadSingleTsFileNode) { // do not need split
+    } else if (planNode instanceof LoadSingleTsFileNode) { // do not need to split
       try {
         StorageEngine.getInstance()
             .getDataRegion((DataRegionId) groupId)


### PR DESCRIPTION
This PR contains:
- Streaming query DataPartition with constraint of TTimePartitionSlotTransmitLimit while loading TsFile.
- Streaming query Schema with constraint of maxLoadingDeviceNumber while loading TsFile.
- Now, you can check loading TsFile progress in datanode log.
  such as: Load TsFile %s Successfully, load process [1/10]
- Optimized the dispatching process in multi-replications cases, TsFile pieces will no longer be serialized multiple times, which means faster loading in multi-replications cases.