### PR TITLE
Fix memory control when creating timeseries using schema template

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/mem/info/BasicMNodeInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/mem/info/BasicMNodeInfo.java
@@ -36,6 +36,6 @@ public class BasicMNodeInfo {
   public int estimateSize() {
     // object header, 8B
     // name reference, name length and name hash code, 8 + 4 + 4 = 16B
-    return 8 + 16;
+    return 8 + 16 + 2 * name.length();
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/schemaregion/SchemaRegionMemoryImpl.java
@@ -1168,6 +1168,10 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   @Override
   public void activateSchemaTemplate(IActivateTemplateInClusterPlan plan, Template template)
       throws MetadataException {
+    if (!regionStatistics.isAllowToCreateNewSeries()) {
+      throw new SeriesOverflowException();
+    }
+
     try {
       getDeviceNodeWithAutoCreate(plan.getActivatePath());
 


### PR DESCRIPTION
## Description

The memory control is missed when creating timeseries using schema template, which results in unlimited memory usage.

Add memory status check.