### PR TITLE
fix a bug: show timeseries failure caused by broken views.

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/exception/metadata/view/BrokenViewException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/metadata/view/BrokenViewException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.exception.metadata.view;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.commons.path.PartialPath;
+
+import java.util.List;
+
+public class BrokenViewException extends MetadataException {
+  public BrokenViewException(String sourcePath, List<MeasurementPath> matchedPaths) {
+    super(
+        String.format(
+            "View is broken! The source path [%s] maps to unmatched %s path(s): %s.",
+            sourcePath, matchedPaths.size(), matchedPaths.toString()));
+  }
+
+  public BrokenViewException(String viewPath, String sourcePath, List<PartialPath> matchedPaths) {
+    super(
+        String.format(
+            "View [%s] is broken! The source path [%s] maps to unmatched %s path(s): %s.",
+            viewPath, sourcePath, matchedPaths.size(), matchedPaths.toString()));
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/LogicalViewSchemaSource.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/source/LogicalViewSchemaSource.java
@@ -70,6 +70,9 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
    */
   private List<ITimeSeriesSchemaInfo> delayedLogicalViewList;
 
+  private static final String unknownDataTypeString = "UNKNOWN";
+  private static final String viewTypeOfLogicalView = "logical";
+
   LogicalViewSchemaSource(
       PartialPath pathPattern, long limit, long offset, SchemaFilter schemaFilter) {
     this.pathPattern = pathPattern;
@@ -126,7 +129,7 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
     return schemaRegion.getSchemaRegionStatistics().getSeriesNumber();
   }
 
-  private List<TSDataType> analyzeDataTypeOfDelayedViews() {
+  private List<String> analyzeDataTypeOfDelayedViews() {
     if (this.delayedLogicalViewList == null || this.delayedLogicalViewList.size() <= 0) {
       return new ArrayList<>();
     }
@@ -150,14 +153,24 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
     CompleteMeasurementSchemaVisitor completeMeasurementSchemaVisitor =
         new CompleteMeasurementSchemaVisitor();
     Map<NodeRef<Expression>, TSDataType> expressionTypes = new HashMap<>();
-    List<TSDataType> dataTypeList = new ArrayList<>();
+    List<String> dataTypeStringList = new ArrayList<>();
     for (ViewExpression viewExpression : viewExpressionList) {
-      Expression expression = transformToExpressionVisitor.process(viewExpression, null);
-      expression = completeMeasurementSchemaVisitor.process(expression, schemaTree);
-      ExpressionTypeAnalyzer.analyzeExpression(expressionTypes, expression);
-      dataTypeList.add(expressionTypes.get(NodeRef.of(expression)));
+      Expression expression = null;
+      boolean viewIsBroken = false;
+      try {
+        expression = transformToExpressionVisitor.process(viewExpression, null);
+        expression = completeMeasurementSchemaVisitor.process(expression, schemaTree);
+        ExpressionTypeAnalyzer.analyzeExpression(expressionTypes, expression);
+      } catch (Exception e) {
+        viewIsBroken = true;
+      }
+      if (viewIsBroken) {
+        dataTypeStringList.add(unknownDataTypeString);
+      } else {
+        dataTypeStringList.add(expressionTypes.get(NodeRef.of(expression)).toString());
+      }
     }
-    return dataTypeList;
+    return dataTypeStringList;
   }
 
   @Override
@@ -166,22 +179,22 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
     if (this.delayedLogicalViewList == null || this.delayedLogicalViewList.size() <= 0) {
       return;
     }
-    List<TSDataType> dataTypeList = this.analyzeDataTypeOfDelayedViews();
+    List<String> dataTypeStringList = this.analyzeDataTypeOfDelayedViews();
     // process delayed tasks
     for (int index = 0; index < this.delayedLogicalViewList.size(); index++) {
       ITimeSeriesSchemaInfo series = this.delayedLogicalViewList.get(index);
-      TSDataType expressionTypeOfThisView = dataTypeList.get(index);
+      String expressionTypeOfThisView = dataTypeStringList.get(index);
 
       builder.getTimeColumnBuilder().writeLong(0);
       builder.writeNullableText(0, series.getFullPath());
       builder.writeNullableText(1, database);
 
-      builder.writeNullableText(2, expressionTypeOfThisView.toString());
+      builder.writeNullableText(2, expressionTypeOfThisView);
 
       builder.writeNullableText(3, mapToString(series.getTags()));
       builder.writeNullableText(4, mapToString(series.getAttributes()));
 
-      builder.writeNullableText(5, "logical");
+      builder.writeNullableText(5, viewTypeOfLogicalView);
       builder.writeNullableText(
           6, ((LogicalViewSchema) series.getSchema()).getExpression().toString());
       builder.declarePosition();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/visitor/CompleteMeasurementSchemaVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/expression/visitor/CompleteMeasurementSchemaVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.mpp.plan.expression.visitor;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.exception.metadata.view.BrokenViewException;
 import org.apache.iotdb.db.mpp.common.schematree.ISchemaTree;
 import org.apache.iotdb.db.mpp.plan.expression.Expression;
 import org.apache.iotdb.db.mpp.plan.expression.binary.BinaryExpression;
@@ -29,7 +30,6 @@ import org.apache.iotdb.db.mpp.plan.expression.multi.FunctionExpression;
 import org.apache.iotdb.db.mpp.plan.expression.ternary.TernaryExpression;
 import org.apache.iotdb.db.mpp.plan.expression.unary.UnaryExpression;
 
-import java.rmi.UnexpectedException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -95,12 +95,7 @@ public class CompleteMeasurementSchemaVisitor extends ExpressionVisitor<Expressi
       } catch (Exception notAMeasurementPath) {
         List<MeasurementPath> actualPaths = schemaTree.searchMeasurementPaths(path).left;
         if (actualPaths.size() != 1) {
-          throw new UnexpectedException(
-              "given one path ["
-                  + path.toString()
-                  + "], "
-                  + "but got unmatched path(s) :"
-                  + actualPaths.toString());
+          throw new BrokenViewException(path.getFullPath(), actualPaths);
         }
         return new TimeSeriesOperand(actualPaths.get(0));
       }


### PR DESCRIPTION
### fix a bug: show timeseries failure caused by broken views.
For broken views, show "UNKNOWN" as data type.
Therefore, users know those views are broken and can use `show view` to find their source paths.

Normal cases (No broken views):
```
IoTDB> create timeseries root.db.d01.s01 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> create timeseries root.db.d02.s01 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> create timeseries root.db.d02.s02 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> CREATE VIEW root.db.device.temp AS root.db.d01.s01;
Msg: The statement is executed successfully.
IoTDB> CREATE VIEW root.db.device.avg AS SELECT (s01+s02) / 2 from root.db.d02;
Msg: The statement is executed successfully.
IoTDB> SHOW TIMESERIES root.**;
+-------------------+-----+--------+--------+--------+-----------+----+----------+--------+------------------+--------+
|         Timeseries|Alias|Database|DataType|Encoding|Compression|Tags|Attributes|Deadband|DeadbandParameters|ViewType|
+-------------------+-----+--------+--------+--------+-----------+----+----------+--------+------------------+--------+
|    root.db.d01.s01| null| root.db|   INT32|     RLE|     SNAPPY|null|      null|    null|              null|        |
|    root.db.d02.s02| null| root.db|   INT32|     RLE|     SNAPPY|null|      null|    null|              null|        |
|    root.db.d02.s01| null| root.db|   INT32|     RLE|     SNAPPY|null|      null|    null|              null|        |
|root.db.device.temp| null| root.db|   INT32|    null|       null|null|      null|    null|              null| logical|
| root.db.device.avg| null| root.db|  DOUBLE|    null|       null|null|      null|    null|              null| logical|
+-------------------+-----+--------+--------+--------+-----------+----+----------+--------+------------------+--------+
Total line number = 5
It costs 0.028s
IoTDB> SHOW VIEW root.**;
+-------------------+--------+--------+----+----------+--------+---------------------------------------+
|         Timeseries|Database|DataType|Tags|Attributes|ViewType|                                 Source|
+-------------------+--------+--------+----+----------+--------+---------------------------------------+
|root.db.device.temp| root.db|   INT32|null|      null| logical|                        root.db.d01.s01|
| root.db.device.avg| root.db|  DOUBLE|null|      null| logical|(root.db.d02.s01 + root.db.d02.s02) / 2|
+-------------------+--------+--------+----+----------+--------+---------------------------------------+
Total line number = 2
It costs 0.019s
IoTDB>
```

Then delete a source timeseries.
```
IoTDB> DELETE TIMESERIES root.db.d02.s02;
Msg: The statement is executed successfully.
IoTDB>
```

Then show timeseries and views.
```
IoTDB> SHOW TIMESERIES root.**;
+-------------------+-----+--------+--------+--------+-----------+----+----------+--------+------------------+--------+
|         Timeseries|Alias|Database|DataType|Encoding|Compression|Tags|Attributes|Deadband|DeadbandParameters|ViewType|
+-------------------+-----+--------+--------+--------+-----------+----+----------+--------+------------------+--------+
|    root.db.d01.s01| null| root.db|   INT32|     RLE|     SNAPPY|null|      null|    null|              null|        |
|    root.db.d02.s01| null| root.db|   INT32|     RLE|     SNAPPY|null|      null|    null|              null|        |
|root.db.device.temp| null| root.db|   INT32|    null|       null|null|      null|    null|              null| logical|
| root.db.device.avg| null| root.db| UNKNOWN|    null|       null|null|      null|    null|              null| logical|
+-------------------+-----+--------+--------+--------+-----------+----+----------+--------+------------------+--------+
Total line number = 4
It costs 0.024s
IoTDB> SHOW VIEW root.**;
+-------------------+--------+--------+----+----------+--------+---------------------------------------+
|         Timeseries|Database|DataType|Tags|Attributes|ViewType|                                 Source|
+-------------------+--------+--------+----+----------+--------+---------------------------------------+
|root.db.device.temp| root.db|   INT32|null|      null| logical|                        root.db.d01.s01|
| root.db.device.avg| root.db| UNKNOWN|null|      null| logical|(root.db.d02.s01 + root.db.d02.s02) / 2|
+-------------------+--------+--------+----+----------+--------+---------------------------------------+
Total line number = 2
It costs 0.015s
IoTDB>
```