### PR TITLE
[IOTDB-5827][To rel/1.1] Change default multi_dir_strategy to SequenceStrategy and fix original bug #9718

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/JVMCommonUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/JVMCommonUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.commons.utils;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
 
 import java.io.File;
@@ -33,6 +34,9 @@ public class JVMCommonUtils {
   public static final int MAX_EXECUTOR_POOL_SIZE = Math.max(100, getCpuCores() * 5);
 
   private static final int CPUS = Runtime.getRuntime().availableProcessors();
+
+  private static final double diskSpaceWarningThreshold =
+      CommonDescriptor.getInstance().getConfig().getDiskSpaceWarningThreshold();
 
   /**
    * get JDK version.
@@ -60,8 +64,14 @@ public class JVMCommonUtils {
     return dirFile.getFreeSpace();
   }
 
+  public static double getDiskFreeRatio(String dir) {
+    File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
+    dirFile.mkdirs();
+    return 1.0 * dirFile.getFreeSpace() / dirFile.getTotalSpace();
+  }
+
   public static boolean hasSpace(String dir) {
-    return getUsableSpace(dir) > 0;
+    return getDiskFreeRatio(dir) > diskSpaceWarningThreshold;
   }
 
   public static long getOccupiedSpace(String folderPath) throws IOException {

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -165,7 +165,7 @@ dn_target_config_node_list=127.0.0.1:10710
 # Set SequenceStrategy,MaxDiskUsableSpaceFirstStrategy and MinFolderOccupiedSpaceFirstStrategy to apply the corresponding strategy.
 # If this property is unset, system will use MaxDiskUsableSpaceFirstStrategy as default strategy.
 # For this property, fully-qualified class name (include package name) and simple class name are both acceptable.
-# dn_multi_dir_strategy=MaxDiskUsableSpaceFirstStrategy
+# dn_multi_dir_strategy=SequenceStrategy
 
 # consensus dir
 # If this property is unset, system will save the data in the default relative path directory under the IoTDB folder(i.e., %IOTDB_HOME%/data/datanode).

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -71,7 +71,7 @@ public class IoTDBConfig {
   private static final Logger logger = LoggerFactory.getLogger(IoTDBConfig.class);
   private static final String MULTI_DIR_STRATEGY_PREFIX =
       "org.apache.iotdb.db.conf.directories.strategy.";
-  private static final String DEFAULT_MULTI_DIR_STRATEGY = "MaxDiskUsableSpaceFirstStrategy";
+  private static final String DEFAULT_MULTI_DIR_STRATEGY = "SequenceStrategy";
 
   private static final String STORAGE_GROUP_MATCHER = "([a-zA-Z0-9`_.\\-\\u2E80-\\u9FFF]+)";
   public static final Pattern STORAGE_GROUP_PATTERN = Pattern.compile(STORAGE_GROUP_MATCHER);

--- a/server/src/main/java/org/apache/iotdb/db/conf/directories/strategy/SequenceStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/directories/strategy/SequenceStrategy.java
@@ -53,10 +53,10 @@ public class SequenceStrategy extends DirectoryStrategy {
   private int tryGetNextIndex(int start) throws DiskSpaceInsufficientException {
     int index = (start + 1) % folders.size();
     while (!JVMCommonUtils.hasSpace(folders.get(index))) {
-      index = (index + 1) % folders.size();
       if (index == start) {
         throw new DiskSpaceInsufficientException(folders);
       }
+      index = (index + 1) % folders.size();
     }
     return index;
   }


### PR DESCRIPTION
## Description
1. change default multi_dir_strategy to SequenceStrategy
2. fix original bug in SequenceStrategy where one folder won't used if others space is limited
3. use `diskSpaceWarningThreshold` to decide whether a folder is full or not

## Test

Tested using 1C1D in fit16 with 1 DataRegion. See the snapshot below. The threshold is set to `0.85` in this test.
![5BpUzfYisk](https://user-images.githubusercontent.com/18027703/234572694-94906065-1d7d-41c5-b9fe-0e34987a11e8.jpg)
