### PR TITLE
[To rel/1.1] [IOTDB-5903] Fix cannot select any inner space compaction task when there is only unsequence data

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionScheduler.java
@@ -53,7 +53,7 @@ public class CompactionScheduler {
   private static IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
   /**
-   * Select compaction task and submit them to CompactionTaskManager
+   * Select compaction task and submit them to CompactionTaskManager.
    *
    * @param tsFileManager tsfileManager that contains source files
    * @param timePartition the time partition to execute the selection

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionTaskManager.java
@@ -71,6 +71,7 @@ public class CompactionTaskManager implements IService {
   private WrappedThreadPoolExecutor subCompactionTaskExecutionPool;
 
   public static volatile AtomicInteger currentTaskNum = new AtomicInteger(0);
+
   private final FixedPriorityBlockingQueue<AbstractCompactionTask> candidateCompactionTaskQueue =
       new FixedPriorityBlockingQueue<>(
           config.getCandidateCompactionTaskQueueSize(), new DefaultCompactionTaskComparatorImpl());
@@ -455,5 +456,9 @@ public class CompactionTaskManager implements IService {
       }
     }
     return storageGroupTasks.get(regionWithSG).get(task);
+  }
+
+  public FixedPriorityBlockingQueue<AbstractCompactionTask> getCandidateCompactionTaskQueue() {
+    return candidateCompactionTaskQueue;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionTaskManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/schedule/CompactionTaskManager.java
@@ -457,8 +457,4 @@ public class CompactionTaskManager implements IService {
     }
     return storageGroupTasks.get(regionWithSG).get(task);
   }
-
-  public FixedPriorityBlockingQueue<AbstractCompactionTask> getCandidateCompactionTaskQueue() {
-    return candidateCompactionTaskQueue;
-  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -2148,18 +2148,20 @@ public class DataRegion implements IDataRegionForQuery {
   }
 
   protected int executeCompaction() {
-    int submittedTask = 0;
+    // the name of this variable is trySubmitCount, because the task submitted to the queue could be
+    // evicted due to the low priority of the task
+    int trySubmitCount = 0;
     try {
       List<Long> timePartitions = new ArrayList<>(tsFileManager.getTimePartitions());
       // sort the time partition from largest to smallest
       timePartitions.sort(Comparator.reverseOrder());
       for (long timePartition : timePartitions) {
-        submittedTask += CompactionScheduler.scheduleCompaction(tsFileManager, timePartition);
+        trySubmitCount += CompactionScheduler.scheduleCompaction(tsFileManager, timePartition);
       }
     } catch (Throwable e) {
       logger.error("Meet error in compaction schedule.", e);
     }
-    return submittedTask;
+    return trySubmitCount;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileManager.java
@@ -346,6 +346,7 @@ public class TsFileManager {
     readLock();
     try {
       Set<Long> timePartitions = new HashSet<>(sequenceFiles.keySet());
+      timePartitions.addAll(unsequenceFiles.keySet());
       return timePartitions;
     } finally {
       readUnlock();

--- a/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionSelectorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/compaction/inner/sizetiered/SizeTieredCompactionSelectorTest.java
@@ -20,14 +20,19 @@
 package org.apache.iotdb.db.engine.compaction.inner.sizetiered;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.engine.compaction.selector.impl.SizeTieredCompactionSelector;
+import org.apache.iotdb.db.engine.storagegroup.DataRegion;
 import org.apache.iotdb.db.engine.storagegroup.FakedTsFileResource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResourceStatus;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -64,5 +69,38 @@ public class SizeTieredCompactionSelectorTest {
         new SizeTieredCompactionSelector("root.test", "0", 9, true, manager)
             .selectInnerSpaceTask(manager.getOrCreateSequenceListByTimePartition(9))
             .size());
+  }
+
+  @Test
+  public void testSubmitWhenSequenceFileIsEmpty() throws Exception {
+    DataRegion region = new DataRegion("root.test", "1");
+    TsFileManager manager = region.getTsFileManager();
+    int originCandidate =
+        IoTDBDescriptor.getInstance().getConfig().getMaxInnerCompactionCandidateFileNum();
+    IoTDBDescriptor.getInstance().getConfig().setMaxInnerCompactionCandidateFileNum(30);
+    boolean enableUnseqCompaction =
+        IoTDBDescriptor.getInstance().getConfig().isEnableUnseqSpaceCompaction();
+    IoTDBDescriptor.getInstance().getConfig().setEnableUnseqSpaceCompaction(true);
+    CompactionTaskManager.getInstance().start();
+    try {
+      for (int i = 1; i < 91; ++i) {
+        TsFileResource resource = Mockito.mock(TsFileResource.class);
+        Mockito.when(resource.getTimePartition()).thenReturn(0L);
+        Mockito.when(resource.getTsFileSize()).thenReturn(100L);
+        Mockito.when(resource.getTsFile())
+            .thenReturn(new File(String.format("%d-%d-0-0.tsfile", i, i)));
+        Mockito.when(resource.getStatus()).thenReturn(TsFileResourceStatus.NORMAL);
+        manager.add(resource, false);
+      }
+      Assert.assertEquals(3, region.compact());
+    } finally {
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setMaxInnerCompactionCandidateFileNum(originCandidate);
+      IoTDBDescriptor.getInstance()
+          .getConfig()
+          .setEnableUnseqSpaceCompaction(enableUnseqCompaction);
+      CompactionTaskManager.getInstance().shutdown(60_000L);
+    }
   }
 }


### PR DESCRIPTION
See [IOTDB-5903](https://issues.apache.org/jira/browse/IOTDB-5903).

The reason is that when getting time partitions from TsFileManager, it will only return the time partitions that contains sequence data.