### PR TITLE
[IOTDB-5807]Fix decompression error for aligned series in fast compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
@@ -52,14 +52,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
-import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TIME_COLUMN_ID;
 
 public class FastCompactionPerformer
     implements ICrossCompactionPerformer, ISeqCompactionPerformer, IUnseqCompactionPerformer {
@@ -172,7 +170,7 @@ public class FastCompactionPerformer
       throws PageException, IOException, WriteProcessException, IllegalPathException {
     // measurement -> tsfile resource -> timeseries metadata <startOffset, endOffset>
     Map<String, Map<TsFileResource, Pair<Long, Long>>> timeseriesMetadataOffsetMap =
-        new HashMap<>();
+        new LinkedHashMap<>();
     List<IMeasurementSchema> measurementSchemas = new ArrayList<>();
 
     // Get all value measurements and their schemas of the current device. Also get start offset and
@@ -184,9 +182,7 @@ public class FastCompactionPerformer
     // overlapped tsfiles contain all the value measurements.
     for (Map.Entry<String, Pair<MeasurementSchema, Map<TsFileResource, Pair<Long, Long>>>> entry :
         deviceIterator.getTimeseriesSchemaAndMetadataOffsetOfCurrentDevice().entrySet()) {
-      if (!entry.getKey().equals(TIME_COLUMN_ID)) {
-        measurementSchemas.add(entry.getValue().left);
-      }
+      measurementSchemas.add(entry.getValue().left);
       timeseriesMetadataOffsetMap.put(entry.getKey(), entry.getValue().right);
     }
 
@@ -218,6 +214,7 @@ public class FastCompactionPerformer
         deviceIterator.getTimeseriesMetadataOffsetOfCurrentDevice();
 
     List<String> allMeasurements = new ArrayList<>(timeseriesMetadataOffsetMap.keySet());
+    allMeasurements.sort((String::compareTo));
 
     int subTaskNums = Math.min(allMeasurements.size(), subTaskNum);
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/ReadPointCompactionPerformer.java
@@ -42,6 +42,7 @@ import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.reader.IPointReader;
 import org.apache.iotdb.tsfile.utils.Pair;
@@ -155,6 +156,7 @@ public class ReadPointCompactionPerformer
       QueryDataSource queryDataSource)
       throws IOException, MetadataException {
     Map<String, MeasurementSchema> schemaMap = deviceIterator.getAllSchemasOfCurrentDevice();
+    IMeasurementSchema timeSchema = schemaMap.remove(TsFileConstant.TIME_COLUMN_ID);
     List<IMeasurementSchema> measurementSchemas = new ArrayList<>(schemaMap.values());
     if (measurementSchemas.isEmpty()) {
       return;
@@ -176,6 +178,7 @@ public class ReadPointCompactionPerformer
     if (dataBlockReader.hasNextBatch()) {
       // chunkgroup is serialized only when at least one timeseries under this device has data
       compactionWriter.startChunkGroup(device, true);
+      measurementSchemas.add(0, timeSchema);
       compactionWriter.startMeasurement(measurementSchemas, 0);
       writeWithReader(compactionWriter, dataBlockReader, device, 0, true);
       compactionWriter.endMeasurement(0);

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/MultiTsFileDeviceIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/MultiTsFileDeviceIterator.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -197,7 +198,6 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
         }
       }
     }
-    schemaMap.remove("");
     return schemaMap;
   }
 
@@ -247,7 +247,7 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
   public Map<String, Pair<MeasurementSchema, Map<TsFileResource, Pair<Long, Long>>>>
       getTimeseriesSchemaAndMetadataOffsetOfCurrentDevice() throws IOException {
     Map<String, Pair<MeasurementSchema, Map<TsFileResource, Pair<Long, Long>>>>
-        timeseriesMetadataOffsetMap = new HashMap<>();
+        timeseriesMetadataOffsetMap = new LinkedHashMap<>();
     for (TsFileResource resource : tsFileResourcesSortedByDesc) {
       if (!deviceIteratorMap.containsKey(resource)
           || !deviceIteratorMap.get(resource).current().equals(currentDevice)) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
@@ -52,6 +52,7 @@ import java.util.Map;
 public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
 
   // measurementID -> tsfile resource -> timeseries metadata <startOffset, endOffset>
+  // linked hash map, which has the same measurement lexicographical order as measurementSchemas.
   // used to get the chunk metadatas from tsfile directly according to timeseries metadata offset.
   private final Map<String, Map<TsFileResource, Pair<Long, Long>>> timeseriesMetadataOffsetMap;
 
@@ -274,7 +275,7 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
               alignedPageHeaders,
               compressedTimePageDatas.get(i),
               alignedPageDatas,
-              new AlignedChunkReader(timeChunk, valueChunks, null),
+              new AlignedChunkReader(timeChunk, valueChunks),
               chunkMetadataElement,
               i == timePageHeaders.size() - 1,
               chunkMetadataElement.priority));

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/writer/AbstractCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/writer/AbstractCompactionWriter.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.schedule.constant.CompactionType;
 import org.apache.iotdb.db.engine.compaction.schedule.constant.ProcessChunkType;
 import org.apache.iotdb.db.service.metrics.recorder.CompactionMetricsManager;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.exception.write.PageException;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
