### PR TITLE
[IOTDB-5831]Fix drop database won't delete totally files in disk during data insertion

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -307,8 +307,11 @@ public class ConfigPlanExecutor {
         return clusterSchemaInfo.adjustMaxRegionGroupCount(
             (AdjustMaxRegionGroupNumPlan) physicalPlan);
       case DeleteDatabase:
-        partitionInfo.deleteDatabase((DeleteDatabasePlan) physicalPlan);
-        return clusterSchemaInfo.deleteDatabase((DeleteDatabasePlan) physicalPlan);
+        try {
+          return clusterSchemaInfo.deleteDatabase((DeleteDatabasePlan) physicalPlan);
+        } finally {
+          partitionInfo.deleteDatabase((DeleteDatabasePlan) physicalPlan);
+        }
       case PreDeleteDatabase:
         return partitionInfo.preDeleteDatabase((PreDeleteDatabasePlan) physicalPlan);
       case SetTTL:


### PR DESCRIPTION
## Description

When dropping database, the database schema shall be removed before database partition table, otherwise the pre-deleted check won't take effect.