### PR TITLE
[IOTDB-5845] Failed to register PipeRuntimeCoordinator to loadPublisher in LoadManager

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -289,12 +289,15 @@ public class ConfigManager implements IManager {
     this.udfManager = new UDFManager(this, udfInfo);
     this.triggerManager = new TriggerManager(this, triggerInfo);
     this.cqManager = new CQManager(this);
-    this.loadManager = new LoadManager(this);
     this.modelManager = new ModelManager(this, modelInfo);
     this.pipeManager = new PipeManager(this, pipeInfo);
 
     this.retryFailedTasksThread = new RetryFailedTasksThread(this);
     this.clusterQuotaManager = new ClusterQuotaManager(this, quotaInfo);
+
+    // Please keep loadManager initializing at last because it may require other managers to
+    // register the eventBus
+    this.loadManager = new LoadManager(this);
   }
 
   public void initConsensusManager() throws IOException {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
@@ -88,8 +88,7 @@ public class LoadManager {
         new StatisticsService(configManager, routeBalancer, loadCache, loadPublisher);
 
     loadPublisher.register(statisticsService);
-    // TODO: enable
-    // loadPublisher.register(configManager.getPipeManager().getPipeRuntimeCoordinator());
+    loadPublisher.register(configManager.getPipeManager().getPipeRuntimeCoordinator());
   }
 
   /**

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/PipeRuntimeCoordinator.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/PipeRuntimeCoordinator.java
@@ -52,6 +52,11 @@ public class PipeRuntimeCoordinator implements IClusterStatusSubscriber {
 
   @Override
   public void onRegionGroupLeaderChanged(RouteChangeEvent event) {
+    // if no pipe task, return
+    if (configManager.getPipeManager().getPipeTaskCoordinator().getPipeTaskInfo().isEmpty()) {
+      return;
+    }
+
     // we only care about data region leader change
     final Map<TConsensusGroupId, Pair<Integer, Integer>> dataRegionGroupToOldAndNewLeaderPairMap =
         new HashMap<>();

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -176,6 +176,10 @@ public class PipeTaskInfo implements SnapshotProcessor {
     return pipeMetaKeeper.getPipeMetaList();
   }
 
+  public boolean isEmpty() {
+    return pipeMetaKeeper.isEmpty();
+  }
+
   /////////////////////////////// Pipe Runtime Management ///////////////////////////////
 
   /** handle the data region leader change event and update the pipe task meta accordingly */

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/task/meta/PipeMetaKeeper.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/task/meta/PipeMetaKeeper.java
@@ -59,6 +59,10 @@ public class PipeMetaKeeper {
     this.pipeNameToPipeMetaMap.clear();
   }
 
+  public boolean isEmpty() {
+    return pipeNameToPipeMetaMap.isEmpty();
+  }
+
   public void processTakeSnapshot(FileOutputStream fileOutputStream) throws IOException {
     ReadWriteIOUtils.write(pipeNameToPipeMetaMap.size(), fileOutputStream);
     for (Map.Entry<String, PipeMeta> entry : pipeNameToPipeMetaMap.entrySet()) {


### PR DESCRIPTION
## Small fix
Fix the bug that loadManager initialization fail, by bringing its initialization to the bottom.

Related to [IOTDB-5845] Pipe: Support handling leader change in PipeRuntimeCoordinator.