### PR TITLE
Add config  min_cross_compaction_unseq_file_level for cross compaction

### DIFF
--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -621,6 +621,10 @@ cluster_name=defaultCluster
 # Datatype: long, Unit: byte
 # max_cross_compaction_candidate_file_size=5368709120
 
+# The min inner compaction level of unsequence file which can be selected as candidate
+# Datatype: int
+# min_cross_compaction_unseq_file_level=1
+
 # If one merge file selection runs for more than this time, it will be ended and its current
 # selection will be used as final selection.
 # When < 0, it means time is unbounded.

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -681,7 +681,7 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "min_cross_compaction_unseq_file_level",
                 Integer.toString(conf.getMinCrossCompactionUnseqFileLevel()))));
-    
+
     conf.setCompactionWriteThroughputMbPerSec(
         Integer.parseInt(
             properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -676,7 +676,12 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "max_cross_compaction_candidate_file_size",
                 Long.toString(conf.getMaxCrossCompactionCandidateFileSize()))));
-
+    conf.setMinCrossCompactionUnseqFileLevel(
+        Integer.parseInt(
+            properties.getProperty(
+                "min_cross_compaction_unseq_file_level",
+                Integer.toString(conf.getMinCrossCompactionUnseqFileLevel()))));
+    
     conf.setCompactionWriteThroughputMbPerSec(
         Integer.parseInt(
             properties.getProperty(


### PR DESCRIPTION
## Description
Before this change, the config `minCrossCompactionUnseqFileLevel` cannot be set by configuration file.

## Test

1. change config file `iotdb-common.properties`
<img width="753" alt="image" src="https://user-images.githubusercontent.com/18027703/236416287-fde32b24-38dc-4a48-9ab0-fdf5add79190.png">

2. snapshot when DataNode starts
<img width="611" alt="image" src="https://user-images.githubusercontent.com/18027703/236416200-303af6b9-2477-4701-8a12-af747e550d1c.png">
