### PR TITLE
[To rel/1.1][IOTDB-5818][Atmos][Compaction]Cross_space compaction of Aligned timeseries is stucked

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/estimator/AbstractCompactionEstimator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/estimator/AbstractCompactionEstimator.java
@@ -39,7 +39,7 @@ public abstract class AbstractCompactionEstimator {
 
   protected IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
-  protected long compressionRatio = (long) CompressionRatio.getInstance().getRatio();
+  protected long compressionRatio = (long) CompressionRatio.getInstance().getRatio() + 1;
 
   /**
    * Estimate the memory cost of compacting the unseq file and its corresponding overlapped seq

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/estimator/AbstractCompactionEstimator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/estimator/AbstractCompactionEstimator.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.engine.compaction.selector.estimator;
 
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.conf.adapter.CompressionRatio;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 
@@ -38,7 +39,7 @@ public abstract class AbstractCompactionEstimator {
 
   protected IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
-  protected int compressionRatio = 5;
+  protected long compressionRatio = (long) CompressionRatio.getInstance().getRatio();
 
   /**
    * Estimate the memory cost of compacting the unseq file and its corresponding overlapped seq

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/estimator/ReadPointCrossCompactionEstimator.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/estimator/ReadPointCrossCompactionEstimator.java
@@ -114,7 +114,11 @@ public class ReadPointCrossCompactionEstimator extends AbstractCrossSpaceEstimat
         seqFileCost = 0;
       } else {
         // We need to multiply the compression ratio here.
-        seqFileCost = compressionRatio * concurrentSeriesNum * config.getTargetChunkSize();
+        seqFileCost =
+            compressionRatio
+                * seqResource.getTsFileSize()
+                * concurrentSeriesNum
+                / fileInfo.totalChunkNum;
       }
 
       if (seqFileCost > maxCostOfReadingSeqFile) {


### PR DESCRIPTION
**Description**
The memory evaluation for cross space compaction was too large, causing the compaction to get stuck.

**Solution**
After experiments, it is found that the memory evaluation of Reading SeqFile is too large, so it is necessary to accurately evaluate this part of the memory. And the compression ratio is taken from the memory.

**Experiment**
Perform a retest experiment on the source files of this environment. The sequential file size is 1.08G, the unsequential file size is 1.1 G, the totalChunkNum in each file is 60200, each device has 301 alignment timeseries, each timeseries has 2 chunks, and there are 100 devices in total. Execute cross space compaction, actual occupied memory: < 900 M, forced frequent triggering of Full GC, occupied memory < 300 M.

- Originally: calculate Read UnseqFile occupies 56.32M, Read SeqFile occupies 1.5G, Write targetFile occupies 300M, total 1.8 G. Here the evaluation of Read SeqFile is too large.

- Improvement: Change the compression ratio to take from the memory, Read UnseqFile occupies 37.54M, Read SeqFile occupies 18.432M, Write targetFile occupies 300M, total 356M.

The following figure is a screenshot of memory usage during compaction.
<img width="1482" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/45144903/237029612-3736957e-e5ed-4431-93af-eab73a67c8ef.png">