### PR TITLE
[To rel/1.1][IOTDB-5832] Fix Bug: The size of readyQueue is negative incorrectly

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/queue/IndexedBlockingQueue.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/queue/IndexedBlockingQueue.java
@@ -104,6 +104,7 @@ public abstract class IndexedBlockingQueue<E extends IDIndexedAccessible> {
       return null;
     }
     size--;
+    Preconditions.checkState(size >= 0, "The size of readyQueue cannot be negative.");
     return output;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/queue/multilevelqueue/MultilevelPriorityQueue.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/queue/multilevelqueue/MultilevelPriorityQueue.java
@@ -157,10 +157,10 @@ public class MultilevelPriorityQueue extends IndexedBlockingReserveQueue<DriverT
     checkArgument(driverTask != null, "driverTask is null");
     for (PriorityQueue<DriverTask> level : levelWaitingSplits) {
       if (level.remove(driverTask)) {
-        break;
+        return driverTask;
       }
     }
-    return driverTask;
+    return null;
   }
 
   @Override


### PR DESCRIPTION
[#5832](https://issues.apache.org/jira/browse/IOTDB-5832)