### PR TITLE
[IOTDB-5911] Fix print-iotdb-data-dir tool cannot work

### DIFF
--- a/server/src/assembly/resources/tools/tsfile/print-iotdb-data-dir.bat
+++ b/server/src/assembly/resources/tools/tsfile/print-iotdb-data-dir.bat
@@ -46,7 +46,7 @@ goto :eof
 @REM -----------------------------------------------------------------------------
 :okClasspath
 
-"%JAVA_HOME%\bin\java" -cp "%CLASSPATH%" %MAIN_CLASS% %*
+"%JAVA_HOME%\bin\java" -cp "%CLASSPATH%" "-Dlogback.configurationFile=%IOTDB_HOME%\conf\logback-tool.xml" %MAIN_CLASS% %*
 
 goto finally
 

--- a/server/src/assembly/resources/tools/tsfile/print-iotdb-data-dir.sh
+++ b/server/src/assembly/resources/tools/tsfile/print-iotdb-data-dir.sh
@@ -48,5 +48,5 @@ done
 
 MAIN_CLASS=org.apache.iotdb.db.tools.IoTDBDataDirViewer
 
-"$JAVA" -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
+"$JAVA" -cp "$CLASSPATH" "-Dlogback.configurationFile=${IOTDB_HOME}/conf/logback-tool.xml" "$MAIN_CLASS" "$@"
 exit $?