@@ -106,8 +107,10 @@ public abstract class AbstractCompactionWriter implements AutoCloseable {
     lastCheckIndex = 0;
     lastTime[subTaskId] = Long.MIN_VALUE;
     if (isAlign) {
-      chunkWriters[subTaskId] = new AlignedChunkWriterImpl(measurementSchemaList);
-      measurementId[subTaskId] = "";
+      // the first is time schema and the rest is value schema list
+      chunkWriters[subTaskId] =
+          new AlignedChunkWriterImpl(measurementSchemaList.remove(0), measurementSchemaList);
+      measurementId[subTaskId] = TsFileConstant.TIME_COLUMN_ID;
     } else {
       chunkWriters[subTaskId] = new ChunkWriterImpl(measurementSchemaList.get(0), true);
       measurementId[subTaskId] = measurementSchemaList.get(0).getMeasurementId();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -84,6 +84,9 @@ public class AbstractCompactionTest {
   protected static String COMPACTION_TEST_SG = TsFileGeneratorUtils.testStorageGroup;
   private TSDataType dataType;
 
+  protected int maxDeviceNum = 25;
+  protected int maxMeasurementNum = 25;
+
   private static final long oldTargetChunkSize =
       IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastNonAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastNonAlignedCrossCompactionTest.java
@@ -30,7 +30,9 @@ import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.write.chunk.ChunkWriterImpl;
@@ -49,7 +51,9 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createChunkWriter;
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createCompressionType;
 import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createDataType;
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createEncodingType;
 import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createTimeseries;
 import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.testStorageGroup;
 import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.writeNonAlignedChunk;
@@ -91,6 +95,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(10);
+        List<TSEncoding> encodings = createEncodingType(10);
+        List<CompressionType> compressionTypes = createCompressionType(10);
         List<PartialPath> timeseriesPath = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
           timeseriesPath.add(
@@ -109,12 +115,13 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         pages.add(new TimeRange(0L, 300L));
         pages.add(new TimeRange(500L, 600L));
 
-        for (IChunkWriter iChunkWriter : createChunkWriter(timeseriesPath, dataTypes, false)) {
+        for (IChunkWriter iChunkWriter :
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false)) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
         tsFileIOWriter.endChunkGroup();
         resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 0);
-        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 599);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 600);
         timeserisPathList.addAll(timeseriesPath);
         tsDataTypes.addAll(dataTypes);
       }
@@ -124,13 +131,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     seqResources.add(resource);
 
     // unseq file 1
+    int measurementNum = 5;
     resource = createEmptyFileAndResource(false);
     try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
       // write the data in device
       for (int deviceIndex = 0; deviceIndex < 15; deviceIndex++) {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
-        List<TSDataType> dataTypes = createDataType(5);
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<PartialPath> timeseriesPath = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
           timeseriesPath.add(
@@ -148,12 +158,13 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<TimeRange> pages = new ArrayList<>();
         pages.add(new TimeRange(200L, 2200L));
 
-        for (IChunkWriter iChunkWriter : createChunkWriter(timeseriesPath, dataTypes, false)) {
+        for (IChunkWriter iChunkWriter :
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false)) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
         tsFileIOWriter.endChunkGroup();
         resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 200);
-        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2199);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2200);
         timeserisPathList.addAll(timeseriesPath);
         tsDataTypes.addAll(dataTypes);
       }
@@ -163,13 +174,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     unseqResources.add(resource);
 
     // seq file 2
+    measurementNum = 5;
     resource = createEmptyFileAndResource(true);
     try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
       // write the data in device
       for (int deviceIndex = 0; deviceIndex < 12; deviceIndex++) {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
-        List<TSDataType> dataTypes = createDataType(5);
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<PartialPath> timeseriesPath = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
           timeseriesPath.add(
@@ -189,12 +203,13 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         pages.add(new TimeRange(1550L, 1700L));
         pages.add(new TimeRange(1750L, 2000L));
 
-        for (IChunkWriter iChunkWriter : createChunkWriter(timeseriesPath, dataTypes, false)) {
+        for (IChunkWriter iChunkWriter :
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false)) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
         tsFileIOWriter.endChunkGroup();
         resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 900);
-        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 1999);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2000);
         timeserisPathList.addAll(timeseriesPath);
         tsDataTypes.addAll(dataTypes);
       }
@@ -204,13 +219,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     seqResources.add(resource);
 
     // unseq file 2
+    measurementNum = 5;
     resource = createEmptyFileAndResource(false);
     try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
       // write the data in device
       for (int deviceIndex = 0; deviceIndex < 15; deviceIndex++) {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
-        List<TSDataType> dataTypes = createDataType(5);
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<PartialPath> timeseriesPath = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
           timeseriesPath.add(
@@ -230,12 +248,13 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         pages.add(new TimeRange(1200L, 1300L));
         pages.add(new TimeRange(1500L, 1600L));
 
-        for (IChunkWriter iChunkWriter : createChunkWriter(timeseriesPath, dataTypes, false)) {
+        for (IChunkWriter iChunkWriter :
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false)) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
         tsFileIOWriter.endChunkGroup();
         resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 550);
-        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 1599);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 1600);
         timeserisPathList.addAll(timeseriesPath);
         tsDataTypes.addAll(dataTypes);
       }
