### PR TITLE
Get canonical path when using IOTDB_DATA_HOME and IOTDB_HOME

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -22,7 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.property.ClientPoolProperty.DefaultProperty;
 import org.apache.iotdb.commons.cluster.NodeStatus;
 import org.apache.iotdb.commons.enums.HandleSystemErrorStrategy;
-import org.apache.iotdb.commons.utils.PathUtils;
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
 
 import org.slf4j.Logger;
@@ -171,12 +171,12 @@ public class CommonConfig {
     } catch (IOException e) {
       logger.error("Fail to get canonical path of {}", homeFile, e);
     }
-    userFolder = PathUtils.addPrefix2FilePath(homeDir, userFolder);
-    roleFolder = PathUtils.addPrefix2FilePath(homeDir, roleFolder);
-    procedureWalFolder = PathUtils.addPrefix2FilePath(homeDir, procedureWalFolder);
-    syncDir = PathUtils.addPrefix2FilePath(homeDir, syncDir);
+    userFolder = FileUtils.addPrefix2FilePath(homeDir, userFolder);
+    roleFolder = FileUtils.addPrefix2FilePath(homeDir, roleFolder);
+    procedureWalFolder = FileUtils.addPrefix2FilePath(homeDir, procedureWalFolder);
+    syncDir = FileUtils.addPrefix2FilePath(homeDir, syncDir);
     for (int i = 0; i < walDirs.length; i++) {
-      walDirs[i] = PathUtils.addPrefix2FilePath(homeDir, walDirs[i]);
+      walDirs[i] = FileUtils.addPrefix2FilePath(homeDir, walDirs[i]);
     }
   }
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.property.ClientPoolProperty.DefaultProperty;
 import org.apache.iotdb.commons.cluster.NodeStatus;
 import org.apache.iotdb.commons.enums.HandleSystemErrorStrategy;
+import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
 
 import org.slf4j.Logger;
@@ -170,24 +171,13 @@ public class CommonConfig {
     } catch (IOException e) {
       logger.error("Fail to get canonical path of {}", homeFile, e);
     }
-    userFolder = addHomeDir(userFolder, homeDir);
-    roleFolder = addHomeDir(roleFolder, homeDir);
-    procedureWalFolder = addHomeDir(procedureWalFolder, homeDir);
-    syncDir = addHomeDir(syncDir, homeDir);
+    userFolder = PathUtils.addPrefix2FilePath(homeDir, userFolder);
+    roleFolder = PathUtils.addPrefix2FilePath(homeDir, roleFolder);
+    procedureWalFolder = PathUtils.addPrefix2FilePath(homeDir, procedureWalFolder);
+    syncDir = PathUtils.addPrefix2FilePath(homeDir, syncDir);
     for (int i = 0; i < walDirs.length; i++) {
-      walDirs[i] = addHomeDir(walDirs[i], homeDir);
+      walDirs[i] = PathUtils.addPrefix2FilePath(homeDir, walDirs[i]);
     }
