### PR TITLE
[IOTDB-5831] Fix drop database won't delete totally files in disk during data insertion

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
@@ -125,6 +125,13 @@ public class ClusterSchemaManager {
           illegalPathException.getErrorCode(), illegalPathException.getMessage());
     }
 
+    if (getPartitionManager().isDatabasePreDeleted(databaseSchemaPlan.getSchema().getName())) {
+      return RpcUtils.getStatus(
+          TSStatusCode.METADATA_ERROR,
+          String.format(
+              "Some other task is deleting database %s", databaseSchemaPlan.getSchema().getName()));
+    }
+
     try {
       clusterSchemaInfo.isDatabaseNameValid(databaseSchemaPlan.getSchema().getName());
     } catch (MetadataException metadataException) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -765,6 +765,10 @@ public class PartitionManager {
     getConsensusManager().write(preDeleteDatabasePlan);
   }
 
+  public boolean isDatabasePreDeleted(String database) {
+    return partitionInfo.isDatabasePreDeleted(database);
+  }
+
   /**
    * Get TSeriesPartitionSlot
    *

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -263,6 +263,11 @@ public class PartitionInfo implements SnapshotProcessor {
     return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
   }
 
+  public boolean isDatabasePreDeleted(String database) {
+    DatabasePartitionTable databasePartitionTable = databasePartitionTables.get(database);
+    return databasePartitionTable != null && !databasePartitionTable.isNotPreDeleted();
+  }
+
   /**
    * Thread-safely delete StorageGroup
    *


### PR DESCRIPTION
## Description

When executing dropping database during data insertion, the database and data partition will be auto created after the database has been set pre-deleted, which results in unreachable regions since the database schema has been deleted in ClusterSchemaManager by the dropping database task.

Add database pre-deleted check and forbid data insertion to a database being deleted. 

