### PR TITLE
[IOTDB-5901][To rel/1.1] Load: load tsfile without data will throw NPE

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/load/LoadSingleTsFileNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/load/LoadSingleTsFileNode.java
@@ -69,6 +69,10 @@ public class LoadSingleTsFileNode extends WritePlanNode {
     this.deleteAfterLoad = deleteAfterLoad;
   }
 
+  public boolean isTsFileEmpty() {
+    return resource.getDevices().isEmpty();
+  }
+
   public boolean needDecodeTsFile(
       Function<List<Pair<String, TTimePartitionSlot>>, List<TRegionReplicaSet>> partitionFetcher)
       throws IOException {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileScheduler.java
@@ -135,7 +135,13 @@ public class LoadTsFileScheduler implements IScheduler {
       LoadSingleTsFileNode node = tsFileNodeList.get(i);
       boolean isLoadSingleTsFileSuccess = true;
       try {
-        if (!node.needDecodeTsFile(
+        if (node.isTsFileEmpty()) {
+          logger.info(
+              String.format(
+                  "Load skip TsFile %s, because it has no data.",
+                  node.getTsFileResource().getTsFilePath()));
+
+        } else if (!node.needDecodeTsFile(
             partitionFetcher::queryDataPartition)) { // do not decode, load locally
           isLoadSingleTsFileSuccess = loadLocally(node);
           node.clean();


### PR DESCRIPTION
Problems:
load a  tsfile without data will throw NPE

java.lang.NullPointerException: null
	at org.apache.iotdb.commons.partition.StorageExecutor.getDataNodeLocation(StorageExecutor.java:39)
	at org.apache.iotdb.db.mpp.plan.planner.plan.FragmentInstance.setExecutorAndHost(FragmentInstance.java:107)
	at org.apache.iotdb.db.mpp.plan.scheduler.load.LoadTsFileScheduler.loadLocally(LoadTsFileScheduler.java:319)
	at org.apache.iotdb.db.mpp.plan.scheduler.load.LoadTsFileScheduler.start(LoadTsFileScheduler.java:140)
	at org.apache.iotdb.db.mpp.plan.execution.QueryExecution.schedule(QueryExecution.java:305)
	at org.apache.iotdb.db.mpp.plan.execution.QueryExecution.start(QueryExecution.java:219)
	at org.apache.iotdb.db.mpp.plan.Coordinator.execute(Coordinator.java:161)
	at org.apache.iotdb.db.service.thrift.impl.ClientRPCServiceImpl.executeStatementInternal(ClientRPCServiceImpl.java:221)
	at org.apache.iotdb.db.service.thrift.impl.ClientRPCServiceImpl.executeStatementV2(ClientRPCServiceImpl.java:502)
	at org.apache.iotdb.service.rpc.thrift.IClientRPCService$Processor$executeStatementV2.getResult(IClientRPCService.java:3689)
	at org.apache.iotdb.service.rpc.thrift.IClientRPCService$Processor$executeStatementV2.getResult(IClientRPCService.java:3669)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
	at org.apache.iotdb.db.service.thrift.ProcessorWithMetrics.process(ProcessorWithMetrics.java:64)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)

This PR contains:
- judge TsFile has data or not in LoadTsFileScheduler
- add UT for loading TsFile without data