### PR TITLE
[IOTDB-5828] Optimize the performance of some parts in metrics, and correcting the metrics count of temporal file size in inner space compaction

### DIFF
--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/net/LinuxNetMetricManager.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/net/LinuxNetMetricManager.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.metrics.metricsets.net;
 
 import org.apache.iotdb.metrics.config.MetricConfig;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
+import org.apache.iotdb.metrics.utils.MetricLevel;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -215,20 +216,22 @@ public class LinuxNetMetricManager implements INetMetricManager {
       log.error("Meets error when reading {} for net status", NET_STATUS_PATH, e);
     }
 
-    // update socket num
-    try {
-      Process process = Runtime.getRuntime().exec(this.getConnectNumCmd);
-      StringBuilder result = new StringBuilder();
-      try (BufferedReader input =
-          new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-        String line;
-        while ((line = input.readLine()) != null) {
-          result.append(line);
+    if (MetricLevel.higherOrEqual(MetricLevel.NORMAL, METRIC_CONFIG.getMetricLevel())) {
+      // update socket num
+      try {
+        Process process = Runtime.getRuntime().exec(this.getConnectNumCmd);
+        StringBuilder result = new StringBuilder();
+        try (BufferedReader input =
+            new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+          String line;
+          while ((line = input.readLine()) != null) {
+            result.append(line);
+          }
         }
+        this.connectionNum = Integer.parseInt(result.toString().trim());
+      } catch (IOException e) {
+        log.error("Failed to get socket num", e);
       }
-      this.connectionNum = Integer.parseInt(result.toString().trim());
-    } catch (IOException e) {
-      log.error("Failed to get socket num", e);
     }
   }
 }

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/net/NetMetrics.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/net/NetMetrics.java
@@ -91,7 +91,7 @@ public class NetMetrics implements IMetricSet {
     }
     metricService.createAutoGauge(
         CONNECTION_NUM,
-        MetricLevel.IMPORTANT,
+        MetricLevel.NORMAL,
         netMetricManager,
         INetMetricManager::getConnectionNum,
         PROCESS_NAME,

--- a/server/src/main/java/org/apache/iotdb/db/engine/TsFileMetricManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/TsFileMetricManager.java
@@ -19,8 +19,13 @@
 
 package org.apache.iotdb.db.engine;
 
+import org.apache.iotdb.db.engine.compaction.execute.task.AbstractCompactionTask;
+import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
+import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.service.metrics.FileMetrics;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -35,6 +40,8 @@ public class TsFileMetricManager {
   private final AtomicInteger modFileNum = new AtomicInteger(0);
 
   private final AtomicLong modFileSize = new AtomicLong(0);
+  private long lastUpdateTime = 0;
+  private static final long UPDATE_INTERVAL = 10_000L;
 
   // compaction temporal files
   private final AtomicLong innerSeqCompactionTempFileSize = new AtomicLong(0);
@@ -102,41 +109,55 @@ public class TsFileMetricManager {
     modFileSize.addAndGet(-size);
   }
 
-  public void addCompactionTempFileSize(boolean innerSpace, boolean seq, long delta) {
-    if (innerSpace) {
-      long unused =
-          seq
-              ? innerSeqCompactionTempFileSize.addAndGet(delta)
-              : innerUnseqCompactionTempFileSize.addAndGet(delta);
-    } else {
-      crossCompactionTempFileSize.addAndGet(delta);
-    }
-  }
-
-  public void addCompactionTempFileNum(boolean innerSpace, boolean seq, int delta) {
-    if (innerSpace) {
-      long unused =
-          seq
-              ? innerSeqCompactionTempFileNum.addAndGet(delta)
-              : innerUnseqCompactionTempFileNum.addAndGet(delta);
-    } else {
-      crossCompactionTempFileNum.addAndGet(delta);
-    }
-  }
-
   public long getInnerCompactionTempFileSize(boolean seq) {
+    updateCompactionTempSize();
     return seq ? innerSeqCompactionTempFileSize.get() : innerUnseqCompactionTempFileSize.get();
   }
 
+  private synchronized void updateCompactionTempSize() {
+    if (System.currentTimeMillis() - lastUpdateTime <= UPDATE_INTERVAL) {
+      return;
+    }
+    lastUpdateTime = System.currentTimeMillis();
+
+    innerSeqCompactionTempFileSize.set(0);
+    innerSeqCompactionTempFileNum.set(0);
+    innerUnseqCompactionTempFileSize.set(0);
+    innerUnseqCompactionTempFileNum.set(0);
+    crossCompactionTempFileSize.set(0);
+    crossCompactionTempFileNum.set(0);
+
+    List<AbstractCompactionTask> runningTasks =
+        CompactionTaskManager.getInstance().getRunningCompactionTaskList();
+    for (AbstractCompactionTask task : runningTasks) {
+      CompactionTaskSummary summary = task.getSummary();
+      if (task instanceof InnerSpaceCompactionTask) {
+        if (task.isInnerSeqTask()) {
+          innerSeqCompactionTempFileSize.addAndGet(summary.getTemporalFileSize());
+          innerSeqCompactionTempFileNum.addAndGet(1);
+        } else {
+          innerUnseqCompactionTempFileSize.addAndGet(summary.getTemporalFileSize());
+          innerUnseqCompactionTempFileNum.addAndGet(1);
+        }
+      } else {
+        crossCompactionTempFileSize.addAndGet(summary.getTemporalFileSize());
+        crossCompactionTempFileNum.addAndGet(summary.getTemporalFileNum());
+      }
+    }
+  }
+
   public long getCrossCompactionTempFileSize() {
+    updateCompactionTempSize();
     return crossCompactionTempFileSize.get();
   }
 
   public long getInnerCompactionTempFileNum(boolean seq) {
+    updateCompactionTempSize();
     return seq ? innerSeqCompactionTempFileNum.get() : innerUnseqCompactionTempFileNum.get();
   }
 
   public long getCrossCompactionTempFileNum() {
+    updateCompactionTempSize();
     return crossCompactionTempFileNum.get();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/FastCompactionPerformer.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICrossCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ISeqCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.IUnseqCompactionPerformer;
@@ -81,8 +80,6 @@ public class FastCompactionPerformer
 
   private boolean isCrossCompaction;
 
-  private long tempFileSize = 0L;
-
   public FastCompactionPerformer(
       List<TsFileResource> seqFiles,
       List<TsFileResource> unseqFiles,
@@ -105,8 +102,7 @@ public class FastCompactionPerformer
   @Override
   public void perform()
       throws IOException, MetadataException, StorageEngineException, InterruptedException {
-    TsFileMetricManager.getInstance()
-        .addCompactionTempFileNum(!isCrossCompaction, !seqFiles.isEmpty(), targetFiles.size());
+    this.subTaskSummary.setTemporalFileNum(targetFiles.size());
     try (MultiTsFileDeviceIterator deviceIterator =
             new MultiTsFileDeviceIterator(seqFiles, unseqFiles, readerCacheMap);
         AbstractCompactionWriter compactionWriter =
@@ -139,11 +135,7 @@ public class FastCompactionPerformer
         // check whether to flush chunk metadata or not
         compactionWriter.checkAndMayFlushChunkMetadata();
         // Add temp file metrics
-        long currentTempFileSize = compactionWriter.getWriterSize();
-        TsFileMetricManager.getInstance()
-            .addCompactionTempFileSize(
-                !isCrossCompaction, !seqFiles.isEmpty(), currentTempFileSize - tempFileSize);
-        tempFileSize = currentTempFileSize;
+        subTaskSummary.setTemporalFileSize(compactionWriter.getWriterSize());
         sortedSourceFiles.clear();
       }
       compactionWriter.endFile();
@@ -156,10 +148,6 @@ public class FastCompactionPerformer
       sortedSourceFiles = null;
       readerCacheMap = null;
       modificationCache = null;
-      TsFileMetricManager.getInstance()
-          .addCompactionTempFileNum(!isCrossCompaction, !seqFiles.isEmpty(), -targetFiles.size());
-      TsFileMetricManager.getInstance()
-          .addCompactionTempFileSize(!isCrossCompaction, !seqFiles.isEmpty(), -tempFileSize);
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/ReadPointCompactionPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/performer/impl/ReadPointCompactionPerformer.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.commons.path.AlignedPath;
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICrossCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.IUnseqCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
@@ -75,7 +74,6 @@ public class ReadPointCompactionPerformer
   private CompactionTaskSummary summary;
 
   private List<TsFileResource> targetFiles = Collections.emptyList();
-  private long tempFileSize = 0L;
 
   public ReadPointCompactionPerformer(
       List<TsFileResource> seqFiles,
@@ -103,8 +101,7 @@ public class ReadPointCompactionPerformer
     QueryResourceManager.getInstance()
         .getQueryFileManager()
         .addUsedFilesForQuery(queryId, queryDataSource);
-    TsFileMetricManager.getInstance()
-        .addCompactionTempFileNum(seqFiles.isEmpty(), false, targetFiles.size());
+    summary.setTemporalFileNum(targetFiles.size());
     try (AbstractCompactionWriter compactionWriter =
         getCompactionWriter(seqFiles, unseqFiles, targetFiles)) {
       // Do not close device iterator, because tsfile reader is managed by FileReaderManager.
@@ -124,6 +121,7 @@ public class ReadPointCompactionPerformer
           compactNonAlignedSeries(
               device, deviceIterator, compactionWriter, fragmentInstanceContext, queryDataSource);
         }
+        summary.setTemporalFileSize(compactionWriter.getWriterSize());
       }
 
       compactionWriter.endFile();
@@ -131,10 +129,6 @@ public class ReadPointCompactionPerformer
 
     } finally {
       QueryResourceManager.getInstance().endQuery(queryId);
-      TsFileMetricManager.getInstance()
-          .addCompactionTempFileNum(seqFiles.isEmpty(), false, -targetFiles.size());
-      TsFileMetricManager.getInstance()
-          .addCompactionTempFileSize(seqFiles.isEmpty(), false, tempFileSize);
     }
   }
 
@@ -186,11 +180,6 @@ public class ReadPointCompactionPerformer
       // check whether to flush chunk metadata or not
       compactionWriter.checkAndMayFlushChunkMetadata();
     }
-    // add temp file metrics
-    long currentWriterSize = compactionWriter.getWriterSize();
-    TsFileMetricManager.getInstance()
-        .addCompactionTempFileSize(seqFiles.isEmpty(), false, currentWriterSize - tempFileSize);
-    tempFileSize = currentWriterSize;
   }
 
   private void compactNonAlignedSeries(
@@ -238,12 +227,6 @@ public class ReadPointCompactionPerformer
       // check whether to flush chunk metadata or not
       compactionWriter.checkAndMayFlushChunkMetadata();
     }
-
-    // add temp file metrics
-    long currentWriterSize = compactionWriter.getWriterSize();
-    TsFileMetricManager.getInstance()
-        .addCompactionTempFileSize(seqFiles.isEmpty(), false, currentWriterSize - tempFileSize);
-    tempFileSize = currentWriterSize;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
@@ -161,6 +161,10 @@ public abstract class AbstractCompactionTask {
     return crossTask;
   }
 
+  public long getTemporalFileSize() {
+    return summary.getTemporalFileSize();
+  }
+
   public boolean isInnerSeqTask() {
     return innerSeqTask;
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CompactionTaskSummary.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CompactionTaskSummary.java
@@ -32,6 +32,8 @@ public class CompactionTaskSummary {
   protected int deserializePageCount = 0;
   protected int mergedChunkNum = 0;
   protected long processPointNum = 0;
+  protected long temporalFileSize = 0;
+  protected int temporalFileNum = 0;
 
   public CompactionTaskSummary() {}
 
@@ -132,6 +134,22 @@ public class CompactionTaskSummary {
     SUCCESS,
     FAILED,
     CANCELED
+  }
+
+  public void setTemporalFileSize(long temporalFileSize) {
+    this.temporalFileSize = temporalFileSize;
+  }
+
+  public long getTemporalFileSize() {
+    return temporalFileSize;
+  }
+
+  public void setTemporalFileNum(int temporalFileNum) {
+    this.temporalFileNum = temporalFileNum;
+  }
+
+  public int getTemporalFileNum() {
+    return temporalFileNum;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/readchunk/AlignedSeriesCompactionExecutor.java
@@ -19,7 +19,6 @@
 package org.apache.iotdb.db.engine.compaction.execute.utils.executor.readchunk;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.schedule.constant.CompactionType;
@@ -131,7 +130,6 @@ public class AlignedSeriesCompactionExecutor {
   }
 
   public void execute() throws IOException {
-    long originTempFileSize = writer.getPos();
     while (readerAndChunkMetadataList.size() > 0) {
       Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> readerListPair =
           readerAndChunkMetadataList.removeFirst();
@@ -162,10 +160,6 @@ public class AlignedSeriesCompactionExecutor {
       chunkWriter.writeToFileWriter(writer);
     }
     writer.checkMetadataSizeAndMayFlush();
-
-    // update temporal file metrics
-    TsFileMetricManager.getInstance()
-        .addCompactionTempFileSize(true, true, writer.getPos() - originTempFileSize);
   }
 
   private void compactOneAlignedChunk(AlignedChunkReader chunkReader, int notNullChunkNum)

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
@@ -47,6 +48,13 @@ public class FileMetrics implements IMetricSet {
   private static final WALManager WAL_MANAGER = WALManager.getInstance();
   private final Runtime runtime = Runtime.getRuntime();
   private String[] getOpenFileNumberCommand;
+
+  @SuppressWarnings("squid:S1075")
+  private String fileHandlerCntPathInLinux = "/proc/%s/fd";
+
+  public FileMetrics() {
+    fileHandlerCntPathInLinux = String.format(fileHandlerCntPathInLinux, METRIC_CONFIG.getPid());
+  }
 
   @Override
   public void bindTo(AbstractMetricService metricService) {
@@ -173,7 +181,7 @@ public class FileMetrics implements IMetricSet {
           };
       metricService.createAutoGauge(
           Metric.FILE_COUNT.toString(),
-          MetricLevel.CORE,
+          MetricLevel.IMPORTANT,
           this,
           FileMetrics::getOpenFileHandlersNumber,
           Tag.NAME.toString(),
@@ -245,9 +253,17 @@ public class FileMetrics implements IMetricSet {
   }
 
   private long getOpenFileHandlersNumber() {
+    long fdCount = 0;
     try {
-      if ((METRIC_CONFIG.getSystemType() == SystemType.LINUX
-              || METRIC_CONFIG.getSystemType() == SystemType.MAC)
+      if (METRIC_CONFIG.getSystemType() == SystemType.LINUX) {
+        // count the fd in the system directory instead of
+        // calling runtime.exec() which could be much slower
+        File fdDir = new File(fileHandlerCntPathInLinux);
+        if (fdDir.exists()) {
+          File[] fds = fdDir.listFiles();
+          fdCount = fds == null ? 0 : fds.length;
+        }
+      } else if ((METRIC_CONFIG.getSystemType() == SystemType.MAC)
           && METRIC_CONFIG.getPid().length() != 0) {
         Process process = runtime.exec(getOpenFileNumberCommand);
         StringBuilder result = new StringBuilder();
@@ -258,11 +274,11 @@ public class FileMetrics implements IMetricSet {
             result.append(line);
           }
         }
-        return Long.parseLong(result.toString().trim());
+        fdCount = Long.parseLong(result.toString().trim());
       }
     } catch (IOException e) {
       LOGGER.warn("Failed to get open file number, because ", e);
     }
-    return 0L;
+    return fdCount;
   }
 }


### PR DESCRIPTION
See [IOTDB-5828](https://issues.apache.org/jira/browse/IOTDB-5828).

This PR optimize the performance of `JVMThreadMetrics` by caching the result of thread infos, and optimize the performance of `FileMetrics` by counting file in system directory(/proc/[PID]/fd) instead of calling Runtime.exec() in Linux. This PR refactor the way of getting file size and count of temporal files in compaction. The way is changed from updating size incrementally to recording by `CompactionTaskSummary`.