### PR TITLE
Fix DataTimeUtils convertLongToData bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
@@ -668,10 +668,10 @@ public class DateTimeUtils {
     String timePrecision = IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision();
     switch (timePrecision) {
       case "ns":
-        timestamp /= 1000_000_000;
+        timestamp /= 1000_000;
         break;
       case "us":
-        timestamp /= 1000_000;
+        timestamp /= 1000;
         break;
     }
     return LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault())


### PR DESCRIPTION
## Description

DataTimeUtils.convertLongToData didn't handle time precision correctly.