### PR TITLE
[IOTDB-5888] Fix some logs didn't consider timestamp precision

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1003,9 +1003,8 @@ public class DataRegion implements IDataRegionForQuery {
                   TSStatusCode.OUT_OF_TTL,
                   String.format(
                       "Insertion time [%s] is less than ttl time bound [%s]",
-                      DateTimeUtils.convertMillsecondToZonedDateTime(currTime),
-                      DateTimeUtils.convertMillsecondToZonedDateTime(
-                          DateTimeUtils.currentTime() - dataTTL)));
+                      DateTimeUtils.convertLongToDate(currTime),
+                      DateTimeUtils.convertLongToDate(DateTimeUtils.currentTime() - dataTTL)));
           loc++;
           noFailure = false;
         } else {
@@ -3168,9 +3167,8 @@ public class DataRegion implements IDataRegionForQuery {
                       TSStatusCode.OUT_OF_TTL.getStatusCode(),
                       String.format(
                           "Insertion time [%s] is less than ttl time bound [%s]",
-                          DateTimeUtils.convertMillsecondToZonedDateTime(insertRowNode.getTime()),
-                          DateTimeUtils.convertMillsecondToZonedDateTime(
-                              DateTimeUtils.currentTime() - dataTTL))));
+                          DateTimeUtils.convertLongToDate(insertRowNode.getTime()),
+                          DateTimeUtils.convertLongToDate(DateTimeUtils.currentTime() - dataTTL))));
           continue;
         }
         // init map

--- a/server/src/main/java/org/apache/iotdb/db/exception/query/OutOfTTLException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/query/OutOfTTLException.java
@@ -32,8 +32,8 @@ public class OutOfTTLException extends WriteProcessException {
     super(
         String.format(
             "Insertion time [%s] is less than ttl time bound [%s]",
-            DateTimeUtils.convertMillsecondToZonedDateTime(insertionTime),
-            DateTimeUtils.convertMillsecondToZonedDateTime(timeLowerBound)),
+            DateTimeUtils.convertLongToDate(insertionTime),
+            DateTimeUtils.convertLongToDate(timeLowerBound)),
         TSStatusCode.OUT_OF_TTL.getStatusCode(),
         true);
   }

--- a/server/src/main/java/org/apache/iotdb/db/tools/IoTDBDataDirViewer.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/IoTDBDataDirViewer.java
@@ -151,9 +151,9 @@ public class IoTDBDataDirViewer {
               "|  |  |  |  |--device %s, start time %d (%s), end time %d (%s)",
               device,
               resource.getStartTime(device),
-              DateTimeUtils.convertMillsecondToZonedDateTime(resource.getStartTime(device)),
+              DateTimeUtils.convertLongToDate(resource.getStartTime(device)),
               resource.getEndTime(device),
-              DateTimeUtils.convertMillsecondToZonedDateTime(resource.getEndTime(device))));
+              DateTimeUtils.convertLongToDate(resource.getEndTime(device))));
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileResourcePrinter.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileResourcePrinter.java
@@ -78,9 +78,9 @@ public class TsFileResourcePrinter {
           "device %s, start time %d (%s), end time %d (%s)%n",
           device,
           resource.getStartTime(device),
-          DateTimeUtils.convertMillsecondToZonedDateTime(resource.getStartTime(device)),
+          DateTimeUtils.convertLongToDate(resource.getStartTime(device)),
           resource.getEndTime(device),
-          DateTimeUtils.convertMillsecondToZonedDateTime(resource.getEndTime(device)));
+          DateTimeUtils.convertLongToDate(resource.getEndTime(device)));
     }
     System.out.println();
   }


### PR DESCRIPTION
## Description

There are some logs and some TsFileTools didn't consider timestamp precision. This PR is for fixing them by using another util function with precision conversion.

