### PR TITLE
[IOTDB-5824] Fix show devices with * cannot display satisfied devices

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
@@ -597,7 +597,7 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R>
         }
 
         // check whether accept the first matched state
-        if (isTargetNodeType(child) && !matchedState.isFinal()) {
+        if (mayTargetNodeType(child) && !matchedState.isFinal()) {
           // not accept the first matched state since this node may be a target result, check the
           // other states
           if (patternFA.mayTransitionOverlap() && transitionIterator.hasNext()) {
@@ -671,7 +671,7 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R>
         child = iterator.next();
 
         stateMatchInfo = new StateMultiMatchInfo(patternFA);
-        if (isTargetNodeType(child)) {
+        if (mayTargetNodeType(child)) {
           for (int i = 0; i < sourceStateMatchInfo.getMatchedStateSize(); i++) {
             sourceState = sourceStateMatchInfo.getMatchedState(i);
             transitionIterator = tryGetNextMatchedState(child, sourceState, stateMatchInfo, true);
@@ -902,5 +902,12 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R>
     }
   }
 
-  protected abstract boolean isTargetNodeType(N node);
+  /**
+   * May node can be accepted if it reaches final state. Its implementation should not depend on the
+   * context.
+   *
+   * @param node node to be checked
+   * @return false is if node must not be accepted. Otherwise, return true.
+   */
+  protected abstract boolean mayTargetNodeType(N node);
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/tree/AbstractTreeVisitor.java
@@ -675,10 +675,12 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R>
           for (int i = 0; i < sourceStateMatchInfo.getMatchedStateSize(); i++) {
             sourceState = sourceStateMatchInfo.getMatchedState(i);
             transitionIterator = tryGetNextMatchedState(child, sourceState, stateMatchInfo, true);
-            if (stateMatchInfo.getMatchedStateSize() > 0 && stateMatchInfo.hasFinalState()) {
+            if (stateMatchInfo.getMatchedStateSize() > 0) {
               stateMatchInfo.setSourceStateOrdinal(i);
               stateMatchInfo.setSourceTransitionIterator(transitionIterator);
-              break;
+              if (stateMatchInfo.hasFinalState()) {
+                break;
+              }
             }
           }
 
@@ -900,7 +902,5 @@ public abstract class AbstractTreeVisitor<N extends ITreeNode, R>
     }
   }
 
-  protected boolean isTargetNodeType(N node) {
-    return false;
-  }
+  protected abstract boolean isTargetNodeType(N node);
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/Traverser.java
@@ -21,6 +21,8 @@ package org.apache.iotdb.db.metadata.mtree.traverser;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.fa.IFAState;
+import org.apache.iotdb.commons.path.fa.IFATransition;
 import org.apache.iotdb.commons.schema.node.IMNode;
 import org.apache.iotdb.commons.schema.node.utils.IMNodeFactory;
 import org.apache.iotdb.commons.schema.node.utils.IMNodeIterator;
@@ -178,5 +180,64 @@ public abstract class Traverser<R, N extends IMNode<N>> extends AbstractTreeVisi
 
   public void setSkipPreDeletedSchema(boolean skipPreDeletedSchema) {
     this.skipPreDeletedSchema = skipPreDeletedSchema;
+  }
+
+  @Override
+  protected IFAState tryGetNextState(
+      N node, IFAState sourceState, Map<String, IFATransition> preciseMatchTransitionMap) {
+    IFATransition transition;
+    IFAState state;
+    if (node.isMeasurement()) {
+      String alias = node.getAsMeasurementMNode().getAlias();
+      if (alias != null) {
+        transition = preciseMatchTransitionMap.get(alias);
+        if (transition != null) {
+          state = patternFA.getNextState(sourceState, transition);
+          if (state.isFinal()) {
+            return state;
+          }
+        }
+      }
+      transition = preciseMatchTransitionMap.get(node.getName());
+      if (transition != null) {
+        state = patternFA.getNextState(sourceState, transition);
+        if (state.isFinal()) {
+          return state;
+        }
+      }
+      return null;
+    }
+
+    transition = preciseMatchTransitionMap.get(node.getName());
+    if (transition == null) {
+      return null;
+    }
+    return patternFA.getNextState(sourceState, transition);
+  }
+
+  @Override
+  protected IFAState tryGetNextState(N node, IFAState sourceState, IFATransition transition) {
+    IFAState state;
+    if (node.isMeasurement()) {
+      String alias = node.getAsMeasurementMNode().getAlias();
+      if (alias != null && transition.isMatch(alias)) {
+        state = patternFA.getNextState(sourceState, transition);
+        if (state.isFinal()) {
+          return state;
+        }
+      }
+      if (transition.isMatch(node.getName())) {
+        state = patternFA.getNextState(sourceState, transition);
+        if (state.isFinal()) {
+          return state;
+        }
+      }
+      return null;
+    }
+
+    if (transition.isMatch(node.getName())) {
+      return patternFA.getNextState(sourceState, transition);
+    }
+    return null;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/TraverserWithLimitOffsetWrapper.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/TraverserWithLimitOffsetWrapper.java
@@ -109,7 +109,7 @@ public class TraverserWithLimitOffsetWrapper<R, N extends IMNode<N>> extends Tra
   }
 
   @Override
-  protected boolean isTargetNodeType(N node) {
+  protected boolean mayTargetNodeType(N node) {
     return false;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/TraverserWithLimitOffsetWrapper.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/TraverserWithLimitOffsetWrapper.java
@@ -109,6 +109,11 @@ public class TraverserWithLimitOffsetWrapper<R, N extends IMNode<N>> extends Tra
   }
 
   @Override
+  protected boolean isTargetNodeType(N node) {
+    return false;
+  }
+
+  @Override
   public void close() {
     traverser.close();
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/DatabaseTraverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/DatabaseTraverser.java
@@ -44,8 +44,8 @@ public abstract class DatabaseTraverser<R, N extends IMNode<N>> extends Traverse
   }
 
   @Override
-  protected boolean isTargetNodeType(N node) {
-    return node.isDatabase();
+  protected boolean mayTargetNodeType(N node) {
+    return collectInternal || node.isDatabase();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/DatabaseTraverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/DatabaseTraverser.java
@@ -44,6 +44,11 @@ public abstract class DatabaseTraverser<R, N extends IMNode<N>> extends Traverse
   }
 
   @Override
+  protected boolean isTargetNodeType(N node) {
+    return node.isDatabase();
+  }
+
+  @Override
   protected boolean acceptFullMatchedNode(N node) {
     return node.isDatabase();
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/EntityTraverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/EntityTraverser.java
@@ -44,6 +44,11 @@ public abstract class EntityTraverser<R, N extends IMNode<N>> extends Traverser<
   }
 
   @Override
+  protected boolean isTargetNodeType(N node) {
+    return node.isDevice();
+  }
+
+  @Override
   protected boolean acceptFullMatchedNode(N node) {
     if (node.isDevice()) {
       return !usingTemplate || schemaTemplateId == node.getAsDeviceMNode().getSchemaTemplateId();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/EntityTraverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/EntityTraverser.java
@@ -44,8 +44,11 @@ public abstract class EntityTraverser<R, N extends IMNode<N>> extends Traverser<
   }
 
   @Override
-  protected boolean isTargetNodeType(N node) {
-    return node.isDevice();
+  protected boolean mayTargetNodeType(N node) {
+    if (node.isDevice()) {
+      return !usingTemplate || schemaTemplateId == node.getAsDeviceMNode().getSchemaTemplateId();
+    }
+    return false;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/MNodeTraverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/MNodeTraverser.java
@@ -51,7 +51,7 @@ public abstract class MNodeTraverser<R, N extends IMNode<N>> extends Traverser<R
   }
 
   @Override
-  protected boolean isTargetNodeType(N node) {
+  protected boolean mayTargetNodeType(N node) {
     return true;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/MNodeTraverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/MNodeTraverser.java
@@ -51,6 +51,11 @@ public abstract class MNodeTraverser<R, N extends IMNode<N>> extends Traverser<R
   }
 
   @Override
+  protected boolean isTargetNodeType(N node) {
+    return true;
+  }
+
+  @Override
   protected boolean acceptFullMatchedNode(N node) {
     if (targetLevel >= 0) {
       if (getSizeOfAncestor() > targetLevel) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/MeasurementTraverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/MeasurementTraverser.java
@@ -42,7 +42,7 @@ public abstract class MeasurementTraverser<R, N extends IMNode<N>> extends Trave
   }
 
   @Override
-  protected boolean isTargetNodeType(N node) {
+  protected boolean mayTargetNodeType(N node) {
     return node.isMeasurement();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/MeasurementTraverser.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/basic/MeasurementTraverser.java
@@ -42,6 +42,11 @@ public abstract class MeasurementTraverser<R, N extends IMNode<N>> extends Trave
   }
 
   @Override
+  protected boolean isTargetNodeType(N node) {
+    return node.isMeasurement();
+  }
+
+  @Override
   protected boolean acceptFullMatchedNode(N node) {
     return node.isMeasurement();
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeDeviceVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeDeviceVisitor.java
@@ -36,7 +36,7 @@ public class SchemaTreeDeviceVisitor extends SchemaTreeVisitor<DeviceSchemaInfo>
   }
 
   @Override
-  protected boolean isTargetNodeType(SchemaNode node) {
+  protected boolean mayTargetNodeType(SchemaNode node) {
     return node.isEntity();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeDeviceVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeDeviceVisitor.java
@@ -36,6 +36,11 @@ public class SchemaTreeDeviceVisitor extends SchemaTreeVisitor<DeviceSchemaInfo>
   }
 
   @Override
+  protected boolean isTargetNodeType(SchemaNode node) {
+    return node.isEntity();
+  }
+
+  @Override
   protected boolean acceptInternalMatchedNode(SchemaNode node) {
     return false;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeMeasurementVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeMeasurementVisitor.java
@@ -38,6 +38,11 @@ public class SchemaTreeMeasurementVisitor extends SchemaTreeVisitor<MeasurementP
   }
 
   @Override
+  protected boolean isTargetNodeType(SchemaNode node) {
+    return node.isMeasurement();
+  }
+
+  @Override
   protected IFAState tryGetNextState(
       SchemaNode node, IFAState sourceState, Map<String, IFATransition> preciseMatchTransitionMap) {
     IFATransition transition;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeMeasurementVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeMeasurementVisitor.java
@@ -38,7 +38,7 @@ public class SchemaTreeMeasurementVisitor extends SchemaTreeVisitor<MeasurementP
   }
 
   @Override
-  protected boolean isTargetNodeType(SchemaNode node) {
+  protected boolean mayTargetNodeType(SchemaNode node) {
     return node.isMeasurement();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeVisitorWithLimitOffsetWrapper.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeVisitorWithLimitOffsetWrapper.java
@@ -102,6 +102,12 @@ public class SchemaTreeVisitorWithLimitOffsetWrapper<R> extends SchemaTreeVisito
   }
 
   @Override
+  protected boolean isTargetNodeType(SchemaNode node) {
+    // do nothing
+    return false;
+  }
+
+  @Override
   public void reset() {
     visitor.reset();
     count = 0;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeVisitorWithLimitOffsetWrapper.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/visitor/SchemaTreeVisitorWithLimitOffsetWrapper.java
@@ -102,7 +102,7 @@ public class SchemaTreeVisitorWithLimitOffsetWrapper<R> extends SchemaTreeVisito
   }
 
   @Override
-  protected boolean isTargetNodeType(SchemaNode node) {
+  protected boolean mayTargetNodeType(SchemaNode node) {
     // do nothing
     return false;
   }


### PR DESCRIPTION
## Description

When traversing a tree structure, the current algorithm takes an greedy strategy that try match the node with states close to final state as much as possible, but not ensure a node due to match a final state do match a final state.

Add final state check and continue the traversing and state matching process until a candidate node match a final state or check all possible states. 