### PR TITLE
Fix potential NPE when deRegisterFragmentInstanceFromQueryMemoryMap

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/memory/MemoryPool.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/memory/MemoryPool.java
@@ -175,10 +175,14 @@ public class MemoryPool {
     Map<String, Map<String, Long>> queryRelatedMemory = queryMemoryReservations.get(queryId);
     if (queryRelatedMemory != null) {
       Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
-      for (Long memoryReserved : fragmentRelatedMemory.values()) {
-        if (memoryReserved != 0) {
-          throw new MemoryLeakException(
-              "PlanNode related memory is not zero when deregister fragment instance from query memory pool.");
+      // fragmentRelatedMemory could be null if the FI has not reserved any memory(For example,
+      // next() of root operator returns no data)
+      if (fragmentRelatedMemory != null) {
+        for (Long memoryReserved : fragmentRelatedMemory.values()) {
+          if (memoryReserved != 0) {
+            throw new MemoryLeakException(
+                "PlanNode related memory is not zero when deregister fragment instance from query memory pool.");
+          }
         }
       }
       synchronized (queryMemoryReservations) {


### PR DESCRIPTION
fragmentRelatedMemory could be null if the FI has not reserved any memory(For example, next() of root operator returns no data).
See the following pic:
<img width="922" alt="截屏2023-05-24 10 37 47" src="https://github.com/apache/iotdb/assets/108499334/57e724d2-64f6-45db-88f9-2aee63925f86">