@@ -249,7 +268,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -282,6 +301,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -293,7 +314,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         pages.add(new TimeRange(100L, 300L));
         pages.add(new TimeRange(500L, 600L));
 
-        for (IChunkWriter iChunkWriter : createChunkWriter(timeseriesPath, dataTypes, false)) {
+        for (IChunkWriter iChunkWriter :
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false)) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
         tsFileIOWriter.endChunkGroup();
@@ -317,6 +339,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -329,7 +353,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(900L, 1189L));
         timeRanges.add(new TimeRange(1301L, 1400L));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeOneNonAlignedPage((ChunkWriterImpl) iChunkWriter, timeRanges, true);
           ((ChunkWriterImpl) iChunkWriter).writeToFileWriter(tsFileIOWriter);
@@ -365,6 +390,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -377,7 +404,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(0L, 1189L));
         timeRanges.add(new TimeRange(1301L, 2000L));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeOneNonAlignedPage((ChunkWriterImpl) iChunkWriter, timeRanges, false);
           ((ChunkWriterImpl) iChunkWriter).writeToFileWriter(tsFileIOWriter);
@@ -411,6 +439,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -424,7 +454,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(1200L, 1300L));
         timeRanges.add(new TimeRange(1500L, 2200L));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
         }
@@ -450,6 +481,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -463,7 +496,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(550L, 700L));
         timeRanges.add(new TimeRange(1050L, 1150L));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
         }
@@ -484,7 +518,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -516,6 +550,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -527,7 +563,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         pages.add(new TimeRange(100L, 300L));
         pages.add(new TimeRange(500L, 600L));
 
-        for (IChunkWriter iChunkWriter : createChunkWriter(timeseriesPath, dataTypes, false)) {
+        for (IChunkWriter iChunkWriter :
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false)) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
         tsFileIOWriter.endChunkGroup();
@@ -551,6 +588,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -563,7 +602,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(900L, 1249L));
         timeRanges.add(new TimeRange(1351L, 1400L));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeOneNonAlignedPage((ChunkWriterImpl) iChunkWriter, timeRanges, true);
           ((ChunkWriterImpl) iChunkWriter).writeToFileWriter(tsFileIOWriter);
@@ -599,6 +639,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -611,7 +653,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(0L, 1249L));
         timeRanges.add(new TimeRange(1351L, 2000L));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeOneNonAlignedPage((ChunkWriterImpl) iChunkWriter, timeRanges, false);
           ((ChunkWriterImpl) iChunkWriter).writeToFileWriter(tsFileIOWriter);
@@ -645,6 +688,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -658,7 +703,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(1250L, 1350L));
         timeRanges.add(new TimeRange(1500L, 2200L));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
         }
@@ -684,6 +730,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -697,7 +745,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(550L, 700L));
         timeRanges.add(new TimeRange(1050L, 1150L));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
         }
