### PR TITLE
support show data types of views; fix some bugs.

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/view/LogicalViewSchema.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/view/LogicalViewSchema.java
@@ -164,7 +164,7 @@ public class LogicalViewSchema
   public int serializedSize() {
     throw new RuntimeException(
         new UnsupportedOperationException(
-            "Can not calculate the size of logical view schema before serializing."));
+            "Can not calculate the size of view schema before serializing."));
   }
 
   @Override
@@ -245,7 +245,7 @@ public class LogicalViewSchema
         throw new RuntimeException(
             new UnexpectedException(
                 String.format(
-                    "Logical view with measurementID [%s] is broken. It stores illegal path [%s].",
+                    "View with measurementID [%s] is broken. It stores illegal path [%s].",
                     this.measurementId, this.getSourcePathStringIfWritable())));
       }
     }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/view/LogicalViewSchema.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/view/LogicalViewSchema.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.commons.schema.view;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.schema.view.viewExpression.ViewExpression;
 import org.apache.iotdb.commons.schema.view.viewExpression.leaf.TimeSeriesViewOperand;
@@ -36,7 +37,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.rmi.UnexpectedException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -243,7 +243,7 @@ public class LogicalViewSchema
         return new PartialPath(((TimeSeriesViewOperand) this.expression).getPathString());
       } catch (IllegalPathException e) {
         throw new RuntimeException(
-            new UnexpectedException(
+            new MetadataException(
                 String.format(
                     "View with measurementID [%s] is broken. It stores illegal path [%s].",
                     this.measurementId, this.getSourcePathStringIfWritable())));

--- a/server/src/main/java/org/apache/iotdb/db/exception/metadata/view/InsertNonWritableViewException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/metadata/view/InsertNonWritableViewException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.exception.metadata.view;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+
+public class InsertNonWritableViewException extends MetadataException {
+  public InsertNonWritableViewException(String path) {
+    super(
+        String.format(
+            "Can not insert data to a view which is not alias series. (View path: %s)", path));
+  }
+
+  public InsertNonWritableViewException() {
+    super("Can not insert data to a view which is not alias series.");
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.exception.metadata.view.InsertNonWritableViewException;
 import org.apache.iotdb.db.metadata.cache.dualkeycache.IDualKeyCache;
 import org.apache.iotdb.db.metadata.cache.dualkeycache.IDualKeyCacheComputation;
 import org.apache.iotdb.db.metadata.cache.dualkeycache.impl.DualKeyCacheBuilder;
@@ -174,9 +175,9 @@ public class TimeSeriesSchemaCache {
       final int realIndex = indexListOfLogicalViewPaths.get(i);
       final int recordMissingIndex = i;
       if (!logicalViewSchema.isWritable()) {
-        throw new RuntimeException(
-            new UnsupportedOperationException(
-                "You can not insert into a view which is not alias series!"));
+        PartialPath path = schemaComputation.getDevicePath();
+        path = path.concatNode(schemaComputation.getMeasurements()[realIndex]);
+        throw new RuntimeException(new InsertNonWritableViewException(path.getFullPath()));
       }
       PartialPath fullPath = logicalViewSchema.getSourcePathIfWritable();
       dualKeyCache.compute(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
@@ -176,7 +176,7 @@ public class TimeSeriesSchemaCache {
       if (!logicalViewSchema.isWritable()) {
         throw new RuntimeException(
             new UnsupportedOperationException(
-                "You can not insert into a logical view which is not alias series!"));
+                "You can not insert into a view which is not alias series!"));
       }
       PartialPath fullPath = logicalViewSchema.getSourcePathIfWritable();
       dualKeyCache.compute(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/result/ShowTimeSeriesResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/result/ShowTimeSeriesResult.java
@@ -39,13 +39,13 @@ public class ShowTimeSeriesResult extends ShowSchemaResult implements ITimeSerie
   private boolean isUnderAlignedDevice;
 
   public ShowTimeSeriesResult(
-      String name,
+      String path,
       String alias,
       IMeasurementSchema measurementSchema,
       Map<String, String> tags,
       Map<String, String> attributes,
       boolean isUnderAlignedDevice) {
-    super(name);
+    super(path);
     this.alias = alias;
     this.measurementSchema = measurementSchema;
     this.tags = tags;

--- a/server/src/main/java/org/apache/iotdb/db/metadata/tag/TagManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/tag/TagManager.java
@@ -32,7 +32,6 @@ import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResul
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.tsfile.utils.Pair;
-import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -276,7 +275,7 @@ public class TagManager {
                 new ShowTimeSeriesResult(
                     node.getFullPath(),
                     node.getAlias(),
-                    (MeasurementSchema) node.getSchema(),
+                    node.getSchema(),
                     tagAndAttributePair.left,
                     tagAndAttributePair.right,
                     node.getParent().getAsDeviceMNode().isAligned());

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/header/ColumnHeaderConstant.java
@@ -184,7 +184,7 @@ public class ColumnHeaderConstant {
   public static final String HYPERPARAMETER = "Hyperparameter";
   public static final String MODEL_PATH = "ModelPath";
 
-  // column names for views (eg. logical view)
+  // column names for views (e.g. logical view)
   public static final String VIEW_TYPE = "ViewType";
   public static final String SOURCE = "Source";
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
@@ -142,6 +142,7 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
     if (!schemaReader.isSuccess()) {
       throw new RuntimeException(schemaReader.getFailure());
     }
+    schemaSource.processDelayedTask(tsBlockBuilder, getDatabase());
     return tsBlockBuilder.build();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/DeviceSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/DeviceSchemaSource.java
@@ -105,4 +105,9 @@ public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
   public long getSchemaStatistic(ISchemaRegion schemaRegion) {
     return schemaRegion.getSchemaRegionStatistics().getDevicesNumber();
   }
+
+  @Override
+  public void processDelayedTask(TsBlockBuilder tsBlockBuilder, String database) {
+    // There is no delayed tasks. So, do nothing.
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/ISchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/ISchemaSource.java
@@ -51,4 +51,14 @@ public interface ISchemaSource<T extends ISchemaInfo> {
   boolean hasSchemaStatistic(ISchemaRegion schemaRegion);
 
   long getSchemaStatistic(ISchemaRegion schemaRegion);
+
+  /**
+   * Some tasks may be delayed, and will be processed before building and returning of
+   * tsBlockBuilder. Those delayed tasks will be processed here. For example, in 'show timeseries'
+   * statement, tasks of processing series of views will be delayed. These tasks will be processed
+   * here, make counts of schema fetching come down.
+   *
+   * @param tsBlockBuilder complete delayed tasks on given tsBlock builder.
+   */
+  void processDelayedTask(TsBlockBuilder tsBlockBuilder, String database);
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/LogicalViewSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/LogicalViewSchemaSource.java
@@ -21,18 +21,32 @@ package org.apache.iotdb.db.mpp.execution.operator.schema.source;
 
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.schema.filter.SchemaFilter;
 import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
+import org.apache.iotdb.commons.schema.view.viewExpression.ViewExpression;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
+import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.query.reader.SchemaReaderLimitOffsetWrapper;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
+import org.apache.iotdb.db.metadata.view.viewExpression.visitor.GetSourcePathsVisitor;
+import org.apache.iotdb.db.metadata.view.viewExpression.visitor.TransformToExpressionVisitor;
+import org.apache.iotdb.db.mpp.common.NodeRef;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant;
+import org.apache.iotdb.db.mpp.common.schematree.ISchemaTree;
+import org.apache.iotdb.db.mpp.plan.analyze.ExpressionTypeAnalyzer;
+import org.apache.iotdb.db.mpp.plan.analyze.schema.ClusterSchemaFetcher;
+import org.apache.iotdb.db.mpp.plan.expression.Expression;
+import org.apache.iotdb.db.mpp.plan.expression.visitor.CompleteMeasurementSchemaVisitor;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -49,6 +63,13 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
 
   private final SchemaFilter schemaFilter;
 
+  /**
+   * The task of processing logical views will be delayed. Those infos will be stored here in
+   * function transformToTsBlockColumns(). <b>If there is no delayed infos of logical views, this
+   * variable may be null.</b>
+   */
+  private List<ITimeSeriesSchemaInfo> delayedLogicalViewList;
+
   LogicalViewSchemaSource(
       PartialPath pathPattern, long limit, long offset, SchemaFilter schemaFilter) {
     this.pathPattern = pathPattern;
@@ -57,6 +78,8 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
     this.offset = offset;
 
     this.schemaFilter = schemaFilter;
+
+    this.delayedLogicalViewList = new ArrayList<>();
   }
 
   @Override
@@ -82,19 +105,15 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
   @Override
   public void transformToTsBlockColumns(
       ITimeSeriesSchemaInfo series, TsBlockBuilder builder, String database) {
-    builder.getTimeColumnBuilder().writeLong(0);
-    builder.writeNullableText(0, series.getFullPath());
-    builder.writeNullableText(1, database);
-
-    builder.writeNullableText(2, "");
-
-    builder.writeNullableText(3, mapToString(series.getTags()));
-    builder.writeNullableText(4, mapToString(series.getAttributes()));
-
-    builder.writeNullableText(5, "logical");
-    builder.writeNullableText(
-        6, ((LogicalViewSchema) series.getSchema()).getExpression().toString());
-    builder.declarePosition();
+    // delay all tasks
+    this.delayedLogicalViewList.add(
+        new ShowTimeSeriesResult(
+            series.getFullPath(),
+            series.getAlias(),
+            series.getSchema(),
+            series.getTags(),
+            series.getAttributes(),
+            series.isUnderAlignedDevice()));
   }
 
   @Override
@@ -105,6 +124,68 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
   @Override
   public long getSchemaStatistic(ISchemaRegion schemaRegion) {
     return schemaRegion.getSchemaRegionStatistics().getSeriesNumber();
+  }
+
+  private List<TSDataType> analyzeDataTypeOfDelayedViews() {
+    if (this.delayedLogicalViewList == null || this.delayedLogicalViewList.size() <= 0) {
+      return new ArrayList<>();
+    }
+    // fetch schema of source paths of views
+    List<ViewExpression> viewExpressionList = new ArrayList<>();
+    for (ITimeSeriesSchemaInfo series : this.delayedLogicalViewList) {
+      viewExpressionList.add(((LogicalViewSchema) series.getSchema()).getExpression());
+    }
+    GetSourcePathsVisitor getSourcePathsVisitor = new GetSourcePathsVisitor();
+    List<PartialPath> sourcePathsNeedFetch;
+    PathPatternTree patternTree = new PathPatternTree();
+    for (ViewExpression viewExpression : viewExpressionList) {
+      sourcePathsNeedFetch = getSourcePathsVisitor.process(viewExpression, null);
+      for (PartialPath path : sourcePathsNeedFetch) {
+        patternTree.appendFullPath(path);
+      }
+    }
+    ISchemaTree schemaTree = ClusterSchemaFetcher.getInstance().fetchSchema(patternTree, null);
+    // process each view expression and get data type
+    TransformToExpressionVisitor transformToExpressionVisitor = new TransformToExpressionVisitor();
+    CompleteMeasurementSchemaVisitor completeMeasurementSchemaVisitor =
+        new CompleteMeasurementSchemaVisitor();
+    Map<NodeRef<Expression>, TSDataType> expressionTypes = new HashMap<>();
+    List<TSDataType> dataTypeList = new ArrayList<>();
+    for (ViewExpression viewExpression : viewExpressionList) {
+      Expression expression = transformToExpressionVisitor.process(viewExpression, null);
+      expression = completeMeasurementSchemaVisitor.process(expression, schemaTree);
+      ExpressionTypeAnalyzer.analyzeExpression(expressionTypes, expression);
+      dataTypeList.add(expressionTypes.get(NodeRef.of(expression)));
+    }
+    return dataTypeList;
+  }
+
+  @Override
+  public void processDelayedTask(TsBlockBuilder builder, String database) {
+    // There is no delayed tasks. So, do nothing.
+    if (this.delayedLogicalViewList == null || this.delayedLogicalViewList.size() <= 0) {
+      return;
+    }
+    List<TSDataType> dataTypeList = this.analyzeDataTypeOfDelayedViews();
+    // process delayed tasks
+    for (int index = 0; index < this.delayedLogicalViewList.size(); index++) {
+      ITimeSeriesSchemaInfo series = this.delayedLogicalViewList.get(index);
+      TSDataType expressionTypeOfThisView = dataTypeList.get(index);
+
+      builder.getTimeColumnBuilder().writeLong(0);
+      builder.writeNullableText(0, series.getFullPath());
+      builder.writeNullableText(1, database);
+
+      builder.writeNullableText(2, expressionTypeOfThisView.toString());
+
+      builder.writeNullableText(3, mapToString(series.getTags()));
+      builder.writeNullableText(4, mapToString(series.getAttributes()));
+
+      builder.writeNullableText(5, "logical");
+      builder.writeNullableText(
+          6, ((LogicalViewSchema) series.getSchema()).getExpression().toString());
+      builder.declarePosition();
+    }
   }
 
   private String mapToString(Map<String, String> map) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/NodeSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/NodeSchemaSource.java
@@ -88,4 +88,9 @@ public class NodeSchemaSource implements ISchemaSource<INodeSchemaInfo> {
   public long getSchemaStatistic(ISchemaRegion schemaRegion) {
     return 0;
   }
+
+  @Override
+  public void processDelayedTask(TsBlockBuilder tsBlockBuilder, String database) {
+    // There is no delayed tasks. So, do nothing.
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/PathsUsingTemplateSource.java
@@ -71,6 +71,11 @@ public class PathsUsingTemplateSource implements ISchemaSource<IDeviceSchemaInfo
     return schemaRegion.getSchemaRegionStatistics().getTemplateActivatedNumber();
   }
 
+  @Override
+  public void processDelayedTask(TsBlockBuilder tsBlockBuilder, String database) {
+    // There is no delayed tasks. So, do nothing.
+  }
+
   private class DevicesUsingTemplateReader implements ISchemaReader<IDeviceSchemaInfo> {
 
     final Iterator<PartialPath> pathPatternIterator;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/TimeSeriesSchemaSource.java
@@ -21,18 +21,33 @@ package org.apache.iotdb.db.mpp.execution.operator.schema.source;
 
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.schema.filter.SchemaFilter;
+import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
+import org.apache.iotdb.commons.schema.view.viewExpression.ViewExpression;
 import org.apache.iotdb.db.metadata.plan.schemaregion.impl.read.SchemaRegionReadPlanFactory;
+import org.apache.iotdb.db.metadata.plan.schemaregion.result.ShowTimeSeriesResult;
 import org.apache.iotdb.db.metadata.query.info.ITimeSeriesSchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.metadata.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.utils.MetaUtils;
+import org.apache.iotdb.db.metadata.view.viewExpression.visitor.GetSourcePathsVisitor;
+import org.apache.iotdb.db.metadata.view.viewExpression.visitor.TransformToExpressionVisitor;
+import org.apache.iotdb.db.mpp.common.NodeRef;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant;
+import org.apache.iotdb.db.mpp.common.schematree.ISchemaTree;
+import org.apache.iotdb.db.mpp.plan.analyze.ExpressionTypeAnalyzer;
+import org.apache.iotdb.db.mpp.plan.analyze.schema.ClusterSchemaFetcher;
+import org.apache.iotdb.db.mpp.plan.expression.Expression;
+import org.apache.iotdb.db.mpp.plan.expression.visitor.CompleteMeasurementSchemaVisitor;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.Pair;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -50,6 +65,13 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
   private final SchemaFilter schemaFilter;
 
   private final Map<Integer, Template> templateMap;
+
+  /**
+   * The task of processing logical views will be delayed. Those infos will be stored here in
+   * function transformToTsBlockColumns(). <b>If there is no delayed infos of logical views, this
+   * variable may be null.</b>
+   */
+  private List<ITimeSeriesSchemaInfo> delayedLogicalViewList;
 
   TimeSeriesSchemaSource(
       PartialPath pathPattern,
@@ -88,26 +110,33 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
   @Override
   public void transformToTsBlockColumns(
       ITimeSeriesSchemaInfo series, TsBlockBuilder builder, String database) {
+    if (series.isLogicalView()) {
+      if (this.delayedLogicalViewList == null) {
+        this.delayedLogicalViewList = new ArrayList<>();
+      }
+      this.delayedLogicalViewList.add(
+          new ShowTimeSeriesResult(
+              series.getFullPath(),
+              series.getAlias(),
+              series.getSchema(),
+              series.getTags(),
+              series.getAttributes(),
+              series.isUnderAlignedDevice()));
+      return;
+    }
     Pair<String, String> deadbandInfo = MetaUtils.parseDeadbandInfo(series.getSchema().getProps());
     builder.getTimeColumnBuilder().writeLong(0);
     builder.writeNullableText(0, series.getFullPath());
     builder.writeNullableText(1, series.getAlias());
     builder.writeNullableText(2, database);
-    if (series.isLogicalView()) {
-      builder.writeNullableText(3, "");
-      builder.writeNullableText(4, "null");
-      builder.writeNullableText(5, "null");
-      builder.writeNullableText(10, "logical");
-    } else {
-      builder.writeNullableText(3, series.getSchema().getType().toString());
-      builder.writeNullableText(4, series.getSchema().getEncodingType().toString());
-      builder.writeNullableText(5, series.getSchema().getCompressor().toString());
-      builder.writeNullableText(10, "");
-    }
+    builder.writeNullableText(3, series.getSchema().getType().toString());
+    builder.writeNullableText(4, series.getSchema().getEncodingType().toString());
+    builder.writeNullableText(5, series.getSchema().getCompressor().toString());
     builder.writeNullableText(6, mapToString(series.getTags()));
     builder.writeNullableText(7, mapToString(series.getAttributes()));
     builder.writeNullableText(8, deadbandInfo.left);
     builder.writeNullableText(9, deadbandInfo.right);
+    builder.writeNullableText(10, "");
     builder.declarePosition();
   }
 
@@ -119,6 +148,69 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
   @Override
   public long getSchemaStatistic(ISchemaRegion schemaRegion) {
     return schemaRegion.getSchemaRegionStatistics().getSeriesNumber();
+  }
+
+  private List<TSDataType> analyzeDataTypeOfDelayedViews() {
+    if (this.delayedLogicalViewList == null || this.delayedLogicalViewList.size() <= 0) {
+      return new ArrayList<>();
+    }
+    // fetch schema of source paths of views
+    List<ViewExpression> viewExpressionList = new ArrayList<>();
+    for (ITimeSeriesSchemaInfo series : this.delayedLogicalViewList) {
+      viewExpressionList.add(((LogicalViewSchema) series.getSchema()).getExpression());
+    }
+    GetSourcePathsVisitor getSourcePathsVisitor = new GetSourcePathsVisitor();
+    List<PartialPath> sourcePathsNeedFetch;
+    PathPatternTree patternTree = new PathPatternTree();
+    for (ViewExpression viewExpression : viewExpressionList) {
+      sourcePathsNeedFetch = getSourcePathsVisitor.process(viewExpression, null);
+      for (PartialPath path : sourcePathsNeedFetch) {
+        patternTree.appendFullPath(path);
+      }
+    }
+    ISchemaTree schemaTree = ClusterSchemaFetcher.getInstance().fetchSchema(patternTree, null);
+    // process each view expression and get data type
+    TransformToExpressionVisitor transformToExpressionVisitor = new TransformToExpressionVisitor();
+    CompleteMeasurementSchemaVisitor completeMeasurementSchemaVisitor =
+        new CompleteMeasurementSchemaVisitor();
+    Map<NodeRef<Expression>, TSDataType> expressionTypes = new HashMap<>();
+    List<TSDataType> dataTypeList = new ArrayList<>();
+    for (ViewExpression viewExpression : viewExpressionList) {
+      Expression expression = transformToExpressionVisitor.process(viewExpression, null);
+      expression = completeMeasurementSchemaVisitor.process(expression, schemaTree);
+      ExpressionTypeAnalyzer.analyzeExpression(expressionTypes, expression);
+      dataTypeList.add(expressionTypes.get(NodeRef.of(expression)));
+    }
+    return dataTypeList;
+  }
+
+  @Override
+  public void processDelayedTask(TsBlockBuilder builder, String database) {
+    if (this.delayedLogicalViewList == null || this.delayedLogicalViewList.size() <= 0) {
+      return;
+    }
+    List<TSDataType> dataTypeList = this.analyzeDataTypeOfDelayedViews();
+    // process delayed tasks
+    for (int index = 0; index < this.delayedLogicalViewList.size(); index++) {
+      ITimeSeriesSchemaInfo series = this.delayedLogicalViewList.get(index);
+      TSDataType expressionTypeOfThisView = dataTypeList.get(index);
+
+      Pair<String, String> deadbandInfo =
+          MetaUtils.parseDeadbandInfo(series.getSchema().getProps());
+      builder.getTimeColumnBuilder().writeLong(0);
+      builder.writeNullableText(0, series.getFullPath());
+      builder.writeNullableText(1, series.getAlias());
+      builder.writeNullableText(2, database);
+      builder.writeNullableText(3, expressionTypeOfThisView.toString());
+      builder.writeNullableText(4, null);
+      builder.writeNullableText(5, null);
+      builder.writeNullableText(6, mapToString(series.getTags()));
+      builder.writeNullableText(7, mapToString(series.getAttributes()));
+      builder.writeNullableText(8, deadbandInfo.left);
+      builder.writeNullableText(9, deadbandInfo.right);
+      builder.writeNullableText(10, "logical");
+      builder.declarePosition();
+    }
   }
 
   private String mapToString(Map<String, String> map) {

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -3240,7 +3240,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       analysis.setFailStatus(
           RpcUtils.getStatus(
               TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode(),
-              "Can not create a logical view based on existing views. Check the query in your SQL."));
+              "Can not create a view based on existing views. Check the query in your SQL."));
       return new Pair<>(null, analysis);
     }
     List<Expression> expressionList = new ArrayList<>();
@@ -3266,7 +3266,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       analysis.setFailStatus(
           RpcUtils.getStatus(
               TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode(),
-              "Can not create a logical view based on non-exist time series."));
+              "Can not create a view based on non-exist time series."));
       return analysis;
     }
     Pair<List<PartialPath>, PartialPath> viewInSourceCheckResult =
@@ -3279,7 +3279,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
               TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode(),
               "Path "
                   + viewInSourceCheckResult.right.toString()
-                  + " does not exist! You can not create a logical view based on non-exist time series."));
+                  + " does not exist! You can not create a view based on non-exist time series."));
       return analysis;
     }
     if (viewInSourceCheckResult.left.size() > 0) {
@@ -3288,7 +3288,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       analysis.setFailStatus(
           RpcUtils.getStatus(
               TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode(),
-              "Can not create a logical view based on existing views."));
+              "Can not create a view based on existing views."));
       return analysis;
     }
     return analysis;
@@ -3324,7 +3324,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       analysis.setFailStatus(
           RpcUtils.getStatus(
               TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode(),
-              "Can not create logical view under template."));
+              "Can not create view under template."));
       return analysis;
     }
     return analysis;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -3314,6 +3314,19 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
               "The number of target and source paths are miss matched! Please check your SQL."));
       return analysis;
     }
