### PR TITLE
[IOTDB-5942] Pipe: Fix bugs in PipeWALResourceManager, EnrichedEvent, IoTDBThriftReceiverV1

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
@@ -93,6 +93,11 @@ public class PipeRuntimeAgent implements IService {
   //////////////////////////// Runtime Exception Handlers ////////////////////////////
 
   public void report(PipeTaskMeta pipeTaskMeta, PipeRuntimeException pipeRuntimeException) {
+    LOGGER.warn(
+        String.format(
+            "PipeRuntimeException: pipe task meta %s, exception %s",
+            pipeTaskMeta, pipeRuntimeException),
+        pipeRuntimeException);
     pipeTaskMeta.trackExceptionMessage(pipeRuntimeException);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/pipe/core/collector/realtime/PipeRealtimeDataRegionHybridCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/core/collector/realtime/PipeRealtimeDataRegionHybridCollector.java
@@ -162,6 +162,7 @@ public class PipeRealtimeDataRegionHybridCollector extends PipeRealtimeDataRegio
         // this event is not reliable anymore. but the data represented by this event
         // has been carried by the following tsfile event, so we can just discard this event.
         event.getTsFileEpoch().migrateState(this, state -> TsFileEpoch.State.USING_TSFILE);
+        LOGGER.warn(String.format("Increase reference count for event %s error.", event));
         return null;
       }
     }
@@ -196,6 +197,7 @@ public class PipeRealtimeDataRegionHybridCollector extends PipeRealtimeDataRegio
                 "TsFile Event %s can not be supplied because the reference count can not be increased, "
                     + "the data represented by this event is lost",
                 event.getEvent());
+        LOGGER.warn(errorMessage);
         PipeAgent.runtime().report(pipeTaskMeta, new PipeRuntimeNonCriticalException(errorMessage));
         return null;
       }

--- a/server/src/main/java/org/apache/iotdb/db/pipe/core/collector/realtime/PipeRealtimeDataRegionLogCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/core/collector/realtime/PipeRealtimeDataRegionLogCollector.java
@@ -94,6 +94,7 @@ public class PipeRealtimeDataRegionLogCollector extends PipeRealtimeDataRegionCo
                 "Tablet Event %s can not be supplied because the reference count can not be increased, "
                     + "the data represented by this event is lost",
                 collectEvent.getEvent());
+        LOGGER.warn(errorMessage);
         PipeAgent.runtime().report(pipeTaskMeta, new PipeRuntimeNonCriticalException(errorMessage));
       }
 

--- a/server/src/main/java/org/apache/iotdb/db/pipe/core/collector/realtime/PipeRealtimeDataRegionTsFileCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/core/collector/realtime/PipeRealtimeDataRegionTsFileCollector.java
@@ -95,6 +95,7 @@ public class PipeRealtimeDataRegionTsFileCollector extends PipeRealtimeDataRegio
                 "TsFile Event %s can not be supplied because the reference count can not be increased, "
                     + "the data represented by this event is lost",
                 collectEvent.getEvent());
+        LOGGER.warn(errorMessage);
         PipeAgent.runtime().report(pipeTaskMeta, new PipeRuntimeNonCriticalException(errorMessage));
       }
 

--- a/server/src/main/java/org/apache/iotdb/db/pipe/core/event/EnrichedEvent.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/core/event/EnrichedEvent.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * additional information mainly includes the reference count of the event.
  */
 public abstract class EnrichedEvent implements Event {
-
   private final AtomicInteger referenceCount;
 
   private final PipeTaskMeta pipeTaskMeta;
@@ -47,7 +46,7 @@ public abstract class EnrichedEvent implements Event {
    * @param holderMessage the message of the invoker
    * @return true if the reference count is increased successfully, false if the event is not
    */
-  public final boolean increaseReferenceCount(String holderMessage) {
+  public boolean increaseReferenceCount(String holderMessage) {
     boolean isSuccessful = true;
     synchronized (this) {
       if (referenceCount.get() == 0) {
@@ -75,7 +74,7 @@ public abstract class EnrichedEvent implements Event {
    * @param holderMessage the message of the invoker
    * @return true if the reference count is decreased successfully, false otherwise
    */
-  public final boolean decreaseReferenceCount(String holderMessage) {
+  public boolean decreaseReferenceCount(String holderMessage) {
     boolean isSuccessful = true;
     synchronized (this) {
       if (referenceCount.get() == 1) {

--- a/server/src/main/java/org/apache/iotdb/db/pipe/core/event/realtime/PipeRealtimeCollectEvent.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/core/event/realtime/PipeRealtimeCollectEvent.java
@@ -66,8 +66,26 @@ public class PipeRealtimeCollectEvent extends EnrichedEvent {
   }
 
   @Override
+  public boolean increaseReferenceCount(String holderMessage) {
+    // This method must be overridden, otherwise during the real-time data collection stage, the
+    // current PipeRealtimeCollectEvent rather than the member variable EnrichedEvent will increase
+    // the reference count, resulting in errors in the reference count of the EnrichedEvent
+    // contained in this PipeRealtimeCollectEvent during the processor and connector stages.
+    return event.increaseReferenceCount(holderMessage);
+  }
+
+  @Override
   public boolean increaseResourceReferenceCount(String holderMessage) {
     return event.increaseResourceReferenceCount(holderMessage);
+  }
+
+  @Override
+  public boolean decreaseReferenceCount(String holderMessage) {
+    // This method must be overridden, otherwise during the real-time data collection stage, the
+    // current PipeRealtimeCollectEvent rather than the member variable EnrichedEvent will increase
+    // the reference count, resulting in errors in the reference count of the EnrichedEvent
+    // contained in this PipeRealtimeCollectEvent during the processor and connector stages.
+    return event.decreaseReferenceCount(holderMessage);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeConnectorSubtask.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeConnectorSubtask.java
@@ -126,7 +126,7 @@ public class PipeConnectorSubtask extends PipeSubtask {
             String.format(
                 "Failed to reconnect to the target system after %d times, stopping current pipe task %s...",
                 MAX_RETRY_TIMES, taskID);
-        LOGGER.error(errorMessage);
+        LOGGER.warn(errorMessage);
         lastFailedCause = throwable;
 
         PipeAgent.runtime().report(taskMeta, new PipeRuntimeCriticalException(errorMessage));

--- a/server/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeSubtask.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeSubtask.java
@@ -169,7 +169,7 @@ public abstract class PipeSubtask implements FutureCallback<Void>, Callable<Void
   protected void releaseLastEvent() {
     if (lastEvent != null) {
       if (lastEvent instanceof EnrichedEvent) {
-        ((EnrichedEvent) lastEvent).decreaseReferenceCount(PipeSubtask.class.getName());
+        ((EnrichedEvent) lastEvent).decreaseReferenceCount(this.getClass().getName());
       }
       lastEvent = null;
     }


### PR DESCRIPTION
- fix bugs in PipeWALResourceManager: Concurrent modification exception when check WAL TTL
- fix bugs in EnrichedEvent: PipeRealtimeCollectEvent reference count error
- fix bugs in IoTDBThriftReceiverV1: Writer stream closed because of tsfile with the same name
- add log when reporting PipeException