### PR TITLE
Support update last cache for data insertion when using template

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1149,19 +1149,17 @@ public class DataRegion implements IDataRegionForQuery {
     if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()) {
       return;
     }
-    for (int i = 0; i < node.getColumns().length; i++) {
-      if (node.getColumns()[i] == null) {
-        continue;
-      }
-      // Update cached last value with high priority
-      DataNodeSchemaCache.getInstance()
-          .updateLastCache(
-              node.getDevicePath(),
-              node.getMeasurements()[i],
-              node.composeLastTimeValuePair(i),
-              true,
-              latestFlushedTime);
-    }
+    DataNodeSchemaCache.getInstance()
+        .updateLastCache(
+            getDatabaseName(),
+            node.getDevicePath(),
+            node.getMeasurements(),
+            node.getMeasurementSchemas(),
+            node.isAligned(),
+            node::composeLastTimeValuePair,
+            index -> node.getColumns()[index] != null,
+            true,
+            latestFlushedTime);
   }
 
   private void insertToTsFileProcessor(
@@ -1191,19 +1189,17 @@ public class DataRegion implements IDataRegionForQuery {
     if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()) {
       return;
     }
-    for (int i = 0; i < node.getValues().length; i++) {
-      if (node.getValues()[i] == null) {
-        continue;
-      }
-      // Update cached last value with high priority
-      DataNodeSchemaCache.getInstance()
-          .updateLastCache(
-              node.getDevicePath(),
-              node.getMeasurements()[i],
-              node.composeTimeValuePair(i),
-              true,
-              latestFlushedTime);
-    }
+    DataNodeSchemaCache.getInstance()
+        .updateLastCache(
+            getDatabaseName(),
+            node.getDevicePath(),
+            node.getMeasurements(),
+            node.getMeasurementSchemas(),
+            node.isAligned(),
+            node::composeTimeValuePair,
+            index -> node.getValues()[index] != null,
+            true,
+            latestFlushedTime);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1899,7 +1899,12 @@ public class DataRegion implements IDataRegionForQuery {
 
       // delete Last cache record if necessary
       // todo implement more precise process
-      DataNodeSchemaCache.getInstance().invalidateAll();
+      DataNodeSchemaCache.getInstance().takeWriteLock();
+      try {
+        DataNodeSchemaCache.getInstance().invalidateAll();
+      } finally {
+        DataNodeSchemaCache.getInstance().releaseWriteLock();
+      }
 
       // write log to impacted working TsFileProcessors
       List<WALFlushListener> walListeners =
@@ -2308,7 +2313,12 @@ public class DataRegion implements IDataRegionForQuery {
     if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()) {
       return;
     }
-    DataNodeSchemaCache.getInstance().invalidateAll();
+    DataNodeSchemaCache.getInstance().takeWriteLock();
+    try {
+      DataNodeSchemaCache.getInstance().invalidateAll();
+    } finally {
+      DataNodeSchemaCache.getInstance().releaseWriteLock();
+    }
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.mpp.common.schematree.ClusterSchemaTree;
 import org.apache.iotdb.db.mpp.plan.analyze.schema.ISchemaComputation;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
 /**
  * This class takes the responsibility of metadata cache management of all DataRegions under
@@ -171,6 +173,28 @@ public class DataNodeSchemaCache {
       Long latestFlushedTime) {
     timeSeriesSchemaCache.updateLastCache(
         devicePath, measurement, timeValuePair, highPriorityUpdate, latestFlushedTime);
+  }
+
+  public void updateLastCache(
+      String database,
+      PartialPath devicePath,
+      String[] measurements,
+      MeasurementSchema[] measurementSchemas,
+      boolean isAligned,
+      Function<Integer, TimeValuePair> timeValuePairProvider,
+      Function<Integer, Boolean> shouldUpdateProvider,
+      boolean highPriorityUpdate,
+      Long latestFlushedTime) {
+    timeSeriesSchemaCache.updateLastCache(
+        database,
+        devicePath,
+        measurements,
+        measurementSchemas,
+        isAligned,
+        timeValuePairProvider,
+        shouldUpdateProvider,
+        highPriorityUpdate,
+        latestFlushedTime);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
@@ -233,9 +233,10 @@ public class TimeSeriesSchemaCache {
             }
             if (value == null) {
               missingMeasurements.add(index);
+            } else {
+              DataNodeLastCacheManager.updateLastCache(
+                  value, timeValuePairProvider.apply(index), highPriorityUpdate, latestFlushedTime);
             }
-            DataNodeLastCacheManager.updateLastCache(
-                value, timeValuePairProvider.apply(index), highPriorityUpdate, latestFlushedTime);
           }
         });
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/dualkeycache/IDualKeyCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/dualkeycache/IDualKeyCache.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.db.metadata.cache.dualkeycache;
 
+import javax.annotation.concurrent.GuardedBy;
+
 /**
  * This interfaces defines the behaviour of a dual key cache. A dual key cache supports manage cache
  * values via two keys, first key and second key. Simply, the structure is like fk -> sk-> value.
@@ -45,11 +47,13 @@ public interface IDualKeyCache<FK, SK, V> {
    * Invalidate all cache values in the cache and clear related cache keys. The cache status and
    * statistics won't be clear and they can still be accessed via cache.stats().
    */
+  @GuardedBy("DataNodeSchemaCache#writeLock")
   void invalidateAll();
 
   /**
    * Clean up all data and info of this cache, including cache keys, cache values and cache stats.
    */
+  @GuardedBy("DataNodeSchemaCache#writeLock")
   void cleanUp();
 
   /** Return all the current cache status and statistics. */

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/dualkeycache/impl/CacheEntryGroupImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/dualkeycache/impl/CacheEntryGroupImpl.java
@@ -42,7 +42,7 @@ public class CacheEntryGroupImpl<FK, SK, V, T extends ICacheEntry<SK, V>>
 
   @Override
   public T getCacheEntry(SK secondKey) {
-    return cacheEntryMap.get(secondKey);
+    return secondKey == null ? null : cacheEntryMap.get(secondKey);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetcher.java
@@ -379,9 +379,4 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
 
     return indexOfMissingMeasurements;
   }
-
-  @Override
-  public void invalidAllCache() {
-    schemaCache.invalidateAll();
-  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ISchemaFetcher.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ISchemaFetcher.java
@@ -92,6 +92,4 @@ public interface ISchemaFetcher {
   Map<Integer, Template> checkAllRelatedTemplate(PartialPath pathPattern);
 
   Pair<Template, List<PartialPath>> getAllPathsSetTemplate(String templateName);
-
-  void invalidAllCache();
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -1625,7 +1625,12 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
     status.setMessage("disable datanode succeed");
     // TODO what need to clean?
     ClusterPartitionFetcher.getInstance().invalidAllCache();
-    DataNodeSchemaCache.getInstance().cleanUp();
+    DataNodeSchemaCache.getInstance().takeWriteLock();
+    try {
+      DataNodeSchemaCache.getInstance().cleanUp();
+    } finally {
+      DataNodeSchemaCache.getInstance().releaseWriteLock();
+    }
     DataNodeDevicePathCache.getInstance().cleanUp();
     return status;
   }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCacheTest.java
@@ -261,5 +261,26 @@ public class DataNodeSchemaCacheTest {
     Assert.assertNotNull(dataNodeSchemaCache.getLastCache(new PartialPath("root.db.d.s1")));
     Assert.assertNull(dataNodeSchemaCache.getLastCache(new PartialPath("root.db.d.s2")));
     Assert.assertNotNull(dataNodeSchemaCache.getLastCache(new PartialPath("root.db.d.s3")));
+
+    dataNodeSchemaCache.updateLastCache(
+        database,
+        device,
+        measurements,
+        measurementSchemas,
+        true,
+        index -> new TimeValuePair(2, new TsPrimitiveType.TsInt(2)),
+        index -> true,
+        true,
+        1L);
+
+    Assert.assertEquals(
+        new TimeValuePair(2, new TsPrimitiveType.TsInt(2)),
+        dataNodeSchemaCache.getLastCache(new PartialPath("root.db.d.s1")));
+    Assert.assertEquals(
+        new TimeValuePair(2, new TsPrimitiveType.TsInt(2)),
+        dataNodeSchemaCache.getLastCache(new PartialPath("root.db.d.s2")));
+    Assert.assertEquals(
+        new TimeValuePair(2, new TsPrimitiveType.TsInt(2)),
+        dataNodeSchemaCache.getLastCache(new PartialPath("root.db.d.s3")));
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCacheTest.java
@@ -233,4 +233,33 @@ public class DataNodeSchemaCacheTest {
     schemaTree.setDatabases(Collections.singleton("root.sg1"));
     return schemaTree;
   }
+
+  @Test
+  public void testUpdateLastCache() throws IllegalPathException {
+    String database = "root.db";
+    PartialPath device = new PartialPath("root.db.d");
+
+    String[] measurements = new String[] {"s1", "s2", "s3"};
+    MeasurementSchema[] measurementSchemas =
+        new MeasurementSchema[] {
+          new MeasurementSchema("s1", TSDataType.INT32),
+          new MeasurementSchema("s2", TSDataType.INT32),
+          new MeasurementSchema("s3", TSDataType.INT32)
+        };
+
+    dataNodeSchemaCache.updateLastCache(
+        database,
+        device,
+        measurements,
+        measurementSchemas,
+        true,
+        index -> new TimeValuePair(1, new TsPrimitiveType.TsInt(1)),
+        index -> index != 1,
+        true,
+        1L);
+
+    Assert.assertNotNull(dataNodeSchemaCache.getLastCache(new PartialPath("root.db.d.s1")));
+    Assert.assertNull(dataNodeSchemaCache.getLastCache(new PartialPath("root.db.d.s2")));
+    Assert.assertNotNull(dataNodeSchemaCache.getLastCache(new PartialPath("root.db.d.s3")));
+  }
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/analyze/FakeSchemaFetcherImpl.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/analyze/FakeSchemaFetcherImpl.java
@@ -147,7 +147,4 @@ public class FakeSchemaFetcherImpl implements ISchemaFetcher {
   public Pair<Template, List<PartialPath>> getAllPathsSetTemplate(String templateName) {
     return null;
   }
-
-  @Override
-  public void invalidAllCache() {}
 }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/Util.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/distribution/Util.java
@@ -343,9 +343,6 @@ public class Util {
       public Pair<Template, List<PartialPath>> getAllPathsSetTemplate(String templateName) {
         return null;
       }
-
-      @Override
-      public void invalidAllCache() {}
     };
   }
 


### PR DESCRIPTION
## Description

Currently, when using template, last cache won't be updated after data insertion since the cache entry hasn't been initialized and cached during schema validation.

Thanks to all related info is present in data insertion plan, we can directly initialize a cache entry and cache the schema and last value.