### PR TITLE
Disable writing metrics by setting DO_NOTHING level

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/WritingMetricsManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/recorder/WritingMetricsManager.java
@@ -26,11 +26,14 @@ import org.apache.iotdb.commons.service.metric.enums.Tag;
 import org.apache.iotdb.db.engine.storagegroup.DataRegion;
 import org.apache.iotdb.db.service.metrics.WritingMetrics;
 import org.apache.iotdb.db.wal.checkpoint.CheckpointType;
+import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.MetricType;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+
+import static org.apache.iotdb.metrics.utils.MetricLevel.DO_NOTHING;
 
 public class WritingMetricsManager {
   public static final WritingMetricsManager INSTANCE = new WritingMetricsManager();
@@ -38,207 +41,243 @@ public class WritingMetricsManager {
   private WritingMetricsManager() {}
 
   public void createDataRegionMemoryCostMetrics(DataRegion dataRegion) {
-    DataRegionId dataRegionId = new DataRegionId(Integer.parseInt(dataRegion.getDataRegionId()));
-    MetricService.getInstance()
-        .createAutoGauge(
-            Metric.DATA_REGION_MEM_COST.toString(),
-            MetricLevel.IMPORTANT,
-            dataRegion,
-            DataRegion::getMemCost,
-            Tag.REGION.toString(),
-            dataRegionId.toString());
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      DataRegionId dataRegionId = new DataRegionId(Integer.parseInt(dataRegion.getDataRegionId()));
+      MetricService.getInstance()
+          .createAutoGauge(
+              Metric.DATA_REGION_MEM_COST.toString(),
+              MetricLevel.IMPORTANT,
+              dataRegion,
+              DataRegion::getMemCost,
+              Tag.REGION.toString(),
+              dataRegionId.toString());
+    }
   }
 
   public void removeDataRegionMemoryCostMetrics(DataRegionId dataRegionId) {
-    MetricService.getInstance()
-        .remove(
-            MetricType.AUTO_GAUGE,
-            Metric.DATA_REGION_MEM_COST.toString(),
-            Tag.REGION.toString(),
-            dataRegionId.toString());
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .remove(
+              MetricType.AUTO_GAUGE,
+              Metric.DATA_REGION_MEM_COST.toString(),
+              Tag.REGION.toString(),
+              dataRegionId.toString());
+    }
   }
 
   public void createWALNodeInfoMetrics(String walNodeId) {
-    Arrays.asList(
-            WritingMetrics.EFFECTIVE_RATIO_INFO,
-            WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_SNAPSHOT,
-            WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_FLUSH)
-        .forEach(
-            name ->
-                MetricService.getInstance()
-                    .getOrCreateHistogram(
-                        Metric.WAL_NODE_INFO.toString(),
-                        MetricLevel.IMPORTANT,
-                        Tag.NAME.toString(),
-                        name,
-                        Tag.TYPE.toString(),
-                        walNodeId));
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      Arrays.asList(
+              WritingMetrics.EFFECTIVE_RATIO_INFO,
+              WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_SNAPSHOT,
+              WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_FLUSH)
+          .forEach(
+              name ->
+                  MetricService.getInstance()
+                      .getOrCreateHistogram(
+                          Metric.WAL_NODE_INFO.toString(),
+                          MetricLevel.IMPORTANT,
+                          Tag.NAME.toString(),
+                          name,
+                          Tag.TYPE.toString(),
+                          walNodeId));
+    }
   }
 
   public void removeWALNodeInfoMetrics(String walNodeId) {
-    Arrays.asList(
-            WritingMetrics.EFFECTIVE_RATIO_INFO,
-            WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_SNAPSHOT,
-            WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_FLUSH)
-        .forEach(
-            name ->
-                MetricService.getInstance()
-                    .remove(
-                        MetricType.HISTOGRAM,
-                        Tag.NAME.toString(),
-                        name,
-                        Tag.TYPE.toString(),
-                        walNodeId));
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      Arrays.asList(
+              WritingMetrics.EFFECTIVE_RATIO_INFO,
+              WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_SNAPSHOT,
+              WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_FLUSH)
+          .forEach(
+              name ->
+                  MetricService.getInstance()
+                      .remove(
+                          MetricType.HISTOGRAM,
+                          Tag.NAME.toString(),
+                          name,
+                          Tag.TYPE.toString(),
+                          walNodeId));
+    }
   }
 
   public void createFlushingMemTableStatusMetrics(DataRegionId dataRegionId) {
-    Arrays.asList(
-            WritingMetrics.MEM_TABLE_SIZE,
-            WritingMetrics.SERIES_NUM,
-            WritingMetrics.POINTS_NUM,
-            WritingMetrics.AVG_SERIES_POINT_NUM,
-            WritingMetrics.COMPRESSION_RATIO,
-            WritingMetrics.FLUSH_TSFILE_SIZE)
-        .forEach(
-            name ->
-                MetricService.getInstance()
-                    .getOrCreateHistogram(
-                        Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
-                        MetricLevel.IMPORTANT,
-                        Tag.NAME.toString(),
-                        name,
-                        Tag.REGION.toString(),
-                        dataRegionId.toString()));
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      Arrays.asList(
+              WritingMetrics.MEM_TABLE_SIZE,
+              WritingMetrics.SERIES_NUM,
+              WritingMetrics.POINTS_NUM,
+              WritingMetrics.AVG_SERIES_POINT_NUM,
+              WritingMetrics.COMPRESSION_RATIO,
+              WritingMetrics.FLUSH_TSFILE_SIZE)
+          .forEach(
+              name ->
+                  MetricService.getInstance()
+                      .getOrCreateHistogram(
+                          Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
+                          MetricLevel.IMPORTANT,
+                          Tag.NAME.toString(),
+                          name,
+                          Tag.REGION.toString(),
+                          dataRegionId.toString()));
+    }
   }
 
   public void removeFlushingMemTableStatusMetrics(DataRegionId dataRegionId) {
-    Arrays.asList(
-            WritingMetrics.MEM_TABLE_SIZE,
-            WritingMetrics.SERIES_NUM,
-            WritingMetrics.POINTS_NUM,
-            WritingMetrics.AVG_SERIES_POINT_NUM,
-            WritingMetrics.COMPRESSION_RATIO,
-            WritingMetrics.FLUSH_TSFILE_SIZE)
-        .forEach(
-            name ->
-                MetricService.getInstance()
-                    .remove(
-                        MetricType.HISTOGRAM,
-                        Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
-                        Tag.NAME.toString(),
-                        name,
-                        Tag.REGION.toString(),
-                        dataRegionId.toString()));
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      Arrays.asList(
+              WritingMetrics.MEM_TABLE_SIZE,
+              WritingMetrics.SERIES_NUM,
+              WritingMetrics.POINTS_NUM,
+              WritingMetrics.AVG_SERIES_POINT_NUM,
+              WritingMetrics.COMPRESSION_RATIO,
+              WritingMetrics.FLUSH_TSFILE_SIZE)
+          .forEach(
+              name ->
+                  MetricService.getInstance()
+                      .remove(
+                          MetricType.HISTOGRAM,
+                          Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
+                          Tag.NAME.toString(),
+                          name,
+                          Tag.REGION.toString(),
+                          dataRegionId.toString()));
+    }
   }
 
   public void recordWALNodeEffectiveInfoRatio(String walNodeId, double ratio) {
-    MetricService.getInstance()
-        .histogram(
-            (long) (ratio * 100),
-            Metric.WAL_NODE_INFO.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.EFFECTIVE_RATIO_INFO,
-            Tag.TYPE.toString(),
-            walNodeId);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .histogram(
+              (long) (ratio * 100),
+              Metric.WAL_NODE_INFO.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.EFFECTIVE_RATIO_INFO,
+              Tag.TYPE.toString(),
+              walNodeId);
+    }
   }
 
   public void recordMemTableRamWhenCauseSnapshot(String walNodeId, long ram) {
-    MetricService.getInstance()
-        .histogram(
-            ram,
-            Metric.WAL_NODE_INFO.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_SNAPSHOT,
-            Tag.TYPE.toString(),
-            walNodeId);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .histogram(
+              ram,
+              Metric.WAL_NODE_INFO.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_SNAPSHOT,
+              Tag.TYPE.toString(),
+              walNodeId);
+    }
   }
 
   public void recordMemTableRamWhenCauseFlush(String walNodeId, long ram) {
-    MetricService.getInstance()
-        .histogram(
-            ram,
-            Metric.WAL_NODE_INFO.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_FLUSH,
-            Tag.TYPE.toString(),
-            walNodeId);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .histogram(
+              ram,
+              Metric.WAL_NODE_INFO.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.OLDEST_MEM_TABLE_RAM_WHEN_CAUSE_FLUSH,
+              Tag.TYPE.toString(),
+              walNodeId);
+    }
   }
 
   public void recordTsFileCompressionRatioOfFlushingMemTable(
       String dataRegionId, double compressionRatio) {
-    MetricService.getInstance()
-        .histogram(
-            (long) (compressionRatio * 100),
-            Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.COMPRESSION_RATIO,
-            Tag.REGION.toString(),
-            new DataRegionId(Integer.parseInt(dataRegionId)).toString());
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .histogram(
+              (long) (compressionRatio * 100),
+              Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.COMPRESSION_RATIO,
+              Tag.REGION.toString(),
+              new DataRegionId(Integer.parseInt(dataRegionId)).toString());
+    }
   }
 
   public void recordFlushingMemTableStatus(
       String storageGroup, long memSize, long seriesNum, long totalPointsNum, long avgSeriesNum) {
-    DataRegionId dataRegionId = getDataRegionIdFromStorageGroupStr(storageGroup);
-    if (dataRegionId == null) {
-      return;
-    }
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      DataRegionId dataRegionId = getDataRegionIdFromStorageGroupStr(storageGroup);
+      if (dataRegionId == null) {
+        return;
+      }
 
-    MetricService.getInstance()
-        .histogram(
-            memSize,
-            Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.MEM_TABLE_SIZE,
-            Tag.REGION.toString(),
-            dataRegionId.toString());
-    MetricService.getInstance()
-        .histogram(
-            seriesNum,
-            Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.SERIES_NUM,
-            Tag.REGION.toString(),
-            dataRegionId.toString());
-    MetricService.getInstance()
-        .histogram(
-            totalPointsNum,
-            Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.POINTS_NUM,
-            Tag.REGION.toString(),
-            dataRegionId.toString());
-    MetricService.getInstance()
-        .histogram(
-            avgSeriesNum,
-            Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.AVG_SERIES_POINT_NUM,
-            Tag.REGION.toString(),
-            dataRegionId.toString());
+      MetricService.getInstance()
+          .histogram(
+              memSize,
+              Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.MEM_TABLE_SIZE,
+              Tag.REGION.toString(),
+              dataRegionId.toString());
+      MetricService.getInstance()
+          .histogram(
+              seriesNum,
+              Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.SERIES_NUM,
+              Tag.REGION.toString(),
+              dataRegionId.toString());
+      MetricService.getInstance()
+          .histogram(
+              totalPointsNum,
+              Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.POINTS_NUM,
+              Tag.REGION.toString(),
+              dataRegionId.toString());
+      MetricService.getInstance()
+          .histogram(
+              avgSeriesNum,
+              Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.AVG_SERIES_POINT_NUM,
+              Tag.REGION.toString(),
+              dataRegionId.toString());
+    }
   }
 
   public void recordFlushTsFileSize(String storageGroup, long size) {
-    DataRegionId dataRegionId = getDataRegionIdFromStorageGroupStr(storageGroup);
-    if (dataRegionId == null) {
-      return;
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      DataRegionId dataRegionId = getDataRegionIdFromStorageGroupStr(storageGroup);
+      if (dataRegionId == null) {
+        return;
+      }
+      MetricService.getInstance()
+          .histogram(
+              size,
+              Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.FLUSH_TSFILE_SIZE,
+              Tag.REGION.toString(),
+              dataRegionId.toString());
     }
-    MetricService.getInstance()
-        .histogram(
-            size,
-            Metric.FLUSHING_MEM_TABLE_STATUS.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.FLUSH_TSFILE_SIZE,
-            Tag.REGION.toString(),
-            dataRegionId.toString());
   }
 
   private DataRegionId getDataRegionIdFromStorageGroupStr(String storageGroup) {
@@ -251,98 +290,122 @@ public class WritingMetricsManager {
   }
 
   public void recordFlushCost(String stage, long costTimeInMillis) {
-    MetricService.getInstance()
-        .timer(
-            costTimeInMillis,
-            TimeUnit.MILLISECONDS,
-            Metric.FLUSH_COST.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.STAGE.toString(),
-            stage);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .timer(
+              costTimeInMillis,
+              TimeUnit.MILLISECONDS,
+              Metric.FLUSH_COST.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.STAGE.toString(),
+              stage);
+    }
   }
 
   public void recordFlushSubTaskCost(String subTaskType, long costTimeInMillis) {
-    MetricService.getInstance()
-        .timer(
-            costTimeInMillis,
-            TimeUnit.MILLISECONDS,
-            Metric.FLUSH_SUB_TASK_COST.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.TYPE.toString(),
-            subTaskType);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .timer(
+              costTimeInMillis,
+              TimeUnit.MILLISECONDS,
+              Metric.FLUSH_SUB_TASK_COST.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.TYPE.toString(),
+              subTaskType);
+    }
   }
 
   public void recordMakeCheckpointCost(CheckpointType type, long costTimeInNanos) {
-    MetricService.getInstance()
-        .timer(
-            costTimeInNanos,
-            TimeUnit.NANOSECONDS,
-            Metric.WAL_COST.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.STAGE.toString(),
-            WritingMetrics.MAKE_CHECKPOINT,
-            Tag.TYPE.toString(),
-            type.toString());
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .timer(
+              costTimeInNanos,
+              TimeUnit.NANOSECONDS,
+              Metric.WAL_COST.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.STAGE.toString(),
+              WritingMetrics.MAKE_CHECKPOINT,
+              Tag.TYPE.toString(),
+              type.toString());
+    }
   }
 
   public void recordSerializeOneWALInfoEntryCost(long costTimeInNanos) {
-    MetricService.getInstance()
-        .timer(
-            costTimeInNanos,
-            TimeUnit.NANOSECONDS,
-            Metric.WAL_COST.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.STAGE.toString(),
-            WritingMetrics.SERIALIZE_WAL_ENTRY,
-            Tag.TYPE.toString(),
-            WritingMetrics.SERIALIZE_ONE_WAL_INFO_ENTRY);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .timer(
+              costTimeInNanos,
+              TimeUnit.NANOSECONDS,
+              Metric.WAL_COST.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.STAGE.toString(),
+              WritingMetrics.SERIALIZE_WAL_ENTRY,
+              Tag.TYPE.toString(),
+              WritingMetrics.SERIALIZE_ONE_WAL_INFO_ENTRY);
+    }
   }
 
   public void recordSerializeWALEntryTotalCost(long costTimeInNanos) {
-    MetricService.getInstance()
-        .timer(
-            costTimeInNanos,
-            TimeUnit.NANOSECONDS,
-            Metric.WAL_COST.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.STAGE.toString(),
-            WritingMetrics.SERIALIZE_WAL_ENTRY,
-            Tag.TYPE.toString(),
-            WritingMetrics.SERIALIZE_WAL_ENTRY_TOTAL);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .timer(
+              costTimeInNanos,
+              TimeUnit.NANOSECONDS,
+              Metric.WAL_COST.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.STAGE.toString(),
+              WritingMetrics.SERIALIZE_WAL_ENTRY,
+              Tag.TYPE.toString(),
+              WritingMetrics.SERIALIZE_WAL_ENTRY_TOTAL);
+    }
   }
 
   public void recordSyncWALBufferCost(long costTimeInNanos, boolean forceFlag) {
-    String syncType = forceFlag ? WritingMetrics.FSYNC : WritingMetrics.SYNC;
-    MetricService.getInstance()
-        .timer(
-            costTimeInNanos,
-            TimeUnit.NANOSECONDS,
-            Metric.WAL_COST.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.STAGE.toString(),
-            WritingMetrics.SYNC_WAL_BUFFER,
-            Tag.TYPE.toString(),
-            syncType);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      String syncType = forceFlag ? WritingMetrics.FSYNC : WritingMetrics.SYNC;
+      MetricService.getInstance()
+          .timer(
+              costTimeInNanos,
+              TimeUnit.NANOSECONDS,
+              Metric.WAL_COST.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.STAGE.toString(),
+              WritingMetrics.SYNC_WAL_BUFFER,
+              Tag.TYPE.toString(),
+              syncType);
+    }
   }
 
   public void recordWALBufferUsedRatio(double usedRatio) {
-    MetricService.getInstance()
-        .histogram(
-            (long) (usedRatio * 100),
-            Metric.WAL_BUFFER.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.USED_RATIO);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .histogram(
+              (long) (usedRatio * 100),
+              Metric.WAL_BUFFER.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.USED_RATIO);
+    }
   }
 
   public void recordWALBufferEntriesCount(long count) {
-    MetricService.getInstance()
-        .histogram(
-            count,
-            Metric.WAL_BUFFER.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            WritingMetrics.ENTRIES_COUNT);
+    if (!DO_NOTHING.equals(
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      MetricService.getInstance()
+          .histogram(
+              count,
+              Metric.WAL_BUFFER.toString(),
+              MetricLevel.IMPORTANT,
+              Tag.NAME.toString(),
+              WritingMetrics.ENTRIES_COUNT);
+    }
   }
 
   public static WritingMetricsManager getInstance() {


### PR DESCRIPTION
## Description

#9674 disabled some query metrics by DO_NOTHING level. This PR is doing the same thing for writing. 
In TSBS test, there is a metric still takes some CPU time when set DO_NOTHING metric level. 

<img width="1915" alt="Screenshot 2023-05-16 at 10 12 12 AM" src="https://github.com/apache/iotdb/assets/25913899/836bbcb7-e4ea-41e7-8a0f-9dc7a2be11da">
