### PR TITLE
[To rel/1.1][IOTDB-5825]Fix error in aligned empty value chunk in fast compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
@@ -168,7 +168,8 @@ public class FastCompactionPerformer
       MultiTsFileDeviceIterator deviceIterator,
       AbstractCompactionWriter fastCrossCompactionWriter)
       throws PageException, IOException, WriteProcessException, IllegalPathException {
-    // measurement -> tsfile resource -> timeseries metadata <startOffset, endOffset>
+    // measurement -> tsfile resource -> timeseries metadata <startOffset, endOffset>, including
+    // empty value chunk metadata
     Map<String, Map<TsFileResource, Pair<Long, Long>>> timeseriesMetadataOffsetMap =
         new LinkedHashMap<>();
     List<IMeasurementSchema> measurementSchemas = new ArrayList<>();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
@@ -69,22 +69,22 @@ public abstract class AbstractCompactionTask {
 
   public abstract void setSourceFilesToCompactionCandidate();
 
-  protected abstract void doCompaction();
+  protected abstract boolean doCompaction();
 
-  public void start() {
+  public boolean start() {
     currentTaskNum.incrementAndGet();
     boolean isSuccess = false;
     CompactionMetricsManager.getInstance().reportTaskStartRunning(crossTask, innerSeqTask);
     try {
       summary.start();
-      doCompaction();
-      isSuccess = true;
+      isSuccess = doCompaction();
     } finally {
       this.currentTaskNum.decrementAndGet();
       summary.finish(isSuccess);
       CompactionTaskManager.getInstance().removeRunningTaskFuture(this);
       CompactionMetricsManager.getInstance()
           .reportTaskFinishOrAbort(crossTask, innerSeqTask, summary.getTimeCost());
+      return isSuccess;
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -103,9 +103,9 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
   }
 
   @Override
-  protected void doCompaction() {
+  protected boolean doCompaction() {
     if (!tsFileManager.isAllowCompaction()) {
-      return;
+      return true;
     }
     long startTime = System.currentTimeMillis();
     // get resource of target file
@@ -117,6 +117,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
         sequence ? "Sequence" : "Unsequence",
         selectedTsFileResourceList.size(),
         selectedFileSize / 1024 / 1024);
+    boolean isSuccess = true;
 
     try {
       targetTsFileResource =
@@ -264,6 +265,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
         FileUtils.delete(logFile);
       }
     } catch (Throwable throwable) {
+      isSuccess = false;
       // catch throwable to handle OOM errors
       if (!(throwable instanceof InterruptedException)) {
         LOGGER.error(
@@ -303,6 +305,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       }
     } finally {
       releaseFileLocksAndResetMergingStatus();
+      return isSuccess;
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
@@ -250,9 +250,15 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
         } else {
           pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, chunkHeader.getDataType());
         }
-        ByteBuffer compressedPageData = chunkReader.readPageDataWithoutUncompressing(pageHeader);
-        valuePageHeaders.get(i).add(pageHeader);
-        compressedValuePageDatas.get(i).add(compressedPageData);
+        if (pageHeader.getCompressedSize() == 0) {
+          // empty value page
+          valuePageHeaders.get(i).add(null);
+          compressedValuePageDatas.get(i).add(null);
+        } else {
+          ByteBuffer compressedPageData = chunkReader.readPageDataWithoutUncompressing(pageHeader);
+          valuePageHeaders.get(i).add(pageHeader);
+          compressedValuePageDatas.get(i).add(compressedPageData);
+        }
       }
     }
 
@@ -294,8 +300,8 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
             .readMemChunk((ChunkMetadata) alignedChunkMetadata.getTimeChunkMetadata());
     List<Chunk> valueChunks = new ArrayList<>();
     for (IChunkMetadata valueChunkMetadata : alignedChunkMetadata.getValueChunkMetadataList()) {
-      if (valueChunkMetadata == null) {
-        // value chunk has been deleted completely
+      if (valueChunkMetadata == null || valueChunkMetadata.getStatistics().getCount() == 0) {
+        // value chunk has been deleted completely or is empty value chunk
         valueChunks.add(null);
         continue;
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/writer/AbstractCompactionWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/writer/AbstractCompactionWriter.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.tsfile.exception.write.PageException;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.common.Chunk;
 import org.apache.iotdb.tsfile.read.common.block.column.Column;
@@ -227,7 +228,7 @@ public abstract class AbstractCompactionWriter implements AutoCloseable {
               valueChunkWriter.getCompressionType(),
               valueChunkWriter.getDataType(),
               valueChunkWriter.getEncodingType(),
-              valueChunkWriter.getStatistics());
+              Statistics.getStatsByType(valueChunkWriter.getDataType()));
           continue;
         }
         CompactionTaskManager.mergeRateLimiterAcquire(

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -472,6 +472,7 @@ public class AbstractCompactionTest {
   protected void validateTargetDatas(
       Map<PartialPath, List<TimeValuePair>> sourceDatas, List<TSDataType> dataTypes)
       throws IOException {
+    Map<PartialPath, List<TimeValuePair>> tmpSourceDatas = new HashMap<>();
     for (Map.Entry<PartialPath, List<TimeValuePair>> entry : sourceDatas.entrySet()) {
       IDataBlockReader tsBlockReader =
           new SeriesDataBlockReader(
@@ -482,6 +483,7 @@ public class AbstractCompactionTest {
               Collections.emptyList(),
               true);
       List<TimeValuePair> timeseriesData = entry.getValue();
+      tmpSourceDatas.put(entry.getKey(), new ArrayList<>(timeseriesData));
       while (tsBlockReader.hasNextBatch()) {
         TsBlock block = tsBlockReader.nextBatch();
         IBatchDataIterator iterator = block.getTsBlockAlignedRowIterator();
@@ -498,6 +500,7 @@ public class AbstractCompactionTest {
         fail();
       }
     }
+    sourceDatas.putAll(tmpSourceDatas);
   }
 
   protected void generateModsFile(

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionTaskComparatorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/CompactionTaskComparatorTest.java
@@ -336,7 +336,9 @@ public class CompactionTaskComparatorTest {
     }
 
     @Override
-    protected void doCompaction() {}
+    protected boolean doCompaction() {
+      return true;
+    }
 
     @Override
     public boolean equalsOtherTask(AbstractCompactionTask other) {
@@ -371,7 +373,9 @@ public class CompactionTaskComparatorTest {
     }
 
     @Override
-    public void doCompaction() {}
+    public boolean doCompaction() {
+      return true;
+    }
 
     @Override
     public boolean equalsOtherTask(AbstractCompactionTask other) {

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastAlignedCrossCompactionTest.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.CrossSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.query.control.FileReaderManager;
@@ -261,6 +262,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -516,6 +530,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -768,6 +795,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1038,6 +1078,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1407,6 +1460,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1784,6 +1850,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -2172,6 +2251,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -2542,6 +2634,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -2914,6 +3019,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -3297,6 +3415,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -3734,6 +3865,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -4175,6 +4319,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -4614,6 +4771,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -5107,6 +5277,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -5544,6 +5727,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -5761,6 +5957,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -6041,6 +6250,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -6449,6 +6671,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -6821,6 +7056,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -7075,6 +7323,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -7214,6 +7475,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -7405,6 +7679,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -7633,6 +7920,19 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastAlignedCrossCompactionTest.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.tsfile.write.chunk.IChunkWriter;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -258,7 +259,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -273,7 +274,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -525,7 +526,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -540,7 +541,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -791,7 +792,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -806,7 +807,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1074,7 +1075,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1089,7 +1090,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1456,7 +1457,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1471,7 +1472,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1846,7 +1847,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1861,7 +1862,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -2246,7 +2247,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -2261,7 +2262,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -2630,7 +2631,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -2645,7 +2646,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3015,7 +3016,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3030,7 +3031,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3411,7 +3412,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3426,7 +3427,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3861,7 +3862,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3876,7 +3877,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -4314,7 +4315,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -4329,7 +4330,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -4767,7 +4768,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -4782,7 +4783,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5272,7 +5273,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5287,7 +5288,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5722,7 +5723,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5737,7 +5738,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5953,7 +5954,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5968,7 +5969,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -6246,7 +6247,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -6261,7 +6262,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -6666,7 +6667,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -6681,7 +6682,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7051,7 +7052,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7066,7 +7067,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7318,7 +7319,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7333,7 +7334,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7471,7 +7472,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7486,7 +7487,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7675,7 +7676,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7690,7 +7691,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7916,7 +7917,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7931,7 +7932,7 @@ public class FastAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastInnerCompactionPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastInnerCompactionPerformerTest.java
@@ -128,7 +128,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
 
@@ -226,7 +226,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     List<TsFileResource> targetResources = tsFileManager.getTsFileList(true);
@@ -367,7 +367,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     List<TsFileResource> targetResources = tsFileManager.getTsFileList(true);
@@ -481,7 +481,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     List<TsFileResource> targetResources = tsFileManager.getTsFileList(false);
@@ -596,7 +596,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(true);
@@ -742,7 +742,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(false);
@@ -877,7 +877,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(false);
@@ -998,7 +998,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(true);
@@ -1089,7 +1089,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     List<TsFileResource> targetResources = tsFileManager.getTsFileList(true);
@@ -1209,7 +1209,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(true);
@@ -1338,7 +1338,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(true);
@@ -1472,7 +1472,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(false);
@@ -1656,7 +1656,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(false);
@@ -1820,7 +1820,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(false);
@@ -1936,7 +1936,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    task.start();
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(false);

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastNonAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastNonAlignedCrossCompactionTest.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.CrossSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.query.control.FileReaderManager;
@@ -284,6 +285,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -534,6 +548,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -782,6 +809,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1049,6 +1089,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1415,6 +1468,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1788,6 +1854,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -2172,6 +2251,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -2539,6 +2631,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -2908,6 +3013,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -3287,6 +3405,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -3721,6 +3852,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -4159,6 +4303,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -4595,6 +4752,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -5085,6 +5255,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -5519,6 +5702,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -5736,6 +5932,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -6016,6 +6225,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -6424,6 +6646,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -6793,6 +7028,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -7047,6 +7295,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -7186,6 +7447,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -7377,6 +7651,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -7598,6 +7885,19 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new FastCompactionPerformer(false),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastNonAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastNonAlignedCrossCompactionTest.java
@@ -41,6 +41,7 @@ import org.apache.iotdb.tsfile.write.chunk.IChunkWriter;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -280,7 +281,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -295,7 +296,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -543,7 +544,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -558,7 +559,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -805,7 +806,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -820,7 +821,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1085,7 +1086,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1100,7 +1101,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1464,7 +1465,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1479,7 +1480,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1850,7 +1851,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1865,7 +1866,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -2246,7 +2247,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -2261,7 +2262,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -2627,7 +2628,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -2642,7 +2643,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3009,7 +3010,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3024,7 +3025,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3401,7 +3402,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3416,7 +3417,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3848,7 +3849,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3863,7 +3864,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -4298,7 +4299,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -4313,7 +4314,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -4748,7 +4749,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -4763,7 +4764,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5250,7 +5251,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5265,7 +5266,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5697,7 +5698,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5712,7 +5713,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5928,7 +5929,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5943,7 +5944,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -6221,7 +6222,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -6236,7 +6237,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -6641,7 +6642,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -6656,7 +6657,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7023,7 +7024,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7038,7 +7039,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7290,7 +7291,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7305,7 +7306,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7443,7 +7444,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7458,7 +7459,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7647,7 +7648,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7662,7 +7663,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7881,7 +7882,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7896,7 +7897,7 @@ public class FastNonAlignedCrossCompactionTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointAlignedCrossCompactionTest.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.tsfile.write.chunk.IChunkWriter;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -261,7 +262,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -276,7 +277,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -528,7 +529,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -543,7 +544,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -794,7 +795,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -809,7 +810,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1077,7 +1078,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1092,7 +1093,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1459,7 +1460,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1474,7 +1475,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1849,7 +1850,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1864,7 +1865,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -2249,7 +2250,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -2264,7 +2265,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -2633,7 +2634,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -2648,7 +2649,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3018,7 +3019,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3033,7 +3034,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3414,7 +3415,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3429,7 +3430,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3864,7 +3865,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3879,7 +3880,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -4317,7 +4318,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -4332,7 +4333,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -4770,7 +4771,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -4785,7 +4786,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5275,7 +5276,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5290,7 +5291,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5725,7 +5726,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5740,7 +5741,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5956,7 +5957,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5971,7 +5972,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -6249,7 +6250,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -6264,7 +6265,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -6669,7 +6670,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -6684,7 +6685,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7054,7 +7055,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7069,7 +7070,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7321,7 +7322,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7336,7 +7337,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7474,7 +7475,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7489,7 +7490,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7678,7 +7679,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7693,7 +7694,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7919,7 +7920,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7934,7 +7935,7 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointAlignedCrossCompactionTest.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.ReadPointCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.CrossSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.query.control.FileReaderManager;
@@ -264,6 +265,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -519,6 +533,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -771,6 +798,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1041,6 +1081,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1410,6 +1463,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1787,6 +1853,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -2175,6 +2254,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -2545,6 +2637,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -2917,6 +3022,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -3300,6 +3418,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -3737,6 +3868,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -4178,6 +4322,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -4617,6 +4774,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -5110,6 +5280,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -5547,6 +5730,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -5764,6 +5960,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -6044,6 +6253,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -6452,6 +6674,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -6824,6 +7059,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -7078,6 +7326,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -7217,6 +7478,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -7408,6 +7682,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -7636,6 +7923,19 @@ public class ReadPointAlignedCrossCompactionTest extends AbstractCompactionTest 
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointNonAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointNonAlignedCrossCompactionTest.java
@@ -41,6 +41,7 @@ import org.apache.iotdb.tsfile.write.chunk.IChunkWriter;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -283,7 +284,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -298,7 +299,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -546,7 +547,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -561,7 +562,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -808,7 +809,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -823,7 +824,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1088,7 +1089,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1103,7 +1104,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1467,7 +1468,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1482,7 +1483,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -1853,7 +1854,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -1868,7 +1869,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -2249,7 +2250,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -2264,7 +2265,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -2630,7 +2631,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -2645,7 +2646,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3012,7 +3013,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3027,7 +3028,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3404,7 +3405,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3419,7 +3420,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -3851,7 +3852,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -3866,7 +3867,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -4301,7 +4302,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -4316,7 +4317,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -4751,7 +4752,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -4766,7 +4767,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5253,7 +5254,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5268,7 +5269,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5700,7 +5701,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5715,7 +5716,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -5931,7 +5932,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -5946,7 +5947,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -6224,7 +6225,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -6239,7 +6240,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -6644,7 +6645,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -6659,7 +6660,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7026,7 +7027,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7041,7 +7042,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7293,7 +7294,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7308,7 +7309,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7446,7 +7447,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7461,7 +7462,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7650,7 +7651,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7665,7 +7666,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
@@ -7884,7 +7885,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new AtomicInteger(0),
             0,
             0);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
 
@@ -7899,7 +7900,7 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
             new ReadPointCompactionPerformer(),
             new AtomicInteger(0),
             0);
-    innerTask.start();
+    Assert.assertTrue(innerTask.start());
     validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointNonAlignedCrossCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/ReadPointNonAlignedCrossCompactionTest.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.ReadPointCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.CrossSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.query.control.FileReaderManager;
@@ -287,6 +288,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -537,6 +551,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -785,6 +812,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1052,6 +1092,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1418,6 +1471,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -1791,6 +1857,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -2175,6 +2254,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -2542,6 +2634,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -2911,6 +3016,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -3290,6 +3408,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -3724,6 +3855,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -4162,6 +4306,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -4598,6 +4755,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -5088,6 +5258,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -5522,6 +5705,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -5739,6 +5935,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -6019,6 +6228,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -6427,6 +6649,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -6796,6 +7031,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -7050,6 +7298,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
     validateSeqFiles(true);
 
     validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
+    validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
   @Test
@@ -7189,6 +7450,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -7380,6 +7654,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 
@@ -7601,6 +7888,19 @@ public class ReadPointNonAlignedCrossCompactionTest extends AbstractCompactionTe
 
     validateSeqFiles(true);
 
+    validateTargetDatas(sourceDatas, tsDataTypes);
+
+    InnerSpaceCompactionTask innerTask =
+        new InnerSpaceCompactionTask(
+            0,
+            tsFileManager,
+            tsFileManager.getTsFileList(true),
+            true,
+            new ReadPointCompactionPerformer(),
+            new AtomicInteger(0),
+            0);
+    innerTask.start();
+    validateSeqFiles(true);
     validateTargetDatas(sourceDatas, tsDataTypes);
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithFastPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithFastPerformerTest.java
@@ -47,6 +47,7 @@ import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -429,7 +430,7 @@ public class CrossSpaceCompactionWithFastPerformerTest {
                     new AtomicInteger(0),
                     0,
                     0);
-            compactionTask.start();
+            Assert.assertTrue(compactionTask.start());
             List<TsFileResource> targetTsfileResourceList = new ArrayList<>();
             for (TsFileResource seqResource : seqResources) {
               TsFileResource targetResource =
@@ -733,7 +734,7 @@ public class CrossSpaceCompactionWithFastPerformerTest {
                     new AtomicInteger(0),
                     0,
                     0);
-            compactionTask.start();
+            Assert.assertTrue(compactionTask.start());
             List<TsFileResource> targetTsfileResourceList = new ArrayList<>();
             for (TsFileResource seqResource : seqResources.subList(1, 4)) {
               TsFileResource targetResource =
@@ -1036,7 +1037,7 @@ public class CrossSpaceCompactionWithFastPerformerTest {
                     new AtomicInteger(0),
                     0,
                     0);
-            compactionTask.start();
+            Assert.assertTrue(compactionTask.start());
             List<TsFileResource> targetTsfileResourceList = new ArrayList<>();
             for (TsFileResource seqResource : seqResources.subList(1, 4)) {
               TsFileResource targetResource =

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithFastPerformerValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithFastPerformerValidationTest.java
@@ -2343,15 +2343,16 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
     for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new FastCompactionPerformer(false),
-              new AtomicInteger(0),
-              0L)
-          .start();
+      Assert.assertTrue(
+          new InnerSpaceCompactionTask(
+                  0,
+                  tsFileManager,
+                  taskResource,
+                  true,
+                  new FastCompactionPerformer(false),
+                  new AtomicInteger(0),
+                  0L)
+              .start());
     }
 
     // select cross compaction
@@ -2369,16 +2370,17 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
     Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new FastCompactionPerformer(true),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new FastCompactionPerformer(true),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -2423,15 +2425,16 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
     for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new FastCompactionPerformer(false),
-              new AtomicInteger(0),
-              0L)
-          .start();
+      Assert.assertTrue(
+          new InnerSpaceCompactionTask(
+                  0,
+                  tsFileManager,
+                  taskResource,
+                  true,
+                  new FastCompactionPerformer(false),
+                  new AtomicInteger(0),
+                  0L)
+              .start());
     }
 
     // select cross compaction
@@ -2504,15 +2507,16 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
     for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new FastCompactionPerformer(false),
-              new AtomicInteger(0),
-              0L)
-          .start();
+      Assert.assertTrue(
+          new InnerSpaceCompactionTask(
+                  0,
+                  tsFileManager,
+                  taskResource,
+                  true,
+                  new FastCompactionPerformer(false),
+                  new AtomicInteger(0),
+                  0L)
+              .start());
     }
 
     // select cross compaction
@@ -2586,15 +2590,16 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
     for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new FastCompactionPerformer(false),
-              new AtomicInteger(0),
-              0L)
-          .start();
+      Assert.assertTrue(
+          new InnerSpaceCompactionTask(
+                  0,
+                  tsFileManager,
+                  taskResource,
+                  true,
+                  new FastCompactionPerformer(false),
+                  new AtomicInteger(0),
+                  0L)
+              .start());
     }
 
     // select cross compaction
@@ -2612,16 +2617,17 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
     Assert.assertEquals(2, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(3, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new FastCompactionPerformer(true),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new FastCompactionPerformer(true),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -2674,15 +2680,16 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
     for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new FastCompactionPerformer(false),
-              new AtomicInteger(0),
-              0L)
-          .start();
+      Assert.assertTrue(
+          new InnerSpaceCompactionTask(
+                  0,
+                  tsFileManager,
+                  taskResource,
+                  true,
+                  new FastCompactionPerformer(false),
+                  new AtomicInteger(0),
+                  0L)
+              .start());
     }
 
     // select cross compaction
@@ -2761,15 +2768,16 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
     for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new FastCompactionPerformer(false),
-              new AtomicInteger(0),
-              0L)
-          .start();
+      Assert.assertTrue(
+          new InnerSpaceCompactionTask(
+                  0,
+                  tsFileManager,
+                  taskResource,
+                  true,
+                  new FastCompactionPerformer(false),
+                  new AtomicInteger(0),
+                  0L)
+              .start());
     }
 
     // select cross compaction
@@ -2849,15 +2857,16 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
     for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new FastCompactionPerformer(false),
-              new AtomicInteger(0),
-              0L)
-          .start();
+      Assert.assertTrue(
+          new InnerSpaceCompactionTask(
+                  0,
+                  tsFileManager,
+                  taskResource,
+                  true,
+                  new FastCompactionPerformer(false),
+                  new AtomicInteger(0),
+                  0L)
+              .start());
     }
 
     // select cross compaction
