### PR TITLE
[IOTDB-5877] Fix StringIndexOutOfBoundsException when invoking Session.createTimeseriesUsingSchemaTemplate with list contains null

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSchemaTemplateIT.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @Category({LocalStandaloneIT.class, ClusterIT.class})
@@ -236,6 +237,20 @@ public class IoTDBSessionSchemaTemplateIT extends AbstractSchemaIT {
   @Test
   public void testBatchActivateTemplate()
       throws StatementExecutionException, IoTDBConnectionException, IOException {
+    try {
+      session.createTimeseriesUsingSchemaTemplate(Collections.singletonList(null));
+      fail();
+    } catch (StatementExecutionException e) {
+      assertEquals("Given device path list should not be  or contains null.", e.getMessage());
+    }
+
+    try {
+      session.createTimeseriesUsingSchemaTemplate(Collections.singletonList("root.db.d1"));
+      fail();
+    } catch (StatementExecutionException e) {
+      assertTrue(e.getMessage().contains("Path [root.db.d1] has not been set any template"));
+    }
+
     session.createDatabase("root.db");
 
     Template temp1 = getTemplate("template1");

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -3348,6 +3348,10 @@ public class Session implements ISession {
   @Override
   public void createTimeseriesUsingSchemaTemplate(List<String> devicePathList)
       throws IoTDBConnectionException, StatementExecutionException {
+    if (devicePathList == null || devicePathList.contains(null)) {
+      throw new StatementExecutionException(
+          "Given device path list should not be  or contains null.");
+    }
     TCreateTimeseriesUsingSchemaTemplateReq request = new TCreateTimeseriesUsingSchemaTemplateReq();
     request.setDevicePathList(devicePathList);
     defaultSessionConnection.createTimeseriesUsingSchemaTemplate(request);


### PR DESCRIPTION
## Description


### Cause
The null in RPC request cannot be recognized by Thrift, thus resulting in StringIndexOutOfBoundsException.


### Solution
Add null check in session and return more readable msg.

