### PR TITLE
[IOTDB-5896] Fix delete aligned TEXT data in TVList NPE

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedDataDeletionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedDataDeletionIT.java
@@ -267,6 +267,23 @@ public class IoTDBAlignedDataDeletionIT {
   }
 
   @Test
+  public void testDeleteAfterColumnExtended() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute("insert into root.vehicle.d0(time,s0) aligned values (10,310)");
+      statement.execute("insert into root.vehicle.d0(time,s3) aligned values (10,'text')");
+      statement.execute("insert into root.vehicle.d0(time,s4) aligned values (10,true)");
+
+      try {
+        statement.execute("DELETE FROM root.vehicle.d0.s3");
+      } catch (SQLException e) {
+        fail(e.getMessage());
+      }
+    }
+  }
+
+  @Test
   public void testFullDeleteWithoutWhereClause() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {

--- a/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -516,8 +516,10 @@ public abstract class AlignedTVList extends TVList {
         int arrayIndex = originRowIndex / ARRAY_SIZE;
         int elementIndex = originRowIndex % ARRAY_SIZE;
         if (dataTypes.get(columnIndex) == TSDataType.TEXT) {
-          memoryBinaryChunkSize[columnIndex] -=
-              getBinarySize(((Binary[]) values.get(columnIndex).get(arrayIndex))[elementIndex]);
+          Binary value = ((Binary[]) values.get(columnIndex).get(arrayIndex))[elementIndex];
+          if (value != null) {
+            memoryBinaryChunkSize[columnIndex] -= getBinarySize(value);
+          }
         }
         markNullValue(columnIndex, arrayIndex, elementIndex);
         deletedNumber++;

--- a/server/src/test/java/org/apache/iotdb/db/utils/datastructure/VectorTVListTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/datastructure/VectorTVListTest.java
@@ -269,7 +269,18 @@ public class VectorTVListTest {
     Assert.assertEquals(tvList.memoryBinaryChunkSize.length, 2);
     Assert.assertEquals(tvList.memoryBinaryChunkSize[0], 324);
 
+    tvList.extendColumn(TSDataType.TEXT);
+    Assert.assertEquals(tvList.memoryBinaryChunkSize.length, 3);
+    Assert.assertEquals(tvList.memoryBinaryChunkSize[0], 324);
+    Assert.assertEquals(tvList.memoryBinaryChunkSize[2], 0);
+
+    tvList.delete(4, 6);
+    Assert.assertEquals(tvList.memoryBinaryChunkSize.length, 3);
+    Assert.assertEquals(tvList.memoryBinaryChunkSize[0], 216);
+    Assert.assertEquals(tvList.memoryBinaryChunkSize[2], 0);
+
     tvList.clear();
     Assert.assertEquals(tvList.memoryBinaryChunkSize[0], 0);
+    Assert.assertEquals(tvList.memoryBinaryChunkSize[2], 0);
   }
 }


### PR DESCRIPTION
## Description

![image](https://github.com/apache/iotdb/assets/25913899/da9e230a-251c-446a-9c7e-c18329ee41e2)


To reproduce:

```sql
insert into root.vehicle.d0(time,s0) aligned values (10,310)
insert into root.vehicle.d0(time,s3) aligned values (10,'text')
insert into root.vehicle.d0(time,s4) aligned values (10,true)
DELETE FROM root.vehicle.d0.s3
```