### PR TITLE
Bump Ratis version to 2.5.2-SNAPSHOT

### DIFF
--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <ratis.version>2.5.1</ratis.version>
+        <ratis.version>2.5.2-7451d86-SNAPSHOT</ratis.version>
         <consensus.test.skip>false</consensus.test.skip>
         <consensus.it.skip>${consensus.test.skip}</consensus.it.skip>
         <consensus.ut.skip>${consensus.test.skip}</consensus.ut.skip>


### PR DESCRIPTION
Upgrade Ratis dependency version to ratis-2.5.2 due to a recent bug fix: https://github.com/apache/ratis/pull/879
The artifacts can be found at https://repository.apache.org/content/groups/snapshots/org/apache/ratis
The git commits mirrors https://github.com/apache/ratis/commits/snapshot-branch2