### PR TITLE
[To rel/1.1][IOTDB-5934] Optimize cluster partition policy

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -68,8 +68,8 @@ public class ConfigNodeConfig {
   /** Default number of DataRegion replicas */
   private int dataReplicationFactor = 1;
 
-  /** Number of SeriesPartitionSlots per StorageGroup */
-  private int seriesSlotNum = 10000;
+  /** Number of SeriesPartitionSlots per Database */
+  private int seriesSlotNum = 1000;
 
   /** SeriesPartitionSlot executor class */
   private String seriesPartitionExecutorClass =

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
@@ -117,6 +117,9 @@ public class SystemPropertiesUtils {
       }
     }
 
+    final String format =
+        "[SystemProperties] The parameter \"{}\" can't be modified after first startup."
+            + " Your configuration: {} will be forced update to: {}";
     // Consensus protocol configuration
     String configNodeConsensusProtocolClass =
         systemProperties.getProperty("config_node_consensus_protocol_class", null);
@@ -124,11 +127,12 @@ public class SystemPropertiesUtils {
       needReWrite = true;
     } else if (!configNodeConsensusProtocolClass.equals(
         conf.getConfigNodeConsensusProtocolClass())) {
-      throw new ConfigurationException(
+      LOGGER.warn(
+          format,
           "config_node_consensus_protocol_class",
           conf.getConfigNodeConsensusProtocolClass(),
-          configNodeConsensusProtocolClass,
-          "config_node_consensus_protocol_class can't be modified after first startup");
+          configNodeConsensusProtocolClass);
+      conf.setConfigNodeConsensusProtocolClass(configNodeConsensusProtocolClass);
     }
 
     String dataRegionConsensusProtocolClass =
@@ -137,11 +141,12 @@ public class SystemPropertiesUtils {
       needReWrite = true;
     } else if (!dataRegionConsensusProtocolClass.equals(
         conf.getDataRegionConsensusProtocolClass())) {
-      throw new ConfigurationException(
+      LOGGER.warn(
+          format,
           "data_region_consensus_protocol_class",
           conf.getDataRegionConsensusProtocolClass(),
-          dataRegionConsensusProtocolClass,
-          "data_region_consensus_protocol_class can't be modified after first startup");
+          dataRegionConsensusProtocolClass);
+      conf.setDataRegionConsensusProtocolClass(dataRegionConsensusProtocolClass);
     }
 
     String schemaRegionConsensusProtocolClass =
@@ -150,11 +155,12 @@ public class SystemPropertiesUtils {
       needReWrite = true;
     } else if (!schemaRegionConsensusProtocolClass.equals(
         conf.getSchemaRegionConsensusProtocolClass())) {
-      throw new ConfigurationException(
+      LOGGER.warn(
+          format,
           "schema_region_consensus_protocol_class",
           conf.getSchemaRegionConsensusProtocolClass(),
-          schemaRegionConsensusProtocolClass,
-          "schema_region_consensus_protocol_class can't be modified after first startup");
+          schemaRegionConsensusProtocolClass);
+      conf.setSchemaRegionConsensusProtocolClass(schemaRegionConsensusProtocolClass);
     }
 
     // PartitionSlot configuration
@@ -164,11 +170,8 @@ public class SystemPropertiesUtils {
       int seriesPartitionSlotNum =
           Integer.parseInt(systemProperties.getProperty("series_partition_slot_num"));
       if (seriesPartitionSlotNum != conf.getSeriesSlotNum()) {
-        throw new ConfigurationException(
-            "series_partition_slot_num",
-            String.valueOf(conf.getSeriesSlotNum()),
-            String.valueOf(seriesPartitionSlotNum),
-            "series_partition_slot_num can't be modified after first startup");
+        LOGGER.warn(format, "series_slot_num", conf.getSeriesSlotNum(), seriesPartitionSlotNum);
+        conf.setSeriesSlotNum(seriesPartitionSlotNum);
       }
     }
 
