### PR TITLE
[To rel/1.1] Refactor compaction task metrics

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CompactionTaskStatus.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CompactionTaskStatus.java
@@ -20,8 +20,8 @@
 package org.apache.iotdb.db.engine.compaction.constant;
 
 public enum CompactionTaskStatus {
-  Waiting,
-  Running,
-  Finished,
-  Aborted
+  WAITING,
+  RUNNING,
+  FINISHED,
+  ABORTED
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CompactionTaskStatus.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CompactionTaskStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.engine.compaction.constant;
+
+public enum CompactionTaskStatus {
+  Waiting,
+  Running,
+  Finished,
+  Aborted
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CompactionTaskType.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/constant/CompactionTaskType.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.engine.compaction.constant;
+
+public enum CompactionTaskType {
+  INNER_SEQ,
+  INNER_UNSEQ,
+  CROSS
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/AbstractCompactionTask.java
@@ -74,7 +74,6 @@ public abstract class AbstractCompactionTask {
   public boolean start() {
     currentTaskNum.incrementAndGet();
     boolean isSuccess = false;
-    CompactionMetricsManager.getInstance().reportTaskStartRunning(crossTask, innerSeqTask);
     try {
       summary.start();
       isSuccess = doCompaction();

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionTaskManager.java
@@ -28,10 +28,12 @@ import org.apache.iotdb.commons.service.ServiceType;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.compaction.constant.CompactionTaskStatus;
+import org.apache.iotdb.db.engine.compaction.constant.CompactionTaskType;
 import org.apache.iotdb.db.engine.compaction.execute.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
+import org.apache.iotdb.db.engine.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.engine.compaction.schedule.comparator.DefaultCompactionTaskComparatorImpl;
-import org.apache.iotdb.db.service.metrics.recorder.CompactionMetricsManager;
 import org.apache.iotdb.db.utils.datastructure.FixedPriorityBlockingQueue;
 
 import com.google.common.util.concurrent.RateLimiter;
@@ -39,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -96,10 +99,6 @@ public class CompactionTaskManager implements IService {
       currentTaskNum = new AtomicInteger(0);
       candidateCompactionTaskQueue.regsitPollLastHook(
           AbstractCompactionTask::resetCompactionCandidateStatusForAllSourceFiles);
-      candidateCompactionTaskQueue.regsitPollLastHook(
-          x ->
-              CompactionMetricsManager.getInstance()
-                  .reportPollTaskFromWaitingQueue(x.isCrossTask(), x.isInnerSeqTask()));
       init = true;
     }
     logger.info("Compaction task manager started.");
@@ -225,11 +224,6 @@ public class CompactionTaskManager implements IService {
       compactionTask.setSourceFilesToCompactionCandidate();
       candidateCompactionTaskQueue.put(compactionTask);
 
-      // add metrics
-      CompactionMetricsManager.getInstance()
-          .reportAddTaskToWaitingQueue(
-              compactionTask.isCrossTask(), compactionTask.isInnerSeqTask());
-
       return true;
     }
     return false;
@@ -349,6 +343,52 @@ public class CompactionTaskManager implements IService {
             getSGWithRegionId(task.getStorageGroupName(), task.getDataRegionId()),
             x -> new ConcurrentHashMap<>())
         .put(task, summary);
+  }
+
+  public Map<CompactionTaskType, Map<CompactionTaskStatus, Integer>> getCompactionTaskStatistic() {
+    Map<CompactionTaskType, Map<CompactionTaskStatus, Integer>> statistic =
+        new EnumMap<>(CompactionTaskType.class);
+
+    // update statistic of waiting tasks
+    List<AbstractCompactionTask> waitingTaskList =
+        this.candidateCompactionTaskQueue.getAllElementAsList();
+    for (AbstractCompactionTask task : waitingTaskList) {
+      if (task instanceof InnerSpaceCompactionTask) {
+        statistic
+            .computeIfAbsent(
+                task.isInnerSeqTask()
+                    ? CompactionTaskType.INNER_SEQ
+                    : CompactionTaskType.INNER_UNSEQ,
+                x -> new EnumMap<>(CompactionTaskStatus.class))
+            .compute(CompactionTaskStatus.Waiting, (k, v) -> v == null ? 1 : v + 1);
+      } else {
+        statistic
+            .computeIfAbsent(
+                CompactionTaskType.CROSS, x -> new EnumMap<>(CompactionTaskStatus.class))
+            .compute(CompactionTaskStatus.Waiting, (k, v) -> v == null ? 1 : v + 1);
+      }
+    }
+
+    // update statistic of running tasks
+    List<AbstractCompactionTask> runningTaskList = this.getRunningCompactionTaskList();
+    for (AbstractCompactionTask task : runningTaskList) {
+      if (task instanceof InnerSpaceCompactionTask) {
+        statistic
+            .computeIfAbsent(
+                task.isInnerSeqTask()
+                    ? CompactionTaskType.INNER_SEQ
+                    : CompactionTaskType.INNER_UNSEQ,
+                x -> new EnumMap<>(CompactionTaskStatus.class))
+            .compute(CompactionTaskStatus.Running, (k, v) -> v == null ? 1 : v + 1);
+      } else {
+        statistic
+            .computeIfAbsent(
+                CompactionTaskType.CROSS, x -> new EnumMap<>(CompactionTaskStatus.class))
+            .compute(CompactionTaskStatus.Running, (k, v) -> v == null ? 1 : v + 1);
+      }
+    }
+
+    return statistic;
   }
 
   public static String getSGWithRegionId(String storageGroupName, String dataRegionId) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionWorker.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionWorker.java
@@ -20,7 +20,6 @@ package org.apache.iotdb.db.engine.compaction.schedule;
 
 import org.apache.iotdb.db.engine.compaction.execute.task.AbstractCompactionTask;
 import org.apache.iotdb.db.engine.compaction.execute.task.CompactionTaskSummary;
-import org.apache.iotdb.db.service.metrics.recorder.CompactionMetricsManager;
 import org.apache.iotdb.db.utils.datastructure.FixedPriorityBlockingQueue;
 
 import org.jetbrains.annotations.NotNull;
@@ -54,8 +53,6 @@ public class CompactionWorker implements Runnable {
           log.warn("CompactionThread-{} terminates because interruption", threadId);
           return;
         }
-        CompactionMetricsManager.getInstance()
-            .reportPollTaskFromWaitingQueue(task.isCrossTask(), task.isInnerSeqTask());
         if (task != null) {
           // add metrics
           if (task.checkValidAndSetMerging()) {

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/CompactionMetricsManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/CompactionMetricsManager.java
@@ -215,26 +215,26 @@ public class CompactionMetricsManager {
     this.waitingSeqInnerCompactionTaskNum.set(
         compactionTaskStatisticMap
             .getOrDefault(CompactionTaskType.INNER_SEQ, Collections.emptyMap())
-            .getOrDefault(CompactionTaskStatus.Waiting, 0));
+            .getOrDefault(CompactionTaskStatus.WAITING, 0));
     this.waitingUnseqInnerCompactionTaskNum.set(
         compactionTaskStatisticMap
             .getOrDefault(CompactionTaskType.INNER_UNSEQ, Collections.emptyMap())
-            .getOrDefault(CompactionTaskStatus.Waiting, 0));
+            .getOrDefault(CompactionTaskStatus.WAITING, 0));
     this.waitingCrossCompactionTaskNum.set(
         compactionTaskStatisticMap
             .getOrDefault(CompactionTaskType.CROSS, Collections.emptyMap())
-            .getOrDefault(CompactionTaskStatus.Waiting, 0));
+            .getOrDefault(CompactionTaskStatus.WAITING, 0));
     this.runningSeqInnerCompactionTaskNum.set(
         compactionTaskStatisticMap
             .getOrDefault(CompactionTaskType.INNER_SEQ, Collections.emptyMap())
-            .getOrDefault(CompactionTaskStatus.Running, 0));
+            .getOrDefault(CompactionTaskStatus.RUNNING, 0));
     this.runningUnseqInnerCompactionTaskNum.set(
         compactionTaskStatisticMap
             .getOrDefault(CompactionTaskType.INNER_UNSEQ, Collections.emptyMap())
-            .getOrDefault(CompactionTaskStatus.Running, 0));
+            .getOrDefault(CompactionTaskStatus.RUNNING, 0));
     this.runningCrossCompactionTaskNum.set(
         compactionTaskStatisticMap
             .getOrDefault(CompactionTaskType.CROSS, Collections.emptyMap())
-            .getOrDefault(CompactionTaskStatus.Running, 0));
+            .getOrDefault(CompactionTaskStatus.RUNNING, 0));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FixedPriorityBlockingQueue.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/FixedPriorityBlockingQueue.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.utils.datastructure;
 
 import com.google.common.collect.MinMaxPriorityQueue;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -186,5 +187,14 @@ public class FixedPriorityBlockingQueue<T> {
   @Override
   public String toString() {
     return queue.toString();
+  }
+
+  public List<T> getAllElementAsList() {
+    this.lock.lock();
+    try {
+      return new ArrayList<>(queue);
+    } finally {
+      this.lock.unlock();
+    }
   }
 }


### PR DESCRIPTION
This PR refactor the way to update compaction task metrics. The previous way to update the metrics is updating the counting value when compaction task is submitted or starts to run, but it could be not accurate because the task submission could fail. This pr change the way of counting task by getting running task list and task waiting queue from task manager, and count them when the metrics framework tries to report the value.