### PR TITLE
[IOTDB-5858] fix the clear of metric in datanode schema cache

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCacheMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCacheMetrics.java
@@ -60,7 +60,19 @@ public class DataNodeSchemaCacheMetrics implements IMetricSet {
   @Override
   public void unbindFrom(AbstractMetricService metricService) {
     metricService.remove(
-        MetricType.AUTO_GAUGE, Metric.CACHE_HIT.toString(), Tag.NAME.toString(), "schemaCache");
+        MetricType.AUTO_GAUGE,
+        Metric.CACHE_HIT.toString(),
+        Tag.NAME.toString(),
+        "SchemaCache",
+        Tag.TYPE.toString(),
+        "hit");
+    metricService.remove(
+        MetricType.AUTO_GAUGE,
+        Metric.CACHE_HIT.toString(),
+        Tag.NAME.toString(),
+        "SchemaCache",
+        Tag.TYPE.toString(),
+        "all");
   }
 
   @Override


### PR DESCRIPTION
fix the clear of metrics in datanode schema cache