### PR TITLE
Support Show View

### DIFF
--- a/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -64,7 +64,7 @@ ddlStatement
     // Quota
     | setSpaceQuota | showSpaceQuota | setThrottleQuota | showThrottleQuota
     // View
-    | createLogicalView | dropLogicalView
+    | createLogicalView | dropLogicalView | showLogicalView
     ;
 
 dmlStatement
@@ -561,6 +561,10 @@ showTrails
 // Create Logical View
 createLogicalView
     : CREATE VIEW viewTargetPaths AS viewSourcePaths
+    ;
+
+showLogicalView
+    : SHOW VIEW prefixPath? timeseriesWhereClause? rowPaginationClause?
     ;
 
 dropLogicalView

--- a/server/src/main/java/org/apache/iotdb/db/metadata/query/reader/SchemaReaderLimitOffsetWrapper.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/query/reader/SchemaReaderLimitOffsetWrapper.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.metadata.query.reader;
+
+import org.apache.iotdb.db.metadata.query.info.ISchemaInfo;
+
+import java.util.NoSuchElementException;
+
+public class SchemaReaderLimitOffsetWrapper<T extends ISchemaInfo> implements ISchemaReader<T> {
+
+  private final ISchemaReader<T> schemaReader;
+
+  private final long limit;
+  private final long offset;
+  private final boolean hasLimit;
+
+  private int count = 0;
+  int curOffset = 0;
+
+  public SchemaReaderLimitOffsetWrapper(ISchemaReader<T> schemaReader, long limit, long offset) {
+    this.schemaReader = schemaReader;
+    this.limit = limit;
+    this.offset = offset;
+    this.hasLimit = limit > 0 || offset > 0;
+
+    if (hasLimit) {
+      while (curOffset < offset && schemaReader.hasNext()) {
+        schemaReader.next();
+        curOffset++;
+      }
+    }
+  }
+
+  @Override
+  public boolean isSuccess() {
+    return schemaReader.isSuccess();
+  }
+
+  @Override
+  public Throwable getFailure() {
+    return schemaReader.getFailure();
+  }
+
+  @Override
+  public void close() throws Exception {
+    schemaReader.close();
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (hasLimit) {
+      return count < limit && schemaReader.hasNext();
+    } else {
+      return schemaReader.hasNext();
+    }
+  }
+
+  @Override
+  public T next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    T result = schemaReader.next();
+    if (hasLimit) {
+      count++;
+    }
+    return result;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
@@ -186,6 +186,7 @@ public class ColumnHeaderConstant {
 
   // column names for views (eg. logical view)
   public static final String VIEW_TYPE = "ViewType";
+  public static final String SOURCE = "Source";
 
   public static final List<ColumnHeader> lastQueryColumnHeaders =
       ImmutableList.of(
@@ -458,4 +459,14 @@ public class ColumnHeaderConstant {
           new ColumnHeader(TRAIL_ID, TSDataType.TEXT),
           new ColumnHeader(MODEL_PATH, TSDataType.TEXT),
           new ColumnHeader(HYPERPARAMETER, TSDataType.TEXT));
+
+  public static final List<ColumnHeader> showLogicalViewColumnHeaders =
+      ImmutableList.of(
+          new ColumnHeader(TIMESERIES, TSDataType.TEXT),
+          new ColumnHeader(DATABASE, TSDataType.TEXT),
+          new ColumnHeader(DATATYPE, TSDataType.TEXT),
+          new ColumnHeader(TAGS, TSDataType.TEXT),
+          new ColumnHeader(ATTRIBUTES, TSDataType.TEXT),
+          new ColumnHeader(VIEW_TYPE, TSDataType.TEXT),
+          new ColumnHeader(SOURCE, TSDataType.TEXT));
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/DatasetHeaderFactory.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/DatasetHeaderFactory.java
@@ -188,4 +188,8 @@ public class DatasetHeaderFactory {
   public static DatasetHeader getShowTrailsHeader() {
     return new DatasetHeader(ColumnHeaderConstant.showTrailsColumnHeaders, true);
   }
+
+  public static DatasetHeader getShowLogicalViewHeader() {
+    return new DatasetHeader(ColumnHeaderConstant.showLogicalViewColumnHeaders, true);
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/LogicalViewSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/LogicalViewSchemaSource.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
+import org.apache.iotdb.db.metadata.query.reader.SchemaReaderLimitOffsetWrapper;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant;
@@ -61,10 +62,13 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
   @Override
   public ISchemaReader<ITimeSeriesSchemaInfo> getSchemaReader(ISchemaRegion schemaRegion) {
     try {
-      return new LogicalViewSchemaReader(
-          schemaRegion.getTimeSeriesReader(
-              SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
-                  pathPattern, Collections.emptyMap(), limit, offset, false, schemaFilter)));
+      return new SchemaReaderLimitOffsetWrapper<ITimeSeriesSchemaInfo>(
+          new LogicalViewSchemaReader(
+              schemaRegion.getTimeSeriesReader(
+                  SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
+                      pathPattern, Collections.emptyMap(), 0, 0, false, schemaFilter))),
+          limit,
+          offset);
     } catch (MetadataException e) {
       throw new RuntimeException(e.getMessage(), e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/LogicalViewSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/LogicalViewSchemaSource.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.execution.operator.schema.source;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.schema.filter.SchemaFilter;
+import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
+import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
+import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
+import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
+import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
+import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
+import org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant;
+import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+import static org.apache.iotdb.db.metadata.MetadataConstant.ALL_MATCH_PATTERN;
+
+public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaInfo> {
+
+  private final PartialPath pathPattern;
+
+  private final long limit;
+  private final long offset;
+
+  private final SchemaFilter schemaFilter;
+
+  LogicalViewSchemaSource(
+      PartialPath pathPattern, long limit, long offset, SchemaFilter schemaFilter) {
+    this.pathPattern = pathPattern;
+
+    this.limit = limit;
+    this.offset = offset;
+
+    this.schemaFilter = schemaFilter;
+  }
+
+  @Override
+  public ISchemaReader<ITimeSeriesSchemaInfo> getSchemaReader(ISchemaRegion schemaRegion) {
+    try {
+      return new LogicalViewSchemaReader(
+          schemaRegion.getTimeSeriesReader(
+              SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
+                  pathPattern, Collections.emptyMap(), limit, offset, false, schemaFilter)));
+    } catch (MetadataException e) {
+      throw new RuntimeException(e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public List<ColumnHeader> getInfoQueryColumnHeaders() {
+    return ColumnHeaderConstant.showLogicalViewColumnHeaders;
+  }
+
+  @Override
+  public void transformToTsBlockColumns(
+      ITimeSeriesSchemaInfo series, TsBlockBuilder builder, String database) {
+    builder.getTimeColumnBuilder().writeLong(0);
+    builder.writeNullableText(0, series.getFullPath());
+    builder.writeNullableText(1, database);
+
+    builder.writeNullableText(2, "");
+
+    builder.writeNullableText(3, mapToString(series.getTags()));
+    builder.writeNullableText(4, mapToString(series.getAttributes()));
+
+    builder.writeNullableText(5, "logical");
+    builder.writeNullableText(
+        6, ((LogicalViewSchema) series.getSchema()).getExpression().toString());
+    builder.declarePosition();
+  }
+
+  @Override
+  public boolean hasSchemaStatistic(ISchemaRegion schemaRegion) {
+    return pathPattern.equals(ALL_MATCH_PATTERN) && (schemaFilter == null);
+  }
+
+  @Override
+  public long getSchemaStatistic(ISchemaRegion schemaRegion) {
+    return schemaRegion.getSchemaRegionStatistics().getSeriesNumber();
+  }
+
+  private String mapToString(Map<String, String> map) {
+    if (map == null || map.isEmpty()) {
+      return null;
+    }
+    String content =
+        map.entrySet().stream()
+            .map(e -> "\"" + e.getKey() + "\"" + ":" + "\"" + e.getValue() + "\"")
+            .collect(Collectors.joining(","));
+    return "{" + content + "}";
+  }
+
+  private static class LogicalViewSchemaReader implements ISchemaReader<ITimeSeriesSchemaInfo> {
+
+    private final ISchemaReader<ITimeSeriesSchemaInfo> timeSeriesReader;
+
+    private ITimeSeriesSchemaInfo nextResult;
+
+    LogicalViewSchemaReader(ISchemaReader<ITimeSeriesSchemaInfo> timeSeriesReader) {
+      this.timeSeriesReader = timeSeriesReader;
+    }
+
+    @Override
+    public boolean isSuccess() {
+      return timeSeriesReader.isSuccess();
+    }
+
+    @Override
+    public Throwable getFailure() {
+      return timeSeriesReader.getFailure();
+    }
+
+    @Override
+    public void close() throws Exception {
+      timeSeriesReader.close();
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (nextResult == null) {
+        getNext();
+      }
+      return nextResult != null;
+    }
+
+    @Override
+    public ITimeSeriesSchemaInfo next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      ITimeSeriesSchemaInfo result = nextResult;
+      nextResult = null;
+      return result;
+    }
+
+    private void getNext() {
+      ITimeSeriesSchemaInfo timeSeriesSchemaInfo;
+      while (timeSeriesReader.hasNext()) {
+        timeSeriesSchemaInfo = timeSeriesReader.next();
+        if (timeSeriesSchemaInfo.isLogicalView()) {
+          nextResult = timeSeriesSchemaInfo;
+          return;
+        }
+      }
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/SchemaSourceFactory.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/SchemaSourceFactory.java
@@ -81,4 +81,9 @@ public class SchemaSourceFactory {
       List<PartialPath> pathPatternList, int templateId) {
     return new PathsUsingTemplateSource(pathPatternList, templateId);
   }
+
+  public static ISchemaSource<ITimeSeriesSchemaInfo> getLogicalViewSchemaSource(
+      PartialPath pathPattern, long limit, long offset, SchemaFilter schemaFilter) {
+    return new LogicalViewSchemaSource(pathPattern, limit, offset, schemaFilter);
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -136,6 +136,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowPathSetTempl
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowPathsUsingTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.view.CreateLogicalViewStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.view.ShowLogicalViewStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.ExplainStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.ShowQueriesStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.ShowVersionStatement;
@@ -3324,6 +3325,22 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     SchemaPartition schemaPartitionInfo = partitionFetcher.getOrCreateSchemaPartition(patternTree);
     analysis.setSchemaPartitionInfo(schemaPartitionInfo);
 
+    return analysis;
+  }
+
+  @Override
+  public Analysis visitShowLogicalView(
+      ShowLogicalViewStatement showLogicalViewStatement, MPPQueryContext context) {
+    context.setQueryType(QueryType.READ);
+    Analysis analysis = new Analysis();
+    analysis.setStatement(showLogicalViewStatement);
+
+    PathPatternTree patternTree = new PathPatternTree();
+    patternTree.appendPathPattern(showLogicalViewStatement.getPathPattern());
+    SchemaPartition schemaPartitionInfo = partitionFetcher.getSchemaPartition(patternTree);
+    analysis.setSchemaPartitionInfo(schemaPartitionInfo);
+
+    analysis.setRespDatasetHeader(DatasetHeaderFactory.getShowLogicalViewHeader());
     return analysis;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
@@ -165,6 +165,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowSchemaTempla
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.UnsetSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.view.CreateLogicalViewStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.view.DeleteLogicalViewStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.view.ShowLogicalViewStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.AuthorStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.ClearCacheStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.ExplainStatement;
@@ -1014,6 +1015,32 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     }
     deleteLogicalViewStatement.setPathPatternList(partialPaths);
     return deleteLogicalViewStatement;
+  }
+
+  @Override
+  public Statement visitShowLogicalView(IoTDBSqlParser.ShowLogicalViewContext ctx) {
+    ShowLogicalViewStatement showLogicalViewStatement;
+    if (ctx.prefixPath() != null) {
+      showLogicalViewStatement = new ShowLogicalViewStatement(parsePrefixPath(ctx.prefixPath()));
+    } else {
+      showLogicalViewStatement =
+          new ShowLogicalViewStatement(new PartialPath(SqlConstant.getSingleRootArray()));
+    }
+    if (ctx.timeseriesWhereClause() != null) {
+      SchemaFilter schemaFilter = parseTimeseriesWhereClause(ctx.timeseriesWhereClause());
+      showLogicalViewStatement.setSchemaFilter(schemaFilter);
+    }
+    if (ctx.rowPaginationClause() != null) {
+      if (ctx.rowPaginationClause().limitClause() != null) {
+        showLogicalViewStatement.setLimit(
+            parseLimitClause(ctx.rowPaginationClause().limitClause()));
+      }
+      if (ctx.rowPaginationClause().offsetClause() != null) {
+        showLogicalViewStatement.setOffset(
+            parseOffsetClause(ctx.rowPaginationClause().offsetClause()));
+      }
+    }
+    return showLogicalViewStatement;
   }
 
   // parse suffix paths in logical view

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
@@ -43,6 +43,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.CountSchemaM
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.DevicesCountNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.DevicesSchemaScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.LevelTimeSeriesCountNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.LogicalViewSchemaScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.NodeManagementMemoryMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.NodePathsConvertNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.NodePathsCountNode;
@@ -1145,6 +1146,14 @@ public class LogicalPlanBuilder {
     this.root =
         new PathsUsingTemplateScanNode(
             context.getQueryId().genPlanNodeId(), pathPatternList, templateId);
+    return this;
+  }
+
+  public LogicalPlanBuilder planLogicalViewSchemaSource(
+      PartialPath pathPattern, SchemaFilter schemaFilter, long limit, long offset) {
+    this.root =
+        new LogicalViewSchemaScanNode(
+            context.getQueryId().genPlanNodeId(), pathPattern, schemaFilter, limit, offset);
     return this;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
@@ -142,6 +142,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.CountSchemaM
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.DevicesCountNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.DevicesSchemaScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.LevelTimeSeriesCountNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.LogicalViewSchemaScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.NodeManagementMemoryMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.NodePathsConvertNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.NodePathsCountNode;
@@ -531,6 +532,8 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
       return visitNodePathsSchemaScan((NodePathsSchemaScanNode) node, context);
     } else if (node instanceof PathsUsingTemplateScanNode) {
       return visitPathsUsingTemplateScan((PathsUsingTemplateScanNode) node, context);
+    } else if (node instanceof LogicalViewSchemaScanNode) {
+      return visitLogicalViewSchemaScan((LogicalViewSchemaScanNode) node, context);
     }
     return visitPlan(node, context);
   }
@@ -2378,6 +2381,23 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
         operatorContext,
         SchemaSourceFactory.getPathsUsingTemplateSource(
             node.getPathPatternList(), node.getTemplateId()));
+  }
+
+  public Operator visitLogicalViewSchemaScan(
+      LogicalViewSchemaScanNode node, LocalExecutionPlanContext context) {
+    OperatorContext operatorContext =
+        context
+            .getDriverContext()
+            .addOperatorContext(
+                context.getNextOperatorId(),
+                node.getPlanNodeId(),
+                SchemaQueryScanOperator.class.getSimpleName());
+    context.getTimeSliceAllocator().recordExecutionWeight(operatorContext, 1);
+    return new SchemaQueryScanOperator<>(
+        node.getPlanNodeId(),
+        operatorContext,
+        SchemaSourceFactory.getLogicalViewSchemaSource(
+            node.getPath(), node.getLimit(), node.getOffset(), node.getSchemaFilter()));
   }
 
   public List<Operator> dealWithConsumeAllChildrenPipelineBreaker(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanNodeType.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/PlanNodeType.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.CountSchemaM
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.DevicesCountNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.DevicesSchemaScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.LevelTimeSeriesCountNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.LogicalViewSchemaScanNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.NodeManagementMemoryMergeNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.NodePathsConvertNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read.NodePathsCountNode;
@@ -175,7 +176,8 @@ public enum PlanNodeType {
   CREATE_LOGICAL_VIEW((short) 73),
   CONSTRUCT_LOGICAL_VIEW_BLACK_LIST((short) 74),
   ROLLBACK_LOGICAL_VIEW_BLACK_LIST((short) 75),
-  DELETE_LOGICAL_VIEW((short) 76);
+  DELETE_LOGICAL_VIEW((short) 76),
+  LOGICAL_VIEW_SCHEMA_SCAN((short) 77);
 
   public static final int BYTES = Short.BYTES;
 
@@ -376,6 +378,8 @@ public enum PlanNodeType {
         return RollbackLogicalViewBlackListNode.deserialize(buffer);
       case 76:
         return DeleteLogicalViewNode.deserialize(buffer);
+      case 77:
+        return LogicalViewSchemaScanNode.deserialize(buffer);
       default:
         throw new IllegalArgumentException("Invalid node type: " + nodeType);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/read/LogicalViewSchemaScanNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/read/LogicalViewSchemaScanNode.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read;
+
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.schema.filter.SchemaFilter;
+import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
+import org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeType;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class LogicalViewSchemaScanNode extends SchemaQueryScanNode {
+
+  private final SchemaFilter schemaFilter;
+
+  public LogicalViewSchemaScanNode(
+      PlanNodeId id, PartialPath partialPath, SchemaFilter schemaFilter, long limit, long offset) {
+    super(id, partialPath, limit, offset, false);
+    this.schemaFilter = schemaFilter;
+  }
+
+  public SchemaFilter getSchemaFilter() {
+    return schemaFilter;
+  }
+
+  @Override
+  protected void serializeAttributes(ByteBuffer byteBuffer) {
+    PlanNodeType.LOGICAL_VIEW_SCHEMA_SCAN.serialize(byteBuffer);
+    ReadWriteIOUtils.write(path.getFullPath(), byteBuffer);
+    SchemaFilter.serialize(schemaFilter, byteBuffer);
+    ReadWriteIOUtils.write(limit, byteBuffer);
+    ReadWriteIOUtils.write(offset, byteBuffer);
+  }
+
+  @Override
+  protected void serializeAttributes(DataOutputStream stream) throws IOException {
+    PlanNodeType.LOGICAL_VIEW_SCHEMA_SCAN.serialize(stream);
+    ReadWriteIOUtils.write(path.getFullPath(), stream);
+    SchemaFilter.serialize(schemaFilter, stream);
+    ReadWriteIOUtils.write(limit, stream);
+    ReadWriteIOUtils.write(offset, stream);
+  }
+
+  public static LogicalViewSchemaScanNode deserialize(ByteBuffer byteBuffer) {
+    String fullPath = ReadWriteIOUtils.readString(byteBuffer);
+    PartialPath path;
+    try {
+      path = new PartialPath(fullPath);
+    } catch (IllegalPathException e) {
+      throw new IllegalArgumentException("Cannot deserialize TimeSeriesSchemaScanNode", e);
+    }
+    SchemaFilter schemaFilter = SchemaFilter.deserialize(byteBuffer);
+    long limit = ReadWriteIOUtils.readLong(byteBuffer);
+    long offset = ReadWriteIOUtils.readLong(byteBuffer);
+
+    PlanNodeId planNodeId = PlanNodeId.deserialize(byteBuffer);
+
+    return new LogicalViewSchemaScanNode(planNodeId, path, schemaFilter, limit, offset);
+  }
+
+  @Override
+  public PlanNode clone() {
+    return new LogicalViewSchemaScanNode(getPlanNodeId(), path, schemaFilter, limit, offset);
+  }
+
+  @Override
+  public List<String> getOutputColumnNames() {
+    return ColumnHeaderConstant.showLogicalViewColumnHeaders.stream()
+        .map(ColumnHeader::getColumnName)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    LogicalViewSchemaScanNode that = (LogicalViewSchemaScanNode) o;
+    return Objects.equals(schemaFilter, that.schemaFilter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), schemaFilter);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "LogicalViewSchemaScanNode-%s:[DataRegion: %s]",
+        this.getPlanNodeId(), this.getRegionReplicaSet());
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/StatementVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/StatementVisitor.java
@@ -92,6 +92,7 @@ import org.apache.iotdb.db.mpp.plan.statement.metadata.template.ShowSchemaTempla
 import org.apache.iotdb.db.mpp.plan.statement.metadata.template.UnsetSchemaTemplateStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.view.CreateLogicalViewStatement;
 import org.apache.iotdb.db.mpp.plan.statement.metadata.view.DeleteLogicalViewStatement;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.view.ShowLogicalViewStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.AuthorStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.ClearCacheStatement;
 import org.apache.iotdb.db.mpp.plan.statement.sys.ExplainStatement;
@@ -251,6 +252,10 @@ public abstract class StatementVisitor<R, C> {
   public R visitDeleteLogicalView(
       DeleteLogicalViewStatement deleteLogicalViewStatement, C context) {
     return visitStatement(deleteLogicalViewStatement, context);
+  }
+
+  public R visitShowLogicalView(ShowLogicalViewStatement showLogicalViewStatement, C context) {
+    return visitStatement(showLogicalViewStatement, context);
   }
 
   // ML Model

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/view/ShowLogicalViewStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/view/ShowLogicalViewStatement.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.plan.statement.metadata.view;
+
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.schema.filter.SchemaFilter;
+import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
+import org.apache.iotdb.db.mpp.plan.statement.metadata.ShowStatement;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ShowLogicalViewStatement extends ShowStatement {
+
+  private final PartialPath pathPattern;
+
+  private SchemaFilter schemaFilter;
+
+  public ShowLogicalViewStatement(PartialPath pathPattern) {
+    super();
+    this.pathPattern = pathPattern;
+  }
+
+  public PartialPath getPathPattern() {
+    return pathPattern;
+  }
+
+  public SchemaFilter getSchemaFilter() {
+    return schemaFilter;
+  }
+
+  public void setSchemaFilter(SchemaFilter schemaFilter) {
+    this.schemaFilter = schemaFilter;
+  }
+
+  @Override
+  public List<PartialPath> getPaths() {
+    return Collections.singletonList(pathPattern);
+  }
+
+  @Override
+  public <R, C> R accept(StatementVisitor<R, C> visitor, C context) {
+    return visitor.visitShowLogicalView(this, context);
+  }
+}


### PR DESCRIPTION
## Description

```
IoTDB> insert into root.db.d(time, s1, s2) aligned values(1, 1, 1)
Msg: The statement is executed successfully.
IoTDB> create view root.view.d(s1, s2) as select s1, s2 from root.db.d
Msg: The statement is executed successfully.
IoTDB> create view root.view.d.s3 as select s1+s2 from root.db.d
Msg: The statement is executed successfully.
IoTDB> create view root.view.d.s4 as select (s1+s2)/2 from root.db.d
Msg: The statement is executed successfully.
IoTDB> show view
+--------------+---------+--------+----+----------+--------+---------------------------------+
|    Timeseries| Database|DataType|Tags|Attributes|ViewType|                           Source|
+--------------+---------+--------+----+----------+--------+---------------------------------+
|root.view.d.s3|root.view|        |null|      null| logical|      root.db.d.s1 + root.db.d.s2|
|root.view.d.s4|root.view|        |null|      null| logical|(root.db.d.s1 + root.db.d.s2) / 2|
|root.view.d.s1|root.view|        |null|      null| logical|                     root.db.d.s1|
|root.view.d.s2|root.view|        |null|      null| logical|                     root.db.d.s2|
+--------------+---------+--------+----+----------+--------+---------------------------------+
Total line number = 4
It costs 0.009s
IoTDB> show view root.*.d.* limit 2 offset 1
+--------------+---------+--------+----+----------+--------+---------------------------------+
|    Timeseries| Database|DataType|Tags|Attributes|ViewType|                           Source|
+--------------+---------+--------+----+----------+--------+---------------------------------+
|root.view.d.s4|root.view|        |null|      null| logical|(root.db.d.s1 + root.db.d.s2) / 2|
|root.view.d.s1|root.view|        |null|      null| logical|                     root.db.d.s1|
+--------------+---------+--------+----+----------+--------+---------------------------------+
Total line number = 2
It costs 0.014s

```