@@ -718,7 +767,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -750,6 +799,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -757,7 +808,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -798,13 +850,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -837,13 +892,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -888,13 +946,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -928,13 +989,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -970,7 +1034,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -1002,6 +1066,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -1009,7 +1075,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1050,13 +1117,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1089,13 +1159,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1134,13 +1207,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -1185,13 +1261,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1232,13 +1311,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1272,13 +1354,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -1315,7 +1400,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -1347,6 +1432,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -1354,7 +1441,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1395,13 +1483,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1434,13 +1525,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1479,13 +1573,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -1530,13 +1627,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1577,13 +1677,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1617,13 +1720,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -1667,7 +1773,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -1699,6 +1805,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -1706,7 +1814,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1749,13 +1858,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1796,13 +1908,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1841,13 +1956,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -1892,13 +2010,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1939,13 +2060,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -1979,13 +2103,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -2029,7 +2156,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -2061,6 +2188,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -2068,7 +2197,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2109,13 +2239,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2148,13 +2281,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2195,13 +2331,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -2246,13 +2385,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2293,13 +2435,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2333,13 +2478,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -2376,7 +2524,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -2408,6 +2556,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -2415,7 +2565,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2456,13 +2607,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2495,13 +2649,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2542,13 +2699,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -2593,13 +2753,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2640,13 +2803,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2680,13 +2846,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -2724,7 +2893,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -2756,6 +2925,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -2763,7 +2934,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2806,13 +2978,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2853,13 +3028,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2900,13 +3078,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -2951,13 +3132,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -2998,13 +3182,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3038,13 +3225,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -3082,7 +3272,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -3114,6 +3304,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -3121,7 +3313,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3162,13 +3355,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3204,13 +3400,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3254,13 +3453,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -3311,13 +3513,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3360,13 +3565,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3400,13 +3608,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -3453,13 +3664,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3492,7 +3706,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -3524,6 +3738,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -3531,7 +3747,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3574,13 +3791,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3616,13 +3836,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3666,13 +3889,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -3724,13 +3950,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3773,13 +4002,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3813,13 +4045,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -3866,13 +4101,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3905,7 +4143,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -3937,6 +4175,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -3944,7 +4184,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -3987,13 +4228,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4029,13 +4273,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4079,13 +4326,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -4137,13 +4387,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4186,13 +4439,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4226,13 +4482,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -4279,13 +4538,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4318,7 +4580,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -4350,6 +4612,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -4357,7 +4621,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4400,13 +4665,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4442,13 +4710,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4492,13 +4763,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -4550,13 +4824,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4599,13 +4876,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4639,13 +4919,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -4692,13 +4975,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4736,13 +5022,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4780,7 +5069,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -4812,6 +5101,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -4819,7 +5110,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4862,13 +5154,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4904,13 +5199,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -4954,13 +5252,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -5009,13 +5310,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -5058,13 +5362,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -5098,13 +5405,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -5151,13 +5461,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -5190,7 +5503,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -5222,6 +5535,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5235,7 +5550,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         pages.add(new TimeRange(100, 199));
         pages.add(new TimeRange(200, 300));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -5268,6 +5584,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5278,7 +5596,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(900, 1400, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -5316,6 +5635,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5326,7 +5647,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(200, 2200, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -5352,6 +5674,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5362,7 +5686,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(550, 800, 70);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -5396,7 +5721,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -5428,6 +5753,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5438,7 +5765,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(100, 300, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -5470,6 +5798,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5481,7 +5811,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<TimeRange> pages = createPages(900, 1199, 100);
         pages.addAll(createPages(1301, 1400, 100));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -5525,6 +5856,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5536,7 +5869,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<TimeRange> pages = createPages(0, 1199, 50);
         pages.addAll(createPages(1301, 2000, 100));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -5568,6 +5902,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5578,7 +5914,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(550, 800, 70);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -5617,6 +5954,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5627,7 +5966,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(350, 400, 70);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -5661,7 +6001,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -5693,6 +6033,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5703,7 +6045,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(0, 300, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -5735,6 +6078,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5746,7 +6091,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<TimeRange> pages = createPages(900, 1199, 100);
         pages.addAll(createPages(1301, 1400, 100));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -5771,6 +6117,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5781,7 +6129,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(1800, 1900, 30);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -5819,6 +6168,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5830,7 +6181,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<TimeRange> pages = createPages(100, 1199, 50);
         pages.addAll(createPages(1301, 1650, 100));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -5862,6 +6214,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5872,7 +6226,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(2200, 2400, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -5905,6 +6260,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5915,7 +6272,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(550, 800, 70);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -5959,6 +6317,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -5969,7 +6329,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(350, 400, 25);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -6007,6 +6368,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6017,7 +6380,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(2700, 2800, 25);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -6044,7 +6408,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -6076,6 +6440,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6083,7 +6449,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -6124,13 +6491,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -6163,13 +6533,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -6210,13 +6583,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -6261,13 +6637,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -6308,13 +6687,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> pages = new ArrayList<>();
@@ -6348,13 +6730,16 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
         }
         List<PartialPath> timeseriesPath =
             createTimeseries(deviceIndex, measurementIndexes, dataTypes, false);
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
 
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
@@ -6392,7 +6777,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -6424,6 +6809,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6434,7 +6821,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(300, 600, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -6472,6 +6860,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6482,7 +6872,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(1600, 1900, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -6514,6 +6905,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6524,7 +6917,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(0, 2000, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -6550,6 +6944,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6560,7 +6956,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(100, 400, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -6593,6 +6990,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6603,7 +7002,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(450, 950, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -6631,7 +7031,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -6663,6 +7063,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6678,7 +7080,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         pages.add(new TimeRange(900, 1100));
         pages.add(new TimeRange(1400, 1600));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -6704,6 +7107,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6714,7 +7119,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> timeRanges = new ArrayList<>();
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           // first page
           timeRanges.clear();
@@ -6765,7 +7171,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -6797,6 +7203,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6807,7 +7215,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(0, 1000, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
@@ -6845,6 +7254,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6855,7 +7266,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(50, 250, 100);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -6902,6 +7314,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(testStorageGroup + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6912,7 +7326,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         // write first chunk
         List<TimeRange> pages = createPages(700, 800, 50);
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, false);
         }
@@ -6947,7 +7362,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,
@@ -6980,6 +7395,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -6991,7 +7408,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         pages.add(new TimeRange(0, 300L));
         pages.add(new TimeRange(500L, 600L));
 
-        for (IChunkWriter iChunkWriter : createChunkWriter(timeseriesPath, dataTypes, false)) {
+        for (IChunkWriter iChunkWriter :
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false)) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
         }
         tsFileIOWriter.endChunkGroup();
@@ -7015,6 +7433,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -7028,7 +7448,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(1350, 1700));
         timeRanges.add(new TimeRange(1750, 2000));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, true);
         }
@@ -7061,6 +7482,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -7072,7 +7495,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         List<TimeRange> timeRanges = new ArrayList<>();
         timeRanges.add(new TimeRange(500, 950));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
         }
@@ -7114,6 +7538,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
 
         List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
         List<Integer> measurementIndexes = new ArrayList<>();
         for (int i = 0; i < measurementNum; i++) {
           measurementIndexes.add(i);
@@ -7126,7 +7552,8 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
         timeRanges.add(new TimeRange(500, 800));
         timeRanges.add(new TimeRange(850, 950));
 
-        List<IChunkWriter> iChunkWriters = createChunkWriter(timeseriesPath, dataTypes, false);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false);
         for (IChunkWriter iChunkWriter : iChunkWriters) {
           writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, timeRanges, false);
         }
@@ -7156,7 +7583,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     tsFileManager.addAll(unseqResources, false);
 
     Map<PartialPath, List<TimeValuePair>> sourceDatas =
-        readSourceFiles(timeserisPathList, tsDataTypes);
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
     CrossSpaceCompactionTask task =
         new CrossSpaceCompactionTask(
             0,

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadChunkInnerCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadChunkInnerCompactionTest.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.engine.compaction;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.compaction.execute.performer.impl.ReadChunkCompactionPerformer;
+import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.exception.StorageEngineException;
+import org.apache.iotdb.db.query.control.FileReaderManager;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.TimeValuePair;
+import org.apache.iotdb.tsfile.read.common.TimeRange;
+import org.apache.iotdb.tsfile.write.chunk.AlignedChunkWriterImpl;
+import org.apache.iotdb.tsfile.write.chunk.ChunkWriterImpl;
+import org.apache.iotdb.tsfile.write.chunk.IChunkWriter;
+import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createChunkWriter;
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createCompressionType;
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createDataType;
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createEncodingType;
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.createTimeseries;
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.writeAlignedChunk;
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.writeNonAlignedChunk;
+import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.writeOneAlignedPage;
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
+
+public class ReadChunkInnerCompactionTest extends AbstractCompactionTest {
+  @Before
+  public void setUp()
+      throws IOException, WriteProcessException, MetadataException, InterruptedException {
+    super.setUp();
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkSize(512);
+    IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(100);
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
+    TSFileDescriptor.getInstance().getConfig().setMaxDegreeOfIndexNode(3);
+  }
+
+  @After
+  public void tearDown() throws IOException, StorageEngineException {
+    super.tearDown();
+    for (TsFileResource tsFileResource : seqResources) {
+      FileReaderManager.getInstance().closeFileAndRemoveReader(tsFileResource.getTsFilePath());
+    }
+    for (TsFileResource tsFileResource : unseqResources) {
+      FileReaderManager.getInstance().closeFileAndRemoveReader(tsFileResource.getTsFilePath());
+    }
+  }
+
+  @Test
+  public void testNonAlignedWithDifferentEncodingAndCompression()
+      throws MetadataException, IOException {
+    List<PartialPath> timeserisPathList = new ArrayList<>();
+    List<TSDataType> tsDataTypes = new ArrayList<>();
+    // seq file 1
+    int measurementNum = 20;
+    TsFileResource resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < 10; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
+        List<PartialPath> timeseriesPath = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          timeseriesPath.add(
+              new MeasurementPath(
+                  COMPACTION_TEST_SG
+                      + PATH_SEPARATOR
+                      + "d"
+                      + deviceIndex
+                      + PATH_SEPARATOR
+                      + "s"
+                      + i,
+                  dataTypes.get(i)));
+        }
+
+        List<TimeRange> pages = new ArrayList<>();
+        pages.add(new TimeRange(0L, 300L));
+        pages.add(new TimeRange(500L, 600L));
+
+        for (IChunkWriter iChunkWriter :
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false)) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 0);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 600);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // seq file 2
+    measurementNum = 15;
+    resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < 12; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
+        List<PartialPath> timeseriesPath = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+          timeseriesPath.add(
+              new MeasurementPath(
+                  COMPACTION_TEST_SG
+                      + PATH_SEPARATOR
+                      + "d"
+                      + deviceIndex
+                      + PATH_SEPARATOR
+                      + "s"
+                      + i,
+                  dataTypes.get(i)));
+        }
+
+        List<TimeRange> pages = new ArrayList<>();
+        pages.add(new TimeRange(900L, 1400L));
+        pages.add(new TimeRange(1550L, 1700L));
+        pages.add(new TimeRange(1750L, 2000L));
+
+        for (IChunkWriter iChunkWriter :
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, false)) {
+          writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 900);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2000);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // start compacting
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    Map<PartialPath, List<TimeValuePair>> sourceDatas =
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, false), tsDataTypes);
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            true,
+            new ReadChunkCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    task.start();
+
+    validateSeqFiles(true);
+
+    validateTargetDatas(sourceDatas, tsDataTypes);
+  }
+
+  @Test
+  public void testAlignedWithDifferentEncodingAndCompression()
+      throws MetadataException, IOException {
+    List<PartialPath> timeserisPathList = new ArrayList<>();
+    List<TSDataType> tsDataTypes = new ArrayList<>();
+    // seq file 1
+    int deviceNum = 10;
+    int measurementNum = 10;
+    TsFileResource resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, true);
+
+        // write first chunk
+        List<TimeRange> pages = new ArrayList<>();
+        pages.add(new TimeRange(0L, 300L));
+        pages.add(new TimeRange(500L, 600L));
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        // write second chunk
+        List<TimeRange> timeRanges = new ArrayList<>();
+        timeRanges.add(new TimeRange(900L, 1199L));
+        timeRanges.add(new TimeRange(1301L, 1400L));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeOneAlignedPage((AlignedChunkWriterImpl) iChunkWriter, timeRanges, true);
+          iChunkWriter.writeToFileWriter(tsFileIOWriter);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 0);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 1400);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+
+        generateModsFile(timeseriesPath, resource, 500, 600);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // seq file 2
+    deviceNum = 5;
+    measurementNum = 20;
+    resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, true);
+
+        // write first chunk
+        List<TimeRange> pages = new ArrayList<>();
+        pages.add(new TimeRange(1800L, 1900L));
+        pages.add(new TimeRange(2150L, 2250L));
+        pages.add(new TimeRange(2400L, 2500L));
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 1800);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2500);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+
+        generateModsFile(timeseriesPath, resource, 1840, 1900);
+        generateModsFile(timeseriesPath, resource, 2150, 2250);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // seq file 3
+    deviceNum = 15;
+    measurementNum = 15;
+    resource = createEmptyFileAndResource(true);
+    try (TsFileIOWriter tsFileIOWriter = new TsFileIOWriter(resource.getTsFile())) {
+      // write the data in device
+      for (int deviceIndex = 0; deviceIndex < deviceNum; deviceIndex++) {
+        tsFileIOWriter.startChunkGroup(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex);
+
+        List<TSDataType> dataTypes = createDataType(measurementNum);
+        List<TSEncoding> encodings = createEncodingType(measurementNum);
+        List<CompressionType> compressionTypes = createCompressionType(measurementNum);
+        List<Integer> measurementIndexes = new ArrayList<>();
+        for (int i = 0; i < measurementNum; i++) {
+          measurementIndexes.add(i);
+        }
+        List<PartialPath> timeseriesPath =
+            createTimeseries(deviceIndex, measurementIndexes, dataTypes, true);
+        List<IChunkWriter> iChunkWriters =
+            createChunkWriter(timeseriesPath, dataTypes, encodings, compressionTypes, true);
+
+        // write first chunk
+        List<TimeRange> pages = new ArrayList<>();
+        pages.add(new TimeRange(2801, 2850));
+        pages.add(new TimeRange(2851, 2900));
+        pages.add(new TimeRange(3300, 3400));
+
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        // write second chunk
+        pages.clear();
+        pages.add(new TimeRange(3950, 4100));
+        pages.add(new TimeRange(4200, 4300));
+        for (IChunkWriter iChunkWriter : iChunkWriters) {
+          writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
+        }
+
+        tsFileIOWriter.endChunkGroup();
+        resource.updateStartTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 2801);
+        resource.updateEndTime(COMPACTION_TEST_SG + PATH_SEPARATOR + "d" + deviceIndex, 4300);
+        timeserisPathList.addAll(timeseriesPath);
+        tsDataTypes.addAll(dataTypes);
+
+        generateModsFile(timeseriesPath, resource, 2801, 2850);
+        generateModsFile(timeseriesPath, resource, 3950, 4100);
+      }
+      tsFileIOWriter.endFile();
+    }
+    resource.serialize();
+    seqResources.add(resource);
+
+    // start compacting
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    Map<PartialPath, List<TimeValuePair>> sourceDatas =
+        readSourceFiles(createTimeseries(maxDeviceNum, maxMeasurementNum, true), tsDataTypes);
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            true,
+            new ReadChunkCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    task.start();
+
+    validateSeqFiles(true);
+
+    validateTargetDatas(sourceDatas, tsDataTypes);
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointAlignedCrossCompactionTest.java
@@ -22,7 +22,7 @@ import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
+import org.apache.iotdb.db.engine.compaction.execute.performer.impl.ReadPointCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.CrossSpaceCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
@@ -59,7 +59,8 @@ import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.w
 import static org.apache.iotdb.db.engine.compaction.utils.TsFileGeneratorUtils.writeOneAlignedPage;
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
 
