### PR TITLE
[IOTDB-5834] Fix unclear error msg when querying nonexistent schema template

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
@@ -741,11 +741,14 @@ public class ClusterSchemaManager {
       }
     }
 
-    Template template =
-        clusterSchemaInfo
-            .getTemplate(new GetSchemaTemplatePlan(templateExtendInfo.getTemplateName()))
-            .getTemplateList()
-            .get(0);
+    TemplateInfoResp resp =
+        clusterSchemaInfo.getTemplate(
+            new GetSchemaTemplatePlan(templateExtendInfo.getTemplateName()));
+    if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+      return resp.getStatus();
+    }
+
+    Template template = resp.getTemplateList().get(0);
     boolean needExtend = false;
     for (String measurement : templateExtendInfo.getMeasurements()) {
       if (!template.hasSchema(measurement)) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/ClusterTemplateManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/ClusterTemplateManager.java
@@ -183,7 +183,7 @@ public class ClusterTemplateManager implements ITemplateManager {
   }
 
   @Override
-  public Template getTemplate(String name) {
+  public Template getTemplate(String name) throws IoTDBException {
     try (ConfigNodeClient configNodeClient =
         CONFIG_NODE_CLIENT_MANAGER.borrowClient(ConfigNodeInfo.CONFIG_REGION_ID)) {
       TGetTemplateResp resp = configNodeClient.getTemplate(name);
@@ -193,8 +193,7 @@ public class ClusterTemplateManager implements ITemplateManager {
         template.deserialize(ByteBuffer.wrap(templateBytes));
         return template;
       } else {
-        throw new RuntimeException(
-            new IoTDBException(resp.status.getMessage(), resp.status.getCode()));
+        throw new IoTDBException(resp.status.getMessage(), resp.status.getCode());
       }
     } catch (ClientManagerException | TException e) {
       throw new RuntimeException(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/ClusterTemplateManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/ClusterTemplateManager.java
@@ -196,7 +196,7 @@ public class ClusterTemplateManager implements ITemplateManager {
         throw new RuntimeException(
             new IoTDBException(resp.status.getMessage(), resp.status.getCode()));
       }
-    } catch (Exception e) {
+    } catch (ClientManagerException | TException e) {
       throw new RuntimeException(
           new IoTDBException(
               "get template info error.", TSStatusCode.UNDEFINED_TEMPLATE.getStatusCode()));

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/ITemplateManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/ITemplateManager.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.metadata.template;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.CreateSchemaTemplateStatement;
 import org.apache.iotdb.tsfile.utils.Pair;
@@ -48,7 +49,7 @@ public interface ITemplateManager {
    * @param name
    * @return Template
    */
-  Template getTemplate(String name);
+  Template getTemplate(String name) throws IoTDBException;
 
   Template getTemplate(int id);
 


### PR DESCRIPTION
## Description


### Before this pr 

see IOTDB-5834

### After this pr
```
IoTDB> alter schema template t1 add (s_speed FLOAT encoding=RLE, FLOAT TEXT encoding=PLAIN compression=SNAPPY);
Msg: 507: Template t1 does not exist
IoTDB> show nodes in schema template t1
Msg: 507: Template t1 does not exist
```


