### PR TITLE
[IOTDB-5899] Fix unexpected TemplateNotExistException when deactivating template

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBDeactivateTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBDeactivateTemplateIT.java
@@ -274,4 +274,26 @@ public class IoTDBDeactivateTemplateIT extends AbstractSchemaIT {
       }
     }
   }
+
+  @Test
+  public void testPathNotSetAndUsingTemplate() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("create database root.db.factory0");
+      statement.execute("create database root.db.factory1");
+      statement.execute("create database root.db.factory2");
+
+      statement.execute("set schema template t1 to root.db.factory0");
+      statement.execute("set schema template t1 to root.db.factory1");
+
+      try {
+        statement.execute("deactivate schema template from root.db.**");
+      } catch (SQLException e) {
+        Assert.assertTrue(
+            e.getMessage()
+                .contains(
+                    "Target schema Template is not activated on any path matched by given path pattern"));
+      }
+    }
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/ConfigMTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/ConfigMTree.java
@@ -538,20 +538,22 @@ public class ConfigMTree {
           @Override
           protected boolean acceptFullMatchedNode(IConfigMNode node) {
             return (node.getSchemaTemplateId() != NON_TEMPLATE)
-                && super.acceptFullMatchedNode(node);
+                || super.acceptFullMatchedNode(node);
           }
 
           @Override
           protected boolean acceptInternalMatchedNode(IConfigMNode node) {
             return (node.getSchemaTemplateId() != NON_TEMPLATE)
-                && super.acceptInternalMatchedNode(node);
+                || super.acceptInternalMatchedNode(node);
           }
 
           @Override
           protected Void collectMNode(IConfigMNode node) {
-            result
-                .computeIfAbsent(node.getSchemaTemplateId(), k -> new HashSet<>())
-                .add(getPartialPathFromRootToNode(node));
+            if (node.getSchemaTemplateId() != NON_TEMPLATE && !node.isSchemaTemplatePreUnset()) {
+              result
+                  .computeIfAbsent(node.getSchemaTemplateId(), k -> new HashSet<>())
+                  .add(getPartialPathFromRootToNode(node));
+            }
             return null;
           }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/ConfigMTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/ConfigMTree.java
@@ -538,13 +538,13 @@ public class ConfigMTree {
           @Override
           protected boolean acceptFullMatchedNode(IConfigMNode node) {
             return (node.getSchemaTemplateId() != NON_TEMPLATE)
-                || super.acceptFullMatchedNode(node);
+                && super.acceptFullMatchedNode(node);
           }
 
           @Override
           protected boolean acceptInternalMatchedNode(IConfigMNode node) {
             return (node.getSchemaTemplateId() != NON_TEMPLATE)
-                || super.acceptInternalMatchedNode(node);
+                && super.acceptInternalMatchedNode(node);
           }
 
           @Override


### PR DESCRIPTION
## Description


### Problem

see [IOTDB-5899](https://issues.apache.org/jira/browse/IOTDB-5899)

### Cause

When traversing the ConfigMTree to get template set info, paths matched by given pattern but not set template on do be collected and the id=-1, representing NON_TEMPLATE , is collected, which results in the TemplateNotExistException.

### Solution

Fix the check of template usage when traversing ConfigMTree.