-public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
+public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest {
+  private final String oldThreadName = Thread.currentThread().getName();
 
   @Before
   public void setUp()
@@ -69,11 +70,13 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     IoTDBDescriptor.getInstance().getConfig().setTargetChunkPointNum(100);
     TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(30);
     TSFileDescriptor.getInstance().getConfig().setMaxDegreeOfIndexNode(3);
+    Thread.currentThread().setName("pool-1-IoTDB-Compaction-1");
   }
 
   @After
   public void tearDown() throws IOException, StorageEngineException {
     super.tearDown();
+    Thread.currentThread().setName(oldThreadName);
     for (TsFileResource tsFileResource : seqResources) {
       FileReaderManager.getInstance().closeFileAndRemoveReader(tsFileResource.getTsFilePath());
     }
@@ -253,7 +256,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -507,7 +510,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -760,7 +763,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -1030,7 +1033,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -1399,7 +1402,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -1776,7 +1779,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -2163,7 +2166,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -2534,7 +2537,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -2906,7 +2909,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -3289,7 +3292,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -3726,7 +3729,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -4166,7 +4169,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -4606,7 +4609,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -5098,7 +5101,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -5535,7 +5538,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -5753,7 +5756,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -6033,7 +6036,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -6440,7 +6443,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -6812,7 +6815,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -7066,7 +7069,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -7206,7 +7209,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -7397,7 +7400,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);
@@ -7625,7 +7628,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             tsFileManager,
             seqResources,
             unseqResources,
