### PR TITLE
[IOTDB-5909] Ignore IoTDBConfigNodeConsensusEfficiencyIT temporary

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/IoTDBConfigNodeConsensusEfficiencyIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/IoTDBConfigNodeConsensusEfficiencyIT.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.rpc.TSStatusCode;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -118,6 +119,7 @@ public class IoTDBConfigNodeConsensusEfficiencyIT {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 
+  @Ignore
   @Test
   public void consensusEfficiencyIT() throws InterruptedException {
     long totalTime = 0;


### PR DESCRIPTION
Waiting for https://issues.apache.org/jira/browse/IOTDB-5906 to fix this IT bug