### PR TITLE
[To rel/1.1] [IOTDB-5844] Fix compaction module getting stuck

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/exception/CompactionMemoryNotEnoughException.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/exception/CompactionMemoryNotEnoughException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.engine.compaction.execute.exception;
+
+public class CompactionMemoryNotEnoughException extends Exception {
+
+  public CompactionMemoryNotEnoughException(String message) {
+    super(message);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.compaction.execute.exception.CompactionExceptionHandler;
+import org.apache.iotdb.db.engine.compaction.execute.exception.CompactionMemoryNotEnoughException;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICrossCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
@@ -98,9 +99,12 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
   @Override
   public boolean doCompaction() {
     try {
-      SystemInfo.getInstance().addCompactionMemoryCost(memoryCost);
+      SystemInfo.getInstance().addCompactionMemoryCost(memoryCost, 60);
     } catch (InterruptedException e) {
       LOGGER.error("Interrupted when allocating memory for compaction", e);
+      return false;
+    } catch (CompactionMemoryNotEnoughException e) {
+      LOGGER.error("No enough memory for current compaction task {}", this, e);
       return false;
     }
     boolean isSuccess = true;

--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.compaction.execute.exception.CompactionMemoryNotEnoughException;
 import org.apache.iotdb.db.engine.flush.FlushManager;
 import org.apache.iotdb.db.engine.storagegroup.DataRegionInfo;
 import org.apache.iotdb.db.engine.storagegroup.TsFileProcessor;
@@ -181,13 +182,22 @@ public class SystemInfo {
     this.flushingMemTablesCost -= flushingMemTableCost;
   }
 
-  public void addCompactionMemoryCost(long memoryCost) throws InterruptedException {
+  public void addCompactionMemoryCost(long memoryCost, long timeOutInSecond)
+      throws InterruptedException, CompactionMemoryNotEnoughException {
     if (!config.isEnableCompactionMemControl()) {
       return;
     }
+    long startTime = System.currentTimeMillis();
     long originSize = this.compactionMemoryCost.get();
     while (originSize + memoryCost > memorySizeForCompaction
         || !compactionMemoryCost.compareAndSet(originSize, originSize + memoryCost)) {
+      if (System.currentTimeMillis() - startTime >= timeOutInSecond * 1000L) {
+        throw new CompactionMemoryNotEnoughException(
+            String.format(
+                "Failed to allocate %d bytes memory for compaction after %d seconds, "
+                    + "total memory budget for compaction module is %d bytes, %d bytes is used",
+                memoryCost, timeOutInSecond, memorySizeForCompaction, originSize));
+      }
       Thread.sleep(100);
       originSize = this.compactionMemoryCost.get();
     }

--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -191,7 +191,8 @@ public class SystemInfo {
       // required memory cost is greater than the total memory budget for compaction
       throw new CompactionMemoryNotEnoughException(
           String.format(
-              "Required memory cost %d bytes is greater than the total memory budget for compaction %d bytes",
+              "Required memory cost %d bytes is greater than "
+                  + "the total memory budget for compaction %d bytes",
               memoryCost, memorySizeForCompaction));
     }
     long startTime = System.currentTimeMillis();

--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -187,6 +187,13 @@ public class SystemInfo {
     if (!config.isEnableCompactionMemControl()) {
       return;
     }
+    if (memoryCost > memorySizeForCompaction) {
+      // required memory cost is greater than the total memory budget for compaction
+      throw new CompactionMemoryNotEnoughException(
+          String.format(
+              "Required memory cost %d bytes is greater than the total memory budget for compaction %d bytes",
+              memoryCost, memorySizeForCompaction));
+    }
     long startTime = System.currentTimeMillis();
     long originSize = this.compactionMemoryCost.get();
     while (originSize + memoryCost > memorySizeForCompaction

--- a/server/src/test/java/org/apache/iotdb/db/sync/pipedata/BufferedPipeDataQueueTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sync/pipedata/BufferedPipeDataQueueTest.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iotdb.db.sync.pipedata;
 
 import org.apache.iotdb.commons.path.PartialPath;
@@ -200,8 +201,8 @@ public class BufferedPipeDataQueueTest {
   }
 
   /**
-   * Step1: recover pipeDataQueue (with an empty latest pipelog) Step2: offer new pipeData Step3:
-   * check result
+   * Step1: recover pipeDataQueue (with an empty latest pipelog). Step2: offer new pipeData. Step3:
+   * check result.
    */
   @Test
   public void testOfferAfterRecoveryWithEmptyPipeLog() {
@@ -296,7 +297,7 @@ public class BufferedPipeDataQueueTest {
     }
   }
 
-  /** Step1: recover pipeDataQueue (without empty latest pipelog) Step2: check result */
+  /** Step1: recover pipeDataQueue (without empty latest pipelog). Step2: check result. */
   @Test
   public void testRecoveryWithEmptyPipeLog() {
     try {
@@ -386,7 +387,7 @@ public class BufferedPipeDataQueueTest {
     }
   }
 
-  /** Step1: recover pipeDataQueue (without empty latest pipelog) Step2: check result */
+  /** Step1: recover pipeDataQueue (without empty latest pipelog). Step2: check result. */
   @Test
   public void testRecoveryWithoutEmptyPipeLog() {
     try {


### PR DESCRIPTION
See [IOTDB-5844](https://issues.apache.org/jira/browse/IOTDB-5844).

To address this issue, we have added a timeout mechanism to the memory allocation step in the compaction process. If sufficient memory is not allocated within a certain amount of time, a CompactionMemoryNotEnoughException will be thrown, an error log will be printed, and the compaction task will be abandoned.