@@ -178,11 +181,12 @@ public class SystemPropertiesUtils {
       needReWrite = true;
     } else if (!Objects.equals(
         seriesPartitionSlotExecutorClass, conf.getSeriesPartitionExecutorClass())) {
-      throw new ConfigurationException(
+      LOGGER.warn(
+          format,
           "series_partition_executor_class",
           conf.getSeriesPartitionExecutorClass(),
-          seriesPartitionSlotExecutorClass,
-          "series_partition_executor_class can't be modified after first startup");
+          seriesPartitionSlotExecutorClass);
+      conf.setSeriesPartitionExecutorClass(seriesPartitionSlotExecutorClass);
     }
 
     if (needReWrite) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -208,6 +208,13 @@ public class PartitionManager {
     // by the number of SeriesPartitionSlots,
     // the number of serialized CreateSchemaPartitionReqs is acceptable.
     synchronized (this) {
+      // Here we should check again if the SchemaPartition
+      // has been created by other threads to improve concurrent performance
+      resp = (SchemaPartitionResp) getSchemaPartition(req);
+      if (resp.isAllPartitionsExist()) {
+        return resp;
+      }
+
       // Filter unassigned SchemaPartitionSlots
       Map<String, List<TSeriesPartitionSlot>> unassignedSchemaPartitionSlotsMap =
           partitionInfo.filterUnassignedSchemaPartitionSlots(req.getPartitionSlotsMap());
@@ -261,7 +268,7 @@ public class PartitionManager {
     resp = (SchemaPartitionResp) getSchemaPartition(req);
     if (!resp.isAllPartitionsExist()) {
       LOGGER.error(
-          "Lacked some SchemaPartition allocation result in the response of getOrCreateDataPartition method");
+          "Lacked some SchemaPartition allocation result in the response of getOrCreateSchemaPartition method");
       resp.setStatus(
           new TSStatus(TSStatusCode.LACK_PARTITION_ALLOCATION.getStatusCode())
               .setMessage("Lacked some SchemaPartition allocation result in the response"));
@@ -307,6 +314,13 @@ public class PartitionManager {
     // by the number of SeriesPartitionSlots,
     // the number of serialized CreateDataPartitionReqs is acceptable.
     synchronized (this) {
+      // Here we should check again if the DataPartition
+      // has been created by other threads to improve concurrent performance
+      resp = (DataPartitionResp) getDataPartition(req);
+      if (resp.isAllPartitionsExist()) {
+        return resp;
+      }
+
       // Filter unassigned DataPartitionSlots
       Map<String, Map<TSeriesPartitionSlot, TTimeSlotList>> unassignedDataPartitionSlotsMap =
           partitionInfo.filterUnassignedDataPartitionSlots(req.getPartitionSlotsMap());

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionGetterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionGetterIT.java
@@ -459,7 +459,7 @@ public class IoTDBPartitionGetterIT {
       Assert.assertEquals(
           TSStatusCode.SUCCESS_STATUS.getStatusCode(), getSeriesSlotListResp.status.getCode());
       Assert.assertEquals(
-          testSeriesPartitionSlotNum + 2, getSeriesSlotListResp.getSeriesSlotListSize());
+          testSeriesPartitionSlotNum, getSeriesSlotListResp.getSeriesSlotListSize());
 
       getSeriesSlotListReq.setType(TConsensusGroupType.ConfigRegion);
 
@@ -467,7 +467,7 @@ public class IoTDBPartitionGetterIT {
       Assert.assertEquals(
           TSStatusCode.SUCCESS_STATUS.getStatusCode(), getSeriesSlotListResp.status.getCode());
       Assert.assertEquals(
-          testSeriesPartitionSlotNum + 2, getSeriesSlotListResp.getSeriesSlotListSize());
+          testSeriesPartitionSlotNum, getSeriesSlotListResp.getSeriesSlotListSize());
 
       getSeriesSlotListReq.setType(TConsensusGroupType.SchemaRegion);
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/utils/ConfigNodeTestUtils.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/utils/ConfigNodeTestUtils.java
@@ -201,7 +201,7 @@ public class ConfigNodeTestUtils {
         "org.apache.iotdb.consensus.simple.SimpleConsensus");
     clusterParameters.setSchemaRegionConsensusProtocolClass(
         "org.apache.iotdb.consensus.simple.SimpleConsensus");
-    clusterParameters.setSeriesPartitionSlotNum(10000);
+    clusterParameters.setSeriesPartitionSlotNum(1000);
     clusterParameters.setSeriesPartitionExecutorClass(
         "org.apache.iotdb.commons.partition.executor.hash.BKDRHashExecutor");
     clusterParameters.setDefaultTTL(Long.MAX_VALUE);

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -71,7 +71,7 @@ cluster_name=defaultCluster
 # And these parameters should be consistent within the ConfigNodeGroup.
 # Number of SeriesPartitionSlots per Database
 # Datatype: Integer
-# series_slot_num=10000
+# series_slot_num=1000
 
 # SeriesPartitionSlot executor class
 # These hashing algorithms are currently supported:


### PR DESCRIPTION
Based on our [experimental results](https://apache-iotdb.feishu.cn/docx/YRsHdu7vJoKe88xpW5hckhWsnjh), the following two optimizations are carried out:

1. Set series_slot_num=1000
2. The getOrCreatePartition() interface checks again to see if the partition exists after acquiring the serial lock