@@ -2938,15 +2947,16 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
     for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new FastCompactionPerformer(false),
-              new AtomicInteger(0),
-              0L)
-          .start();
+      Assert.assertTrue(
+          new InnerSpaceCompactionTask(
+                  0,
+                  tsFileManager,
+                  taskResource,
+                  true,
+                  new FastCompactionPerformer(false),
+                  new AtomicInteger(0),
+                  0L)
+              .start());
     }
 
     // select cross compaction

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithReadPointPerformerValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithReadPointPerformerValidationTest.java
@@ -2229,16 +2229,17 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
     Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new ReadPointCompactionPerformer(),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new ReadPointCompactionPerformer(),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -2309,16 +2310,17 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
     Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new ReadPointCompactionPerformer(),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new ReadPointCompactionPerformer(),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -2390,16 +2392,17 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
     Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new ReadPointCompactionPerformer(),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new ReadPointCompactionPerformer(),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -2472,16 +2475,17 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
     Assert.assertEquals(2, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(3, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new ReadPointCompactionPerformer(),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new ReadPointCompactionPerformer(),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -2560,16 +2564,17 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
     Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new ReadPointCompactionPerformer(),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new ReadPointCompactionPerformer(),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -2647,16 +2652,17 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
     Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new ReadPointCompactionPerformer(),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new ReadPointCompactionPerformer(),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -2735,16 +2741,17 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
     Assert.assertEquals(1, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(2, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new ReadPointCompactionPerformer(),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new ReadPointCompactionPerformer(),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -2824,16 +2831,17 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
     Assert.assertEquals(2, sourceFiles.getSeqFiles().size());
     Assert.assertEquals(3, sourceFiles.getUnseqFiles().size());
 
-    new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            sourceFiles.getSeqFiles(),
-            sourceFiles.getUnseqFiles(),
-            new ReadPointCompactionPerformer(),
-            new AtomicInteger(0),
-            sourceFiles.getTotalMemoryCost(),
-            0)
-        .start();
+    Assert.assertTrue(
+        new CrossSpaceCompactionTask(
+                0,
+                tsFileManager,
+                sourceFiles.getSeqFiles(),
+                sourceFiles.getUnseqFiles(),
+                new ReadPointCompactionPerformer(),
+                new AtomicInteger(0),
+                sourceFiles.getTotalMemoryCost(),
+                0)
+            .start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/utils/MultiTsFileDeviceIteratorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/utils/MultiTsFileDeviceIteratorTest.java
@@ -401,7 +401,7 @@ public class MultiTsFileDeviceIteratorTest extends AbstractCompactionTest {
             new ReadChunkCompactionPerformer(),
             new AtomicInteger(),
             0L);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -545,7 +545,7 @@ public class MultiTsFileDeviceIteratorTest extends AbstractCompactionTest {
             new ReadChunkCompactionPerformer(),
             new AtomicInteger(),
             0L);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -688,7 +688,7 @@ public class MultiTsFileDeviceIteratorTest extends AbstractCompactionTest {
             new ReadPointCompactionPerformer(),
             new AtomicInteger(),
             0L);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -831,7 +831,7 @@ public class MultiTsFileDeviceIteratorTest extends AbstractCompactionTest {
             new ReadPointCompactionPerformer(),
             new AtomicInteger(),
             0L);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -984,7 +984,7 @@ public class MultiTsFileDeviceIteratorTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(),
             0L);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());
@@ -1129,7 +1129,7 @@ public class MultiTsFileDeviceIteratorTest extends AbstractCompactionTest {
             new FastCompactionPerformer(false),
             new AtomicInteger(),
             0L);
-    task.start();
+    Assert.assertTrue(task.start());
 
     validateSeqFiles(true);
     validateTargetDatas(sourceData, Collections.emptyList());

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
@@ -406,10 +406,6 @@ public class ValueChunkWriter {
     return compressionType;
   }
 
-  public Statistics<? extends Serializable> getStatistics() {
-    return statistics;
-  }
-
   /** only used for test */
   public PublicBAOS getPageBuffer() {
     return pageBuffer;


### PR DESCRIPTION
**Description**
When there is an aligned empty value chunk in the source file, the fast compaction will report that the array is out of bounds.
 
**Reason**
When there is an aligned empty value chunk in the source file, it will also have corresponding chunkMetadata in the TsFile, but fastCompaction does not judge the empty value chunk when reading chunkMetadata, resulting in subsequent errors.
 
**Solution**
When reading chunkMetadata, it is necessary to judge whether it is an empty value chunk, and when decomposing a chunk into a page, judge whether it is an empty value page.