### PR TITLE
Support schema cache when querying all measurement of devices using template

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
@@ -557,8 +557,8 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
           // if without MULTI_LEVEL_PATH_WILDCARD, scan and check
           if ((PathPatternUtil.hasWildcard(nodes1[i - 1])
                   && PathPatternUtil.isNodeMatch(nodes1[i - 1], nodes2[j - 1]))
-              || (PathPatternUtil.hasWildcard(nodes2[i - 1])
-                  && PathPatternUtil.isNodeMatch(nodes2[i - 1], nodes1[j - 1]))
+              || (PathPatternUtil.hasWildcard(nodes2[j - 1])
+                  && PathPatternUtil.isNodeMatch(nodes2[j - 1], nodes1[i - 1]))
               || nodes1[i - 1].equals(nodes2[j - 1])) {
             // if nodes1[i-1] and nodes[2] is matched, dp[i][j] = dp[i-1][j-1]
             dp[i][j] |= dp[i - 1][j - 1];

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD;
@@ -117,13 +116,16 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
 
   // e.g. root.db.d.s, root.db.d.*, root.db.d.s*, not include patterns like root.db.d.**
   public boolean hasExplicitDevice() {
+    if (nodes[nodes.length - 1].equals(MULTI_LEVEL_PATH_WILDCARD)) {
+      return false;
+    }
     for (int i = 0; i < nodes.length - 1; i++) {
       // *, ** , d*, *d*
       if (PathPatternUtil.hasWildcard(nodes[i])) {
         return false;
       }
     }
-    return !nodes[nodes.length - 1].equals(MULTI_LEVEL_PATH_WILDCARD);
+    return true;
   }
 
   /**
@@ -337,8 +339,8 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
     if (patternNode.equals(MULTI_LEVEL_PATH_WILDCARD)) {
       isMatch = matchPath(pathNodes, pathIndex + 1, patternIndex + 1, true, pathIsPrefix);
     } else {
-      if (patternNode.contains(ONE_LEVEL_PATH_WILDCARD)) {
-        if (Pattern.matches(patternNode.replace("*", ".*"), pathNode)) {
+      if (PathPatternUtil.hasWildcard(patternNode)) {
+        if (PathPatternUtil.isNodeMatch(patternNode, pathNode)) {
           isMatch = matchPath(pathNodes, pathIndex + 1, patternIndex + 1, false, pathIsPrefix);
         }
       } else {
@@ -374,6 +376,13 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
       }
       if (nodes[i].equals(ONE_LEVEL_PATH_WILDCARD)) {
         continue;
+      }
+      if (PathPatternUtil.hasWildcard(nodes[i])) {
+        if (PathPatternUtil.isNodeMatch(nodes[i], rNodes[i])) {
+          continue;
+        } else {
+          return false;
+        }
       }
       if (!nodes[i].equals(rNodes[i])) {
         return false;
@@ -429,7 +438,8 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
         } else {
           // if without MULTI_LEVEL_PATH_WILDCARD, scan and check
           if (!rNodes[j - 1].equals(MULTI_LEVEL_PATH_WILDCARD)
-              && (lNodes[i - 1].equals(ONE_LEVEL_PATH_WILDCARD)
+              && ((PathPatternUtil.hasWildcard(lNodes[i - 1])
+                      && PathPatternUtil.isNodeMatch(lNodes[i - 1], rNodes[j - 1]))
                   || lNodes[i - 1].equals(rNodes[j - 1]))) {
             // if nodes1[i-1] includes rNodes[j-1], dp[i][j] = dp[i-1][j-1]
             newDp[j] |= dp[j - 1];
@@ -459,7 +469,10 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
         return checkOverlapWithMultiLevelWildcard(nodes, rNodes);
       }
       // if without MULTI_LEVEL_PATH_WILDCARD, scan and check
-      if (nodes[i].equals(ONE_LEVEL_PATH_WILDCARD) || rNodes[i].equals(ONE_LEVEL_PATH_WILDCARD)) {
+      if ((PathPatternUtil.hasWildcard(nodes[i])
+              && PathPatternUtil.isNodeMatch(nodes[i], rNodes[i]))
+          || (PathPatternUtil.hasWildcard(rNodes[i])
+              && PathPatternUtil.isNodeMatch(rNodes[i], nodes[i]))) {
         continue;
       }
       if (!nodes[i].equals(rNodes[i])) {
@@ -494,8 +507,8 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
         return true;
       } else if (nodes[i].equals(ONE_LEVEL_PATH_WILDCARD)) {
         rNodesIndex++;
-      } else if (nodes[i].contains(ONE_LEVEL_PATH_WILDCARD)) {
-        if (!Pattern.compile(nodes[i].replace("*", ".*")).matcher(rNodes[rNodesIndex]).matches()) {
+      } else if (PathPatternUtil.hasWildcard(nodes[i])) {
+        if (!PathPatternUtil.isNodeMatch(nodes[i], rNodes[rNodesIndex])) {
           return false;
         } else {
           rNodesIndex++;
@@ -542,8 +555,10 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
           }
         } else {
           // if without MULTI_LEVEL_PATH_WILDCARD, scan and check
-          if (nodes1[i - 1].equals(ONE_LEVEL_PATH_WILDCARD)
-              || nodes2[j - 1].equals(ONE_LEVEL_PATH_WILDCARD)
+          if ((PathPatternUtil.hasWildcard(nodes1[i - 1])
+                  && PathPatternUtil.isNodeMatch(nodes1[i - 1], nodes2[j - 1]))
+              || (PathPatternUtil.hasWildcard(nodes2[i - 1])
+                  && PathPatternUtil.isNodeMatch(nodes2[i - 1], nodes1[j - 1]))
               || nodes1[i - 1].equals(nodes2[j - 1])) {
             // if nodes1[i-1] and nodes[2] is matched, dp[i][j] = dp[i-1][j-1]
             dp[i][j] |= dp[i - 1][j - 1];

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
@@ -107,11 +107,23 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
 
   public boolean hasWildcard() {
     for (String node : nodes) {
-      if (ONE_LEVEL_PATH_WILDCARD.equals(node) || MULTI_LEVEL_PATH_WILDCARD.equals(node)) {
+      // *, ** , d*, *d*
+      if (PathPatternUtil.hasWildcard(node)) {
         return true;
       }
     }
     return false;
+  }
+
+  // e.g. root.db.d.s, root.db.d.*, root.db.d.s*, not include patterns like root.db.d.**
+  public boolean hasExplicitDevice() {
+    for (int i = 0; i < nodes.length - 1; i++) {
+      // *, ** , d*, *d*
+      if (PathPatternUtil.hasWildcard(nodes[i])) {
+        return false;
+      }
+    }
+    return !nodes[nodes.length - 1].equals(MULTI_LEVEL_PATH_WILDCARD);
   }
 
   /**

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternNode.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternNode.java
@@ -122,7 +122,7 @@ public class PathPatternNode<V, VSerializer extends PathPatternNode.Serializer<V
   }
 
   public boolean isWildcard() {
-    return name.equals(ONE_LEVEL_PATH_WILDCARD) || name.equals(MULTI_LEVEL_PATH_WILDCARD);
+    return PathPatternUtil.hasWildcard(name);
   }
 
   public boolean isMultiLevelWildcard() {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternUtil.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternUtil.java
@@ -36,7 +36,12 @@ public class PathPatternUtil {
     return node.startsWith(ONE_LEVEL_PATH_WILDCARD) || node.endsWith(ONE_LEVEL_PATH_WILDCARD);
   }
 
-  /** The input patternNode shall be a string starts or ends with *, e.g. *, **, d*, *d* */
+  /**
+   * Determine if a node pattern matches a node name.
+   *
+   * @param patternNode must be a string starts or ends with *, e.g. *, **, d*, *d*
+   * @param nodeName node to match
+   */
   public static boolean isNodeMatch(String patternNode, String nodeName) {
     if (patternNode.equals(ONE_LEVEL_PATH_WILDCARD)
         || patternNode.equals(MULTI_LEVEL_PATH_WILDCARD)) {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternUtil.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.path;
+
+import java.util.regex.Pattern;
+
+import static org.apache.iotdb.commons.conf.IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD;
+import static org.apache.iotdb.commons.conf.IoTDBConstant.ONE_LEVEL_PATH_WILDCARD;
+
+public class PathPatternUtil {
+
+  private PathPatternUtil() {}
+
+  /**
+   * The input string is a single node of a path pattern. Return true if the node may be a
+   * patternNode that can match batch explicit node names. e.g. *, e.g. *, **, d*, *d*.
+   */
+  public static boolean hasWildcard(String node) {
+    return node.startsWith(ONE_LEVEL_PATH_WILDCARD) || node.endsWith(ONE_LEVEL_PATH_WILDCARD);
+  }
+
+  /** The input patternNode shall be a string starts or ends with *, e.g. *, **, d*, *d* */
+  public static boolean isNodeMatch(String patternNode, String nodeName) {
+    if (patternNode.equals(ONE_LEVEL_PATH_WILDCARD)
+        || patternNode.equals(MULTI_LEVEL_PATH_WILDCARD)) {
+      return true;
+    }
+    return Pattern.matches(patternNode.replace("*", ".*"), nodeName);
+  }
+}

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/fa/nfa/SimpleNFA.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/fa/nfa/SimpleNFA.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.commons.path.fa.nfa;
 
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternUtil;
 import org.apache.iotdb.commons.path.fa.IFAState;
 import org.apache.iotdb.commons.path.fa.IFATransition;
 import org.apache.iotdb.commons.path.fa.IPatternFA;
@@ -127,7 +128,7 @@ public class SimpleNFA implements IPatternFA {
       } else if (rawNodes[nextIndex].equals(ONE_LEVEL_PATH_WILDCARD)) {
         patternNodes[nextIndex] =
             new OneLevelWildcardMatchNode(nextIndex, currentNode.getTracebackNode());
-      } else if (rawNodes[nextIndex].contains(ONE_LEVEL_PATH_WILDCARD)) {
+      } else if (PathPatternUtil.hasWildcard(rawNodes[nextIndex])) {
         patternNodes[nextIndex] = new RegexMatchNode(nextIndex, currentNode.getTracebackNode());
       } else {
         patternNodes[nextIndex] = new NameMatchNode(nextIndex, currentNode.getTracebackNode());

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCache.java
@@ -122,6 +122,10 @@ public class DataNodeSchemaCache {
     }
   }
 
+  public ClusterSchemaTree getMatchedSchemaWithTemplate(PartialPath path) {
+    return deviceUsingTemplateSchemaCache.getMatchedSchemaWithTemplate(path);
+  }
+
   public List<Integer> computeWithoutTemplate(ISchemaComputation schemaComputation) {
     return timeSeriesSchemaCache.compute(schemaComputation);
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/ClusterTemplateManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/ClusterTemplateManager.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternUtil;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.confignode.rpc.thrift.TCreateSchemaTemplateReq;
 import org.apache.iotdb.confignode.rpc.thrift.TGetAllTemplatesResp;
@@ -61,7 +62,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD;
-import static org.apache.iotdb.commons.conf.IoTDBConstant.ONE_LEVEL_PATH_WILDCARD;
 
 public class ClusterTemplateManager implements ITemplateManager {
 
@@ -379,7 +379,7 @@ public class ClusterTemplateManager implements ITemplateManager {
     // and the following logic is equivalent with the above expression
 
     String measurement = pathPattern.getTailNode();
-    if (measurement.contains(ONE_LEVEL_PATH_WILDCARD)) {
+    if (PathPatternUtil.hasWildcard(measurement)) {
       // if measurement is wildcard, e.g. root.sg.d1.**, root.sg.d1.*, root.sg.d1.s*
       return pathPattern.overlapWithFullPathPrefix(pathSetTemplate);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetchExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ClusterSchemaFetchExecutor.java
@@ -91,7 +91,7 @@ class ClusterSchemaFetchExecutor {
    * @param rawPatternTree the pattern tree consisting of the fullPathList
    * @return fetched schema
    */
-  ClusterSchemaTree fetchSchemaOfPreciseMatch(
+  ClusterSchemaTree fetchSchemaOfPreciseMatchOrPreciseDeviceUsingTemplate(
       List<PartialPath> fullPathList, PathPatternTree rawPatternTree) {
     ClusterSchemaTree schemaTree =
         executeSchemaFetchQuery(


### PR DESCRIPTION
## Description

Currently, a device using schema template may be cached in DataNodeSchemaCache, but the cache is only used for data insertion.

Enable data query to benefit from such device cache when querying all measurements of the device, e.g. select * from root.db.d, with schema template t1 set on db.