+    // make sure all paths are NOt under any template
+    try {
+      for (PartialPath path : createLogicalViewStatement.getTargetPathList()) {
+        checkIsTemplateCompatible(path, null);
+      }
+    } catch (Exception e) {
+      analysis.setFinishQueryAfterAnalyze(true);
+      analysis.setFailStatus(
+          RpcUtils.getStatus(
+              TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode(),
+              "Can not create logical view under template."));
+      return analysis;
+    }
     return analysis;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -1779,7 +1779,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
     PartialPath oldName = renameLogicalViewStatement.getOldName();
     if (oldName.hasWildcard()) {
       future.setException(
-          new MetadataException("Rename logical view doesn't support path pattern with wildcard."));
+          new MetadataException("Rename view doesn't support path pattern with wildcard."));
       return future;
     }
 


### PR DESCRIPTION
### calculate data type of views dynamically, and show them

```
IoTDB> create timeseries root.abcd.d01.s01 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> CREATE VIEW root.abcd.device.temp AS root.abcd.d01.s01;
Msg: The statement is executed successfully.
IoTDB> create timeseries root.abcd.d01.s02 FLOAT encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> CREATE VIEW root.abcd.device.temp2 AS SELECT (s01+s02) FROM root.abcd.d01;
Msg: The statement is executed successfully.
IoTDB>
IoTDB> show timeseries root.**;
+----------------------+-----+---------+--------+--------+-----------+----+----------+--------+------------------+--------+
|            Timeseries|Alias| Database|DataType|Encoding|Compression|Tags|Attributes|Deadband|DeadbandParameters|ViewType|
+----------------------+-----+---------+--------+--------+-----------+----+----------+--------+------------------+--------+
|     root.abcd.d01.s02| null|root.abcd|   FLOAT|     RLE|     SNAPPY|null|      null|    null|              null|        |
|     root.abcd.d01.s01| null|root.abcd|   INT32|     RLE|     SNAPPY|null|      null|    null|              null|        |
| root.abcd.device.temp| null|root.abcd|   INT32|    null|       null|null|      null|    null|              null| logical|
|root.abcd.device.temp2| null|root.abcd|  DOUBLE|    null|       null|null|      null|    null|              null| logical|
+----------------------+-----+---------+--------+--------+-----------+----+----------+--------+------------------+--------+
Total line number = 4
It costs 0.026s
IoTDB> show view root.**;
+----------------------+---------+--------+----+----------+--------+-------------------------------------+
|            Timeseries| Database|DataType|Tags|Attributes|ViewType|                               Source|
+----------------------+---------+--------+----+----------+--------+-------------------------------------+
| root.abcd.device.temp|root.abcd|   INT32|null|      null| logical|                    root.abcd.d01.s01|
|root.abcd.device.temp2|root.abcd|  DOUBLE|null|      null| logical|root.abcd.d01.s01 + root.abcd.d01.s02|
+----------------------+---------+--------+----+----------+--------+-------------------------------------+
Total line number = 2
It costs 0.016s
IoTDB>
```


