### PR TITLE
[IOTDB-5851] Fix Npe with limit clause

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/SharedTsBlockQueue.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/SharedTsBlockQueue.java
@@ -269,7 +269,9 @@ public class SharedTsBlockQueue {
               bufferRetainedSizeInBytes);
       bufferRetainedSizeInBytes = 0;
     }
-    sinkChannel.close();
+    if (sinkChannel != null) {
+      sinkChannel.close();
+    }
   }
 
   /** Destroy the queue and cancel the future. Should only be called in abnormal case */

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/SharedTsBlockQueue.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/exchange/SharedTsBlockQueue.java
@@ -270,6 +270,14 @@ public class SharedTsBlockQueue {
       bufferRetainedSizeInBytes = 0;
     }
     if (sinkChannel != null) {
+      // attention: LocalSinkChannel of this SharedTsBlockQueue could be null when we close
+      // LocalSourceHandle(with limit clause it's possible) before constructing the corresponding
+      // LocalSinkChannel.
+      // If this close method is invoked by LocalSourceHandle, listener of LocalSourceHandle will
+      // remove the LocalSourceHandle from the map of MppDataExchangeManager and later when
+      // LocalSinkChannel is initialized, it will construct a new SharedTsBlockQueue.
+      // It is still safe that we let the LocalSourceHandle close successfully in this case. Because
+      // the QueryTerminator will do the final cleaning logic.
       sinkChannel.close();
     }
   }


### PR DESCRIPTION
NPE is caused by early close of ISourceHandle. Details could be found in: https://apache-iotdb.feishu.cn/docx/TcNYdAoU4o3u2oxzf91cY5jcn7c