### PR TITLE
[IOTDB-5872] Reduce some IoTConsensus index logs

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -219,7 +219,7 @@ public class IoTConsensusServerImpl {
           .update(writeToStateMachineStartTime - getStateMachineLockTime);
       IndexedConsensusRequest indexedConsensusRequest =
           buildIndexedConsensusRequestForLocalRequest(request);
-      if (indexedConsensusRequest.getSearchIndex() % 1000 == 0) {
+      if (indexedConsensusRequest.getSearchIndex() % 10000 == 0) {
         logger.info(
             "DataRegion[{}]: index after build: safeIndex:{}, searchIndex: {}",
             thisNode.getGroupId(),

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -221,7 +221,7 @@ public class LogDispatcher {
               peer,
               initialSyncIndex,
               config.getReplication().getCheckpointGap());
-      this.syncStatus = new SyncStatus(controller, config, impl::getSearchIndex);
+      this.syncStatus = new SyncStatus(controller, config);
       this.walEntryIterator = reader.getReqIterator(START_INDEX);
       this.metrics = new LogDispatcherThreadMetrics(this);
     }

--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatus.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatus.java
@@ -24,21 +24,18 @@ import org.apache.iotdb.consensus.config.IoTConsensusConfig;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.LongSupplier;
 
 public class SyncStatus {
 
   private final IoTConsensusConfig config;
   private final IndexController controller;
-  private final LongSupplier supplier;
   private final LinkedList<Batch> pendingBatches = new LinkedList<>();
   private final IoTConsensusMemoryManager iotConsensusMemoryManager =
       IoTConsensusMemoryManager.getInstance();
 
-  public SyncStatus(IndexController controller, IoTConsensusConfig config, LongSupplier supplier) {
+  public SyncStatus(IndexController controller, IoTConsensusConfig config) {
     this.controller = controller;
     this.config = config;
-    this.supplier = supplier;
   }
 
   /** we may block here if the synchronization pipeline is full. */
@@ -64,8 +61,7 @@ public class SyncStatus {
         Iterator<Batch> iterator = pendingBatches.iterator();
         Batch current = iterator.next();
         while (current.isSynced()) {
-          controller.updateAndGet(
-              current.getEndIndex(), supplier.getAsLong() == current.getEndIndex());
+          controller.updateAndGet(current.getEndIndex(), false);
           iterator.remove();
           iotConsensusMemoryManager.free(current.getSerializedSize(), false);
           if (iterator.hasNext()) {

--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatusTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatusTest.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.function.LongSupplier;
 
 public class SyncStatusTest {
 
@@ -47,7 +46,6 @@ public class SyncStatusTest {
       new Peer(new DataRegionId(1), 2, new TEndPoint("127.0.0.1", 6667));
   private static final IoTConsensusConfig config = new IoTConsensusConfig.Builder().build();
   private static final long CHECK_POINT_GAP = 500;
-  private static final LongSupplier supplier = () -> -1L;
 
   @Before
   public void setUp() throws IOException {
@@ -66,7 +64,7 @@ public class SyncStatusTest {
         new IndexController(storageDir.getAbsolutePath(), peer, 0, CHECK_POINT_GAP);
     Assert.assertEquals(0, controller.getCurrentIndex());
 
-    SyncStatus status = new SyncStatus(controller, config, supplier);
+    SyncStatus status = new SyncStatus(controller, config);
     List<Batch> batchList = new ArrayList<>();
 
     for (long i = 0; i < config.getReplication().getMaxPendingBatchesNum(); i++) {
@@ -98,7 +96,7 @@ public class SyncStatusTest {
     Assert.assertEquals(0, controller.getCurrentIndex());
     Assert.assertEquals(0, controller.getLastFlushedIndex());
 
-    SyncStatus status = new SyncStatus(controller, config, supplier);
+    SyncStatus status = new SyncStatus(controller, config);
     List<Batch> batchList = new ArrayList<>();
 
     for (long i = 0; i < config.getReplication().getMaxPendingBatchesNum(); i++) {
@@ -136,7 +134,7 @@ public class SyncStatusTest {
     Assert.assertEquals(0, controller.getCurrentIndex());
     Assert.assertEquals(0, controller.getLastFlushedIndex());
 
-    SyncStatus status = new SyncStatus(controller, config, supplier);
+    SyncStatus status = new SyncStatus(controller, config);
     List<Batch> batchList = new ArrayList<>();
 
     for (long i = 0; i < config.getReplication().getMaxPendingBatchesNum(); i++) {
@@ -186,7 +184,7 @@ public class SyncStatusTest {
         new IndexController(storageDir.getAbsolutePath(), peer, 0, CHECK_POINT_GAP);
     Assert.assertEquals(0, controller.getCurrentIndex());
 
-    SyncStatus status = new SyncStatus(controller, config, supplier);
+    SyncStatus status = new SyncStatus(controller, config);
     List<Batch> batchList = new ArrayList<>();
 
     for (long i = 0; i < config.getReplication().getMaxPendingBatchesNum(); i++) {


### PR DESCRIPTION
## Description

#### In a long-running cluster, most of the logs are related to the index, reducing the number of index logs can help reduce the number of logs.
- Change the print length of the index log segment from 1000 to 10000.
- Deleted index persistence when synchronization was completed.