### fix bug: check template info before creating logical view.
```
IoTDB> create database root.db;
Msg: The statement is executed successfully.
IoTDB> create schema template t1(s_0 DOUBLE compressor=SNAPPY ,s_1  DOUBLE ENCODING=RLE compressor=LZ4 ,s_2  DOUBLE ENCODING=TS_2DIFF compressor=GZIP,s_3 DOUBLE ENCODING=GORILLA compressor=ZSTD,s_4 DOUBLE compressor=ZSTD,s_5 DOUBLE ENCODING=CHIMP compressor=UNCOMPRESSED,s_6 DOUBLE compressor=LZ4,s_7 DOUBLE compressor=GZIP,s_8 DOUBLE compressor=ZSTD,s_9 DOUBLE compressor=ZSTD,s_10 DOUBLE compressor=SNAPPY,s_11 DOUBLE compressor=UNCOMPRESSED);
Msg: The statement is executed successfully.
IoTDB> set  schema template t1 to root.db;
Msg: The statement is executed successfully.
IoTDB> create view root.db.dev_of_view1.col0 as select s_0 from root.db.t1;
Msg: 300: Columns in the query statement is empty. Please check your SQL.
IoTDB> insert into root.db.t1(time,s_1) values (1,1.1);
Msg: The statement is executed successfully.
IoTDB> create view root.db.dev_of_view1.col0 as select s_0 from root.db.t1;
Msg: 300: Can not create logical view under template.
IoTDB>
```

Users can NOT create logical view under templates now.

### Optimize exception throwing for insertions of views.
```
IoTDB> create timeseries root.db.origin.s02 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> create timeseries root.db.origin.s03 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> CREATE VIEW root.db.myview.non_writable AS SELECT (s02+s03)/2 FROM root.db.origin;
Msg: The statement is executed successfully.
IoTDB>
IoTDB> insert into root.db.myview(timestamp,non_writable) values(2, 137);
Msg: 507: Can not insert data to a view which is not alias series. (View path: root.db.myview.non_writable)
IoTDB>
```