-  }
-
-  private String addHomeDir(String dir, String homeDir) {
-    if (!new File(dir).isAbsolute() && homeDir != null && homeDir.length() > 0) {
-      if (!homeDir.endsWith(File.separator)) {
-        dir = homeDir + File.separatorChar + dir;
-      } else {
-        dir = homeDir + dir;
-      }
-    }
-    return dir;
   }
 
   public String getEncryptDecryptProvider() {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 public class CommonConfig {
@@ -163,6 +164,12 @@ public class CommonConfig {
   CommonConfig() {}
 
   public void updatePath(String homeDir) {
+    File homeFile = new File(homeDir);
+    try {
+      homeDir = homeFile.getCanonicalPath();
+    } catch (IOException e) {
+      logger.error("Fail to get canonical path of {}", homeFile, e);
+    }
     userFolder = addHomeDir(userFolder, homeDir);
     roleFolder = addHomeDir(roleFolder, homeDir);
     procedureWalFolder = addHomeDir(procedureWalFolder, homeDir);

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -165,6 +165,10 @@ public class CommonConfig {
   CommonConfig() {}
 
   public void updatePath(String homeDir) {
+    if (homeDir == null) {
+      return;
+    }
+
     File homeFile = new File(homeDir);
     try {
       homeDir = homeFile.getCanonicalPath();

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -153,4 +153,16 @@ public class FileUtils {
       org.apache.commons.io.FileUtils.delete(file);
     }
   }
+
+  /** Add a prefix to a relative path file */
+  public static String addPrefix2FilePath(String prefix, String file) {
+    if (!new File(file).isAbsolute() && prefix != null && prefix.length() > 0) {
+      if (!prefix.endsWith(File.separator)) {
+        file = prefix + File.separatorChar + file;
+      } else {
+        file = prefix + file;
+      }
+    }
+    return file;
+  }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/PathUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/PathUtils.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.tsfile.exception.PathParseException;
 import org.apache.iotdb.tsfile.read.common.parser.PathNodesGenerator;
 import org.apache.iotdb.tsfile.read.common.parser.PathVisitor;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -202,17 +201,5 @@ public class PathUtils {
       return false;
     }
     return src.length() == (src.replace("``", "").length() + num);
-  }
-
-  /** Add a prefix to a relative path file */
-  public static String addPrefix2FilePath(String prefix, String file) {
-    if (!new File(file).isAbsolute() && prefix != null && prefix.length() > 0) {
-      if (!prefix.endsWith(File.separator)) {
-        file = prefix + File.separatorChar + file;
-      } else {
-        file = prefix + file;
-      }
-    }
-    return file;
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/PathUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/PathUtils.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.tsfile.exception.PathParseException;
 import org.apache.iotdb.tsfile.read.common.parser.PathNodesGenerator;
 import org.apache.iotdb.tsfile.read.common.parser.PathVisitor;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -201,5 +202,17 @@ public class PathUtils {
       return false;
     }
     return src.length() == (src.replace("``", "").length() + num);
+  }
+
+  /** Add a prefix to a relative path file */
+  public static String addPrefix2FilePath(String prefix, String file) {
+    if (!new File(file).isAbsolute() && prefix != null && prefix.length() > 0) {
+      if (!prefix.endsWith(File.separator)) {
+        file = prefix + File.separatorChar + file;
+      } else {
+        file = prefix + file;
+      }
+    }
+    return file;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.conf;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.property.ClientPoolProperty.DefaultProperty;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.db.audit.AuditLogOperation;
@@ -1324,18 +1325,7 @@ public class IoTDBConfig {
     } catch (IOException e) {
       logger.error("Fail to get canonical path of {}", dataHomeFile, e);
     }
-    return addDirPrefix(dataHomeDir, dir);
-  }
-
-  private String addDirPrefix(String prefix, String dir) {
-    if (!new File(dir).isAbsolute() && prefix != null && prefix.length() > 0) {
-      if (!prefix.endsWith(File.separator)) {
-        dir = prefix + File.separatorChar + dir;
-      } else {
-        dir = prefix + dir;
-      }
-    }
-    return dir;
+    return PathUtils.addPrefix2FilePath(dataHomeDir, dir);
   }
 
   void confirmMultiDirStrategy() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1319,6 +1319,10 @@ public class IoTDBConfig {
     if (dataHomeDir == null) {
       dataHomeDir = System.getProperty(IoTDBConstant.IOTDB_HOME, null);
     }
+    if (dataHomeDir == null) {
+      return dir;
+    }
+
     File dataHomeFile = new File(dataHomeDir);
     try {
       dataHomeDir = dataHomeFile.getCanonicalPath();

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.db.conf;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.property.ClientPoolProperty.DefaultProperty;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
-import org.apache.iotdb.commons.utils.PathUtils;
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.db.audit.AuditLogOperation;
@@ -1325,7 +1325,7 @@ public class IoTDBConfig {
     } catch (IOException e) {
       logger.error("Fail to get canonical path of {}", dataHomeFile, e);
     }
-    return PathUtils.addPrefix2FilePath(dataHomeDir, dir);
+    return FileUtils.addPrefix2FilePath(dataHomeDir, dir);
   }
 
   void confirmMultiDirStrategy() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -51,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1316,6 +1317,12 @@ public class IoTDBConfig {
     String dataHomeDir = System.getProperty(IoTDBConstant.IOTDB_DATA_HOME, null);
     if (dataHomeDir == null) {
       dataHomeDir = System.getProperty(IoTDBConstant.IOTDB_HOME, null);
+    }
+    File dataHomeFile = new File(dataHomeDir);
+    try {
+      dataHomeDir = dataHomeFile.getCanonicalPath();
+    } catch (IOException e) {
+      logger.error("Fail to get canonical path of {}", dataHomeFile, e);
     }
     return addDirPrefix(dataHomeDir, dir);
   }


### PR DESCRIPTION
Current addDataHomeDir method in the IoTDBConfig cannot fulfill its responsibilities. We should get canonical path when using IOTDB_DATA_HOME and IOTDB_HOME
![截屏2023-06-02 15 27 56](https://github.com/apache/iotdb/assets/43991780/ca2683fc-a1b7-4cdc-91d4-87b7070417b0)
