### PR TITLE
[IOTDB-5843] Stall write requests when system shutting down

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -134,7 +134,7 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
     }
 
     Message ret = null;
-    waitUntilSystemNotReadOnly();
+    waitUntilSystemAllowApply();
     TSStatus finalStatus = null;
     boolean shouldRetry = false;
     boolean firstTry = true;
@@ -169,8 +169,8 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
             new ResponseMessage(
                 new TSStatus(TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode())
                     .setMessage("internal error. statemachine throws a runtime exception: " + rte));
-        if (applicationStateMachine.isReadOnly()) {
-          waitUntilSystemNotReadOnly();
+        if (Utils.stallApply()) {
+          waitUntilSystemAllowApply();
           shouldRetry = true;
         } else {
           break;
@@ -191,8 +191,8 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
     return CompletableFuture.completedFuture(ret);
   }
 
-  private void waitUntilSystemNotReadOnly() {
-    while (applicationStateMachine.isReadOnly()) {
+  private void waitUntilSystemAllowApply() {
+    while (Utils.stallApply()) {
       try {
         TimeUnit.SECONDS.sleep(60);
       } catch (InterruptedException e) {

--- a/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -29,7 +29,6 @@ import org.apache.iotdb.commons.client.exception.ClientManagerException;
 import org.apache.iotdb.commons.client.property.ClientPoolProperty;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
-import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.commons.utils.TestOnly;
@@ -248,7 +247,7 @@ class RatisConsensus implements IConsensus {
     }
 
     // current Peer is group leader and in ReadOnly State
-    if (isLeader(consensusGroupId) && CommonDescriptor.getInstance().getConfig().isReadOnly()) {
+    if (isLeader(consensusGroupId) && Utils.rejectWrite()) {
       try {
         forceStepDownLeader(raftGroup);
       } catch (Exception e) {

--- a/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/statemachine/DataRegionStateMachine.java
@@ -82,8 +82,7 @@ public class DataRegionStateMachine extends BaseStateMachine {
 
   @Override
   public boolean isReadOnly() {
-    return CommonDescriptor.getInstance().getConfig().isReadOnly()
-        && !CommonDescriptor.getInstance().getConfig().isStopping();
+    return CommonDescriptor.getInstance().getConfig().isReadOnly();
   }
 
   @Override


### PR DESCRIPTION
# Changes proposed
See https://issues.apache.org/jira/browse/IOTDB-5843.
In RatisConsensus
1. reject client write-requests when system-readonly.
2. stall state machine applying when system-readonly (not because of shutting down)
