### PR TITLE
[To rel/1.1] [IOTDB-5828] Optimize the performance of some parts in metrics, and correcting the metrics count of temporal file size in inner space compaction

### DIFF
--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/jvm/JvmThreadMetrics.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/jvm/JvmThreadMetrics.java
@@ -36,7 +36,8 @@ import java.util.Map;
 public class JvmThreadMetrics implements IMetricSet {
   private static long lastUpdateTime = 0L;
   private static final long UPDATE_INTERVAL = 10_000L;
-  private static Map<Thread.State, Integer> threadStateCountMap = new HashMap<>();
+  private static Map<Thread.State, Integer> threadStateCountMap =
+      new HashMap<>(Thread.State.values().length + 1, 1.0f);
 
   @Override
   public void bindTo(AbstractMetricService metricService) {
@@ -109,7 +110,7 @@ public class JvmThreadMetrics implements IMetricSet {
         info -> {
           if (info != null) {
             Thread.State state = info.getThreadState();
-            threadStateCountMap.put(state, threadStateCountMap.getOrDefault(state, 0) + 1);
+            threadStateCountMap.compute(state, (k, v) -> v == null ? 1 : v + 1);
           }
         });
   }

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/jvm/JvmThreadMetrics.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/jvm/JvmThreadMetrics.java
@@ -25,11 +25,19 @@ import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.MetricType;
 
 import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** This file is modified from io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics */
 public class JvmThreadMetrics implements IMetricSet {
+  private static long lastUpdateTime = 0L;
+  private static final long UPDATE_INTERVAL = 10_000L;
+  private static Map<Thread.State, Integer> threadStateCountMap = new HashMap<>();
+
   @Override
   public void bindTo(AbstractMetricService metricService) {
     ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
@@ -85,9 +93,25 @@ public class JvmThreadMetrics implements IMetricSet {
 
   // VisibleForTesting
   static long getThreadStateCount(ThreadMXBean threadBean, Thread.State state) {
-    return Arrays.stream(threadBean.getThreadInfo(threadBean.getAllThreadIds()))
-        .filter(threadInfo -> threadInfo != null && threadInfo.getThreadState() == state)
-        .count();
+    checkAndUpdate(threadBean);
+    return threadStateCountMap.getOrDefault(state, 0);
+  }
+
+  private static void checkAndUpdate(ThreadMXBean threadBean) {
+    if (System.currentTimeMillis() - lastUpdateTime < UPDATE_INTERVAL) {
+      return;
+    }
+    lastUpdateTime = System.currentTimeMillis();
+    threadStateCountMap.clear();
+    List<ThreadInfo> infoList =
+        Arrays.asList(threadBean.getThreadInfo(threadBean.getAllThreadIds()));
+    infoList.forEach(
+        info -> {
+          if (info != null) {
+            Thread.State state = info.getThreadState();
+            threadStateCountMap.put(state, threadStateCountMap.getOrDefault(state, 0) + 1);
+          }
+        });
   }
 
   private static String getStateTagValue(Thread.State state) {

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/jvm/JvmThreadMetrics.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/jvm/JvmThreadMetrics.java
@@ -28,7 +28,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,8 +36,8 @@ import java.util.Map;
 public class JvmThreadMetrics implements IMetricSet {
   private static long lastUpdateTime = 0L;
   private static final long UPDATE_INTERVAL = 10_000L;
-  private static Map<Thread.State, Integer> threadStateCountMap =
-      new HashMap<>(Thread.State.values().length + 1, 1.0f);
+  private static final Map<Thread.State, Integer> threadStateCountMap =
+      new EnumMap<>(Thread.State.class);
 
   @Override
   public void bindTo(AbstractMetricService metricService) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/TsFileMetricManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/TsFileMetricManager.java
@@ -19,8 +19,13 @@
 
 package org.apache.iotdb.db.engine;
 
+import org.apache.iotdb.db.engine.compaction.execute.task.AbstractCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.service.metrics.FileMetrics;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -35,6 +40,8 @@ public class TsFileMetricManager {
   private final AtomicInteger modFileNum = new AtomicInteger(0);
 
   private final AtomicLong modFileSize = new AtomicLong(0);
+  private long lastUpdateTime = 0;
+  private static final long UPDATE_INTERVAL = 10_000L;
 
   // compaction temporal files
   private final AtomicLong innerSeqCompactionTempFileSize = new AtomicLong(0);
@@ -102,41 +109,55 @@ public class TsFileMetricManager {
     modFileSize.addAndGet(-size);
   }
 
-  public void addCompactionTempFileSize(boolean innerSpace, boolean seq, long delta) {
-    if (innerSpace) {
-      long unused =
-          seq
-              ? innerSeqCompactionTempFileSize.addAndGet(delta)
-              : innerUnseqCompactionTempFileSize.addAndGet(delta);
-    } else {
-      crossCompactionTempFileSize.addAndGet(delta);
-    }
-  }
-
-  public void addCompactionTempFileNum(boolean innerSpace, boolean seq, int delta) {
-    if (innerSpace) {
-      long unused =
-          seq
-              ? innerSeqCompactionTempFileNum.addAndGet(delta)
-              : innerUnseqCompactionTempFileNum.addAndGet(delta);
-    } else {
-      crossCompactionTempFileNum.addAndGet(delta);
-    }
-  }
-
   public long getInnerCompactionTempFileSize(boolean seq) {
+    updateCompactionTempSize();
     return seq ? innerSeqCompactionTempFileSize.get() : innerUnseqCompactionTempFileSize.get();
   }
 
+  private synchronized void updateCompactionTempSize() {
+    if (System.currentTimeMillis() - lastUpdateTime <= UPDATE_INTERVAL) {
+      return;
+    }
+    lastUpdateTime = System.currentTimeMillis();
+
+    innerSeqCompactionTempFileSize.set(0);
+    innerSeqCompactionTempFileNum.set(0);
+    innerUnseqCompactionTempFileSize.set(0);
+    innerUnseqCompactionTempFileNum.set(0);
+    crossCompactionTempFileSize.set(0);
+    crossCompactionTempFileNum.set(0);
+
+    List<AbstractCompactionTask> runningTasks =
+        CompactionTaskManager.getInstance().getRunningCompactionTaskList();
+    for (AbstractCompactionTask task : runningTasks) {
+      CompactionTaskSummary summary = task.getSummary();
+      if (task instanceof InnerSpaceCompactionTask) {
+        if (task.isInnerSeqTask()) {
+          innerSeqCompactionTempFileSize.addAndGet(summary.getTemporalFileSize());
+          innerSeqCompactionTempFileNum.addAndGet(1);
+        } else {
+          innerUnseqCompactionTempFileSize.addAndGet(summary.getTemporalFileSize());
+          innerUnseqCompactionTempFileNum.addAndGet(1);
+        }
+      } else {
+        crossCompactionTempFileSize.addAndGet(summary.getTemporalFileSize());
+        crossCompactionTempFileNum.addAndGet(summary.getTemporalFileNum());
+      }
+    }
+  }
+
   public long getCrossCompactionTempFileSize() {
+    updateCompactionTempSize();
     return crossCompactionTempFileSize.get();
   }
 
   public long getInnerCompactionTempFileNum(boolean seq) {
+    updateCompactionTempSize();
     return seq ? innerSeqCompactionTempFileNum.get() : innerUnseqCompactionTempFileNum.get();
   }
 
   public long getCrossCompactionTempFileNum() {
+    updateCompactionTempSize();
     return crossCompactionTempFileNum.get();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
@@ -80,8 +80,6 @@ public class FastCompactionPerformer
 
   private boolean isCrossCompaction;
 
-  private long tempFileSize = 0L;
-
   public FastCompactionPerformer(
       List<TsFileResource> seqFiles,
       List<TsFileResource> unseqFiles,

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICrossCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ISeqCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.IUnseqCompactionPerformer;
@@ -105,8 +104,7 @@ public class FastCompactionPerformer
   @Override
   public void perform()
       throws IOException, MetadataException, StorageEngineException, InterruptedException {
-    TsFileMetricManager.getInstance()
-        .addCompactionTempFileNum(!isCrossCompaction, !seqFiles.isEmpty(), targetFiles.size());
+    this.subTaskSummary.setTemporalFileNum(targetFiles.size());
     try (MultiTsFileDeviceIterator deviceIterator =
             new MultiTsFileDeviceIterator(seqFiles, unseqFiles, readerCacheMap);
         AbstractCompactionWriter compactionWriter =
@@ -139,11 +137,7 @@ public class FastCompactionPerformer
         // check whether to flush chunk metadata or not
         compactionWriter.checkAndMayFlushChunkMetadata();
         // Add temp file metrics
-        long currentTempFileSize = compactionWriter.getWriterSize();
-        TsFileMetricManager.getInstance()
-            .addCompactionTempFileSize(
-                !isCrossCompaction, !seqFiles.isEmpty(), currentTempFileSize - tempFileSize);
-        tempFileSize = currentTempFileSize;
+        subTaskSummary.setTemporalFileSize(compactionWriter.getWriterSize());
         sortedSourceFiles.clear();
       }
       compactionWriter.endFile();
@@ -156,10 +150,6 @@ public class FastCompactionPerformer
       sortedSourceFiles = null;
       readerCacheMap = null;
       modificationCache = null;
-      TsFileMetricManager.getInstance()
-          .addCompactionTempFileNum(!isCrossCompaction, !seqFiles.isEmpty(), -targetFiles.size());
-      TsFileMetricManager.getInstance()
-          .addCompactionTempFileSize(!isCrossCompaction, !seqFiles.isEmpty(), -tempFileSize);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/ReadPointCompactionPerformer.java
@@ -74,7 +74,6 @@ public class ReadPointCompactionPerformer
   private CompactionTaskSummary summary;
 
   private List<TsFileResource> targetFiles = Collections.emptyList();
-  private long tempFileSize = 0L;
 
   public ReadPointCompactionPerformer(
       List<TsFileResource> seqFiles,

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
@@ -161,6 +161,10 @@ public abstract class AbstractCompactionTask {
     return crossTask;
   }
 
+  public long getTemporalFileSize() {
+    return summary.getTemporalFileSize();
+  }
+
   public boolean isInnerSeqTask() {
     return innerSeqTask;
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CompactionTaskSummary.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CompactionTaskSummary.java
@@ -32,6 +32,8 @@ public class CompactionTaskSummary {
   protected int deserializePageCount = 0;
   protected int mergedChunkNum = 0;
   protected long processPointNum = 0;
+  protected long temporalFileSize = 0;
+  protected int temporalFileNum = 0;
 
   public CompactionTaskSummary() {}
 
@@ -132,6 +134,22 @@ public class CompactionTaskSummary {
     SUCCESS,
     FAILED,
     CANCELED
+  }
+
+  public void setTemporalFileSize(long temporalFileSize) {
+    this.temporalFileSize = temporalFileSize;
+  }
+
+  public long getTemporalFileSize() {
+    return temporalFileSize;
+  }
+
+  public void setTemporalFileNum(int temporalFileNum) {
+    this.temporalFileNum = temporalFileNum;
+  }
+
+  public int getTemporalFileNum() {
+    return temporalFileNum;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
@@ -130,7 +130,6 @@ public class AlignedSeriesCompactionExecutor {
   }
 
   public void execute() throws IOException {
-    long originTempFileSize = writer.getPos();
     while (readerAndChunkMetadataList.size() > 0) {
       Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> readerListPair =
           readerAndChunkMetadataList.removeFirst();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
@@ -19,7 +19,6 @@
 package org.apache.iotdb.db.engine.compaction.execute.utils.executor.readchunk;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.schedule.constant.CompactionType;
@@ -162,10 +161,6 @@ public class AlignedSeriesCompactionExecutor {
       chunkWriter.writeToFileWriter(writer);
     }
     writer.checkMetadataSizeAndMayFlush();
-
-    // update temporal file metrics
-    TsFileMetricManager.getInstance()
-        .addCompactionTempFileSize(true, true, writer.getPos() - originTempFileSize);
   }
 
   private void compactOneAlignedChunk(AlignedChunkReader chunkReader, int notNullChunkNum)

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
@@ -179,7 +179,7 @@ public class FileMetrics implements IMetricSet {
           };
       metricService.createAutoGauge(
           Metric.FILE_COUNT.toString(),
-          MetricLevel.CORE,
+          MetricLevel.IMPORTANT,
           this,
           FileMetrics::getOpenFileHandlersNumber,
           Tag.NAME.toString(),

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
@@ -48,10 +48,12 @@ public class FileMetrics implements IMetricSet {
   private static final WALManager WAL_MANAGER = WALManager.getInstance();
   private final Runtime runtime = Runtime.getRuntime();
   private String[] getOpenFileNumberCommand;
-  private String fileHandlerCntPath = "/proc/%s/fd";
+
+  @SuppressWarnings("squid:S1075")
+  private String fileHandlerCntPathInLinux = "/proc/%s/fd";
 
   public FileMetrics() {
-    fileHandlerCntPath = String.format(fileHandlerCntPath, METRIC_CONFIG.getPid());
+    fileHandlerCntPathInLinux = String.format(fileHandlerCntPathInLinux, METRIC_CONFIG.getPid());
   }
 
   @Override
@@ -256,7 +258,7 @@ public class FileMetrics implements IMetricSet {
       if (METRIC_CONFIG.getSystemType() == SystemType.LINUX) {
         // count the fd in the system directory instead of
         // calling runtime.exec() which could be much slower
-        File fdDir = new File(fileHandlerCntPath);
+        File fdDir = new File(fileHandlerCntPathInLinux);
         if (fdDir.exists()) {
           File[] fds = fdDir.listFiles();
           fdCount = fds == null ? 0 : fds.length;


### PR DESCRIPTION
See [IOTDB-5828](https://issues.apache.org/jira/browse/IOTDB-5828).

This PR optimize the performance of `JVMThreadMetrics` by caching the result of thread infos, and optimize the performance of `FileMetrics` by counting file in system directory(/proc/[PID]/fd) instead of calling Runtime.exec() in Linux. This PR refactor the way of getting file size and count of temporal files in compaction. The way is changed from updating size incrementally to recording by `CompactionTaskSummary`.