### PR TITLE
[IOTDB-5882] Support create empty schema template

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -222,7 +222,7 @@ tagWhereClause
 // ---- Create Schema Template
 createSchemaTemplate
     : CREATE SCHEMA TEMPLATE templateName=identifier
-    ALIGNED? LR_BRACKET templateMeasurementClause (COMMA templateMeasurementClause)* RR_BRACKET
+    ALIGNED? (LR_BRACKET templateMeasurementClause (COMMA templateMeasurementClause)* RR_BRACKET)?
     ;
 
 templateMeasurementClause


### PR DESCRIPTION
## Description


### Motivation

When user cannot define specific measurements before data insertion, it's necessary to set up an empty schema template and auto extend it during data insertion.

### Modification

Session already support create empty schema template, thus only antlr is modified to support create empty schema template via SQL.
