### PR TITLE
Remove unecessary synchronized on decrementCnt of SinkListener

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
@@ -63,6 +63,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -401,7 +402,7 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
 
     private final AtomicInteger cnt;
 
-    private volatile boolean hasDecremented = false;
+    private final AtomicBoolean hasDecremented = new AtomicBoolean(false);
 
     public ISinkChannelListenerImpl(
         TFragmentInstanceId localFragmentInstanceId,
@@ -441,9 +442,9 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
       }
     }
 
-    private synchronized void decrementCnt() {
-      if (!hasDecremented) {
-        hasDecremented = true;
+    private void decrementCnt() {
+      if (!hasDecremented.get()) {
+        hasDecremented.compareAndSet(false, true);
         if (cnt.decrementAndGet() == 0) {
           closeShuffleSinkHandle();
         }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/MPPDataExchangeManager.java
@@ -443,8 +443,7 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
     }
 
     private void decrementCnt() {
-      if (!hasDecremented.get()) {
-        hasDecremented.compareAndSet(false, true);
+      if (hasDecremented.compareAndSet(false, true)) {
         if (cnt.decrementAndGet() == 0) {
           closeShuffleSinkHandle();
         }


### PR DESCRIPTION
At first, we add synchronized on decrementGet method to avoid concurrent modification on cnt or we may close the shuffleSinkHandle wrongly. However, using AtomicBoolean is enough to ensure that one channel only decrement the cnt once.
Moreover, adding synchronized on decrementGet method could lead to dead lock. Thread A invokes onFinsh of ISinkLitsener and holds the lock of it. Then A tries to lock the corresponding SinkChannel while Thread B invokes close of SinkChannel first and holds the lock of SinkChannel and then try to lock ISinkListener.
So we need to remove the synchonized keyword on decrementGet method.