### PR TITLE
[IOTDB-5831] Fix create region failure after recreate db

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
@@ -232,7 +232,18 @@ public class ClusterSchemaManager {
    * @return DatabaseSchemaResp
    */
   public DatabaseSchemaResp getMatchedDatabaseSchema(GetDatabasePlan getStorageGroupPlan) {
-    return (DatabaseSchemaResp) getConsensusManager().read(getStorageGroupPlan).getDataset();
+    DatabaseSchemaResp resp =
+        (DatabaseSchemaResp) getConsensusManager().read(getStorageGroupPlan).getDataset();
+    List<String> preDeletedDatabaseList = new ArrayList<>();
+    for (String database : resp.getSchemaMap().keySet()) {
+      if (getPartitionManager().isDatabasePreDeleted(database)) {
+        preDeletedDatabaseList.add(database);
+      }
+    }
+    for (String preDeletedDatabase : preDeletedDatabaseList) {
+      resp.getSchemaMap().remove(preDeletedDatabase);
+    }
+    return resp;
   }
 
   /** Only used in cluster tool show Databases. */


### PR DESCRIPTION
## Description


### Problem
![c94696e4fb690a9ba78087b4381b521](https://user-images.githubusercontent.com/38524330/237049727-06a68f37-9fc3-4048-b0c2-05ad5a5095e6.png)

### Cause

The DataNode fetched the predeleted database and carries on to create regions, while the database is deleted, which results in the region creation failure.

### Solution

Add predeleted check on ConfigNode when return database msg to DataNode.
