### PR TITLE
[IOTDB-5844] Fix compaction module getting stuck 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/exception/CompactionMemoryNotEnoughException.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/exception/CompactionMemoryNotEnoughException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.engine.compaction.execute.exception;
+
+public class CompactionMemoryNotEnoughException extends Exception {
+
+  public CompactionMemoryNotEnoughException(String message) {
+    super(message);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.TsFileMetricManager;
 import org.apache.iotdb.db.engine.compaction.execute.exception.CompactionExceptionHandler;
+import org.apache.iotdb.db.engine.compaction.execute.exception.CompactionMemoryNotEnoughException;
 import org.apache.iotdb.db.engine.compaction.execute.performer.ICrossCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.performer.impl.FastCompactionPerformer;
 import org.apache.iotdb.db.engine.compaction.execute.task.subtask.FastCompactionTaskSummary;
@@ -98,9 +99,12 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
   @Override
   public boolean doCompaction() {
     try {
-      SystemInfo.getInstance().addCompactionMemoryCost(memoryCost);
+      SystemInfo.getInstance().addCompactionMemoryCost(memoryCost, 60);
     } catch (InterruptedException e) {
       LOGGER.error("Interrupted when allocating memory for compaction", e);
+      return false;
+    } catch (CompactionMemoryNotEnoughException e) {
+      LOGGER.error("No enough memory for current compaction task {}", this, e);
       return false;
     }
     boolean isSuccess = true;


### PR DESCRIPTION
See [IOTDB-5844](https://issues.apache.org/jira/browse/IOTDB-5844).

To address this issue, we have added a timeout mechanism to the memory allocation step in the compaction process. If sufficient memory is not allocated within a certain amount of time, a CompactionMemoryNotEnoughException will be thrown, an error log will be printed, and the compaction task will be abandoned.