-            new FastCompactionPerformer(true),
+            new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0,
             0);

--- a/server/src/test/java/org/apache/iotdb/db/query/reader/series/AlignedSeriesScanLimitOffsetPushDownTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/reader/series/AlignedSeriesScanLimitOffsetPushDownTest.java
@@ -32,7 +32,9 @@ import org.apache.iotdb.db.mpp.plan.statement.component.Ordering;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
@@ -105,6 +107,13 @@ public class AlignedSeriesScanLimitOffsetPushDownTest {
             new AlignedPath(TEST_DEVICE, "s3"));
     List<TSDataType> dataTypes =
         Arrays.asList(TSDataType.INT32, TSDataType.INT32, TSDataType.INT32);
+    List<TSEncoding> encodings =
+        Arrays.asList(TSEncoding.PLAIN, TSEncoding.PLAIN, TSEncoding.PLAIN);
+    List<CompressionType> compressionTypes =
+        Arrays.asList(
+            CompressionType.UNCOMPRESSED,
+            CompressionType.UNCOMPRESSED,
+            CompressionType.UNCOMPRESSED);
 
     // prepare file 1
     File seqFile1 = new File(TestConstant.getTestTsFilePath(TEST_DATABASE, 0, 0, 1));
@@ -118,7 +127,8 @@ public class AlignedSeriesScanLimitOffsetPushDownTest {
       List<TimeRange> pages = new ArrayList<>();
       // prepare f1-c1-p1
       pages.add(new TimeRange(0L, 9L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, true)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, true)) {
         writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();
@@ -139,7 +149,8 @@ public class AlignedSeriesScanLimitOffsetPushDownTest {
 
       // prepare f2-c1-p1
       AlignedChunkWriterImpl alignedChunkWriter =
-          (AlignedChunkWriterImpl) createChunkWriter(writtenPaths, dataTypes, true).get(0);
+          (AlignedChunkWriterImpl)
+              createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, true).get(0);
       TimePageWriter timePageWriter = alignedChunkWriter.getTimeChunkWriter().getPageWriter();
       // write time page
       for (long timestamp = 10L; timestamp <= 19L; timestamp++) {
@@ -207,7 +218,8 @@ public class AlignedSeriesScanLimitOffsetPushDownTest {
       // prepare f3-c1-p1
       List<TimeRange> pages = new ArrayList<>();
       pages.add(new TimeRange(20L, 29L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, true)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, true)) {
         writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();
@@ -217,7 +229,8 @@ public class AlignedSeriesScanLimitOffsetPushDownTest {
 
       // prepare f3-c2-p1
       AlignedChunkWriterImpl alignedChunkWriter =
-          (AlignedChunkWriterImpl) createChunkWriter(writtenPaths, dataTypes, true).get(0);
+          (AlignedChunkWriterImpl)
+              createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, true).get(0);
       TimePageWriter timePageWriter = alignedChunkWriter.getTimeChunkWriter().getPageWriter();
       // write time page
       for (long timestamp = 30L; timestamp <= 39L; timestamp++) {
@@ -285,13 +298,15 @@ public class AlignedSeriesScanLimitOffsetPushDownTest {
       // prepare f4-c1-p1
       List<TimeRange> pages = new ArrayList<>();
       pages.add(new TimeRange(40L, 49L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, true)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, true)) {
         writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
 
       // prepare f4-c1-p2
       AlignedChunkWriterImpl alignedChunkWriter =
-          (AlignedChunkWriterImpl) createChunkWriter(writtenPaths, dataTypes, true).get(0);
+          (AlignedChunkWriterImpl)
+              createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, true).get(0);
       TimePageWriter timePageWriter = alignedChunkWriter.getTimeChunkWriter().getPageWriter();
       // write time page
       for (long timestamp = 50L; timestamp <= 59L; timestamp++) {
@@ -343,7 +358,8 @@ public class AlignedSeriesScanLimitOffsetPushDownTest {
       // prepare f4-c1-p3
       pages.clear();
       pages.add(new TimeRange(60L, 69L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, true)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, true)) {
         writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
 
@@ -354,7 +370,8 @@ public class AlignedSeriesScanLimitOffsetPushDownTest {
       pages.clear();
       // prepare f4-c2-p1
       pages.add(new TimeRange(70L, 79L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, true)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, true)) {
         writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();
@@ -377,7 +394,8 @@ public class AlignedSeriesScanLimitOffsetPushDownTest {
       pages.add(new TimeRange(70L, 79L));
       // prepare f5-c1-p2
       pages.add(new TimeRange(80L, 89L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, true)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, true)) {
         writeAlignedChunk((AlignedChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();

--- a/server/src/test/java/org/apache/iotdb/db/query/reader/series/SeriesScanLimitOffsetPushDownTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/reader/series/SeriesScanLimitOffsetPushDownTest.java
@@ -32,7 +32,9 @@ import org.apache.iotdb.db.mpp.plan.statement.component.Ordering;
 import org.apache.iotdb.db.query.control.FileReaderManager;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
@@ -48,6 +50,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -90,6 +93,8 @@ public class SeriesScanLimitOffsetPushDownTest {
   public static void setUp() throws IOException, WriteProcessException, IllegalPathException {
     List<PartialPath> writtenPaths = Collections.singletonList(new PartialPath(TEST_PATH));
     List<TSDataType> dataTypes = Collections.singletonList(TSDataType.INT32);
+    List<TSEncoding> encodings = Arrays.asList(TSEncoding.PLAIN);
+    List<CompressionType> compressionTypes = Arrays.asList(CompressionType.UNCOMPRESSED);
 
     // prepare file 1
     File seqFile1 = new File(TestConstant.getTestTsFilePath(TEST_DATABASE, 0, 0, 1));
@@ -103,7 +108,8 @@ public class SeriesScanLimitOffsetPushDownTest {
       List<TimeRange> pages = new ArrayList<>();
       // prepare f1-c1-p1
       pages.add(new TimeRange(0L, 9L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, false)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, false)) {
         writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();
@@ -124,7 +130,8 @@ public class SeriesScanLimitOffsetPushDownTest {
       List<TimeRange> pages = new ArrayList<>();
       // prepare f2-c1-p1
       pages.add(new TimeRange(10L, 19L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, false)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, false)) {
         writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();
@@ -134,7 +141,8 @@ public class SeriesScanLimitOffsetPushDownTest {
       pages.clear();
       // prepare f2-c2-p1
       pages.add(new TimeRange(20L, 29L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, false)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, false)) {
         writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();
@@ -157,7 +165,8 @@ public class SeriesScanLimitOffsetPushDownTest {
       pages.add(new TimeRange(30L, 39L));
       // prepare f3-c1-p2
       pages.add(new TimeRange(40L, 49L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, false)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, false)) {
         writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();
@@ -167,7 +176,8 @@ public class SeriesScanLimitOffsetPushDownTest {
       pages.clear();
       // prepare f3-c2-p1
       pages.add(new TimeRange(50L, 59L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, false)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, false)) {
         writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();
@@ -190,7 +200,8 @@ public class SeriesScanLimitOffsetPushDownTest {
       pages.add(new TimeRange(50L, 59L));
       // prepare f4-c1-p2
       pages.add(new TimeRange(60L, 69L));
-      for (IChunkWriter iChunkWriter : createChunkWriter(writtenPaths, dataTypes, false)) {
+      for (IChunkWriter iChunkWriter :
+          createChunkWriter(writtenPaths, dataTypes, encodings, compressionTypes, false)) {
         writeNonAlignedChunk((ChunkWriterImpl) iChunkWriter, tsFileIOWriter, pages, true);
       }
       tsFileIOWriter.endChunkGroup();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -929,7 +929,7 @@ public class TsFileSequenceReader implements AutoCloseable {
           boolean needChunkMetadata)
           throws IOException {
     Map<String, Pair<List<IChunkMetadata>, Pair<Long, Long>>> timeseriesMetadataOffsetMap =
-        new HashMap<>();
+        new LinkedHashMap<>();
     List<MetadataIndexEntry> childrenEntryList = measurementNode.getChildren();
     for (int i = 0; i < childrenEntryList.size(); i++) {
       long startOffset = childrenEntryList.get(i).getOffset();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/ChunkReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/ChunkReader.java
@@ -100,6 +100,10 @@ public class ChunkReader implements IChunkReader {
     }
   }
 
+  /**
+   * Constructor of ChunkReader without deserializing chunk into page. This is used for fast
+   * compaction.
+   */
   public ChunkReader(Chunk chunk) {
     this.filter = null;
     this.chunkDataBuffer = chunk.getData();


### PR DESCRIPTION
**Bug Description**
1. If the compression method of the aligned value series is different from that of the time series, an error will be reported when decompressing.
2. If the compression method of the aligned value series is different from that of the time series,  the target file will be corrupted.

**Reason**
1. When reading the source file, all value columns share an uncompressor, resulting in decompression failure.
2. The compression method of the time column in the alignment timeseries takes the first value column. If the source file is in the order of s0 s1 s2, and during fast compaction, the read order is s1 s0 s2 and then written to the target file in this order, that is , the time column of the original file is actually compressed according to the s0 method, and the newly written time column is compressed according to the s1 method, so if the compression method of s1 is different from s0,  the target file will be corrupted if flushing time page or chunk directly.

**Solution**
1. When reading files, each value column needs to have its own umcompressor.
2. For the alignment timeseries, when writing a new file, the compression method of the time column uses the default snappy; when rewriting the file, the compression method of the time column is consistent with that of the source file