--- a/server/src/main/java/org/apache/iotdb/db/tools/IoTDBDataDirViewer.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/IoTDBDataDirViewer.java
@@ -40,7 +40,7 @@ public class IoTDBDataDirViewer {
     String[] data_dir;
     String outFile = "IoTDB_data_dir_overview.txt";
     if (args.length == 0) {
-      String path = "data/data";
+      String path = "data/datanode/data";
       data_dir = path.split(","); // multiple data dirs separated by comma
     } else if (args.length == 1) {
       data_dir = args[0].split(",");
@@ -56,7 +56,7 @@ public class IoTDBDataDirViewer {
       for (String dir : data_dir) {
         File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
         File[] seqAndUnseqDirs = dirFile.listFiles();
-        if (seqAndUnseqDirs == null || seqAndUnseqDirs.length != 2) {
+        if (seqAndUnseqDirs == null) {
           throw new IOException(
               "Irregular data dir structure.There should be a sequence and unsequence directory "
                   + "under the data directory "
@@ -64,20 +64,20 @@ public class IoTDBDataDirViewer {
         }
         List<File> fileList = Arrays.asList(seqAndUnseqDirs);
         fileList.sort((Comparator.comparing(File::getName)));
-        if (!"sequence".equals(seqAndUnseqDirs[0].getName())
-            || !"unsequence".equals(seqAndUnseqDirs[1].getName())) {
+        if (!"sequence".equals(seqAndUnseqDirs[1].getName())
+            || !"unsequence".equals(seqAndUnseqDirs[2].getName())) {
           throw new IOException(
               "Irregular data dir structure.There should be a sequence and unsequence directory "
                   + "under the data directory "
-                  + dirFile.getName());
+                  + dirFile.getPath());
         }
 
         printlnBoth(pw, "|==============================================================");
         printlnBoth(pw, "|" + dir);
         printlnBoth(pw, "|--sequence");
-        printFilesInSeqOrUnseqDir(seqAndUnseqDirs[0], pw);
-        printlnBoth(pw, "|--unsequence");
         printFilesInSeqOrUnseqDir(seqAndUnseqDirs[1], pw);
+        printlnBoth(pw, "|--unsequence");
+        printFilesInSeqOrUnseqDir(seqAndUnseqDirs[2], pw);
       }
       printlnBoth(pw, "|==============================================================");
     }
@@ -105,14 +105,31 @@ public class IoTDBDataDirViewer {
     File[] files = storageGroup.listFiles();
     if (files == null) {
       throw new IOException(
-          "Irregular data dir structure.There should be timeInterval directories under "
+          "Irregular data dir structure.There should be dataRegion directories under "
               + "the database directory "
               + storageGroup.getName());
     }
     List<File> fileList = Arrays.asList(files);
     fileList.sort((Comparator.comparing(File::getName)));
-    for (File file : files) {
+    for (File file : fileList) {
       printlnBoth(pw, "|  |  |--" + file.getName());
+      printFilesInDataRegionDir(file, pw);
+    }
+  }
+
+  private static void printFilesInDataRegionDir(File dataRegion, PrintWriter pw)
+      throws IOException {
+    File[] files = dataRegion.listFiles();
+    if (files == null) {
+      throw new IOException(
+          "Irregular data dir structure.There should be timeInterval directories under "
+              + "the database directory "
+              + dataRegion.getName());
+    }
+    List<File> fileList = Arrays.asList(files);
+    fileList.sort((Comparator.comparing(File::getName)));
+    for (File file : fileList) {
+      printlnBoth(pw, "|  |  |  |--" + file.getName());
       printFilesInTimeInterval(file, pw);
     }
   }
@@ -128,8 +145,8 @@ public class IoTDBDataDirViewer {
     }
     List<File> fileList = Arrays.asList(files);
     fileList.sort((Comparator.comparing(File::getName)));
-    for (File file : files) {
-      printlnBoth(pw, "|  |  |  |--" + file.getName());
+    for (File file : fileList) {
+      printlnBoth(pw, "|  |  |  |  |--" + file.getName());
 
       // To print the content if it is a tsfile.resource
       if (file.getName().endsWith(".tsfile.resource")) {
@@ -148,7 +165,7 @@ public class IoTDBDataDirViewer {
       printlnBoth(
           pw,
           String.format(
-              "|  |  |  |  |--device %s, start time %d (%s), end time %d (%s)",
+              "|  |  |  |  |  |--device %s, start time %d (%s), end time %d (%s)",
               device,
               resource.getStartTime(device),
               DateTimeUtils.convertLongToDate(resource.getStartTime(device)),


### PR DESCRIPTION
## Description

In V1.1.0:

```
$ ./tools/tsfile/print-iotdb-data-dir.sh  ~/Documents/iotdb/data/datanode/data/
---------------------
Starting Printing the IoTDB Data Directory Overview
---------------------
output save path:IoTDB_data_dir_overview.txt
data dir num:1
113  [main] WARN  o.a.i.t.c.conf.TSFileDescriptor - not found iotdb-common.properties, use the default configs. 
Exception in thread "main" java.io.IOException: Irregular data dir structure.There should be a sequence and unsequence directory under the data directory data
        at org.apache.iotdb.db.tools.IoTDBDataDirViewer.main(IoTDBDataDirViewer.java:63)
```


After this fixing:
```
$ ./print-iotdb-data-dir.sh ~/Documents/iotdb/data/datanode/data/
---------------------
Starting Printing the IoTDB Data Directory Overview
---------------------
output save path:IoTDB_data_dir_overview.txt
data dir num:1
|==============================================================
|/Users/ht/Documents/iotdb/data/datanode/data/
|--sequence
|  |--root.sg
|  |  |--1
|  |  |  |--0
|  |  |  |  |--1684730267178-1-0-0.tsfile
|  |  |  |  |--1684730267178-1-0-0.tsfile.resource
|  |  |  |  |  |--device root.sg.d1, start time 1 (1970-01-01T08:00:00.001), end time 1 (1970-01-01T08:00:00.001)
|  |  |  |--2
|  |  |  |  |--1684742734592-1-0-0.tsfile
|  |  |  |  |--1684742734592-1-0-0.tsfile.resource
|  |  |  |  |  |--device root.sg.d1, start time 1684741261 (1970-01-20T19:59:01.261), end time 1684741261 (1970-01-20T19:59:01.261)
|  |  |--2
|  |  |  |--2785
|  |  |  |  |--1684741262502-1-0-0.tsfile
|  |  |  |  |--1684741262502-1-0-0.tsfile.resource
|  |  |  |  |  |--device root.sg.d1, start time 1684741261202 (2023-05-22T15:41:01.202), end time 1684741261202 (2023-05-22T15:41:01.202)
|--unsequence
|==============================================================
```
