### PR TITLE
[To rel/1.1][IOTDB-5929] Enable DataPartition inherit policy

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -109,9 +109,9 @@ public class ConfigNodeConfig {
 
   /**
    * DataPartition within the same SeriesPartitionSlot will inherit the allocation result of the
-   * previous TimePartitionSlot if set true
+   * predecessor or successor TimePartitionSlot if set true
    */
-  private boolean enableDataPartitionInheritPolicy = false;
+  private boolean enableDataPartitionInheritPolicy = true;
 
   /** Max concurrent client number */
   private int rpcMaxConcurrentClientNum = 65535;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
@@ -220,10 +220,15 @@ public class SystemPropertiesUtils {
 
     // Cluster configuration
     systemProperties.setProperty("cluster_name", conf.getClusterName());
+    LOGGER.info("[SystemProperties] store cluster_name: {}", conf.getClusterName());
     systemProperties.setProperty("config_node_id", String.valueOf(conf.getConfigNodeId()));
+    LOGGER.info("[SystemProperties] store config_node_id: {}", conf.getConfigNodeId());
     systemProperties.setProperty(
         "is_seed_config_node",
         String.valueOf(ConfigNodeDescriptor.getInstance().isSeedConfigNode()));
+    LOGGER.info(
+        "[SystemProperties] store is_seed_config_node: {}",
+        ConfigNodeDescriptor.getInstance().isSeedConfigNode());
 
     // Startup configuration
     systemProperties.setProperty("cn_internal_address", String.valueOf(conf.getInternalAddress()));

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -528,22 +528,22 @@ public class PartitionManager {
   }
 
   /**
-   * Only leader use this interface. Checks whether the specified DataPartition has a predecessor
-   * and returns if it does
+   * Only leader use this interface. Checks whether the specified DataPartition has a predecessor or
+   * successor and returns if it does
    *
-   * @param storageGroup StorageGroupName
+   * @param database DatabaseName
    * @param seriesPartitionSlot Corresponding SeriesPartitionSlot
    * @param timePartitionSlot Corresponding TimePartitionSlot
    * @param timePartitionInterval Time partition interval
    * @return The specific DataPartition's predecessor if exists, null otherwise
    */
-  public TConsensusGroupId getPrecededDataPartition(
-      String storageGroup,
+  public TConsensusGroupId getAdjacentDataPartition(
+      String database,
       TSeriesPartitionSlot seriesPartitionSlot,
       TTimePartitionSlot timePartitionSlot,
       long timePartitionInterval) {
-    return partitionInfo.getPrecededDataPartition(
-        storageGroup, seriesPartitionSlot, timePartitionSlot, timePartitionInterval);
+    return partitionInfo.getAdjacentDataPartition(
+        database, seriesPartitionSlot, timePartitionSlot, timePartitionInterval);
   }
 
   /**

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
@@ -228,11 +228,11 @@ public class DatabasePartitionTable {
    * @param timePartitionInterval Time partition interval
    * @return The specific DataPartition's predecessor if exists, null otherwise
    */
-  public TConsensusGroupId getPrecededDataPartition(
+  public TConsensusGroupId getAdjacentDataPartition(
       TSeriesPartitionSlot seriesPartitionSlot,
       TTimePartitionSlot timePartitionSlot,
       long timePartitionInterval) {
-    return dataPartitionTable.getPrecededDataPartition(
+    return dataPartitionTable.getAdjacentDataPartition(
         seriesPartitionSlot, timePartitionSlot, timePartitionInterval);
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -370,23 +370,24 @@ public class PartitionInfo implements SnapshotProcessor {
   }
 
   /**
-   * Checks whether the specified DataPartition has a predecessor and returns if it does
+   * Checks whether the specified DataPartition has a predecessor or successor and returns if it
+   * does
    *
-   * @param storageGroup StorageGroupName
+   * @param database DatabaseName
    * @param seriesPartitionSlot Corresponding SeriesPartitionSlot
    * @param timePartitionSlot Corresponding TimePartitionSlot
    * @param timePartitionInterval Time partition interval
    * @return The specific DataPartition's predecessor if exists, null otherwise
    */
-  public TConsensusGroupId getPrecededDataPartition(
-      String storageGroup,
+  public TConsensusGroupId getAdjacentDataPartition(
+      String database,
       TSeriesPartitionSlot seriesPartitionSlot,
       TTimePartitionSlot timePartitionSlot,
       long timePartitionInterval) {
-    if (databasePartitionTables.containsKey(storageGroup)) {
+    if (databasePartitionTables.containsKey(database)) {
       return databasePartitionTables
-          .get(storageGroup)
-          .getPrecededDataPartition(seriesPartitionSlot, timePartitionSlot, timePartitionInterval);
+          .get(database)
+          .getAdjacentDataPartition(seriesPartitionSlot, timePartitionSlot, timePartitionInterval);
     } else {
       return null;
     }

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -129,10 +129,10 @@ cluster_name=defaultCluster
 
 
 # Whether to enable the DataPartition inherit policy.
-# DataPartition within the same SeriesPartitionSlot will inherit
-# the allocation result of the previous TimePartitionSlot if set true
+# DataPartition within the same SeriesPartitionSlot will inherit the allocation result of
+# the predecessor or successor TimePartitionSlot if set true
 # Datatype: Boolean
-# enable_data_partition_inherit_policy=false
+# enable_data_partition_inherit_policy=true
 
 
 # The policy of cluster RegionGroups' leader distribution.

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartitionTable.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartitionTable.java
@@ -99,21 +99,22 @@ public class DataPartitionTable {
   }
 
   /**
-   * Checks whether the specified DataPartition has a predecessor and returns if it does
+   * Checks whether the specified DataPartition has a predecessor or successor and returns if it
+   * does
    *
    * @param seriesPartitionSlot Corresponding SeriesPartitionSlot
    * @param timePartitionSlot Corresponding TimePartitionSlot
    * @param timePartitionInterval Time partition interval
    * @return The specific DataPartition's predecessor if exists, null otherwise
    */
-  public TConsensusGroupId getPrecededDataPartition(
+  public TConsensusGroupId getAdjacentDataPartition(
       TSeriesPartitionSlot seriesPartitionSlot,
       TTimePartitionSlot timePartitionSlot,
       long timePartitionInterval) {
     if (dataPartitionMap.containsKey(seriesPartitionSlot)) {
       return dataPartitionMap
           .get(seriesPartitionSlot)
-          .getPrecededDataPartition(timePartitionSlot, timePartitionInterval);
+          .getAdjacentDataPartition(timePartitionSlot, timePartitionInterval);
     } else {
       return null;
     }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
@@ -122,24 +122,30 @@ public class SeriesPartitionTable {
   }
 
   /**
-   * Checks whether the specified DataPartition has a predecessor and returns if it does
+   * Checks whether the specified DataPartition has a predecessor or successor and returns if it
+   * does
    *
    * @param timePartitionSlot Corresponding TimePartitionSlot
    * @param timePartitionInterval Time partition interval
    * @return The specific DataPartition's predecessor if exists, null otherwise
    */
-  public TConsensusGroupId getPrecededDataPartition(
+  public TConsensusGroupId getAdjacentDataPartition(
       TTimePartitionSlot timePartitionSlot, long timePartitionInterval) {
-    if (timePartitionSlot.getStartTime() < timePartitionInterval) {
-      // The first DataPartition doesn't have predecessor
-      return null;
-    } else {
+    if (timePartitionSlot.getStartTime() >= timePartitionInterval) {
+      // Check predecessor first
       TTimePartitionSlot predecessorSlot =
           new TTimePartitionSlot(timePartitionSlot.getStartTime() - timePartitionInterval);
-      return seriesPartitionMap
-          .getOrDefault(predecessorSlot, Collections.singletonList(null))
-          .get(0);
+      TConsensusGroupId predecessor =
+          seriesPartitionMap.getOrDefault(predecessorSlot, Collections.singletonList(null)).get(0);
+      if (predecessor != null) {
+        return predecessor;
+      }
     }
+
+    // Check successor
+    TTimePartitionSlot successorSlot =
+        new TTimePartitionSlot(timePartitionSlot.getStartTime() + timePartitionInterval);
+    return seriesPartitionMap.getOrDefault(successorSlot, Collections.singletonList(null)).get(0);
   }
 
   /**


### PR DESCRIPTION
We've found in real production environment that queries across different DataRegionGroups are time-consuming. Therefore we should enable and enhance the DataPartition inherit policy. The new created DataPartition will inherit its neighbor(predecessor or successor)'s allocate result if the neighbor is allocated before.