### PR TITLE
[IOTDB-5884] Throw Exception when alter template with duplicate measurement

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBExtendTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBExtendTemplateIT.java
@@ -84,6 +84,15 @@ public class IoTDBExtendTemplateIT extends AbstractSchemaIT {
       statement.execute(
           "ALTER SCHEMA TEMPLATE t1 ADD(s3 INT64 ENCODING=RLE, s4 DOUBLE ENCODING=GORILLA)");
 
+      try {
+        statement.execute(
+            "ALTER SCHEMA TEMPLATE t1 ADD(s5 INT64 ENCODING=RLE, s5 DOUBLE ENCODING=GORILLA)");
+      } catch (SQLException e) {
+        Assert.assertTrue(
+            e.getMessage()
+                .contains("Duplicated measurement [s5] in schema template alter request"));
+      }
+
       String[] sqls =
           new String[] {
             "show timeseries",

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/alter/TemplateExtendInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/alter/TemplateExtendInfo.java
@@ -28,7 +28,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class TemplateExtendInfo extends TemplateAlterInfo {
 
@@ -100,6 +102,24 @@ public class TemplateExtendInfo extends TemplateAlterInfo {
       compressors = new ArrayList<>();
     }
     compressors.add(compressionType);
+  }
+
+  // deduplicate the measurements with same name, keep the first one
+  public TemplateExtendInfo deduplicate() {
+    if (measurements == null || measurements.isEmpty()) {
+      return new TemplateExtendInfo();
+    }
+    Set<String> set = new HashSet<>();
+    TemplateExtendInfo result = new TemplateExtendInfo();
+    for (int i = 0; i < measurements.size(); i++) {
+      if (set.contains(measurements.get(i))) {
+        continue;
+      }
+      set.add(measurements.get(i));
+      result.addMeasurement(
+          measurements.get(i), dataTypes.get(i), encodings.get(i), compressors.get(i));
+    }
+    return result;
   }
 
   public void serialize(OutputStream outputStream) throws IOException {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/alter/TemplateExtendInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/alter/TemplateExtendInfo.java
@@ -104,6 +104,21 @@ public class TemplateExtendInfo extends TemplateAlterInfo {
     compressors.add(compressionType);
   }
 
+  // if there's duplicate measurements, return the first one, otherwise return null
+  public String getFirstDuplicateMeasurement() {
+    if (measurements != null) {
+      Set<String> set = new HashSet<>();
+      for (String measurement : measurements) {
+        if (set.contains(measurement)) {
+          return measurement;
+        } else {
+          set.add(measurement);
+        }
+      }
+    }
+    return null;
+  }
+
   // deduplicate the measurements with same name, keep the first one
   public TemplateExtendInfo deduplicate() {
     if (measurements == null || measurements.isEmpty()) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/AutoCreateSchemaExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/AutoCreateSchemaExecutor.java
@@ -162,15 +162,17 @@ class AutoCreateSchemaExecutor {
     }
   }
 
+  // used for insert record or tablet
   void autoExtendTemplate(
       String templateName, List<String> measurementList, List<TSDataType> dataTypeList) {
     internalExtendTemplate(templateName, measurementList, dataTypeList, null, null);
   }
 
+  // used for insert records or tablets
   void autoExtendTemplate(Map<String, TemplateExtendInfo> templateExtendInfoMap) {
     TemplateExtendInfo templateExtendInfo;
     for (Map.Entry<String, TemplateExtendInfo> entry : templateExtendInfoMap.entrySet()) {
-      templateExtendInfo = entry.getValue();
+      templateExtendInfo = entry.getValue().deduplicate();
       internalExtendTemplate(
           entry.getKey(),
           templateExtendInfo.getMeasurements(),
@@ -225,6 +227,7 @@ class AutoCreateSchemaExecutor {
     }
   }
 
+  // used for load TsFile
   void autoCreateMissingMeasurements(
       ClusterSchemaTree schemaTree,
       List<PartialPath> devicePathList,
@@ -346,6 +349,7 @@ class AutoCreateSchemaExecutor {
 
     if (!templateExtendInfoMap.isEmpty()) {
       for (TemplateExtendInfo templateExtendInfo : templateExtendInfoMap.values()) {
+        templateExtendInfo = templateExtendInfo.deduplicate();
         internalExtendTemplate(
             templateExtendInfo.getTemplateName(),
             templateExtendInfo.getMeasurements(),

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -212,10 +212,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.db.client.ConfigNodeClient.MSG_RECONNECTION_FAIL;
@@ -1392,20 +1390,16 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
         .getOperationType()
         .equals(TemplateAlterOperationType.EXTEND_TEMPLATE)) {
       // check duplicate measurement
-      Set<String> existingMeasurements = new HashSet<>();
       TemplateExtendInfo templateExtendInfo =
           (TemplateExtendInfo) alterSchemaTemplateStatement.getTemplateAlterInfo();
-      for (String measurement : templateExtendInfo.getMeasurements()) {
-        if (existingMeasurements.contains(measurement)) {
-          future.setException(
-              new MetadataException(
-                  String.format(
-                      "Duplicated measurement [%s] in schema template alter request",
-                      measurement)));
-          return future;
-        } else {
-          existingMeasurements.add(measurement);
-        }
+      String duplicateMeasurement = templateExtendInfo.getFirstDuplicateMeasurement();
+      if (duplicateMeasurement != null) {
+        future.setException(
+            new MetadataException(
+                String.format(
+                    "Duplicated measurement [%s] in schema template alter request",
+                    duplicateMeasurement)));
+        return future;
       }
     }
 


### PR DESCRIPTION
## Description


### Problem

When there's duplicate measurement in one template extension request, there's no exception returned but the request is executed successfully and the registered measurement is the first one.

### Cause

When extending schema template on configNode, the measurement duplication will be ignored and the first one takes effect.

### Solution

Add duplication check on dataNode before sending RPC request to configNode.
Add deduplication in template auto extension during data insertion with insert records or tablets or TsFile load.
