### PR TITLE
[IOTDB-5863]add configNode configuration information print

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -29,6 +29,8 @@ import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.rpc.RpcUtils;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Arrays;
 
 public class ConfigNodeConfig {
 
@@ -1135,5 +1137,30 @@ public class ConfigNodeConfig {
 
   public void setForceWalPeriodForConfigNodeSimpleInMs(long forceWalPeriodForConfigNodeSimpleInMs) {
     this.forceWalPeriodForConfigNodeSimpleInMs = forceWalPeriodForConfigNodeSimpleInMs;
+  }
+
+  public String getConfigMessage() {
+    StringBuilder configMessage = new StringBuilder();
+    String configContent;
+    for (Field configField : ConfigNodeConfig.class.getDeclaredFields()) {
+      try {
+        String configType = configField.getGenericType().getTypeName();
+        if (configType.contains("java.lang.String[]")) {
+          String[] configList = (String[]) configField.get(this);
+          configContent = Arrays.asList(configList).toString();
+        } else {
+          configContent = configField.get(this).toString();
+        }
+        configMessage
+            .append("\n\t")
+            .append(configField.getName())
+            .append("=")
+            .append(configContent)
+            .append(";");
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+    return configMessage.toString();
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -70,6 +70,8 @@ public class ConfigNode implements ConfigNodeMBean {
 
   private static final int INIT_NON_SEED_CONFIG_NODE_ID = -1;
 
+  private static final String CONFIGURATION = "IoTDB configuration: {}";
+
   private final String mbeanName =
       String.format(
           "%s:%s=%s",
@@ -120,6 +122,7 @@ public class ConfigNode implements ConfigNodeMBean {
         // Notice: We always set up Seed-ConfigNode's RPC service lastly to ensure
         // that the external service is not provided until ConfigNode is fully available
         setUpRPCService();
+        LOGGER.info(CONFIGURATION, CONF.getConfigMessage());
         LOGGER.info(
             "{} has successfully restarted and joined the cluster: {}.",
             ConfigNodeConstant.GLOBAL_NAME,
@@ -154,7 +157,7 @@ public class ConfigNode implements ConfigNodeMBean {
         // that the external service is not provided until Seed-ConfigNode is fully initialized
         setUpRPCService();
         // The initial startup of Seed-ConfigNode finished
-
+        LOGGER.info(CONFIGURATION, CONF.getConfigMessage());
         LOGGER.info(
             "{} has successfully started and joined the cluster: {}.",
             ConfigNodeConstant.GLOBAL_NAME,
@@ -169,6 +172,7 @@ public class ConfigNode implements ConfigNodeMBean {
       sendRegisterConfigNodeRequest();
       // The initial startup of Non-Seed-ConfigNode is not yet finished,
       // we should wait for leader's scheduling
+      LOGGER.info(CONFIGURATION, CONF.getConfigMessage());
       LOGGER.info(
           "{} {} has registered successfully. Waiting for the leader's scheduling to join the cluster: {}.",
           ConfigNodeConstant.GLOBAL_NAME,


### PR DESCRIPTION
see more information in [IOTDB-5863](https://issues.apache.org/jira/browse/IOTDB-5863)
When starting configNode, its configuration information will now be printed.
![image](https://github.com/apache/iotdb/assets/38746920/8e6e1b51-4088-4197-af35-ecf37795d1b6)
