### PR TITLE
Fix only update last cache on follower

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1149,7 +1149,8 @@ public class DataRegion implements IDataRegionForQuery {
   private void tryToUpdateBatchInsertLastCache(InsertTabletNode node, long latestFlushedTime) {
     if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()
         || (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-            && !node.isFromLeaderWhenUsingIoTConsensus())) {
+            && node.isSyncFromLeaderWhenUsingIoTConsensus())) {
+      // disable updating last cache on follower
       return;
     }
     String[] measurements = node.getMeasurements();
@@ -1202,7 +1203,8 @@ public class DataRegion implements IDataRegionForQuery {
   private void tryToUpdateInsertLastCache(InsertRowNode node, long latestFlushedTime) {
     if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()
         || (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-            && !node.isFromLeaderWhenUsingIoTConsensus())) {
+            && node.isSyncFromLeaderWhenUsingIoTConsensus())) {
+      // disable updating last cache on follower
       return;
     }
     String[] measurements = node.getMeasurements();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertNode.java
@@ -294,9 +294,10 @@ public abstract class InsertNode extends WritePlanNode {
 
   /**
    * Notice: Call this method ONLY when using IOT_CONSENSUS, other consensus protocol cannot
-   * distinguish whether the insertNode is from leader by this method.
+   * distinguish whether the insertNode sync from leader by this method.
+   * isSyncFromLeaderWhenUsingIoTConsensus == true means this node is a follower
    */
-  public boolean isFromLeaderWhenUsingIoTConsensus() {
+  public boolean isSyncFromLeaderWhenUsingIoTConsensus() {
     return searchIndex == ConsensusReqReader.DEFAULT_SEARCH_INDEX;
   }
 


### PR DESCRIPTION
## Description

https://github.com/apache/iotdb/pull/9821 should disable the last cache on follower. However, that PR has a mistake that would disable the last cache on leader. 

This PR is for fixing it.