### PR TITLE
Update schema memory control config

### DIFF
--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -186,7 +186,7 @@ cluster_name=defaultCluster
 # storage_query_schema_consensus_free_memory_proportion=3:3:1:1:2
 
 # Schema Memory Allocation Ratio: SchemaRegion, SchemaCache, and PartitionCache.
-# The parameter form is a:b:c, where a, b and d are integers. for example: 1:1:1 , 6:2:1
+# The parameter form is a:b:c, where a, b and c are integers. for example: 1:1:1 , 6:2:1
 # schema_memory_proportion=5:4:1
 
 # Memory allocation ratio in StorageEngine: Write, Compaction

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -185,9 +185,9 @@ cluster_name=defaultCluster
 # If you have high level of writing pressure and low level of reading pressure, please adjust it to for example 6:1:1:1:2
 # storage_query_schema_consensus_free_memory_proportion=3:3:1:1:2
 
-# Schema Memory Allocation Ratio: SchemaRegion, SchemaCache, PartitionCache and LastCache.
-# The parameter form is a:b:c:d, where a, b, c and d are integers. for example: 1:1:1:1 , 6:2:1:1
-# schema_memory_allocate_proportion=5:3:1:1
+# Schema Memory Allocation Ratio: SchemaRegion, SchemaCache, and PartitionCache.
+# The parameter form is a:b:c, where a, b and d are integers. for example: 1:1:1 , 6:2:1
+# schema_memory_proportion=5:4:1
 
 # Memory allocation ratio in StorageEngine: Write, Compaction
 # The parameter form is a:b:c:d, where a, b, c and d are integers. for example: 8:2 , 7:3

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1786,9 +1786,9 @@ public class IoTDBDescriptor {
 
     int proportionSum = 10;
     int schemaRegionProportion = 5;
-    int schemaCacheProportion = 3;
+    int schemaCacheProportion = 4;
     int partitionCacheProportion = 1;
-    int lastCacheProportion = 1;
+    int lastCacheProportion = 0;
 
     String schemaMemoryAllocatePortion =
         properties.getProperty("schema_memory_allocate_proportion");
@@ -1805,6 +1805,22 @@ public class IoTDBDescriptor {
         schemaCacheProportion = Integer.parseInt(proportions[1].trim());
         partitionCacheProportion = Integer.parseInt(proportions[2].trim());
         lastCacheProportion = Integer.parseInt(proportions[3].trim());
+      }
+    } else {
+      schemaMemoryAllocatePortion = properties.getProperty("schema_memory_proportion");
+      if (schemaMemoryAllocatePortion != null) {
+        String[] proportions = schemaMemoryAllocatePortion.split(":");
+        int loadedProportionSum = 0;
+        for (String proportion : proportions) {
+          loadedProportionSum += Integer.parseInt(proportion.trim());
+        }
+
+        if (loadedProportionSum != 0) {
+          proportionSum = loadedProportionSum;
+          schemaRegionProportion = Integer.parseInt(proportions[0].trim());
+          schemaCacheProportion = Integer.parseInt(proportions[1].trim());
+          partitionCacheProportion = Integer.parseInt(proportions[2].trim());
+        }
       }
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1790,8 +1790,7 @@ public class IoTDBDescriptor {
     int partitionCacheProportion = 1;
     int lastCacheProportion = 0;
 
-    String schemaMemoryAllocatePortion =
-        properties.getProperty("schema_memory_allocate_proportion");
+    String schemaMemoryAllocatePortion = properties.getProperty("schema_memory_proportion");
     if (schemaMemoryAllocatePortion != null) {
       String[] proportions = schemaMemoryAllocatePortion.split(":");
       int loadedProportionSum = 0;
@@ -1804,10 +1803,10 @@ public class IoTDBDescriptor {
         schemaRegionProportion = Integer.parseInt(proportions[0].trim());
         schemaCacheProportion = Integer.parseInt(proportions[1].trim());
         partitionCacheProportion = Integer.parseInt(proportions[2].trim());
-        lastCacheProportion = Integer.parseInt(proportions[3].trim());
       }
+
     } else {
-      schemaMemoryAllocatePortion = properties.getProperty("schema_memory_proportion");
+      schemaMemoryAllocatePortion = properties.getProperty("schema_memory_allocate_proportion");
       if (schemaMemoryAllocatePortion != null) {
         String[] proportions = schemaMemoryAllocatePortion.split(":");
         int loadedProportionSum = 0;
@@ -1820,6 +1819,7 @@ public class IoTDBDescriptor {
           schemaRegionProportion = Integer.parseInt(proportions[0].trim());
           schemaCacheProportion = Integer.parseInt(proportions[1].trim());
           partitionCacheProportion = Integer.parseInt(proportions[2].trim());
+          lastCacheProportion = Integer.parseInt(proportions[3].trim());
         }
       }
     }


### PR DESCRIPTION
## Description


### Motivation

The lastcache parameter in ```schema_memory_allocate_proportion``` is useless, thus should be removed. 

Besides, we need to keep compatible with previous properties file.

### Modification

Introduce new config ```schema_memory_proportion```, which keep consistency with other parameters on naming style and only cover schema region, schema cache and partition cache. 

The old config ```schema_memory_allocate_proportion``` is removed from properties file, but still can take effect if an IoTDB is upgrade from previous version.
