### PR TITLE
[To rel/1.1][IOTDB-5867]Build device time index when validating tsfiles after compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -435,6 +435,11 @@ public class TsFileResource {
     }
   }
 
+  /** Only used for compaction to validate tsfile. */
+  public ITimeIndex getTimeIndex() {
+    return timeIndex;
+  }
+
   /**
    * Whether this TsFileResource contains this device, if false, it must not contain this device, if
    * true, it may or may not contain this device

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/AbstractCompactionTest.java
@@ -65,7 +65,6 @@ import org.junit.Assert;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -486,7 +485,7 @@ public class AbstractCompactionTest {
               FragmentInstanceContext.createFragmentInstanceContextForCompaction(
                   EnvironmentUtils.TEST_QUERY_CONTEXT.getQueryId()),
               tsFileManager.getTsFileList(true),
-              Collections.emptyList(),
+              tsFileManager.getTsFileList(false),
               true);
       List<TimeValuePair> timeseriesData = entry.getValue();
       tmpSourceDatas.put(entry.getKey(), new ArrayList<>(timeseriesData));

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastCrossCompactionPerformerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/FastCrossCompactionPerformerTest.java
@@ -3924,6 +3924,11 @@ public class FastCrossCompactionPerformerTest extends AbstractCompactionTest {
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     CompactionUtils.moveTargetFile(targetResources, false, COMPACTION_TEST_SG);
+    tsFileManager.addAll(targetResources, true);
+    targetResources.get(3).degradeTimeIndex();
+    targetResources.get(2).degradeTimeIndex();
+    Assert.assertTrue(
+        CompactionUtils.validateTsFileResources(tsFileManager, COMPACTION_TEST_SG, 0));
 
     List<String> deviceIdList = new ArrayList<>();
     deviceIdList.add(COMPACTION_TEST_SG + PATH_SEPARATOR + "d0");

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithFastPerformerValidationTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/cross/CrossSpaceCompactionWithFastPerformerValidationTest.java
@@ -2194,6 +2194,17 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
       tsFileManager.getTsFileList(true).get(i).degradeTimeIndex();
     }
 
+    // meet overlap files
+    Assert.assertFalse(
+        CompactionUtils.validateTsFileResources(tsFileManager, COMPACTION_TEST_SG, 0));
+
+    tsFileManager.getTsFileList(true).get(0).deserialize();
+    tsFileManager.getTsFileList(true).get(1).deserialize();
+    tsFileManager.getTsFileList(true).get(0).degradeTimeIndex();
+    tsFileManager.getTsFileList(true).get(1).degradeTimeIndex();
+    Assert.assertTrue(
+        CompactionUtils.validateTsFileResources(tsFileManager, COMPACTION_TEST_SG, 0));
+
     // seq file 4,5 and 6 are being compacted by inner space compaction
     List<TsFileResource> sourceFiles = new ArrayList<>();
     sourceFiles.add(seqResources.get(4));
@@ -2204,9 +2215,8 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
     InnerSpaceCompactionTask innerSpaceCompactionTask =
         new InnerSpaceCompactionTask(
             0, tsFileManager, sourceFiles, true, performer, new AtomicInteger(0), 0);
-    if (!CompactionUtils.validateTsFileResources(tsFileManager, COMPACTION_TEST_SG, 0)) {
-      Assert.fail("meet overlap seq files");
-    }
+    Assert.assertTrue(
+        CompactionUtils.validateTsFileResources(tsFileManager, COMPACTION_TEST_SG, 0));
     innerSpaceCompactionTask.start();
     validateSeqFiles(true);
   }


### PR DESCRIPTION
In order to strengthen the accuracy of compaction, all tsfiles will be checked for time range of devices to determine whether there is overlap. If it is fileTimeIndex, it needs to be upgraded to deviceTimeIndex.