### PR TITLE
Combine DataNodeSchemaCache of Template and Non-Template Scenarios 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
@@ -67,7 +67,10 @@ public class DataNodeSchemaCache {
   }
 
   public double getHitRate() {
-    return 0;
+    return (deviceUsingTemplateSchemaCache.getHitCount() + timeSeriesSchemaCache.getHitCount())
+        * 1.0
+        / (deviceUsingTemplateSchemaCache.getRequestCount()
+            + timeSeriesSchemaCache.getRequestCount());
   }
 
   public static DataNodeSchemaCache getInstance() {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
@@ -24,24 +24,21 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.metadata.cache.dualkeycache.IDualKeyCache;
-import org.apache.iotdb.db.metadata.cache.dualkeycache.IDualKeyCacheComputation;
-import org.apache.iotdb.db.metadata.cache.dualkeycache.impl.DualKeyCacheBuilder;
-import org.apache.iotdb.db.metadata.cache.dualkeycache.impl.DualKeyCachePolicy;
+import org.apache.iotdb.db.metadata.template.ClusterTemplateManager;
+import org.apache.iotdb.db.metadata.template.ITemplateManager;
+import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.mpp.common.schematree.ClusterSchemaTree;
 import org.apache.iotdb.db.mpp.plan.analyze.schema.ISchemaComputation;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
-import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
@@ -53,28 +50,24 @@ public class DataNodeSchemaCache {
   private static final Logger logger = LoggerFactory.getLogger(DataNodeSchemaCache.class);
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
-  private final IDualKeyCache<PartialPath, String, SchemaCacheEntry> dualKeyCache;
+  private final ITemplateManager templateManager = ClusterTemplateManager.getInstance();
+
+  private final DeviceUsingTemplateSchemaCache deviceUsingTemplateSchemaCache;
+
+  private final TimeSeriesSchemaCache timeSeriesSchemaCache;
 
   // cache update or clean have higher priority than cache read
   private final ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock(false);
 
   private DataNodeSchemaCache() {
-    DualKeyCacheBuilder<PartialPath, String, SchemaCacheEntry> dualKeyCacheBuilder =
-        new DualKeyCacheBuilder<>();
-    dualKeyCache =
-        dualKeyCacheBuilder
-            .cacheEvictionPolicy(DualKeyCachePolicy.LRU)
-            .memoryCapacity(config.getAllocateMemoryForSchemaCache())
-            .firstKeySizeComputer(PartialPath::estimateSize)
-            .secondKeySizeComputer(s -> 32 + 2 * s.length())
-            .valueSizeComputer(SchemaCacheEntry::estimateSize)
-            .build();
+    deviceUsingTemplateSchemaCache = new DeviceUsingTemplateSchemaCache(templateManager);
+    timeSeriesSchemaCache = new TimeSeriesSchemaCache();
 
     MetricService.getInstance().addMetricSet(new DataNodeSchemaCacheMetrics(this));
   }
 
   public double getHitRate() {
-    return dualKeyCache.stats().hitRate() * 100;
+    return 0;
   }
 
   public static DataNodeSchemaCache getInstance() {
@@ -110,110 +103,60 @@ public class DataNodeSchemaCache {
    * @return timeseries partialPath and its SchemaEntity
    */
   public ClusterSchemaTree get(PartialPath devicePath, String[] measurements) {
-    ClusterSchemaTree schemaTree = new ClusterSchemaTree();
-    Set<String> storageGroupSet = new HashSet<>();
-
-    dualKeyCache.compute(
-        new IDualKeyCacheComputation<PartialPath, String, SchemaCacheEntry>() {
-          @Override
-          public PartialPath getFirstKey() {
-            return devicePath;
-          }
-
-          @Override
-          public String[] getSecondKeyList() {
-            return measurements;
-          }
-
-          @Override
-          public void computeValue(int index, SchemaCacheEntry value) {
-            if (value != null) {
-              schemaTree.appendSingleMeasurement(
-                  devicePath.concatNode(value.getSchemaEntryId()),
-                  value.getMeasurementSchema(),
-                  value.getTagMap(),
-                  null,
-                  value.isAligned());
-              storageGroupSet.add(value.getStorageGroup());
-            }
-          }
-        });
-    schemaTree.setDatabases(storageGroupSet);
-    return schemaTree;
+    return timeSeriesSchemaCache.get(devicePath, measurements);
   }
 
   public ClusterSchemaTree get(PartialPath fullPath) {
-    SchemaCacheEntry schemaCacheEntry =
-        dualKeyCache.get(fullPath.getDevicePath(), fullPath.getMeasurement());
-    ClusterSchemaTree schemaTree = new ClusterSchemaTree();
-    if (schemaCacheEntry != null) {
-      schemaTree.appendSingleMeasurement(
-          fullPath,
-          schemaCacheEntry.getMeasurementSchema(),
-          schemaCacheEntry.getTagMap(),
-          null,
-          schemaCacheEntry.isAligned());
-      schemaTree.setDatabases(Collections.singleton(schemaCacheEntry.getStorageGroup()));
-    }
-    return schemaTree;
-  }
-
-  public List<Integer> compute(ISchemaComputation schemaComputation) {
-    List<Integer> indexOfMissingMeasurements = new ArrayList<>();
-    final AtomicBoolean isFirstMeasurement = new AtomicBoolean(true);
-    dualKeyCache.compute(
-        new IDualKeyCacheComputation<PartialPath, String, SchemaCacheEntry>() {
-          @Override
-          public PartialPath getFirstKey() {
-            return schemaComputation.getDevicePath();
-          }
-
-          @Override
-          public String[] getSecondKeyList() {
-            return schemaComputation.getMeasurements();
-          }
-
-          @Override
-          public void computeValue(int index, SchemaCacheEntry value) {
-            if (value == null) {
-              indexOfMissingMeasurements.add(index);
-            } else {
-              if (isFirstMeasurement.get()) {
-                schemaComputation.computeDevice(value.isAligned());
-                isFirstMeasurement.getAndSet(false);
-              }
-              schemaComputation.computeMeasurement(index, value);
-            }
-          }
-        });
-    return indexOfMissingMeasurements;
-  }
-
-  public void put(ClusterSchemaTree schemaTree) {
-    for (MeasurementPath measurementPath : schemaTree.getAllMeasurement()) {
-      putSingleMeasurementPath(schemaTree.getBelongedDatabase(measurementPath), measurementPath);
+    ClusterSchemaTree clusterSchemaTree = deviceUsingTemplateSchemaCache.get(fullPath);
+    if (clusterSchemaTree == null) {
+      return timeSeriesSchemaCache.get(fullPath);
+    } else {
+      return clusterSchemaTree;
     }
   }
 
-  public void putSingleMeasurementPath(String storageGroup, MeasurementPath measurementPath) {
-    SchemaCacheEntry schemaCacheEntry =
-        new SchemaCacheEntry(
-            storageGroup,
-            (MeasurementSchema) measurementPath.getMeasurementSchema(),
-            measurementPath.getTagMap(),
-            measurementPath.isUnderAlignedEntity());
-    dualKeyCache.put(
-        measurementPath.getDevicePath(), measurementPath.getMeasurement(), schemaCacheEntry);
+  public List<Integer> computeWithoutTemplate(ISchemaComputation schemaComputation) {
+    return timeSeriesSchemaCache.compute(schemaComputation);
+  }
+
+  public List<Integer> computeWithTemplate(ISchemaComputation schemaComputation) {
+    return deviceUsingTemplateSchemaCache.compute(schemaComputation);
+  }
+
+  /**
+   * Store the fetched schema in either the schemaCache or templateSchemaCache, depending on its
+   * associated device.
+   */
+  public void put(ClusterSchemaTree tree) {
+    Optional<Pair<Template, ?>> templateInfo;
+    PartialPath devicePath;
+    Set<PartialPath> templateDevices = new HashSet<>();
+    Set<PartialPath> commonDevices = new HashSet<>();
+    for (MeasurementPath path : tree.getAllMeasurement()) {
+      devicePath = path.getDevicePath();
+      if (templateDevices.contains(devicePath)) {
+        continue;
+      }
+
+      if (commonDevices.contains(devicePath)) {
+        timeSeriesSchemaCache.putSingleMeasurementPath(tree.getBelongedDatabase(path), path);
+        continue;
+      }
+
+      templateInfo = Optional.ofNullable(templateManager.checkTemplateSetInfo(devicePath));
+      if (templateInfo.isPresent()) {
+        deviceUsingTemplateSchemaCache.put(
+            devicePath, tree.getBelongedDatabase(devicePath), templateInfo.get().left.getId());
+        templateDevices.add(devicePath);
+      } else {
+        timeSeriesSchemaCache.putSingleMeasurementPath(tree.getBelongedDatabase(path), path);
+        commonDevices.add(devicePath);
+      }
+    }
   }
 
   public TimeValuePair getLastCache(PartialPath seriesPath) {
-    SchemaCacheEntry entry =
-        dualKeyCache.get(seriesPath.getDevicePath(), seriesPath.getMeasurement());
-    if (null == entry) {
-      return null;
-    }
-
-    return DataNodeLastCacheManager.getLastCache(entry);
+    return timeSeriesSchemaCache.getLastCache(seriesPath);
   }
 
   /** get SchemaCacheEntry and update last cache */
@@ -223,13 +166,8 @@ public class DataNodeSchemaCache {
       TimeValuePair timeValuePair,
       boolean highPriorityUpdate,
       Long latestFlushedTime) {
-    SchemaCacheEntry entry = dualKeyCache.get(devicePath, measurement);
-    if (null == entry) {
-      return;
-    }
-
-    DataNodeLastCacheManager.updateLastCache(
-        entry, timeValuePair, highPriorityUpdate, latestFlushedTime);
+    timeSeriesSchemaCache.updateLastCache(
+        devicePath, measurement, timeValuePair, highPriorityUpdate, latestFlushedTime);
   }
 
   /**
@@ -242,33 +180,17 @@ public class DataNodeSchemaCache {
       TimeValuePair timeValuePair,
       boolean highPriorityUpdate,
       Long latestFlushedTime) {
-    PartialPath seriesPath = measurementPath.transformToPartialPath();
-    SchemaCacheEntry entry =
-        dualKeyCache.get(seriesPath.getDevicePath(), seriesPath.getMeasurement());
-    if (null == entry) {
-      synchronized (dualKeyCache) {
-        entry = dualKeyCache.get(seriesPath.getDevicePath(), seriesPath.getMeasurement());
-        if (null == entry) {
-          entry =
-              new SchemaCacheEntry(
-                  storageGroup,
-                  (MeasurementSchema) measurementPath.getMeasurementSchema(),
-                  measurementPath.getTagMap(),
-                  measurementPath.isUnderAlignedEntity());
-          dualKeyCache.put(seriesPath.getDevicePath(), seriesPath.getMeasurement(), entry);
-        }
-      }
-    }
-
-    DataNodeLastCacheManager.updateLastCache(
-        entry, timeValuePair, highPriorityUpdate, latestFlushedTime);
+    timeSeriesSchemaCache.updateLastCache(
+        storageGroup, measurementPath, timeValuePair, highPriorityUpdate, latestFlushedTime);
   }
 
   public void invalidateAll() {
-    dualKeyCache.invalidateAll();
+    deviceUsingTemplateSchemaCache.invalidateCache();
+    timeSeriesSchemaCache.invalidateAll();
   }
 
   public void cleanUp() {
-    dualKeyCache.cleanUp();
+    deviceUsingTemplateSchemaCache.invalidateCache();
+    timeSeriesSchemaCache.invalidateAll();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DeviceUsingTemplateSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DeviceUsingTemplateSchemaCache.java
@@ -64,6 +64,14 @@ public class DeviceUsingTemplateSchemaCache {
             .build();
   }
 
+  public long getHitCount() {
+    return cache.stats().hitCount();
+  }
+
+  public long getRequestCount() {
+    return cache.stats().requestCount();
+  }
+
   public ClusterSchemaTree get(PartialPath fullPath) {
     DeviceCacheEntry deviceCacheEntry = cache.getIfPresent(fullPath.getDevicePath());
     ClusterSchemaTree schemaTree = new ClusterSchemaTree();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.metadata.cache;
+
+import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.metadata.cache.dualkeycache.IDualKeyCache;
+import org.apache.iotdb.db.metadata.cache.dualkeycache.IDualKeyCacheComputation;
+import org.apache.iotdb.db.metadata.cache.dualkeycache.impl.DualKeyCacheBuilder;
+import org.apache.iotdb.db.metadata.cache.dualkeycache.impl.DualKeyCachePolicy;
+import org.apache.iotdb.db.mpp.common.schematree.ClusterSchemaTree;
+import org.apache.iotdb.db.mpp.plan.analyze.schema.ISchemaComputation;
+import org.apache.iotdb.tsfile.read.TimeValuePair;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TimeSeriesSchemaCache {
+
+  private static final Logger logger = LoggerFactory.getLogger(DataNodeSchemaCache.class);
+  private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
+
+  private final IDualKeyCache<PartialPath, String, SchemaCacheEntry> dualKeyCache;
+
+  TimeSeriesSchemaCache() {
+    DualKeyCacheBuilder<PartialPath, String, SchemaCacheEntry> dualKeyCacheBuilder =
+        new DualKeyCacheBuilder<>();
+    dualKeyCache =
+        dualKeyCacheBuilder
+            .cacheEvictionPolicy(DualKeyCachePolicy.LRU)
+            .memoryCapacity(config.getAllocateMemoryForSchemaCache())
+            .firstKeySizeComputer(PartialPath::estimateSize)
+            .secondKeySizeComputer(s -> 32 + 2 * s.length())
+            .valueSizeComputer(SchemaCacheEntry::estimateSize)
+            .build();
+  }
+
+  public double getHitRate() {
+    return dualKeyCache.stats().hitRate() * 100;
+  }
+
+  /**
+   * Get SchemaEntity info without auto create schema
+   *
+   * @param devicePath should not be measurementPath or AlignedPath
+   * @param measurements
+   * @return timeseries partialPath and its SchemaEntity
+   */
+  public ClusterSchemaTree get(PartialPath devicePath, String[] measurements) {
+    ClusterSchemaTree schemaTree = new ClusterSchemaTree();
+    Set<String> storageGroupSet = new HashSet<>();
+
+    dualKeyCache.compute(
+        new IDualKeyCacheComputation<PartialPath, String, SchemaCacheEntry>() {
+          @Override
+          public PartialPath getFirstKey() {
+            return devicePath;
+          }
+
+          @Override
+          public String[] getSecondKeyList() {
+            return measurements;
+          }
+
+          @Override
+          public void computeValue(int index, SchemaCacheEntry value) {
+            if (value != null) {
+              schemaTree.appendSingleMeasurement(
+                  devicePath.concatNode(value.getSchemaEntryId()),
+                  value.getMeasurementSchema(),
+                  value.getTagMap(),
+                  null,
+                  value.isAligned());
+              storageGroupSet.add(value.getStorageGroup());
+            }
+          }
+        });
+    schemaTree.setDatabases(storageGroupSet);
+    return schemaTree;
+  }
+
+  public ClusterSchemaTree get(PartialPath fullPath) {
+    SchemaCacheEntry schemaCacheEntry =
+        dualKeyCache.get(fullPath.getDevicePath(), fullPath.getMeasurement());
+    ClusterSchemaTree schemaTree = new ClusterSchemaTree();
+    if (schemaCacheEntry != null) {
+      schemaTree.appendSingleMeasurement(
+          fullPath,
+          schemaCacheEntry.getMeasurementSchema(),
+          schemaCacheEntry.getTagMap(),
+          null,
+          schemaCacheEntry.isAligned());
+      schemaTree.setDatabases(Collections.singleton(schemaCacheEntry.getStorageGroup()));
+    }
+    return schemaTree;
+  }
+
+  public List<Integer> compute(ISchemaComputation schemaComputation) {
+    List<Integer> indexOfMissingMeasurements = new ArrayList<>();
+    final AtomicBoolean isFirstMeasurement = new AtomicBoolean(true);
+    dualKeyCache.compute(
+        new IDualKeyCacheComputation<PartialPath, String, SchemaCacheEntry>() {
+          @Override
+          public PartialPath getFirstKey() {
+            return schemaComputation.getDevicePath();
+          }
+
+          @Override
+          public String[] getSecondKeyList() {
+            return schemaComputation.getMeasurements();
+          }
+
+          @Override
+          public void computeValue(int index, SchemaCacheEntry value) {
+            if (value == null) {
+              indexOfMissingMeasurements.add(index);
+            } else {
+              if (isFirstMeasurement.get()) {
+                schemaComputation.computeDevice(value.isAligned());
+                isFirstMeasurement.getAndSet(false);
+              }
+              schemaComputation.computeMeasurement(index, value);
+            }
+          }
+        });
+    return indexOfMissingMeasurements;
+  }
+
+  public void put(ClusterSchemaTree schemaTree) {
+    for (MeasurementPath measurementPath : schemaTree.getAllMeasurement()) {
+      putSingleMeasurementPath(schemaTree.getBelongedDatabase(measurementPath), measurementPath);
+    }
+  }
+
+  public void putSingleMeasurementPath(String storageGroup, MeasurementPath measurementPath) {
+    SchemaCacheEntry schemaCacheEntry =
+        new SchemaCacheEntry(
+            storageGroup,
+            (MeasurementSchema) measurementPath.getMeasurementSchema(),
+            measurementPath.getTagMap(),
+            measurementPath.isUnderAlignedEntity());
+    dualKeyCache.put(
+        measurementPath.getDevicePath(), measurementPath.getMeasurement(), schemaCacheEntry);
+  }
+
+  public TimeValuePair getLastCache(PartialPath seriesPath) {
+    SchemaCacheEntry entry =
+        dualKeyCache.get(seriesPath.getDevicePath(), seriesPath.getMeasurement());
+    if (null == entry) {
+      return null;
+    }
+
+    return DataNodeLastCacheManager.getLastCache(entry);
+  }
+
+  /** get SchemaCacheEntry and update last cache */
+  public void updateLastCache(
+      PartialPath devicePath,
+      String measurement,
+      TimeValuePair timeValuePair,
+      boolean highPriorityUpdate,
+      Long latestFlushedTime) {
+    SchemaCacheEntry entry = dualKeyCache.get(devicePath, measurement);
+    if (null == entry) {
+      return;
+    }
+
+    DataNodeLastCacheManager.updateLastCache(
+        entry, timeValuePair, highPriorityUpdate, latestFlushedTime);
+  }
+
+  /**
+   * get or create SchemaCacheEntry and update last cache, only support non-aligned sensor or
+   * aligned sensor without only one sub sensor
+   */
+  public void updateLastCache(
+      String storageGroup,
+      MeasurementPath measurementPath,
+      TimeValuePair timeValuePair,
+      boolean highPriorityUpdate,
+      Long latestFlushedTime) {
+    PartialPath seriesPath = measurementPath.transformToPartialPath();
+    SchemaCacheEntry entry =
+        dualKeyCache.get(seriesPath.getDevicePath(), seriesPath.getMeasurement());
+    if (null == entry) {
+      synchronized (dualKeyCache) {
+        entry = dualKeyCache.get(seriesPath.getDevicePath(), seriesPath.getMeasurement());
+        if (null == entry) {
+          entry =
+              new SchemaCacheEntry(
+                  storageGroup,
+                  (MeasurementSchema) measurementPath.getMeasurementSchema(),
+                  measurementPath.getTagMap(),
+                  measurementPath.isUnderAlignedEntity());
+          dualKeyCache.put(seriesPath.getDevicePath(), seriesPath.getMeasurement(), entry);
+        }
+      }
+    }
+
+    DataNodeLastCacheManager.updateLastCache(
+        entry, timeValuePair, highPriorityUpdate, latestFlushedTime);
+  }
+
+  public void invalidateAll() {
+    dualKeyCache.invalidateAll();
+  }
+
+  public void cleanUp() {
+    dualKeyCache.cleanUp();
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
@@ -62,8 +62,12 @@ public class TimeSeriesSchemaCache {
             .build();
   }
 
-  public double getHitRate() {
-    return dualKeyCache.stats().hitRate() * 100;
+  public long getHitCount() {
+    return dualKeyCache.stats().hitCount();
+  }
+
+  public long getRequestCount() {
+    return dualKeyCache.stats().requestCount();
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetcher.java
@@ -18,13 +18,11 @@
  */
 package org.apache.iotdb.db.mpp.plan.analyze.schema;
 
-import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.metadata.cache.DataNodeSchemaCache;
-import org.apache.iotdb.db.metadata.cache.DataNodeTemplateSchemaCache;
 import org.apache.iotdb.db.metadata.template.ClusterTemplateManager;
 import org.apache.iotdb.db.metadata.template.ITemplateManager;
 import org.apache.iotdb.db.metadata.template.Template;
@@ -46,7 +44,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -58,8 +55,6 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
   private final Coordinator coordinator = Coordinator.getInstance();
   private final DataNodeSchemaCache schemaCache = DataNodeSchemaCache.getInstance();
   private final ITemplateManager templateManager = ClusterTemplateManager.getInstance();
-  private final DataNodeTemplateSchemaCache templateSchemaCache =
-      DataNodeTemplateSchemaCache.getInstance();
   MPPQueryContext context = null;
 
   private final AutoCreateSchemaExecutor autoCreateSchemaExecutor =
@@ -90,16 +85,13 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
                   ClusterPartitionFetcher.getInstance(),
                   this,
                   config.getQueryTimeoutThreshold()),
-          this::cacheUpdater);
+          schemaCache::put);
 
   private final NormalSchemaFetcher normalSchemaFetcher =
       new NormalSchemaFetcher(schemaCache, autoCreateSchemaExecutor, clusterSchemaFetchExecutor);
   private final TemplateSchemaFetcher templateSchemaFetcher =
       new TemplateSchemaFetcher(
-          templateManager,
-          templateSchemaCache,
-          autoCreateSchemaExecutor,
-          clusterSchemaFetchExecutor);
+          templateManager, schemaCache, autoCreateSchemaExecutor, clusterSchemaFetchExecutor);
 
   private static final class ClusterSchemaFetcherHolder {
     private static final ClusterSchemaFetcher INSTANCE = new ClusterSchemaFetcher();
@@ -140,10 +132,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
         ClusterSchemaTree cachedSchema;
         Set<String> storageGroupSet = new HashSet<>();
         for (PartialPath fullPath : fullPathList) {
-          cachedSchema = templateSchemaCache.get(fullPath);
-          if (cachedSchema.isEmpty()) {
-            cachedSchema = schemaCache.get(fullPath);
-          }
+          cachedSchema = schemaCache.get(fullPath);
           if (cachedSchema.isEmpty()) {
             isAllCached = false;
             break;
@@ -170,45 +159,12 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
     return clusterSchemaFetchExecutor.fetchSchemaOfFuzzyMatch(patternTree, true);
   }
 
-  /**
-   * Store the fetched schema in either the schemaCache or templateSchemaCache, depending on its
-   * associated device.
-   */
-  private void cacheUpdater(ClusterSchemaTree tree) {
-    Optional<Pair<Template, ?>> templateInfo;
-    PartialPath devicePath;
-    Set<PartialPath> templateDevices = new HashSet<>();
-    Set<PartialPath> commonDevices = new HashSet<>();
-    for (MeasurementPath path : tree.getAllMeasurement()) {
-      devicePath = path.getDevicePath();
-      if (templateDevices.contains(devicePath)) {
-        continue;
-      }
-
-      if (commonDevices.contains(devicePath)) {
-        schemaCache.putSingleMeasurementPath(tree.getBelongedDatabase(path), path);
-        continue;
-      }
-
-      templateInfo = Optional.ofNullable(templateManager.checkTemplateSetInfo(devicePath));
-      if (templateInfo.isPresent()) {
-        templateSchemaCache.put(
-            devicePath, tree.getBelongedDatabase(devicePath), templateInfo.get().left.getId());
-        templateDevices.add(devicePath);
-      } else {
-        schemaCache.putSingleMeasurementPath(tree.getBelongedDatabase(path), path);
-        commonDevices.add(devicePath);
-      }
-    }
-  }
-
   @Override
   public void fetchAndComputeSchemaWithAutoCreate(
       ISchemaComputationWithAutoCreation schemaComputationWithAutoCreation) {
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
     // operation executed by delete timeseries will be effective.
     schemaCache.takeReadLock();
-    templateSchemaCache.takeReadLock();
     try {
       Pair<Template, PartialPath> templateSetInfo =
           templateManager.checkTemplateSetInfo(schemaComputationWithAutoCreation.getDevicePath());
@@ -235,7 +191,6 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
       }
     } finally {
       schemaCache.releaseReadLock();
-      templateSchemaCache.releaseReadLock();
     }
   }
 
@@ -245,7 +200,6 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
     // operation executed by delete timeseries will be effective.
     schemaCache.takeReadLock();
-    templateSchemaCache.takeReadLock();
     try {
 
       List<ISchemaComputationWithAutoCreation> normalTimeSeriesRequestList = new ArrayList<>();
@@ -273,7 +227,6 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
       }
     } finally {
       schemaCache.releaseReadLock();
-      templateSchemaCache.releaseReadLock();
     }
   }
 
@@ -429,7 +382,6 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
 
   @Override
   public void invalidAllCache() {
-    DataNodeSchemaCache.getInstance().invalidateAll();
-    DataNodeTemplateSchemaCache.getInstance().invalidateCache();
+    schemaCache.invalidateAll();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/NormalSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/NormalSchemaFetcher.java
@@ -50,7 +50,7 @@ class NormalSchemaFetcher {
   List<Integer> processNormalTimeSeries(
       ISchemaComputationWithAutoCreation schemaComputationWithAutoCreation) {
     List<Integer> indexOfMissingMeasurements =
-        schemaCache.compute(schemaComputationWithAutoCreation);
+        schemaCache.computeWithoutTemplate(schemaComputationWithAutoCreation);
     // all schema can be taken from cache
     if (indexOfMissingMeasurements.isEmpty()) {
       return indexOfMissingMeasurements;
@@ -98,7 +98,8 @@ class NormalSchemaFetcher {
     List<Integer> indexOfMissingMeasurements;
     for (int i = 0, size = schemaComputationWithAutoCreationList.size(); i < size; i++) {
       schemaComputationWithAutoCreation = schemaComputationWithAutoCreationList.get(i);
-      indexOfMissingMeasurements = schemaCache.compute(schemaComputationWithAutoCreation);
+      indexOfMissingMeasurements =
+          schemaCache.computeWithoutTemplate(schemaComputationWithAutoCreation);
       if (!indexOfMissingMeasurements.isEmpty()) {
         indexOfDevicesWithMissingMeasurements.add(i);
         indexOfMissingMeasurementsList.add(indexOfMissingMeasurements);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/TemplateSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/TemplateSchemaFetcher.java
@@ -22,7 +22,7 @@ package org.apache.iotdb.db.mpp.plan.analyze.schema;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.metadata.cache.DataNodeTemplateSchemaCache;
+import org.apache.iotdb.db.metadata.cache.DataNodeSchemaCache;
 import org.apache.iotdb.db.metadata.template.ITemplateManager;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.template.alter.TemplateExtendInfo;
@@ -43,14 +43,14 @@ class TemplateSchemaFetcher {
 
   private final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private final ITemplateManager templateManager;
-  private final DataNodeTemplateSchemaCache templateSchemaCache;
+  private final DataNodeSchemaCache templateSchemaCache;
 
   private final AutoCreateSchemaExecutor autoCreateSchemaExecutor;
   private final ClusterSchemaFetchExecutor clusterSchemaFetchExecutor;
 
   TemplateSchemaFetcher(
       ITemplateManager templateManager,
-      DataNodeTemplateSchemaCache templateSchemaCache,
+      DataNodeSchemaCache templateSchemaCache,
       AutoCreateSchemaExecutor autoCreateSchemaExecutor,
       ClusterSchemaFetchExecutor clusterSchemaFetchExecutor) {
     this.templateManager = templateManager;
@@ -80,7 +80,7 @@ class TemplateSchemaFetcher {
     }
 
     List<Integer> indexOfMissingMeasurements =
-        templateSchemaCache.conformsToTemplateCache(schemaComputationWithAutoCreation);
+        templateSchemaCache.computeWithTemplate(schemaComputationWithAutoCreation);
     // all schema can be taken from cache
     if (indexOfMissingMeasurements.isEmpty()) {
       return indexOfMissingMeasurements;
@@ -157,7 +157,7 @@ class TemplateSchemaFetcher {
     for (int i = 0, size = schemaComputationWithAutoCreationList.size(); i < size; i++) {
       schemaComputationWithAutoCreation = schemaComputationWithAutoCreationList.get(i);
       indexOfMissingMeasurements =
-          templateSchemaCache.conformsToTemplateCache(schemaComputationWithAutoCreation);
+          templateSchemaCache.computeWithTemplate(schemaComputationWithAutoCreation);
       if (!indexOfMissingMeasurements.isEmpty()) {
         indexOfDevicesWithMissingMeasurements.add(i);
         indexOfMissingMeasurementsList.add(indexOfMissingMeasurements);

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -62,7 +62,6 @@ import org.apache.iotdb.db.engine.settle.SettleRequestHandler;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.metadata.cache.DataNodeDevicePathCache;
 import org.apache.iotdb.db.metadata.cache.DataNodeSchemaCache;
-import org.apache.iotdb.db.metadata.cache.DataNodeTemplateSchemaCache;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
@@ -415,14 +414,11 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
   @Override
   public TSStatus invalidateSchemaCache(TInvalidateCacheReq req) {
     DataNodeSchemaCache.getInstance().takeWriteLock();
-    DataNodeTemplateSchemaCache.getInstance().takeWriteLock();
     try {
       DataNodeSchemaCache.getInstance().invalidateAll();
-      DataNodeTemplateSchemaCache.getInstance().invalidateCache();
       return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     } finally {
       DataNodeSchemaCache.getInstance().releaseWriteLock();
-      DataNodeTemplateSchemaCache.getInstance().releaseWriteLock();
     }
   }
 
@@ -488,16 +484,12 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
   public TSStatus invalidateMatchedSchemaCache(TInvalidateMatchedSchemaCacheReq req)
       throws TException {
     DataNodeSchemaCache cache = DataNodeSchemaCache.getInstance();
-    DataNodeTemplateSchemaCache templateSchemaCache = DataNodeTemplateSchemaCache.getInstance();
     cache.takeWriteLock();
-    templateSchemaCache.takeWriteLock();
     try {
       // todo implement precise timeseries clean rather than clean all
       cache.invalidateAll();
-      templateSchemaCache.invalidateCache();
     } finally {
       cache.releaseWriteLock();
-      templateSchemaCache.releaseWriteLock();
     }
     return RpcUtils.SUCCESS_STATUS;
   }


### PR DESCRIPTION
## Description

Currently, the DataNodeSchemaCache manages the timeseries not using template cache and DataNodeTemplateSchemaCache manages devices using template. It is hard to manage the total cache stats when keeping these separated. 

Combine these two cache.