### PR TITLE
[To rel/1.1] Fix only update last cache on follower

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1145,7 +1145,8 @@ public class DataRegion implements IDataRegionForQuery {
   private void tryToUpdateBatchInsertLastCache(InsertTabletNode node, long latestFlushedTime) {
     if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()
         || (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-            && !node.isFromLeaderWhenUsingIoTConsensus())) {
+            && node.isSyncFromLeaderWhenUsingIoTConsensus())) {
+      // disable updating last cache on follower
       return;
     }
     for (int i = 0; i < node.getColumns().length; i++) {
@@ -1188,7 +1189,8 @@ public class DataRegion implements IDataRegionForQuery {
   private void tryToUpdateInsertLastCache(InsertRowNode node, long latestFlushedTime) {
     if (!IoTDBDescriptor.getInstance().getConfig().isLastCacheEnabled()
         || (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-            && !node.isFromLeaderWhenUsingIoTConsensus())) {
+            && node.isSyncFromLeaderWhenUsingIoTConsensus())) {
+      // disable updating last cache on follower
       return;
     }
     for (int i = 0; i < node.getValues().length; i++) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/write/InsertNode.java
@@ -294,9 +294,10 @@ public abstract class InsertNode extends WritePlanNode {
 
   /**
    * Notice: Call this method ONLY when using IOT_CONSENSUS, other consensus protocol cannot
-   * distinguish whether the insertNode is from leader by this method.
+   * distinguish whether the insertNode sync from leader by this method.
+   * isSyncFromLeaderWhenUsingIoTConsensus == true means this node is a follower
    */
-  public boolean isFromLeaderWhenUsingIoTConsensus() {
+  public boolean isSyncFromLeaderWhenUsingIoTConsensus() {
     return searchIndex == ConsensusReqReader.DEFAULT_SEARCH_INDEX;
   }
 


### PR DESCRIPTION
## Description

https://github.com/apache/iotdb/pull/9821 should disable the last cache on follower. However, that PR has a mistake that would disable the last cache on leader.

This PR is for fixing it.