### PR TITLE
[IOTDB-5905] Fix aligned timeseries data point lost after flushed in some scenario

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -143,6 +143,10 @@
                     <groupId>io.dropwizard.metrics</groupId>
                     <artifactId>metrics-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
@@ -218,6 +218,37 @@ public class IoTDBInsertAlignedValuesIT {
   }
 
   @Test
+  public void testInsertAlignedValuesWithSameTimestamp() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.addBatch("insert into root.sg.d1(time,s2) aligned values(1,2)");
+      statement.addBatch("insert into root.sg.d1(time,s1) aligned values(1,2)");
+      statement.executeBatch();
+
+      try (ResultSet resultSet = statement.executeQuery("select s1, s2 from root.sg.d1")) {
+
+        assertTrue(resultSet.next());
+        assertEquals(1, resultSet.getLong(1));
+        assertEquals(2.0F, resultSet.getObject(2));
+        assertEquals(2.0F, resultSet.getObject(3));
+
+        assertFalse(resultSet.next());
+      }
+
+      statement.execute("flush");
+      try (ResultSet resultSet = statement.executeQuery("select s1, s2 from root.sg.d1")) {
+
+        assertTrue(resultSet.next());
+        assertEquals(1, resultSet.getLong(1));
+        assertEquals(2.0F, resultSet.getObject(2));
+        assertEquals(2.0F, resultSet.getObject(3));
+
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
   public void testInsertWithWrongMeasurementNum1() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AlignedWritableMemChunk.java
@@ -315,17 +315,16 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
     int range = 0;
     for (int sortedRowIndex = 0; sortedRowIndex < list.rowCount(); sortedRowIndex++) {
       long time = list.getTime(sortedRowIndex);
+      if (range == 0) {
+        pageRange.add(sortedRowIndex);
+      }
+      range++;
+      if (range == maxNumberOfPointsInPage) {
+        pageRange.add(sortedRowIndex);
+        range = 0;
+      }
 
-      if (sortedRowIndex == list.rowCount() - 1 || time != list.getTime(sortedRowIndex + 1)) {
-        if (range == 0) {
-          pageRange.add(sortedRowIndex);
-        }
-        range++;
-        if (range == maxNumberOfPointsInPage) {
-          pageRange.add(sortedRowIndex);
-          range = 0;
-        }
-      } else {
+      if (sortedRowIndex != list.rowCount() - 1 && time == list.getTime(sortedRowIndex + 1)) {
         if (Objects.isNull(timeDuplicateInfo)) {
           timeDuplicateInfo = new boolean[list.rowCount()];
         }


### PR DESCRIPTION
## Description

This PR is fixing the following bug.

![image](https://github.com/apache/iotdb/assets/25913899/a13cacb7-2578-4e6e-8aef-7d4e0cd3c937)
