### PR TITLE
Follower doesn't need to update last cache when using IoT_consensus

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1143,7 +1143,9 @@ public class DataRegion implements IDataRegionForQuery {
   }
 
   private void tryToUpdateBatchInsertLastCache(InsertTabletNode node, long latestFlushedTime) {
-    if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()) {
+    if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()
+        || (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
+            && !node.isFromLeaderWhenUsingIoTConsensus())) {
       return;
     }
     for (int i = 0; i < node.getColumns().length; i++) {
@@ -1184,7 +1186,9 @@ public class DataRegion implements IDataRegionForQuery {
   }
 
   private void tryToUpdateInsertLastCache(InsertRowNode node, long latestFlushedTime) {
-    if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()) {
+    if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()
+        || (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
+            && !node.isFromLeaderWhenUsingIoTConsensus())) {
       return;
     }
     for (int i = 0; i < node.getValues().length; i++) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertNode.java
@@ -292,6 +292,14 @@ public abstract class InsertNode extends WritePlanNode {
 
   public abstract Object getFirstValueOfIndex(int index);
 
+  /**
+   * Notice: Call this method ONLY when using IOT_CONSENSUS, other consensus protocol cannot
+   * distinguish whether the insertNode is from leader by this method.
+   */
+  public boolean isFromLeaderWhenUsingIoTConsensus() {
+    return searchIndex == ConsensusReqReader.DEFAULT_SEARCH_INDEX;
+  }
+
   // region partial insert
   /**
    * Mark failed measurement, measurements[index], dataTypes[index] and values/columns[index] would


### PR DESCRIPTION
Cherry-pick from PR https://github.com/apache/iotdb/pull/9811

## Description
Currently, the Last cache on follower is not used for Last Query. Disabling update last cache on follower can save some memory and improve the write performance on follower node.
