### PR TITLE
[To rel/1.1] Remove unnecessary lock in runningToFinshed of DriverScheduler

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
@@ -488,13 +488,11 @@ public class DriverScheduler implements IDriverScheduler, IService {
       } finally {
         task.unlock();
       }
-      // wrap this clearDriverTask to avoid that status is changed to Aborted during clearDriverTask
-      task.lock();
-      try {
-        clearDriverTask(task);
-      } finally {
-        task.unlock();
-      }
+      // Wrapping clearDriverTask with task.lock() may lead to deadlock. For example:
+      // Thread A locks a task and then try to remove it from a SynchronizedSet(instance related
+      // tasks) which will try to get the lock of SynchronizedSet.
+      // Thread B locks the SynchronizedSet first and then tries to lock the task.
+      clearDriverTask(task);
     }
 
     @Override


### PR DESCRIPTION
Wrapping clearDriverTask with task.lock() may lead to deadlock. For example:
Thread A locks a task and then try to remove it from a SynchronizedSet(instance relatedtasks) which will try to get the lock of SynchronizedSet.
Thread B locks the SynchronizedSet first and then tries to lock the task.