### PR TITLE
Optimize measurementId serialization in WAL

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALWriteUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALWriteUtils.java
@@ -124,7 +124,8 @@ public class WALWriteUtils {
       return write(NO_BYTE_TO_READ, buffer);
     }
     int len = 0;
-    byte[] bytes = s.getBytes();
+    byte[] bytes = new byte[s.length()];
+    s.getBytes(0, s.length(), bytes, 0);
     len += write(bytes.length, buffer);
     buffer.put(bytes);
     len += bytes.length;


### PR DESCRIPTION
## Description

The String of measurementId comes from Thrift and it should always be UTF-8 encoding. 

Before:

<img width="1851" alt="Screenshot 2023-05-12 at 12 04 28 PM" src="https://github.com/apache/iotdb/assets/25913899/1a6baa9f-6933-4cf5-b2da-8bdef2e6316a">

After:
<img width="1911" alt="Screenshot 2023-05-12 at 12 05 30 PM" src="https://github.com/apache/iotdb/assets/25913899/6bf96503-553d-4e85-b844-48444f36b2aa">
